### PR TITLE
chore(ui): allow using night-mode on elements other than root

### DIFF
--- a/weave-js/src/common/css/Base.less
+++ b/weave-js/src/common/css/Base.less
@@ -1030,7 +1030,7 @@ img.ui.avatar.image {
     color: @error;
 }
 
-html.night-mode {
+.night-mode {
     transition: @nightModeTransition;
     filter: @nightModeFilter;
     img, video, iframe, .inverted.segment, .editable-image, .run-logs, .search-nav, .media-card__fullscreen,


### PR DESCRIPTION
Removes the `html` element selector on the night mode CSS rule so it will apply to any element that has the `night-mode` class. 

The goal here is to allow Storybook to show side-by-side what a component looks like in regular vs. night mode. This will allow the Storybook files to just import the exact night mode definition from here and apply it to a `div`, rather than having to duplicate the rules and keep them in sync.