### PR TITLE
Fix lint issues using prettier, commit them back to branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,10 @@ jobs:
             yarn install --frozen-lockfile
             yarn eslint
             yarn tslint
+            yarn prettier-fix
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git diff --quiet && git diff --staged --quiet || (git commit -am "Format code" && git push)
             yarn prettier
             yarn run tsc
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,10 @@ jobs:
     name: WeaveJS Lint and Compile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v1
         with:
           node-version: "16.x"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,14 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: "16.x"
-      - run: cd weave-js && yarn install --frozen-lockfile && yarn eslint && yarn tslint && yarn prettier && yarn run tsc
+      - run: |
+            set -e
+            cd weave-js
+            yarn install --frozen-lockfile
+            yarn eslint
+            yarn tslint
+            yarn prettier
+            yarn run tsc
 
   test:
     name: Python unit tests


### PR DESCRIPTION
- actions/checkout@v2 is used with fetch-depth: 0 and token: ${{ secrets.GITHUB_TOKEN }} to get all history and allow push operations respectively
- run command is broken down into new lines
- actual implementation in 68-71