### PR TITLE
chore: bump Dockerfile to alpine-3.17_glibc-2.34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-glibc:alpine-3.9_glibc-2.29
+FROM frolvlad/alpine-glibc:alpine-3.17_glibc-2.34
 LABEL MAINTAINER="danny goldstein <danny@wandb.com>"
 
 ENV CONDA_VERSION=4.9.2 \


### PR DESCRIPTION
Alpine 3.9.6 is no longer supported by the Alpine maintainers, so upgrading to the most recent version of this image.
Additionally, resolves the following:
- https://security.snyk.io/vuln/SNYK-ALPINE39-OPENSSL-1089235
- https://security.snyk.io/vuln/SNYK-ALPINE39-OPENSSL-1089232
- https://security.snyk.io/vuln/SNYK-ALPINE39-OPENSSL-1089234
- https://security.snyk.io/vuln/SNYK-ALPINE39-OPENSSL-1089233
- https://security.snyk.io/vuln/SNYK-ALPINE39-OPENSSL-1089231
- https://security.snyk.io/vuln/SNYK-ALPINE39-MUSL-1042761
- https://security.snyk.io/vuln/SNYK-ALPINE39-OPENSSL-1089236