### PR TITLE
feat: Allowing UI configuration to be passed in from outside

### DIFF
--- a/weave-js/src/common/components/JupyterViewer.tsx
+++ b/weave-js/src/common/components/JupyterViewer.tsx
@@ -1,3 +1,4 @@
+import {UIConfigOptions} from '@wandb/weave/components/Panel2/panellib/libpanel';
 import AU from 'ansi_up';
 import classnames from 'classnames';
 import * as Prism from 'prismjs';
@@ -175,8 +176,13 @@ function processOutputs(
   return outputs;
 }
 
-const JupyterViewerFromRun: React.FC<JupyterProps> = props => {
-  const {useLoadFile, file} = props;
+type JupyterUIConfig = {
+  rules: UIConfigOptions['html'];
+};
+const JupyterViewerFromRun: React.FC<
+  JupyterProps & JupyterUIConfig
+> = props => {
+  const {useLoadFile, file, rules} = props;
   const [raw, setRaw] = useState<any>();
   const [error, setErrorVal] = useState(false);
   const setError = useCallback(() => setErrorVal(true), [setErrorVal]);
@@ -196,7 +202,7 @@ const JupyterViewerFromRun: React.FC<JupyterProps> = props => {
     return <WandbLoader name="jupyter-vewier" />;
   }
 
-  return <JupyterViewer raw={raw} />;
+  return <JupyterViewer raw={raw} rules={rules} />;
 };
 
 export const JupyterCell: React.FC<{
@@ -205,7 +211,8 @@ export const JupyterCell: React.FC<{
   saveCode?: (code: string) => void;
   id: string;
   readonly: boolean;
-}> = ({cell, id, runCode, saveCode, readonly}) => {
+  rules: UIConfigOptions['html'];
+}> = ({cell, id, runCode, saveCode, readonly, rules = []}) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // This effect resizes the iframe so we don't have extra space / scrollbars
@@ -288,7 +295,8 @@ export const JupyterCell: React.FC<{
           className="output"
           dangerouslySetInnerHTML={{
             __html: generateHTML(
-              sourceAsArray(cell.source).join('')
+              sourceAsArray(cell.source).join(''),
+              rules
             ).toString(),
           }}
         />
@@ -301,8 +309,8 @@ export const JupyterCell: React.FC<{
 
 export const JupyterViewer: React.FC<{
   raw: string;
-}> = props => {
-  const {raw} = props;
+  rules: UIConfigOptions['html'];
+}> = ({raw, rules}) => {
   const idRef = useRef(ID());
   useEffect(() => {
     Prism.highlightAll();
@@ -333,6 +341,7 @@ export const JupyterViewer: React.FC<{
       {notebook.cells.map((cell, i) => (
         <JupyterCell
           readonly={true}
+          rules={rules}
           cell={cell}
           id={`${idRef.current}-cell-${i}`}
           key={`${idRef.current}-cell-${i}`}

--- a/weave-js/src/common/components/JupyterViewer.tsx
+++ b/weave-js/src/common/components/JupyterViewer.tsx
@@ -211,7 +211,7 @@ export const JupyterCell: React.FC<{
   id: string;
   readonly: boolean;
 }> = ({cell, id, runCode, saveCode, readonly}) => {
-  const {allowScopedStyles} = usePanelSettings(
+  const panelSettings = usePanelSettings(
     'JupyterViewer'
   ) as JupyterViewPanelSettings;
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -296,7 +296,7 @@ export const JupyterCell: React.FC<{
           className="output"
           dangerouslySetInnerHTML={{
             __html: generateHTML(sourceAsArray(cell.source).join(''), {
-              allowScopedStyles,
+              allowScopedStyles: panelSettings?.allowScopedStyles ?? false,
             }).toString(),
           }}
         />

--- a/weave-js/src/common/util/markdown.test.ts
+++ b/weave-js/src/common/util/markdown.test.ts
@@ -1,28 +1,46 @@
-import {defaultSchema as gh} from 'hast-util-sanitize/lib/schema';
-
-import {buildSanitizationSchema, generateHTML, isMarkdown} from './markdown';
+import {
+  DEFAULT_SANITIZATION_SCHEMA,
+  buildSanitizationSchema,
+  generateHTML,
+  isMarkdown,
+} from './markdown';
 
 describe('buildSanitizationSchema', () => {
   it('built schema allows scoped styles with `allowScopedStyles` rule', () => {
-    expect(gh.tagNames?.includes('style')).toBe(false);
-    expect(gh.attributes.style).toBe(undefined);
+    // preconditions
+    expect(DEFAULT_SANITIZATION_SCHEMA.tagNames?.includes('style')).toBe(false);
+    expect(DEFAULT_SANITIZATION_SCHEMA.attributes?.style).toBe(undefined);
 
-    const builtSchema = buildSanitizationSchema(['allowScopedStyles'], gh);
+    // actual test
+    const builtSchema = buildSanitizationSchema({allowScopedStyles: true});
     expect(builtSchema.tagNames?.includes('style')).toBe(true);
-    expect(builtSchema.attributes.style.includes('scoped')).toBe(true);
+    expect(builtSchema.attributes?.style?.includes('scoped')).toBe(true);
+  });
+  it('built schema works correclty without `allowScopedStyles`', () => {
+    // preconditions
+    expect(DEFAULT_SANITIZATION_SCHEMA.tagNames?.includes('style')).toBe(false);
+    expect(DEFAULT_SANITIZATION_SCHEMA.attributes?.style).toBe(undefined);
+
+    // actual test
+    const falseCaseSchema = buildSanitizationSchema({allowScopedStyles: false});
+    expect(falseCaseSchema.tagNames?.includes('style')).toBeFalsy();
+    expect(falseCaseSchema.attributes?.style?.includes('scoped')).toBeFalsy();
+    const undefinedCaseSchema = buildSanitizationSchema();
+    expect(undefinedCaseSchema.tagNames?.includes('style')).toBeFalsy();
+    expect(
+      undefinedCaseSchema.attributes?.style?.includes('scoped')
+    ).toBeFalsy();
   });
 });
 
 describe('generateHTML', () => {
   it('does not allow basic script tags', () => {
     const someHTML = '<script>alert(123)</script>';
-    console.log(generateHTML(someHTML).value);
     expect(generateHTML(someHTML).value.indexOf('script')).toEqual(-1);
   });
 
   it('does not allow basic script tags in tag params', () => {
     const someHTML = '<a href=<script>alert(123)</script>> link </a>';
-    console.log(generateHTML(someHTML).value);
     expect(generateHTML(someHTML).value.indexOf('script')).toEqual(-1);
   });
 });

--- a/weave-js/src/common/util/markdown.test.ts
+++ b/weave-js/src/common/util/markdown.test.ts
@@ -1,4 +1,17 @@
-import {generateHTML, isMarkdown} from './markdown';
+import {defaultSchema as gh} from 'hast-util-sanitize/lib/schema';
+
+import {buildSanitizationSchema, generateHTML, isMarkdown} from './markdown';
+
+describe('buildSanitizationSchema', () => {
+  it('built schema allows scoped styles with `allowScopedStyles` rule', () => {
+    expect(gh.tagNames?.includes('style')).toBe(false);
+    expect(gh.attributes.style).toBe(undefined);
+
+    const builtSchema = buildSanitizationSchema(['allowScopedStyles'], gh);
+    expect(builtSchema.tagNames?.includes('style')).toBe(true);
+    expect(builtSchema.attributes.style.includes('scoped')).toBe(true);
+  });
+});
 
 describe('generateHTML', () => {
   it('does not allow basic script tags', () => {

--- a/weave-js/src/common/util/markdown.ts
+++ b/weave-js/src/common/util/markdown.ts
@@ -42,11 +42,9 @@ export function markdownToText(markdown: string, rules: SanitizationRules) {
 
 type SanitizationRules = {allowScopedStyles?: boolean};
 export function buildSanitizationSchema(rules?: SanitizationRules) {
-  // Since this function deals with security, it is deliberately written in a simple
-  // and understandable manner
   const newSchema = {...DEFAULT_SANITIZATION_SCHEMA};
   if (rules?.allowScopedStyles) {
-    Object.assign(newSchema, SANITIZATION_SCHEMAS_FOR_RULES.allowScopedStyles);
+    _.merge(newSchema, SANITIZATION_SCHEMAS_FOR_RULES.allowScopedStyles);
   }
 
   return newSchema;

--- a/weave-js/src/components/Panel2/PanelFileJupyter/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelFileJupyter/Component.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 
 import * as CGReact from '../../../react';
 import * as Panel2 from '../panel';
-import {UIConfigOptions} from '../panellib/libpanel';
 import {inputType} from './common';
 
 type PanelJupyterProps = Panel2.PanelProps<typeof inputType>;
@@ -29,11 +28,7 @@ const PanelJupyter: React.FC<PanelJupyterProps> = props => {
         flex: '1 1 auto',
         overflow: 'auto',
       }}>
-      <JupyterViewer
-        raw={content}
-        // @ts-ignore Not sure why panelSpec isn't on props, it should be!
-        rules={props.panelSpec.uiConfig.html as UIConfigOptions['html']}
-      />
+      <JupyterViewer raw={content} />
     </div>
   );
 };

--- a/weave-js/src/components/Panel2/PanelFileJupyter/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelFileJupyter/Component.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import * as CGReact from '../../../react';
 import * as Panel2 from '../panel';
+import {UIConfigOptions} from '../panellib/libpanel';
 import {inputType} from './common';
 
 type PanelJupyterProps = Panel2.PanelProps<typeof inputType>;
@@ -28,7 +29,11 @@ const PanelJupyter: React.FC<PanelJupyterProps> = props => {
         flex: '1 1 auto',
         overflow: 'auto',
       }}>
-      <JupyterViewer raw={content} />
+      <JupyterViewer
+        raw={content}
+        // @ts-ignore Not sure why panelSpec isn't on props, it should be!
+        rules={props.panelSpec.uiConfig.html as UIConfigOptions['html']}
+      />
     </div>
   );
 };

--- a/weave-js/src/components/Panel2/panellib/libpanel.ts
+++ b/weave-js/src/components/Panel2/panellib/libpanel.ts
@@ -53,14 +53,6 @@ interface Dimensions {
   height: number | undefined;
 }
 
-const htmlRules = ['allowScopedStyles'] as const;
-type HTMLRules = (typeof htmlRules)[number];
-
-export type UIConfigOptions = {
-  // allowScopedStyles: in Jupyter panels, allow <style scoped> tags in output html
-  html: HTMLRules[];
-};
-
 export interface PanelSpec<X, C, T extends Type> {
   id: string;
   hidden?: boolean;
@@ -75,12 +67,6 @@ export interface PanelSpec<X, C, T extends Type> {
   ConfigComponent?: React.ComponentType<PanelPropsInternal<any, C, X>>;
   Component: React.ComponentType<PanelPropsInternal<any, C, X>>;
   inputType: T;
-  /**
-   * UI rules are declarative way to toggle behavior in Weave panels
-   *
-   * Downstream code with configuration options will
-   */
-  uiConfig?: UIConfigOptions;
 
   outputType?: (inputType: T) => Type;
 

--- a/weave-js/src/components/Panel2/panellib/libpanel.ts
+++ b/weave-js/src/components/Panel2/panellib/libpanel.ts
@@ -52,6 +52,15 @@ interface Dimensions {
   width: number | undefined;
   height: number | undefined;
 }
+
+const htmlRules = ['allowScopedStyles'] as const;
+type HTMLRules = (typeof htmlRules)[number];
+
+export type UIConfigOptions = {
+  // allowScopedStyles: in Jupyter panels, allow <style scoped> tags in output html
+  html: HTMLRules[];
+};
+
 export interface PanelSpec<X, C, T extends Type> {
   id: string;
   hidden?: boolean;
@@ -65,8 +74,13 @@ export interface PanelSpec<X, C, T extends Type> {
   ) => Promise<C> | C;
   ConfigComponent?: React.ComponentType<PanelPropsInternal<any, C, X>>;
   Component: React.ComponentType<PanelPropsInternal<any, C, X>>;
-
   inputType: T;
+  /**
+   * UI rules are declarative way to toggle behavior in Weave panels
+   *
+   * Downstream code with configuration options will
+   */
+  uiConfig?: UIConfigOptions;
 
   outputType?: (inputType: T) => Type;
 

--- a/weave-js/src/context.tsx
+++ b/weave-js/src/context.tsx
@@ -1,5 +1,6 @@
 import {Client} from '@wandb/weave/core';
-import React, {createContext, useContext, useMemo} from 'react';
+import React, {FC, createContext, useContext, useMemo} from 'react';
+import _ from 'lodash';
 
 import {WeaveApp} from './weave';
 
@@ -46,6 +47,23 @@ export const WeaveFeaturesContext = createContext<WeaveFeatures>({
   betaFeatures: {},
 });
 WeaveFeaturesContext.displayName = 'WeaveFeaturesContext';
+
+export const WeaveFeaturesContextProvider: FC<{features: WeaveFeatures}> =
+  React.memo(props => {
+    const prevFeatures = {...useWeaveFeaturesContext()};
+
+    // for panelSettings, we can't do a simple spread operator combine, since we
+    // need to retain values from both panelSettings if they exist. Spread operator
+    // will only retain the props.features copy of panelSettings, ignoring any panelSettings
+    // in prevFeatures.
+    const newFeatures = _.merge(prevFeatures, props.features);
+
+    return (
+      <WeaveFeaturesContext.Provider value={newFeatures}>
+        {props.children}
+      </WeaveFeaturesContext.Provider>
+    );
+  });
 
 export const useWeaveFeaturesContext = () => {
   return useContext(WeaveFeaturesContext);

--- a/weave-js/src/context.tsx
+++ b/weave-js/src/context.tsx
@@ -74,5 +74,5 @@ export const useWeaveDashUiEnable = () => {
 };
 
 export const usePanelSettings = (type: PanelSettingPanel) => {
-  return useWeaveFeaturesContext().panelSettings?.[type];
+  return useWeaveFeaturesContext().panelSettings?.[type] ?? {};
 };

--- a/weave-js/src/context.tsx
+++ b/weave-js/src/context.tsx
@@ -13,11 +13,14 @@ export type WeaveWBBetaFeatures = {
   'weave-devpopup'?: boolean;
 };
 
+export type PanelSettingPanel = 'JupyterViewer';
+
 export interface WeaveFeatures {
   actions?: boolean;
   fullscreenMode?: boolean;
   dashUi?: boolean;
   betaFeatures: WeaveWBBetaFeatures;
+  panelSettings?: Record<PanelSettingPanel, any>;
 }
 
 export const ClientContext = React.createContext<ClientState>({
@@ -50,4 +53,8 @@ export const useWeaveFeaturesContext = () => {
 
 export const useWeaveDashUiEnable = () => {
   return useContext(WeaveFeaturesContext).dashUi;
+};
+
+export const usePanelSettings = (type: PanelSettingPanel) => {
+  return useWeaveFeaturesContext().panelSettings?.[type];
 };

--- a/weave-js/src/context.tsx
+++ b/weave-js/src/context.tsx
@@ -21,7 +21,7 @@ export interface WeaveFeatures {
   fullscreenMode?: boolean;
   dashUi?: boolean;
   betaFeatures: WeaveWBBetaFeatures;
-  panelSettings?: Record<PanelSettingPanel, any>;
+  panelSettings?: Record<PanelSettingPanel, unknown>;
 }
 
 export const ClientContext = React.createContext<ClientState>({


### PR DESCRIPTION
In order to allow Markdown => HTML rules to be relaxed depending on the security of the outside environment we need a way to trigger changes in the sanitization schema from outside Weave. 

The usage of WeaveFeaturesContext is explained here: https://github.com/wandb/weave/pull/28#pullrequestreview-1475643423

Original slack thread: https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1686328384196249
ticket: https://wandb.atlassian.net/browse/WB-12729
wand PR that is blocked by this PR: https://github.com/wandb/core/pull/15416

