### PR TITLE
Re-enable capturing of error logs

### DIFF
--- a/weave/ecosystem/test_notebook_ecosystem_executions.py
+++ b/weave/ecosystem/test_notebook_ecosystem_executions.py
@@ -6,7 +6,7 @@ def test_playback():
 
     for payload in [execute_payloads[-1]]:
         res = handle_request(payload, True)
-        res.unwrap()
+        res.results.unwrap()
 
 
 execute_payloads = [

--- a/weave/tests/test_execution_graphs.py
+++ b/weave/tests/test_execution_graphs.py
@@ -8,7 +8,7 @@ import json
 def test_graph_playback():
     for payload in execute_payloads:
         res = handle_request(payload, True, storage.make_js_serializer())
-        assert "err" not in res
+        res.results.unwrap()
 
 
 def test_zlib_playback():
@@ -37,7 +37,7 @@ def test_zlib_playback():
     }
 
     response = handle_request(**execute_args)
-    assert "err" not in response
+    response.results.unwrap()
 
 
 # (Only used in zlib test) - if you are testing a `WeaveNullishResponseException`, you can

--- a/weave/util.py
+++ b/weave/util.py
@@ -44,7 +44,7 @@ def raise_exception_with_sentry_if_available(
 
 def capture_exception_with_sentry_if_available(
     err: Exception, fingerprint: typing.Any
-) -> None:
+) -> typing.Union[None, str]:
     init_sentry()
     try:
         import sentry_sdk
@@ -53,7 +53,8 @@ def capture_exception_with_sentry_if_available(
     else:
         with sentry_sdk.push_scope() as scope:
             scope.fingerprint = fingerprint
-            sentry_sdk.capture_exception(err)
+            return sentry_sdk.capture_exception(err)
+    return None
 
 
 def get_notebook_name():
@@ -143,7 +144,6 @@ def _resolve_path(path: str, current_working_directory: str) -> list[str]:
 def relpath_no_syscalls(
     target_path: str, start_path: str, current_working_directory: str
 ) -> str:
-
     target_parts = _resolve_path(target_path, current_working_directory)
     start_parts = _resolve_path(start_path, current_working_directory)
 

--- a/weave/value_or_error.py
+++ b/weave/value_or_error.py
@@ -37,7 +37,7 @@ class Value(_ValueOrErrorInterface[ValueType]):
         try:
             return Value(fn(self._value))
         except Exception as e:
-            logging.error(e, exc_info=True)
+            # logging.error(e, exc_info=True)
             if DEBUG:
                 raise e
             return Error(e)
@@ -49,7 +49,7 @@ class Value(_ValueOrErrorInterface[ValueType]):
             fn(self._value)
             return self
         except Exception as e:
-            logging.error(e, exc_info=True)
+            # logging.error(e, exc_info=True)
             if DEBUG:
                 raise e
             return Error(e)

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -194,18 +194,23 @@ def _log_errors(
     errors: list[dict] = []
 
     for error in processed_response["errors"]:
+        last_traceback_line = ""
+        if len(error["traceback"]) > 0:
+            last_traceback_line = error["traceback"][-1]
         errors.append(
             {
-                "error": "node_execution_error",
                 "message": error["message"],
-                "node_str": [],
+                "traceback": error["traceback"],
+                "last_traceback_line": last_traceback_line,
+                "error_type": "node_execution_error",
+                "node_strs": [],
             }
         )
 
     for node_ndx, error_ndx in processed_response["node_to_error"].items():
         try:
             node_str = graph.node_expr_str(graph.map_const_nodes_to_x(nodes[node_ndx]))
-            errors[error_ndx]["node_str"].append(node_str)
+            errors[error_ndx]["node_strs"].append(node_str)
         except Exception:
             pass
 

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -147,8 +147,8 @@ def list_ops():
 class ErrorDetailsDict(typing.TypedDict):
     message: str
     error_type: str
-    sentry_id: typing.Union[str, None]
     traceback: list[str]
+    # sentry_id: typing.Union[str, None]
 
 
 class ResponseDict(typing.TypedDict):
@@ -164,7 +164,7 @@ def _exception_to_error_details(
         "error_type": type(e).__name__,
         "message": str(e),
         "traceback": traceback.format_tb(e.__traceback__),
-        "sentry_id": sentry_id,
+        # "sentry_id": sentry_id,
     }
 
 
@@ -208,9 +208,9 @@ def _log_errors(
                 "message": error["message"],
                 "error_type": error["error_type"],
                 "traceback": error["traceback"],
-                "sentry_id": error["sentry_id"],
                 "error_tag": "node_execution_error",
                 "node_strs": [],
+                # "sentry_id": error["sentry_id"],
             }
         )
 

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -202,8 +202,8 @@ def _log_errors(
                 "node_str": [],
             }
         )
-    
-     for node_ndx, error_ndx in processed_response["node_to_error"].items():
+
+    for node_ndx, error_ndx in processed_response["node_to_error"].items():
         try:
             node_str = graph.node_expr_str(graph.map_const_nodes_to_x(nodes[node_ndx]))
             errors[error_ndx]["node_str"].append(node_str)
@@ -214,6 +214,7 @@ def _log_errors(
         # This should be logged to DD, but 1 log per error
         # class, not 1 log per error.
         logging.error(error_dict)
+
 
 @blueprint.route("/__weave/execute", methods=["POST"])
 def execute():

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -146,6 +146,8 @@ def list_ops():
 
 class ErrorDetailsDict(typing.TypedDict):
     message: str
+    error_type: str
+    sentry_id: typing.Union[str, None]
     traceback: list[str]
 
 

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -189,10 +189,9 @@ def _value_or_errors_to_response(
 
 
 def _log_errors(
-    processed_response: ResponseDict, request_response: server.HandleRequestResponse
+    processed_response: ResponseDict, nodes: value_or_error.ValueOrErrors[graph.Node]
 ):
     errors: list[dict] = []
-    nodes: value_or_error.ValueOrErrors[graph.Node] = request_response.nodes
 
     for error in processed_response["errors"]:
         errors.append(
@@ -272,7 +271,7 @@ def execute():
 
     response_payload = _value_or_errors_to_response(fixed_response)
 
-    _log_errors(response_payload, fixed_response)
+    _log_errors(response_payload, response.nodes)
 
     if request.headers.get("x-weave-include-execution-time"):
         response_payload["execution_time"] = (elapsed) * 1000

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -171,11 +171,11 @@ def _value_or_errors_to_response(
     for val, error in vore.iter_items():
         if error != None:
             error = typing.cast(Exception, error)
-            util.capture_exception_with_sentry_if_available(error, ())
             data.append(None)
             if error in error_lookup:
                 error_ndx = error_lookup[error]
             else:
+                util.capture_exception_with_sentry_if_available(error, ())
                 error_ndx = len(error_lookup)
                 error_lookup[error] = error_ndx
             node_errors[len(data) - 1] = error_ndx

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -206,9 +206,10 @@ def _log_errors(
         errors.append(
             {
                 "message": error["message"],
-                "error_type": error["message"],
+                "error_type": error["error_type"],
                 "traceback": error["traceback"],
-                "error_type": "node_execution_error",
+                "sentry_id": error["sentry_id"],
+                "error_tag": "node_execution_error",
                 "node_strs": [],
             }
         )


### PR DESCRIPTION
About 2 weeks ago, I implemented node-level error handling. Well, that was really nice, but hid a bunch of node errors from getting captured in DD and Sentry. This PR logs out the errors to Sentry and DD before returning the response to the caller.