### PR TITLE
make rules param to markdownToText optional

### DIFF
--- a/weave-js/src/common/util/markdown.ts
+++ b/weave-js/src/common/util/markdown.ts
@@ -32,7 +32,7 @@ const SANITIZATION_SCHEMAS_FOR_RULES: Record<keyof SanitizationRules, Schema> =
     },
   };
 
-export function markdownToText(markdown: string, rules: SanitizationRules) {
+export function markdownToText(markdown: string, rules?: SanitizationRules) {
   const html = generateHTML(markdown, rules);
   const tempDiv = document.createElement('div');
   tempDiv.innerHTML = html.toString();


### PR DESCRIPTION
Having a required second param for that method is a breaking API change, did not intend to do that.