### PR TITLE
Fix broken markdown tests

### DIFF
--- a/weave-js/src/common/util/markdown.test.ts
+++ b/weave-js/src/common/util/markdown.test.ts
@@ -16,7 +16,7 @@ describe('buildSanitizationSchema', () => {
     expect(builtSchema.tagNames?.includes('style')).toBe(true);
     expect(builtSchema.attributes?.style?.includes('scoped')).toBe(true);
   });
-  it('built schema works correclty without `allowScopedStyles`', () => {
+  it('built schema works correctly without `allowScopedStyles`', () => {
     // preconditions
     expect(DEFAULT_SANITIZATION_SCHEMA.tagNames?.includes('style')).toBe(false);
     expect(DEFAULT_SANITIZATION_SCHEMA.attributes?.style).toBe(undefined);

--- a/weave-js/src/common/util/markdown.ts
+++ b/weave-js/src/common/util/markdown.ts
@@ -32,7 +32,7 @@ const SANITIZATION_SCHEMAS_FOR_RULES: Record<keyof SanitizationRules, Schema> =
     },
   };
 
-export function markdownToText(markdown: string, rules: SanitizationRules) {
+export function markdownToText(markdown: string, rules?: SanitizationRules) {
   const html = generateHTML(markdown, rules);
   const tempDiv = document.createElement('div');
   tempDiv.innerHTML = html.toString();

--- a/weave-js/src/common/util/markdown.ts
+++ b/weave-js/src/common/util/markdown.ts
@@ -42,7 +42,7 @@ export function markdownToText(markdown: string, rules?: SanitizationRules) {
 
 type SanitizationRules = {allowScopedStyles?: boolean};
 export function buildSanitizationSchema(rules?: SanitizationRules) {
-  const newSchema = {...DEFAULT_SANITIZATION_SCHEMA};
+  const newSchema = _.cloneDeep(DEFAULT_SANITIZATION_SCHEMA);
   if (rules?.allowScopedStyles) {
     _.merge(newSchema, SANITIZATION_SCHEMAS_FOR_RULES.allowScopedStyles);
   }


### PR DESCRIPTION
The _.merge was overwriting the values in newSchema, and while the spread operator above was meant to create a new copy of the object, the fact that it didn't do a deep copy of everything in the JSON object meant we were actually changing values inside the DEFAULT object, which caused failures in the tests.