### PR TITLE
Check second argument type

### DIFF
--- a/weave/show.py
+++ b/weave/show.py
@@ -125,6 +125,10 @@ def show_url(obj=None):
 
 
 def show(obj=None, height=400):
+
+    if not isinstance(height, int):
+        raise errors.WeaveApiError("height (second argument) must be an integer")
+
     if not util.is_notebook():
         usage_analytics.show_called({"error": True})
         raise RuntimeError(


### PR DESCRIPTION
Fix an issue when user passed wrong type to height on `weave.show()`
<img width="812" alt="image" src="https://github.com/wandb/weave/assets/18441985/a89f0177-eab5-4eab-bf6a-eb0a342a764d">
