### PR TITLE
Perf fixes, including for zoom synchronized plots.

### DIFF
--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -47,9 +47,8 @@ import {isGroupNode, nextPanelName} from './panelTree';
 import {toWeaveType} from './toWeaveType';
 // import {VarBar} from '../Sidebar/VarBar';
 import {GRAY_350, GRAY_500, GRAY_800} from '../../common/css/globals.styles';
-import {inJupyterCell} from '../PagePanelComponents/util';
+// import {inJupyterCell} from '../PagePanelComponents/util';
 import {useUpdateConfig2} from './PanelComp';
-import {useTraceUpdate} from '@wandb/weave/common/util/hooks';
 
 const LAYOUT_MODES = [
   'horizontal' as const,
@@ -701,7 +700,7 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
   const setPanelIsHighlightedByPath = useSetPanelInputExprIsHighlighted();
   const setItemIsHighlighted = useCallback(
     (name: string, isHighlighted: boolean) => {
-      // NOTE: this is uses updateConfig2, even though we don't intend to update
+      // NOTE: this uses updateConfig2, even though we don't intend to update
       // the config (we just return it from the updateConfig2 callback). This
       // let's us get access to the current config, without depending on it
       // in our closure. This is critical for performance.
@@ -734,10 +733,6 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
     },
     [mutateItem, setItemIsHighlighted]
   );
-  useTraceUpdate('PG handleSiblingVarEvent', {
-    mutateItem,
-    setItemIsHighlighted,
-  });
 
   const childPanelsByKey = useMemo(() => {
     let newVars: {[name: string]: NodeOrVoidNode} = {};
@@ -775,7 +770,7 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
     [childPanelsByKey]
   );
 
-  const inJupyter = inJupyterCell();
+  // const inJupyter = inJupyterCell();
   // TODO: This special-case rendering is insane
   const isVarBar = _.isEqual(groupPath, [`sidebar`]);
   // if (isVarBar) {

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -2937,7 +2937,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
             } else {
               console.log('MOUSEUP NONCONST');
               // ['x' as const, 'y' as const].forEach(dimName => {
-              ['x' as const].forEach(dimName => {
+              ['x' as const, 'y' as const].forEach(dimName => {
                 const axisSignal: [number, number] | string[] = signal[dimName];
                 const currentSetting =
                   currConcreteConfig.signals.domain[dimName];

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -134,7 +134,7 @@ import {useTraceUpdate} from '@wandb/weave/common/util/hooks';
 const recordEvent = makeEventRecorder('Plot');
 
 // const PANELPLOT_MAX_DATAPOINTS = 2000;
-const DOMAIN_DATAFETCH_EXTRA_EXTENT = 0.5;
+const DOMAIN_DATAFETCH_EXTRA_EXTENT = 2;
 
 const defaultFontStyleDict = {
   titleFont: 'Source Sans Pro',
@@ -1777,7 +1777,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
 
   const isDash = useWeaveDashUiEnable();
 
-  let flatResultNode = useMemo(() => {
+  const flatResultNode = useMemo(() => {
     const arrayArg: {
       [key: number]: ReturnType<
         typeof TableState.tableGetResultTableNode
@@ -2879,7 +2879,6 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
       }
 
       vegaView.addEventListener('mouseup', async () => {
-        console.log('MOUSEUP');
         const currBrushMode = brushModeRef.current;
         const currUpdateConfig2 = updateConfig2Ref.current;
         const currUpdateConfig = updateConfigRef.current;
@@ -2902,7 +2901,6 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
           const settingName = currBrushMode === 'zoom' ? 'domain' : 'selection';
 
           if (settingName === 'domain') {
-            console.log('MOUSEUP DOMAIN');
             const settingNodesAreConst = ['x' as const, 'y' as const].every(
               dimName => {
                 const currentSettingNode = currConfig.signals.domain[dimName];
@@ -2935,8 +2933,6 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
                 currUpdateConfig(newConfig);
               });
             } else {
-              console.log('MOUSEUP NONCONST');
-              // ['x' as const, 'y' as const].forEach(dimName => {
               ['x' as const, 'y' as const].forEach(dimName => {
                 const axisSignal: [number, number] | string[] = signal[dimName];
                 const currentSetting =
@@ -2944,7 +2940,6 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
 
                 if (!_.isEqual(currentSetting, axisSignal)) {
                   if (!isConstNode(currConfig.signals.domain[dimName])) {
-                    console.log('MOUSEUP MUTATE');
                     currMutateDomain[dimName]({
                       val: constNode(toWeaveType(axisSignal), axisSignal),
                     });
@@ -2960,7 +2955,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
                   }
                 }
 
-                // // need to clear out the old selection, if there is one
+                // need to clear out the old selection, if there is one
                 currUpdateConfig2((oldConfig: PlotConfig) => {
                   return produce(oldConfig, draft => {
                     draft.signals.selection[dimName] = undefined;

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -129,7 +129,6 @@ import {
 } from '../Icons';
 import styled from 'styled-components';
 import {PopupMenu, Section} from '../../Sidebar/PopupMenu';
-import {useTraceUpdate} from '@wandb/weave/common/util/hooks';
 
 const recordEvent = makeEventRecorder('Plot');
 
@@ -212,7 +211,6 @@ const useConfig = (
     stack,
     weave
   );
-  useTraceUpdate('pp refined', {tableStates, inputNode, stack, weave});
 
   const configWithRefinedExpressions = useMemo(() => {
     return loadable.loading

--- a/weave-js/src/core/hl.ts
+++ b/weave-js/src/core/hl.ts
@@ -1122,3 +1122,23 @@ function simpleOpString(op: EditingOp, opStore: OpStore): string {
     opStore
   )} `;
 }
+
+// Return a list where each element is a node that is the first input to the next
+// element. The last element is the node itself.
+export function linearize(node: NodeOrVoidNode) {
+  function _linearize(node: OutputNode): OutputNode[] {
+    const firstArg = Object.values(node.fromOp.inputs)[0];
+    if (firstArg == null) {
+      return [node];
+    }
+    if (firstArg.nodeType !== 'output') {
+      return [node];
+    }
+    return [..._linearize(firstArg), node];
+  }
+
+  if (node.nodeType !== 'output') {
+    return undefined;
+  }
+  return _linearize(node);
+}

--- a/weave-js/src/core/hl.ts
+++ b/weave-js/src/core/hl.ts
@@ -1126,15 +1126,15 @@ function simpleOpString(op: EditingOp, opStore: OpStore): string {
 // Return a list where each element is a node that is the first input to the next
 // element. The last element is the node itself.
 export function linearize(node: NodeOrVoidNode) {
-  function _linearize(node: OutputNode): OutputNode[] {
-    const firstArg = Object.values(node.fromOp.inputs)[0];
+  function _linearize(n: OutputNode): OutputNode[] {
+    const firstArg = Object.values(n.fromOp.inputs)[0];
     if (firstArg == null) {
-      return [node];
+      return [n];
     }
     if (firstArg.nodeType !== 'output') {
-      return [node];
+      return [n];
     }
-    return [..._linearize(firstArg), node];
+    return [..._linearize(firstArg), n];
   }
 
   if (node.nodeType !== 'output') {

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -20,6 +20,7 @@ import {
   isFunctionType,
   isVoidNode,
   isWeaveDebugEnabled,
+  linearize,
   Node,
   NodeOrVoidNode,
   Op,
@@ -27,6 +28,7 @@ import {
   opDefIsLowLevel,
   opIndex,
   OpInputs,
+  OutputNode,
   pushFrame,
   resolveVar,
   simplify,
@@ -189,7 +191,11 @@ const clientEval = (node: NodeOrVoidNode, env: Stack): NodeOrVoidNode => {
           },
         },
       };
-    } else if (name === 'Object-__getattr__' || name === 'pick') {
+    } else if (
+      name === 'Object-__getattr__' ||
+      name === 'pick' ||
+      name === 'index'
+    ) {
       let resolvedVal = callResolverSimple(name, inputs, node.fromOp);
       if (resolvedVal.nodeType != null) {
         resolvedVal = clientEval(resolvedVal, env);
@@ -474,6 +480,63 @@ export const parseRef = (ref: string): ArtifactURI => {
   };
 };
 
+// True if we can do a client-side set mutation
+const canClientSet = (linearNodes: OutputNode[] | undefined) => {
+  if (linearNodes == null) {
+    return true;
+  }
+  return linearNodes.every(n => {
+    // Must be allowed ops
+    if (!['pick', 'Object-__getattr__', 'index'].includes(n.fromOp.name)) {
+      return false;
+    }
+    // non arg0 must be const
+    if (
+      Object.values(n.fromOp.inputs)
+        .slice(1)
+        .some(i => !isConstNode(i))
+    ) {
+      return false;
+    }
+    return true;
+  });
+};
+
+// Perform a client side set mutation, returning the new value.
+// Should be equivalent to the server side set mutation (but handles fewer ops).
+const clientSet = (linearNodes: OutputNode[] | undefined, value: any) => {
+  if (linearNodes == null) {
+    return value;
+  }
+  let arg0 = Object.values(linearNodes[0].fromOp.inputs)[0];
+  const results: any[] = [];
+  const opInputs: Array<{[key: string]: any}> = [];
+  // Execute forward
+  for (const node of linearNodes) {
+    const inputs = {...node.fromOp.inputs};
+    inputs[Object.keys(inputs)[0]] = arg0;
+    arg0 = callResolverSimple(node.fromOp.name, inputs, node.fromOp);
+    opInputs.push(inputs);
+    results.push(arg0);
+  }
+
+  let res = value;
+
+  for (let i = linearNodes.length - 1; i >= 0; i--) {
+    const node = linearNodes[i];
+    const inputs = Object.values(opInputs[i]);
+    if (node.fromOp.name === 'pick') {
+      inputs[0][inputs[1].val] = res;
+    } else if (node.fromOp.name === 'Object-__getattr__') {
+      inputs[0][inputs[1].val] = res;
+    } else if (node.fromOp.name === 'index') {
+      inputs[0][inputs[1].val] = res;
+    }
+    res = inputs[0];
+  }
+  return res;
+};
+
 export const absoluteTargetMutation = (absoluteTarget: NodeOrVoidNode) => {
   const rootOutputNode = getChainRootOutputNode(absoluteTarget);
   const rootConstNode = getChainRootConst(absoluteTarget);
@@ -542,7 +605,8 @@ export const makeCallAction = (
       ...inputs,
       root_args: rootArgsNode,
     });
-    return client.action(calledNode as any).then(final => {
+
+    const onDone = (final: any) => {
       if (final == null && ignoreNullResult) {
         // pass
       } else if (mutationStyle === 'clientRef') {
@@ -611,7 +675,20 @@ export const makeCallAction = (
       // how to apply the mutation results back to some user-held state
       // (unlike in graphql).
       return true;
-    });
+    };
+
+    const linearNodes = linearize(absoluteTarget);
+
+    if (
+      inputs.val.nodeType === 'const' &&
+      actionName === 'set' &&
+      canClientSet(linearNodes)
+    ) {
+      const final = clientSet(linearNodes, inputs.val.val);
+      return onDone(final);
+    } else {
+      return client.action(calledNode as any).then(onDone);
+    }
   };
 };
 

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -57,7 +57,6 @@ import {ClientContext, useWeaveContext, useWeaveDashUiEnable} from './context';
 import {getUnresolvedVarNodes} from './core/callers';
 import {useDeepMemo} from './hookUtils';
 import {consoleLog} from './util';
-import {useTraceUpdate} from './common/util/hooks';
 
 /**
  * React hook-style function to get the
@@ -235,6 +234,8 @@ const errorToText = (e: any) => {
 
 let useNodeValueId = 0;
 
+// Construct an id, once per mounted component. Use this to help in
+// debugging.
 export const useId = () => {
   const callSiteId = useRef(useNodeValueId++);
   return callSiteId.current;
@@ -318,15 +319,15 @@ export const useNodeValue = <T extends Type>(
       if (client == null) {
         throw new Error('client not initialized!');
       }
-      if (callSite != null) {
-        console.log('useNodeValue subscribe', callSite, node);
-      }
+      // if (callSite != null) {
+      //   console.log('useNodeValue subscribe', callSite, node);
+      // }
       const obs = client.subscribe(node);
       const sub = obs.subscribe(
         nodeRes => {
-          if (callSite != null) {
-            console.log('useNodeValue resolve', callSite, node);
-          }
+          // if (callSite != null) {
+          //   console.log('useNodeValue resolve', callSite, node);
+          // }
           setResult({node, value: nodeRes});
         },
         caughtError => {
@@ -338,12 +339,12 @@ export const useNodeValue = <T extends Type>(
       return;
     }
   }, [client, node, memoCacheId, callSite, skip]);
-  useTraceUpdate('useNodeValue' + callSite, {
-    client,
-    node,
-    memoCacheId,
-    callSite,
-  });
+  // useTraceUpdate('useNodeValue' + callSite, {
+  //   client,
+  //   node,
+  //   memoCacheId,
+  //   callSite,
+  // });
 
   const finalResult = useMemo(() => {
     // Just rethrow the error in the render thread so it can be caught

--- a/weave/execute_fast.py
+++ b/weave/execute_fast.py
@@ -77,7 +77,9 @@ def _resolve_static_branches(map_fn):
                 return _resolve_static_branches(fixed)
 
         if all(isinstance(v, graph.ConstNode) for v in inputs.values()):
-            res = weave_internal.use(map_fn)
+            call_node = graph.OutputNode(map_fn.type, map_fn.from_op.name, inputs)
+            res = weave_internal.use(call_node)
+            result_store[map_fn] = res
             return graph.ConstNode(map_fn.type, res)
         return graph.OutputNode(map_fn.type, map_fn.from_op.name, inputs)
     elif isinstance(map_fn, graph.ConstNode):


### PR DESCRIPTION
This fixes issues where plots synchronized on zoom ranges would make additional unnecessary queries. And should generally improve app performance given the fixes to ref equality and resolve_static_values.

Perf:
- Fix ChildPanel and PanelGroup callback construction. We were always create non-ref-equal stack variables for all components, so the entire tree would generally rerender all the time.
- Adds client side mutations. If we're mutating a const node with a set of known ops (pick, getattr, index) we can perform the mutation on the client immediately.
- Fixes a python issue where resolve_static_values over-executed ops.

Debugging:
- adds an optional callSite parameter to useNodeValue, that can be used for debug logging