### PR TITLE
Revert "Revert "WIP: Stream Tables""

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-wandb>=0.15.4
+wandb==0.15.4 # Pinning as 0.15.5 will contain the huge artifact refactor.
 python-json-logger>=2.0.4
 numpy>=1.21
 pandas>=1.5.3  # current Colab version

--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -20,7 +20,7 @@ from . import file_util
 from . import weave_types as types
 from . import artifact_fs
 from . import filesystem
-from . import wandb_artifact_pusher
+from .wandb_interface import wandb_artifact_pusher
 
 from urllib import parse
 

--- a/weave/ops_domain/history.py
+++ b/weave/ops_domain/history.py
@@ -4,6 +4,7 @@ from . import wb_util
 from . import table
 from .. import weave_types as types
 from .. import artifact_fs
+from ..wandb_interface import wandb_stream_table
 
 
 class TypeCount(typing.TypedDict):
@@ -61,4 +62,8 @@ def history_key_type_count_to_weave_type(tc: TypeCount) -> types.Type:
         return ImageArtifactFileRefType()
     elif tc_type == "wb_trace_tree":
         return WBTraceTree.WeaveType()  # type: ignore
+    else:
+        possible_type = wandb_stream_table.maybe_history_type_to_weave_type(tc_type)
+        if possible_type is not None:
+            return possible_type
     return types.UnknownType()

--- a/weave/ops_domain/wb_util.py
+++ b/weave/ops_domain/wb_util.py
@@ -1,7 +1,9 @@
 import typing
 from urllib import parse
+
 from .. import weave_types as types
 from .. import decorator_type
+from ..wandb_interface import wandb_stream_table
 
 
 from . import table
@@ -43,9 +45,7 @@ def filesystem_artifact_file_from_artifact_path(artifact_path: str):
 
 
 def filesystem_runfiles_from_run_path(run_path: RunPath, file_path: str):
-    uri = WeaveWBRunFilesURI(
-        f"{run_path.entity_name}/{run_path.project_name}/{run_path.run_name}",
-        None,
+    uri = WeaveWBRunFilesURI.from_run_identifiers(
         run_path.entity_name,
         run_path.project_name,
         run_path.run_name,
@@ -123,6 +123,9 @@ def _process_run_dict_item(val, run_path: typing.Optional[RunPath] = None):
                 model_dict_dumps=val.get("model_dict_dumps"),
                 model_hash=val.get("model_hash"),
             )
+
+        if wandb_stream_table.is_weave_encoded_history_cell(val):
+            return wandb_stream_table.from_weave_encoded_history_cell(val)
 
     return val
 

--- a/weave/runfiles_wandb.py
+++ b/weave/runfiles_wandb.py
@@ -75,6 +75,9 @@ class WandbRunFiles(artifact_fs.FilesystemArtifact):
 
     @property
     def is_saved(self) -> bool:
+        # Note: I think this is OK to always be true, since run files are
+        # effectively always saved. But conceptually, the run could still be
+        # "open" which might warrant returning `False`.
         return True
 
     @property
@@ -196,7 +199,26 @@ class WeaveWBRunFilesURI(uris.WeaveURI):
         else:
             project_name, run_name = path.split("/", 1)
             path = ""
-        return cls(netloc, None, entity_name, project_name, run_name, path or None)
+        return cls(
+            f"{entity_name}/{project_name}/{run_name}",
+            None,
+            entity_name,
+            project_name,
+            run_name,
+            path or None,
+        )
+
+    @classmethod
+    def from_run_identifiers(
+        cls, entity_name: str, project_name: str, run_name: str
+    ) -> "WeaveWBRunFilesURI":
+        return cls(
+            f"{entity_name}/{project_name}/{run_name}",
+            None,
+            entity_name,
+            project_name,
+            run_name,
+        )
 
     def to_ref(self) -> WandbRunFilesRef:
         return WandbRunFilesRef.from_uri(self)

--- a/weave/show.py
+++ b/weave/show.py
@@ -124,7 +124,7 @@ def show_url(obj=None):
     return panel_url
 
 
-def show(obj=None, height=400):
+def show(obj: typing.Any = None, height: int = 400) -> typing.Any:
     if not util.is_notebook():
         usage_analytics.show_called({"error": True})
         raise RuntimeError(

--- a/weave/tests/test_artifact_metadata.py
+++ b/weave/tests/test_artifact_metadata.py
@@ -1,6 +1,6 @@
 import wandb
 import weave
-from weave.wandb_artifact_pusher import write_artifact_to_wandb
+from weave.wandb_interface.wandb_artifact_pusher import write_artifact_to_wandb
 from .. import artifact_local
 from .. import artifact_wandb
 

--- a/weave/tests/test_wb_stream_tables.py
+++ b/weave/tests/test_wb_stream_tables.py
@@ -1,0 +1,148 @@
+import time
+import pytest
+import weave
+from weave import weave_types
+from weave.wandb_interface.wandb_stream_table import StreamTable
+import numpy as np
+from PIL import Image
+
+
+# Example of end to end integration test
+def test_stream_logging(user_by_api_key_in_env):
+    st = StreamTable(
+        "test_table",
+        project_name="stream-tables",
+        entity_name=user_by_api_key_in_env.username,
+    )
+    for i in range(10):
+        st.log({"hello": f"world_{i}", "index": i, "nested": {"a": [i]}})
+    st.finish()
+
+    hist_node = (
+        weave.ops.project(user_by_api_key_in_env.username, "stream-tables")
+        .run("test_table")
+        .history2()
+    )
+
+    exp_type = weave_types.TypedDict({"a": weave_types.List(weave_types.Int())})
+    nested_type = hist_node.type.value.object_type.property_types["nested"].members[1]
+    assert exp_type.assign_type(nested_type)
+    assert weave.use(hist_node["hello"]).to_pylist_tagged() == [
+        f"world_{i}" for i in range(10)
+    ]
+    assert weave.use(hist_node["index"]).to_pylist_tagged() == [i for i in range(10)]
+    assert weave.use(hist_node["nested"]).to_pylist_tagged() == [
+        {"a": [i]} for i in range(10)
+    ]
+
+
+def test_stream_logging_image(user_by_api_key_in_env):
+    def image():
+        imarray = np.random.rand(100, 100, 3) * 255
+        return Image.fromarray(imarray.astype("uint8")).convert("RGBA")
+
+    st = StreamTable(
+        "test_table-8",
+        project_name="stream-tables",
+        entity_name=user_by_api_key_in_env.username,
+    )
+    for i in range(3):
+        st.log({"image": image()})
+    st.finish()
+
+    # There is a race case here. For some reason, there is a lag between file uploading
+    # and the W&B server being able to properly authenticate the file download request.
+    # In lieu of a proper polling/waiting mechanism, we just sleep for a bit. UGLY!
+    time.sleep(5)
+
+    hist_node = (
+        weave.ops.project(user_by_api_key_in_env.username, "stream-tables")
+        .run("test_table-8")
+        .history2()
+    )
+
+    images = weave.use(hist_node["image"]).to_pylist_tagged()
+    assert len(images) == 3
+    assert (np.array(images[0]) != np.array(images[1])).any()
+    assert isinstance(images[0], Image.Image)
+
+
+def test_multi_writers_sequential(user_by_api_key_in_env):
+    st = StreamTable(
+        "test_table",
+        project_name="stream-tables",
+        entity_name=user_by_api_key_in_env.username,
+    )
+    indexes = []
+    writers = []
+
+    def do_asserts():
+        time.sleep(3)
+
+        hist_node = (
+            weave.ops.project(user_by_api_key_in_env.username, "stream-tables")
+            .run("test_table")
+            .history2()
+        )
+        assert weave.use(hist_node["index"]).to_pylist_tagged() == indexes
+        assert weave.use(hist_node["writer"]).to_pylist_tagged() == writers
+        assert weave.use(hist_node["_step"]).to_pylist_tagged() == indexes
+
+    for i in range(10):
+        indexes.append(i)
+        writers.append("a")
+        st.log({"index": i, "writer": "a"})
+
+    # Notably before finish
+    do_asserts()
+
+    st.finish()
+
+    st = StreamTable(
+        "test_table",
+        project_name="stream-tables",
+        entity_name=user_by_api_key_in_env.username,
+    )
+    for i in range(10):
+        indexes.append(10 + i)
+        writers.append("b")
+        st.log({"index": 10 + i, "writer": "b"})
+    st.finish()
+
+    do_asserts()
+
+
+@pytest.mark.skip(reason="This is expected to fail until W&B updates step management")
+def test_multi_writers_parallel(user_by_api_key_in_env):
+    st_1 = StreamTable(
+        "test_table",
+        project_name="stream-tables",
+        entity_name=user_by_api_key_in_env.username,
+    )
+    st_2 = StreamTable(
+        "test_table",
+        project_name="stream-tables",
+        entity_name=user_by_api_key_in_env.username,
+    )
+
+    indexes = []
+    writers = []
+
+    for i in range(5):
+        st_1.log({"index": i * 2, "writer": "a"})
+        st_2.log({"index": i * 2 + 1, "writer": "b"})
+        indexes.append(i * 2)
+        indexes.append(i * 2 + 1)
+        writers.append("a")
+        writers.append("b")
+    st_1.finish()
+    st_2.finish()
+
+    hist_node = (
+        weave.ops.project(user_by_api_key_in_env.username, "stream-tables")
+        .run("test_table")
+        .history2()
+    )
+    assert weave.use(hist_node["index"]) == indexes
+    assert weave.use(hist_node["writer"]) == writers
+    assert weave.use(hist_node["_step"]) == [i for i in range(20)]

--- a/weave/wandb_interface/wandb_lite_run.py
+++ b/weave/wandb_interface/wandb_lite_run.py
@@ -1,0 +1,150 @@
+import datetime
+import json
+import typing
+from wandb.apis.public import Run
+from wandb.sdk.internal.file_pusher import FilePusher
+from wandb.sdk.internal import file_stream
+from wandb.sdk.internal.internal_api import Api as InternalApi
+from wandb.sdk.lib import runid
+from weave.wandb_client_api import wandb_public_api
+
+
+class InMemoryLazyLiteRun:
+    # ID
+    _entity_name: str
+    _project_name: str
+    _run_name: str
+    _step: int = 0
+
+    # Optional
+    _job_type: typing.Optional[str] = None
+
+    # Property Cache
+    _i_api: typing.Optional[InternalApi] = None
+    _run: typing.Optional[Run] = None
+    _stream: typing.Optional[file_stream.FileStreamApi] = None
+    _pusher: typing.Optional[FilePusher] = None
+
+    def __init__(
+        self,
+        entity_name: typing.Optional[str] = None,
+        project_name: typing.Optional[str] = None,
+        run_name: typing.Optional[str] = None,
+        job_type: typing.Optional[str] = None,
+    ):
+        entity_name = entity_name or wandb_public_api().default_entity
+        project_name = project_name or "uncategorized"
+
+        assert entity_name is not None
+        assert project_name is not None
+
+        self._entity_name = entity_name
+        self._project_name = project_name
+        self._run_name = run_name or runid.generate_id()
+        self._job_type = job_type
+
+    def ensure_run(self) -> Run:
+        return self.run
+
+    @property
+    def i_api(self) -> InternalApi:
+        if self._i_api is None:
+            self._i_api = InternalApi(
+                {"project": self._project_name, "entity": self._entity_name}
+            )
+        return self._i_api
+
+    @property
+    def run(self) -> Run:
+        if self._run is None:
+            # Ensure project exists
+            self.i_api.upsert_project(
+                project=self._project_name, entity=self._entity_name
+            )
+
+            # Produce a run
+            run_res, _, _ = self.i_api.upsert_run(
+                name=self._run_name,
+                job_type=self._job_type,
+                project=self._project_name,
+                entity=self._entity_name,
+            )
+
+            self._run = Run(
+                wandb_public_api().client,
+                run_res["project"]["entity"]["name"],
+                run_res["project"]["name"],
+                run_res["name"],
+                {
+                    "id": run_res["id"],
+                    "config": "{}",
+                    "systemMetrics": "{}",
+                    "summaryMetrics": "{}",
+                    "tags": [],
+                    "description": None,
+                    "notes": None,
+                    "state": "running",
+                },
+            )
+
+            self.i_api.set_current_run_id(self._run.id)
+            # TODO: After gorilla is updated to support parallel runs
+            # we can drop this completely
+            self._step = self._run.lastHistoryStep + 1
+
+        return self._run
+
+    @property
+    def stream(self) -> file_stream.FileStreamApi:
+        if self._stream is None:
+            # Setup the FileStream
+            self._stream = file_stream.FileStreamApi(
+                self.i_api, self.run.id, datetime.datetime.utcnow().timestamp()
+            )
+            self._stream.set_file_policy(
+                "wandb-history.jsonl",
+                file_stream.JsonlFilePolicy(start_chunk_id=self._step),
+            )
+            self._stream.start()
+
+        return self._stream
+
+    @property
+    def pusher(self) -> FilePusher:
+        if self._pusher is None:
+            self._pusher = FilePusher(self.i_api, self.stream)
+
+        return self._pusher
+
+    def log(self, row_dict: dict) -> None:
+        stream = self.stream
+        row_dict = {
+            **row_dict,
+            # Required by gorilla
+            # NOTE: This should be changed after gorilla is updated
+            # to support parallel runs
+            "_step": self._step,
+            "_timestamp": datetime.datetime.utcnow().timestamp(),
+        }
+        self._step += 1
+        stream.push("wandb-history.jsonl", json.dumps(row_dict))
+
+    def finish(self) -> None:
+        if self._stream is not None:
+            # Finalize the run
+            self.stream.finish(0)
+
+        if self._pusher is not None:
+            # Wait for the FilePusher and FileStream to finish
+            self.pusher.finish()
+            self.pusher.join()
+
+        # Reset fields
+        self._stream = None
+        self._pusher = None
+        self._run = None
+        self._i_api = None
+        self._step = 0
+
+    def __del__(self) -> None:
+        self.finish()

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -1,0 +1,249 @@
+import contextlib
+import json
+import logging
+import os
+import random
+import shutil
+import typing
+import uuid
+
+from wandb.sdk.lib.paths import LogicalPath
+
+from .wandb_lite_run import InMemoryLazyLiteRun
+
+from .. import runfiles_wandb
+from .. import storage
+from .. import weave_types
+from .. import artifact_base
+from .. import file_util
+
+if typing.TYPE_CHECKING:
+    from wandb.sdk.internal.file_pusher import FilePusher
+
+# Shawn recommended we only encode leafs, but in my testing, nested structures
+# are not handled as well in in gorilla and we can do better using just weave.
+# Uncomment the below to use gorilla for nested structures.
+TRUST_GORILLA_FOR_NESTED_STRUCTURES = False
+
+# Weave types are parametrized, but gorilla expects just simple strings. We could
+# send the top-level string over the wire, but this fails to encode type specifics
+# and therefore loses information. With this flag, we instead stringify the JSON type
+# and send that over the wire. This is a bit of a hack, but it works.
+ENCODE_ENTIRE_TYPE = True
+TYPE_ENCODE_PREFIX = "_wt_::"
+
+
+class WandbLiveRunFiles(runfiles_wandb.WandbRunFiles):
+    _file_pusher: typing.Optional["FilePusher"] = None
+    _temp_dir: typing.Optional[str] = None
+
+    def set_file_pusher(self, pusher: "FilePusher") -> None:
+        # It is the responsibility of the caller to ensure this file pusher is
+        # correctly associated with the corresponding run.
+        self._file_pusher = pusher
+
+    def temp_dir(self) -> str:
+        if self._temp_dir is None:
+            rand_part = "".join(random.choice("0123456789ABCDEF") for _ in range(16))
+            self._temp_dir = os.path.join(
+                runfiles_wandb.wandb_run_dir(), "upload_cache", f"tmp_{rand_part}"
+            )
+            os.makedirs(self._temp_dir, exist_ok=True)
+        return self._temp_dir
+
+    def cleanup(self) -> None:
+        if self._temp_dir is not None:
+            shutil.rmtree(self._temp_dir)
+            self._temp_dir = None
+
+    def __del__(self) -> None:
+        self.cleanup()
+
+    @contextlib.contextmanager
+    def new_file(
+        self, path: str, binary: bool = False
+    ) -> typing.Generator[typing.IO, None, None]:
+        if self._file_pusher is None:
+            raise ValueError(
+                "WandbLiveRunFiles must be associated with a file pusher to use new_file"
+            )
+
+        dir_path = self.temp_dir()
+        file_path = os.path.join(dir_path, path)
+        with file_util.safe_open(file_path, "wb" if binary else "w") as file:
+            yield file
+            self._file_pusher.file_changed(LogicalPath(path), file_path)
+
+
+class StreamTable:
+    _lite_run: InMemoryLazyLiteRun
+    _table_name: str
+    _project_name: str
+    _entity_name: str
+
+    _artifact: typing.Optional[WandbLiveRunFiles] = None
+
+    def __init__(
+        self,
+        table_name: str,
+        project_name: typing.Optional[str] = None,
+        entity_name: typing.Optional[str] = None,
+    ):
+        splits = table_name.split("/")
+        if len(splits) == 1:
+            pass
+        elif len(splits) == 2:
+            if project_name is not None:
+                raise ValueError(
+                    f"Cannot specify project_name and table_name with '/' in it: {table_name}"
+                )
+            project_name = splits[0]
+            table_name = splits[1]
+        elif len(splits) == 3:
+            if project_name is not None or entity_name is not None:
+                raise ValueError(
+                    f"Cannot specify project_name or entity_name and table_name with 2 '/'s in it: {table_name}"
+                )
+            entity_name = splits[0]
+            project_name = splits[1]
+            table_name = splits[2]
+
+        # For now, we force the user to specify the entity and project
+        # technically, we could infer the entity from the API key, but
+        # that tends to confuse users.
+        if entity_name is None or entity_name == "":
+            raise ValueError(f"Must specify entity_name")
+        elif project_name is None or project_name == "":
+            raise ValueError(f"Must specify project_name")
+        elif table_name is None or table_name == "":
+            raise ValueError(f"Must specify table_name")
+
+        job_type = "wb_stream_table"
+        self._lite_run = InMemoryLazyLiteRun(
+            entity_name, project_name, table_name, job_type
+        )
+        self._table_name = table_name
+        self._project_name = project_name
+        self._entity_name = entity_name
+
+    def log(self, row_or_rows: typing.Union[dict, list[dict]]) -> None:
+        if isinstance(row_or_rows, dict):
+            row_or_rows = [row_or_rows]
+
+        for row in row_or_rows:
+            self._log_row(row)
+
+    def _log_row(self, row: dict) -> None:
+        self._lite_run.ensure_run()
+        if self._artifact is None:
+            uri = runfiles_wandb.WeaveWBRunFilesURI.from_run_identifiers(
+                self._entity_name,
+                self._project_name,
+                self._table_name,
+            )
+            self._artifact = WandbLiveRunFiles(name=uri.name, uri=uri)
+            self._artifact.set_file_pusher(self._lite_run.pusher)
+        payload = row_to_weave(row, self._artifact)
+        self._lite_run.log(payload)
+
+    def finish(self) -> None:
+        if self._artifact is not None:
+            self._artifact.cleanup()
+            self._artifact = None
+        self._lite_run.finish()
+
+    def __del__(self) -> None:
+        self.finish()
+
+
+def maybe_history_type_to_weave_type(tc_type: str) -> typing.Optional[weave_types.Type]:
+    if tc_type.startswith(TYPE_ENCODE_PREFIX):
+        w_type = json.loads(tc_type[len(TYPE_ENCODE_PREFIX) :])
+        return weave_types.TypeRegistry.type_from_dict(w_type)
+    else:
+        possible_type = weave_types.type_name_to_type(tc_type)
+        if possible_type is not None:
+            try:
+                return possible_type()
+            except Exception as e:
+                logging.warning(
+                    f"StreamTable Type Error: Found type for {tc_type}, but blind construction failed: {e}",
+                )
+    return None
+
+
+def is_weave_encoded_history_cell(cell: dict) -> bool:
+    return "_weave_type" in cell and "_val" in cell
+
+
+def from_weave_encoded_history_cell(cell: dict) -> typing.Any:
+    if not is_weave_encoded_history_cell(cell):
+        raise ValueError(f"Expected weave encoded history cell, got {cell}")
+    weave_json = {
+        "_type": cell["_weave_type"],
+        "_val": cell["_val"],
+    }
+    return storage.from_python(weave_json)
+
+
+def row_to_weave(
+    row: typing.Dict[str, typing.Any], artifact: WandbLiveRunFiles
+) -> typing.Dict[str, typing.Any]:
+    return {key: obj_to_weave(value, artifact) for key, value in row.items()}
+
+
+def obj_to_weave(obj: typing.Any, artifact: WandbLiveRunFiles) -> typing.Any:
+    def recurse(obj: typing.Any) -> typing.Any:
+        return obj_to_weave(obj, artifact)
+
+    # all primitives
+    if isinstance(obj, (int, float, str, bool, type(None))):
+        return obj
+    else:
+        if TRUST_GORILLA_FOR_NESTED_STRUCTURES:
+            if isinstance(obj, dict):
+                return {key: recurse(value) for key, value in obj.items()}
+            elif isinstance(obj, list):
+                return [recurse(value) for value in obj]
+            elif isinstance(obj, tuple):
+                return [recurse(value) for value in obj]
+            elif isinstance(obj, set):
+                return [recurse(value) for value in obj]
+            elif isinstance(obj, frozenset):
+                return [recurse(value) for value in obj]
+            else:
+                return leaf_to_weave(obj, artifact)
+        else:
+            return leaf_to_weave(obj, artifact)
+
+
+def w_type_to_type_name(w_type: typing.Union[str, dict]) -> str:
+    if isinstance(w_type, str):
+        return w_type
+    if ENCODE_ENTIRE_TYPE:
+        return TYPE_ENCODE_PREFIX + json.dumps(w_type)
+    else:
+        return w_type["type"]
+
+
+def leaf_to_weave(leaf: typing.Any, artifact: WandbLiveRunFiles) -> typing.Any:
+    def ref_persister_artifact(
+        type: weave_types.Type, refs: typing.Iterable[artifact_base.ArtifactRef]
+    ) -> artifact_base.Artifact:
+        # Save all the reffed objects into the new artifact.
+        for mem_ref in refs:
+            if mem_ref.path is not None and mem_ref._type is not None:
+                # Hack: add a random salt to the end (i really want content addressing here)
+                # but this is a quick fix to avoid collisions
+                path = mem_ref.path + "-" + str(uuid.uuid4())
+                artifact.set(path, mem_ref._type, mem_ref._obj)
+        return artifact
+
+    res = storage.to_python(leaf, None, ref_persister_artifact)
+
+    w_type = res["_type"]
+    type_name = w_type_to_type_name(w_type)
+
+    # Optimization: If we have ENCODE_ENTIRE_TYPE=True, then we can
+    # avoid re-saving the type info in _weave_type
+    return {"_type": type_name, "_weave_type": res["_type"], "_val": res["_val"]}

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -185,7 +185,7 @@ def from_weave_encoded_history_cell(cell: dict) -> typing.Any:
     if "_weave_type" in cell:
         weave_type = cell["_weave_type"]
     elif cell["_type"].startswith(TYPE_ENCODE_PREFIX):
-        weave_type = cell["_type"][len(TYPE_ENCODE_PREFIX) :]
+        weave_type = json.loads(cell["_type"][len(TYPE_ENCODE_PREFIX) :])
     else:
         raise ValueError(f"Expected weave encoded history cell, got {cell}")
     weave_json = {

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -16,6 +16,8 @@ from .. import storage
 from .. import weave_types
 from .. import artifact_base
 from .. import file_util
+from .. import graph
+from .. import ops_domain
 
 if typing.TYPE_CHECKING:
     from wandb.sdk.internal.file_pusher import FilePusher
@@ -132,6 +134,16 @@ class StreamTable:
 
         for row in row_or_rows:
             self._log_row(row)
+
+    def _ipython_display_(self) -> graph.Node:
+        from .. import show
+
+        node = (
+            ops_domain.project(self._entity_name, self._project_name)
+            .run(self._table_name)
+            .history2()
+        )
+        return show(node)
 
     def _log_row(self, row: dict) -> None:
         self._lite_run.ensure_run()


### PR DESCRIPTION
Double Revert!

https://github.com/wandb/weave/pull/59 got merged too early... this is the re-do of that

----

This PR introduced a new top-level class: StreamTable which has a very simple API:

```python
st = StreamTable("entity/project/table_name")
st.log(row_or_list_of_rows)
```

Currently we only support sequential multi-writers (meaning you can stop and start over and over and keep logging to the same table). Soon we will have gorilla support for parallel writers (which should be only a few lines to uptake).

This data can be accessed by viewing the history of the run. Soon (my remaining TODO), we will also have top-level ops: opProjectStreams and opProjectStream which will give direct access to the underlying table. This will ensure we can swap out a first-class table API without users needing to know

Finally, the `row_or_list_of_rows` is completely encoded using Weave! So anything Weave supports we do too! All file types work out of the box by saving to run files.

Logging is all done async and does not block the user process (until `st.finish()` is called - which allows for lingering files to be uploaded)

Open Issues:
* [ ] Create Root ops to navigate streams

Consider:
* Do we want to create a `DataTable` Weave interface that we can have `streamtable`, `table` inherit from?
   * Basically: how to handle the duality of run-backed vs non-run-backed
* What about Tables? Do we want to provide quick access to run-logged tables? Maybe conceptually those are "versioned tables"? You can pick a version, first, last, concat, or join?