### PR TITLE
chore: immer 10 compatibility

### DIFF
--- a/weave-js/src/components/PagePanel.tsx
+++ b/weave-js/src/components/PagePanel.tsx
@@ -1,7 +1,7 @@
 import Loader from '@wandb/weave/common/components/WandbLoader';
 import * as globals from '@wandb/weave/common/css/globals.styles';
 import {NodeOrVoidNode, voidNode} from '@wandb/weave/core';
-import produce from 'immer';
+import {produce} from 'immer';
 import React, {FC, useCallback, useEffect, useRef, useState} from 'react';
 import {Icon} from 'semantic-ui-react';
 import styled, {ThemeProvider} from 'styled-components';

--- a/weave-js/src/components/Panel2/PanelCard.tsx
+++ b/weave-js/src/components/Panel2/PanelCard.tsx
@@ -1,6 +1,6 @@
 import * as globals from '@wandb/weave/common/css/globals.styles';
 import {NodeOrVoidNode, voidNode} from '@wandb/weave/core';
-import produce from 'immer';
+import {produce} from 'immer';
 import React, {useState} from 'react';
 import styled, {css} from 'styled-components';
 

--- a/weave-js/src/components/Panel2/PanelEachColumn.tsx
+++ b/weave-js/src/components/Panel2/PanelEachColumn.tsx
@@ -10,7 +10,7 @@ import {
   varNode,
   voidNode,
 } from '@wandb/weave/core';
-import produce from 'immer';
+import {produce} from 'immer';
 import React, {useCallback, useMemo, useState} from 'react';
 import styled from 'styled-components';
 

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -14,7 +14,7 @@ import {
   Stack,
   voidNode,
 } from '@wandb/weave/core';
-import produce, {Draft} from 'immer';
+import {Draft, produce} from 'immer';
 import * as _ from 'lodash';
 import React, {useCallback, useMemo} from 'react';
 import {Button} from 'semantic-ui-react';

--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -1,6 +1,6 @@
 import {useTraceUpdate} from '@wandb/weave/common/util/hooks';
 import {constNodeUnsafe, Node, NodeOrVoidNode} from '@wandb/weave/core';
-import produce from 'immer';
+import {produce} from 'immer';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import _ from 'lodash';

--- a/weave-js/src/components/Panel2/PanelProjectionConverter/component.tsx
+++ b/weave-js/src/components/Panel2/PanelProjectionConverter/component.tsx
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import {produce} from 'immer';
 import React, {useCallback, useMemo} from 'react';
 
 import {useNodeWithServerType} from '../../../react';

--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -52,7 +52,7 @@ import {
   voidNode,
   WeaveInterface,
 } from '@wandb/weave/core';
-import produce from 'immer';
+import {produce} from 'immer';
 import _ from 'lodash';
 
 export type ColumnId = string;

--- a/weave-js/src/components/Panel2/libchildpanel.ts
+++ b/weave-js/src/components/Panel2/libchildpanel.ts
@@ -1,4 +1,4 @@
-import produce from 'immer';
+import {produce} from 'immer';
 import {useCallback} from 'react';
 
 export const useChildUpdateConfig2 = (

--- a/weave-js/src/components/Panel2/panelTree.ts
+++ b/weave-js/src/components/Panel2/panelTree.ts
@@ -18,7 +18,7 @@ import {
   Stack,
   voidNode,
 } from '@wandb/weave/core';
-import produce from 'immer';
+import {produce} from 'immer';
 import * as _ from 'lodash';
 
 import {

--- a/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
@@ -1,5 +1,5 @@
 import {callOpVeryUnsafe, NodeOrVoidNode, varNode} from '@wandb/weave/core';
-import produce from 'immer';
+import {produce} from 'immer';
 import React, {memo, useCallback, useMemo} from 'react';
 
 import {getFullChildPanel} from '../Panel2/ChildPanel';

--- a/weave-js/src/components/Sidebar/VarBar.tsx
+++ b/weave-js/src/components/Sidebar/VarBar.tsx
@@ -1,5 +1,5 @@
 import {NodeOrVoidNode} from '@wandb/weave/core';
-import produce from 'immer';
+import {produce} from 'immer';
 import _ from 'lodash';
 import {FC, memo, ReactNode, useCallback, useMemo} from 'react';
 import {StrictMenuItemProps} from 'semantic-ui-react';

--- a/weave-js/src/components/WeavePanelBank/PBSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PBSection.tsx
@@ -6,7 +6,7 @@ import {
   DragDropProvider,
   DragHandle,
 } from '@wandb/weave/common/containers/DragDropContainer';
-import produce from 'immer';
+import {produce} from 'immer';
 import * as _ from 'lodash';
 import React, {useRef, useState} from 'react';
 import Measure from 'react-measure';

--- a/weave-js/src/components/WeavePanelBank/PanelBankFlowSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PanelBankFlowSection.tsx
@@ -1,7 +1,7 @@
 import {LegacyWBIcon} from '@wandb/weave/common/components/elements/LegacyWBIcon';
 import {DropTarget} from '@wandb/weave/common/containers/DragDropContainer';
 import classNames from 'classnames';
-import produce from 'immer';
+import {produce} from 'immer';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Resizable, ResizeCallbackData} from 'react-resizable';

--- a/weave-js/src/components/WeavePanelBank/PanelBankGridSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PanelBankGridSection.tsx
@@ -8,7 +8,7 @@ import {
   DropTarget,
 } from '@wandb/weave/common/containers/DragDropContainer';
 import classNames from 'classnames';
-import produce from 'immer';
+import {produce} from 'immer';
 import * as _ from 'lodash';
 import React, {
   useCallback,


### PR DESCRIPTION
I'm working on an [upgrade to Vite 4 in core](https://github.com/wandb/core/pull/15611), which itself will require building core with Immer v10, which removed the default export for `produce` and now requires a named import instead. This change will make weave's code work with both versions, then we can upgrade in weave itself later.