### PR TITLE
fix: narrow domain types  in panelplot

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/versions/index.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/versions/index.ts
@@ -10,6 +10,7 @@ import * as v9 from './v9';
 import * as v10 from './v10';
 import * as v11 from './v11';
 import * as v12 from './v12';
+import * as v13 from './v13';
 
 export type {Scale, ScaleType} from './v10';
 export type {Signals} from './v12';
@@ -25,7 +26,7 @@ export const DEFAULT_SCALE_TYPE = v10.DEFAULT_SCALE_TYPE;
 export const LAZY_PATHS = v12.LAZY_PATHS;
 export const DEFAULT_LAZY_PATH_VALUES = v12.DEFAULT_LAZY_PATH_VALUES;
 
-const migrateCommon = migrator
+export const {migrate} = migrator
   .makeMigrator(v2.migrate)
   .add(v3.migrate)
   .add(v4.migrate)
@@ -35,9 +36,9 @@ const migrateCommon = migrator
   .add(v8.migrate)
   .add(v9.migrate)
   .add(v10.migrate)
-  .add(v11.migrate);
-
-export const {migrate} = migrateCommon.add(v12.migrate);
+  .add(v11.migrate)
+  .add(v12.migrate)
+  .add(v13.migrate);
 
 export type AnyPlotConfig = Parameters<typeof migrate>[number];
 export type PlotConfig = ReturnType<typeof migrate>;
@@ -52,5 +53,5 @@ export type ContinuousSelection = v11.ContinuousSelection;
 export type DiscreteSelection = v11.DiscreteSelection;
 export type AxisSelections = v11.AxisSelections;
 
-export type ConcretePlotConfig = v12.ConcretePlotConfig;
+export type ConcretePlotConfig = v13.ConcretePlotConfig;
 export type ConcreteSeriesConfig = ConcretePlotConfig['series'][number];

--- a/weave-js/src/components/Panel2/PanelPlot/versions/v12.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/versions/v12.ts
@@ -42,10 +42,16 @@ export const migrate = (config: v11.PlotConfig): PlotConfig => {
       ...config.signals,
       domain: {
         x: weave.constNode(
+          // this is problematic because weave python doesnt know
+          // how to deserialize 'any' if its a number. this is why
+          // we will update this in version 13
           {type: 'union', members: [{type: 'list', objectType: 'any'}, 'none']},
           config.signals.domain.x ?? null
         ),
         y: weave.constNode(
+          // this is problematic because weave python doesnt know
+          // how to deserialize 'any' if its a number. this is why
+          // we will update this in version 13
           {type: 'union', members: [{type: 'list', objectType: 'any'}, 'none']},
           config.signals.domain.y ?? null
         ),

--- a/weave-js/src/components/Panel2/PanelPlot/versions/v13.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/versions/v13.ts
@@ -28,17 +28,6 @@ export type ConcretePlotConfig = Omit<
 export const migrate = (config: v12.PlotConfig): PlotConfig => {
   // if we have const nodes for x or y, we need to narrow the type by looking at the values
 
-  const newTypeFromValue = (value: any): weave.Type => {
-    const weaveType: weave.Type = toWeaveType(value);
-    if (weave.isAssignableTo(weaveType, weave.list('number'))) {
-      return weave.list('number');
-    } else if (weave.isAssignableTo(weaveType, weave.list('string'))) {
-      return weave.list('string');
-    } else {
-      return 'none';
-    }
-  };
-
   return {
     ...config,
     configVersion: 13,
@@ -47,13 +36,13 @@ export const migrate = (config: v12.PlotConfig): PlotConfig => {
       domain: {
         x: weave.isConstNode(config.signals.domain.x)
           ? weave.constNode(
-              newTypeFromValue(config.signals.domain.x.val),
+              toWeaveType(config.signals.domain.x.val),
               config.signals.domain.x.val
             )
           : config.signals.domain.x,
         y: weave.isConstNode(config.signals.domain.y)
           ? weave.constNode(
-              newTypeFromValue(config.signals.domain.y.val),
+              toWeaveType(config.signals.domain.y.val),
               config.signals.domain.y.val
             )
           : config.signals.domain.y,


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14186

Fixes https://weights-biases.sentry.io/issues/4022125791/?project=6620563&referrer=jira_integration

Fixes an issue that caused a full page panelplot crash with weave1 enabled. The issue was due to the fact that v12 of the panelplot config typed `LazyAxisSelection`s as `maybe(list(any))`. Weave python does not know how to deserialize const nodes of this type, so any stored panelplot configs with nonnull domains would cause a weave1 crash. 

This fixes this by adding a new config version migrated to have narrower types. 