### PR TITLE
fix: table headers appear at bottom when no rows

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -84,7 +84,7 @@ import weave
 weave.use_frontend_devmode()
 ```
 
-This tells the weave API to load the frontend from the development server on port :3000. The dev frontend will talk to your running backdend server on port :9994.
+This tells the weave API to load the frontend from the development server on port :3000. The dev frontend will talk to your running backend server on port :9994.
 
 You can tell everything is working if the weave UI renders and you see your server print out some logs whenever you interact with weave.
 

--- a/weave-js/src/components/Panel2/PanelComp.styles.ts
+++ b/weave-js/src/components/Panel2/PanelComp.styles.ts
@@ -78,7 +78,7 @@ export const DevQueryPopupLabel = styled.span`
 `;
 
 const gradient = keyframes`
-  { 
+  {
     0%   { background-position: 0 0; }
     100% { background-position: -200% 0; }
   }
@@ -125,6 +125,7 @@ export const GrowToParent = styled.div`
   width: 100%;
   height: 100%;
 `;
+GrowToParent.displayName = 'GrowToParent';
 
 export const FullScreenModal = styled(Modal.Content)`
   height: calc(90vh - 73px);

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1022,11 +1022,11 @@ const PanelTableInner: React.FC<
           />
         </PanelContextProvider>
       )}
-      {unpinnedData.length === 0 ? (
+      {unpinnedData.length === 0 && (
         <div
           style={{
             textAlign: 'center',
-            position: 'relative',
+            position: 'absolute',
             width: '100%',
             height: `${
               height -
@@ -1061,7 +1061,8 @@ const PanelTableInner: React.FC<
             </div>
           )}
         </div>
-      ) : props.config.simpleTable ? (
+      )}
+      {props.config.simpleTable ? (
         ConfiguredTable
       ) : (
         <WeaveActionContextProvider newActions={actions}>

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1022,7 +1022,7 @@ const PanelTableInner: React.FC<
           />
         </PanelContextProvider>
       )}
-      {unpinnedData.length === 0 && (
+      {unpinnedData.length === 0 ? (
         <div
           style={{
             textAlign: 'center',
@@ -1061,8 +1061,7 @@ const PanelTableInner: React.FC<
             </div>
           )}
         </div>
-      )}
-      {props.config.simpleTable ? (
+      ) : props.config.simpleTable ? (
         ConfiguredTable
       ) : (
         <WeaveActionContextProvider newActions={actions}>


### PR DESCRIPTION
Problem: When there are no rows to display in a table the table header is appearing beneath the "no rows" message.

Longer term we may consider additional improvements to the zero rows condition, but for now just trying to restore previous behavior.

Note: the solution here is reverting a previous change that was intended to fix a problem with the "remove filter" button not being clickable. I haven't been able to reproduce that problem, if it reoccurs will try to fix it another way.

Internal Jira: https://wandb.atlassian.net/browse/WB-14244
Internal Slack: 
https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1687892535814509?thread_ts=1687892494.958909&cid=C03BSTEBD7F
https://weightsandbiases.slack.com/archives/C05DURZNT41/p1687890163378049

Before:
<img width="1123" alt="Screenshot 2023-06-27 at 1 16 15 PM" src="https://github.com/wandb/weave/assets/112953339/06f853ad-f53e-45cb-bc14-de01a2686ecf">

After:
<img width="1014" alt="Screenshot 2023-06-28 at 12 48 12 PM" src="https://github.com/wandb/weave/assets/112953339/645940be-08ca-4886-85a9-c42f97486001">
