### PR TITLE
fix: fix Float object not subscriptable

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -55,7 +55,6 @@ import {
   varNode,
   voidNode,
   withoutTags,
-  unwrapTaggedValues,
   taggedValueValueType,
   isTaggedValue,
 } from '@wandb/weave/core';
@@ -132,7 +131,6 @@ import {
 } from '../Icons';
 import styled from 'styled-components';
 import {PopupMenu, Section} from '../../Sidebar/PopupMenu';
-import {types} from '@babel/core';
 
 const recordEvent = makeEventRecorder('Plot');
 

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -55,6 +55,9 @@ import {
   varNode,
   voidNode,
   withoutTags,
+  unwrapTaggedValues,
+  taggedValueValueType,
+  isTaggedValue,
 } from '@wandb/weave/core';
 import {produce} from 'immer';
 import _ from 'lodash';
@@ -129,6 +132,7 @@ import {
 } from '../Icons';
 import styled from 'styled-components';
 import {PopupMenu, Section} from '../../Sidebar/PopupMenu';
+import {types} from '@babel/core';
 
 const recordEvent = makeEventRecorder('Plot');
 
@@ -2078,8 +2082,11 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
             if (!isTypedDict(rowType)) {
               throw new Error('expected typed dict');
             }
-            const mappedPropTypes = _.mapKeys(rowType.propertyTypes, (v, k) =>
-              PlotState.fixKeyForVega(k)
+            const mappedPropTypes = _.mapValues(
+              _.mapKeys(rowType.propertyTypes, (v, k) =>
+                PlotState.fixKeyForVega(k)
+              ),
+              (v, k) => (v && isTaggedValue(v) ? taggedValueValueType(v) : v)
             );
             const series = concreteConfig.series[row._seriesIndex];
             const seriesName = PlotState.defaultSeriesName(series, weave);
@@ -2137,6 +2144,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
           },
           {nodeValue, nodeType}
         );
+
         return constNodeUnsafe(typedDict(type), value);
       }
     );


### PR DESCRIPTION
Fixes https://weights-biases.sentry.io/issues/4167873076/?project=6620563&referrer=jira_integration

https://wandb.atlassian.net/browse/WB-14188

Ensures that we use the correct value types for our line tooltip nodes. These were sometimes typed as tagged values before, but they were never tagged values since we never called tag getter ops on them in the panelplot weave query. This ensures we always strip the tags from the types. 