### PR TITLE
fix: fix full page crash in trace tree viewer

### DIFF
--- a/weave-js/src/components/Panel2/useAssetFromArtifact.ts
+++ b/weave-js/src/components/Panel2/useAssetFromArtifact.ts
@@ -9,6 +9,7 @@ import {
   opFileContents,
   opFileDirectUrlAsOf,
   OutputNode,
+  WBTraceTreeType,
   TableType,
   Type,
   VoidNode,
@@ -19,7 +20,7 @@ import {useEffect, useMemo, useRef, useState} from 'react';
 import * as CGReact from '../../react';
 
 export const useAssetURLFromArtifact = <
-  InputNodeInternalType extends Exclude<MediaType, TableType>
+  InputNodeInternalType extends Exclude<MediaType, TableType | WBTraceTreeType>
 >(
   inputNode: Node<InputNodeInternalType>,
   ignoreExpiration?: boolean
@@ -49,7 +50,7 @@ export const useAssetURLFromArtifact = <
 };
 
 export const useAssetContentFromArtifact = <
-  InputNodeInternalType extends Exclude<MediaType, TableType>
+  InputNodeInternalType extends Exclude<MediaType, TableType | WBTraceTreeType>
 >(
   inputNode: Node<InputNodeInternalType>
 ) => {

--- a/weave-js/src/core/model/types.ts
+++ b/weave-js/src/core/model/types.ts
@@ -146,6 +146,7 @@ export const BASIC_MEDIA_TYPES: MediaType[] = [
   {type: 'table', columnTypes: {}},
   {type: 'joined-table', columnTypes: {}},
   {type: 'partitioned-table', columnTypes: {}},
+  {type: 'wb_trace_tree'},
 ];
 // TODO: make this systematic -- we should use some kind of registry
 // to ensure that every type is included
@@ -304,7 +305,8 @@ export type MediaType =
   | PytorchSavedModelType
   | TableType
   | JoinedTableType
-  | PartitionedTableType;
+  | PartitionedTableType
+  | WBTraceTreeType;
 
 export type MediaTypesWithoutPath = WBTraceTreeType;
 

--- a/weave/wandb_util.py
+++ b/weave/wandb_util.py
@@ -174,7 +174,7 @@ def _convert_type(old_type: Weave0TypeJson) -> types.Type:
         return ops.MoleculeArtifactFileRef.WeaveType()  # type: ignore
 
     elif old_type_name == "wb_trace_tree":
-        return ops_domain.trace_tree.WBTraceTree.WeaveType()
+        return ops_domain.trace_tree.WBTraceTree.WeaveType()  # type: ignore
 
     #
     # Table Types

--- a/weave/wandb_util.py
+++ b/weave/wandb_util.py
@@ -4,6 +4,7 @@ import typing
 from . import weave_types as types
 from . import errors
 from . import ops
+from . import ops_domain
 
 
 class Weave0TypeJson(typing.TypedDict):
@@ -171,6 +172,10 @@ def _convert_type(old_type: Weave0TypeJson) -> types.Type:
         return types.Number()  # type: ignore
     elif is_python_object_type and old_type["params"].get("class_name") == "Molecule":
         return ops.MoleculeArtifactFileRef.WeaveType()  # type: ignore
+
+    elif old_type_name == "wb_trace_tree":
+        return ops_domain.trace_tree.WBTraceTree.WeaveType()
+
     #
     # Table Types
     #


### PR DESCRIPTION
Fixes https://app.datadoghq.com/rum/replay/sessions/c5ed94d1-0d66-45bf-9966-9c711c32718e?highlightedEventId=AgAAAYj-aJxW2SBhiwAAAAAAAAAYAAAAAEFZai1hS05XQUFDN3dHX0xXZUtrU2dBQgAAACQAAAAAMDE4OGZlNmItYzBjOS00MGU3LTk1YjgtMmVkNmE2YWVmMWZj&p_devtools_tab=performance&seed=62c6b482-a313-45da-bf69-102c758f69bb&ts=1687895448662&from=1687895448274

We were not handling the wb_trace_tree type in `_convert_type`. This fixes that and also makes `wb_trace_tree` a media type so its properties are not transformed into columns in tables. 