### PR TITLE
feat: support Images/separated in history

### DIFF
--- a/weave/ops_domain/history.py
+++ b/weave/ops_domain/history.py
@@ -62,6 +62,8 @@ def history_key_type_count_to_weave_type(tc: TypeCount) -> types.Type:
         return ImageArtifactFileRefType()
     elif tc_type == "wb_trace_tree":
         return WBTraceTree.WeaveType()  # type: ignore
+    elif tc_type == "images/separated":
+        return types.List(ImageArtifactFileRefType())
     else:
         possible_type = wandb_stream_table.maybe_history_type_to_weave_type(tc_type)
         if possible_type is not None:

--- a/weave/ops_domain/wb_util.py
+++ b/weave/ops_domain/wb_util.py
@@ -115,6 +115,25 @@ def _process_run_dict_item(val, run_path: typing.Optional[RunPath] = None):
                 height=val["height"],
                 sha256=val["sha256"],
             )
+        if val["_type"] == "images/separated" and run_path is not None:
+            from . import ImageArtifactFileRef
+
+            image_list: list[ImageArtifactFileRef] = []
+
+            for path in val["filenames"]:
+                fs_artifact_file = filesystem_runfiles_from_run_path(run_path, path)
+                image_list.append(
+                    ImageArtifactFileRef(
+                        fs_artifact_file.artifact,
+                        fs_artifact_file.path,
+                        format=val["format"],
+                        width=val["width"],
+                        height=val["height"],
+                        sha256=val.get("sha256", path),
+                    )
+                )
+
+            return image_list
         if val["_type"] == "wb_trace_tree":
             from .trace_tree import WBTraceTree
 


### PR DESCRIPTION
Supports images/separated in history, fixing this full page crash 

https://app.datadoghq.com/rum/replay/sessions/04539f46-014f-4b65-8e51-6c90d89c9228?seed=2e0629b8-f92a-496b-9876-af1a4385577d&ts=1687907305412&from=1687907305305