### PR TITLE
fix: 'NoneType' object has no attribute 'startswith'

### DIFF
--- a/weave/ops_domain/history.py
+++ b/weave/ops_domain/history.py
@@ -8,7 +8,7 @@ from ..wandb_interface import wandb_stream_table
 
 
 class TypeCount(typing.TypedDict):
-    type: str
+    type: typing.Optional[str]
     count: int
     keys: dict[str, list["TypeCount"]]  # type: ignore
     items: list["TypeCount"]  # type: ignore
@@ -64,7 +64,7 @@ def history_key_type_count_to_weave_type(tc: TypeCount) -> types.Type:
         return WBTraceTree.WeaveType()  # type: ignore
     elif tc_type == "images/separated":
         return types.List(ImageArtifactFileRefType())
-    else:
+    elif isinstance(tc_type, str):
         possible_type = wandb_stream_table.maybe_history_type_to_weave_type(tc_type)
         if possible_type is not None:
             return possible_type


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14287

Fixes a regression in our handling of summary and history objects. We would raise anytime we didn't have an explicit history keytype for a summary or history entry (like a number or typeddict). This was due to the new streamtable section of the `history_key_type_count_to_weave_type` switch statement. `maybe_history_type_to_weave_type` would raise if `tc_type` was `None`. Now it correctly returns `types.UnknownType()` as before. 