### PR TITLE
fix: empty Runs and Artifacts tabs of project overview

### DIFF
--- a/weave-js/src/components/Panel2/PanelProjectOverview.tsx
+++ b/weave-js/src/components/Panel2/PanelProjectOverview.tsx
@@ -85,12 +85,12 @@ const PanelProjectOverviewNew: React.FC<
     return names;
   }, [projectDashboardExist, projectObjectsExist, props.isRoot]);
 
-  const runsRenderSpec = usePanelById('op-runs_render');
+  const runsRenderSpec = usePanelById('ProjectRunsTable');
   const runsNode = useMemo(() => {
     return opProjectRuns({project: props.input}) as any;
   }, [props.input]);
 
-  const artifactsRenderSpec = usePanelById('op-artifacts_render');
+  const artifactsRenderSpec = usePanelById('ProjectArtifactsTable');
   const artifactsNode = useMemo(() => {
     return opProjectArtifacts({project: props.input}) as any;
   }, [props.input]);

--- a/weave-js/src/components/Panel2/PanelRegistry.tsx
+++ b/weave-js/src/components/Panel2/PanelRegistry.tsx
@@ -62,7 +62,7 @@ import {Spec as WebVizSpec} from './PanelWebViz';
 
 // TODO: Wrap Panel components with makeSpec calls
 
-// These are the all the registered panels. To register a new one, just add
+// These are all the registered panels. To register a new one, just add
 // its spec here.
 // The order of this array determines the default panel recommendation order.
 // See scoreHandlerStack in availablePanels.ts for the function that

--- a/weave/ecosystem/wandb/wandb_objs.py
+++ b/weave/ecosystem/wandb/wandb_objs.py
@@ -111,58 +111,64 @@ def entity_render(
     )
 
 
-@weave.op()
-def runs_render(
-    runs: weave.Node[list[wb_domain_types.Run]],
-) -> weave.panels.Table:
-    return weave.panels.Table(
-        runs,
-        columns=[
-            lambda run: weave.panels.WeaveLink(
-                run.id(),
-                vars={
-                    "entity_name": entity_name_op(run.project().entity()),
-                    "project_name": project_name_op(run.project()),
-                    "run_id": run.id(),
-                },
-                to=lambda input, vars: weave.ops.project(
-                    vars["entity_name"], vars["project_name"]
-                ).run(vars["run_id"]),
-            ),
-            lambda run: run_ops.run_name(run),
-            lambda run: run.createdAt(),
-        ],
-    )
+@weave.type()
+class ProjectRunsTable(weave.Panel):
+    id = "project-runs-table"
+    input_node: weave.Node[list[wb_domain_types.Run]]
+
+    @weave.op()
+    def render(self) -> weave.panels.Table:
+        return weave.panels.Table(
+            self.input_node,
+            columns=[
+                lambda run: weave.panels.WeaveLink(
+                    run.id(),
+                    vars={
+                        "entity_name": entity_name_op(run.project().entity()),
+                        "project_name": project_name_op(run.project()),
+                        "run_id": run.id(),
+                    },
+                    to=lambda input, vars: weave.ops.project(
+                        vars["entity_name"], vars["project_name"]
+                    ).run(vars["run_id"]),
+                ),
+                lambda run: run_ops.run_name(run),
+                lambda run: run.createdAt(),
+            ],
+        )
 
 
-@weave.op()
-def artifacts_render(
-    artifacts: weave.Node[list[wb_domain_types.ArtifactCollection]],
-) -> weave.panels.Table:
-    # This breaks if there is a variable in the node
-    # types_names = weave.use(artifacts._get_op("type")().name().unique())
-    # return weave.panels.Card(
-    #     title="Artifacts",
-    #     subtitle="",
-    #     content=[
-    #         weave.panels.CardTab(name=type_name, content=[type_name])
-    #         for type_name in types_names
-    #     ],
-    # )
-    return weave.panels.Table(
-        artifacts,
-        columns=[
-            lambda artifact: weave.panels.WeaveLink(
-                artifact._get_op("name")(),
-                vars={
-                    "entity_name": entity_name_op(artifact.project().entity()),
-                    "project_name": project_name_op(artifact.project()),
-                    "artifact_name": artifact._get_op("name")(),
-                },
-                to=lambda input, vars: weave.ops.project(
-                    vars["entity_name"], vars["project_name"]
-                ).artifact(vars["artifact_name"]),
-            ),
-            lambda artifact: artifact.createdAt(),
-        ],
-    )
+@weave.type()
+class ProjectArtifactsTable(weave.Panel):
+    id = "project-artifacts-table"
+    input_node: weave.Node[list[wb_domain_types.ArtifactCollection]]
+
+    @weave.op()
+    def render(self) -> weave.panels.Table:
+        # This breaks if there is a variable in the node
+        # types_names = weave.use(artifacts._get_op("type")().name().unique())
+        # return weave.panels.Card(
+        #     title="Artifacts",
+        #     subtitle="",
+        #     content=[
+        #         weave.panels.CardTab(name=type_name, content=[type_name])
+        #         for type_name in types_names
+        #     ],
+        # )
+        return weave.panels.Table(
+            self.input_node,
+            columns=[
+                lambda artifact: weave.panels.WeaveLink(
+                    artifact._get_op("name")(),
+                    vars={
+                        "entity_name": entity_name_op(artifact.project().entity()),
+                        "project_name": project_name_op(artifact.project()),
+                        "artifact_name": artifact._get_op("name")(),
+                    },
+                    to=lambda input, vars: weave.ops.project(
+                        vars["entity_name"], vars["project_name"]
+                    ).artifact(vars["artifact_name"]),
+                ),
+                lambda artifact: artifact.createdAt(),
+            ],
+        )

--- a/weave/language_features/tagging/process_opdef_resolve_fn.py
+++ b/weave/language_features/tagging/process_opdef_resolve_fn.py
@@ -1,8 +1,8 @@
 """
-This file contains a single exported function `process_opdef_resolve_fn`. Techncailly,
+This file contains a single exported function `process_opdef_resolve_fn`. Technically,
 this could have been implemented in `op_def.py`, but we want to keep all the tagging-related
 logic in one place. Therefore, in op_def.py we import this function and call it to post-process
-the result of the op_def's resolve_fn. 
+the result of the op_def's resolve_fn.
 """
 
 import typing


### PR DESCRIPTION
Problem: Runs and Artifacts tabs of Project Overview panel are empty.

Internal Jira: https://wandb.atlassian.net/browse/WB-14326
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1687987478104619

Before:
<img width="1079" alt="Screenshot 2023-06-29 at 4 08 40 PM" src="https://github.com/wandb/weave/assets/112953339/4eea9ba1-1fbd-4aee-a91a-d3f5af9d0d1b">

After:
<img width="1076" alt="Screenshot 2023-06-29 at 4 08 17 PM" src="https://github.com/wandb/weave/assets/112953339/42e0a7fd-049d-4d09-af73-b1dfedb359b2">
