### PR TITLE
chore: add ruff for fast linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.275
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,9 @@ ignore = "E714"
 
 [tool.ruff]
 line-length = 180
-ignore = ["E711"]
+show-fixes = true
+select = [
+]
 
 [tool.flake8]
 max-line-length = 180

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ ignore = "E714"
 line-length = 180
 show-fixes = true
 select = [
+  "FIX001", # https://beta.ruff.rs/docs/rules/#flake8-fixme-fix
+  "FIX003",
 ]
 
 [tool.flake8]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,6 +11,7 @@ twine>=4.0.0
 sqlalchemy>=2.0.1
 duckdb # TODO: Remove me once we refactor runs2
 mypy==1.0.0
+ruff==0.0.275
 types-pytz
 types-Pillow
 types-Flask-Cors


### PR DESCRIPTION
ruff is an extremely fast Python linter, written in Rust. It can do many of the same checks as flake8/pylint and other tools. The W&B SDK started using it recently.

See https://beta.ruff.rs/docs/rules/ for the rules we can choose to enable. Lots of possibilities to improve consistency, readability, and performance.

After installation you can run `ruff check .` to manually check for issues. I have also added it to pre-commit.

This PR intentionally enables almost no rules. We can turn them on one-by-one to incrementally ratchet up quality. 

I enabled two rules, mostly as an placeholder showing how to do it. These disallow `FIXME` and `XXX` annotations, none of which exist in the repo today. (We have very many TODO comments.) This is handy, as you can annotate something with FIXME to make sure you address it before putting up a PR.