### PR TITLE
fix: update type results type handling in trace tree

### DIFF
--- a/weave/ops_domain/trace_tree.py
+++ b/weave/ops_domain/trace_tree.py
@@ -21,7 +21,7 @@ class SpanKind:
 
 @weave.type()
 class Result:
-    inputs: typing.Optional[typing.Dict[str, typing.Any]]
+    inputs: typing.Optional[typing.Union[typing.Dict[str, typing.Any], list[str]]]
     outputs: typing.Optional[typing.Dict[str, typing.Any]]
 
 
@@ -90,15 +90,25 @@ def get_first_error(span: Span) -> typing.Optional[str]:
     return None
 
 
+def standarize_result_inputs(result: typing.Optional[Result]) -> typing.Dict[str, str]:
+    if result is None:
+        return {}
+    if isinstance(result.inputs, dict):
+        return result.inputs
+    if result.inputs is None:
+        return {}
+    if isinstance(result.inputs, list):
+        return {str(i): v for i, v in enumerate(result.inputs)}
+    raise ValueError(f"Unexpected result inputs type: {type(result.inputs)}")
+
+
 def get_trace_input_str(span: Span) -> str:
     return "\n\n".join(
         [
             "\n\n".join(
                 [
                     f"**{ndx}.{eKey}:** {eValue}"
-                    for eKey, eValue in (
-                        (result.inputs or {}) if result is not None else {}
-                    ).items()
+                    for eKey, eValue in standarize_result_inputs(result).items()
                 ]
             )
             for ndx, result in enumerate(span.results or [])

--- a/weave/ops_domain/trace_tree.py
+++ b/weave/ops_domain/trace_tree.py
@@ -21,6 +21,11 @@ class SpanKind:
 
 @weave.type()
 class Result:
+    # NOTE: In principle this type should be typing.Optional[typing.Dict[str, typing.Any]],
+    # but due to a bug in our langchain integration, we have some cases where
+    # inputs was logged as a list[str] instead of a dict[str, Any]. The more flexible type
+    # below allows our PanelTraceViewer to work in both cases, but were it not for that bug,
+    # this extra flexible type wouldn't be needed.
     inputs: typing.Optional[typing.Union[typing.Dict[str, typing.Any], list[str]]]
     outputs: typing.Optional[typing.Dict[str, typing.Any]]
 
@@ -98,6 +103,10 @@ def standarize_result_inputs(result: typing.Optional[Result]) -> typing.Dict[str
     if result.inputs is None:
         return {}
     if isinstance(result.inputs, list):
+        # NOTE: In principle this block should not be needed, but due to a bug in our
+        # langchain integration, we have some cases where inputs was logged as a list[str]
+        # instead of a dict[str, Any]. This block allows PanelTraceViewer to work in both cases,
+        # but were it not for that bug, this block wouldn't be needed.
         return {str(i): v for i, v in enumerate(result.inputs)}
     raise ValueError(f"Unexpected result inputs type: {type(result.inputs)}")
 

--- a/weave/tests/fixture_fakewandb.py
+++ b/weave/tests/fixture_fakewandb.py
@@ -354,7 +354,7 @@ class PatchedSDKArtifact(wandb.Artifact):
     def commit_hash(self) -> str:
         if not hasattr(self, "_commit_hash"):
             self._commit_hash = uuid.uuid4().hex[:20]
-        return self._commit_hash
+        return typing.cast(str, self._commit_hash)
 
 
 OriginalArtifactSymbol = wandb.Artifact


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14364

Fixes https://weights-biases.sentry.io/issues/4284886999/?project=6620563&referrer=slack&rule_id=12726589

`Result.inputs` can sometimes be a list of strings, but we were expecting it to be a dict. This adds handling for the list of strings case to reproduce the output in weave0. 

Testing: tested locally. 