### PR TITLE
fix: entering a whitespace-only expression and clicking away would crash

### DIFF
--- a/weave-js/src/panel/WeaveExpression/hooks.ts
+++ b/weave-js/src/panel/WeaveExpression/hooks.ts
@@ -460,7 +460,10 @@ export const useSuggestionVisualState = ({
     let rect = domRange.getBoundingClientRect();
 
     if (rect.top === 0 && rect.left === 0) {
-      rect = (domRange.startContainer as any).getBoundingClientRect();
+      const castContainer = domRange.startContainer as any;
+      if (castContainer.getBoundingClientRect) {
+        rect = castContainer.getBoundingClientRect();
+      }
     }
 
     if (rect.top === 0 && rect.left === 0) {


### PR DESCRIPTION
Entering a space character into a panel expression editor and then clicking away would throw an uncaught exception.

Problem: `domRange.startContainer` can be a text node that doesn't have a `getBoundingClientRect` method. This was masked by a cast.

Internal Jira: https://wandb.atlassian.net/browse/WB-14369
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1688159224967539

