### PR TITLE
fix: load python grammar in notebooks

### DIFF
--- a/weave-js/src/components/Panel2/PanelFileTextDiff/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelFileTextDiff/Component.tsx
@@ -7,6 +7,8 @@ import {
   opFileSize,
 } from '@wandb/weave/core';
 import numeral from 'numeral';
+import 'prismjs/components/prism-python';
+
 import Prism from 'prismjs';
 import React from 'react';
 import ReactDiffViewer, {DiffMethod} from 'react-diff-viewer';


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14115

Ensures that the python prism language grammar is imported when serving via PagePanel.

Related to https://github.com/wandb/core/pull/15816 which fixes this in app. 