### PR TITLE
fix: update dropna optype

### DIFF
--- a/weave-js/src/core/ops/primitives/list.test.ts
+++ b/weave-js/src/core/ops/primitives/list.test.ts
@@ -6,6 +6,7 @@ import {
   functionType,
   list,
   maybe,
+  nonNullable,
   taggedValue,
   typedDict,
 } from '../../model';
@@ -246,6 +247,37 @@ describe('List Ops', () => {
         } as any),
       }),
       {type: list(type, 0, 3), resolvedType: list(type, 0, 3), value: input}
+    );
+  });
+
+  it('opDropna - drop one', async () => {
+    const type: Type = maybe(
+      typedDict({col_a: 'number', col_b: maybe('string')})
+    );
+
+    const input = [
+      {col_a: 1, col_b: 'hello'},
+      {col_a: 2, col_b: null},
+      {col_a: 3, col_b: 'world'},
+      null,
+    ];
+
+    const elemNodes = input.map(elem => constNode(type, elem));
+
+    await testNode(
+      opDropNa({
+        arr: opArray({
+          '0': elemNodes[0],
+          '1': elemNodes[1],
+          '2': elemNodes[2],
+          '3': elemNodes[3],
+        } as any),
+      }),
+      {
+        type: list(nonNullable(type), 0, 4),
+        resolvedType: list(nonNullable(type), 0, 4),
+        value: input.slice(0, 3),
+      }
     );
   });
 });

--- a/weave-js/src/core/ops/primitives/list.test.ts
+++ b/weave-js/src/core/ops/primitives/list.test.ts
@@ -283,26 +283,7 @@ describe('List Ops', () => {
   });
 
   it('opDropna - verify unions are stripped of nones', async () => {
-    const type: Type = {
-      type: 'list',
-      objectType: {
-        type: 'union',
-        members: [
-          'none',
-          {
-            type: 'list',
-            objectType: {
-              type: 'typedDict',
-              propertyTypes: {},
-            },
-          },
-        ],
-      },
-      maxLength: 50,
-    };
-
-    // const objectType = listObjectType(type);
-
+    const type = list(maybe(list(typedDict({}))));
     const input = [
       [
         {col_a: 1, col_b: 'hello'},
@@ -312,10 +293,10 @@ describe('List Ops', () => {
       [{col_a: 3, col_b: 'hello'}],
     ];
 
-    // const elemNodes = input.map(elem => constNode(objectType, elem));
-
-    await testNode(opDropNa({arr: constNode(type as any, input)}), {
+    await testNode(opDropNa({arr: constNode(type, input)}), {
       value: input.filter(elem => elem !== null),
+      type: list(list(typedDict({})), 0),
+      resolvedType: list(list(typedDict({})), 0),
     });
   });
 });

--- a/weave-js/src/core/ops/primitives/list.test.ts
+++ b/weave-js/src/core/ops/primitives/list.test.ts
@@ -5,6 +5,7 @@ import {
   constNumberList,
   functionType,
   list,
+  listObjectType,
   maybe,
   nonNullable,
   taggedValue,
@@ -279,6 +280,43 @@ describe('List Ops', () => {
         value: input.slice(0, 3),
       }
     );
+  });
+
+  it('opDropna - verify unions are stripped of nones', async () => {
+    const type: Type = {
+      type: 'list',
+      objectType: {
+        type: 'union',
+        members: [
+          'none',
+          {
+            type: 'list',
+            objectType: {
+              type: 'typedDict',
+              propertyTypes: {},
+            },
+          },
+        ],
+      },
+      maxLength: 50,
+    };
+
+    // const objectType = listObjectType(type);
+
+    const input = [
+      [
+        {col_a: 1, col_b: 'hello'},
+        {col_a: 2, col_b: 'world'},
+      ],
+      null,
+      [{col_a: 3, col_b: 'hello'}],
+    ];
+
+    // const elemNodes = input.map(elem => constNode(objectType, elem));
+
+    await testNode(opDropNa({arr: constNode(type as any, input)}), {
+      value: input.filter(elem => elem !== null),
+    });
   });
 });
 

--- a/weave-js/src/core/ops/primitives/list.test.ts
+++ b/weave-js/src/core/ops/primitives/list.test.ts
@@ -1,5 +1,7 @@
 import {typeToString} from '../../language/js/print';
 import {
+  Type,
+  constNode,
   constNumberList,
   functionType,
   list,
@@ -8,9 +10,11 @@ import {
   typedDict,
 } from '../../model';
 import {constFunction, constNone, constNumber, constString} from '../../model';
+import {OpDefWeave} from '../../opStore';
 import {normalizeType, testClient, testNode} from '../../testUtil';
 import {randomlyDownsample} from '../util';
 import {
+  opDropNa,
   opJoinAll,
   opJoinAllReturnType,
   opRandomGaussian,
@@ -220,6 +224,29 @@ describe('List Ops', () => {
     console.log(typeToString(returnType, false));
     console.log(typeToString(expType, false));
     expect(normalizeType(returnType)).toEqual(normalizeType(expType));
+  });
+
+  it('opDropna - no effect', async () => {
+    const type: Type = typedDict({col_a: 'number', col_b: maybe('string')});
+
+    const input = [
+      {col_a: 1, col_b: 'hello'},
+      {col_a: 2, col_b: null},
+      {col_a: 3, col_b: 'world'},
+    ];
+
+    const elemNodes = input.map(elem => constNode(type, elem));
+
+    await testNode(
+      opDropNa({
+        arr: opArray({
+          '0': elemNodes[0],
+          '1': elemNodes[1],
+          '2': elemNodes[2],
+        } as any),
+      }),
+      {type: list(type, 0, 3), resolvedType: list(type, 0, 3), value: input}
+    );
   });
 });
 

--- a/weave-js/src/core/ops/primitives/list.test.ts
+++ b/weave-js/src/core/ops/primitives/list.test.ts
@@ -5,14 +5,12 @@ import {
   constNumberList,
   functionType,
   list,
-  listObjectType,
   maybe,
   nonNullable,
   taggedValue,
   typedDict,
 } from '../../model';
 import {constFunction, constNone, constNumber, constString} from '../../model';
-import {OpDefWeave} from '../../opStore';
 import {normalizeType, testClient, testNode} from '../../testUtil';
 import {randomlyDownsample} from '../util';
 import {

--- a/weave-js/src/core/ops/primitives/list.ts
+++ b/weave-js/src/core/ops/primitives/list.ts
@@ -423,8 +423,9 @@ export const opGetIndexCheckpointTag = makeTagGetterOp({
   hidden: true,
 });
 
-export const opDropNa = makeBasicOp({
+export const opDropNa = makeConfigurableStandardOp({
   name: 'dropna',
+  typeConfig: {dims: 1},
   argTypes: {
     arr: {type: 'list', objectType: 'any'},
   },

--- a/weave-js/src/core/ops/primitives/list.ts
+++ b/weave-js/src/core/ops/primitives/list.ts
@@ -423,9 +423,8 @@ export const opGetIndexCheckpointTag = makeTagGetterOp({
   hidden: true,
 });
 
-export const opDropNa = makeConfigurableStandardOp({
+export const opDropNa = makeBasicOp({
   name: 'dropna',
-  typeConfig: {dims: 1},
   argTypes: {
     arr: {type: 'list', objectType: 'any'},
   },


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14394

there is a bug in opDropna in weaveJS. the bug is if you call opDropna on a node with this type:
```json
{
    "type": "tagged",
    "tag": {...},
    "value": {
        "type": "list",
        "objectType": {
            "type": "union",
            "members": [
                "none",
                {
                    "type": "list",
                    "objectType": {
                        "type": "tagged",
                        "tag": {...},
                        "value": {
                            "type": "typedDict",
                            "propertyTypes": {}
                        }
                    }
                }
            ]
        },
        "maxLength": 50
    }
}
```

then the output type you get back is the same as the input type, despite the fact that the none should be removed from the union by the weaveJS `opDropna` returnType function. this is incorrect - the none should be stripped from the output type.

`opDropna` is a standardConfigurableOp , which means its `returnType` function is called by the `mntTypeApply` hook. there is an issue in that hook, which i traced down to this part of mntTypeApplyHelper,

```typescript
} else if (isUnion(type)) {
    // If it is a union, apply the function to each member, then union the results.
    return union(
      type.members.map(m => {
        return mntTypeApplyHelper(
          m,
          fn,
          listDepth,
          tags,
          nones,
          ancestorTag,
          noneTypeResult
        );
      })
    );
  }
```
where basically we apply the `opDropna` `returnType` function to `'none'` and then `list(…)` and then `union` the results. so the `‘none’` stays in the union.

the solution is to change the opType of `opDropna` from configurableStandard to `basic`, so that we don't have to go through `mntTypeApplyHelper`. This PR does this