### PR TITLE
fix busted line numbers in tests: remove esbuild jest

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -203,9 +203,6 @@
       "react-app-polyfill/jsdom"
     ],
     "testEnvironment": "jsdom",
-    "transform": {
-      "^.+\\.[t|j]sx?$": "esbuild-jest"
-    },
     "transformIgnorePatterns": [
       "^.+\\.module\\.(css|sass|scss)$"
     ],


### PR DESCRIPTION
Gets error messages from jest to show up on the correct lines. 