### PR TITLE
fix: update partition table type inference to use all sampled data

### DIFF
--- a/weave/ops_domain/table.py
+++ b/weave/ops_domain/table.py
@@ -619,19 +619,25 @@ class _TableLikeAWLFromFileResult:
     data: dict
 
 
-def _get_table_like_awl_from_file(
-    file: typing.Union[
-        artifact_fs.FilesystemArtifactFile, artifact_fs.FilesystemArtifactDir, None
-    ],
-    num_parts: int = 1,
-) -> _TableLikeAWLFromFileResult:
+def _get_table_data_from_file(file: artifact_fs.FilesystemArtifactFile) -> dict:
     tracer = engine_trace.tracer()
     if file is None or isinstance(file, artifact_fs.FilesystemArtifactDir):
         raise errors.WeaveInternalError("File is None or a directory")
     with file.open() as f:
         with tracer.trace("get_table:jsonload"):
             data = json.load(f)
+    return data
 
+
+def _get_table_like_awl_from_file(
+    file: typing.Union[
+        artifact_fs.FilesystemArtifactFile, artifact_fs.FilesystemArtifactDir, None
+    ],
+    num_parts: int = 1,
+) -> _TableLikeAWLFromFileResult:
+    if file is None or isinstance(file, artifact_fs.FilesystemArtifactDir):
+        raise errors.WeaveInternalError("File is None or a directory")
+    data = _get_table_data_from_file(file)
     if file.path.endswith(".joined-table.json"):
         awl = _get_joined_table_awl_from_file(data, file)
     elif file.path.endswith(".partitioned-table.json"):
@@ -645,9 +651,11 @@ def _get_table_like_awl_from_file(
     return _TableLikeAWLFromFileResult(awl, data)
 
 
-def _get_table_awl_from_file(
-    data: dict, file: artifact_fs.FilesystemArtifactFile, num_parts: int = 1
-) -> "ops_arrow.ArrowWeaveList":
+def _get_rows_and_object_type_awl_from_file(
+    data: dict,
+    file: artifact_fs.FilesystemArtifactFile,
+    num_parts: int = 1,
+) -> typing.Tuple[list, types.Type]:
     tracer = engine_trace.tracer()
     rows: list = []
     object_type = None
@@ -664,10 +672,24 @@ def _get_table_awl_from_file(
         else:
             raise errors.WeaveInternalError("Unknown table file format for data")
 
+    return rows, object_type
+
+
+def _get_table_awl_from_rows_object_type(
+    rows: list, object_type: types.Type, file: artifact_fs.FilesystemArtifactFile
+) -> "ops_arrow.ArrowWeaveList":
+    tracer = engine_trace.tracer()
     with tracer.trace("get_table:to_arrow"):
         return ops_arrow.to_arrow_from_list_and_artifact(
             rows, object_type, file.artifact
         )
+
+
+def _get_table_awl_from_file(
+    data: dict, file: artifact_fs.FilesystemArtifactFile, num_parts: int = 1
+) -> "ops_arrow.ArrowWeaveList":
+    rows, object_type = _get_rows_and_object_type_awl_from_file(data, file, num_parts)
+    return _get_table_awl_from_rows_object_type(rows, object_type, file)
 
 
 def _get_partitioned_table_awl_from_file(
@@ -685,8 +707,21 @@ def _get_partitioned_table_awl_from_file(
         asyncio.run(ensure_files(part_dir.files))
 
         num_parts = len(part_dir.files)
+        rrows: list[list] = []
+        object_types: list[types.Type] = []
         for file in part_dir.files.values():
-            all_aws.append(_get_table_like_awl_from_file(file, num_parts).awl)
+            data = _get_table_data_from_file(file)
+            rows, object_type = _get_rows_and_object_type_awl_from_file(
+                data, file, num_parts
+            )
+            rrows.append(rows)
+            object_types.append(object_type)
+        object_type = types.union(*object_types)
+
+        for rows, file in zip(rrows, part_dir.files.values()):
+            all_aws.append(
+                _get_table_awl_from_rows_object_type(rows, object_type, file)
+            )
     arrow_weave_list = ops_arrow.ops.concat.raw_resolve_fn(all_aws)
     return arrow_weave_list
 


### PR DESCRIPTION
Fix https://wandb.atlassian.net/browse/WB-14409

When reading partitioned tables, we were sampling `1000 / num_partitions` rows from each partition and using those rows to determine the object type for each partition. When `num_partitions` was large, this could lead to sampling only a few rows to get the row type, leading to incorrect type inference. This manifested as an `invalid null error` in the ticket above. We sampled some rows from a partition that happened to be null to determine the type, but the rest of the data was not null. 

The fix here is to sample 1000 / num_partitions rows from each partition, and then take the `union` of the types from each partition to get the final type. Then we use that global type when converting the read data to an AWL. 

Related to #41, which introduced this I believe. 