### PR TITLE
fix: make AxisScale serializable in python, make scale configurable from python code

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -1942,6 +1942,12 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
   );
   */
 
+  function scaleToVegaScale(s: Scale) {
+    return _.mapKeys(_.omitBy(s, _.isNil), (v, k) =>
+      k === 'scaleType' ? 'type' : k
+    );
+  }
+
   type DiscreteMappingScale = {domain: string[]; range: number[][]};
   const lineStyleScale: DiscreteMappingScale = useMemo(() => {
     const scale: DiscreteMappingScale = {
@@ -2794,7 +2800,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
     }
     // TODO(np): fixme
     if (axisSettings.x.scale != null) {
-      newSpec.encoding.x.scale = axisSettings.x.scale;
+      newSpec.encoding.x.scale = scaleToVegaScale(axisSettings.x.scale);
     }
     if (axisSettings.x.noTitle) {
       newSpec.encoding.x.axis.title = null;
@@ -2820,7 +2826,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
       newSpec.encoding.y.axis = {...defaultFontStyleDict};
       // TODO(np): fixme
       if (axisSettings.y.scale != null) {
-        newSpec.encoding.y.scale = axisSettings.y.scale;
+        newSpec.encoding.y.scale = scaleToVegaScale(axisSettings.y.scale);
       }
       if (axisSettings.y.noTitle) {
         newSpec.encoding.y.axis.title = null;
@@ -2846,8 +2852,10 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
     }
 
     if (newSpec.encoding.color != null) {
-      if (axisSettings?.color?.scale) {
-        newSpec.encoding.color.scale = axisSettings.color.scale;
+      if (axisSettings?.color?.scale != null) {
+        newSpec.encoding.color.scale = scaleToVegaScale(
+          axisSettings.color.scale
+        );
       }
 
       if (axisSettings.color && axisSettings.color.noTitle) {

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -750,7 +750,7 @@ const ScaleConfigOptionComp: FC<ScaleConfigOptionProps> = ({
   axis,
 }) => {
   const currentScaleType =
-    getScaleValue<ScaleType>(`type`) ?? DEFAULT_SCALE_TYPE;
+    getScaleValue<ScaleType>(`scaleType`) ?? DEFAULT_SCALE_TYPE;
 
   const scaleTypeSpecificProp = SCALE_TYPE_SPECIFIC_PROPS[currentScaleType];
   const scaleTypeSpecificPropValue: number | undefined =
@@ -766,7 +766,7 @@ const ScaleConfigOptionComp: FC<ScaleConfigOptionProps> = ({
           options={SCALE_TYPE_OPTIONS}
           value={currentScaleType}
           onChange={(event, {value}) => {
-            setScaleValue(`type`, value as ScaleType);
+            setScaleValue(`scaleType`, value as ScaleType);
           }}
         />
       </ConfigPanel.ConfigOption>
@@ -2722,7 +2722,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
 
         for (const axis of [`x`, `y`] as const) {
           if (
-            concreteConfig.axisSettings[axis].scale?.type === `log` &&
+            concreteConfig.axisSettings[axis].scale?.scaleType === `log` &&
             row[vegaCols[i][axis]] <= 0
           ) {
             return false;

--- a/weave-js/src/components/Panel2/PanelPlot/versions/index.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/versions/index.ts
@@ -11,8 +11,9 @@ import * as v10 from './v10';
 import * as v11 from './v11';
 import * as v12 from './v12';
 import * as v13 from './v13';
+import * as v14 from './v14';
 
-export type {Scale, ScaleType} from './v10';
+export type {Scale, ScaleType} from './v14';
 export type {Signals} from './v12';
 
 export const PLOT_DIMS_UI = v2.PLOT_DIMS_UI;
@@ -38,7 +39,8 @@ export const {migrate} = migrator
   .add(v10.migrate)
   .add(v11.migrate)
   .add(v12.migrate)
-  .add(v13.migrate);
+  .add(v13.migrate)
+  .add(v14.migrate);
 
 export type AnyPlotConfig = Parameters<typeof migrate>[number];
 export type PlotConfig = ReturnType<typeof migrate>;
@@ -53,5 +55,5 @@ export type ContinuousSelection = v11.ContinuousSelection;
 export type DiscreteSelection = v11.DiscreteSelection;
 export type AxisSelections = v11.AxisSelections;
 
-export type ConcretePlotConfig = v13.ConcretePlotConfig;
+export type ConcretePlotConfig = v14.ConcretePlotConfig;
 export type ConcreteSeriesConfig = ConcretePlotConfig['series'][number];

--- a/weave-js/src/components/Panel2/PanelPlot/versions/v14.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/versions/v14.ts
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+import * as v10 from './v10';
+import * as v13 from './v13';
+
+export type {ScaleType} from './v10';
+
+type AxisSettingsPrev = v13.PlotConfig[`axisSettings`];
+type AxisSettingPrev = AxisSettingsPrev[keyof AxisSettingsPrev];
+type ScalePrev = v10.Scale;
+
+export type Scale = Omit<ScalePrev, 'type'> & {
+  scaleType?: v10.ScaleType;
+};
+
+export type AxisSetting = Omit<AxisSettingPrev, 'scale'> & {
+  scale?: Scale | null;
+};
+
+export type AxisSettings = {
+  x: AxisSetting;
+  y: AxisSetting;
+  color: AxisSetting;
+};
+
+type OmitKeys = 'configVersion' | 'axisSettings';
+
+type Diff = {
+  configVersion: 14;
+  axisSettings: AxisSettings;
+};
+
+export type PlotConfig = Omit<v13.PlotConfig, OmitKeys> & Diff;
+export type ConcretePlotConfig = Omit<v13.ConcretePlotConfig, OmitKeys> & Diff;
+
+export const migrate = (config: v13.PlotConfig): PlotConfig => {
+  return {
+    ...config,
+    axisSettings: ['x' as const, 'y' as const, 'color' as const].reduce(
+      (agg, axis) => {
+        const setting = config.axisSettings[axis];
+        _.set(
+          agg,
+          axis,
+          _.mapKeys(setting, k => (k === 'type' ? 'scaleType' : k))
+        );
+        return agg;
+      },
+      {} as AxisSettings
+    ),
+    configVersion: 14,
+  };
+};

--- a/weave-js/src/components/Panel2/PanelPlot/versions/v14.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/versions/v14.ts
@@ -41,7 +41,7 @@ export const migrate = (config: v13.PlotConfig): PlotConfig => {
         _.set(
           agg,
           axis,
-          _.mapKeys(setting, k => (k === 'type' ? 'scaleType' : k))
+          _.mapKeys(setting, (v, k) => (k === 'type' ? 'scaleType' : k))
         );
         return agg;
       },

--- a/weave/panels/panel_plot.py
+++ b/weave/panels/panel_plot.py
@@ -254,6 +254,9 @@ ScaleType = typing.Literal["linear", "log"]
 
 @weave.type()
 class AxisScale:
+    # need to use scaleType instead of `type` here because
+    # `type` serializes to the same key as the
+    # `type` used by ObjectType
     scaleType: typing.Optional[ScaleType]
     range: typing.Optional[
         dict[typing.Literal["field"], typing.Callable[[str], str]]

--- a/weave/panels/panel_plot.py
+++ b/weave/panels/panel_plot.py
@@ -253,10 +253,12 @@ ScaleType = typing.Literal["linear", "log"]
 
 
 @weave.type()
-class Scale:
-    type: typing.Optional[ScaleType]
-    range: typing.Optional[dict[typing.Literal["field"], typing.Callable[[str], str]]]
-    base: typing.Optional[float]  # for log scale
+class AxisScale:
+    scaleType: typing.Optional[ScaleType]
+    range: typing.Optional[
+        dict[typing.Literal["field"], typing.Callable[[str], str]]
+    ] = None
+    base: typing.Optional[float] = None  # for log scale
 
 
 @weave.type()
@@ -265,7 +267,7 @@ class AxisSetting:
     noTitle: bool
     noTicks: bool
     title: typing.Optional[str] = None
-    scale: typing.Optional[Scale] = None
+    scale: typing.Optional[AxisScale] = None
 
 
 @weave.type()
@@ -330,7 +332,7 @@ class PlotConfig:
     legendSettings: typing.Optional[LegendSettings]
     configOptionsExpanded: typing.Optional[ConfigOptionsExpanded]
     signals: Signals
-    configVersion: int = 12
+    configVersion: int = 14
 
 
 def set_through_array(
@@ -477,6 +479,8 @@ class Plot(panel.Panel, codifiable_value_mixin.CodifiableValueMixin):
         no_legend: bool = False,
         x_title: typing.Optional[str] = None,
         y_title: typing.Optional[str] = None,
+        x_axis_type: typing.Optional[ScaleType] = None,
+        y_axis_type: typing.Optional[ScaleType] = None,
         color_title: typing.Optional[str] = None,
         domain_x: typing.Optional[SelectFunction] = None,
         domain_y: typing.Optional[SelectFunction] = None,
@@ -529,6 +533,11 @@ class Plot(panel.Panel, codifiable_value_mixin.CodifiableValueMixin):
             config_axisSettings.x.title = x_title
             config_axisSettings.y.title = y_title
             config_axisSettings.color.title = color_title
+
+            if x_axis_type is not None:
+                config_axisSettings.x.scale = AxisScale(scaleType=x_axis_type)
+            if y_axis_type is not None:
+                config_axisSettings.y.scale = AxisScale(scaleType=y_axis_type)
 
             config_legendSettings = LegendSettings(
                 x=LegendSetting(), y=LegendSetting(), color=LegendSetting()

--- a/weave/tests/test_plot.py
+++ b/weave/tests/test_plot.py
@@ -8,6 +8,8 @@ from weave.panels.panel_plot import Plot, Series, PlotConstants
 from .test_run_segment import create_experiment
 from .. import storage
 
+from weave import weave_types as types
+
 from contextlib import contextmanager
 
 
@@ -1762,3 +1764,19 @@ def test_actual_config_value(fixed_random_seed):
             "configVersion": 7,
         },
     }
+
+
+def test_panel_plot_scale_serialization():
+    # checks a problem case where scale would not be serialized correctly as an AxisScale object
+    plot = weave.panels.Plot(
+        [1, 2, 3, 4],
+        x=lambda row: row,
+        x_title="x",
+        y=lambda row: row**2,
+        y_title="y",
+        y_axis_type="log",
+    )
+    type = types.TypeRegistry.type_of(plot)
+    serialized = type.to_dict()
+    deserialized = types.TypeRegistry.type_from_dict(serialized)
+    assert deserialized.assign_type(type) and type.assign_type(deserialized)


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14410

Fixes two issues related to scales in panelplot. 

1. Calling `type_of(panel_plot.Scale(...)).to_dict()` did not produce the correct serialized type because `Scale` has a `type` attribute that collides with weave's `ObjectType` `type` attribute. I renamed this attribute `scaleType` so that it doesn't collide and the type can be correctly deserialized from its serialized version. Added a migration to enforce this and a unit test. 
2. The serialized version of `Scale` constructed from python code includes all keys, with values of `None` if a value is unset or null. This caused an error to be raised in Vega because the corresponding javascript object contained entries like `{scale: {..., range: None}}` instead of just omitting the `range` key. This would lead to explicitly trying to set the scale range to None instead of using the default scale range (behavior when the key is not present). Fixed here with the `scaleToVegaScale` function. 

Note: this PR is ❌  due to a chicken-egg situation with core CI