### PR TITLE
feat: suggestion popup restyled and less invasive

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -27,6 +27,7 @@
     "@babylonjs/loaders": "^4.2.0",
     "@babylonjs/viewer": "^4.2.0",
     "@datadog/browser-logs": "^1.12.7",
+    "@floating-ui/react": "^0.24.5",
     "@material-ui/core": "^4.11.4",
     "@monaco-editor/react": "^4.3.1",
     "@sentry/react": "^6.17.3",

--- a/weave-js/src/panel/WeaveExpression/OpDoc.styles.ts
+++ b/weave-js/src/panel/WeaveExpression/OpDoc.styles.ts
@@ -9,7 +9,7 @@ OpNameRow.displayName = 'S.OpNameRow';
 
 export const OpName = styled.h2`
   flex: 1 1 auto;
-  font-size: 18px;
+  font-size: 15px;
   font-weight: 600;
   margin-bottom: 2px;
 `;
@@ -25,7 +25,7 @@ export const Section = styled.div`
 `;
 
 export const Subheader = styled.h3`
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
   margin-bottom: 2px;
 `;
@@ -49,4 +49,8 @@ export const ArgList = styled.ul`
 export const ArgName = styled.span`
   font-size: 14px;
   font-weight: 600;
+`;
+
+export const Code = styled.code`
+  font-family: Inconsolata;
 `;

--- a/weave-js/src/panel/WeaveExpression/OpDoc.styles.ts
+++ b/weave-js/src/panel/WeaveExpression/OpDoc.styles.ts
@@ -1,10 +1,24 @@
 import styled from 'styled-components';
+import * as globals from '@wandb/weave/common/css/globals.styles';
+
+export const OpNameRow = styled.div`
+  display: flex;
+  height: 24px;
+`;
+OpNameRow.displayName = 'S.OpNameRow';
 
 export const OpName = styled.h2`
+  flex: 1 1 auto;
   font-size: 18px;
   font-weight: 600;
   margin-bottom: 2px;
 `;
+OpName.displayName = 'S.OpName';
+
+export const OpClose = styled.div`
+  margin-left: 10px;
+`;
+OpClose.displayName = 'S.OpClose';
 
 export const Section = styled.div`
   margin-bottom: 8px;
@@ -18,6 +32,7 @@ export const Subheader = styled.h3`
 
 export const Markdown = styled.div`
   font-size: 14px;
+  color: ${globals.MOON_250};
 `;
 
 export const ArgList = styled.ul`

--- a/weave-js/src/panel/WeaveExpression/OpDoc.tsx
+++ b/weave-js/src/panel/WeaveExpression/OpDoc.tsx
@@ -74,7 +74,7 @@ const OpDoc: React.FC<OpDocProps> = ({
       }}>
       <S.OpNameRow>
         <S.OpName>
-          <code>{displayName}</code>
+          <S.Code>{displayName}</S.Code>
         </S.OpName>
         {onClose && (
           <S.OpClose>

--- a/weave-js/src/panel/WeaveExpression/OpDoc.tsx
+++ b/weave-js/src/panel/WeaveExpression/OpDoc.tsx
@@ -3,7 +3,10 @@ import {opDisplayName} from '@wandb/weave/core';
 import React from 'react';
 
 import {useWeaveContext} from '../../context';
+
 import * as S from './OpDoc.styles';
+import {IconClose} from '../../components/Panel2/Icons';
+import {IconButton} from '../../components/IconButton';
 
 export interface OpDocProps {
   opName: string;
@@ -11,9 +14,16 @@ export interface OpDocProps {
 
   // For __getattr__ ops only
   attributeName?: string;
+
+  onClose?: () => void;
 }
 
-const OpDoc: React.FC<OpDocProps> = ({opName, className, attributeName}) => {
+const OpDoc: React.FC<OpDocProps> = ({
+  opName,
+  className,
+  attributeName,
+  onClose,
+}) => {
   const {client} = useWeaveContext();
   const opDef = client.opStore.getOpDef(opName);
 
@@ -62,9 +72,18 @@ const OpDoc: React.FC<OpDocProps> = ({opName, className, attributeName}) => {
         // can register!
         ev.preventDefault();
       }}>
-      <S.OpName>
-        <code>{displayName}</code>
-      </S.OpName>
+      <S.OpNameRow>
+        <S.OpName>
+          <code>{displayName}</code>
+        </S.OpName>
+        {onClose && (
+          <S.OpClose>
+            <IconButton onClick={onClose}>
+              <IconClose />
+            </IconButton>
+          </S.OpClose>
+        )}
+      </S.OpNameRow>
       <S.Section>
         <S.Markdown dangerouslySetInnerHTML={{__html: description}} />
       </S.Section>

--- a/weave-js/src/panel/WeaveExpression/SuggestionRow.tsx
+++ b/weave-js/src/panel/WeaveExpression/SuggestionRow.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import * as globals from '@wandb/weave/common/css/globals.styles';
+import {IconInfo} from '../../components/Panel2/Icons';
+import type {AutosuggestResult} from '@wandb/weave/core';
+import styled from 'styled-components';
+import * as S from './styles';
+import _ from 'lodash';
+
+export const Row = styled.div`
+  position: relative;
+  height: 24px;
+`;
+Row.displayName = 'S.Row';
+
+export const Suggestion = styled.div`
+  position: absolute;
+  left: 0;
+`;
+Suggestion.displayName = 'S.Suggestion';
+
+export const Info = styled.div<{isOpenInfo: boolean}>`
+  background-color: ${globals.MOON_100};
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0 10px;
+
+  color: ${props => (props.isOpenInfo ? globals.MOON_800 : globals.MOON_450)};
+  &:hover {
+    color: ${globals.MOON_800};
+  }
+`;
+Info.displayName = 'S.Info';
+
+type SuggestionRowProps = {
+  suggestion: AutosuggestResult<any>;
+  idx: number;
+  suggestionIndex?: number;
+  setSuggestionIndex?: React.Dispatch<React.SetStateAction<number>>;
+  takeSuggestion: (s: AutosuggestResult<any>) => void;
+
+  hasInfo: boolean;
+  setIsOverInfo: React.Dispatch<React.SetStateAction<boolean>>;
+  isOpenInfo: boolean;
+  setIsOpenInfo: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const SuggestionRow = ({
+  suggestion,
+  idx,
+  suggestionIndex,
+  setSuggestionIndex,
+  takeSuggestion,
+  hasInfo,
+  setIsOverInfo,
+  isOpenInfo,
+  setIsOpenInfo,
+}: SuggestionRowProps) => {
+  const isDefault = idx === suggestionIndex;
+  const openPopup = () => setIsOverInfo(true);
+  const onMouseEnter = _.debounce(() => {
+    setTimeout(openPopup, 400);
+  }, 400);
+  const onMouseLeave = () => {
+    onMouseEnter.cancel();
+    setIsOverInfo(false);
+  };
+  const onClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (isOpenInfo) {
+      setIsOverInfo(false);
+    }
+    setIsOpenInfo(!isOpenInfo);
+  };
+  return (
+    <li
+      className={
+        (isDefault ? 'default-suggestion ' : '') + S.SUGGESTION_OPTION_CLASS
+      }
+      // Note: we don't clear the suggestion index on mouse leave - we want
+      // it to remain in case the user is just mousing over to click on something
+      // in the op doc.
+      onMouseEnter={
+        setSuggestionIndex ? () => setSuggestionIndex(idx) : undefined
+      }
+      onMouseDown={ev => {
+        // Prevent this element from taking focus
+        // otherwise it disappears before the onClick
+        // can register!
+        ev.preventDefault();
+      }}
+      onClick={() => takeSuggestion(suggestion)}>
+      <Row>
+        <Suggestion>{suggestion.suggestionString.trim()}</Suggestion>
+        {isDefault && hasInfo && (
+          <Info
+            isOpenInfo={isOpenInfo}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+            onClick={onClick}>
+            <IconInfo width={18} height={18} />
+          </Info>
+        )}
+      </Row>
+    </li>
+  );
+};

--- a/weave-js/src/panel/WeaveExpression/index.tsx
+++ b/weave-js/src/panel/WeaveExpression/index.tsx
@@ -109,9 +109,21 @@ export const WeaveExpression: React.FC<WeaveExpressionProps> = props => {
     [editor]
   );
 
+  // Don't show suggestions when the editor is first focused.
+  // A mouse down or key press will unsuppress them.
+  const [isFirstFocused, setIsFirstFocused] = useState(false);
+  const suppressingFocus = () => {
+    setIsFirstFocused(true);
+    onFocus();
+  };
+  const mouseDownHandler = () => {
+    setIsFirstFocused(false);
+  };
+
   // Certain keys have special behavior
   const keyDownHandler = React.useCallback(
     ev => {
+      setIsFirstFocused(false);
       if (ev.key === 'Enter' && !ev.shiftKey && !props.liveUpdate) {
         // Apply outstanding changes to expression
         ev.preventDefault();
@@ -211,9 +223,10 @@ export const WeaveExpression: React.FC<WeaveExpressionProps> = props => {
             // placeholder={<div>"Weave expression"</div>}
             className={isValid ? 'valid' : 'invalid'}
             onCopy={copyHandler}
+            onMouseDown={mouseDownHandler}
             onKeyDown={keyDownHandler}
             onBlur={onBlur}
-            onFocus={onFocus}
+            onFocus={suppressingFocus}
             decorate={decorate}
             renderLeaf={leafProps => <Leaf {...leafProps} />}
             style={{overflowWrap: 'anywhere'}}
@@ -243,9 +256,10 @@ export const WeaveExpression: React.FC<WeaveExpressionProps> = props => {
         </S.EditableContainer>
         {!props.frozen && (
           <Suggestions
-            forceHidden={suppressSuggestions || isBusy}
+            forceHidden={suppressSuggestions || isBusy || isFirstFocused}
             {...suggestions}
             suggestionIndex={suggestionIndex}
+            setSuggestionIndex={setSuggestionIndex}
           />
         )}
       </Slate>

--- a/weave-js/src/panel/WeaveExpression/styles.ts
+++ b/weave-js/src/panel/WeaveExpression/styles.ts
@@ -171,6 +171,7 @@ export const StyledOpDoc = styled(OpDoc)`
   background-color: ${globals.MOON_900};
   padding: 12px;
   border-radius: 4px;
+  box-shadow: 0px 12px 24px 0px rgba(14, 16, 20, 0.16);
 
   & a {
     color: ${globals.TEAL_500};

--- a/weave-js/src/panel/WeaveExpression/styles.ts
+++ b/weave-js/src/panel/WeaveExpression/styles.ts
@@ -105,28 +105,31 @@ export const SuggestionContainer = styled.div`
   transition: opacity 0.3s;
   opacity: 0;
 `;
+SuggestionContainer.displayName = 'S.SuggestionContainer';
+
 export const SUGGESTION_OPTION_CLASS = 'suggestion-option';
 export const SuggestionPane = styled.div<{isBusy: boolean}>`
-  background-color: rgba(0, 0, 0, 0.9);
-  color: #ddd;
   display: inline-block;
 
-  padding: 10px;
-  border-radius: 3px;
+  background-color: ${globals.WHITE};
+  border: 1px solid ${globals.MOON_250};
+  border-radius: 4px;
+  box-shadow: 0px 12px 24px 0px rgba(14, 16, 20, 0.16);
+
   width: 250px;
 
   & div.type-display {
     font-weight: 600;
 
-    padding-bottom: 10px;
+    padding: 10px;
     margin-bottom: 10px;
-    border-bottom: 2px solid #666;
+    border-bottom: 1px solid ${globals.MOON_250};
   }
 
   & ul.items-list {
     margin: 0px;
     list-style: none;
-    padding: 0px;
+    padding: 0 6px 6px 6px;
     max-height: 250px;
     overflow-y: scroll;
     overflow-x: hidden;
@@ -153,33 +156,28 @@ export const SuggestionPane = styled.div<{isBusy: boolean}>`
     padding-left: 5px;
 
     &.default-suggestion {
-      background-color: rgba(255, 255, 255, 0.2);
-      padding-right: 30px;
-    }
-
-    &.default-suggestion:before {
-      color: ${props => (props.isBusy ? globals.gray500 : globals.primary)};
-      text-align: right;
-      content: '⇥';
-      float: right;
-      margin-right: -25px;
-    }
-
-    &:hover {
-      background-color: rgba(255, 255, 255, 0.2);
+      background-color: ${globals.MOON_100};
     }
   }
 `;
 
 export const StyledOpDoc = styled(OpDoc)`
   display: inline-block;
+  max-width: 400px;
   vertical-align: top;
   margin-left: 5px;
 
-  background-color: #fffeee;
-  padding: 10px;
-  border-radius: 3px;
-  border: 1px solid black;
+  color: ${globals.WHITE};
+  background-color: ${globals.MOON_900};
+  padding: 12px;
+  border-radius: 4px;
 
-  max-width: 250px;
+  & a {
+    color: ${globals.TEAL_500};
+
+    &:hover {
+      color: ${globals.TEAL_450};
+    }
+  }
 `;
+StyledOpDoc.displayName = 'S.StyledOpDoc';

--- a/weave-js/src/panel/WeaveExpression/types.ts
+++ b/weave-js/src/panel/WeaveExpression/types.ts
@@ -33,7 +33,9 @@ export interface SuggestionProps {
   items: Array<AutosuggestResult<any>>;
 
   isBusy: boolean;
+
   suggestionIndex?: number;
+  setSuggestionIndex?: React.Dispatch<React.SetStateAction<number>>;
 
   forceHidden?: boolean;
 

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -1478,6 +1478,34 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.41.0.tgz#080321c3b68253522f7646b55b577dd99d2950b3"
   integrity sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==
 
+"@floating-ui/core@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.3.1.tgz#4d795b649cc3b1cbb760d191c80dcb4353c9a366"
+  integrity sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g==
+
+"@floating-ui/dom@^1.3.0":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.4.4.tgz#cf859dde33995a4e7b6ded16c98cb73b2ebfffd0"
+  integrity sha512-21hhDEPOiWkGp0Ys4Wi6Neriah7HweToKra626CIK712B5m9qkdz54OP9gVldUg+URnBTpv/j/bi/skmGdstXQ==
+  dependencies:
+    "@floating-ui/core" "^1.3.1"
+
+"@floating-ui/react-dom@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.1.tgz#7972a4fc488a8c746cded3cfe603b6057c308a91"
+  integrity sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==
+  dependencies:
+    "@floating-ui/dom" "^1.3.0"
+
+"@floating-ui/react@^0.24.5":
+  version "0.24.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.24.5.tgz#a5ba451c308ce112e98c59dcb89b28d100236cde"
+  integrity sha512-p/cOvACHFooJX5yTaim8PZgMAt67IIBAkynZfWiLsor5aUE6all1OJ73eVpjATUxFP5l8gqOszvP1Zr22T2UgQ==
+  dependencies:
+    "@floating-ui/react-dom" "^2.0.1"
+    aria-hidden "^1.2.3"
+    tabbable "^6.0.1"
+
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"
@@ -3210,6 +3238,13 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-hidden@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.3.tgz#14aeb7fb692bbb72d69bebfa47279c1fd725e954"
+  integrity sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==
+  dependencies:
+    tslib "^2.0.0"
 
 aria-query@^5.1.3:
   version "5.1.3"
@@ -11317,6 +11352,11 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tabbable@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
+
 tailwindcss@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.2.tgz#2f9e35d715fdf0bbf674d90147a0684d7054a2d3"
@@ -11659,6 +11699,11 @@ tslib@^1.10.0, tslib@^1.13.0, tslib@^1.7.1, tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.0.tgz#b295854684dbda164e181d259a22cd779dcd7bc3"
+  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
 tslib@~2.4.0:
   version "2.4.1"


### PR DESCRIPTION
Internal Jira: WB-14130

Updated suggestion panel to obscure less of the expression editor in use:
* Suggestions are suppressed on first focus
* OpDoc panel is hidden by default, hover over info icon to show or click it to persist.
* Suggestions panel is now positioned at bottom left of editor instead of at cursor. Uses [Floating UI](https://floating-ui.com/) to reposition within viewport.
* Styling updates

Before:
<img width="902" alt="Screenshot 2023-07-10 at 2 07 47 PM" src="https://github.com/wandb/weave/assets/112953339/b43ccf02-9b48-4d4c-8abf-487eb3187e1f">

After:
<img width="591" alt="Screenshot 2023-07-10 at 2 06 59 PM" src="https://github.com/wandb/weave/assets/112953339/323a571a-44c6-4285-92d2-b0265c322896">
