### PR TITLE
feat: add parllelism to derived op resolver

### DIFF
--- a/weave/derive_op.py
+++ b/weave/derive_op.py
@@ -26,6 +26,10 @@ USE_PARALLEL_DOWNLOAD = True
 USE_PARALLEL_REFINE = True
 USE_PARALLEL_RESOLVE = True
 
+_PARALLEL_ALLOWLIST = ["refine_history_metrics", "artifactVersion-historyMetrics"]
+PARALLEL_REFINE_ALLOWLIST = _PARALLEL_ALLOWLIST
+PARALLEL_RESOLVE_ALLOWLIST = _PARALLEL_ALLOWLIST
+
 
 class DeriveOpHandler:
     """
@@ -286,7 +290,7 @@ class MappedDeriveOpHandler(DeriveOpHandler):
 
                 if not list_:
                     return types.List(types.NoneType())
-                if USE_PARALLEL_REFINE:
+                if USE_PARALLEL_REFINE and orig_op.name in PARALLEL_REFINE_ALLOWLIST:
                     types_to_merge = list(parallelism.do_in_parallel(refine_one, list_))
                 else:
                     types_to_merge = list(map(refine_one, list_))
@@ -318,7 +322,7 @@ class MappedDeriveOpHandler(DeriveOpHandler):
                         )
                     return None
 
-            if USE_PARALLEL_RESOLVE:
+            if USE_PARALLEL_RESOLVE and orig_op.name in PARALLEL_RESOLVE_ALLOWLIST:
                 return list(parallelism.do_in_parallel(resolve_one, list_))
             else:
                 return list(map(resolve_one, list_))

--- a/weave/derive_op.py
+++ b/weave/derive_op.py
@@ -304,10 +304,8 @@ class MappedDeriveOpHandler(DeriveOpHandler):
                     tag_store_curr_node_id, tag_store_mem_map
                 ):
                     if not (
-                        x is None
-                        or isinstance(x, box.BoxedNone)
-                        or types.is_optional(first_arg.type)
-                    ):
+                        x is None or isinstance(x, box.BoxedNone)
+                    ) or types.is_optional(first_arg.type):
                         return orig_op.resolve_fn(
                             **{
                                 mapped_param_name: tag_store.add_tags(

--- a/weave/ops_primitives/pandas_.py
+++ b/weave/ops_primitives/pandas_.py
@@ -209,6 +209,9 @@ class DataFrameTable:
     def _count(self):
         return len(self._df)
 
+    def __len__(self):
+        return self._count()
+
     @op()
     def count(self) -> int:
         return self._count()


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14201

This PR is a workaround for a performance regression in the model registry described in the above JIRA ticket. We understand the source of the regression, but the correct fix will involve implementing a new plugin type. This quick fix improves the performance by parallelizing the refinement and resolution of mapped ops, which is the hot spot. There are other ways to improve this but @tssweeney and I decided this was the best immediate course of action. 

This has the potential to improve the performance of all mapped ops by our parallelism factor if they are IO bound. 