### PR TITLE
fix: Handle unserialized numpy arrays in table read path 

### DIFF
--- a/weave/tests/test_numpy.py
+++ b/weave/tests/test_numpy.py
@@ -1,6 +1,9 @@
 import numpy as np
 from .. import types_numpy as numpy_types
 from .. import weave_types as types
+from ..ops_domain import table
+from .. import artifact_wandb
+from .. import artifact_fs
 
 
 def test_construct_numpy_type():
@@ -19,3 +22,135 @@ def test_construct_numpy_type():
     arr = np.array(1)
     t_inferred = types.TypeRegistry.type_of(arr)
     assert t_inferred.assign_type(t)
+
+
+def test_construct_numpy_type_from_table_file():
+    data = {
+        "_type": "table",
+        "column_types": {
+            "params": {
+                "type_map": {
+                    "tca": {
+                        "params": {
+                            "allowed_types": [
+                                {"wb_type": "none"},
+                                {"wb_type": "string"},
+                            ]
+                        },
+                        "wb_type": "union",
+                    },
+                    "pxe": {
+                        "params": {
+                            "allowed_types": [
+                                {"wb_type": "none"},
+                                {"wb_type": "string"},
+                            ]
+                        },
+                        "wb_type": "union",
+                    },
+                    "gmi": {
+                        "params": {
+                            "allowed_types": [
+                                {
+                                    "params": {
+                                        "box_layers": {
+                                            "params": {"is_set": False, "val": {}},
+                                            "wb_type": "const",
+                                        },
+                                        "box_score_keys": {
+                                            "params": {"is_set": True, "val": []},
+                                            "wb_type": "const",
+                                        },
+                                        "class_map": {
+                                            "params": {"is_set": False, "val": {}},
+                                            "wb_type": "const",
+                                        },
+                                        "mask_layers": {
+                                            "params": {"is_set": False, "val": {}},
+                                            "wb_type": "const",
+                                        },
+                                    },
+                                    "wb_type": "image-file",
+                                },
+                                {"wb_type": "none"},
+                            ]
+                        },
+                        "wb_type": "union",
+                    },
+                    "sbo": {
+                        "params": {
+                            "allowed_types": [
+                                {"wb_type": "none"},
+                                {
+                                    "params": {
+                                        "type_map": {
+                                            "direction": {"wb_type": "number"},
+                                            "image": {
+                                                "params": {
+                                                    "serialization_path": None,
+                                                    "shape": [3, 3, 3],
+                                                },
+                                                "wb_type": "ndarray",
+                                            },
+                                            "mission": {"wb_type": "string"},
+                                        }
+                                    },
+                                    "wb_type": "typedDict",
+                                },
+                            ]
+                        },
+                        "wb_type": "union",
+                    },
+                    "txet": {
+                        "params": {
+                            "allowed_types": [
+                                {"wb_type": "none"},
+                                {"wb_type": "string"},
+                            ]
+                        },
+                        "wb_type": "union",
+                    },
+                }
+            },
+            "wb_type": "typedDict",
+        },
+        "columns": ["gmi", "sbo", "txet", "tca", "pxe"],
+        "data": [
+            [
+                {
+                    "_type": "image-file",
+                    "format": "png",
+                    "height": 192,
+                    "path": "media/images/test.png",
+                    "sha256": "blank",
+                    "width": 352,
+                },
+                {
+                    "direction": 0,
+                    "image": [
+                        [[1, 2, 3], [1, 4, 5], [1, 4, 20]],
+                        [[1, 2, 3], [1, 4, 5], [10, 3, 2]],
+                        [[1, 3, 3], [1, 4, 5], [1, -1, 2]],
+                    ],
+                    "mission": "test",
+                },
+                "blah",
+                "blah",
+                "blah2",
+            ]
+        ],
+        "ncols": 5,
+        "nrows": 1,
+    }
+
+    # generate a dummy artifact so we can call _get_rows_and_object_type_from_weave_format
+    # this artifact is not actually used, it just needs to have a file
+    art = artifact_wandb.WandbArtifact("test")
+    fs_artifact_file = artifact_fs.FilesystemArtifactFile(art, "test")
+    _, object_type = table._get_rows_and_object_type_from_weave_format(
+        data, fs_artifact_file
+    )
+
+    assert types.List(types.List(types.List(types.Int()))).assign_type(
+        object_type.property_types["sbo"].property_types["image"]
+    )

--- a/weave/tests/test_numpy.py
+++ b/weave/tests/test_numpy.py
@@ -143,8 +143,11 @@ def test_construct_numpy_type_from_table_file():
         "nrows": 1,
     }
 
-    # generate a dummy artifact so we can call _get_rows_and_object_type_from_weave_format
-    # this artifact is not actually used, it just needs to have a file
+    # generate a dummy filesystem artifact file so we can call
+    # _get_rows_and_object_type_from_weave_format. that function
+    # requires a filesystemartifactfile, but doesn't actually use it.
+    # thus we can just use a dummy here.
+
     art = artifact_wandb.WandbArtifact("test")
     fs_artifact_file = artifact_fs.FilesystemArtifactFile(art, "test")
     _, object_type = table._get_rows_and_object_type_from_weave_format(

--- a/weave/tests/test_wb_data_types.py
+++ b/weave/tests/test_wb_data_types.py
@@ -100,8 +100,8 @@ def make_molecule():
         # Domain Types
         #
         (datetime.datetime.now(), types.Timestamp()),  # type: ignore
-        # See comment in wandb_util.py - this may change in the future
-        (np.array([1, 2, 3]), types.NoneType()),
+        # See comment in wandb_util.py and https://github.com/wandb/weave/pull/140
+        (np.array([1, 2, 3]), types.List(types.UnknownType())),
         #
         # Media Types
         #

--- a/weave/wandb_util.py
+++ b/weave/wandb_util.py
@@ -22,7 +22,7 @@ foreign_index_type_names = set(["foreignIndex", "wandb.TableForeignIndex"])
 
 
 # This should ideally match `mediaTable.ts` in Weave0.
-def _convert_type(old_type: Weave0TypeJson) -> types.Type:
+def _convert_type(old_type: Weave0TypeJson, data=None) -> types.Type:
     old_type_name = old_type["wb_type"]
     is_python_object_type = old_type_name == "pythonObject" or old_type_name == "object"
     #
@@ -105,8 +105,13 @@ def _convert_type(old_type: Weave0TypeJson) -> types.Type:
         return types.Int()
     elif old_type_name == "ndarray":
         # return ops.LegacyTableNDArrayType()
-        # Just return NoneType. The data is None.
-        return types.NoneType()
+        if old_type.get("params", {}).get("serialization_path") is not None:
+            # Just return NoneType. The data is None.
+            return types.NoneType()
+
+        # SDK converted the array to a pylist
+        return types.List(types.UnknownType())
+
         # return NumpyArrayType("f", shape=old_type._params.get("shape", (0,)))
     #
     # Media Types

--- a/weave/wandb_util.py
+++ b/weave/wandb_util.py
@@ -22,7 +22,7 @@ foreign_index_type_names = set(["foreignIndex", "wandb.TableForeignIndex"])
 
 
 # This should ideally match `mediaTable.ts` in Weave0.
-def _convert_type(old_type: Weave0TypeJson, data=None) -> types.Type:
+def _convert_type(old_type: Weave0TypeJson) -> types.Type:
     old_type_name = old_type["wb_type"]
     is_python_object_type = old_type_name == "pythonObject" or old_type_name == "object"
     #


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14433

Fixes an error in the file-table read path that was improperly typing unserialized (i.e., raw pylist) numpy arrays as `None`. This happens whenever the SDK logs a table where a numpy array is not a top level key. Now numpy arrays of this type are typed as `List(Unknown())`. The unknown is filled in later in the path, which fixes the arrow mapping error we see above. 