### PR TITLE
fix inference of valid embedding columns in panel projection converter

### DIFF
--- a/weave-js/src/components/Panel2/PanelProjectionConverter/util.ts
+++ b/weave-js/src/components/Panel2/PanelProjectionConverter/util.ts
@@ -3,8 +3,8 @@ import {
   isAssignableTo,
   list,
   listObjectType,
-  maybe,
   Node,
+  nonNullable,
   nullableTaggableValue,
   Type,
   typedDict,
@@ -21,10 +21,10 @@ export const getValidColumns = (inputType: Type) => {
     const allPaths = allObjPaths(innerType);
 
     validEmbeddingColumns = allPaths
-      .filter(path => isAssignableTo(path.type, maybe(list('number'))))
+      .filter(path => isAssignableTo(nonNullable(path.type), list('number')))
       .map(path => path.path.join('.'));
     validNumericColumns = allPaths
-      .filter(path => isAssignableTo(path.type, maybe('number')))
+      .filter(path => isAssignableTo(nonNullable(path.type), 'number'))
       .map(path => path.path.join('.'));
   }
   return {

--- a/weave/ops_arrow/dict.py
+++ b/weave/ops_arrow/dict.py
@@ -255,9 +255,12 @@ def awl_2d_projection(
         # where we have a column of Optional[number]
         none_indices = np.argwhere(np.isnan(np_array_of_embeddings))
         column_indices = none_indices[:, 1]
-        np_array_of_embeddings[none_indices] = np.nanmean(
-            np_array_of_embeddings, axis=0
-        )[column_indices]
+
+        np.put(
+            np_array_of_embeddings,
+            none_indices,
+            np.nanmean(np_array_of_embeddings, axis=0)[column_indices],
+        )
 
         # if any remaining nans (can only happen if all values in a column are nan), replace with zeros
         # such columns will be removed in the next step

--- a/weave/ops_arrow/dict.py
+++ b/weave/ops_arrow/dict.py
@@ -251,12 +251,17 @@ def awl_2d_projection(
         # coerce to float to turn Nones into nans
         np_array_of_embeddings = np_array_of_embeddings.astype("f")
 
-        # impute nones with average
+        # impute nans with average value for column - this handles the case
+        # where we have a column of Optional[number]
         none_indices = np.argwhere(np.isnan(np_array_of_embeddings))
         column_indices = none_indices[:, 1]
         np_array_of_embeddings[none_indices] = np.nanmean(
             np_array_of_embeddings, axis=0
         )[column_indices]
+
+        # if any remaining nans (can only happen if all values in a column are nan), replace with zeros
+        # such columns will be removed in the next step
+        np_array_of_embeddings = np.nan_to_num(np_array_of_embeddings)
 
         # remove 0-only columns
         np_array_of_embeddings = np_array_of_embeddings[

--- a/weave/ops_arrow/dict.py
+++ b/weave/ops_arrow/dict.py
@@ -227,7 +227,7 @@ def awl_2d_projection(
     data = table._arrow_data_asarray_no_tags()
 
     def default_projection():
-        return np.array([[0, 0] for row in data])
+        return np.zeros((len(data), 2))
 
     if len(inputColumnNames) == 0 or len(data) < 2:
         np_projection = default_projection()
@@ -247,9 +247,20 @@ def awl_2d_projection(
                 col for col in column_data if not isinstance(col, pa.NullArray)
             ]
             np_array_of_embeddings = np.array(column_data).T
+
+        # coerce to float to turn Nones into nans
+        np_array_of_embeddings = np_array_of_embeddings.astype("f")
+
+        # impute nones with average
+        none_indices = np.argwhere(np.isnan(np_array_of_embeddings))
+        column_indices = none_indices[:, 1]
+        np_array_of_embeddings[none_indices] = np.nanmean(
+            np_array_of_embeddings, axis=0
+        )[column_indices]
+
         # remove 0-only columns
         np_array_of_embeddings = np_array_of_embeddings[
-            :, ~(np_array_of_embeddings.sum(axis=0) == 0)
+            :, ~((np_array_of_embeddings == 0).all(axis=0))
         ]
         # If the selected data is not a 2D array, or if it has less than 2 columns, then
         # we can't perform a 2D projection. In this case, we just return a 2D array of


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14436

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
(3 additional frame(s) were not displayed)
...
  File "weave/execute.py", line 410, in execute_sync_op
    return op_def.resolve_fn(**inputs)
  File "weave/op_def.py", line 359, in resolve_fn
    return process_opdef_resolve_fn.process_opdef_resolve_fn(
  File "weave/language_features/tagging/process_opdef_resolve_fn.py", line 123, in process_opdef_resolve_fn
    res = propagate_arrow_tags(op_def, resolve_fn, args, kwargs)
  File "weave/language_features/tagging/process_opdef_resolve_fn.py", line 78, in propagate_arrow_tags
    res = resolve_fn(*tag_stripped_args, **tag_stripped_kwargs)
  File "weave/ops_arrow/dict.py", line 252, in awl_2d_projection
    :, ~(np_array_of_embeddings.sum(axis=0) == 0)
```

Our previous logic for determining valid embedding columns could result in a column with type `'none'` being selected. When this happened, it triggered an error server side in WP and a resulting panel crash. Here I updated the logic to only consider columns valid that are numeric.