### PR TITLE
chore: git ignore macOS Desktop Services Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .python-version
 .ipynb_checkpoints
 dist/


### PR DESCRIPTION
git should ignore .DS_Store files.