### PR TITLE
chore: Enable polling on weave pages

### DIFF
--- a/weave-js/src/contextProviders.tsx
+++ b/weave-js/src/contextProviders.tsx
@@ -89,7 +89,8 @@ const useRemoteEcosystemClient = (
 export const RemoteEcosystemComputeGraphContextProvider: React.FC<{
   isAdmin?: boolean;
   tokenFunc?: () => Promise<string | undefined>;
-}> = React.memo(({isAdmin, tokenFunc, children}) => {
+  shouldPoll?: boolean;
+}> = React.memo(({isAdmin, tokenFunc, shouldPoll, children}) => {
   const tf = useMemo(() => {
     const dummy = async () => undefined;
     return tokenFunc != null ? tokenFunc : dummy;
@@ -98,6 +99,7 @@ export const RemoteEcosystemComputeGraphContextProvider: React.FC<{
   if (client == null) {
     return <></>;
   }
+  client.setPolling(!!shouldPoll);
   return (
     <ComputeGraphContextProviderFromClient
       client={client}
@@ -144,7 +146,7 @@ export const NotebookComputeGraphContextProvider: React.FC = React.memo(
 
     return (
       <WeaveFeaturesContext.Provider value={defaultWBFeatureState}>
-        <RemoteEcosystemComputeGraphContextProvider>
+        <RemoteEcosystemComputeGraphContextProvider shouldPoll={true}>
           {children}
         </RemoteEcosystemComputeGraphContextProvider>
       </WeaveFeaturesContext.Provider>


### PR DESCRIPTION
This is AMAZING! our old polling logic works out of the box! In W&B main app, until we are fully moved over to Weave1, then our polling logic will cause issues by invalidating the shared Apollo cache. But here we are totally in the clear!