### PR TITLE
stats: monitor size of tag store at beginning of each request

### DIFF
--- a/weave/engine_trace.py
+++ b/weave/engine_trace.py
@@ -247,6 +247,7 @@ class WeaveWriter:
 
 
 def tracer():
+
     if os.getenv("DD_ENV"):
         from ddtrace import tracer as ddtrace_tracer
 
@@ -310,7 +311,7 @@ def _initialize_statsd():
         return DummyStatsd()
 
 
-def statsd() -> typing.Any:
+def statsd():
     global _STATSD
     if _STATSD is None:
         _STATSD = _initialize_statsd()

--- a/weave/engine_trace.py
+++ b/weave/engine_trace.py
@@ -247,7 +247,6 @@ class WeaveWriter:
 
 
 def tracer():
-
     if os.getenv("DD_ENV"):
         from ddtrace import tracer as ddtrace_tracer
 
@@ -311,7 +310,7 @@ def _initialize_statsd():
         return DummyStatsd()
 
 
-def statsd():
+def statsd() -> typing.Any:
     global _STATSD
     if _STATSD is None:
         _STATSD = _initialize_statsd()

--- a/weave/language_features/tagging/tag_store.py
+++ b/weave/language_features/tagging/tag_store.py
@@ -30,7 +30,7 @@ from ... import engine_trace
 
 from collections import defaultdict
 
-statsd = engine_trace.statsd()
+statsd = engine_trace.statsd()  # type: ignore
 
 NodeTagStoreType = dict[int, dict[str, typing.Any]]
 TagStoreType = defaultdict[int, NodeTagStoreType]

--- a/weave/language_features/tagging/tag_store.py
+++ b/weave/language_features/tagging/tag_store.py
@@ -61,7 +61,7 @@ def record_current_tag_store_size() -> None:
         n_tag_store_entries = sum(len(current_mmap[key]) for key in current_mmap)
     else:
         n_tag_store_entries = 0
-    logging.debug(f"Current number of tag store entries: {n_tag_store_entries}")
+    logging.info(f"Current number of tag store entries: {n_tag_store_entries}")
     statsd.gauge("weave.tag_store.num_entries", n_tag_store_entries)
 
 

--- a/weave/language_features/tagging/tag_store.py
+++ b/weave/language_features/tagging/tag_store.py
@@ -14,7 +14,7 @@ The primary user-facing functions are:
 * `find_tag` - used to recursively lookup the tag for a given object
 
 """
-
+import logging
 import contextvars
 from contextlib import contextmanager
 import typing
@@ -25,7 +25,12 @@ from ... import box
 from ... import weave_types as types
 from ... import errors
 
+
+from ... import engine_trace
+
 from collections import defaultdict
+
+statsd = engine_trace.statsd()
 
 NodeTagStoreType = dict[int, dict[str, typing.Any]]
 TagStoreType = defaultdict[int, NodeTagStoreType]
@@ -48,6 +53,16 @@ def _current_obj_tag_mem_map() -> typing.Optional[NodeTagStoreType]:
     if node_tags is None:
         return None
     return node_tags[_OBJ_TAGS_CURR_NODE_ID.get()]
+
+
+def record_current_tag_store_size() -> None:
+    current_mmap = _OBJ_TAGS_MEM_MAP.get()
+    if current_mmap is not None:
+        n_tag_store_entries = sum(len(current_mmap[key]) for key in current_mmap)
+    else:
+        n_tag_store_entries = 0
+    logging.debug(f"Current number of tag store entries: {n_tag_store_entries}")
+    statsd.gauge("weave.tag_store.num_entries", n_tag_store_entries)
 
 
 @contextmanager

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -32,6 +32,7 @@ from weave import filesystem
 from weave.server_error_handling import client_safe_http_exceptions_as_werkzeug
 from weave import storage
 from weave import wandb_api
+from weave.language_features.tagging import tag_store
 
 # PROFILE_DIR = "/tmp/weave/profile"
 PROFILE_DIR = None
@@ -257,6 +258,7 @@ def execute():
         "serialize_fn": storage.make_js_serializer(),
     }
     root_span = tracer.current_root_span()
+    tag_store.record_current_tag_store_size()
     if not PROFILE_DIR:
         start_time = time.time()
         with client_safe_http_exceptions_as_werkzeug():


### PR DESCRIPTION
Adds logging and monitoring of the number of entries of our tag store at the beginning of each weave_server.execute call. 