### PR TITLE
chore: Enable in-app board generation

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -23,18 +23,18 @@ import {
   opProjectArtifact,
   opRootProject,
   opTableRows,
-  varNode,
 } from '@wandb/weave/core';
 import {NavigateToExpressionType, SetPreviewNodeType} from './common';
 import {useNodeValue} from '@wandb/weave/react';
-import {useNewDashFromItems} from '../../Panel2/PanelRootBrowser/util';
-import {getFullChildPanel} from '../../Panel2/ChildPanel';
 import {useWeaveContext} from '@wandb/weave/context';
 import {
   HomePreviewSidebarTemplate,
   HomeBoardPreview,
   HomeExpressionPreviewParts,
 } from './HomePreviewSidebar';
+import {useMakeLocalBoardFromNode} from '../../Panel2/pyBoardGen';
+import WandbLoader from '@wandb/weave/common/components/WandbLoader';
+import {IconMagicWandStar} from '../../Icon';
 
 type CenterEntityBrowserPropsType = {
   entityName: string;
@@ -470,7 +470,9 @@ const CenterProjectTablesBrowser: React.FC<
     return combined;
   }, [isLoading, loggedTables.result, runStreams.result]);
 
-  const makeNewDashboard = useNewDashFromItems();
+  const [seedingBoard, setSeedingBoard] = useState(false);
+
+  const makeBoardFromNode = useMakeLocalBoardFromNode();
   const browserActions: Array<
     CenterBrowserActionType<(typeof browserData)[number]>
   > = useMemo(() => {
@@ -497,13 +499,12 @@ const CenterProjectTablesBrowser: React.FC<
                   icon: IconAddNew,
                   label: 'Seed new board',
                   onClick: () => {
-                    const name =
-                      'dashboard-' + moment().format('YY_MM_DD_hh_mm_ss');
-                    makeNewDashboard(
-                      name,
-                      {panel0: getFullChildPanel(varNode(expr.type, 'var0'))},
-                      {var0: expr},
+                    setSeedingBoard(true);
+                    makeBoardFromNode(
+                      'py_board-seed_board',
+                      expr,
                       newDashExpr => {
+                        setSeedingBoard(false);
                         props.navigateToExpression(newDashExpr);
                       }
                     );
@@ -526,7 +527,7 @@ const CenterProjectTablesBrowser: React.FC<
       [
         {
           icon: IconAddNew,
-          label: 'Seed new board',
+          label: 'Seed basic board',
           onClick: row => {
             const node = tableRowToNode(
               row.kind,
@@ -534,15 +535,28 @@ const CenterProjectTablesBrowser: React.FC<
               props.projectName,
               row._id
             );
-            const name = 'dashboard-' + moment().format('YY_MM_DD_hh_mm_ss');
-            makeNewDashboard(
-              name,
-              {panel0: getFullChildPanel(varNode(node.type, 'var0'))},
-              {var0: node},
-              newDashExpr => {
-                props.navigateToExpression(newDashExpr);
-              }
+            setSeedingBoard(true);
+            makeBoardFromNode('py_board-seed_board', node, newDashExpr => {
+              setSeedingBoard(false);
+              props.navigateToExpression(newDashExpr);
+            });
+          },
+        },
+        {
+          icon: IconMagicWandStar,
+          label: 'Seed auto board',
+          onClick: row => {
+            const node = tableRowToNode(
+              row.kind,
+              props.entityName,
+              props.projectName,
+              row._id
             );
+            setSeedingBoard(true);
+            makeBoardFromNode('py_board-seed_autoboard', node, newDashExpr => {
+              setSeedingBoard(false);
+              props.navigateToExpression(newDashExpr);
+            });
           },
         },
         {
@@ -559,6 +573,8 @@ const CenterProjectTablesBrowser: React.FC<
             );
           },
         },
+      ],
+      [
         {
           icon: IconCopy,
           label: 'Copy Weave expression',
@@ -577,36 +593,39 @@ const CenterProjectTablesBrowser: React.FC<
         },
       ],
     ];
-  }, [makeNewDashboard, props, weave]);
+  }, [makeBoardFromNode, props, weave]);
 
   return (
-    <CenterBrowser
-      allowSearch
-      title={browserTitle}
-      selectedRowId={selectedRowId}
-      noDataCTA={`No Weave tables found for project: ${props.entityName}/${props.projectName}`}
-      breadcrumbs={[
-        {
-          key: 'entity',
-          text: props.entityName,
-          onClick: () => {
-            props.setSelectedProjectName(undefined);
-            props.setSelectedAssetType(undefined);
+    <>
+      {seedingBoard && <WandbLoader />}
+      <CenterBrowser
+        allowSearch
+        title={browserTitle}
+        selectedRowId={selectedRowId}
+        noDataCTA={`No Weave tables found for project: ${props.entityName}/${props.projectName}`}
+        breadcrumbs={[
+          {
+            key: 'entity',
+            text: props.entityName,
+            onClick: () => {
+              props.setSelectedProjectName(undefined);
+              props.setSelectedAssetType(undefined);
+            },
           },
-        },
-        {
-          key: 'project',
-          text: props.projectName,
-          onClick: () => {
-            props.setSelectedAssetType(undefined);
+          {
+            key: 'project',
+            text: props.projectName,
+            onClick: () => {
+              props.setSelectedAssetType(undefined);
+            },
           },
-        },
-      ]}
-      loading={isLoading}
-      filters={{kind: {placeholder: 'All table kinds'}}}
-      columns={['name', 'kind', 'updated at', 'created at', 'created by']}
-      data={browserData}
-      actions={browserActions}
-    />
+        ]}
+        loading={isLoading}
+        filters={{kind: {placeholder: 'All table kinds'}}}
+        columns={['name', 'kind', 'updated at', 'created at', 'created by']}
+        data={browserData}
+        actions={browserActions}
+      />
+    </>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -23,6 +23,7 @@ import {
   opProjectArtifact,
   opRootProject,
   opTableRows,
+  varNode,
 } from '@wandb/weave/core';
 import {NavigateToExpressionType, SetPreviewNodeType} from './common';
 import {useNodeValue} from '@wandb/weave/react';
@@ -35,6 +36,8 @@ import {
 import {useMakeLocalBoardFromNode} from '../../Panel2/pyBoardGen';
 import WandbLoader from '@wandb/weave/common/components/WandbLoader';
 import {IconMagicWandStar} from '../../Icon';
+import {getFullChildPanel} from '../../Panel2/ChildPanel';
+import {useNewDashFromItems} from '../../Panel2/PanelRootBrowser/util';
 
 type CenterEntityBrowserPropsType = {
   entityName: string;
@@ -471,6 +474,7 @@ const CenterProjectTablesBrowser: React.FC<
   }, [isLoading, loggedTables.result, runStreams.result]);
 
   const [seedingBoard, setSeedingBoard] = useState(false);
+  const makeNewDashboard = useNewDashFromItems();
 
   const makeBoardFromNode = useMakeLocalBoardFromNode();
   const browserActions: Array<
@@ -499,12 +503,13 @@ const CenterProjectTablesBrowser: React.FC<
                   icon: IconAddNew,
                   label: 'Seed new board',
                   onClick: () => {
-                    setSeedingBoard(true);
-                    makeBoardFromNode(
-                      'py_board-seed_board',
-                      expr,
+                    const name =
+                      'dashboard-' + moment().format('YY_MM_DD_hh_mm_ss');
+                    makeNewDashboard(
+                      name,
+                      {panel0: getFullChildPanel(varNode(expr.type, 'var0'))},
+                      {var0: expr},
                       newDashExpr => {
-                        setSeedingBoard(false);
                         props.navigateToExpression(newDashExpr);
                       }
                     );
@@ -527,7 +532,7 @@ const CenterProjectTablesBrowser: React.FC<
       [
         {
           icon: IconAddNew,
-          label: 'Seed basic board',
+          label: 'Seed new board',
           onClick: row => {
             const node = tableRowToNode(
               row.kind,

--- a/weave-js/src/components/Panel2/pyBoardGen.tsx
+++ b/weave-js/src/components/Panel2/pyBoardGen.tsx
@@ -1,0 +1,89 @@
+// This file provides utilities for generating dashboards.
+import {
+  callOpVeryUnsafe,
+  constNone,
+  constString,
+  dereferenceAllVars,
+  Node,
+  opGet,
+} from '@wandb/weave/core';
+import {
+  absoluteTargetMutation,
+  makeMutation,
+  useClientContext,
+  useRefreshAllNodes,
+} from '@wandb/weave/react';
+import _ from 'lodash';
+import {useCallback} from 'react';
+
+import {usePanelContext} from './PanelContext';
+import moment from 'moment';
+
+export const useMakeLocalBoardFromNode = () => {
+  const simpleSetter = useMakeSimpleSetMutation();
+  return useCallback(
+    (
+      boardGenOpName: string,
+      inputNode: Node,
+      onCreated: (newPanel: Node) => void,
+      boardName?: string,
+      config: Node = constNone()
+    ) => {
+      if (!boardName) {
+        boardName = 'board-' + moment().format('YY_MM_DD_hh_mm_ss');
+      }
+      simpleSetter(
+        `local-artifact:///${boardName}:latest/obj`,
+        callOpVeryUnsafe(
+          boardGenOpName,
+          {input_node: inputNode, config},
+          'any' as const
+        ) as any,
+        onCreated
+      );
+    },
+    [simpleSetter]
+  );
+};
+
+// The whole mutation system in react.tsx is insanely complicated.
+// This function attempts to reduce the complexity to just what
+// most callers need.
+const useMakeSimpleSetMutation = () => {
+  const refreshAll = useRefreshAllNodes();
+  const {stack, triggerExpressionEvent} = usePanelContext();
+  const {client} = useClientContext();
+  return useCallback(
+    async (
+      targetURI: string,
+      setValueFromNode: Node,
+      onCreated?: (newPanel: Node) => void
+    ) => {
+      if (client) {
+        const target = opGet({
+          uri: constString(targetURI),
+        });
+        const absoluteTarget = dereferenceAllVars(target, stack).node;
+        const {rootArgs, mutationStyle, rootType} =
+          absoluteTargetMutation(absoluteTarget);
+        const mutation = makeMutation(
+          target,
+          'set',
+          refreshAll,
+          stack,
+          triggerExpressionEvent,
+          absoluteTarget,
+          mutationStyle,
+          rootArgs,
+          rootType,
+          client,
+          onCreated
+        );
+        await mutation({
+          val: setValueFromNode,
+        });
+      }
+    },
+    [client, refreshAll, stack, triggerExpressionEvent]
+  );
+};

--- a/weave-js/src/core/hl.ts
+++ b/weave-js/src/core/hl.ts
@@ -33,7 +33,6 @@ import {nodesEqual} from './model/graph/editing';
 import {isVarNode} from './model/graph/typeHelpers';
 import {
   allObjPaths,
-  functionType,
   isAssignableTo,
   isConstType,
   isFunction,

--- a/weave/panels_py/__init__.py
+++ b/weave/panels_py/__init__.py
@@ -1,1 +1,2 @@
 from . import panel_autoboard
+from . import panel_seedboard

--- a/weave/panels_py/panel_autoboard.py
+++ b/weave/panels_py/panel_autoboard.py
@@ -195,7 +195,6 @@ def auto_panels(
     groupby_key_node = weave_internal.make_var_node(groupby.type, "groupby")
 
     for key, prop_type in property_types.items():
-
         if weave.types.optional(weave.types.Number()).assign_type(prop_type):
             panel = timeseries_sum_bar(
                 data_node,
@@ -315,3 +314,13 @@ class AutoBoard(weave.Panel):
     @weave.op()  # type: ignore
     def render(self) -> weave.panels.Group:
         return auto_panels(self.input_node, self.config)  # type: ignore
+
+
+@weave.op(  # type: ignore
+    name="py_board-seed_autoboard",
+)
+def seed_autoboard(
+    input_node: weave.Node[typing.Any],
+    config: typing.Optional[AutoBoardConfig] = None,
+) -> weave.panels.Group:
+    return auto_panels(input_node, config)  # type: ignore

--- a/weave/panels_py/panel_seedboard.py
+++ b/weave/panels_py/panel_seedboard.py
@@ -1,0 +1,33 @@
+import typing
+
+import weave
+from .. import weave_internal
+
+
+@weave.type()
+class PyBoardSeedBoardConfig:
+    pass
+
+
+@weave.op(  # type: ignore
+    name="py_board-seed_board",
+)
+def seed_board(
+    input_node: weave.Node[typing.Any],
+    config: typing.Optional[PyBoardSeedBoardConfig] = None,
+) -> weave.panels.Group:
+    control_items = [
+        weave.panels.GroupPanel(
+            input_node,
+            id="data",
+        ),
+    ]
+
+    panels = [
+        weave.panels.BoardPanel(
+            weave_internal.make_var_node(input_node.type, "data"),
+            id="table",
+            layout=weave.panels.BoardPanelLayout(x=0, y=0, w=24, h=6),
+        ),
+    ]
+    return weave.panels.Board(vars=control_items, panels=panels)


### PR DESCRIPTION
This is a small PoC of how we can quickly add python-defined board generation to the UI. This is not quite the long term design, but will work for upcoming customer demos.