### PR TITLE
chore: hide join ops and fix ci

### DIFF
--- a/weave-js/src/core/ops/primitives/list.ts
+++ b/weave-js/src/core/ops/primitives/list.ts
@@ -793,6 +793,7 @@ const listToDict = (
 // TODO: fix
 export const opJoin = makeOp({
   name: 'join',
+  hidden: true,
   argTypes: {
     arr1: maybe({type: 'list', objectType: 'any'}),
     arr2: maybe({type: 'list', objectType: 'any'}),
@@ -1072,7 +1073,7 @@ const cloneDeepObj = (obj: {[key: string]: any}): any => {
 };
 
 export const opJoinAll = makeOp({
-  hidden: false,
+  hidden: true,
   name: 'joinAll',
   argTypes: {
     arrs: {

--- a/weave/ops_arrow/list_join.py
+++ b/weave/ops_arrow/list_join.py
@@ -209,6 +209,7 @@ def _joined_all_output_type_tag_type(
 
 @op(
     name="ArrowWeaveList-joinAll",
+    hidden=True,
     input_type={
         "arrs": types.List(types.optional(ArrowWeaveListType(types.TypedDict({})))),
         "joinFn": lambda input_types: types.Function(
@@ -227,6 +228,7 @@ def _join_2_output_type(input_types):
 
 @op(
     name="ArrowWeaveList-join",
+    hidden=True,
     input_type={
         "arr1": ArrowWeaveListType(types.TypedDict({})),
         "arr2": ArrowWeaveListType(types.TypedDict({})),

--- a/weave/ops_primitives/list_.py
+++ b/weave/ops_primitives/list_.py
@@ -533,6 +533,7 @@ def _join_output_type(input_types):
 
 
 @op(
+    hidden=True,
     input_type={
         "arr1": types.List(types.TypedDict({})),
         "arr2": types.List(types.TypedDict({})),
@@ -603,6 +604,7 @@ def _join_2_output_type(input_types):
 
 @op(
     name="join",
+    hidden=True,
     input_type={
         "arr1": types.List(),
         "arr2": types.List(),
@@ -698,6 +700,7 @@ def _all_join_keys_mapping(
 
 @op(
     name="joinAll",
+    hidden=True,
     input_type={
         "arrs": types.List(types.optional(types.List(types.TypedDict({})))),
         "joinFn": lambda input_types: types.Function(


### PR DESCRIPTION
This PR: https://github.com/wandb/weave/commit/9a8e2f3c703afdc626c508538c7af62856131646#diff-4a28bd768628f497eeadc66d62441e5030f8f1e33d3f8d7726918f026d36bf38 changed the definition of `isProducibleType` which makes suggestions. As a result, `join` is now a suggested op. This is breaking integration tests here: https://app.circleci.com/pipelines/github/wandb/core/85001/workflows/c168d99e-3bb3-4188-a0a5-dea20c70fce4/jobs/1931955/tests 

I don't think we really want to expose join, so I just took it as an opportunity to explicitly hide these ops