### PR TITLE
chore: Hide `urllib3` warnings

### DIFF
--- a/weave/wandb_interface/wandb_lite_run.py
+++ b/weave/wandb_interface/wandb_lite_run.py
@@ -14,6 +14,11 @@ from weave.wandb_client_api import wandb_public_api
 logger = logging.getLogger(__name__)
 
 
+# We disable urllib warnings because they are noisy and not actionable.
+logging.getLogger("urllib3").setLevel(logging.ERROR)
+logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)
+
+
 class WeaveWandbRunException(Exception):
     pass
 


### PR DESCRIPTION
`urllib3` emits a bunch of nasty `WARNING:urllib3.connectionpool:Connection pool is full, discarding connection` warnings when we open up more than 10 connections. This PR changes the logger to not emit warnings. These warnings do not indicate data loss and is more informational than useful.