### PR TITLE
basic StreamTable usage

### DIFF
--- a/examples/experimental/ProductionMonitoring/StreamTable.md
+++ b/examples/experimental/ProductionMonitoring/StreamTable.md
@@ -1,0 +1,17 @@
+# StreamTable
+
+A Weave StreamTable object enables continuous streaming of data from an application or service to W&B. This is an extension of the standard
+wandb Table object to handle monitoring use cases. Instead of uploading a complete Table object once, you can
+append data repeatedly to a StreamTable object with `.log([your data rows])`. 
+
+## Create a StreamTable
+
+```
+from weave.monitoring import StreamTable
+st = StreamTable("my_entity_name/my_project_name/my_table_name")
+```
+
+## Log data to a StreamTable
+
+## Usage notes 
+

--- a/examples/experimental/ProductionMonitoring/stream_table_api.ipynb
+++ b/examples/experimental/ProductionMonitoring/stream_table_api.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "eccb44d3",
+   "metadata": {},
+   "source": [
+    "# Weave StreamTable Usage\n",
+    "\n",
+    "This notebook demonstrates basic StreamTable usage with interactive examples.\n",
+    "TODO: link to source code?\n",
+    "\n",
+    "## Step 0: Setup\n",
+    "\n",
+    "All the StreamTables created in this notebook will be saved to the WB_PROJECT under the WB_ENTITY account on the public W&B cloud. \n",
+    "\n",
+    "**Please login to W&B and edit these** before running this demo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51c30e7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import weave\n",
+    "from weave.monitoring import StreamTable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5684f0b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WB_ENTITY = \"stacey\"\n",
+    "WB_PROJECT = \"mesa\"\n",
+    "STREAM_TABLE_NAME = \"my_stream_table\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f676d96",
+   "metadata": {},
+   "source": [
+    "## Step 1: Define a StreamTable\n",
+    "\n",
+    "StreamTable has a single required argument: the name of the StreamTable object.\n",
+    "\n",
+    "```python\n",
+    "st = StreamTable(\"stacey/mesa/my_stream_table\")\n",
+    "```\n",
+    "\n",
+    "This takes the form \"my_wb_entity/my_wb_project_name/my_stream_table_name\", where you can modify the component names to the relevant strings (e.g. your W&B username or shared W&B team name, a new or existing W&B project name).\n",
+    "\n",
+    "\n",
+    "**Note**: if you are logged in on the current machine and have a ~/.netrc file saved with your W&B credentials, this will be the default entity used if you do not pass in an entity to the constructor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25bfa9dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st = StreamTable(f\"{WB_ENTITY}/{WB_PROJECT}/{STREAM_TABLE_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "073d25c9",
+   "metadata": {},
+   "source": [
+    "## Step 2: Log some data\n",
+    "\n",
+    "To add rows to the StreamTable, call `.log()` on the StreamTable object. \n",
+    "`.log()` accepts a single dictionary or a list of dictionaries, where each dictionary entry corresponds to one row of the table. In each dictionary, the keys are column names and the values are the corresponding cell values.\n",
+    "\n",
+    "```python\n",
+    "st.log({\"one_column_name\" : \"value_a\", \"another_column_name\" : 7})\n",
+    "st.log([({\"one_column_name\" : \"value_b\", \"another_column_name\" : 19},\n",
+    "         {\"one_column_name\" : \"value_c\", \"another_column_name\" : 28},\n",
+    "         {\"one_column_name\" : \"value_d\", \"another_column_name\" : 36}]\n",
+    "```\n",
+    "\n",
+    "The first call to `.log()` will return a Weave Panel URL, where you can view, edit, and save the resulting StreamTable as a Weave Board, of the form:\n",
+    "\n",
+    "View data at : https://weave.wandb.ai/?exp=get%28%0A++++%22wandb-artifact%3A%2F%2F%2Fstacey%2Fmesa%2Fmy_stream_1%3Alatest%2Fobj%22%29%0A++.rows\n",
+    "\n",
+    "Subsequent log calls will silently append these rows to the StreamTable instance.\n",
+    "\n",
+    "In a notebook, the StreamTable variable on a line by itself will return a Weave Panel view of the StreamTable. The StreamTable will contain all the logged columns and their values, as well as a `timestamp` column indicating when the row was logged. By default, rows will be ordered by oldest first. You can modify a StreamTable Panel as you would a wandb.Table: sort, filter, group, etc.\n",
+    "\n",
+    "**Note: Column display order is currently non-deterministic**. If you would like to modify the order, open the StreamTable Panel in a new window as a Board and edit/save a Board from this seed. There are two options to achieve this:\n",
+    "* via the weave.wandb.ai URL\n",
+    "* via \"Open in new tab\" arrow button, revealed in the menu when you hover on the right side of a StreamTable panel displayed in the notebok)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b928c2e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# log data to the StreamTable as a dictionary or list of dictionaries\n",
+    "st.log({\"col_a\" : \"1\", \"col_b\" : \"17\", \"col_c\" : \"42\"})\n",
+    "\n",
+    "# show the StreamTable\n",
+    "st"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83cec916",
+   "metadata": {},
+   "source": [
+    "## Step 3: Log more data & explore the results!\n",
+    "\n",
+    "Continue logging as much data as you like. If you save the StreamTable Panel as a Board, the Board will continue to update as you stream more data to the same StreamTable instance.\n",
+    "\n",
+    "### Important usage notes\n",
+    "\n",
+    "Some details to keep in mind for this early iteration of the StreamTables API:\n",
+    "\n",
+    "* **columns must match exactly in each log**: each dictionary passed to .log() must contain a key for every column in the StreamTable instance. Skipping a key, even if its value is null, or adding a new key/column name after the first log call, may break the StreamTable. \n",
+    "* **columns will union across singleton types but not container types**: we strongly recommend keeping the values in one column to one object type (Number, String, image, etc). Logging multiple different singletons to one column will work—that column will become a Union type. However, logging a container type—say, a List of objects to a String type column—may break the StreamTable.\n",
+    "* **optionally use `.finish()` before viewing the StreamTable**: if you'd like to wait for all the rows to finish logging their values before displaying the StreamTable, call `.finish()`. This will take longer to display the Weave Panel if you are logging a large number of rows, or if each log call takes a while to complete (e.g. each row returns the result of running inference on some input to a model). Note that the weave.wandb.ai URL will still show a snapshot of your data at the time it finishes loading — you may need to refresh the page to get all the rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "294d68c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "st.log({\"col_a\" : 5, \"col_b\" : -24, \"col_c\" : \"hello\"})\n",
+    "st.log([{\"col_a\" : 255, \"col_b\" : 3.1415926, \"col_c\" : \"hi!\"}])\n",
+    "\n",
+    "# optional: wait for all the rows to finish logging before loading\n",
+    "st.finish()\n",
+    "\n",
+    "st"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds two files:

- an interactive notebook walkthrough of StreamTable usage here: examples/experimental/ProductionMonitoring/stream_table_api.ipynb
- WIP: a markdown file version of these docs (short, placeholder for now): examples/experimental/ProductionMonitoring/StreamTable.md

TODOs:

- [ ]  finish StreamTable.md, figure out where to link to it?
- [ ]  I still don't understand if/how one can "open/close" a single StreamTable instance — is there a notion of "I'm done logging to this StreamTable" and "I've closed/stopped/shutdown everything, but now I'm back and I'd like to continue appending to this particular StreamTable instance"?
- [ ]  do folks need to login / just have a netrc? can we remove the "entity" requirement, it's extra and not actually required
- [ ]  shall we include a real URL to a real Board? I can publish one, and it will look a bit different probably
- [ ]  in my testing, .finish() doesn't actually make much difference UX wise — trying to log 1000 rows, I still get incomplete rows in the Board, and slow/shimmery/incomplete loading in the in-notebook panel. Should we recommend/mention it at all? Or just leave this as a note for our demos?