### PR TITLE
Fix innerref warning

### DIFF
--- a/weave-js/src/common/components/elements/LegacyWBIcon.tsx
+++ b/weave-js/src/common/components/elements/LegacyWBIcon.tsx
@@ -60,6 +60,9 @@ const LegacyWBIconComp = React.forwardRef<HTMLElement, LegacyWBIconProps>(
       style,
       'data-test': dataTest,
     };
+    if (ref == null) {
+      return <Icon {...passProps} className={className} />;
+    }
     return (
       <Ref innerRef={ref}>
         <Icon {...passProps} className={className} />


### PR DESCRIPTION
LegacyWBIcon required a ref but we dont pass one in most times
![Screenshot 2023-07-14 at 9 42 51 AM](https://github.com/wandb/weave/assets/25037002/4d87a200-8c78-44cb-9981-32c77a4ac49b)
