### PR TITLE
chore: prevent 'Functions are not valid as a React child' warning

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
@@ -98,7 +98,7 @@ export const HomePreviewSidebarTemplate: React.FC<{
                   justifyContent: 'center',
                   gap: '8px',
                 }}>
-                {props.primaryAction.icon}
+                <props.primaryAction.icon />
                 {props.primaryAction.label}
               </LayoutElements.HStack>
             </WBButton>
@@ -111,7 +111,7 @@ export const HomePreviewSidebarTemplate: React.FC<{
                   justifyContent: 'center',
                   gap: '8px',
                 }}>
-                {props.secondaryAction.icon}
+                <props.secondaryAction.icon />
                 {props.secondaryAction.label}
               </LayoutElements.HStack>
             </WBButton>


### PR DESCRIPTION
When viewing preview, was getting this console warning:

<img width="1469" alt="Screenshot 2023-07-14 at 3 00 10 PM" src="https://github.com/wandb/weave/assets/112953339/5d039492-5979-4f81-8f65-401ed2062205">
