### PR TITLE
chore: refine signal handlers

### DIFF
--- a/weave/signal_handlers.py
+++ b/weave/signal_handlers.py
@@ -1,47 +1,84 @@
 import gc
 import os
+import logging
 import datetime
 import threading
 import traceback
 import signal
 import sys
 import typing
+import pathlib
 from types import FrameType
 
 
 from . import environment
 
 
-def install_signal_handlers() -> None:
+def dump_folder() -> pathlib.Path:
+    folder = pathlib.Path(os.environ.get("WEAVE_DEBUG_DUMP_FOLDER", ""))
+    tmp = pathlib.Path("/tmp")
+    if folder == "" or not folder.exists():
+        if folder == "":
+            logging.warning(
+                f"WEAVE_DEBUG_DUMP_FOLDER {folder} does not exist, using /tmp"
+            )
+        folder = tmp
+    return folder.absolute()
+
+
+def make_output_path(root: str) -> str:
+    return str(
+        dump_folder()
+        / f"{root}-{os.getpid()}-{datetime.datetime.now().isoformat()}.txt".replace(
+            " ", "_"
+        )
+    )
+
+
+def dump_stack_traces(signal: int, frame: typing.Optional[FrameType]) -> None:
+    """Function to be executed when the signal is received."""
+
+    id_to_name = dict([(th.ident, th.name) for th in threading.enumerate()])
+    code = []
+    for threadId, stack in sys._current_frames().items():
+        thread_name = id_to_name.get(threadId, "")
+        if thread_name == "MainThread" and frame is not None:
+            stack = frame
+        code.append("\n# Thread: %s(%d)" % (thread_name, threadId))
+        for filename, lineno, name, line in traceback.extract_stack(stack):
+            code.append('File: "%s", line %d, in %s' % (filename, lineno, name))
+            if line:
+                code.append("  %s" % (line.strip()))
+
+    output_path = make_output_path("weave_server_stack_dump")
+    with open(output_path, "w+") as f:
+        f.write("\n".join(code))
+
+
+def objgraph_getnewids(signal: int, frame: typing.Optional[FrameType]) -> None:
     import objgraph
+
+    gc.collect()
+    output_path = make_output_path("weave_server_objgraph_newids")
+    with open(output_path, "w") as f:
+        objgraph.get_new_ids(limit=100, file=f)
+
+
+def objgraph_showgrowth(signal: int, frame: typing.Optional[FrameType]) -> None:
+    import objgraph
+
+    gc.collect()
+    output_path = make_output_path("weave_server_objgraph_growth")
+    with open(output_path, "w") as f:
+        objgraph.show_growth(limit=100, file=f)
+
+
+def install_signal_handlers() -> None:
 
     if (
         environment.memdump_sighandler_enabled()
         or environment.stack_dump_sighandler_enabled()
     ):
-
-        def dump_stack_traces(signal: int, frame: typing.Optional[FrameType]) -> None:
-            """Function to be executed when the signal is received."""
-
-            id_to_name = dict([(th.ident, th.name) for th in threading.enumerate()])
-            code = []
-            for threadId, stack in sys._current_frames().items():
-                thread_name = id_to_name.get(threadId, "")
-                if thread_name == "MainThread" and frame is not None:
-                    stack = frame
-                code.append("\n# Thread: %s(%d)" % (thread_name, threadId))
-                for filename, lineno, name, line in traceback.extract_stack(stack):
-                    code.append('File: "%s", line %d, in %s' % (filename, lineno, name))
-                    if line:
-                        code.append("  %s" % (line.strip()))
-
-            with open(
-                f"/tmp/weave_thread_stacks.{os.getpid()}-{datetime.datetime.now()}.txt".replace(
-                    " ", "_"
-                ),
-                "w+",
-            ) as f:
-                f.write("\n".join(code))
 
         # Here we set the SIGUSR1 signal handler to our function dump_stack_traces
         # To use, send a SIGUSR1 signal to set a baseline, then do some requests.
@@ -59,12 +96,6 @@ def install_signal_handlers() -> None:
         # objgraph.show_most_common_types(limit=20)
         # obj = objgraph.by_type('TypedDict')[100]
 
-        def objgraph_getnewids(signal: int, frame: typing.Optional[FrameType]) -> None:
-            gc.collect()
-            fname = f"/tmp/weave-server-objgraph-newids-{os.getpid()}-{datetime.datetime.now().isoformat()}.txt"
-            with open(fname, "w") as f:
-                objgraph.get_new_ids(limit=100, file=f)
-
         def sigusr1_handler(signal: int, frame: typing.Optional[FrameType]) -> None:
             if environment.memdump_sighandler_enabled():
                 objgraph_getnewids(signal, frame)
@@ -74,13 +105,5 @@ def install_signal_handlers() -> None:
         signal.signal(signal.SIGUSR1, sigusr1_handler)
 
         if environment.memdump_sighandler_enabled():
-
-            def objgraph_showgrowth(
-                signal: int, frame: typing.Optional[FrameType]
-            ) -> None:
-                gc.collect()
-                fname = f"/tmp/weave-server-objgraph-growth-{os.getpid()}-{datetime.datetime.now().isoformat()}.txt"
-                with open(fname, "w") as f:
-                    objgraph.show_growth(limit=100, file=f)
 
             signal.signal(signal.SIGUSR2, objgraph_showgrowth)

--- a/weave/signal_handlers.py
+++ b/weave/signal_handlers.py
@@ -1,0 +1,86 @@
+import gc
+import os
+import datetime
+import threading
+import traceback
+import signal
+import sys
+import typing
+from types import FrameType
+
+
+from . import environment
+
+
+def install_signal_handlers() -> None:
+    import objgraph
+
+    if (
+        environment.memdump_sighandler_enabled()
+        or environment.stack_dump_sighandler_enabled()
+    ):
+
+        def dump_stack_traces(signal: int, frame: typing.Optional[FrameType]) -> None:
+            """Function to be executed when the signal is received."""
+
+            id_to_name = dict([(th.ident, th.name) for th in threading.enumerate()])
+            code = []
+            for threadId, stack in sys._current_frames().items():
+                thread_name = id_to_name.get(threadId, "")
+                if thread_name == "MainThread" and frame is not None:
+                    stack = frame
+                code.append("\n# Thread: %s(%d)" % (thread_name, threadId))
+                for filename, lineno, name, line in traceback.extract_stack(stack):
+                    code.append('File: "%s", line %d, in %s' % (filename, lineno, name))
+                    if line:
+                        code.append("  %s" % (line.strip()))
+
+            with open(
+                f"/tmp/weave_thread_stacks.{os.getpid()}-{datetime.datetime.now()}.txt".replace(
+                    " ", "_"
+                ),
+                "w+",
+            ) as f:
+                f.write("\n".join(code))
+
+        # Here we set the SIGUSR1 signal handler to our function dump_stack_traces
+        # To use, send a SIGUSR1 signal to set a baseline, then do some requests.
+        # Then send a SIGUSR2 signal to drop the server into pdb and do
+        # import objgraph
+        # obj_ids = objgraph.get_new_ids()
+        # This will contain all the ids of objects that have been created since
+        # the last call to objgraph.get_new_ids()
+        # Then you can inspect objects like:
+        # obj_id = obj_ids['TypedDict'][0]
+        # obj = objgraph.at(obj_id)
+        # objgraph.show_backrefs([obj], max_depth=15)
+        #
+        # Other useful objgraph commands:
+        # objgraph.show_most_common_types(limit=20)
+        # obj = objgraph.by_type('TypedDict')[100]
+
+        def objgraph_getnewids(signal: int, frame: typing.Optional[FrameType]) -> None:
+            gc.collect()
+            fname = f"/tmp/weave-server-objgraph-newids-{os.getpid()}-{datetime.datetime.now().isoformat()}.txt"
+            with open(fname, "w") as f:
+                objgraph.get_new_ids(limit=100, file=f)
+
+        def sigusr1_handler(signal: int, frame: typing.Optional[FrameType]) -> None:
+            if environment.memdump_sighandler_enabled():
+                objgraph_getnewids(signal, frame)
+            if environment.stack_dump_sighandler_enabled():
+                dump_stack_traces(signal, frame)
+
+        signal.signal(signal.SIGUSR1, sigusr1_handler)
+
+        if environment.memdump_sighandler_enabled():
+
+            def objgraph_showgrowth(
+                signal: int, frame: typing.Optional[FrameType]
+            ) -> None:
+                gc.collect()
+                fname = f"/tmp/weave-server-objgraph-growth-{os.getpid()}-{datetime.datetime.now().isoformat()}.txt"
+                with open(fname, "w") as f:
+                    objgraph.show_growth(limit=100, file=f)
+
+            signal.signal(signal.SIGUSR2, objgraph_showgrowth)

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -1,14 +1,9 @@
 import cProfile
-import datetime
-import gc
 import os
-import objgraph
 import logging
 import pathlib
 import time
 import traceback
-import threading
-import signal
 import sys
 import base64
 import typing
@@ -38,6 +33,7 @@ from weave.server_error_handling import client_safe_http_exceptions_as_werkzeug
 from weave import storage
 from weave import wandb_api
 from weave.language_features.tagging import tag_store
+from weave import signal_handlers
 
 # PROFILE_DIR = "/tmp/weave/profile"
 PROFILE_DIR = None
@@ -94,72 +90,7 @@ if os.environ.get("FLASK_DEBUG"):
 static_folder = os.path.join(os.path.dirname(__file__), "frontend")
 blueprint = Blueprint("weave", "weave-server", static_folder=static_folder)
 
-
-if (
-    environment.memdump_sighandler_enabled()
-    or environment.stack_dump_sighandler_enabled()
-):
-
-    def dump_stack_traces(signal, frame):
-        """Function to be executed when the signal is received."""
-        id_to_name = dict([(th.ident, th.name) for th in threading.enumerate()])
-        code = []
-        code.append(f"\nMain thread: {traceback.format_stack(frame)}")
-        for threadId, stack in sys._current_frames().items():
-            thread_name = id_to_name.get(threadId, "")
-            if thread_name == "MainThread":
-                continue
-            code.append("\n# Thread: %s(%d)" % (thread_name, threadId))
-            for filename, lineno, name, line in traceback.extract_stack(stack):
-                code.append('File: "%s", line %d, in %s' % (filename, lineno, name))
-                if line:
-                    code.append("  %s" % (line.strip()))
-
-        with open(
-            f"/tmp/weave_thread_stacks.{os.getpid()}-{datetime.datetime.now()}.txt",
-            "w+",
-        ) as f:
-            f.write("\n".join(code))
-
-    # Here we set the SIGUSR1 signal handler to our function dump_stack_traces
-    # To use, send a SIGUSR1 signal to set a baseline, then do some requests.
-    # Then send a SIGUSR2 signal to drop the server into pdb and do
-    # import objgraph
-    # obj_ids = objgraph.get_new_ids()
-    # This will contain all the ids of objects that have been created since
-    # the last call to objgraph.get_new_ids()
-    # Then you can inspect objects like:
-    # obj_id = obj_ids['TypedDict'][0]
-    # obj = objgraph.at(obj_id)
-    # objgraph.show_backrefs([obj], max_depth=15)
-    #
-    # Other useful objgraph commands:
-    # objgraph.show_most_common_types(limit=20)
-    # obj = objgraph.by_type('TypedDict')[100]
-
-    def objgraph_getnewids(signal, frame):
-        gc.collect()
-        fname = f"/tmp/weave-server-objgraph-newids-{os.getpid()}-{datetime.datetime.now().isoformat()}.txt"
-        with open(fname, "w") as f:
-            objgraph.get_new_ids(limit=100, file=f)
-
-    def sigusr1_handler(signal, frame):
-        if environment.memdump_sighandler_enabled():
-            objgraph_getnewids(signal, frame)
-        if environment.stack_dump_sighandler_enabled():
-            dump_stack_traces(signal, frame)
-
-    signal.signal(signal.SIGUSR1, sigusr1_handler)
-
-    if environment.memdump_sighandler_enabled():
-
-        def objgraph_showgrowth(signal, frame):
-            gc.collect()
-            fname = f"/tmp/weave-server-objgraph-growth-{os.getpid()}-{datetime.datetime.now().isoformat()}.txt"
-            with open(fname, "w") as f:
-                objgraph.show_growth(limit=100, file=f)
-
-        signal.signal(signal.SIGUSR2, objgraph_showgrowth)
+signal_handlers.install_signal_handlers()
 
 
 def import_ecosystem():


### PR DESCRIPTION
* Fixes an issue where the trace dumper was writing the traceback for the signal handler and not the main thread from when the signal was called
* Refactors signal handler installation to make it more modular
* Fixes an issue where memory dump handlers and traceback dump handlers were not being properly interleaved