### PR TITLE
chore: dont intercept other signal handling paths, fix path setting bug

### DIFF
--- a/weave/signal_handlers.py
+++ b/weave/signal_handlers.py
@@ -15,10 +15,11 @@ from . import environment
 
 
 def dump_folder() -> pathlib.Path:
-    folder = pathlib.Path(os.environ.get("WEAVE_DEBUG_DUMP_FOLDER", ""))
+    raw_folder = os.environ.get("WEAVE_DEBUG_DUMP_FOLDER", "")
+    folder = pathlib.Path(raw_folder)
     tmp = pathlib.Path("/tmp")
-    if folder == "" or not folder.exists():
-        if folder == "":
+    if raw_folder == "" or not folder.exists():
+        if raw_folder == "":
             logging.warning(
                 f"WEAVE_DEBUG_DUMP_FOLDER {folder} does not exist, using /tmp"
             )

--- a/weave/signal_handlers.py
+++ b/weave/signal_handlers.py
@@ -73,13 +73,30 @@ def objgraph_showgrowth(signal: int, frame: typing.Optional[FrameType]) -> None:
         objgraph.show_growth(limit=100, file=f)
 
 
-def install_signal_handlers() -> None:
+def install_signal_handler_to_be_called_after_existing(
+    signum: int, handler: typing.Callable[[int, typing.Optional[FrameType]], None]
+) -> None:
+    cur_sig_handler = signal.getsignal(signum)
+    if (
+        cur_sig_handler is not None
+        and cur_sig_handler != signal.SIG_DFL
+        and cur_sig_handler != signal.SIG_IGN
+    ):
 
+        def new_handler(signal: int, frame: typing.Optional[FrameType]) -> None:
+            cur_sig_handler(signal, frame)  # type: ignore
+            handler(signal, frame)
+
+        signal.signal(signum, new_handler)
+    else:
+        signal.signal(signum, handler)
+
+
+def install_signal_handlers() -> None:
     if (
         environment.memdump_sighandler_enabled()
         or environment.stack_dump_sighandler_enabled()
     ):
-
         # Here we set the SIGUSR1 signal handler to our function dump_stack_traces
         # To use, send a SIGUSR1 signal to set a baseline, then do some requests.
         # Then send a SIGUSR2 signal to drop the server into pdb and do
@@ -102,8 +119,11 @@ def install_signal_handlers() -> None:
             if environment.stack_dump_sighandler_enabled():
                 dump_stack_traces(signal, frame)
 
-        signal.signal(signal.SIGUSR1, sigusr1_handler)
+        install_signal_handler_to_be_called_after_existing(
+            signal.SIGUSR1, sigusr1_handler
+        )
 
         if environment.memdump_sighandler_enabled():
-
-            signal.signal(signal.SIGUSR2, objgraph_showgrowth)
+            install_signal_handler_to_be_called_after_existing(
+                signal.SIGUSR2, objgraph_showgrowth
+            )

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -33,7 +33,7 @@ from weave.server_error_handling import client_safe_http_exceptions_as_werkzeug
 from weave import storage
 from weave import wandb_api
 from weave.language_features.tagging import tag_store
-from weave import signal_handlers
+
 
 # PROFILE_DIR = "/tmp/weave/profile"
 PROFILE_DIR = None
@@ -89,8 +89,6 @@ if os.environ.get("FLASK_DEBUG"):
 
 static_folder = os.path.join(os.path.dirname(__file__), "frontend")
 blueprint = Blueprint("weave", "weave-server", static_folder=static_folder)
-
-signal_handlers.install_signal_handlers()
 
 
 def import_ecosystem():


### PR DESCRIPTION
* Fixes a bug where the default signal handling dump path was not being set properly
* Does not install debugging signal handlers by default
* Preserves existing signal handling paths if they exist