### PR TITLE
fix: not reflecting UTC timezone properly

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterBrowser.tsx
@@ -10,6 +10,7 @@ import {WeaveAnimatedLoader} from '../../Panel2/WeaveAnimatedLoader';
 const TableRow = styled.tr<{$highlighted?: boolean}>`
   background-color: ${props => (props.$highlighted ? '#f8f9fa' : '')};
 `;
+TableRow.displayName = 'S.TableRow';
 
 const CenterTable = styled.table`
   width: 100%;
@@ -79,6 +80,7 @@ const CenterTable = styled.table`
     }
   }
 `;
+CenterTable.displayName = 'S.CenterTable';
 
 const CenterTableActionCellAction = styled(LayoutElements.HBlock)`
   padding: 0px 12px;
@@ -92,11 +94,13 @@ const CenterTableActionCellAction = styled(LayoutElements.HBlock)`
     background-color: #f5f6f7;
   }
 `;
+CenterTableActionCellAction.displayName = 'S.CenterTableActionCellAction';
 
 const CenterTableActionCellContents = styled(LayoutElements.VStack)`
   align-items: center;
   justify-content: center;
 `;
+CenterTableActionCellContents.displayName = 'S.CenterTableActionCellContents';
 
 const CenterTableActionCellIcon = styled(LayoutElements.VStack)`
   align-items: center;
@@ -109,26 +113,31 @@ const CenterTableActionCellIcon = styled(LayoutElements.VStack)`
     color: #038194;
   }
 `;
+CenterTableActionCellIcon.displayName = 'S.CenterTableActionCellIcon';
 
 const CenterSpaceTableSpace = styled(LayoutElements.Space)`
   overflow: auto;
 `;
+CenterSpaceTableSpace.displayName = 'S.CenterSpaceTableSpace';
 
 const CenterSpaceControls = styled(LayoutElements.HBlock)`
   gap: 8px;
 `;
+CenterSpaceControls.displayName = 'S.CenterSpaceControls';
 
 const CenterSpaceTitle = styled(LayoutElements.HBlock)`
   font-size: 24px;
   font-weight: 600;
   padding: 12px 8px;
 `;
+CenterSpaceTitle.displayName = 'S.CenterSpaceTitle';
 
 const CenterSpaceHeader = styled(LayoutElements.VBlock)`
   padding: 12px 16px;
   gap: 12px;
   border-bottom: 1px solid #dadee3;
 `;
+CenterSpaceHeader.displayName = 'S.CenterSpaceHeader';
 
 type CenterBrowserDataType<E extends {[key: string]: string | number} = {}> = {
   _id: string;

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -103,7 +103,7 @@ export const CenterEntityBrowserInner: React.FC<
         (meta.num_stream_tables + meta.num_logged_tables ?? 0) > 0
           ? meta.num_stream_tables + meta.num_logged_tables
           : null,
-      'updated at': moment.utc(meta.updatedAt).calendar(),
+      'updated at': moment.utc(meta.updatedAt).local().calendar(),
     }));
   }, [projectsMeta.result]);
 
@@ -311,8 +311,8 @@ const CenterProjectBoardsBrowser: React.FC<
     return boards.result.map(b => ({
       _id: b.name,
       name: b.name,
-      'updated at': moment.utc(b.updatedAt).calendar(),
-      'created at': moment.utc(b.createdAt).calendar(),
+      'updated at': moment.utc(b.updatedAt).local().calendar(),
+      'created at': moment.utc(b.createdAt).local().calendar(),
       'created by': b.createdByUserName,
     }));
   }, [boards]);
@@ -455,8 +455,8 @@ const CenterProjectTablesBrowser: React.FC<
       _updatedAt: b.updatedAt,
       name: b.name,
       kind: 'Stream Table',
-      'updated at': moment.utc(b.updatedAt).calendar(),
-      'created at': moment.utc(b.createdAt).calendar(),
+      'updated at': moment.utc(b.updatedAt).local().calendar(),
+      'created at': moment.utc(b.createdAt).local().calendar(),
       'created by': b.createdByUserName,
     }));
     const logged = loggedTables.result.map(b => ({
@@ -464,8 +464,8 @@ const CenterProjectTablesBrowser: React.FC<
       _updatedAt: b.updatedAt,
       name: b.name,
       kind: 'Logged Table',
-      'updated at': moment.utc(b.updatedAt).calendar(),
-      'created at': moment.utc(b.createdAt).calendar(),
+      'updated at': moment.utc(b.updatedAt).local().calendar(),
+      'created at': moment.utc(b.createdAt).local().calendar(),
       'created by': b.createdByUserName,
     }));
     const combined = [...streams, ...logged];

--- a/weave/weave_types.py
+++ b/weave/weave_types.py
@@ -658,7 +658,8 @@ class Timestamp(Type):
     def from_isostring(self, iso: str) -> datetime.datetime:
         # NOTE: This assumes ISO 8601 format from GQL endpoints, it does NOT
         # support RFC 3339 strings with a "Z" at the end before python 3.11
-        return datetime.datetime.fromisoformat(iso)
+        tz_naive = datetime.datetime.fromisoformat(iso)
+        return tz_naive.replace(tzinfo=datetime.timezone.utc)
 
     def save_instance(self, obj, artifact, name):
         if artifact is None:


### PR DESCRIPTION
My time zone is five hours behind UTC. The timestamps we are showing for created/updated times are 10 hours ahead for me, frequently showing that things were updated "tomorrow" or later today. I think there are two issues:

1. Our stored/API timestamps are UTC (as they should be) but if we are showing relative times like "tomorrow" it should be based on user's local time. We are showing a relative display for UTC with no time zone indication.
2. There is no timezone information being passed into `datetime.datetime.fromisoformat` so it is creating a timezone naive object. Because of this, something I didn't track down is assuming it to be local rather than UTC.

Before:
<img width="853" alt="Screenshot 2023-07-18 at 9 27 40 AM" src="https://github.com/wandb/weave/assets/112953339/8e701bfc-54fd-4db7-bf62-3b3ef99900f7">

After:
<img width="876" alt="Screenshot 2023-07-18 at 9 28 10 AM" src="https://github.com/wandb/weave/assets/112953339/73b4a407-ffcb-4537-b476-e0563c5116aa">

As a follow up, we should probably be giving user control of / displaying what timezone something is for PanelDate.