### PR TITLE
feat: select entity/project on publish new

### DIFF
--- a/weave-js/src/components/PagePanelComponents/PublishModal.tsx
+++ b/weave-js/src/components/PagePanelComponents/PublishModal.tsx
@@ -1,0 +1,219 @@
+import {
+  Dropdown,
+  DropdownItemProps,
+  Form,
+  Input,
+  Modal,
+} from 'semantic-ui-react';
+import React from 'react';
+import styled from 'styled-components';
+import {RED_550} from '@wandb/weave/common/css/color.styles';
+import {WBButton} from '@wandb/weave/common/components/elements/WBButtonNew';
+import * as query from './Home/query';
+import {useIsAuthenticated} from './util';
+import {useEffect, useState} from 'react';
+import * as w from '@wandb/weave/core';
+import {useNodeValue} from '@wandb/weave/react';
+import {Icon} from '../Icon';
+import {TakeActionType} from './persistenceStateMachine';
+import * as M from './Modal.styles';
+
+const Error = styled.div`
+  font-size: 14px;
+  color: ${RED_550};
+`;
+Error.displayName = 'S.Error';
+
+type PublishModalProps = {
+  defaultName: string | null;
+  open: boolean;
+  acting: boolean;
+  takeAction: TakeActionType;
+  onClose: () => void;
+};
+
+// TODO: Starting/ending with '.' or '-' should probably not be allowed.
+const isValidBoardName = (name: string) => {
+  return (
+    0 < name.length && name.length <= 128 && /^[a-zA-Z0-9_.-]+$/.test(name)
+  );
+};
+
+export const PublishModal = ({
+  defaultName,
+  open,
+  acting,
+  takeAction,
+  onClose,
+}: PublishModalProps) => {
+  const [boardName, setBoardName] = useState(defaultName ?? '');
+  const [entityName, setEntityName] = useState('');
+  const [projectName, setProjectName] = useState('');
+  const isValidName = isValidBoardName(boardName);
+  const showError = boardName.length > 0 && !isValidName;
+
+  const isAuthenticated = useIsAuthenticated();
+  const userEntities = query.useUserEntities(isAuthenticated);
+  const userName = query.useUserName(isAuthenticated);
+
+  const iconStyle = {
+    verticalAlign: 'middle',
+    display: 'inline-block',
+    marginRight: 8,
+  };
+
+  const entityOptions: DropdownItemProps[] =
+    userEntities.result.length === 0
+      ? []
+      : userEntities.result.sort().map(entName => ({
+          icon: (
+            <Icon
+              name={
+                entName === userName.result
+                  ? 'user-profile-personal'
+                  : 'users-team'
+              }
+              style={iconStyle}
+            />
+          ),
+          value: entName,
+          text: entName,
+        }));
+
+  const projectsNode = w.opEntityProjects({
+    entity: w.opRootEntity({
+      entityName: w.constString(entityName),
+    }),
+  });
+  const projectDataNode = w.opMap({
+    arr: projectsNode,
+    mapFn: w.constFunction({row: 'project'}, ({row}) => {
+      return w.opDict({
+        name: w.opProjectName({project: row}),
+      } as any);
+    }),
+  });
+
+  // Initialize the entity selector to first option (user entity)
+  useEffect(() => {
+    if (!userEntities.loading && entityOptions.length > 0) {
+      setEntityName(entityOptions[0].value as string);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userEntities.loading]);
+
+  const projectNamesValue = useNodeValue(projectDataNode, {
+    skip: entityName === '',
+  });
+  const projectNames: string[] = projectNamesValue.result
+    ? projectNamesValue.result
+        .map((project: {name: string}) => project.name)
+        .filter((name: string) => name !== 'model-registry')
+    : [];
+
+  projectNames.sort();
+  const projectOptions = projectNames.map(name => ({
+    icon: <Icon name="folder-project" style={iconStyle} />,
+    value: name,
+    text: name,
+  }));
+
+  // Initalize the project selector to "weave" project if available,
+  // otherwise first project.
+  useEffect(() => {
+    if (!projectNamesValue.loading && projectNames.length > 0) {
+      const defaultProjectName = projectNames.includes('weave')
+        ? 'weave'
+        : projectNames[0];
+      setProjectName(defaultProjectName);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectNamesValue.loading]);
+
+  const onPublish = async () => {
+    takeAction(
+      'publish_new',
+      {
+        entityName,
+        projectName,
+        name: boardName,
+      },
+      () => {
+        onClose();
+      }
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      closeOnDimmerClick={false}
+      size="small">
+      <Modal.Content>
+        <M.Title>Publish board</M.Title>
+        <M.Description>
+          Name your board and select a destination entity and project in Weights
+          & Biases.
+        </M.Description>
+        <Form>
+          <Form.Field>
+            <label>Name</label>
+            <Input
+              value={boardName}
+              placeholder="Name"
+              onChange={e => setBoardName(e.target.value)}
+              error={showError}
+            />
+            {showError && (
+              <Error>Spaces and special characters are not allowed.</Error>
+            )}
+          </Form.Field>
+          <Form.Field>
+            <label>Entity</label>
+            <Dropdown
+              placeholder="Select entity"
+              fluid
+              selection
+              options={entityOptions}
+              value={entityName}
+              onChange={(e, data) => {
+                setEntityName(data.value as string);
+                setProjectName('');
+              }}
+            />
+          </Form.Field>
+          <Form.Field>
+            <label>Project</label>
+            {projectOptions.length > 0 ? (
+              <Dropdown
+                placeholder="Select project"
+                fluid
+                selection
+                options={projectOptions}
+                value={projectName}
+                onChange={(e, data) => {
+                  setProjectName(data.value as string);
+                }}
+              />
+            ) : (
+              <span>Entity has no project</span>
+            )}
+          </Form.Field>
+        </Form>
+        <M.Buttons>
+          <WBButton
+            variant="confirm"
+            loading={acting}
+            disabled={!isValidName || !entityName || !projectName || acting}
+            onClick={onPublish}>
+            Publish board
+          </WBButton>
+          <WBButton variant="ghost" onClick={onClose}>
+            Cancel
+          </WBButton>
+        </M.Buttons>
+      </Modal.Content>
+    </Modal>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/PublishModal.tsx
+++ b/weave-js/src/components/PagePanelComponents/PublishModal.tsx
@@ -85,14 +85,6 @@ export const PublishModal = ({
       entityName: w.constString(entityName),
     }),
   });
-  const projectDataNode = w.opMap({
-    arr: projectsNode,
-    mapFn: w.constFunction({row: 'project'}, ({row}) => {
-      return w.opDict({
-        name: w.opProjectName({project: row}),
-      } as any);
-    }),
-  });
 
   // Initialize the entity selector to first option (user entity)
   useEffect(() => {
@@ -102,13 +94,14 @@ export const PublishModal = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userEntities.loading]);
 
+  const projectDataNode = w.opProjectName({project: projectsNode});
   const projectNamesValue = useNodeValue(projectDataNode, {
     skip: entityName === '',
   });
   const projectNames: string[] = projectNamesValue.result
-    ? projectNamesValue.result
-        .map((project: {name: string}) => project.name)
-        .filter((name: string) => name !== 'model-registry')
+    ? projectNamesValue.result.filter(
+        (name: string) => name !== 'model-registry'
+      )
     : [];
 
   projectNames.sort();

--- a/weave-js/src/components/PagePanelComponents/persistenceStateMachine.ts
+++ b/weave-js/src/components/PagePanelComponents/persistenceStateMachine.ts
@@ -280,7 +280,7 @@ export const useStateMachine = (
             entity_name:
               actionOptions.entityName != null
                 ? constString(actionOptions.entityName)
-                : constString(''),
+                : constNone(),
           },
           newRoot => {
             updateNode(newRoot);

--- a/weave-js/src/components/PagePanelComponents/persistenceStateMachine.ts
+++ b/weave-js/src/components/PagePanelComponents/persistenceStateMachine.ts
@@ -272,15 +272,22 @@ export const useStateMachine = (
             artifact_name:
               actionOptions.name != null
                 ? constString(toArtifactSafeName(actionOptions.name))
-                : constNone(), // TODO: Allow user to specify name
-            project_name: constString('weave'), // TODO: Allow user to specify name
+                : constNone(),
+            project_name:
+              actionOptions.projectName != null
+                ? constString(actionOptions.projectName)
+                : constString('weave'),
+            entity_name:
+              actionOptions.entityName != null
+                ? constString(actionOptions.entityName)
+                : constString(''),
           },
           newRoot => {
             updateNode(newRoot);
           }
         );
       } else if (action === 'commit') {
-        await makeMutation(inputNode, 'merge', {}, newRoot => {
+        await makeMutation(inputNode, 'merge_artifact', {}, newRoot => {
           updateNode(newRoot);
         });
       } else if (action === 'delete_local' || action === 'delete_remote') {

--- a/weave-js/src/components/PagePanelComponents/util.ts
+++ b/weave-js/src/components/PagePanelComponents/util.ts
@@ -104,7 +104,7 @@ export const weaveTypeIsPanelGroup = (weaveType?: Type) => {
 };
 
 export const toArtifactSafeName = (name: string) =>
-  name.replace(/[^a-zA-Z0-9]/g, '_');
+  name.replace(/[^a-zA-Z0-9-.]/g, '_');
 
 const entityNameFromRemoteURI = (uri: RemoteURIType) => {
   const parts = uri.split(REMOTE_URI_PREFIX)[1].split('/');

--- a/weave/ops_primitives/weave_api.py
+++ b/weave/ops_primitives/weave_api.py
@@ -614,6 +614,7 @@ def publish_artifact(
     self: graph.Node[typing.Any],
     artifact_name: typing.Optional[str],
     project_name: typing.Optional[str],
+    entity_name: typing.Optional[str],
     # root_args: typing.Any = None,
 ) -> str:
     head_ref = _artifact_ref_from_uri(_get_uri_from_node(self, "Publish"), "Publish")
@@ -622,6 +623,7 @@ def publish_artifact(
         head_ref.get(),
         art_name,
         project_name,
+        wb_entity_name=entity_name,
         metadata=head_ref.artifact.metadata.as_dict(),
     )
     return str(ref)

--- a/weave/storage.py
+++ b/weave/storage.py
@@ -63,10 +63,42 @@ def _ensure_object_components_are_published(
 def _assert_valid_name_part(part: typing.Optional[str] = None):
     if part is None:
         return
-    # if not re.match(r"^[a-zA-Z0-9_\-.]+$", part): # from W&B Artifacts
     if not re.match(r"^[a-zA-Z0-9_\-]+$", part):
         raise ValueError(
             "Invalid name part %s. Must be alphanumeric, dashes, or underscores." % part
+        )
+
+
+def _assert_valid_entity_name(part: typing.Optional[str] = None):
+    if part is None:
+        return
+    if not re.match(r"^[a-z0-9_\-]+$", part):
+        raise ValueError(
+            "Invalid entity name %s. Must be lowercase, digits, dashes, or underscores."
+            % part
+        )
+
+
+def _assert_valid_project_name(part: typing.Optional[str] = None):
+    if part is None:
+        return
+    if len(part) > 128:
+        raise ValueError("Invalid project name %s. Must be <= 128 characters." % part)
+    if re.match(r"[\\#?%:]", part):
+        raise ValueError(
+            "Invalid project name %s. Can not contain \\, #, ?, %%, or :" % part
+        )
+
+
+def _assert_valid_artifact_name(part: typing.Optional[str] = None):
+    if part is None:
+        return
+    if len(part) > 128:
+        raise ValueError("Invalid artifact name %s. Must be <= 128 characters." % part)
+    if not re.match(r"^[a-zA-Z0-9_\-.]+$", part):  # from W&B Artifacts
+        raise ValueError(
+            "Invalid artifact name %s. Must be alphanumeric, periods, dashes, or underscores."
+            % part
         )
 
 
@@ -88,11 +120,11 @@ def _direct_publish(
     name = name or _get_name(weave_type, obj)
     wb_artifact_type_name = wb_artifact_type_name or weave_type.name
 
-    _assert_valid_name_part(name)
-    _assert_valid_name_part(wb_project_name)
+    _assert_valid_artifact_name(name)
+    _assert_valid_project_name(wb_project_name)
     _assert_valid_name_part(wb_artifact_type_name)
     _assert_valid_name_part(branch_name)
-    _assert_valid_name_part(wb_entity_name)
+    _assert_valid_entity_name(wb_entity_name)
     # Validate entity name once we have them
 
     obj = box.box(obj)

--- a/weave/tests/test_artifact_metadata.py
+++ b/weave/tests/test_artifact_metadata.py
@@ -58,6 +58,7 @@ def test_artifact_metadata(user_by_api_key_in_env):
         weave.ops.get(local_art.uri + "/obj"),
         "test_artifact",
         "test_project",
+        None,
     )
     remote_ref = artifact_wandb.WandbArtifactRef.from_uri(
         artifact_wandb.WeaveWBArtifactURI.parse(remote_uri)

--- a/weave/tests/test_mutation2.py
+++ b/weave/tests/test_mutation2.py
@@ -143,7 +143,7 @@ def test_artifact_history_remote_with_branch(user_by_api_key_in_env):
     uri = "local-artifact:///art:main/obj"
     weave.save([0], "art:main")
     art = weave.ops.get(uri)
-    published_art_uri = weave.ops.publish_artifact(art, "art", None)
+    published_art_uri = weave.ops.publish_artifact(art, "art", None, None)
 
     art = weave.ops.get(
         f"wandb-artifact:///{user_by_api_key_in_env.username}/weave/art:latest/obj"
@@ -173,7 +173,7 @@ def test_artifact_history_remote_with_hash(user_by_api_key_in_env):
     uri = "local-artifact:///art:main/obj"
     weave.save([0], "art:main")
     art = weave.ops.get(uri)
-    published_art_uri = weave.ops.publish_artifact(art, "art", None)
+    published_art_uri = weave.ops.publish_artifact(art, "art", None, None)
     assert "latest" not in published_art_uri
     assert "main" not in published_art_uri
 

--- a/weave/tests/test_publish_flow.py
+++ b/weave/tests/test_publish_flow.py
@@ -116,7 +116,7 @@ There are 3 actions:
    * The branchpoint URI can be any of the 6 location types above.
 
 In summary, there will be 22 tests:
-   
+
 * 6 `Persist` tests
 * 6 `Mutate` tests
 * 2 * 6 `Merge` tests (2 types of branchpoints, and 6 branch location types.)
@@ -965,7 +965,7 @@ def test_publish_saved_node(user_by_api_key_in_env):
     assert saved.from_op.inputs["uri"].val.startswith("local-artifact://")
     assert weave.use(saved) == data
 
-    published_art_uri = weave.ops.publish_artifact(saved, "my_list", None)
+    published_art_uri = weave.ops.publish_artifact(saved, "my_list", None, None)
     assert published_art_uri.startswith("wandb-artifact://")
     assert weave.use(weave.get(published_art_uri)) == data
 
@@ -1018,7 +1018,7 @@ def test_end_to_end_save_and_publish_flow(user_by_api_key_in_env):
     assert weave.use(merged_node) == branched_data
 
     # Step 4: Publish the new version remotely
-    published_uri = weave.ops.publish_artifact(merged_node, "my_list", None)
+    published_uri = weave.ops.publish_artifact(merged_node, "my_list", None, None)
     assert published_uri.startswith("wandb-artifact://")
     assert weave.use(weave.get(published_uri)) == branched_data
 


### PR DESCRIPTION
When publishing a new board, allow the user to select entity and project.

<img width="741" alt="Screenshot 2023-07-19 at 12 28 49 PM" src="https://github.com/wandb/weave/assets/112953339/512b92c6-24fe-4461-9d7e-668bd1e613b8">

Internal Jira: https://wandb.atlassian.net/browse/WB-14207 (partial)