### PR TITLE
fix: silence error logs in notebook

### DIFF
--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -620,7 +620,7 @@ def _call_and_ensure_awl(
             implementation in compile."
         if isinstance(res, list):
             res = convert.to_arrow(res)
-            logging.error(err_msg)
+            logging.warning(err_msg)
         else:
             raise errors.WeaveVectorizationError(err_msg)
 

--- a/weave/ops_primitives/projection_utils.py
+++ b/weave/ops_primitives/projection_utils.py
@@ -104,7 +104,7 @@ def perform_2D_projection_with_timeout(
         result = result_queue.get(timeout=timeout)
     except queue.Empty:
         target.kill()
-        logging.error(
+        logging.warning(
             f"Projection timed out after {timeout} seconds, killing process {target.pid}, returning empty projection",
         )
 

--- a/weave/server.py
+++ b/weave/server.py
@@ -238,13 +238,11 @@ def capture_weave_server_logs(log_level: int = logging.INFO):
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)
 
-    console_log_settings: typing.Optional[logs.LogSettings]
+    console_log_settings: typing.Optional[logs.LogSettings] = None
     if not util.is_notebook() or util.parse_boolean_env_var(
         "WEAVE_SERVER_FORCE_HTTP_SERVER_CONSOLE_LOGS"
     ):
         console_log_settings = logs.LogSettings(logs.LogFormat.PRETTY, level=None)
-    else:
-        console_log_settings = None
 
     logs.enable_stream_logging(
         root_logger,

--- a/weave/server.py
+++ b/weave/server.py
@@ -238,8 +238,16 @@ def capture_weave_server_logs(log_level: int = logging.INFO):
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)
 
+    console_log_settings: typing.Optional[logs.LogSettings]
+    if not util.is_notebook() or util.parse_boolean_env_var(
+        "WEAVE_SERVER_FORCE_HTTP_SERVER_CONSOLE_LOGS"
+    ):
+        console_log_settings = logs.LogSettings(logs.LogFormat.PRETTY, level=None)
+    else:
+        console_log_settings = None
+
     logs.enable_stream_logging(
         root_logger,
-        wsgi_stream_settings=logs.LogSettings(logs.LogFormat.PRETTY, level=None),
+        wsgi_stream_settings=console_log_settings,
         pid_logfile_settings=logs.LogSettings(logs.LogFormat.PRETTY, logging.INFO),
     )


### PR DESCRIPTION
Internal JIRA: https://wandb.atlassian.net/browse/WB-14631

![image](https://github.com/wandb/weave/assets/2769632/c5218bb2-28b2-44bb-b3a8-e7dcf5accf71)

Silences error logs in notebooks/colab by default, like those shown above. Enables forcing them on with a flag. 