### PR TITLE
chore (weave): Fix seed board from StreamTable

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -14,6 +14,7 @@ import {
   Node,
   callOpVeryUnsafe,
   constString,
+  list,
   opArtifactMembershipArtifactVersion,
   opArtifactMembershipForAlias,
   opArtifactVersionFile,
@@ -23,6 +24,7 @@ import {
   opProjectArtifact,
   opRootProject,
   opTableRows,
+  typedDict,
   varNode,
 } from '@wandb/weave/core';
 import {NavigateToExpressionType, SetPreviewNodeType} from './common';
@@ -400,9 +402,13 @@ const tableRowToNode = (
     const uri = `wandb-artifact:///${entityName}/${projectName}/${artName}:latest/obj`;
     const node = opGet({uri: constString(uri)});
     node.type = {type: 'stream_table'} as any;
-    newExpr = callOpVeryUnsafe('stream_table-rows', {
-      self: node,
-    }) as any;
+    newExpr = callOpVeryUnsafe(
+      'stream_table-rows',
+      {
+        self: node,
+      },
+      list(typedDict({}))
+    ) as any;
   } else {
     // This is a  hacky here. Would be nice to have better mapping
     const artNameParts = artName.split('-', 3);

--- a/weave/compile.py
+++ b/weave/compile.py
@@ -173,6 +173,10 @@ def _dispatch_map_fn_no_refine(node: graph.Node) -> typing.Optional[graph.Output
         ):
             output_type = op.unrefined_output_type_for_params(params)
 
+        # Consider: If the UI does a `callOpVeryUnsafe`, it is possible that the
+        # graph is not correctly typed. Consider checking if they type is `Any`,
+        # then we may want to use the concrete output type instead.
+
         res = graph.OutputNode(_remove_optional(output_type), op.uri, params)
         # logging.info("Dispatched (no refine): %s -> %s", node, res.type)
         return res


### PR DESCRIPTION
Basically anytime we do `callOpVeryUnsafe` without a type, we run the risk of making un-compilable graphs. Here I fix it for StreamTable.rows when seeding a table.

Fixes https://wandb.atlassian.net/browse/WB-14622