### PR TITLE
chore(sdk): Append weave to server weave urls

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -86,7 +86,7 @@ def weave_server_url() -> str:
     base_url = wandb_base_url()
     default = "https://weave.wandb.ai"
     if base_url != "https://api.wandb.ai":
-        default = base_url
+        default = base_url + "/weave"
     return os.getenv("WEAVE_SERVER_URL", default)
 
 


### PR DESCRIPTION
Quick fix for self hosted weave, we always expose it under `/weave` in self hosted.