### PR TITLE
chore(server): Move op logging to info

### DIFF
--- a/weave/execute.py
+++ b/weave/execute.py
@@ -478,7 +478,7 @@ def execute_forward_node(
         return {"cache_used": False}
 
     # This is expensive!
-    logging.info(
+    logging.debug(
         "Executing op: %s"  # expr: %s"
         % (node.from_op.name)  # , graph_debug.node_expr_str_full(node))
     )


### PR DESCRIPTION
Reduce the amount of bytes logged, these details don't seem needed in production when we have execution summary.