### PR TITLE
chore: make weave exit 0 on SIGTERM

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -111,6 +111,10 @@ def memdump_sighandler_enabled() -> bool:
     return util.parse_boolean_env_var("WEAVE_ENABLE_MEMDUMP_SIGHANDLER")
 
 
+def sigterm_sighandler_enabled() -> bool:
+    return util.parse_boolean_env_var("WEAVE_ENABLE_SIGTERM_SIGHANDLER")
+
+
 def weave_wandb_cookie() -> typing.Optional[str]:
     cookie = os.environ.get("WEAVE_WANDB_COOKIE")
     if cookie:

--- a/weave/signal_handlers.py
+++ b/weave/signal_handlers.py
@@ -128,3 +128,8 @@ def install_signal_handlers() -> None:
             install_signal_handler_to_be_called_after_existing(
                 signal.SIGUSR2, objgraph_showgrowth
             )
+
+        def sigterm_handler(signal: int, frame: typing.Optional[FrameType]) -> None:
+            sys.exit(0)
+
+        signal.signal(signal.SIGTERM, sigterm_handler)

--- a/weave/signal_handlers.py
+++ b/weave/signal_handlers.py
@@ -132,4 +132,5 @@ def install_signal_handlers() -> None:
         def sigterm_handler(signal: int, frame: typing.Optional[FrameType]) -> None:
             sys.exit(0)
 
-        signal.signal(signal.SIGTERM, sigterm_handler)
+        if environment.sigterm_sighandler_enabled():
+            signal.signal(signal.SIGTERM, sigterm_handler)


### PR DESCRIPTION
I'm working on running the core integration tests as Kubernetes Jobs, and I need all the support containers to exit 0 when they receive a SIGTERM -- otherwise, Kubernetes interprets the shutdown as a failure and cancels the rest of the tests. Since SIGTERM isn't mentioned anywhere else in the repo, I'm guessing there's no graceful shutdown behavior to preserve -- if so, then it should be safe to add this handler to immediately exit 0 when SIGTERM is sent.