### PR TITLE
fix: dont crash artifact files page if users choose panelobject

### DIFF
--- a/weave-js/src/components/Panel2/PanelObject.tsx
+++ b/weave-js/src/components/Panel2/PanelObject.tsx
@@ -15,7 +15,6 @@ import {
   Node,
   unionObjectTypeAttrTypes,
   isObjectTypeLike,
-  Weave,
   Type,
 } from '@wandb/weave/core';
 
@@ -136,7 +135,7 @@ export const PanelObject: React.FC<PanelObjectProps> = props => {
           opObjGetAttr({self: objNode, name: constString(key)}),
       };
     } else {
-      throw new Error('Invalid input type for PanelObject');
+      throw new Error('Invalid input type');
     }
   }, [props.input.type]);
   const propertyTypes = _.mapKeys(objPropTypes, (v, k) => escapeDots(k));

--- a/weave-js/src/components/Panel2/PanelObject.tsx
+++ b/weave-js/src/components/Panel2/PanelObject.tsx
@@ -115,7 +115,7 @@ export const PanelObject: React.FC<PanelObjectProps> = props => {
   // This is needed because dict(str, Any) is assignable to the input type
   // of this panel, but we cant render that with a PanelObject at the moment
   // so we have this more restrictive type checker to ensure we do not try to
-  // render nodes of that type the same way that we would render true typedDicts.
+  // render dicts the same way that we would render true typedDicts.
 
   const typeIsRenderableByPanelObject = (type: Type): boolean => {
     return isTypedDictLike(type) || isObjectTypeLike(type);

--- a/weave-js/src/components/Panel2/PanelObject.tsx
+++ b/weave-js/src/components/Panel2/PanelObject.tsx
@@ -112,7 +112,7 @@ export const PanelObject: React.FC<PanelObjectProps> = props => {
     [props.input.type]
   );
 
-  // This is needed because dicts(str, Any) is assignable to the input type
+  // This is needed because dict(str, Any) is assignable to the input type
   // of this panel, but we cant render that with a PanelObject at the moment
   // so we have this more restrictive type checker to ensure we do not try to
   // render nodes of that type the same way that we would render true typedDicts.


### PR DESCRIPTION
Internal JIRA ticket: https://wandb.atlassian.net/browse/WB-14782

Fixes an issue in the artifacts files page where users would get a full page crash if they tried to view a directory with PanelObject. The problem was that PanelObject was not equipped to render dict{str, directory}, but that type was assignable to the Panel's input type, typedDict({}). The files page would sometimes supply that type as input to a nested PanelObject. 

I updated the type system to allow typedDicts to be declared as not allowing dicts to be assigned to them.