### PR TITLE
fix: Fix panel crash (unable to dispatch projection2d) due to bug in hash.ts

### DIFF
--- a/weave-js/src/core/model/graph/editing/hash.ts
+++ b/weave-js/src/core/model/graph/editing/hash.ts
@@ -91,7 +91,7 @@ export class MemoizedHasher implements Hasher {
     if (node.nodeType === 'const') {
       // TODO: think about what to do with function types. Right now we'll hash
       // the json representation of the graph there (which includes types).
-      return hash(JSON.stringify(node.val));
+      return hash(JSON.stringify(node));
     } else if (node.nodeType === 'output') {
       // important nodeId of an output op == opId of the op we came from
       return this.opId(node.fromOp);


### PR DESCRIPTION
Internal JIRA ticket: https://wandb.atlassian.net/browse/WB-14781

Fixes a bug in `hash.ts` where we were getting collisions due to only hashing values instead of entire nodes (values and types). 

The particular collision we were getting here was:

```
{
   "nodeType": "const",
    "value": [],
    "type": {"type": "list", "objectType": "string"}
}
```

was colliding with

```
{
   "nodeType": "const",
    "value": [],
    "type": {"type": "list", "objectType": {"type": "typedDict", "propertyTypes": {}}}
}
``` 

leading the latter type to be used in both instances, causing the wrong type to be propagated in the type system in weave python, manifesting downstream as a dispatch error.

This fixes the issue by hashing the entire node instead of just the value, leading nodes with the same value but different types to be serialized separately. 
