### PR TITLE
chore: utility for setting document title

### DIFF
--- a/weave-js/index.html
+++ b/weave-js/index.html
@@ -23,7 +23,7 @@
     <meta name="functions-insert-dynamic-meta" />
     <meta name="referrer" content="no-referrer-when-downgrade" />
     <link rel="icon" href="/favicon.ico" />
-    <title>Weave Panel</title>
+    <title>Weave</title>
     <!-- See WeaveLoader.css for original source -->
     <style>
       @keyframes logo-animation{0%,100%,70%{transform:scale(1) rotate(0);opacity:.6}7.5%,8%{transform:scale(.75) rotate(0);opacity:.8}25%,47.5%{transform:scale(1) rotate(180deg);opacity:.6}55%,55.5%{transform:scale(.75) rotate(180deg);opacity:.8}}#weave-loader{width:64px;height:64px;opacity:.6;position:absolute;top:calc(50% - 32px);left:calc(50% - 32px);animation:4s ease-out infinite logo-animation}

--- a/weave-js/src/util/document.ts
+++ b/weave-js/src/util/document.ts
@@ -1,0 +1,9 @@
+export function setDocumentTitle(
+  title: string,
+  appendWeave: boolean = true
+): void {
+  if (appendWeave) {
+    title += ' – Weave';
+  }
+  document.title = title;
+}


### PR DESCRIPTION
Pulling out part of https://github.com/wandb/weave/pull/217

Utility method for setting the document title, which will become helpful for disambiguating items in the browser's back button menu once routing goes in.