### PR TITLE
feat: more robust and transparent loading of ecosystem

### DIFF
--- a/weave/ecosystem/all.py
+++ b/weave/ecosystem/all.py
@@ -51,7 +51,5 @@ try:
         modules = ", ".join(LOAD_RESULTS[result]) or "None"
         logger.info(f"  {result}: {modules}")
 
-except Exception as e:
-    print(e)
 finally:
     context_state.clear_loading_built_ins(loading_builtins_token)

--- a/weave/ecosystem/all.py
+++ b/weave/ecosystem/all.py
@@ -1,36 +1,57 @@
+import importlib
+import logging
+import os
+import typing
+from collections import defaultdict, Counter
 from weave import context_state
+
+logger = logging.getLogger(__name__)
 
 loading_builtins_token = context_state.set_loading_built_ins()
 
+ALL_MODULES = (
+    "example",
+    "bertviz",
+    "xgboost",
+    "shap",
+    "sklearn",
+    "torchvision",
+    "torch_mnist_model_example",
+    "huggingface",
+    "craiyon",
+    "spacy",
+    "lens",
+    "wandb",
+    "scenario",
+    "shawn",
+    "replicate",
+    "openai",
+    "py",
+    "langchain",
+    "umap",
+    "hdbscan",
+)
+
+LOAD_RESULTS: typing.DefaultDict[str, list[str]] = defaultdict(list[str])
+
 try:
-    from . import example
+    logger.info("Loading weave.ecosystem")
+    for module in ALL_MODULES:
+        try:
+            globals()[module] = importlib.import_module(f"weave.ecosystem.{module}")
+            LOAD_RESULTS["loaded"].append(module)
+        except ImportError as exc:
+            logger.debug(f"  {module} extension is unavailable, missing {exc.name}")
+            LOAD_RESULTS["unavailable"].append(module)
+        except Exception as exc:
+            logger.error(f"  Error loading {module}")
+            logger.error(exc)
+            LOAD_RESULTS["error"].append(module)
+    for result in ("loaded", "unavailable", "error"):
+        modules = ", ".join(LOAD_RESULTS[result]) or "None"
+        logger.info(f"  {result}: {modules}")
 
-    from . import bertviz
-
-    from . import xgboost
-    from . import shap
-
-    from . import sklearn
-    from . import torchvision
-    from . import torch_mnist_model_example
-    from . import huggingface
-
-    from . import craiyon
-
-    from . import spacy
-    from . import lens
-    from . import wandb
-    from . import scenario
-    from . import shawn
-    from . import wandb
-    from . import replicate
-    from . import openai
-    from . import py
-
-    from . import langchain
-
-    from . import umap
-    from . import hdbscan
-
+except Exception as e:
+    print(e)
 finally:
     context_state.clear_loading_built_ins(loading_builtins_token)

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -103,17 +103,11 @@ def import_ecosystem():
             from weave.ecosystem import all
         except (ImportError, OSError, wandb.Error):
             pass
-            # logging.warning(
-            #     'Failed to import "weave.ecosystem". Weave ecosystem features will be disabled. '
-            #     'To fix this, install ecosystem dependencies with "pip install weave[ecosystem]". '
-            #     "To disable this message, set WEAVE_SERVER_DISABLE_ECOSYSTEM=1."
-            # )
 
 
 def make_app():
-    import_ecosystem()
-
     logs.configure_logger()
+    import_ecosystem()
 
     app = Flask(__name__)
     app.register_blueprint(blueprint)


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-14865
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1690921044929769?thread_ts=1690905026.878269&cid=C03BSTEBD7F

Load ecosystem modules one at a time, catching import errors, and reporting out status at end.
Previously, any import error would cause the ecosystem loading to stop, and the error was silent. 

Example output when a dependency, e.g. one newly added, is not in the virtualenv:
<img width="1628" alt="Screenshot 2023-08-04 at 1 59 42 PM" src="https://github.com/wandb/weave/assets/112953339/fe1d5128-ac13-4bca-9575-dac341b0f77b">

Example output when all dependencies are available:
<img width="1626" alt="Screenshot 2023-08-04 at 1 59 04 PM" src="https://github.com/wandb/weave/assets/112953339/3970743f-fd86-4678-b203-22e00377edb5">


