### PR TITLE
fix(weave): Pin sentry version to exclude release which breaks Python unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 wandb>=0.15.5
+sentry-sdk[flask]>=1.0.0,<1.29.0 # 1.29.0 adds monkey-patched GQL error handling which breaks our unit tests communicating with the server
 python-json-logger>=2.0.4
 numpy>=1.21
 pandas>=1.5.3  # current Colab version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wandb>=0.15.5
-sentry-sdk[flask]>=1.0.0,<1.29.0 # 1.29.0 adds monkey-patched GQL error handling which breaks our unit tests communicating with the server
+sentry-sdk<1.29.0 # 1.29.0 adds monkey-patched GQL error handling which breaks our unit tests communicating with the server
 python-json-logger>=2.0.4
 numpy>=1.21
 pandas>=1.5.3  # current Colab version


### PR DESCRIPTION
Sentry 1.29.0 has this PR (https://github.com/getsentry/sentry-python/pull/2243) which broke GQL response handling in our Python unit tests. GQL requests would be sent and returned correctly with data, except our SDK receives empty data because of Sentry monkeypatching. 