### PR TITLE
chore: update some places to use new common component Button

### DIFF
--- a/weave-js/src/components/PagePanelComponents/DeleteActionModal.tsx
+++ b/weave-js/src/components/PagePanelComponents/DeleteActionModal.tsx
@@ -1,7 +1,7 @@
 import {Modal} from 'semantic-ui-react';
 import React from 'react';
-import {WBButton} from '@wandb/weave/common/components/elements/WBButtonNew';
 import * as M from './Modal.styles';
+import {Button} from '../Button';
 
 type DeleteActionModalProps = {
   open: boolean;
@@ -29,12 +29,12 @@ export const DeleteActionModal = ({
           referencing this board.
         </M.Description>
         <M.Buttons>
-          <WBButton variant="confirm" disabled={acting} onClick={onDelete}>
+          <Button disabled={acting} onClick={onDelete}>
             Delete board
-          </WBButton>
-          <WBButton variant="ghost" onClick={onClose}>
+          </Button>
+          <Button variant="ghost" onClick={onClose}>
             Cancel
-          </WBButton>
+          </Button>
         </M.Buttons>
       </Modal.Content>
     </Modal>

--- a/weave-js/src/components/PagePanelComponents/Home/HomeTopBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeTopBar.tsx
@@ -4,14 +4,11 @@ import React, {useCallback, useState} from 'react';
 import getConfig from '../../../config';
 
 import styled from 'styled-components';
-import {WBButton} from '../../../common/components/elements/WBButtonNew';
 import {useWeaveContext} from '../../../context';
-import {
-  IconAddNew as IconAddNewUnstyled,
-  IconWeaveLogo,
-} from '../../Panel2/Icons';
+import {IconWeaveLogo} from '../../Panel2/Icons';
 import {useNewPanelFromRootQueryCallback} from '../../Panel2/PanelRootBrowser/util';
 import {NavigateToExpressionType} from './common';
+import {Button} from '../../Button';
 
 export const HomeTopBar: React.FC<{
   navigateToExpression: NavigateToExpressionType;
@@ -48,10 +45,9 @@ export const HomeTopBar: React.FC<{
         Weave
       </TopBarLeft>
       <TopBarRight>
-        <WBButton variant={`confirm`} onClick={newDashboard}>
-          <IconAddNew />
+        <Button onClick={newDashboard} icon="add-new">
           New board
-        </WBButton>
+        </Button>
       </TopBarRight>
     </TopBar>
   );
@@ -81,10 +77,4 @@ const WeaveLogo = styled(IconWeaveLogo)`
   width: 32px;
   height: 32px;
   margin-right: 12px;
-`;
-
-const IconAddNew = styled(IconAddNewUnstyled)`
-  width: 18px;
-  height: 18px;
-  margin-right: 6px;
 `;

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -41,11 +41,9 @@ import {useWeaveContext} from '../../context';
 import {WeaveExpression} from '../../panel/WeaveExpression';
 import {useNodeWithServerType} from '../../react';
 import {consoleLog} from '../../util';
-import {IconButton} from '../IconButton';
 import {Tooltip} from '../Tooltip';
 import * as ConfigPanel from './ConfigPanel';
 import {ConfigSection} from './ConfigPanel';
-import {IconPencilEdit} from './Icons';
 import {Panel, PanelConfigEditor, useUpdateConfig2} from './PanelComp';
 import {
   ExpressionEvent,
@@ -71,9 +69,9 @@ import {getStackIdAndName} from './panellib/libpanel';
 import {replaceChainRoot} from '@wandb/weave/core/mutate';
 
 import {OutlineItemPopupMenu} from '../Sidebar/OutlineItemPopupMenu';
-import {IconOverflowHorizontal} from './Icons';
 import {getConfigForPath} from './panelTree';
 import {usePanelPanelContext} from './PanelPanelContextProvider';
+import {Button} from '../Button';
 
 // This could be rendered as a code block with assignments, like
 // so.
@@ -616,12 +614,12 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
               <Tooltip
                 position="top center"
                 trigger={
-                  <IconButton
-                    // disabled={isLoading}
-                    data-test="panel-config"
-                    onClick={() => setInspectingPanel(props.pathEl ?? '')}>
-                    <IconPencilEdit />
-                  </IconButton>
+                  <Button
+                    variant="ghost"
+                    size="small"
+                    icon="pencil-edit"
+                    onClick={() => setInspectingPanel(props.pathEl ?? '')}
+                  />
                 }>
                 Open panel editor
               </Tooltip>
@@ -632,9 +630,11 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
                 updateConfig={updateConfig}
                 updateConfig2={updateConfig2}
                 trigger={
-                  <IconButton>
-                    <IconOverflowHorizontal />
-                  </IconButton>
+                  <Button
+                    variant="ghost"
+                    size="small"
+                    icon="overflow-horizontal"
+                  />
                 }
                 onOpen={() => setIsMenuOpen(true)}
                 onClose={() => setIsMenuOpen(false)}

--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -16,7 +16,6 @@ import {
   getFullChildPanel,
   CHILD_PANEL_DEFAULT_CONFIG,
 } from './ChildPanel';
-import {IconBack, IconClose, IconOverflowHorizontal} from './Icons';
 import * as Panel2 from './panel';
 import {Panel2Loader, useUpdateConfig2} from './PanelComp';
 import {PanelContextProvider, usePanelContext} from './PanelContext';
@@ -30,10 +29,10 @@ import {
 import {useSetPanelRenderedConfig} from './PanelRenderedConfigContext';
 import {OutlineItemPopupMenu} from '../Sidebar/OutlineItemPopupMenu';
 import {getConfigForPath} from './panelTree';
-import {IconButton} from '../IconButton';
 import * as SidebarConfig from '../Sidebar/Config';
 import {useScrollbarVisibility} from '../../core/util/scrollbar';
 import {PanelPanelContextProvider} from './PanelPanelContextProvider';
+import {Button} from '../Button';
 
 const inputType = {type: 'Panel' as const};
 type PanelPanelProps = Panel2.PanelProps<
@@ -243,9 +242,12 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
               <SidebarConfig.HeaderTopText>Outline</SidebarConfig.HeaderTopText>
             </SidebarConfig.HeaderTopLeft>
             <SidebarConfig.HeaderTopRight>
-              <IconButton onClick={closeEditor}>
-                <IconClose />
-              </IconButton>
+              <Button
+                icon="close"
+                variant="ghost"
+                size="small"
+                onClick={closeEditor}
+              />
             </SidebarConfig.HeaderTopRight>
           </SidebarConfig.HeaderTop>
         </SidebarConfig.Header>
@@ -265,9 +267,7 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
       <SidebarConfig.Header>
         <SidebarConfig.HeaderTop lessLeftPad>
           <SidebarConfig.HeaderTopLeft canGoBack onClick={goBackToOutline}>
-            <IconButton>
-              <IconBack />
-            </IconButton>
+            <Button icon="back" variant="ghost" size="small" />
             <SidebarConfig.HeaderTopText>Outline</SidebarConfig.HeaderTopText>
           </SidebarConfig.HeaderTopLeft>
           <SidebarConfig.HeaderTopRight>
@@ -280,18 +280,23 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
                 updateConfig2={panelUpdateConfig2}
                 goBackToOutline={goBackToOutline}
                 trigger={
-                  <IconButton>
-                    <IconOverflowHorizontal />
-                  </IconButton>
+                  <Button
+                    icon="overflow-horizontal"
+                    variant="ghost"
+                    size="small"
+                  />
                 }
                 isOpen={isOutlineMenuOpen}
                 onOpen={() => setIsOutlineMenuOpen(true)}
                 onClose={() => setIsOutlineMenuOpen(false)}
               />
             )}
-            <IconButton onClick={closeEditor}>
-              <IconClose />
-            </IconButton>
+            <Button
+              icon="close"
+              variant="ghost"
+              size="small"
+              onClick={closeEditor}
+            />
           </SidebarConfig.HeaderTopRight>
         </SidebarConfig.HeaderTop>
         {!selectedIsRoot && (

--- a/weave-js/src/components/Sidebar/VarBar.tsx
+++ b/weave-js/src/components/Sidebar/VarBar.tsx
@@ -7,19 +7,13 @@ import styled from 'styled-components';
 import {GRAY_350} from '../../common/css/globals.styles';
 import {useWeaveContext} from '../../context';
 import {useNodeWithServerType} from '../../react';
-import {IconButton} from '../IconButton';
 import {
   ChildPanelConfig,
   ChildPanelFullConfig,
   useChildPanelConfig,
 } from '../Panel2/ChildPanel';
 import * as ConfigPanel from '../Panel2/ConfigPanel';
-import {
-  IconAddNew,
-  IconDelete,
-  IconOverflowHorizontal,
-  IconPencilEdit,
-} from '../Panel2/Icons';
+import {IconDelete} from '../Panel2/Icons';
 import {
   ExpressionEvent,
   PanelContextProvider,
@@ -30,6 +24,7 @@ import {useSetInspectingChildPanel} from '../Panel2/PanelInteractContext';
 import {Tooltip} from '../Tooltip';
 import * as SidebarConfig from './Config';
 import {PopupMenu} from './PopupMenu';
+import {Button} from '../Button';
 
 type VarBarProps = {
   config: PanelGroupConfig;
@@ -61,11 +56,7 @@ const VarBarComp: FC<VarBarProps> = props => {
             <SidebarConfig.HeaderTopRight>
               <Tooltip
                 position="top center"
-                trigger={
-                  <IconButton onClick={handleAddVar}>
-                    <IconAddNew />
-                  </IconButton>
-                }>
+                trigger={<Button icon="add-new" onClick={handleAddVar} />}>
                 New variable
               </Tooltip>
             </SidebarConfig.HeaderTopRight>
@@ -208,17 +199,16 @@ const VarComp: FC<VarProps> = ({
           <Tooltip
             position="top center"
             trigger={
-              <IconButton onClick={() => setInspectingPanel(name)}>
-                <IconPencilEdit />
-              </IconButton>
+              <Button
+                icon="pencil-edit"
+                onClick={() => setInspectingPanel(name)}
+              />
             }>
             Open panel editor
           </Tooltip>
           <PopupMenu
             trigger={
-              <IconButton>
-                <IconOverflowHorizontal />
-              </IconButton>
+              <Button variant="ghost" size="small" icon="overflow-horizontal" />
             }
             position={`bottom right`}
             items={menuItems}

--- a/weave-js/src/components/WeavePanelBank/PBSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PBSection.tsx
@@ -26,15 +26,10 @@ import {
   SCROLLBAR_STYLES,
   WHITE,
 } from '../../common/css/globals.styles';
-import {
-  IconAddNew as IconAddNewUnstyled,
-  IconPencilEdit,
-} from '../Panel2/Icons';
+import {IconAddNew as IconAddNewUnstyled} from '../Panel2/Icons';
 import {inJupyterCell} from '../PagePanelComponents/util';
 import {useScrollbarVisibility} from '../../core/util/scrollbar';
 import {Tooltip} from '../Tooltip';
-import {IconButton} from '../IconButton';
-import {WBButton} from '../../common/components/elements/WBButtonNew';
 import {
   useGetPanelIsHoveredByGroupPath,
   useGetPanelIsHoveredInOutlineByGroupPath,
@@ -42,6 +37,7 @@ import {
   useSetInspectingPanel,
   useSetPanelIsHovered,
 } from '../Panel2/PanelInteractContext';
+import {Button} from '../Button';
 
 interface PBSectionProps {
   mode: 'grid' | 'flow';
@@ -109,18 +105,21 @@ export const PBSection: React.FC<PBSectionProps> = props => {
                     <Tooltip
                       position="bottom right"
                       trigger={
-                        <IconButton
-                          onClick={() => setInspectingPanel(groupPath)}>
-                          <IconPencilEdit />
-                        </IconButton>
+                        <Button
+                          variant="ghost"
+                          icon="pencil-edit"
+                          onClick={() => setInspectingPanel(groupPath)}
+                        />
                       }>
                       Open panel editor
                     </Tooltip>
                     {enableAddPanel && (
-                      <WBButton onClick={handleAddPanel}>
-                        <IconAddNew $marginRight={6} />
+                      <Button
+                        variant="ghost"
+                        onClick={handleAddPanel}
+                        icon="add-new">
                         New panel
-                      </WBButton>
+                      </Button>
                     )}
                   </ActionBar>
                 )}

--- a/weave-js/src/panel/WeaveExpression/OpDoc.tsx
+++ b/weave-js/src/panel/WeaveExpression/OpDoc.tsx
@@ -5,8 +5,7 @@ import React from 'react';
 import {useWeaveContext} from '../../context';
 
 import * as S from './OpDoc.styles';
-import {IconClose} from '../../components/Panel2/Icons';
-import {IconButton} from '../../components/IconButton';
+import {Button} from '../../components/Button';
 
 export interface OpDocProps {
   opName: string;
@@ -77,10 +76,13 @@ const OpDoc: React.FC<OpDocProps> = ({
           <S.Code>{displayName}</S.Code>
         </S.OpName>
         {onClose && (
-          <S.OpClose>
-            <IconButton onClick={onClose}>
-              <IconClose />
-            </IconButton>
+          <S.OpClose data-mode="dark">
+            <Button
+              variant="ghost"
+              size="small"
+              icon="close"
+              onClick={onClose}
+            />
           </S.OpClose>
         )}
       </S.OpNameRow>


### PR DESCRIPTION
Update parts of Weave to use the common component Button. This makes e.g. the background highlighting for the pencil button the same as the new panel button next to it.

Before:
<img width="166" alt="Screenshot 2023-08-04 at 9 30 09 PM" src="https://github.com/wandb/weave/assets/112953339/d0252363-f9a2-4e4b-9ed2-85ef1ccbc240">
<img width="256" alt="Screenshot 2023-08-04 at 9 30 00 PM" src="https://github.com/wandb/weave/assets/112953339/6ae26a6e-e7de-4137-b313-1b64d14c80bc">

After:
<img width="167" alt="Screenshot 2023-08-04 at 9 30 16 PM" src="https://github.com/wandb/weave/assets/112953339/f2c7a47a-2d3e-41b9-b764-2c62ec31e6f6">
<img width="263" alt="Screenshot 2023-08-04 at 9 29 40 PM" src="https://github.com/wandb/weave/assets/112953339/8cd98bc4-0200-4094-b78c-1729d563a568">
