### PR TITLE
chore(weave): Fix null image path

### DIFF
--- a/weave/ops_domain/wbmedia.py
+++ b/weave/ops_domain/wbmedia.py
@@ -176,7 +176,8 @@ class ImageArtifactFileRefType(types.ObjectType):
                 # In these cases, having the correct classes in each key is not
                 # needed.
                 key: []
-                for key in obj.masks.keys() if obj.masks[key] is not None
+                for key in obj.masks.keys()
+                if obj.masks[key] is not None
             }
         else:
             maskLayers = {}

--- a/weave/ops_domain/wbmedia.py
+++ b/weave/ops_domain/wbmedia.py
@@ -176,7 +176,7 @@ class ImageArtifactFileRefType(types.ObjectType):
                 # In these cases, having the correct classes in each key is not
                 # needed.
                 key: []
-                for key in obj.masks.keys()
+                for key in obj.masks.keys() if obj.masks[key] is not None
             }
         else:
             maskLayers = {}


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-14784

the path variable below would come back as null, we could also just do a null check in the frontend

now instead of returning  mask: { loadedFrom, path: null}, it returns mask: null which doesnt call this SegmentationMaskFromCG

``` 
const SegmentationMaskFromCG: FC<SegmentationMaskFromCGProps> = props => {
  const {filePath, classSet, maskControls} = props;
  const {loadedFrom, path} = filePath;

  const fileNode = useMemo(
    () =>
      opArtifactVersionFile({
        artifactVersion: loadedFrom as any,
        path: constString(path),
      }) as
        | Node<{
            type: 'file';
            extension: string;
          }>
        | VoidNode,
    [loadedFrom, path]
  );
```