### PR TITLE
ci: decrease CI unit test timeout to 10 minutes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,7 +96,7 @@ jobs:
 
   test:
     name: Python unit tests
-    timeout-minutes: 25
+    timeout-minutes: 10 # do not lower! running longer than this indicates an issue with the tests. fix there.
     needs:
       - build-container
     # runs-on: [self-hosted, runner]


### PR DESCRIPTION
Decreases CI unit test timeout to 10 minutes. Anything longer indicates an issue with the underlying tests and will fail anyway. This makes failures happen faster. 