### PR TITLE
chore: Projection pushdown for get -> AWL

### DIFF
--- a/weave/artifact_fs.py
+++ b/weave/artifact_fs.py
@@ -252,8 +252,9 @@ class FilesystemArtifactRef(artifact_base.ArtifactRef):
                 # TODO: fix
                 self._type = ot
             elif ot.name == "ArrowWeaveList":
-                # Hack here... just need to do this for now
-                # TODO
+                # Necessary when using extra, which we use for column pushdown to get->AWL ops.
+                # (get column pushdown is behind a feature flag currently)
+                # This is basically a no-op and we need to refactor to remove this whole ifblock.
                 self._type = ot
             else:
                 print(

--- a/weave/artifact_fs.py
+++ b/weave/artifact_fs.py
@@ -251,6 +251,10 @@ class FilesystemArtifactRef(artifact_base.ArtifactRef):
                 # work!
                 # TODO: fix
                 self._type = ot
+            elif ot.name == "ArrowWeaveList":
+                # Hack here... just need to do this for now
+                # TODO
+                self._type = ot
             else:
                 print(
                     "SELF TYPE",

--- a/weave/compile.py
+++ b/weave/compile.py
@@ -400,15 +400,16 @@ def compile_apply_column_pushdown(
             top_level_cols = list(projection_cols.keys())
             if top_level_cols:
                 uri = uris.WeaveURI.parse(node.from_op.inputs["uri"].val)
-                uri.extra = ["pick", ",".join(top_level_cols)]
-                return graph.OutputNode(
-                    node.type,
-                    "get",
-                    {"uri": weave_internal.const(str(uri))},
-                )
+                if hasattr(uri, "extra"):
+                    uri.extra = ["pick", ",".join(top_level_cols)]
+                    return graph.OutputNode(
+                        node.type,
+                        "get",
+                        {"uri": weave_internal.const(str(uri))},
+                    )
         return node
 
-    return graph.map_nodes_full(leaf_nodes, _replace_with_column_pushdown)
+    return graph.map_nodes_and_catch_full(leaf_nodes, _replace_with_column_pushdown)
 
 
 def compile_fix_calls(

--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -17,6 +17,7 @@ from .language_features.tagging.tag_store import isolated_tagging_context
 from . import logs
 from . import io_service
 from . import logs
+from . import feature_flags
 import logging
 
 from flask.testing import FlaskClient
@@ -86,6 +87,11 @@ def guard(*args, **kwargs):
 
 def pytest_sessionstart(session):
     context_state.disable_analytics()
+
+    # Don't turn this on yet, there are still the following failures:
+    # - ops_primitives/test_typeddict.py has two flaky tests (fail sometimes but not all)
+    # - "tests/test_list_arrow_compat.py::test_join_all[ArrowNode]" fails
+    # feature_flags.GET_AWL_PROJECTION_PUSHDOWN = True
 
 
 @pytest.fixture()

--- a/weave/environment.py
+++ b/weave/environment.py
@@ -170,3 +170,9 @@ def weave_wandb_api_key() -> typing.Optional[str]:
 
 def projection_timeout_sec() -> typing.Optional[typing.Union[int, float]]:
     return util.parse_number_env_var("WEAVE_PROJECTION_TIMEOUT_SEC")
+
+
+def value_or_error_debug() -> bool:
+    # Raise errors immediately in compile/execute paths instead of
+    # returning them as data.
+    return util.parse_boolean_env_var("WEAVE_VALUE_OR_ERROR_DEBUG")

--- a/weave/errors.py
+++ b/weave/errors.py
@@ -103,10 +103,6 @@ class WeaveTableDeserializationError(WeaveBaseError):
     pass
 
 
-class WeaveStitchGraphMergeError(WeaveBaseError):
-    pass
-
-
 class WeaveHashConstTypeError(WeaveBaseError):
     """Raised if __hash__ is called on a Const Type.
 
@@ -149,4 +145,8 @@ class WeaveWBHistoryTranslationError(WeaveBaseError):
 
 
 class WeaveWandbAuthenticationException(Exception):
+    pass
+
+
+class WeaveStitchError(WeaveBaseError):
     pass

--- a/weave/execute.py
+++ b/weave/execute.py
@@ -1,4 +1,3 @@
-import dataclasses
 import logging
 import contextlib
 import contextvars
@@ -353,7 +352,7 @@ def execute_forward(fg: forward_graph.ForwardGraph, no_cache=False) -> ExecuteSt
                                 traceback.format_exc(),
                             )
                         )
-                        if value_or_error.DEBUG:
+                        if environment.value_or_error_debug():
                             raise
                         forward_node.set_result(forward_graph.ErrorResult(e))
                         report = {"cache_used": False, "already_executed": False}

--- a/weave/feature_flags.py
+++ b/weave/feature_flags.py
@@ -1,0 +1,6 @@
+# Enables projection pushdown for get(*)->AWL queries.
+# This is disabled in prod and unit tests for now.
+# There are a few things to fix
+#    - some failing tests
+#    - decide final "extra" format for specifying loading columns from an artifact list
+GET_AWL_PROJECTION_PUSHDOWN = False

--- a/weave/feature_flags.py
+++ b/weave/feature_flags.py
@@ -3,4 +3,12 @@
 # There are a few things to fix
 #    - some failing tests
 #    - decide final "extra" format for specifying loading columns from an artifact list
+# We can enable it when it becomes necessary, which will happen if we ship any code where
+# we want users to save thousands of columns inside AWLs that they have.
+# I ran into it as I was messing with and testing other perf stuff.
+# Note we already do projection pushdown for StreamTable and wandb history read code paths.
+# We just don't do it on AWLs that users save directly (but this feature flag enables that)
+#
+# Without this, thousands of columns and hundreds of thousand plus rows within an AWL gets really slow.
+# With this its nice and fast!
 GET_AWL_PROJECTION_PUSHDOWN = False

--- a/weave/graph.py
+++ b/weave/graph.py
@@ -335,39 +335,55 @@ OnErrorFnType = typing.Optional[typing.Callable[[int, Exception], Node]]
 def map_nodes_top_level(
     leaf_nodes: list[Node],
     map_fn: typing.Callable[[Node], typing.Optional[Node]],
-    on_error: OnErrorFnType = None,
 ) -> list[Node]:
     """Map nodes in dag represented by leaf nodes, but not sub-lambdas"""
     already_mapped: dict[Node, Node] = {}
-    results: list[Node] = []
-    for node_ndx, node in enumerate(leaf_nodes):
-        try:
-            results.append(_map_nodes(node, map_fn, already_mapped, False))
-        except Exception as e:
-            if on_error:
-                results.append(on_error(node_ndx, e))
-            else:
-                raise e
-
-    return results
+    return [_map_nodes(n, map_fn, already_mapped, False) for n in leaf_nodes]
 
 
 def map_nodes_full(
     leaf_nodes: list[Node],
     map_fn: typing.Callable[[Node], typing.Optional[Node]],
-    on_error: OnErrorFnType = None,
 ) -> list[Node]:
     """Map nodes in dag represented by leaf nodes, including sub-lambdas"""
     already_mapped: dict[Node, Node] = {}
-    results: list[Node] = []
-    for node_ndx, node in enumerate(leaf_nodes):
-        try:
-            results.append(_map_nodes(node, map_fn, already_mapped, True))
-        except Exception as e:
-            if on_error:
-                results.append(on_error(node_ndx, e))
-            else:
-                raise e
+    return [_map_nodes(n, map_fn, already_mapped, True) for n in leaf_nodes]
+
+
+def map_nodes_and_catch_top_level(
+    leaf_nodes: typing.Sequence[typing.Union[Node, Exception]],
+    map_fn: typing.Callable[[Node], typing.Optional[Node]],
+) -> list[typing.Union[Node, Exception]]:
+    """Map nodes in dag represented by leaf nodes, but not sub-lambdas"""
+    already_mapped: dict[Node, Node] = {}
+    results: list[typing.Union[Node, Exception]] = []
+    for node in leaf_nodes:
+        if isinstance(node, Exception):
+            results.append(node)
+        else:
+            try:
+                results.append(_map_nodes(node, map_fn, already_mapped, False))
+            except Exception as e:
+                results.append(e)
+
+    return results
+
+
+def map_nodes_and_catch_full(
+    leaf_nodes: typing.Sequence[typing.Union[Node, Exception]],
+    map_fn: typing.Callable[[Node], typing.Optional[Node]],
+) -> list[typing.Union[Node, Exception]]:
+    """Map nodes in dag represented by leaf nodes, including sub-lambdas"""
+    already_mapped: dict[Node, Node] = {}
+    results: list[typing.Union[Node, Exception]] = []
+    for node in leaf_nodes:
+        if isinstance(node, Exception):
+            results.append(node)
+        else:
+            try:
+                results.append(_map_nodes(node, map_fn, already_mapped, True))
+            except Exception as e:
+                results.append(e)
 
     return results
 

--- a/weave/graph.py
+++ b/weave/graph.py
@@ -6,6 +6,7 @@ from . import errors
 from . import weave_types
 from . import uris
 from . import storage
+from . import environment
 
 T = typing.TypeVar("T")
 
@@ -353,8 +354,13 @@ def map_nodes_full(
 def map_nodes_and_catch_top_level(
     leaf_nodes: typing.Sequence[typing.Union[Node, Exception]],
     map_fn: typing.Callable[[Node], typing.Optional[Node]],
-) -> list[typing.Union[Node, Exception]]:
+) -> typing.Sequence[typing.Union[Node, Exception]]:
     """Map nodes in dag represented by leaf nodes, but not sub-lambdas"""
+    if environment.value_or_error_debug():
+        # cast is safe because when debug is enabled, leaf_nodes is a list of Nodes
+        nodes = typing.cast(list[Node], leaf_nodes)
+        return map_nodes_top_level(nodes, map_fn)
+
     already_mapped: dict[Node, Node] = {}
     results: list[typing.Union[Node, Exception]] = []
     for node in leaf_nodes:
@@ -372,8 +378,13 @@ def map_nodes_and_catch_top_level(
 def map_nodes_and_catch_full(
     leaf_nodes: typing.Sequence[typing.Union[Node, Exception]],
     map_fn: typing.Callable[[Node], typing.Optional[Node]],
-) -> list[typing.Union[Node, Exception]]:
+) -> typing.Sequence[typing.Union[Node, Exception]]:
     """Map nodes in dag represented by leaf nodes, including sub-lambdas"""
+    if not environment.value_or_error_debug():
+        # cast is safe because when debug is enabled, leaf_nodes is a list of Nodes
+        nodes = typing.cast(list[Node], leaf_nodes)
+        return map_nodes_full(nodes, map_fn)
+
     already_mapped: dict[Node, Node] = {}
     results: list[typing.Union[Node, Exception]] = []
     for node in leaf_nodes:

--- a/weave/ops_arrow/arrow.py
+++ b/weave/ops_arrow/arrow.py
@@ -14,6 +14,7 @@ from .. import mappers_python
 from .. import weave_types as types
 from .. import errors
 from .. import artifact_fs
+from .. import feature_flags
 
 
 def arrow_type_to_weave_type(pa_type: pa.DataType) -> types.Type:
@@ -237,8 +238,29 @@ class ArrowWeaveListType(types.Type):
                 res = convert.from_parquet_friendly(l)
         elif artifact.metadata["_weave_awl_format"] == 2:
             # v2 AWL format
+            columns = None
+            if (
+                feature_flags.GET_AWL_PROJECTION_PUSHDOWN
+                and extra
+                and extra[0] == "pick"
+                and isinstance(self.object_type, types.TypedDict)
+            ):
+                self_keys = set(self.object_type.property_types.keys())
+                columns = list(set(extra[1].split(",")) & self_keys)
+                if not columns and self_keys:
+                    # if there was no intersection, but there are keys, just
+                    # pick the first one, to ensure we get a valid table
+                    columns = [list(self_keys)[0]]
+                object_type = types.TypedDict(
+                    {
+                        k: v
+                        for k, v in object_type.property_types.items()
+                        if k in columns
+                    }
+                )
+
             with artifact.open(f"{name}.ArrowWeaveList.feather", binary=True) as f:
-                table = pf.read_table(f)
+                table = pf.read_table(f, columns=columns)
             if isinstance(object_type, types.TypedDict):
                 if not object_type.property_types:
                     arr = pa.repeat({}, len(table))
@@ -257,52 +279,6 @@ class ArrowWeaveListType(types.Type):
 
         res.validate()
         return res
-
-    # def load_instance_with_cols(
-    #     self, artifact: artifact_fs.FilesystemArtifact, name: str, extra=None
-    # ):
-    #     columns = None
-    #     if (
-    #         extra
-    #         and extra[0] == "pick"
-    #         and isinstance(self.object_type, types.TypedDict)
-    #     ):
-    #         self_keys = set(self.object_type.property_types.keys())
-    #         columns = list(set(extra[1].split(",")) & self_keys)
-    #         if not columns and self_keys:
-    #             # if there was no intersection, but there are keys, just
-    #             # pick the first one, to ensure we get a valid table
-    #             columns = [list(self_keys)[0]]
-    #     with artifact.open(f"{name}.ArrowWeaveList.feather", binary=True) as f:
-    #         table = pf.read_table(f, columns=columns)
-    #     if isinstance(self.object_type, types.TypedDict):
-    #         arr = pa.StructArray.from_arrays(
-    #             [table[i].combine_chunks() for i in range(len(table.schema))],
-    #             names=[f.name for f in table.schema],
-    #         )
-    #     else:
-    #         arr = table["arr"].combine_chunks()
-
-    #     with artifact.open(f"{name}.ArrowWeaveList.type.json") as f:
-    #         object_type = json.load(f)
-    #         object_type = types.TypeRegistry.type_from_dict(object_type)
-    #         if columns is not None:
-    #             object_type = types.TypedDict(
-    #                 {
-    #                     k: v
-    #                     for k, v in object_type.property_types.items()
-    #                     if k in columns
-    #                 }
-    #             )
-    #     from . import list_
-
-    #     with list_.unsafe_awl_construction("load_from_parquet"):
-    #         l = self.instance_class(arr, object_type=object_type, artifact=artifact)  # type: ignore
-    #         from . import convert
-
-    #         res = convert.from_parquet_friendly(l)
-    #     res.validate()
-    #     return res
 
 
 def rewrite_weavelist_refs(arrow_data, object_type, source_artifact, target_artifact):

--- a/weave/ops_arrow/arrow.py
+++ b/weave/ops_arrow/arrow.py
@@ -258,6 +258,52 @@ class ArrowWeaveListType(types.Type):
         res.validate()
         return res
 
+    # def load_instance_with_cols(
+    #     self, artifact: artifact_fs.FilesystemArtifact, name: str, extra=None
+    # ):
+    #     columns = None
+    #     if (
+    #         extra
+    #         and extra[0] == "pick"
+    #         and isinstance(self.object_type, types.TypedDict)
+    #     ):
+    #         self_keys = set(self.object_type.property_types.keys())
+    #         columns = list(set(extra[1].split(",")) & self_keys)
+    #         if not columns and self_keys:
+    #             # if there was no intersection, but there are keys, just
+    #             # pick the first one, to ensure we get a valid table
+    #             columns = [list(self_keys)[0]]
+    #     with artifact.open(f"{name}.ArrowWeaveList.feather", binary=True) as f:
+    #         table = pf.read_table(f, columns=columns)
+    #     if isinstance(self.object_type, types.TypedDict):
+    #         arr = pa.StructArray.from_arrays(
+    #             [table[i].combine_chunks() for i in range(len(table.schema))],
+    #             names=[f.name for f in table.schema],
+    #         )
+    #     else:
+    #         arr = table["arr"].combine_chunks()
+
+    #     with artifact.open(f"{name}.ArrowWeaveList.type.json") as f:
+    #         object_type = json.load(f)
+    #         object_type = types.TypeRegistry.type_from_dict(object_type)
+    #         if columns is not None:
+    #             object_type = types.TypedDict(
+    #                 {
+    #                     k: v
+    #                     for k, v in object_type.property_types.items()
+    #                     if k in columns
+    #                 }
+    #             )
+    #     from . import list_
+
+    #     with list_.unsafe_awl_construction("load_from_parquet"):
+    #         l = self.instance_class(arr, object_type=object_type, artifact=artifact)  # type: ignore
+    #         from . import convert
+
+    #         res = convert.from_parquet_friendly(l)
+    #     res.validate()
+    #     return res
+
 
 def rewrite_weavelist_refs(arrow_data, object_type, source_artifact, target_artifact):
     if _object_type_has_props(object_type):

--- a/weave/ops_domain/run_history/history_op_common.py
+++ b/weave/ops_domain/run_history/history_op_common.py
@@ -244,7 +244,7 @@ def make_run_history_gql_field(inputs: InputAndStitchProvider, inner: str):
     node = inputs.stitched_obj.node
     if node is None:
         raise errors.WeaveInternalError('unexpected, node is None for "run_history"')
-    paths_from_node = _history_node_known_keys(inputs.stitched_obj.node)
+    paths_from_node = _history_node_known_keys(node)
 
     # If we don't have any paths from the node, then we need to refine it.
     if len(paths_from_node) == 0:

--- a/weave/ops_domain/run_history/history_op_common.py
+++ b/weave/ops_domain/run_history/history_op_common.py
@@ -242,6 +242,8 @@ def make_run_history_gql_field(inputs: InputAndStitchProvider, inner: str):
     all_known_paths = ["_step"]
 
     node = inputs.stitched_obj.node
+    if node is None:
+        raise errors.WeaveInternalError('unexpected, node is None for "run_history"')
     paths_from_node = _history_node_known_keys(inputs.stitched_obj.node)
 
     # If we don't have any paths from the node, then we need to refine it.

--- a/weave/ops_primitives/weave_api.py
+++ b/weave/ops_primitives/weave_api.py
@@ -572,8 +572,10 @@ def _artifact_ref_from_uri(
 def merge_artifact(
     self: graph.Node[typing.Any], root_args: typing.Any = None
 ) -> typing.Any:
-    self = compile.compile_fix_calls([self])[0]
-    return _merge(_get_uri_from_node(self, "Merge"))
+    fixed_self = compile.compile_fix_calls([self])[0]
+    if isinstance(fixed_self, Exception):
+        raise fixed_self
+    return _merge(_get_uri_from_node(fixed_self, "Merge"))
 
 
 @mutation

--- a/weave/stitch.py
+++ b/weave/stitch.py
@@ -128,7 +128,7 @@ def stitch_and_catch(
     leaf_nodes: typing.Sequence[typing.Union[graph.Node, Exception]],
     var_values: typing.Optional[dict[str, ObjectRecorder]] = None,
     stitched_graph: typing.Optional[StitchedGraph] = None,
-) -> tuple[StitchedGraph, typing.List[typing.Union[graph.Node, Exception]]]:
+) -> tuple[StitchedGraph, typing.Sequence[typing.Union[graph.Node, Exception]]]:
     """Given a list of leaf nodes, stitch the graph together."""
 
     if stitched_graph is None:

--- a/weave/value_or_error.py
+++ b/weave/value_or_error.py
@@ -3,11 +3,11 @@ import os
 import typing
 import logging
 
+from . import environment
+
 
 ValueType = typing.TypeVar("ValueType")
 ValueType2 = typing.TypeVar("ValueType2")
-
-DEBUG = False or os.environ.get("WEAVE_VALUE_OR_ERROR_DEBUG", False)
 
 
 class _ValueOrErrorInterface(typing.Generic[ValueType]):
@@ -55,7 +55,7 @@ class Error(_ValueOrErrorInterface[typing.Any]):
     _error: Exception
 
     def __post_init__(self) -> None:
-        if DEBUG:
+        if environment.value_or_error_debug():
             raise self._error
 
     def unwrap(self) -> typing.Any:

--- a/weave/weave_types.py
+++ b/weave/weave_types.py
@@ -731,6 +731,7 @@ class UnionType(Type):
     #     raise Exception('invalid')
     @classmethod
     def from_dict(cls, d):
+        return union(*[TypeRegistry.type_from_dict(mem) for mem in d["members"]])
         return merge_many_types(
             [TypeRegistry.type_from_dict(mem) for mem in d["members"]]
         )

--- a/weave/weave_types.py
+++ b/weave/weave_types.py
@@ -731,7 +731,6 @@ class UnionType(Type):
     #     raise Exception('invalid')
     @classmethod
     def from_dict(cls, d):
-        return union(*[TypeRegistry.type_from_dict(mem) for mem in d["members"]])
         return merge_many_types(
             [TypeRegistry.type_from_dict(mem) for mem in d["members"]]
         )


### PR DESCRIPTION
Do projection pushdown (ie only read columns from disk that are needed by the given weave expression) for expressions of the form get(*)->ArrowWeaveList. 

This is behind a feature flag controlled by feature_flags.GET_AWL_PROJECTION_PUSHDOWN and disabled in prod and tests for now.

The bulk of this PR refactors the error returning pattern we use in compile. I return Exceptions directly from map_nodes instead of passing them back via callback.

Doing this means that stitch needs to correctly create ObjectRecorders for tags that are saved in the AWL that will be returned by the get operation, by walking the AWL type.