### PR TITLE
ci: fix streamtable flake

### DIFF
--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -216,10 +216,10 @@ class _StreamTableSync:
         self._lite_run.log(payload)
 
     def finish(self) -> None:
-        if self._artifact:
-            self._artifact.cleanup()
         if self._lite_run:
             self._lite_run.finish()
+        if self._artifact:
+            self._artifact.cleanup()
 
     def __del__(self) -> None:
         self.finish()


### PR DESCRIPTION
Fixes flake affecting  tests/test_wb_stream_table.py::test_stream_logging_image, where temporary files were being reaped before the file pusher had a chance to upload them. 