### PR TITLE
ci: increase mypy timeout in ci

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,7 @@ jobs:
 
   lint:
     name: Python lint
-    timeout-minutes: 5
+    timeout-minutes: 7
     needs:
       - build-container
     # runs-on: [self-hosted, runner]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,10 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.0.0"
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.320
     hooks:
-      - id: mypy
-        exclude: .*pyi$
+    - id: pyright      
   - repo: local
     hooks:
       - id: jupyter-nb-clear-output

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
     rev: "v1.0.0"
     hooks:
       - id: mypy
-        additional_dependencies: [types-all, wandb>=0.15.5]
         exclude: .*pyi$
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,12 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.320
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.0.0"
     hooks:
-    - id: pyright      
+      - id: mypy
+        additional_dependencies: [types-all, wandb>=0.15.5]
+        exclude: .*pyi$
   - repo: local
     hooks:
       - id: jupyter-nb-clear-output


### PR DESCRIPTION
Increase mypy timeout so we dont fail linting checks waiting for mypy to finish running after containers take longer than normal to come up. We can put this back down when we replace mypy with pyright. 