### PR TITLE
chore(weave): Make History3 Universal

### DIFF
--- a/weave-js/src/components/Panel2/BokehViewer.tsx
+++ b/weave-js/src/components/Panel2/BokehViewer.tsx
@@ -55,9 +55,15 @@ const BokehViewerInner = (props: BokehViewerProps) => {
       if (bokehDivRef.current) {
         bokehDivRef.current.innerHTML = '';
       }
+      let root_id = 0;
+      // TODO: Why is this check necessary? Seems like it is with our test
+      // bokeh files
+      if (props.bokehJson.roots.root_ids != null) {
+        root_id = props.bokehJson.roots.root_ids[0];
+      }
       (window as any).Bokeh.embed.embed_item({
         doc: props.bokehJson,
-        root_id: props.bokehJson.roots.root_ids[0],
+        root_id: root_id,
         target_id: bokehDivId,
       });
     }

--- a/weave-js/src/components/Panel2/PanelObject.tsx
+++ b/weave-js/src/components/Panel2/PanelObject.tsx
@@ -135,7 +135,14 @@ export const PanelObject: React.FC<PanelObjectProps> = props => {
           opObjGetAttr({self: objNode, name: constString(key)}),
       };
     } else {
-      throw new Error('Invalid input type');
+      // TODO: Ugg.. what is happening here???
+      return {
+        objPropTypes: {},
+        pickOrGetattr: (objNode: Node, key: string) => {
+          throw new Error('Invalid input type');
+        },
+      };
+      // throw new Error('Invalid input type');
     }
   }, [props.input.type]);
   const propertyTypes = _.mapKeys(objPropTypes, (v, k) => escapeDots(k));

--- a/weave/mappers_python_def.py
+++ b/weave/mappers_python_def.py
@@ -17,6 +17,8 @@ from . import val_const
 from . import artifact_fs
 from . import timestamp as weave_timestamp
 from .language_features.tagging import tagged_value_type
+from . import artifact_mem
+from . import runfiles_wandb
 
 
 class TypedDictToPyDict(mappers_weave.TypedDictMapper):
@@ -278,6 +280,13 @@ class DefaultToPy(mappers.Mapper):
         # If the ref exists elsewhere, just return its uri.
         # TODO: This doesn't deal with MemArtifactRef!
         existing_ref = storage._get_ref(obj)
+
+        # TODO: This seems totally wrong
+        if isinstance(existing_ref, artifact_mem.MemArtifactRef):
+            obj = existing_ref.get()
+            if isinstance(obj, runfiles_wandb.WandbRunFiles):
+                return str(obj.uri)
+
         if isinstance(existing_ref, artifact_fs.FilesystemArtifactRef):
             if existing_ref.is_saved:
                 if self._use_stable_refs:

--- a/weave/ops_arrow/arrow.py
+++ b/weave/ops_arrow/arrow.py
@@ -405,10 +405,15 @@ def _rewrite_ref_for_save(entry: str, object_type, source_artifact, target_artif
         # Our source is an artifact, construct a full URI.
         return str(source_artifact.ref_from_local_str(entry, object_type).uri)
 
+    # TODO: This feels hacky. I am not really sure why we need to do this.
+    obj = source_artifact.get(entry, object_type)
+    if isinstance(object_type, artifact_fs.FilesystemArtifactType) and isinstance(
+        obj, artifact_fs.FilesystemArtifact
+    ):
+        return str(obj.uri)
+
     # Source is ObjLookupMem, save to the artifact
-    return target_artifact.set(
-        entry, object_type, source_artifact.get(entry, object_type)
-    ).local_ref_str()
+    return target_artifact.set(entry, object_type, obj).local_ref_str()
 
 
 def pretty_print_arrow_type(t: typing.Union[pa.Schema, pa.DataType, pa.Field]) -> str:

--- a/weave/ops_domain/run_history/run_history_ops.py
+++ b/weave/ops_domain/run_history/run_history_ops.py
@@ -1,0 +1,698 @@
+import dataclasses
+import json
+import logging
+import typing
+import pyarrow as pa
+
+
+from .context import get_error_on_non_vectorized_history_transform
+from ...compile_domain import wb_gql_op_plugin
+from ...api import op
+from ... import weave_types as types
+from .. import trace_tree, wb_domain_types as wdt
+from ... import artifact_mem
+from .. import wb_util
+from ...ops_arrow import ArrowWeaveList, ArrowWeaveListType, convert
+from ... import engine_trace
+from ... import errors
+from ...wandb_interface import wandb_stream_table
+from . import history_op_common
+from ... import artifact_base, io_service
+from .. import wbmedia
+from ... import artifact_fs
+from ...ops_arrow.list_ import (
+    PathItemType,
+    PathType,
+    weave_arrow_type_check,
+)
+
+tracer = engine_trace.tracer()
+
+
+@op(
+    name="run-refine_history_type",
+    render_info={"type": "function"},
+    hidden=True,
+    plugins=wb_gql_op_plugin(lambda inputs, inner: "historyKeys"),
+)
+def refine_history_type(run: wdt.Run) -> types.Type:
+    # TODO: Consider merging `_unflatten_history_object_type` into the main path
+    return ArrowWeaveListType(
+        _unflatten_history_object_type(history_op_common.refine_history_type(run))
+    )
+
+
+@op(
+    name="run-history",
+    refine_output_type=refine_history_type,
+    plugins=wb_gql_op_plugin(history_op_common.make_run_history_gql_field),
+    output_type=types.List(types.TypedDict({})),
+)
+def history(run: wdt.Run):
+    # TODO: This is now equivalent to hist2
+    return history_op_common.mock_history_rows(run)
+
+
+@op(
+    render_info={"type": "function"},
+    plugins=wb_gql_op_plugin(lambda inputs, inner: "historyKeys"),
+    hidden=True,
+)
+def refine_history_with_columns_type(
+    run: wdt.Run, history_cols: list[str]
+) -> types.Type:
+    # TODO: Consider merging `_unflatten_history_object_type` into the main path
+    return ArrowWeaveListType(
+        _unflatten_history_object_type(
+            history_op_common.refine_history_type(
+                run,
+                columns=history_op_common.get_full_columns_prefixed(run, history_cols),
+            )
+        )
+    )
+
+
+@op(
+    name="run-history_with_columns",
+    refine_output_type=refine_history_with_columns_type,
+    plugins=wb_gql_op_plugin(history_op_common.make_run_history_gql_field),
+    output_type=types.List(types.TypedDict({})),
+    hidden=True,
+)
+def history_with_columns(run: wdt.Run, history_cols: list[str]):
+    return _get_history(
+        run, history_op_common.get_full_columns_prefixed(run, history_cols)
+    )
+
+
+@dataclasses.dataclass
+class PathTree:
+    children: typing.Dict[PathItemType, "PathTree"] = dataclasses.field(
+        default_factory=dict
+    )
+    data: typing.Optional[typing.Any] = None
+
+
+def _get_history(run: wdt.Run, columns=None):
+    # 1. Get the flattened Weave-Type given HistoryKeys
+    # 2. Read in the live set
+    # 3. Raw-load each parquet file
+    # 4. For each flattened column:
+    #   a. If it contains a type requiring in-mem processing, then
+    #       i. For liveset -> we must pass each item `_process_run_dict_item`, then use convert.to_arrow
+    #       ii. For parquet -> we must extract the pyobj, us `_process_run_dict_item`, convert.to_arrow
+    #   b. If the nested type contains a custom type or object type, then we must adjust the structure:
+    #       i. For liveset -> we can pass each item to the simplified `_reconstruct_run_item`, then use convert.to_arrow(already_mapped = true)
+    #       ii. For parquet -> we need to use the `_correct_awl` to adjust the structure.
+    #   c. For all other types
+    #       i. For liveset -> we can just use convert.to_arrow
+    #       ii. For parquet -> no op
+    # 5. Now we concat the converted liveset and parquet files
+    # 6. Finally, unflatten the columns and return the result
+    # 7. Optionally: verify the AWL
+
+    artifact = artifact_mem.MemArtifact()
+
+    # 1. Get the flattened Weave-Type given HistoryKeys
+    flattened_object_type = history_op_common.refine_history_type(run, columns=columns)
+    final_type = _unflatten_history_object_type(flattened_object_type)
+
+    # 2. Read in the live set
+    raw_live_data = _get_live_data_from_run(run, columns=columns)
+
+    # 3.a: Raw-load each parquet file
+    raw_history_awl_tables = _read_raw_history_awl_tables(
+        run, columns=columns, artifact=artifact
+    )
+
+    # 3.b: Collapse unions
+    union_collapsed_awl_tables = [
+        _collapse_unions(awl) for awl in raw_history_awl_tables
+    ]
+
+    # 4. Process all the data
+    raw_history_pa_tables = [
+        history_op_common.awl_to_pa_table(awl) for awl in union_collapsed_awl_tables
+    ]
+
+    run_path = wb_util.RunPath(
+        run.gql["project"]["entity"]["name"],
+        run.gql["project"]["name"],
+        run.gql["name"],
+    )
+    (
+        live_columns,
+        live_columns_already_mapped,
+        processed_history_pa_tables,
+    ) = _process_all_columns(
+        flattened_object_type, raw_live_data, raw_history_pa_tables, run_path, artifact
+    )
+
+    live_data_awl = _construct_live_data_awl(
+        live_columns,
+        live_columns_already_mapped,
+        flattened_object_type,
+        len(raw_live_data),
+        artifact,
+    )
+
+    # 5.a Now we concat the converted liveset and parquet files
+    concatted_awl = history_op_common.concat_awls(
+        [
+            live_data_awl,
+            *{
+                ArrowWeaveList(
+                    table, object_type=flattened_object_type, artifact=artifact
+                )
+                for table in processed_history_pa_tables
+            },
+        ]
+    )
+
+    if len(concatted_awl) == 0:
+        return convert.to_arrow([], types.List(final_type), artifact=artifact)
+
+    sorted_table = history_op_common.sort_history_pa_table(
+        history_op_common.awl_to_pa_table(concatted_awl)
+    )
+
+    # 6. Finally, unflatten the columns
+    final_array = _unflatten_pa_table(sorted_table)
+
+    # 7. Optionally: verify the AWL
+    reason = weave_arrow_type_check(final_type, final_array)
+
+    if reason != None:
+        raise errors.WeaveWBHistoryTranslationError(
+            f"Failed to effectively convert column of Gorilla Parquet History to expected history type: {reason}"
+        )
+    return ArrowWeaveList(
+        final_array,
+        final_type,
+        artifact=artifact,
+    )
+
+
+def _construct_live_data_awl(
+    live_columns: dict[str, list],
+    live_columns_already_mapped: dict[str, list],
+    flattened_object_type: types.TypedDict,
+    num_rows: int,
+    artifact: artifact_mem.MemArtifact,
+) -> ArrowWeaveList:
+    live_columns_to_data = [
+        {k: v[i] for k, v in live_columns.items()} for i in range(num_rows)
+    ]
+
+    live_columns_already_mapped_to_data = [
+        {k: v[i] for k, v in live_columns_already_mapped.items()}
+        for i in range(num_rows)
+    ]
+
+    partial_live_data_awl = convert.to_arrow(
+        live_columns_to_data,
+        types.List(
+            types.TypedDict(
+                {
+                    k: v
+                    for k, v in flattened_object_type.property_types.items()
+                    if k in live_columns
+                }
+            )
+        ),
+        artifact=artifact,
+    )
+    partial_live_data_already_mapped_awl = convert.to_arrow_from_list_and_artifact(
+        live_columns_already_mapped_to_data,
+        types.TypedDict(
+            {
+                k: v
+                for k, v in flattened_object_type.property_types.items()
+                if k in live_columns_already_mapped
+            }
+        ),
+        artifact=artifact,
+        py_objs_already_mapped=True,
+    )
+
+    field_names = []
+    field_arrays = []
+    for field_ndx, field in enumerate(partial_live_data_awl._arrow_data.type):
+        field_names.append(field.name)
+        field_arrays.append(partial_live_data_awl._arrow_data.field(field_ndx))
+
+    for field_ndx, field in enumerate(
+        partial_live_data_already_mapped_awl._arrow_data.type
+    ):
+        field_names.append(field.name)
+        field_arrays.append(
+            partial_live_data_already_mapped_awl._arrow_data.field(field_ndx)
+        )
+
+    return ArrowWeaveList(
+        pa.StructArray.from_arrays(field_arrays, field_names),
+        flattened_object_type,
+        artifact=artifact,
+    )
+
+
+def _process_all_columns(
+    flattened_object_type: types.TypedDict,
+    raw_live_data: list[dict],
+    raw_history_pa_tables: list[pa.Table],
+    run_path: wb_util.RunPath,
+    artifact: artifact_mem.MemArtifact,
+):
+    live_columns = {}
+    live_columns_already_mapped = {}
+    processed_history_pa_tables = [*raw_history_pa_tables]
+
+    for col_name, col_type in flattened_object_type.property_types.items():
+        raw_live_column = _extract_column_from_live_data(raw_live_data, col_name)
+        processed_live_column = None
+        if _column_type_requires_in_memory_transformation(col_type):
+            _non_vectorized_warning(
+                f"Encountered a history column requiring non-vectorized, in-memory processing: {col_name}: {col_type}"
+            )
+            processed_live_column = _process_column_in_memory(raw_live_column, run_path)
+            live_columns[col_name] = processed_live_column
+
+            for table_ndx, table in enumerate(processed_history_pa_tables):
+                fields = [field.name for field in table.schema]
+                new_col = _process_history_column_in_memory(
+                    table[col_name], col_type, run_path, artifact
+                )
+                processed_history_pa_tables[table_ndx] = table.set_column(
+                    fields.index(col_name), col_name, new_col
+                )
+
+        elif _is_directly_convertible_type(col_type):
+            live_columns_already_mapped[col_name] = raw_live_column
+            # Important that this runs before the else branch
+            continue
+        else:
+            processed_live_column = _reconstruct_original_live_data_col(raw_live_column)
+            live_columns_already_mapped[col_name] = processed_live_column
+
+            for table_ndx, table in enumerate(processed_history_pa_tables):
+                fields = [field.name for field in table.schema]
+                new_col = _drop_types_from_encoded_types(
+                    ArrowWeaveList(
+                        table[col_name],
+                        None,
+                        artifact=artifact,
+                    )
+                )
+                arrow_col = new_col._arrow_data
+                if types.Timestamp().assign_type(types.non_none(col_type)):
+                    arrow_col = arrow_col.cast("int64").cast(
+                        pa.timestamp("ms", tz="UTC")
+                    )
+                processed_history_pa_tables[table_ndx] = table.set_column(
+                    fields.index(col_name), col_name, arrow_col
+                )
+
+    return live_columns, live_columns_already_mapped, processed_history_pa_tables
+
+
+def _non_vectorized_warning(message: str):
+    logging.warning(message)
+    if get_error_on_non_vectorized_history_transform():
+        raise errors.WeaveWBHistoryTranslationError(message)
+
+
+def _build_array_from_tree(tree: PathTree) -> pa.Array:
+    children_struct_array = []
+    if len(tree.children) > 0:
+        mask = None
+        children_data = {}
+        for k, v in tree.children.items():
+            children_data[k] = _build_array_from_tree(v)
+            child_is_null = _is_null(children_data[k])
+            if mask is None:
+                mask = child_is_null
+            else:
+                mask = pa.compute.and_(mask, child_is_null)
+
+        children_struct = pa.StructArray.from_arrays(
+            children_data.values(), children_data.keys(), mask=mask
+        )
+        children_struct_array = [children_struct]
+    children_arrays = [*(tree.data or []), *children_struct_array]
+
+    if len(children_arrays) == 0:
+        raise errors.WeaveWBHistoryTranslationError(
+            "Cannot build array from empty tree"
+        )
+    elif len(children_arrays) == 1:
+        return children_arrays[0]
+
+    num_rows = len(children_arrays[0])
+
+    return _union_from_column_data(num_rows, children_arrays)
+
+
+def _unflatten_pa_table(array: pa.Table) -> pa.StructArray:
+    cols = array.schema.names
+    new_tree = PathTree(data=[])
+    for col_name in cols:
+        path = col_name.split(".")
+        target = new_tree
+        for part in path:
+            if part not in target.children:
+                target.children[part] = PathTree(data=[])
+            target = target.children[part]
+        if not isinstance(target.data, list):
+            raise errors.WeaveWBHistoryTranslationError(
+                f"Encountered unexpected data in PathTree: {type(target.data)}"
+            )
+        target.data.append(array[col_name].combine_chunks())
+
+    # Recursively resolve the tree
+    return _build_array_from_tree(new_tree)
+
+
+def _union_collapse_mapper(
+    awl: ArrowWeaveList, path: PathType
+) -> typing.Optional[ArrowWeaveList]:
+    object_type = types.non_none(awl.object_type)
+    if types.TypedDict({}).assign_type(object_type):
+        object_type = typing.cast(types.TypedDict, object_type)
+        columns = list(object_type.property_types.keys())
+        arrow_data = awl._arrow_data
+        arrow_columns = [c.name for c in arrow_data.type]
+        if all([c.startswith("_type_") for c in columns]):
+            logging.warning(
+                f"Encountered history store union: this requires a non-vectorized transformation on the order of number of rows (but fortunately does not require transforming to python). Path: {path}, Type: {object_type}"
+            )
+            num_rows = len(arrow_data)
+            weave_type_members = []
+            for col_name in columns:
+                weave_type_members.append(object_type.property_types[col_name])
+
+            union_arr = _union_from_column_data(
+                num_rows,
+                [
+                    arrow_data.field(arrow_columns.index(col_name))
+                    for col_name in columns
+                ],
+            )
+            return ArrowWeaveList(
+                union_arr, types.union(*weave_type_members), awl._artifact
+            )
+
+    return None
+
+
+def _union_from_column_data(num_rows: int, columns: list[pa.Array]) -> pa.Array:
+    type_array = pa.nulls(num_rows, type=pa.int8())
+    offset_array = pa.nulls(num_rows, type=pa.int32())
+    arrays = []
+    for col_ndx, column_data in enumerate(columns):
+        is_usable = pa.compute.invert(_is_null(column_data))
+        new_data = column_data.filter(is_usable)
+        arrays.append(new_data)
+        type_array = pa.compute.replace_with_mask(
+            type_array,
+            is_usable,
+            pa.array([col_ndx] * len(is_usable), type=pa.int8()),
+        )
+        offset_array = pa.compute.replace_with_mask(
+            offset_array,
+            is_usable,
+            pa.array(list(range(len(new_data))), type=pa.int32()),
+        )
+
+    arrays.append(pa.nulls(1, type=pa.int8()))
+    type_array = pa.compute.fill_null(type_array, len(arrays) - 1)
+    offset_array = pa.compute.fill_null(offset_array, 0)
+
+    return pa.UnionArray.from_dense(type_array, offset_array, arrays)
+
+
+def _is_null(array: pa.Array) -> pa.Array:
+    if isinstance(array, pa.ChunkedArray):
+        array = array.combine_chunks()
+
+    base_truth = pa.compute.is_null(array)
+
+    if pa.types.is_struct(array.type):
+        children_nulls = [_is_null(array.field(i)) for i in range(len(array.type))]
+        if len(children_nulls) == 0:
+            return pa.array([True] * len(array), type=pa.bool_())
+        else:
+            curr = children_nulls[0]
+            for child in children_nulls[1:]:
+                curr = pa.compute.and_(curr, child)
+            return pa.compute.or_(curr, base_truth)
+
+    return base_truth
+
+
+def _collapse_unions(awl: ArrowWeaveList) -> ArrowWeaveList:
+    return awl.map_column(_union_collapse_mapper)
+
+
+def _drop_types_mapper(
+    awl: ArrowWeaveList, path: PathType
+) -> typing.Optional[ArrowWeaveList]:
+    object_type = types.non_none(awl.object_type)
+    if types.TypedDict(
+        {"_type": types.optional(types.String()), "_val": types.Any()}
+    ).assign_type(object_type):
+        return awl.column("_val")
+    return None
+
+
+def _drop_types_from_encoded_types(awl: ArrowWeaveList) -> ArrowWeaveList:
+    return awl.map_column(_drop_types_mapper)
+
+
+def _get_live_data_from_run(run: wdt.Run, columns=None):
+    raw_live_data = run.gql["sampledParquetHistory"]["liveData"]
+    if columns is None:
+        return raw_live_data
+    column_set = set(columns)
+    return [{k: v for k, v in row.items() if k in column_set} for row in raw_live_data]
+
+
+def _extract_column_from_live_data(live_data: list[dict], column_name: str):
+    return [row.get(column_name, None) for row in live_data]
+
+
+def _process_column_in_memory(live_column: list, run_path: wb_util.RunPath) -> list:
+    return [_process_live_object_in_memory(item, run_path) for item in live_column]
+
+
+def _process_live_object_in_memory(
+    live_data: typing.Any, run_path: wb_util.RunPath
+) -> typing.Any:
+    if isinstance(live_data, list):
+        return [_process_live_object_in_memory(cell, run_path) for cell in live_data]
+    if isinstance(live_data, dict):
+        if live_data.get("_type") != None:
+            return wb_util._process_run_dict_item(live_data, run_path)
+        else:
+            return {
+                key: _process_live_object_in_memory(val, run_path)
+                for key, val in live_data.items()
+            }
+    return live_data
+
+
+def _process_history_column_in_memory(
+    history_column: pa.Array,
+    col_type: types.Type,
+    run_path: wb_util.RunPath,
+    artifact: artifact_base.Artifact,
+) -> pa.Array:
+    pyobj = history_column.to_pylist()
+    processed_data = _process_column_in_memory(pyobj, run_path)
+    awl = convert.to_arrow(
+        processed_data,
+        types.List(col_type),
+        artifact=artifact,
+    )
+    return pa.chunked_array([awl._arrow_data])
+
+
+# Copy from common - need to merge back
+def _read_raw_history_awl_tables(
+    run: wdt.Run,
+    columns=None,
+    artifact: typing.Optional[artifact_base.Artifact] = None,
+) -> list[ArrowWeaveList]:
+    io = io_service.get_sync_client()
+    tables = []
+    for url in run.gql["sampledParquetHistory"]["parquetUrls"]:
+        local_path = io.ensure_file_downloaded(url)
+        if local_path is not None:
+            path = io.fs.path(local_path)
+            awl = history_op_common.awl_from_local_parquet_path(
+                path, None, columns=columns, artifact=artifact
+            )
+            awl.map_column(_parse_bytes_mapper)
+            tables.append(awl)
+    return tables
+
+    # return history_op_common.process_history_awl_tables(tables)
+
+
+def _parse_bytes_to_json(bytes: bytes):
+    return json.loads(bytes.decode("utf-8"))
+
+
+def _parse_bytes_mapper(
+    awl: ArrowWeaveList, path: PathType
+) -> typing.Optional[ArrowWeaveList]:
+    obj_type = types.non_none(awl.object_type)
+    if types.Bytes().assign_type(obj_type):
+        _non_vectorized_warning(
+            f"Encountered bytes in column {path}, requires in-memory processing"
+        )
+        data = [
+            _parse_bytes_to_json(row) if row is not None else None
+            for row in awl._arrow_data.to_pylist()
+        ]
+        wb_type = types.TypeRegistry.type_of(data)
+        if not hasattr(wb_type, "object_type"):
+            raise errors.WeaveWBHistoryTranslationError(
+                f"Expected type with object_type attribute, got {wb_type}"
+            )
+        wb_type = typing.cast(types.List, wb_type)
+        return convert.to_arrow_from_list_and_artifact(
+            data,
+            wb_type.object_type,
+            artifact=awl._artifact or artifact_mem.MemArtifact(),
+            py_objs_already_mapped=True,
+        )
+    return None
+
+
+def _column_type_requires_in_memory_transformation(col_type: types.Type):
+    return _column_type_requires_in_memory_transformation_recursive(col_type)
+
+
+def _is_directly_convertible_type(col_type: types.Type):
+    return _is_directly_convertible_type_recursive(col_type)
+
+
+_weave_types_requiring_in_memory_transformation = (
+    # TODO: We should at a minimum get ImageArtifactFileRefType working
+    # in the vectorized way. I think we can get the others working as well
+    wbmedia.ImageArtifactFileRefType,  # type: ignore
+    wbmedia.AudioArtifactFileRef.WeaveType,  # type: ignore
+    wbmedia.BokehArtifactFileRef.WeaveType,  # type: ignore
+    wbmedia.VideoArtifactFileRef.WeaveType,  # type: ignore
+    wbmedia.Object3DArtifactFileRef.WeaveType,  # type: ignore
+    wbmedia.MoleculeArtifactFileRef.WeaveType,  # type: ignore
+    wbmedia.HtmlArtifactFileRef.WeaveType,  # type: ignore
+    wbmedia.LegacyTableNDArrayType,
+    wb_util.WbHistogram,
+    trace_tree.WBTraceTree.WeaveType,  # type: ignore
+    types.UnknownType,
+    artifact_fs.FilesystemArtifactFileType,  # Tables
+)
+
+
+def _column_type_requires_in_memory_transformation_recursive(col_type: types.Type):
+    if types.NoneType().assign_type(col_type):
+        return False
+    non_none_type = types.non_none(col_type)
+    if isinstance(non_none_type, types.UnionType):
+        return True
+    elif isinstance(non_none_type, _weave_types_requiring_in_memory_transformation):
+        return True
+    elif isinstance(non_none_type, types.List):
+        return _column_type_requires_in_memory_transformation_recursive(
+            non_none_type.object_type
+        )
+    elif isinstance(non_none_type, types.TypedDict):
+        for k, v in non_none_type.property_types.items():
+            if _column_type_requires_in_memory_transformation_recursive(v):
+                return True
+        return False
+    else:
+        return False
+
+
+def _is_directly_convertible_type_recursive(col_type: types.Type):
+    if types.NoneType().assign_type(col_type):
+        return True
+    non_none_type = types.non_none(col_type)
+    if types.union(
+        *[
+            types.Number(),
+            types.Int(),
+            types.Float(),
+            types.String(),
+            types.Boolean(),
+        ]
+    ).assign_type(col_type):
+        return True
+    elif isinstance(non_none_type, types.List):
+        return _is_directly_convertible_type_recursive(non_none_type.object_type)
+    elif isinstance(non_none_type, types.TypedDict):
+        for k, v in non_none_type.property_types.items():
+            if not _is_directly_convertible_type_recursive(v):
+                return False
+        return True
+    else:
+        return False
+
+
+def _reconstruct_original_live_data_col(row: list):
+    return [_reconstruct_original_live_data_cell(cell) for cell in row]
+
+
+def _reconstruct_original_live_data_cell(live_data: typing.Any) -> typing.Any:
+    if isinstance(live_data, list):
+        return [_reconstruct_original_live_data_cell(cell) for cell in live_data]
+    if isinstance(live_data, dict):
+        if wandb_stream_table.is_weave_encoded_history_cell(live_data):
+            return live_data["_val"]
+        return {
+            key: _reconstruct_original_live_data_cell(val)
+            for key, val in live_data.items()
+        }
+    return live_data
+
+
+def _unflatten_history_object_type(obj_type: types.TypedDict) -> types.TypedDict:
+    # Need to combine top-level maps. Note: this is not a recursive function
+    # since the flattening only happens top level in gorilla.
+    dict_keys: dict[str, types.Type] = {}
+    for key, val in obj_type.property_types.items():
+        path_parts = key.split(".")
+        prop_types = dict_keys
+
+        for part in path_parts[:-1]:
+            found = False
+            prop_types_inner: dict[str, types.Type] = {}
+            default_dict = types.TypedDict(prop_types_inner)
+            if part not in prop_types:
+                prop_types[part] = default_dict
+                prop_types = prop_types_inner
+            elif part in prop_types:
+                prop_type = prop_types[part]
+                if isinstance(prop_type, types.TypedDict):
+                    prop_types = prop_type.property_types
+                    found = True
+                elif isinstance(prop_type, types.UnionType):
+                    for member in prop_type.members:
+                        if isinstance(member, types.TypedDict):
+                            prop_types = member.property_types
+                            found = True
+                            break
+
+                if not found:
+                    prop_types[part] = types.union(prop_type, default_dict)
+                    prop_types = prop_types_inner
+
+        final_part = path_parts[-1]
+        if final_part not in prop_types:
+            prop_types[final_part] = val
+        else:
+            prop_types[final_part] = types.union(val, prop_types[final_part])
+
+    return types.TypedDict(dict_keys)

--- a/weave/tests/test_wb_data_types.py
+++ b/weave/tests/test_wb_data_types.py
@@ -808,3 +808,43 @@ def test_html_encoding_decoding(fake_wandb):
     contents = file.file_contents(file_node)
     result = weave.use(contents)
     assert HTML_STRING in result
+
+
+def test_media_logging_to_history(user_by_api_key_in_env):
+    # TODO: Make this test exercise both the parquet and liveset
+    # paths. Also test for values.
+    log_dict = {
+        "image": make_image(),
+        "audio": make_audio(),
+        "html": make_html(),
+        "bokeh": make_bokeh(),
+        "video": make_video(),
+        "object3d": make_object3d(),
+        "molecule": make_molecule(),
+        "table": make_table(),
+        "simple_image_table": make_simple_image_table(),
+        "all_types_table": [
+            make_image(),
+            make_audio(),
+            make_html(),
+            make_bokeh(),
+            make_video(),
+            make_object3d(),
+            make_molecule(),
+            make_table(),
+            make_simple_image_table(),
+        ],
+    }
+    run = wandb.init(project="test_media_logging_to_history")
+    run.log(log_dict)
+    run.finish()
+
+    history_node = (
+        weave.ops.project(run.entity, run.project)
+        .run(run.id)
+        .history()
+        .map(lambda row: weave.ops.dict_(**{key: row[key] for key in log_dict.keys()}))
+    )
+
+    history = weave.use(history_node).to_pylist_notags()
+    assert len(history) == 1


### PR DESCRIPTION
We currently have 3 history paths. Besides being a maintenance pain, this has some disadvantages - mainly that each path is optimized differently:
- `history`: Used for all history ops today
   - Pros:
       - Pretty robust - handles almost every type.
   - Cons:
       - Slow: since it reads everything into memory and processes every single cell.
       - Complex Unions: not supported
       - Custom Weave Types: not supported
- `history2`: used only in the special run branching logic
   - Pros:
       - Pretty robust - handles almost every type.
       - Faster than `history` as it stays in arrow where possible.
   - Cons:
       - Seems broken for reading media types currently in UI
       - Complex Unions: not supported
       - Custom Weave Types: not supported
- `history3`: used for StreamTable.rows
   - Pros:
       - Fast: Stays in arrow almost exclusively
       - Supports complex unions and custom weave types
   - Cons:
       - Seems broken for reading media types currently in UI
       - Does not support media types


Now, we are refactoring the StreamTable implementation to essentially just wrap run.log. This means that we need to support all legacy media types as well. So, the goal is to collapse all this into a single implementation.

TODO:

- [ ] Make history3 support all media types (even if that means a speed degradation in such cases)
- [ ] Make history3 fast for images (like history2)
- [ ] Figure out why the arrowification of media types breaks in UI (for h2 and h3)
- [ ] Replace all code paths for history with history3 (and just name it history)
