### PR TITLE
chore: improve empty board styling

### DIFF
--- a/weave-js/src/components/Alert.styles.ts
+++ b/weave-js/src/components/Alert.styles.ts
@@ -1,0 +1,59 @@
+import {
+  GOLD_300,
+  GOLD_600,
+  GREEN_300,
+  GREEN_600,
+  hexToRGB,
+  MOON_800,
+  MOON_950,
+  RED_300,
+  RED_500,
+  TEAL_300,
+  TEAL_600,
+} from '../common/css/globals.styles';
+import {Icon as IconComp} from './Icon';
+import styled from 'styled-components';
+
+type AlertProps = {
+  severity: string;
+};
+
+const BG_COLORS: Record<string, string> = {
+  default: hexToRGB(MOON_950, 0.04),
+  error: hexToRGB(RED_300, 0.48),
+  warning: hexToRGB(GOLD_300, 0.48),
+  info: hexToRGB(TEAL_300, 0.48),
+  success: hexToRGB(GREEN_300, 0.48),
+};
+
+const TEXT_COLORS: Record<string, string> = {
+  default: MOON_800,
+  error: RED_500,
+  warning: GOLD_600,
+  info: TEAL_600,
+  success: GREEN_600,
+};
+
+export const Alert = styled.div<AlertProps>`
+  background-color: ${props => BG_COLORS[props.severity]};
+  color: ${props => TEXT_COLORS[props.severity]};
+  padding: 6px 16px;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 20px;
+  display: flex;
+  align-items: center;
+`;
+
+export const Icon = styled(IconComp)`
+  font-size: 20px;
+  margin-right: 8px;
+  flex: 0 0 auto;
+`;
+
+export const Message = styled.div`
+  // This value chosen to make the alert the same height as our source select widgets.
+  padding: 3px;
+  flex: 1 1 auto;
+`;

--- a/weave-js/src/components/Alert.tsx
+++ b/weave-js/src/components/Alert.tsx
@@ -1,0 +1,43 @@
+/**
+ * Display an info message to the user.
+ */
+
+import {IconName} from './Icon';
+import React from 'react';
+
+import * as S from './Alert.styles';
+
+export const AlertSeverities = {
+  Error: 'error',
+  Warning: 'warning',
+  Info: 'info',
+  Success: 'success',
+} as const;
+export type AlertSeverity =
+  (typeof AlertSeverities)[keyof typeof AlertSeverities];
+
+const ICONS: Record<AlertSeverity, string> = {
+  error: 'failed',
+  warning: 'warning',
+  info: 'info',
+  success: 'checkmark-circle',
+};
+
+type AlertProps = {
+  severity?: AlertSeverity;
+  icon?: IconName | null;
+  children: React.ReactNode;
+};
+
+export const Alert = ({severity, icon, children}: AlertProps) => {
+  // User can override icon including to force it not to be shown.
+  // Otherwise fallback to show the icon associated with the severity.
+  const iconName =
+    icon === null || icon ? icon : severity ? ICONS[severity] : null;
+  return (
+    <S.Alert severity={severity ?? 'default'}>
+      {iconName !== null && <S.Icon name={iconName} width={16} height={16} />}
+      <S.Message>{children}</S.Message>
+    </S.Alert>
+  );
+};

--- a/weave-js/src/components/WeavePanelBank/PanelBankEmptySectionWatermark.tsx
+++ b/weave-js/src/components/WeavePanelBank/PanelBankEmptySectionWatermark.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Alert} from '../Alert';
 
 // This is a merge of 4 files from app.
 
@@ -103,7 +104,11 @@ interface EmptyVisualizationsProps {
 
 export const EmptyVisualizations = (props: EmptyVisualizationsProps) => {
   return (
-    <div>EMPTY</div>
+    <div style={{padding: '8px 32px'}}>
+      <Alert severity="info">
+        Click the "New panel" button to start building a board.
+      </Alert>
+    </div>
     // <EmptyWatermark
     //   className="empty-watermark-visualizations"
     //   // imageSource={emptyImg}


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-14551

Copies the Alert component originally built for Launch into Weave, uses it as a short-term fix for the empty board state styling. (Commented out code indicates we eventually want to do something more sophisticated here.)

@Cecile0112358 there are now a few different alert/banner components around, it might be good to unify as part of the overall common components effort.

Before:
![image](https://github.com/wandb/weave/assets/112953339/30469a75-6520-4124-99a1-99d5f6782013)

After:
![image](https://github.com/wandb/weave/assets/112953339/127d7fa8-2fb6-475e-9278-4974b07dd032)

