### PR TITLE
fix: fix panel crash in prompts custom column due to incorrect panel for table type

### DIFF
--- a/weave-js/src/components/Panel2/availablePanels.test.ts
+++ b/weave-js/src/components/Panel2/availablePanels.test.ts
@@ -368,7 +368,6 @@ describe('panel chaining', () => {
       excludePlot: true,
     }).stackIds.map(s => s.id);
 
-    expect(stacks.length).toEqual(1);
-    expect(stacks[0]).toBe('maybe.object-file.object');
+    expect(stacks).toEqual(['maybe.object-file.object']);
   });
 });

--- a/weave-js/src/components/Panel2/availablePanels.test.ts
+++ b/weave-js/src/components/Panel2/availablePanels.test.ts
@@ -278,4 +278,97 @@ describe('panel chaining', () => {
       )
     ).toContain('row.row.image-file');
   });
+
+  it('maybe file case', () => {
+    const type = {
+      type: 'tagged',
+      tag: {
+        type: 'tagged',
+        tag: {
+          type: 'tagged',
+          tag: {
+            type: 'tagged',
+            tag: {
+              type: 'tagged',
+              tag: {
+                type: 'typedDict',
+                propertyTypes: {
+                  entityName: 'string',
+                  projectName: 'string',
+                },
+              },
+              value: {
+                type: 'typedDict',
+                propertyTypes: {
+                  project: 'project',
+                  filter: 'string',
+                  order: 'string',
+                },
+              },
+            },
+            value: {
+              type: 'typedDict',
+              propertyTypes: {
+                entityName: 'string',
+                projectName: 'string',
+              },
+            },
+          },
+          value: {
+            type: 'typedDict',
+            propertyTypes: {
+              project: 'project',
+              filter: 'string',
+              order: 'string',
+            },
+          },
+        },
+        value: {
+          type: 'typedDict',
+          propertyTypes: {
+            run: 'run',
+          },
+        },
+      },
+      value: {
+        type: 'union',
+        members: [
+          'none',
+          {
+            type: 'file',
+            _base_type: {
+              type: 'FileBase',
+            },
+            extension: 'json',
+            wbObjectType: {
+              type: 'table',
+              _base_type: {
+                type: 'Object',
+              },
+              _is_object: true,
+              _rows: {
+                type: 'ArrowWeaveList',
+                _base_type: {
+                  type: 'list',
+                },
+                objectType: {
+                  type: 'typedDict',
+                  propertyTypes: {},
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as Type;
+
+    const stacks = AvailablePanels.getPanelStacksForType(type, undefined, {
+      excludeTable: true,
+      excludeMultiTable: true,
+      excludePlot: true,
+    }).stackIds.map(s => s.id);
+
+    expect(stacks.length).toEqual(1);
+    expect(stacks[0]).toBe('maybe.object-file.object');
+  });
 });

--- a/weave-js/src/core/model/helpers.ts
+++ b/weave-js/src/core/model/helpers.ts
@@ -983,7 +983,7 @@ export function isFile(t: Type): t is File {
 }
 
 export function isFileLike(t: Type): t is File {
-  t = nullableTaggableValue(t);
+  t = unwrapTaggedValues(t);
   return isFile(t);
 }
 

--- a/weave-js/src/core/model/helpers.ts
+++ b/weave-js/src/core/model/helpers.ts
@@ -983,7 +983,10 @@ export function isFile(t: Type): t is File {
 }
 
 export function isFileLike(t: Type): t is File {
-  t = unwrapTaggedValues(t);
+  if (isTaggedValue(t)) {
+    t = taggedValueValueType(t);
+  }
+
   return isFile(t);
 }
 


### PR DESCRIPTION
Internal JIRA ticket: https://wandb.atlassian.net/browse/WB-14924

Fixes an issue where PanelWBObject was being marked available to handle `union[null, file]`, due to `isFileLike()` returning true for unions of files with none. This narrows the types the converter can handle to non-null assignable types, fixing a downstream panel crash in prompts. Adds a unit test for this case. 