### PR TITLE
feat: allow deleting boards without opening them first

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -5,6 +5,7 @@ import {
   IconChevronDown,
   IconInfo,
   IconOpenNewTab,
+  IconDelete,
 } from '@wandb/weave/components/Icon';
 import * as query from './query';
 import {CenterBrowser, CenterBrowserActionType} from './HomeCenterBrowser';
@@ -299,6 +300,7 @@ const CenterProjectBoardsBrowser: React.FC<
   CenterProjectBrowserInnerPropsType
 > = props => {
   const browserTitle = 'Boards';
+  const [deletingId, setDeletingId] = useState<string | undefined>();
   const [selectedRowId, setSelectedRowId] = useState<string | undefined>();
 
   const boards = query.useProjectBoards(props.entityName, props.projectName);
@@ -350,6 +352,16 @@ const CenterProjectBoardsBrowser: React.FC<
           },
         },
       ],
+      [
+        {
+          icon: IconDelete,
+          label: 'Delete board',
+          onClick: row => {
+            const uri = `wandb-artifact:///${props.entityName}/${props.projectName}/${row._id}:latest/obj`;
+            setDeletingId(uri);
+          },
+        },
+      ],
     ];
   }, [props, setSelectedRowId]);
 
@@ -358,6 +370,10 @@ const CenterProjectBoardsBrowser: React.FC<
       allowSearch
       title={browserTitle}
       selectedRowId={selectedRowId}
+      setSelectedRowId={setSelectedRowId}
+      setPreviewNode={props.setPreviewNode}
+      deletingId={deletingId}
+      setDeletingId={setDeletingId}
       noDataCTA={`No Weave boards found for project: ${props.entityName}/${props.projectName}`}
       breadcrumbs={[
         {

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterLocalBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterLocalBrowser.tsx
@@ -1,6 +1,10 @@
 import {opGet, constString} from '@wandb/weave/core';
 import React, {useMemo, useState} from 'react';
-import {IconInfo, IconOpenNewTab} from '../../Panel2/Icons';
+import {
+  IconDelete,
+  IconInfo,
+  IconOpenNewTab,
+} from '@wandb/weave/components/Icon';
 import {CenterBrowserActionType, CenterBrowser} from './HomeCenterBrowser';
 import {SetPreviewNodeType, NavigateToExpressionType} from './common';
 import * as query from './query';
@@ -21,6 +25,9 @@ const rowToExpression = (row: any) => {
 export const CenterLocalBrowser: React.FC<
   CenterLocalBrowserPropsType
 > = props => {
+  const [deletingId, setDeletingId] = useState<string | undefined>();
+  const [isModalActing, setIsModalActing] = useState(false);
+
   const localDashboards = query.useLocalDashboards();
   const [selectedRowId, setSelectedRowId] = useState<string | undefined>();
 
@@ -71,6 +78,16 @@ export const CenterLocalBrowser: React.FC<
           },
         },
       ],
+      [
+        {
+          icon: IconDelete,
+          label: 'Delete board',
+          onClick: row => {
+            const uri = `local-artifact:///${row._id}:latest/obj`;
+            setDeletingId(uri);
+          },
+        },
+      ],
     ];
   }, [props]);
 
@@ -79,11 +96,17 @@ export const CenterLocalBrowser: React.FC<
       allowSearch
       title={'Local Boards'}
       selectedRowId={selectedRowId}
+      setSelectedRowId={setSelectedRowId}
+      setPreviewNode={props.setPreviewNode}
       noDataCTA={`No Local Weave boards found.`}
       loading={localDashboards.loading}
       columns={['name', 'latest version id', 'updated at']}
       data={browserData}
       actions={browserActions}
+      deletingId={deletingId}
+      setDeletingId={setDeletingId}
+      isModalActing={isModalActing}
+      setIsModalActing={setIsModalActing}
     />
   );
 };


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-14944

Right now the "Delete board" action is only available when viewing that board. This adds that action to the overflow menu in the browser.