### PR TITLE
fix(weave): Avoiding expensive/brittle ID generation

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -484,8 +484,8 @@ export function equalStates(aTable: TableState, bTable?: TableState) {
   return true;
 }
 
-export function appendEmptyColumn(ts: TableState) {
-  const colId = newColumnId(ts);
+export function appendEmptyColumn(ts: TableState, index?: number) {
+  const colId = `col-${index}` ?? newColumnId(ts);
   return produce(ts, draft => {
     draft.columns[colId] = {
       panelId: '',
@@ -1501,9 +1501,10 @@ export function addNamedColumnToTable(
   table: TableState,
   name: string,
   selectFn: NodeOrVoidNode<Type>,
-  panelDef?: {panelID: string; panelConfig: any}
+  panelDef?: {panelID: string; panelConfig: any},
+  index?: number
 ): TableState {
-  table = appendEmptyColumn(table);
+  table = appendEmptyColumn(table, index);
   const columnId = table.order[table.order.length - 1];
   table = updateColumnSelect(table, columnId, selectFn);
   table = updateColumnName(table, columnId, name);

--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -485,7 +485,7 @@ export function equalStates(aTable: TableState, bTable?: TableState) {
 }
 
 export function appendEmptyColumn(ts: TableState, index?: number) {
-  const colId = index ? `col-${index}` : newColumnId(ts);
+  const colId = index == null ? `col-${index}` : newColumnId(ts);
   return produce(ts, draft => {
     draft.columns[colId] = {
       panelId: '',

--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -485,7 +485,7 @@ export function equalStates(aTable: TableState, bTable?: TableState) {
 }
 
 export function appendEmptyColumn(ts: TableState, index?: number) {
-  const colId = index == null ? `col-${index}` : newColumnId(ts);
+  const colId = index == null ? newColumnId(ts) : `col-${index}`;
   return produce(ts, draft => {
     draft.columns[colId] = {
       panelId: '',

--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -485,7 +485,7 @@ export function equalStates(aTable: TableState, bTable?: TableState) {
 }
 
 export function appendEmptyColumn(ts: TableState, index?: number) {
-  const colId = `col-${index}` ?? newColumnId(ts);
+  const colId = index ? `col-${index}` : newColumnId(ts);
   return produce(ts, draft => {
     draft.columns[colId] = {
       panelId: '',


### PR DESCRIPTION
Generating tables with > 1000 columns from the client can force exhaustion on the ability of weave to generate new column IDs. This is a temporary patch that allows columns of known size to declare the numeric ID range in advance, saving both compute time in Weave and avoiding errors where the `newColumnId` fn cannot generate a unique ID.

Note: this is a patch to fix an immediate customer issue and should be followed by a better/more stable method for ID generation. 