### PR TITLE
chore(weave): Fix stitch for StreamTable

### DIFF
--- a/weave/compile.py
+++ b/weave/compile.py
@@ -653,6 +653,27 @@ def _compile(
     with tracer.trace("compile:function_calls"):
         results = results.batch_map(_track_errors(compile_function_calls))
     with tracer.trace("compile:quote"):
+        # Mission critical to call `compile:quote` before and node re-writing
+        # compilers such as compile:node_ops and compile:gql. Why?:
+        #
+        # It is useful to define a "static lambda". A "static lambda" is a const
+        # node of type function with no inputs. This is used in our system to
+        # represent a constant value which is a node. Useful for generating
+        # boards or any sort of op that operates on nodes themselves.
+        #
+        # Moreover, this compile step will automatically "quote" inputs to ops
+        # that expect node inputs - effectively making static lambdas when
+        # called for.
+        #
+        # Furthermore, it is important to know that stream table rows (and many
+        # other ops) now support expansion (meaning they get expanded into a
+        # chain of new nodes in the compile pass).
+        #
+        # Conceptually, this created an issue: Compile passes that mutate nodes
+        # (eg node expansion or gql compile) would modify the quoted node. But,
+        # these functions that consume nodes do not want modified nodes.
+        # Instead, we want the raw node that the caller intended. For this
+        # reason we should always call compile:quote before any node re-writing.
         results = results.batch_map(_track_errors(compile_quote))
 
     # Some ops require const input nodes. This pass executes any branches necessary
@@ -662,8 +683,6 @@ def _compile(
         results = results.batch_map(_track_errors(compile_resolve_required_consts))
 
     with tracer.trace("compile:node_ops"):
-        # Mission critical to call `compile_quote` before this so that
-        # we do not expand quoted nodes.
         results = results.batch_map(_track_errors(compile_node_ops))
 
     # Now that we have the correct calls, we can do our forward-looking pushdown

--- a/weave/compile_domain.py
+++ b/weave/compile_domain.py
@@ -106,7 +106,7 @@ def apply_domain_op_gql_translation(
                 },
             )
 
-    res = graph.map_nodes_full(leaf_nodes, _replace_with_merged_gql, on_error)
+    res = graph.map_nodes_full(leaf_nodes, _replace_with_merged_gql, on_error, True)
 
     combined_query_fragment = "\n".join(fragments)
     query_str = f"query WeavePythonCG {{ {combined_query_fragment} }}"

--- a/weave/stitch.py
+++ b/weave/stitch.py
@@ -140,12 +140,20 @@ def stitch(
             input_dict = {k: sg.get_result(v) for k, v in node.from_op.inputs.items()}
             sg.add_result(node, stitch_node(node, input_dict, sg))
         elif isinstance(node, graph.ConstNode):
-            is_static_function_branch = (
-                isinstance(node.type, types.Function)
-                and len(node.type.input_types) == 0
-            )
-            if is_static_function_branch:
-                sg.add_result(node, subgraph_stitch(node.val, {}, sg))
+            # Note from Tim: I believe this block of code should be correct (ie. stitching inside
+            # of static lambdas). I wrote it while implementing a fix but it ended up not being needed.
+            # Stitch is a particularly touchy part of the code base. So i would rather leave this
+            # code commented out for now, but not delete it. My gut tells me that any static lambda
+            # will be re-executed if needed and therefore re-stitched. And furthermore, any caller
+            # of stitch right now (eg. gql compile) should explicitly NOT mutate static lambdas. So
+            # it might be a foot-gun to allow this code to run, even if it is correct. Let's find a
+            # use case for this code before we uncomment it.
+            # is_static_lambda = (
+            #     isinstance(node.type, types.Function)
+            #     and len(node.type.input_types) == 0
+            # )
+            # if is_static_lambda:
+            #     sg.add_result(node, subgraph_stitch(node.val, {}, sg))
             sg.add_result(node, ObjectRecorder(node, val=node.val))
         elif isinstance(node, graph.VarNode):
             if var_values and node.name in var_values:

--- a/weave/stitch.py
+++ b/weave/stitch.py
@@ -29,6 +29,7 @@ from . import errors
 from . import registry_mem
 from . import op_def
 from .language_features.tagging import opdef_util
+from . import weave_types as types
 
 
 @dataclasses.dataclass
@@ -139,6 +140,12 @@ def stitch(
             input_dict = {k: sg.get_result(v) for k, v in node.from_op.inputs.items()}
             sg.add_result(node, stitch_node(node, input_dict, sg))
         elif isinstance(node, graph.ConstNode):
+            is_static_function_branch = (
+                isinstance(node.type, types.Function)
+                and len(node.type.input_types) == 0
+            )
+            if is_static_function_branch:
+                sg.add_result(node, subgraph_stitch(node.val, {}, sg))
             sg.add_result(node, ObjectRecorder(node, val=node.val))
         elif isinstance(node, graph.VarNode):
             if var_values and node.name in var_values:

--- a/weave/tests/test_compile.py
+++ b/weave/tests/test_compile.py
@@ -199,20 +199,22 @@ def test_compile_lambda_uniqueness():
     assert count_nodes(compiled) == 15
 
 
-def test_compile_through_execution(user_by_api_key_in_env):
-    run = wandb.init(project="project_exists")
-    for i in range(10):
-        run.log({"val": i, "cat": i % 2})
-    run.finish()
+# We actually don't want this to work because it would require
+# mutating a static lambda function!
+# def test_compile_through_execution(user_by_api_key_in_env):
+#     run = wandb.init(project="project_exists")
+#     for i in range(10):
+#         run.log({"val": i, "cat": i % 2})
+#     run.finish()
 
-    """
-    This test demonstrates successful execution when there is an explicit
-    const function instead of a direct node (resulting in an intermediate execution op)
-    """
-    history_node = weave.ops.project(run.entity, run.project).run(run.id).history2()
-    pick = const(history_node).pick("val")
-    res = weave.use(pick)
-    assert res.to_pylist_notags() == list(range(10))
+#     """
+#     This test demonstrates successful execution when there is an explicit
+#     const function instead of a direct node (resulting in an intermediate execution op)
+#     """
+#     history_node = weave.ops.project(run.entity, run.project).run(run.id).history2()
+#     pick = const(history_node).pick("val")
+#     res = weave.use(pick)
+#     assert res.to_pylist_notags() == list(range(10))
 
 
 def test_compile_through_function_call(user_by_api_key_in_env):

--- a/weave/tests/test_wb_stream_table.py
+++ b/weave/tests/test_wb_stream_table.py
@@ -172,3 +172,16 @@ def test_stream_authed(user_by_api_key_in_env):
 
     a = weave.use(st.rows()["hello"]).to_pylist_tagged()
     assert a == ["world"]
+
+
+def test_stream_templates(user_by_api_key_in_env):
+    st = make_stream_table(
+        "test_table",
+        project_name="stream-tables",
+        entity_name=user_by_api_key_in_env.username,
+    )
+    st.log({"hello": "world"})
+    st.finish()
+
+    a = weave.use(st.rows().get_board_templates_for_node())
+    assert len(a) > 0


### PR DESCRIPTION
This is a pretty tricky PR. It is useful to define a "static lambda". A "static lambda" is a const node of type function with no inputs. This is used in our system to represent a constant value which is a node. Useful for generating boards or any sort of op that operates on nodes themselves.

Moreover, it is also useful to remind ourselves that our compile pass will automatically "quote" inputs to ops that expect node inputs - effectively making static lambdas when called for. 

Furthermore, it is important to know that stream table rows (and many other ops) now support expansion (meaning they get expanded into a chain of new nodes in the compile pass).

Conceptually, this created an issue: Compile passes that mutate nodes (eg node expansion or gql compile) would modify the quoted node. But, these functions that consume nodes do not want modified nodes. Instead, we want the raw node that the caller intended. For this reason, I added a flag to `map_nodes_full` that allows the caller to skip static lambdas.