### PR TITLE
fix: Add configurable retry of wandb GQL timeouts

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -170,3 +170,10 @@ def weave_wandb_api_key() -> typing.Optional[str]:
 
 def projection_timeout_sec() -> typing.Optional[typing.Union[int, float]]:
     return util.parse_number_env_var("WEAVE_PROJECTION_TIMEOUT_SEC")
+
+
+def num_gql_timeout_retries() -> int:
+    raw = util.parse_number_env_var("WEAVE_WANDB_GQL_NUM_TIMEOUT_RETRIES")
+    if raw is None:
+        return 0
+    return int(raw)

--- a/weave/ops_domain/wbgqlquery_op.py
+++ b/weave/ops_domain/wbgqlquery_op.py
@@ -6,6 +6,7 @@ from ..wandb_client_api import wandb_gql_query
 from ..language_features.tagging import tagged_value_type
 from .. import engine_trace
 from .. import errors
+from .. import environment
 
 
 def _wbgqlquery_output_type(input_types: dict[str, types.Type]) -> types.Type:
@@ -26,9 +27,12 @@ def _wbgqlquery_output_type(input_types: dict[str, types.Type]) -> types.Type:
 )
 def wbgqlquery(query_str, alias_list):
     tracer = engine_trace.tracer()
+    num_timeout_retries = environment.num_gql_timeout_retries()
     with tracer.trace("wbgqlquery:public_api"):
         logging.info("Executing GQL query: %s", query_str)
-        gql_payload = wandb_gql_query(query_str)
+        gql_payload = wandb_gql_query(
+            query_str, num_timeout_retries=num_timeout_retries
+        )
     for alias in alias_list:
         if alias not in gql_payload:
             raise errors.WeaveGQLExecuteMissingAliasError(

--- a/weave/wandb_client_api.py
+++ b/weave/wandb_client_api.py
@@ -3,6 +3,7 @@
 
 from wandb.apis import public
 from wandb.sdk.internal.internal_api import _thread_local_api_settings
+import logging
 import typing
 
 from . import errors
@@ -39,9 +40,12 @@ def wandb_gql_query(
                 public.gql(query_str),
                 variable_values=variables,
             )
-        except (exceptions.ReadTimeout, exceptions.ConnectTimeout):
+        except exceptions.Timeout as e:
             if attempt_no == num_timeout_retries:
                 raise
+            logging.warn(
+                f'wandb GQL query timed out: "{e.args[0]}", retrying (num_attempts={attempt_no + 1})'
+            )
 
 
 def set_wandb_thread_local_api_settings(

--- a/weave/wandb_client_api.py
+++ b/weave/wandb_client_api.py
@@ -44,7 +44,7 @@ def wandb_gql_query(
             if attempt_no == num_timeout_retries:
                 raise
             logging.warn(
-                f'wandb GQL query timed out: "{e.args[0]}", retrying (num_attempts={attempt_no + 1})'
+                f'wandb GQL query timed out: "{e}", retrying (num_attempts={attempt_no + 1})'
             )
 
 


### PR DESCRIPTION
Internal JIRA ticket: https://wandb.atlassian.net/browse/WB-14961

Occasionally, the odd GQL request will hit a 30s read timeout and lead to a random page crash. This adds configurable timeout retry logic like we have for auth. In production, we should set this to 1 to mimic our auth retry logic. That way we wont overwhelm gorilla but will drastically reduce our chances of having a read timeout crash a page. 