### PR TITLE
fix: Fixed over-aggressive PanelMaybe

### DIFF
--- a/weave-js/src/components/Panel2/PanelComp.tsx
+++ b/weave-js/src/components/Panel2/PanelComp.tsx
@@ -276,17 +276,17 @@ export const PanelComp2Inner = (props: PanelComp2Props) => {
     }
   }, [panelSpec, props, configMode, updateConfig2]);
 
-  const {inPanelMaybe} = usePanelContext();
+  const {panelMaybeNode} = usePanelContext();
 
   unboundedContent = useMemo(() => {
     return dashUiEnabled ? (
-      <PanelCompErrorBoundary inPanelMaybe={inPanelMaybe}>
+      <PanelCompErrorBoundary inPanelMaybe={panelMaybeNode != null}>
         {unboundedContent}
       </PanelCompErrorBoundary>
     ) : (
       unboundedContent
     );
-  }, [dashUiEnabled, inPanelMaybe, unboundedContent]);
+  }, [dashUiEnabled, panelMaybeNode, unboundedContent]);
 
   if (props.input.nodeType === 'void') {
     return (

--- a/weave-js/src/components/Panel2/PanelContext.tsx
+++ b/weave-js/src/components/Panel2/PanelContext.tsx
@@ -6,6 +6,7 @@ import {
   NodeOrVoidNode,
   pushFrame,
   resolveVar,
+  Node,
 } from '@wandb/weave/core';
 import {consoleGroup, consoleLog} from '@wandb/weave/util';
 import React, {ReactNode, useCallback, useContext, useMemo} from 'react';
@@ -110,7 +111,7 @@ export interface PanelContextState {
   selectedPath?: string[];
 
   // Use to inform useNodeValue that we're inside PanelMaybe.
-  inPanelMaybe: boolean;
+  panelMaybeNode: Node | null;
 
   triggerExpressionEvent: (
     target: NodeOrVoidNode,
@@ -136,7 +137,7 @@ const DEFAULT_CONTEXT: PanelContextState = {
   lastFrame: {},
   stack: [],
   path: [],
-  inPanelMaybe: false,
+  panelMaybeNode: null,
   triggerExpressionEvent: () => {},
 };
 
@@ -149,7 +150,7 @@ export const PanelContextProvider: React.FC<{
   newVars?: Frame;
   newPath?: string;
   selectedPath?: string[];
-  inPanelMaybe?: boolean;
+  panelMaybeNode?: Node | null;
   // Handle events that occur on consuming expressions of variables
   // added in this frame.
   handleVarEvent?: (
@@ -164,7 +165,7 @@ export const PanelContextProvider: React.FC<{
     newPath,
     selectedPath,
     children,
-    inPanelMaybe,
+    panelMaybeNode,
     handleVarEvent,
     dashboardConfigOptions,
   }) => {
@@ -215,7 +216,7 @@ export const PanelContextProvider: React.FC<{
         stack: childStack,
         path: childPath,
         selectedPath: selectedPath ?? prevSelectedPath,
-        inPanelMaybe: inPanelMaybe ?? false,
+        panelMaybeNode: panelMaybeNode ?? null,
         triggerExpressionEvent,
         dashboardConfigOptions,
       };
@@ -226,7 +227,7 @@ export const PanelContextProvider: React.FC<{
       childPath,
       selectedPath,
       prevSelectedPath,
-      inPanelMaybe,
+      panelMaybeNode,
       triggerExpressionEvent,
       dashboardConfigOptions,
     ]);

--- a/weave-js/src/components/Panel2/PanelMaybe.tsx
+++ b/weave-js/src/components/Panel2/PanelMaybe.tsx
@@ -2,6 +2,7 @@ import {
   isAssignableTo,
   isTaggedValueLike,
   isUnion,
+  Node,
   nonNullableDeep,
   taggedValue,
   taggedValueTagType,
@@ -144,6 +145,7 @@ const PanelMaybe: React.FC<PanelMaybeProps> = props => {
 
   return (
     <MaybeWrapper
+      node={nodeWithConvertedType}
       deps={[
         nodeWithConvertedType,
         props.child,
@@ -170,7 +172,7 @@ const PanelMaybe: React.FC<PanelMaybeProps> = props => {
   );
 };
 
-export const MaybeWrapper: React.FC<{deps?: any[]}> = props => {
+export const MaybeWrapper: React.FC<{node: Node; deps?: any[]}> = props => {
   // We always render our child, so that its useNodeValue calls can be merged
   // with other active components. Ie, we don't want to waterfall here.
 
@@ -183,7 +185,7 @@ export const MaybeWrapper: React.FC<{deps?: any[]}> = props => {
   );
 
   return (
-    <PanelContextProvider inPanelMaybe={true}>
+    <PanelContextProvider panelMaybeNode={props.node}>
       <NullResultErrorBoundary key={boundaryKey} onErrorCapture={openLatch}>
         {props.children}
       </NullResultErrorBoundary>

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -244,7 +244,7 @@ export const useNodeValue = <T extends Type>(
   const panelCompCtx = useContext(PanelCompContext);
   const context = useClientContext();
   const client = context.client;
-  const {stack, inPanelMaybe} = usePanelContext();
+  const {stack, panelMaybeNode} = usePanelContext();
 
   // consoleLog('USE NODE VALUE PRE CLIENT EVAL', weave.expToString(node), stack);
 
@@ -353,7 +353,11 @@ export const useNodeValue = <T extends Type>(
       result: result.value,
     };
   }, [error, node, result.node, result.value]);
-  if (!finalResult.loading && inPanelMaybe && finalResult.result == null) {
+  if (
+    !finalResult.loading &&
+    panelMaybeNode === node &&
+    finalResult.result == null
+  ) {
     // Throw NullResult for PanelMaybe to catch.
     throw new NullResult(result.node);
   }


### PR DESCRIPTION
Fixes cases where nested null responses trigger PanelMaybe's null detection incorrectly.

Say you have Maybe.Table

Prior to this PR, if any descendent query in the tree returned a None response, we would trigger the Maybe error boundary and render None for the whole table.

This makes it so we only throw NullResult if the NullResult happens on the exact Node PanelMaybe is monitoring...
- This is still not quite right, since Weave propagates nulls, now we may be too conservative
