### PR TITLE
feature: Recommended board implementation

### DIFF
--- a/examples/monitoring/OpenAIMonitoring.ipynb
+++ b/examples/monitoring/OpenAIMonitoring.ipynb
@@ -22,13 +22,13 @@
    "outputs": [],
    "source": [
     "# Pass <wandb_team_or_user>/<wandb_project>/<table_name>\n",
-    "m = init_monitor('shawn/oai-mon/test8')\n",
+    "m = init_monitor('shawn/oai-mon2/test15')\n",
     "\n",
     "# Do an initial request, otherwise we don't have a type on which to recommend the OpenAI board!\n",
     "# We need at least 2 requests for the Board to work, otherwise we get divide by zero errors.\n",
     "# TODO: fix this onboarding issue\n",
-    "r = openai.ChatCompletion.create(model=OPENAI_MODEL, messages=[{\"role\": \"user\", \"content\": f\"hello world!\"}])\n",
-    "r = openai.ChatCompletion.create(model=OPENAI_MODEL, messages=[{\"role\": \"user\", \"content\": f\"what is 2+2?\"}])"
+    "#r = openai.ChatCompletion.create(model=OPENAI_MODEL, messages=[{\"role\": \"user\", \"content\": f\"hello world!\"}])\n",
+    "#r = openai.ChatCompletion.create(model=OPENAI_MODEL, messages=[{\"role\": \"user\", \"content\": f\"what is 2+2?\"}])"
    ]
   },
   {

--- a/weave-js/src/components/PagePanelComponents/Home/HintWrapper.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HintWrapper.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import * as globals from '@wandb/weave/common/css/globals.styles';
+import styled, {keyframes} from 'styled-components';
+
+const bounce = keyframes`
+  0%, 20%, 50%, 80%, 100% {
+    transform: translateY(-50%) translateX(0);
+  }
+  40% {
+    transform: translateY(-50%) translateX(-15px);
+  }
+  60% {
+    transform: translateY(-50%) translateX(-5px);
+  }
+`;
+
+const Wrapper = styled.div`
+  position: relative;
+  display: inline-block; /* Adjust this if needed */
+`;
+
+const HintArrow = styled.div`
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-left: 10px solid ${globals.TEAL_LIGHT};
+  top: 50%;
+  left: -15px;
+  transform: translateY(-50%);
+  zindex: 10;
+  animation: ${bounce} 2s infinite;
+`;
+
+export const HintWrapper: React.FC = ({children}) => {
+  return (
+    <Wrapper>
+      {children}
+      <HintArrow />
+    </Wrapper>
+  );
+};
+
+export default HintWrapper;

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -529,13 +529,14 @@ const CenterProjectTablesBrowser: React.FC<
         <HomePreviewSidebarTemplate
           title={row.name}
           setPreviewNode={setPreviewNode}
-          primaryAction={{
-            icon: IconOpenNewTab,
-            label: 'Open Table',
-            onClick: () => {
-              navigateToExpression(expr);
-            },
-          }}>
+          // primaryAction={{
+          //   icon: IconOpenNewTab,
+          //   label: 'Open Table',
+          //   onClick: () => {
+          //     navigateToExpression(expr);
+          //   },
+          // }}
+        >
           <HomeExpressionPreviewParts
             expr={expr}
             navigateToExpression={navigateToExpression}

--- a/weave/core_types/__init__.py
+++ b/weave/core_types/__init__.py
@@ -1,1 +1,1 @@
-from .stream_table_type import StreamTableType
+from .stream_table_type import StreamTableObj

--- a/weave/core_types/stream_table_type.py
+++ b/weave/core_types/stream_table_type.py
@@ -1,10 +1,16 @@
+import typing
 from .. import decorator_type
+
+
+class Hints(typing.TypedDict):
+    integrations: list[str]
 
 
 @decorator_type.type(
     "stream_table",
 )
-class StreamTableType:
+class StreamTableObj:
     table_name: str  # maps to run name in W&B data model
     project_name: str
     entity_name: str
+    hints: typing.Optional[Hints]

--- a/weave/monitoring/openai.py
+++ b/weave/monitoring/openai.py
@@ -2,6 +2,7 @@ import typing
 import openai
 
 from . import monitor
+from ..wandb_interface import wandb_stream_table
 
 
 def delta_update(value: dict, delta: dict) -> dict:
@@ -98,3 +99,6 @@ class ChatCompletion:
     @staticmethod
     def create(**kwargs: typing.Any) -> typing.Any:
         return monitored_create(**kwargs)
+
+
+wandb_stream_table.add_integration_hint("openai")

--- a/weave/ops_domain/stream_table_ops.py
+++ b/weave/ops_domain/stream_table_ops.py
@@ -1,13 +1,13 @@
 from weave import weave_types
 from ..ops_arrow.arrow import ArrowWeaveListType
-from ..core_types import StreamTableType
+from ..core_types import StreamTableObj
 from ..api import op
 from .project_ops import project
 from .. import compile
 from .. import op_def
 
 
-def _get_history_node(steam_table: StreamTableType):
+def _get_history_node(steam_table: StreamTableObj):
     with op_def.no_refine():
         return (
             project(steam_table.entity_name, steam_table.project_name)
@@ -17,7 +17,7 @@ def _get_history_node(steam_table: StreamTableType):
 
 
 @op()
-def _rows_type(steam_table: StreamTableType) -> weave_types.Type:
+def _rows_type(steam_table: StreamTableObj) -> weave_types.Type:
     with compile.enable_compile():
         return compile.compile([_get_history_node(steam_table)])[0].type
 
@@ -27,5 +27,5 @@ def _rows_type(steam_table: StreamTableType) -> weave_types.Type:
     output_type=ArrowWeaveListType(weave_types.TypedDict({})),
     refine_output_type=_rows_type,
 )
-def rows(steam_table: StreamTableType):
+def rows(steam_table: StreamTableObj):
     return _get_history_node(steam_table)


### PR DESCRIPTION
This is an attempt to smooth out onboarding. Problem: if you call init_monitor but don't log any rows, we print a link to the streamtable, but since there are no rows we don't have a type yet.

This adds a _hints field to StreamTableObj, which has an integrations sub-key. when our openai integration is imported, it adds an entry to a global, and all created StreamTables populate this _hints field.

Then we use _hints in the UI to suggest additional boards.

We also hard-code that the openai board is a "recommended board", which gets its own UI area, a primary color, and a bouncy arrow.

<img width="1617" alt="image" src="https://github.com/wandb/weave/assets/499383/5ae4d745-685d-4c83-b3f4-b55794980594">

There's a problem though, clicking the link fails, because our node still doesn't have the correct type, so the generator op can't actually dispatch / run. I think I can solve this by forcing the correct type on the node.