### PR TITLE
ci: avoid rebuilding ecosystem in docker when frontend changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,6 @@ jobs:
       # this script is hardcoded to build for linux/amd64
       - name: Prune docker cache
         run: docker system prune -f
-      - name: Build unit test image
-        run: python3 docker_build.py build_deps weave-test builder . Dockerfile.test
       - name: Build integration test image
         run: python3 docker_build.py build weave-integration-test . Dockerfile.test
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,8 +34,8 @@ jobs:
       # this script is hardcoded to build for linux/amd64
       - name: Prune docker cache
         run: docker system prune -f
-      - name: Build integration test image
-        run: python3 docker_build.py build weave-integration-test . Dockerfile.test
+      - name: Build test image
+        run: python3 docker_build.py build weave-test . Dockerfile.test
 
   lint:
     name: Python lint
@@ -93,7 +93,7 @@ jobs:
         job_num: [0, 1]
 
     # runs-on: ubuntu-latest
-    container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-integration-test:${{ github.sha }}
+    container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test:${{ github.sha }}
     services:
       wandbservice:
         image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
@@ -149,7 +149,7 @@ jobs:
     runs-on: [self-hosted, gke-runner]
     # runs-on: ubuntu-latest
 
-    container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-integration-test:${{ github.sha }}
+    container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test:${{ github.sha }}
 
     strategy:
       fail-fast: false

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -26,7 +26,8 @@ RUN --mount=type=cache,target=/usr/local/share/.cache \
     yarn install --frozen-lockfile && \
     yarn build && \
     echo $SHA1 > ./build/sha1.txt && \
-    rm -rf node_modules && cd -
+    rm -rf node_modules && mv build /root/weave-js-build && cd -
+
 
 
 ENTRYPOINT "/bin/bash"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -15,8 +15,12 @@ RUN --mount=type=cache,target=/root/.cache /bin/bash -c "source venv/bin/activat
 
 RUN apt update && apt install -y gcc g++ make libcairo2-dev libjpeg-dev libgif-dev libpango1.0-dev
 
+COPY integration_test/package.json /root/integration_test/package.json
+COPY integration_test/package-lock.json /root/integration_test/package-lock.json
+RUN --mount=type=cache,target=/usr/local/share/.cache cd integration_test && npm install
+
 COPY weave-js /root/weave-js
-WORKDIR /root/weave-js
+
 RUN --mount=type=cache,target=/usr/local/share/.cache \
     SHA1=$(find $JS_DIR -not -path "*/.vite-cache/*" -not -path "*/node_modules/*" -not -path "*/build/*" -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d " " -f1) && \
     yarn install --frozen-lockfile && \
@@ -24,8 +28,5 @@ RUN --mount=type=cache,target=/usr/local/share/.cache \
     echo $SHA1 > ./build/sha1.txt && \
     rm -rf node_modules
 
-COPY integration_test/package.json /root/integration_test/package.json
-COPY integration_test/package-lock.json /root/integration_test/package-lock.json
-RUN --mount=type=cache,target=/usr/local/share/.cache cd integration_test && npm install
 
 ENTRYPOINT "/bin/bash"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -21,8 +21,8 @@ RUN --mount=type=cache,target=/usr/local/share/.cache cd integration_test && npm
 
 COPY weave-js /root/weave-js
 
-RUN cd weave-js && --mount=type=cache,target=/usr/local/share/.cache \
-    SHA1=$(find $JS_DIR -not -path "*/.vite-cache/*" -not -path "*/node_modules/*" -not -path "*/build/*" -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d " " -f1) && \
+RUN -mount=type=cache,target=/usr/local/share/.cache \
+    cd weave-js && SHA1=$(find $JS_DIR -not -path "*/.vite-cache/*" -not -path "*/node_modules/*" -not -path "*/build/*" -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d " " -f1) && \
     yarn install --frozen-lockfile && \
     yarn build && \
     echo $SHA1 > ./build/sha1.txt && \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -21,12 +21,12 @@ RUN --mount=type=cache,target=/usr/local/share/.cache cd integration_test && npm
 
 COPY weave-js /root/weave-js
 
-RUN --mount=type=cache,target=/usr/local/share/.cache \
+RUN cd weave-js && --mount=type=cache,target=/usr/local/share/.cache \
     SHA1=$(find $JS_DIR -not -path "*/.vite-cache/*" -not -path "*/node_modules/*" -not -path "*/build/*" -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d " " -f1) && \
     yarn install --frozen-lockfile && \
     yarn build && \
     echo $SHA1 > ./build/sha1.txt && \
-    rm -rf node_modules
+    rm -rf node_modules && cd -
 
 
 ENTRYPOINT "/bin/bash"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache cd integration_test && npm
 
 COPY weave-js /root/weave-js
 
-RUN -mount=type=cache,target=/usr/local/share/.cache \
+RUN --mount=type=cache,target=/usr/local/share/.cache \
     cd weave-js && SHA1=$(find $JS_DIR -not -path "*/.vite-cache/*" -not -path "*/node_modules/*" -not -path "*/build/*" -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d " " -f1) && \
     yarn install --frozen-lockfile && \
     yarn build && \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,11 +8,7 @@ COPY requirements.* /root/
 WORKDIR /root
 RUN python3 -m venv venv
 RUN --mount=type=cache,target=/root/.cache /bin/bash -c "source venv/bin/activate && \
-    pip install -r requirements.test.txt -r requirements.dev.txt"
-
-ENTRYPOINT "/bin/bash"
-
-FROM node:16 as js_builder
+    pip install -r requirements.test.txt -r requirements.dev.txt -r requirements.ecosystem.txt"
 
 RUN apt update && apt install -y gcc g++ make libcairo2-dev libjpeg-dev libgif-dev libpango1.0-dev
 
@@ -25,19 +21,8 @@ RUN --mount=type=cache,target=/usr/local/share/.cache \
     echo $SHA1 > ./build/sha1.txt && \
     rm -rf node_modules
 
-# final stage
-FROM builder
-WORKDIR /root
-
-COPY requirements.ecosystem.txt /root
-RUN --mount=type=cache,target=/root/.cache /bin/bash -c "source venv/bin/activate && \
-    pip install -r requirements.ecosystem.txt"
-
 COPY integration_test/package.json /root/integration_test/package.json
 COPY integration_test/package-lock.json /root/integration_test/package-lock.json
 RUN --mount=type=cache,target=/usr/local/share/.cache cd integration_test && npm install
-
-# TODO, currently builder doesn't support --link
-COPY --from=js_builder /root/weave-js/build /root/weave-js-build
 
 ENTRYPOINT "/bin/bash"

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,7 +8,10 @@ COPY requirements.* /root/
 WORKDIR /root
 RUN python3 -m venv venv
 RUN --mount=type=cache,target=/root/.cache /bin/bash -c "source venv/bin/activate && \
-    pip install -r requirements.test.txt -r requirements.dev.txt -r requirements.ecosystem.txt"
+    pip install -r requirements.test.txt -r requirements.dev.txt"
+RUN --mount=type=cache,target=/root/.cache /bin/bash -c "source venv/bin/activate && \
+    pip install -r requirements.ecosystem.txt"
+
 
 RUN apt update && apt install -y gcc g++ make libcairo2-dev libjpeg-dev libgif-dev libpango1.0-dev
 


### PR DESCRIPTION
This PR simplifies the way we build our dockerfile, consolidating everything into a single stage to produce an image that can be used for unit tests (which now also run ecosystem unit tests), linting, and frontend tests. I moved the ecosystem install to the beginning of the dockerfile (before the JS steps) instead of the end, which means we can avoid having to rebuild layers when javascript changes (which happens more frequently than ecosystem deps change). This should improve overall CI performance.
