### PR TITLE
chore(weave): Remove unneeded data fetching in board hot path

### DIFF
--- a/weave-js/src/components/PagePanelComponents/PersistenceManager.tsx
+++ b/weave-js/src/components/PagePanelComponents/PersistenceManager.tsx
@@ -630,6 +630,47 @@ const HeaderLogoControls: React.FC<{
 }> = ({inputNode, headerEl, goHome, updateNode, inputConfig}) => {
   const [anchorHomeEl, setAnchorHomeEl] = useState<HTMLElement | null>(null);
   const expandedHomeControls = Boolean(anchorHomeEl);
+
+  return (
+    <>
+      <HeaderLeftControls
+        onClick={e => {
+          setAnchorHomeEl(headerEl);
+        }}>
+        <WeaveLogo open={anchorHomeEl != null} />
+        {expandedHomeControls ? <IconUp /> : <IconDown />}
+      </HeaderLeftControls>
+      <CustomPopover
+        open={expandedHomeControls}
+        anchorEl={anchorHomeEl}
+        onClose={() => setAnchorHomeEl(null)}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}>
+        <HeaderLogoPopoverContent
+          inputNode={inputNode}
+          inputConfig={inputConfig}
+          updateNode={updateNode}
+          goHome={goHome}
+          onClose={() => setAnchorHomeEl(null)}
+        />
+      </CustomPopover>
+    </>
+  );
+};
+
+const HeaderLogoPopoverContent: React.FC<{
+  inputNode: NodeOrVoidNode;
+  inputConfig: any;
+  updateNode: (node: NodeOrVoidNode) => void;
+  goHome?: () => void;
+  onClose: () => void;
+}> = ({inputNode, goHome, updateNode, inputConfig, onClose}) => {
   const inputType = useNodeWithServerType(inputNode).result?.type;
   const isPanel = weaveTypeIsPanel(inputType || ('any' as const));
   const isGroup = weaveTypeIsPanelGroup(inputType);
@@ -721,70 +762,48 @@ const HeaderLogoControls: React.FC<{
   const versionValue = useNodeValue(versionNode);
 
   return (
-    <>
-      <HeaderLeftControls
-        onClick={e => {
-          setAnchorHomeEl(headerEl);
+    <CustomMenu>
+      {seedItems != null && (
+        <MenuItem
+          onClick={() => {
+            onClose();
+            newDashboard();
+          }}>
+          <MenuIcon>
+            <IconAddNew />
+          </MenuIcon>
+          <MenuText>Seed new board</MenuText>
+        </MenuItem>
+      )}
+      <MenuItem
+        onClick={() => {
+          onClose();
+          goHome?.();
         }}>
-        <WeaveLogo open={anchorHomeEl != null} />
-        {expandedHomeControls ? <IconUp /> : <IconDown />}
-      </HeaderLeftControls>
-      <CustomPopover
-        open={expandedHomeControls}
-        anchorEl={anchorHomeEl}
-        onClose={() => setAnchorHomeEl(null)}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'center',
+        <MenuIcon>
+          <IconBack />
+        </MenuIcon>
+        <MenuText>Back to home</MenuText>
+      </MenuItem>
+      <MenuItem
+        onClick={() => {
+          onClose();
+          window.open('https://github.com/wandb/weave', '_blank');
         }}>
-        <CustomMenu>
-          {seedItems != null && (
-            <MenuItem
-              onClick={() => {
-                setAnchorHomeEl(null);
-                newDashboard();
-              }}>
-              <MenuIcon>
-                <IconAddNew />
-              </MenuIcon>
-              <MenuText>Seed new board</MenuText>
-            </MenuItem>
-          )}
-          <MenuItem
-            onClick={() => {
-              setAnchorHomeEl(null);
-              goHome?.();
-            }}>
-            <MenuIcon>
-              <IconBack />
-            </MenuIcon>
-            <MenuText>Back to home</MenuText>
-          </MenuItem>
-          <MenuItem
-            onClick={() => {
-              setAnchorHomeEl(null);
-              window.open('https://github.com/wandb/weave', '_blank');
-            }}>
-            <MenuIcon>
-              <IconDocs />
-            </MenuIcon>
-            <MenuText>Weave documentation</MenuText>
-          </MenuItem>
-          <MenuDivider />
-          <MenuItem disabled>
-            <MenuText>
-              Weave {versionValue.result}
-              <br />
-              by Weights & Biases
-            </MenuText>
-          </MenuItem>
-        </CustomMenu>
-      </CustomPopover>
-    </>
+        <MenuIcon>
+          <IconDocs />
+        </MenuIcon>
+        <MenuText>Weave documentation</MenuText>
+      </MenuItem>
+      <MenuDivider />
+      <MenuItem disabled>
+        <MenuText>
+          Weave {versionValue.result}
+          <br />
+          by Weights & Biases
+        </MenuText>
+      </MenuItem>
+    </CustomMenu>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/PublishModal.tsx
+++ b/weave-js/src/components/PagePanelComponents/PublishModal.tsx
@@ -3,9 +3,10 @@ import {
   DropdownItemProps,
   Form,
   Input,
+  Loader,
   Modal,
 } from 'semantic-ui-react';
-import React from 'react';
+import React, {useMemo} from 'react';
 import styled from 'styled-components';
 import {RED_550} from '@wandb/weave/common/css/color.styles';
 import {WBButton} from '@wandb/weave/common/components/elements/WBButtonNew';
@@ -52,33 +53,40 @@ export const PublishModal = ({
   const isValidName = isValidBoardName(boardName);
   const showError = boardName.length > 0 && !isValidName;
 
-  const isAuthenticated = useIsAuthenticated();
-  const userEntities = query.useUserEntities(isAuthenticated);
-  const userName = query.useUserName(isAuthenticated);
+  // Make sure we only make requests once this is open
+  const isAuthenticated = useIsAuthenticated(!open);
+  const userEntities = query.useUserEntities(isAuthenticated && open);
+  const userName = query.useUserName(isAuthenticated && open);
 
-  const iconStyle = {
-    verticalAlign: 'middle',
-    display: 'inline-block',
-    marginRight: 8,
-  };
+  const iconStyle = useMemo(
+    () => ({
+      verticalAlign: 'middle',
+      display: 'inline-block',
+      marginRight: 8,
+    }),
+    []
+  );
 
-  const entityOptions: DropdownItemProps[] =
-    userEntities.result.length === 0
-      ? []
-      : userEntities.result.sort().map(entName => ({
-          icon: (
-            <Icon
-              name={
-                entName === userName.result
-                  ? 'user-profile-personal'
-                  : 'users-team'
-              }
-              style={iconStyle}
-            />
-          ),
-          value: entName,
-          text: entName,
-        }));
+  const entityOptions: DropdownItemProps[] = useMemo(
+    () =>
+      userEntities.result.length === 0
+        ? []
+        : userEntities.result.sort().map(entName => ({
+            icon: (
+              <Icon
+                name={
+                  entName === userName.result
+                    ? 'user-profile-personal'
+                    : 'users-team'
+                }
+                style={iconStyle}
+              />
+            ),
+            value: entName,
+            text: entName,
+          })),
+    [iconStyle, userEntities.result, userName.result]
+  );
 
   const projectsNode = w.opEntityProjects({
     entity: w.opRootEntity({
@@ -89,10 +97,17 @@ export const PublishModal = ({
   // Initialize the entity selector to first option (user entity)
   useEffect(() => {
     if (!userEntities.loading && entityOptions.length > 0) {
+      if (userName.result != null) {
+        for (const option of entityOptions) {
+          if (option.value === userName.result) {
+            setEntityName(userName.result);
+            return;
+          }
+        }
+      }
       setEntityName(entityOptions[0].value as string);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userEntities.loading]);
+  }, [entityOptions, userEntities.loading, userName.result]);
 
   const projectDataNode = w.opProjectName({project: projectsNode});
   const projectNamesValue = useNodeValue(projectDataNode, {
@@ -149,63 +164,75 @@ export const PublishModal = ({
           Name your board and select a destination entity and project in Weights
           & Biases.
         </M.Description>
-        <Form>
-          <Form.Field>
-            <label>Name</label>
-            <Input
-              value={boardName}
-              placeholder="Name"
-              onChange={e => setBoardName(e.target.value)}
-              error={showError}
-            />
-            {showError && (
-              <Error>Spaces and special characters are not allowed.</Error>
-            )}
-          </Form.Field>
-          <Form.Field>
-            <label>Entity</label>
-            <Dropdown
-              placeholder="Select entity"
-              fluid
-              selection
-              options={entityOptions}
-              value={entityName}
-              onChange={(e, data) => {
-                setEntityName(data.value as string);
-                setProjectName('');
-              }}
-            />
-          </Form.Field>
-          <Form.Field>
-            <label>Project</label>
-            {projectOptions.length > 0 ? (
-              <Dropdown
-                placeholder="Select project"
-                fluid
-                selection
-                options={projectOptions}
-                value={projectName}
-                onChange={(e, data) => {
-                  setProjectName(data.value as string);
-                }}
-              />
-            ) : (
-              <span>Entity has no project</span>
-            )}
-          </Form.Field>
-        </Form>
-        <M.Buttons>
-          <WBButton
-            variant="confirm"
-            loading={acting}
-            disabled={!isValidName || !entityName || !projectName || acting}
-            onClick={onPublish}>
-            Publish board
-          </WBButton>
-          <WBButton variant="ghost" onClick={onClose}>
-            Cancel
-          </WBButton>
-        </M.Buttons>
+        {isAuthenticated === false ? (
+          <span>Please authenticate with W&B to publish boards</span>
+        ) : (
+          <>
+            <Form>
+              <Form.Field>
+                <label>Name</label>
+                <Input
+                  value={boardName}
+                  placeholder="Name"
+                  onChange={e => setBoardName(e.target.value)}
+                  error={showError}
+                />
+                {showError && (
+                  <Error>Spaces and special characters are not allowed.</Error>
+                )}
+              </Form.Field>
+              <Form.Field>
+                <label>Entity</label>
+                {userEntities.loading ? (
+                  <Loader active inline size="tiny" />
+                ) : (
+                  <Dropdown
+                    placeholder="Select entity"
+                    fluid
+                    selection
+                    options={entityOptions}
+                    value={entityName}
+                    onChange={(e, data) => {
+                      setEntityName(data.value as string);
+                      setProjectName('');
+                    }}
+                  />
+                )}
+              </Form.Field>
+              <Form.Field>
+                <label>Project</label>
+                {userEntities.loading || projectNamesValue.loading ? (
+                  <Loader active inline size="tiny" />
+                ) : projectOptions.length > 0 ? (
+                  <Dropdown
+                    placeholder="Select project"
+                    fluid
+                    selection
+                    options={projectOptions}
+                    value={projectName}
+                    onChange={(e, data) => {
+                      setProjectName(data.value as string);
+                    }}
+                  />
+                ) : (
+                  <span>Entity has no project</span>
+                )}
+              </Form.Field>
+            </Form>
+            <M.Buttons>
+              <WBButton
+                variant="confirm"
+                loading={acting}
+                disabled={!isValidName || !entityName || !projectName || acting}
+                onClick={onPublish}>
+                Publish board
+              </WBButton>
+              <WBButton variant="ghost" onClick={onClose}>
+                Cancel
+              </WBButton>
+            </M.Buttons>
+          </>
+        )}
       </Modal.Content>
     </Modal>
   );

--- a/weave-js/src/components/PagePanelComponents/PublishModal.tsx
+++ b/weave-js/src/components/PagePanelComponents/PublishModal.tsx
@@ -40,6 +40,12 @@ const isValidBoardName = (name: string) => {
   );
 };
 
+const iconStyle = {
+  verticalAlign: 'middle',
+  display: 'inline-block',
+  marginRight: 8,
+};
+
 export const PublishModal = ({
   defaultName,
   open,
@@ -57,15 +63,6 @@ export const PublishModal = ({
   const isAuthenticated = useIsAuthenticated(!open);
   const userEntities = query.useUserEntities(isAuthenticated && open);
   const userName = query.useUserName(isAuthenticated && open);
-
-  const iconStyle = useMemo(
-    () => ({
-      verticalAlign: 'middle',
-      display: 'inline-block',
-      marginRight: 8,
-    }),
-    []
-  );
 
   const entityOptions: DropdownItemProps[] = useMemo(
     () =>
@@ -85,7 +82,7 @@ export const PublishModal = ({
             value: entName,
             text: entName,
           })),
-    [iconStyle, userEntities.result, userName.result]
+    [userEntities.result, userName.result]
   );
 
   const projectsNode = w.opEntityProjects({

--- a/weave-js/src/components/PagePanelComponents/util.ts
+++ b/weave-js/src/components/PagePanelComponents/util.ts
@@ -28,11 +28,14 @@ export const inJupyterCell = () => {
 // TODO: currently deprecated, but works in all browsers
 declare function btoa(s: string): string;
 
-export const useIsAuthenticated = () => {
+export const useIsAuthenticated = (skip: boolean = false) => {
   const [isAuth, setIsAuth] = useState<boolean | undefined>(undefined);
   const anonApiKey = getCookie('anon_api_key');
 
   useEffect(() => {
+    if (skip) {
+      setIsAuth(false);
+    }
     const additionalHeaders: Record<string, string> = {};
     if (anonApiKey != null && anonApiKey !== '') {
       additionalHeaders['x-wandb-anonymous-auth-id'] = btoa(anonApiKey);
@@ -61,7 +64,7 @@ export const useIsAuthenticated = () => {
       .catch(err => {
         setIsAuth(false);
       });
-  }, [anonApiKey]);
+  }, [anonApiKey, skip]);
   return isAuth;
 };
 


### PR DESCRIPTION
When loading a board, there are a handful of data requests that are not used in many cases. This removes these queries which has 2 benefits:
1. There is less data requested
2. The cache key for gql requests can be shared across more requests which are not co-mingled with these extra data requests

Basically all this does is delay loading information needed for modals until they popup

This reduces the empty board load time from 500-700ms to 30-70ms!