### PR TITLE
chore(weave): Cache Ops endpoint

### DIFF
--- a/weave/registry_mem.py
+++ b/weave/registry_mem.py
@@ -1,4 +1,5 @@
 import typing
+import datetime
 
 from weave.op_args import OpNamedArgs
 
@@ -26,13 +27,26 @@ class Registry:
 
     _op_versions: typing.Dict[typing.Tuple[str, str], op_def.OpDef]
 
+    # Maintains a timestamp of when the registry was last updated.
+    # This is useful for caching the ops dictionary when serving
+    # the registry over HTTP.
+    _updated_at: float
+
     def __init__(self):
         self._types = {}
         self._ops = {}
         self._ops_by_common_name = {}
         self._op_versions = {}
+        self.mark_updated()
+
+    def mark_updated(self) -> None:
+        self._updated_at = datetime.datetime.now().timestamp()
+
+    def updated_at(self) -> float:
+        return self._updated_at
 
     def register_op(self, op: op_def.OpDef):
+        self.mark_updated()
         # Always save OpDefs any time they are declared
         location = context_state.get_loading_op_location()
         is_loading = location is not None
@@ -130,6 +144,7 @@ class Registry:
 
     def rename_op(self, name, new_name):
         """Internal use only, used during op bootstrapping at decorator time"""
+        self.mark_updated()
         op = self._ops.pop(name)
         op.name = new_name
         self._ops[new_name] = op

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -136,7 +136,7 @@ def list_ops():
     global ops_cache
     with wandb_api.from_environment():
         # TODO: this is super slow.
-        if False and not environment.wandb_production():
+        if not environment.wandb_production():
             registry_mem.memory_registry.load_saved_ops()
         if (
             ops_cache is None

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -123,21 +123,38 @@ def make_app():
     return app
 
 
+class OpsCache(typing.TypedDict):
+    updated_at: float
+    ops_data: typing.Optional[dict]
+
+
+ops_cache: typing.Optional[OpsCache] = None
+
+
 @blueprint.route("/__weave/ops", methods=["GET"])
 def list_ops():
+    global ops_cache
     with wandb_api.from_environment():
         # TODO: this is super slow.
-        if not environment.wandb_production():
+        if False and not environment.wandb_production():
             registry_mem.memory_registry.load_saved_ops()
-        ops = registry_mem.memory_registry.list_ops()
-        ret = []
-        for op in ops:
-            try:
-                serialized_op = op.to_dict()
-            except errors.WeaveSerializeError:
-                continue
-            ret.append(serialized_op)
-        return {"data": ret}
+        if (
+            ops_cache is None
+            or ops_cache["updated_at"] < registry_mem.memory_registry.updated_at()
+        ):
+            ops = registry_mem.memory_registry.list_ops()
+            ret = []
+            for op in ops:
+                try:
+                    serialized_op = op.to_dict()
+                except errors.WeaveSerializeError:
+                    continue
+                ret.append(serialized_op)
+            ops_cache = {
+                "updated_at": registry_mem.memory_registry.updated_at(),
+                "data": ret,
+            }
+    return ops_cache
 
 
 class ErrorDetailsDict(typing.TypedDict):


### PR DESCRIPTION
This one is a small perf improvement, but we hit `/ops` on initial page load which can take 80-100ms to execute and blocks all other executions.

With this change, we cache the serialized op results, resulting in 50-70ms load. 

Small, but every full page load is blocked by this.