### PR TITLE
fix: fix model registry page crash when historyStep == null

### DIFF
--- a/weave/ops_domain/artifact_version_ops.py
+++ b/weave/ops_domain/artifact_version_ops.py
@@ -373,6 +373,9 @@ def _get_history_metrics(
     entity_name = created_by["project"]["entity"]["name"]
     history_step = artifactVersion.gql["historyStep"]
 
+    if history_step is None:
+        return {}
+
     node = OutputNode(
         types.TypedDict({}),
         "run-historyAsOf",


### PR DESCRIPTION
Internal JIRA: https://wandb.atlassian.net/browse/WB-15084

Handles `historyStep == null` in `_get_history_metrics()`, fixing a page crash in the model registry.

