### PR TITLE
chore(weave): Share memo context across nested execution and memoize artifact URI calls

### DIFF
--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -21,6 +21,7 @@ from . import file_util
 from . import weave_types as types
 from . import artifact_fs
 from . import filesystem
+from . import memo
 from .wandb_interface import wandb_artifact_pusher
 
 from urllib import parse
@@ -89,6 +90,7 @@ class WandbArtifactManifest:
 
 # TODO: Get rid of this, we have the new wandb api service! But this
 # is still used in a couple places.
+@memo.memo  # Per-request memo reduces duplicate calls to the API
 def get_wandb_read_artifact(path: str):
     return wandb_client_api.wandb_public_api().artifact(path)
 


### PR DESCRIPTION
2 things:

1. we can use our per-execution `@memo` to memoize the uri resolution of artifacts. This means that for each graph, we will only attempt to resolve a URI once, rather than for each time the artifact is constructed (typically once per opGet and opGetRefine)
2. this didn't work right away because the memoization is reset each time we enter another execution hander. I don't see a reason why these can't be shared, so this PR also only sets up a fresh memo cache if one does not already exist.

Practically, shaves off another 100ms from the OpenAI board.