### PR TITLE
fix: compare node/panelMaybeNode with dereferenced vars in useNodeValue

### DIFF
--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -252,6 +252,13 @@ export const useNodeValue = <T extends Type>(
     return dereferenceAllVars(node, stack).node as NodeOrVoidNode<T>;
   }, [node, stack]);
 
+  const dereferencedPanelMaybeNode = useMemo(() => {
+    if (panelMaybeNode == null) {
+      return null;
+    }
+    return dereferenceAllVars(panelMaybeNode, stack).node;
+  }, [panelMaybeNode, stack]);
+
   node = useRefEqualWithoutTypes(node) as NodeOrVoidNode<T>;
 
   node = useMemo(
@@ -334,7 +341,6 @@ export const useNodeValue = <T extends Type>(
   //   memoCacheId,
   //   callSite,
   // });
-
   const finalResult = useMemo(() => {
     // Just rethrow the error in the render thread so it can be caught
     // by an error boundary.
@@ -355,7 +361,10 @@ export const useNodeValue = <T extends Type>(
   }, [error, node, result.node, result.value]);
   if (
     !finalResult.loading &&
-    panelMaybeNode === node &&
+    ((dereferencedPanelMaybeNode === panelMaybeNode &&
+      dereferencedPanelMaybeNode === node) ||
+      (dereferencedPanelMaybeNode !== panelMaybeNode &&
+        _.isEqual(dereferencedPanelMaybeNode, node))) &&
     finalResult.result == null
   ) {
     // Throw NullResult for PanelMaybe to catch.

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -248,16 +248,11 @@ export const useNodeValue = <T extends Type>(
 
   // consoleLog('USE NODE VALUE PRE CLIENT EVAL', weave.expToString(node), stack);
 
+  const origNode = node;
+
   node = useMemo(() => {
     return dereferenceAllVars(node, stack).node as NodeOrVoidNode<T>;
   }, [node, stack]);
-
-  const dereferencedPanelMaybeNode = useMemo(() => {
-    if (panelMaybeNode == null) {
-      return null;
-    }
-    return dereferenceAllVars(panelMaybeNode, stack).node;
-  }, [panelMaybeNode, stack]);
 
   node = useRefEqualWithoutTypes(node) as NodeOrVoidNode<T>;
 
@@ -361,10 +356,7 @@ export const useNodeValue = <T extends Type>(
   }, [error, node, result.node, result.value]);
   if (
     !finalResult.loading &&
-    ((dereferencedPanelMaybeNode === panelMaybeNode &&
-      dereferencedPanelMaybeNode === node) ||
-      (dereferencedPanelMaybeNode !== panelMaybeNode &&
-        _.isEqual(dereferencedPanelMaybeNode, node))) &&
+    panelMaybeNode === origNode &&
     finalResult.result == null
   ) {
     // Throw NullResult for PanelMaybe to catch.


### PR DESCRIPTION
Internal JIRA: https://wandb.atlassian.net/browse/WB-15092

Fixes an issue where `PanelMaybe` did not work properly for graphs with vars, causing page crashes.