### PR TITLE
chore(weave): Extend Artifact Cache to Cross-Request

### DIFF
--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -90,7 +90,7 @@ class WandbArtifactManifest:
 
 # TODO: Get rid of this, we have the new wandb api service! But this
 # is still used in a couple places.
-@memo.memo  # Per-request memo reduces duplicate calls to the API
+@memo.cross_request_memo  # memo reduces duplicate calls to the API
 def get_wandb_read_artifact(path: str):
     return wandb_client_api.wandb_public_api().artifact(path)
 


### PR DESCRIPTION
Playing with he new OpenAI dashboard, I discovered it is very common for successive requests to instantiate the same wand artifact. The last optimization memoized this lookup on a per-request level. This PR goes further and uses a short-lived 5-second cross-request cache to cache such lookups - reducing the duplicative artifact queries