### PR TITLE
chore(dev): remove file path from sha1 calculation

### DIFF
--- a/weave/frontend/build.sh
+++ b/weave/frontend/build.sh
@@ -2,7 +2,7 @@ set -e
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 JS_DIR=$SCRIPT_DIR/../../weave-js
-SHA1=$(find $JS_DIR -not -path "*/.vite-cache/*" -not -path "*/node_modules/*" -not -path "*/build/*" -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -d " " -f1)
+SHA1=$(find $JS_DIR -not -path "*/.vite-cache/*" -not -path "*/node_modules/*" -not -path "*/build/*" -type f -print0 | sort -z | xargs -0 sha1sum | cut -d " " -f1 | sha1sum | cut -d " " -f1)
 
 yarn --cwd=$JS_DIR install --frozen-lockfile
 yarn --cwd=$SCRIPT_DIR/../../weave-js build


### PR DESCRIPTION
Currently, the sha1sum is computed over the file list that includes the path:
```
139b8d024c433f23555bef3b65229f41b69ab637  /Users/jzhao/code/weave/weave/frontend/../../weave-js/tailwind.config.cjs
```
This is unstable since the file path differs depending on where it is called while the content hash is stable. The fix just takes the first column to hash which only include the content hashes.