### PR TITLE
Update default time format

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -85,6 +85,17 @@ export const CenterEntityBrowserInner: React.FC<
     props.entityName
   );
 
+  moment.updateLocale('en', {
+    calendar : {
+      sameDay: '[Today]',
+      nextDay: '[Tomorrow]',
+      nextWeek: 'dddd',
+      lastDay: '[Yesterday]',
+      lastWeek: '[Last] dddd',
+      sameElse: 'YYYY-MM-DD'
+    }
+  });
+
   const browserData = useMemo(() => {
     // TODO: make sorting more customizable and awesome
     const sortedMeta = [...projectsMeta.result].sort(

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterLocalBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterLocalBrowser.tsx
@@ -24,6 +24,17 @@ export const CenterLocalBrowser: React.FC<
   const localDashboards = query.useLocalDashboards();
   const [selectedRowId, setSelectedRowId] = useState<string | undefined>();
 
+  moment.updateLocale('en', {
+    calendar : {
+      sameDay: '[Today]',
+      nextDay: '[Tomorrow]',
+      nextWeek: 'dddd',
+      lastDay: '[Yesterday]',
+      lastWeek: '[Last] dddd',
+      sameElse: 'YYYY-MM-DD'
+    }
+  });
+
   const browserData = useMemo(() => {
     return localDashboards.result
       .sort(a => -a.createdAt)


### PR DESCRIPTION
Add a change so that we display the default time beyond last week to be `YYYY-MM-DD` when browsing tables/boards on local/cloud. 