### PR TITLE
chore(weave): Stop published board editing from harsh reloading

### DIFF
--- a/weave-js/src/components/PagePanel.tsx
+++ b/weave-js/src/components/PagePanel.tsx
@@ -50,6 +50,7 @@ import {useUpdateConfigForPanelNode} from './Panel2/PanelPanel';
 import {PanelRenderedConfigContextProvider} from './Panel2/PanelRenderedConfigContext';
 import Inspector from './Sidebar/Inspector';
 import {useWeaveAutomation} from './automation';
+import {useHistory} from 'react-router-dom';
 
 const JupyterControlsHelpText = styled.div<{active: boolean}>`
   width: max-content;
@@ -134,6 +135,7 @@ type PagePanelProps = {
 const PagePanel = ({browserType}: PagePanelProps) => {
   const weave = useWeaveContext();
   const location = usePoorMansLocation();
+  const history = useHistory();
   const urlParams = new URLSearchParams(location.search);
   const fullScreen = urlParams.get('fullScreen') != null;
   const moarfullScreen = urlParams.get('moarFullScreen') != null;
@@ -150,6 +152,7 @@ const PagePanel = ({browserType}: PagePanelProps) => {
   const inJupyter = inJupyterCell();
   const authed = useIsAuthenticated();
   const isLocal = isServedLocally();
+  const transparentlyMountExpString = useRef('');
 
   const setUrlExp = useCallback(
     (exp: NodeOrVoidNode) => {
@@ -162,17 +165,17 @@ const PagePanel = ({browserType}: PagePanelProps) => {
       searchParams.set('exp', newExpStr);
       const pathname = inJupyterCell() ? window.location.pathname : '/';
 
-      if (newExpStr.startsWith('get') && expString?.startsWith('get')) {
-        // In the specific case that we are updating a get with another get
-        // which happens when we transition between published and local states,
-        // then don't retain the history. We used to always do a replace and
-        // it was super confusing
-        window.history.replaceState(null, '', `${pathname}?${searchParams}`);
-      } else {
-        window.history.pushState(null, '', `${pathname}?${searchParams}`);
+      if (
+        newExpStr.startsWith('get') &&
+        expString?.startsWith('get') &&
+        newExpStr.includes('local-artifact') &&
+        expString.includes('wandb-artifact')
+      ) {
+        transparentlyMountExpString.current = newExpStr;
       }
+      history.push(`${pathname}?${searchParams}`);
     },
-    [expString, weave]
+    [expString, history, weave]
   );
 
   const [config, setConfig] = useState<ChildPanelFullConfig>(
@@ -237,14 +240,22 @@ const PagePanel = ({browserType}: PagePanelProps) => {
 
   useEffect(() => {
     consoleLog('PAGE PANEL MOUNT', window.location.href);
-    setLoading(true);
+    const doTransparently =
+      expString != null && transparentlyMountExpString.current === expString;
+    setLoading(!doTransparently);
     if (expString != null) {
       weave.expression(expString, []).then(res => {
-        updateConfig({
-          input_node: res.expr as any,
-          id: panelId,
-          config: panelConfig,
-        } as any);
+        if (doTransparently) {
+          updateConfig({
+            input_node: res.expr as any,
+          });
+        } else {
+          updateConfig({
+            input_node: res.expr as any,
+            id: panelId,
+            config: panelConfig,
+          } as any);
+        }
         setLoading(false);
       });
     } else if (expNode != null) {

--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -1,4 +1,4 @@
-import {constNodeUnsafe, Node, NodeOrVoidNode} from '@wandb/weave/core';
+import {constNodeUnsafe, NodeOrVoidNode} from '@wandb/weave/core';
 import {produce} from 'immer';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
@@ -44,8 +44,6 @@ export const useUpdateConfigForPanelNode = (
   input: NodeOrVoidNode,
   updateInput?: (newInput: NodeOrVoidNode) => void
 ) => {
-  const weave = useWeaveContext();
-
   const setServerPanelConfig = useMutation(input, 'set');
 
   const updateConfigForPanelNode = useCallback(

--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -45,20 +45,8 @@ export const useUpdateConfigForPanelNode = (
   updateInput?: (newInput: NodeOrVoidNode) => void
 ) => {
   const weave = useWeaveContext();
-  const handleRootUpdate = useCallback(
-    (newVal: Node) => {
-      consoleLog('PANEL PANEL HANDLE ROOT UPDATE', newVal);
-      if (
-        weave.expToString(input) !== weave.expToString(newVal) &&
-        updateInput
-      ) {
-        updateInput(newVal as any);
-      }
-    },
-    [input, updateInput, weave]
-  );
 
-  const setServerPanelConfig = useMutation(input, 'set', handleRootUpdate);
+  const setServerPanelConfig = useMutation(input, 'set');
 
   const updateConfigForPanelNode = useCallback(
     (newConfig: any) => {


### PR DESCRIPTION
This has bothered me for a while. When you make any edit to a published board (basically any interaction)... there is a slight delay, then a full page reload. It is super jarring. This fixes that 👍 .

This also fixes back buttons as well when making such edits.

To be honest, i am not proud of this solution... the way saved panel updates hare handled between PagePanel & PanelPanel & ChildPanel is a spaghetti of indirection and this PR just patches on top of that. We really should audit this entire code path and refactor it to be more understandable and maintainable. 

**Before:**
![2023-08-16 09 21 11](https://github.com/wandb/weave/assets/2142768/62381428-b009-46de-b3fe-b4cd8f68b6c2)


**After:**
![2023-08-16 09 17 26](https://github.com/wandb/weave/assets/2142768/b4b306d5-71ad-4368-8394-815d41e24468)
