### PR TITLE
chore(weave): Update homepage headers and move new board button

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Home.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Home.tsx
@@ -156,13 +156,13 @@ const HomeComp: FC<HomeProps> = props => {
     userName.result,
   ]);
 
-  const draftsSection = useMemo(() => {
+  const localSection = useMemo(() => {
     if (!isLocallyServed) {
       return [];
     }
     return [
       {
-        title: `Drafts`,
+        title: `Local`,
         items: [
           // Home Page TODO: Enable browsing assets in draft state on remote server
           // {
@@ -194,8 +194,8 @@ const HomeComp: FC<HomeProps> = props => {
   }, [history, props.browserType, isLocallyServed]);
 
   const navSections = useMemo(() => {
-    return [...recentSection, ...wandbSection, ...draftsSection];
-  }, [draftsSection, recentSection, wandbSection]);
+    return [...recentSection, ...wandbSection, ...localSection];
+  }, [localSection, recentSection, wandbSection]);
 
   const loading = userName.loading || isAuthenticated === undefined;
   const REDIRECT_RECENTS = [`/${URL_RECENT}`, `/${URL_RECENT}/`];
@@ -236,10 +236,7 @@ const HomeComp: FC<HomeProps> = props => {
   return (
     <LayoutElements.VStack>
       <LayoutElements.Block>
-        <HomeTopBar
-          inJupyter={props.inJupyter}
-          navigateToExpression={navigateToExpression}
-        />
+        <HomeTopBar />
       </LayoutElements.Block>
       {/* Main Region */}
       <LayoutElements.HSpace
@@ -247,7 +244,7 @@ const HomeComp: FC<HomeProps> = props => {
           gap: '12px',
         }}>
         {/* Left Bar */}
-        <LeftNav sections={navSections} />
+        <LeftNav sections={navSections} inJupyter={props.inJupyter} navigateToExpression={navigateToExpression}/>
         {/* Center Content */}
         {!loading && (
           <CenterSpace>

--- a/weave-js/src/components/PagePanelComponents/Home/Home.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Home.tsx
@@ -244,7 +244,11 @@ const HomeComp: FC<HomeProps> = props => {
           gap: '12px',
         }}>
         {/* Left Bar */}
-        <LeftNav sections={navSections} inJupyter={props.inJupyter} navigateToExpression={navigateToExpression}/>
+        <LeftNav
+          sections={navSections}
+          inJupyter={props.inJupyter}
+          navigateToExpression={navigateToExpression}
+        />
         {/* Center Content */}
         {!loading && (
           <CenterSpace>

--- a/weave-js/src/components/PagePanelComponents/Home/HomeLeftNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeLeftNav.tsx
@@ -1,9 +1,17 @@
-import React from 'react';
+import { Button } from '@wandb/weave/components/Button';
+import {MOON_800} from '@wandb/weave/common/css/color.styles';
+import {voidNode} from '@wandb/weave/core';
 
+import React, {useCallback, useState} from 'react';
 import styled from 'styled-components';
 import * as LayoutElements from './LayoutElements';
 import {Link} from 'react-router-dom';
-import {MOON_800} from '@wandb/weave/common/css/color.styles';
+import moment from 'moment';
+
+import getConfig from '../../../config';
+import {useWeaveContext} from '../../../context';
+import {useNewPanelFromRootQueryCallback} from '../../Panel2/PanelRootBrowser/util';
+import {NavigateToExpressionType} from './common';
 
 const LeftNavItemBlock = styled(LayoutElements.HBlock)`
   margin: 0px 0px 0px 12px;
@@ -19,9 +27,41 @@ const LeftNavItemBlock = styled(LayoutElements.HBlock)`
   }
 `;
 
+const NewBoardButtonWrapper = styled.div`
+  margin: 24px 24px 16px 24px
+`;
+NewBoardButtonWrapper.displayName = 'S.NewBoardButton';
+
 export const LeftNav: React.FC<{
   sections: LeftNavSectionProps[];
+  inJupyter: boolean;
+  navigateToExpression: NavigateToExpressionType;
 }> = props => {
+  const now = moment().format('YY_MM_DD_hh_mm_ss');
+  const inJupyter = props.inJupyter;
+  const defaultName = now;
+  const [newName] = useState('');
+  const weave = useWeaveContext();
+  const name = 'dashboard-' + (newName === '' ? defaultName : newName);
+  const makeNewDashboard = useNewPanelFromRootQueryCallback();
+  const {urlPrefixed} = getConfig();
+  const newDashboard = useCallback(() => {
+    makeNewDashboard(name, voidNode(), true, newDashExpr => {
+      if (inJupyter) {
+        const expStr = weave
+          .expToString(newDashExpr)
+          .replace(/\n+/g, '')
+          .replace(/\s+/g, '');
+        window.open(
+          urlPrefixed(`?exp=${encodeURIComponent(expStr)}`),
+          '_blank'
+        );
+      } else {
+        props.navigateToExpression(newDashExpr);
+      }
+    });
+  }, [inJupyter, makeNewDashboard, name, props, urlPrefixed, weave]);
+
   return (
     <LayoutElements.VBlock
       style={{
@@ -29,6 +69,11 @@ export const LeftNav: React.FC<{
         paddingTop: '0px', // Cecile's design has spacing here, but i kind of like it without
         overflowY: 'auto',
       }}>
+      <NewBoardButtonWrapper>
+        <Button variant="secondary" onClick={newDashboard} icon="add-new" size='large' >
+          New blank board
+        </Button>
+      </NewBoardButtonWrapper>
       {props.sections.map((section, i) => (
         <LeftNavSection key={i} {...section} />
       ))}
@@ -48,7 +93,7 @@ const LeftNavSection: React.FC<LeftNavSectionProps> = props => {
         marginBottom: '16px',
       }}>
       {/* Header */}
-      <LayoutElements.HBlock
+      <LayoutElements.BlockHeader
         style={{
           textTransform: 'uppercase',
           padding: '10px 24px',
@@ -58,7 +103,7 @@ const LeftNavSection: React.FC<LeftNavSectionProps> = props => {
           top: 0,
         }}>
         {props.title}
-      </LayoutElements.HBlock>
+      </LayoutElements.BlockHeader>
       {/* Items */}
       <LayoutElements.VBlock>
         {props.items.map((item, i) => (

--- a/weave-js/src/components/PagePanelComponents/Home/HomeLeftNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeLeftNav.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wandb/weave/components/Button';
+import {Button} from '@wandb/weave/components/Button';
 import {MOON_800} from '@wandb/weave/common/css/color.styles';
 import {voidNode} from '@wandb/weave/core';
 
@@ -28,7 +28,7 @@ const LeftNavItemBlock = styled(LayoutElements.HBlock)`
 `;
 
 const NewBoardButtonWrapper = styled.div`
-  margin: 24px 24px 16px 24px
+  margin: 24px 24px 16px 24px;
 `;
 NewBoardButtonWrapper.displayName = 'S.NewBoardButton';
 
@@ -70,7 +70,11 @@ export const LeftNav: React.FC<{
         overflowY: 'auto',
       }}>
       <NewBoardButtonWrapper>
-        <Button variant="secondary" onClick={newDashboard} icon="add-new" size='large' >
+        <Button
+          variant="secondary"
+          onClick={newDashboard}
+          icon="add-new"
+          size="large">
           New blank board
         </Button>
       </NewBoardButtonWrapper>

--- a/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@wandb/weave/components/Button';
+
 import React from 'react';
 import * as LayoutElements from './LayoutElements';
 import styled from 'styled-components';
@@ -17,6 +19,8 @@ import {WeaveAnimatedLoader} from '../../Panel2/WeaveAnimatedLoader';
 import {useNodeWithServerType} from '@wandb/weave/react';
 import {MOON_250} from '@wandb/weave/common/css/color.styles';
 import {useHistory} from 'react-router-dom';
+
+import * as Tabs from '../../Tabs'
 
 const CenterSpace = styled(LayoutElements.VSpace)`
   border: 1px solid ${MOON_250};
@@ -156,16 +160,47 @@ export const HomeExpressionPreviewParts: React.FC<{
   const generators = useBoardGeneratorsForNode(expr);
   const [isGenerating, setIsGenerating] = React.useState(false);
   const makeBoardFromNode = useMakeLocalBoardFromNode();
+
+  const [copyButtonText, setCopyButtonText] = React.useState<"Copy" | "Copied">("Copy");
+
   return (
     <LayoutElements.VStack style={{gap: '16px'}}>
       <LayoutElements.VBlock style={{gap: '8px'}}>
-        <span style={{color: '#2B3038', fontWeight: 600}}>Preview</span>
+        <LayoutElements.BlockHeader>
+          PREVIEW
+          <Button
+            onClick={() => {
+              navigateToExpression(expr);
+            }}
+            size='small'
+            variant='ghost'
+            icon='full-screen-mode-expand'
+          >
+            Expand
+          </Button>
+        </LayoutElements.BlockHeader>
         <LayoutElements.Block>
           <PreviewNode inputExpr={inputExpr} />
         </LayoutElements.Block>
       </LayoutElements.VBlock>
       <LayoutElements.VBlock style={{gap: '8px'}}>
-        <span style={{color: '#2B3038', fontWeight: 600}}>Expression</span>
+      <LayoutElements.BlockHeader>
+          EXPRESSION
+          <Button
+            onClick={() => {
+              navigator.clipboard.writeText(weave.expToString(expr));
+              setCopyButtonText("Copied")
+              setTimeout(() => {
+                setCopyButtonText("Copy")
+              }, 3000);
+            }}
+            size='small'
+            variant='ghost'
+            icon='copy'
+          >
+            {copyButtonText}
+          </Button>
+        </LayoutElements.BlockHeader>
         <LayoutElements.Block>
           <WeaveExpression
             expr={expr}
@@ -190,9 +225,18 @@ export const HomeExpressionPreviewParts: React.FC<{
       ) : (
         generators.result.length > 0 && (
           <LayoutElements.VBlock style={{gap: '8px'}}>
-            <span style={{color: '#2B3038', fontWeight: 600}}>
-              Available Templates
-            </span>
+            <LayoutElements.BlockHeader>
+              CREATE A BOARD
+              {/* <Button
+                onClick={() => {
+                  console.log('view all templates')
+                }}
+                size='small'
+                variant='ghost'
+              >
+                View all templates
+              </Button> */}
+            </LayoutElements.BlockHeader>
             <LayoutElements.VStack
               style={{
                 gap: '8px',
@@ -291,3 +335,28 @@ export const HomeBoardPreview: React.FC<{
     </HomePreviewSidebarTemplate>
   );
 };
+
+export const HomePreviewTabs: React.FC<{
+  expr: Node;
+  navigateToExpression: NavigateToExpressionType;
+}> = ({expr, navigateToExpression}) => {
+  const [tabValue, setTabValue] = React.useState('Overview');
+
+  return (  
+    <Tabs.Root value={tabValue} onValueChange={(val) => setTabValue(val)}>
+      <Tabs.List>
+        <Tabs.Trigger value="Overview">Overview</Tabs.Trigger>
+        <Tabs.Trigger value="Templates">Templates</Tabs.Trigger>
+        <Tabs.Trigger value="Boards">Boards</Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="Overview">
+        <HomeExpressionPreviewParts
+          expr={expr}
+          navigateToExpression={navigateToExpression}
+        />
+      </Tabs.Content>
+      <Tabs.Content value="Templates">Templates</Tabs.Content>
+      <Tabs.Content value="Boards">Boards</Tabs.Content>
+    </Tabs.Root>
+  );
+}

--- a/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wandb/weave/components/Button';
+import {Button} from '@wandb/weave/components/Button';
 
 import React from 'react';
 import * as LayoutElements from './LayoutElements';
@@ -20,7 +20,7 @@ import {useNodeWithServerType} from '@wandb/weave/react';
 import {MOON_250} from '@wandb/weave/common/css/color.styles';
 import {useHistory} from 'react-router-dom';
 
-import * as Tabs from '../../Tabs'
+import * as Tabs from '../../Tabs';
 
 const CenterSpace = styled(LayoutElements.VSpace)`
   border: 1px solid ${MOON_250};
@@ -161,7 +161,9 @@ export const HomeExpressionPreviewParts: React.FC<{
   const [isGenerating, setIsGenerating] = React.useState(false);
   const makeBoardFromNode = useMakeLocalBoardFromNode();
 
-  const [copyButtonText, setCopyButtonText] = React.useState<"Copy" | "Copied">("Copy");
+  const [copyButtonText, setCopyButtonText] = React.useState<'Copy' | 'Copied'>(
+    'Copy'
+  );
 
   return (
     <LayoutElements.VStack style={{gap: '16px'}}>
@@ -172,10 +174,9 @@ export const HomeExpressionPreviewParts: React.FC<{
             onClick={() => {
               navigateToExpression(expr);
             }}
-            size='small'
-            variant='ghost'
-            icon='full-screen-mode-expand'
-          >
+            size="small"
+            variant="ghost"
+            icon="full-screen-mode-expand">
             Expand
           </Button>
         </LayoutElements.BlockHeader>
@@ -184,20 +185,19 @@ export const HomeExpressionPreviewParts: React.FC<{
         </LayoutElements.Block>
       </LayoutElements.VBlock>
       <LayoutElements.VBlock style={{gap: '8px'}}>
-      <LayoutElements.BlockHeader>
+        <LayoutElements.BlockHeader>
           EXPRESSION
           <Button
             onClick={() => {
               navigator.clipboard.writeText(weave.expToString(expr));
-              setCopyButtonText("Copied")
+              setCopyButtonText('Copied');
               setTimeout(() => {
-                setCopyButtonText("Copy")
+                setCopyButtonText('Copy');
               }, 3000);
             }}
-            size='small'
-            variant='ghost'
-            icon='copy'
-          >
+            size="small"
+            variant="ghost"
+            icon="copy">
             {copyButtonText}
           </Button>
         </LayoutElements.BlockHeader>
@@ -342,8 +342,8 @@ export const HomePreviewTabs: React.FC<{
 }> = ({expr, navigateToExpression}) => {
   const [tabValue, setTabValue] = React.useState('Overview');
 
-  return (  
-    <Tabs.Root value={tabValue} onValueChange={(val) => setTabValue(val)}>
+  return (
+    <Tabs.Root value={tabValue} onValueChange={val => setTabValue(val)}>
       <Tabs.List>
         <Tabs.Trigger value="Overview">Overview</Tabs.Trigger>
         <Tabs.Trigger value="Templates">Templates</Tabs.Trigger>
@@ -359,4 +359,4 @@ export const HomePreviewTabs: React.FC<{
       <Tabs.Content value="Boards">Boards</Tabs.Content>
     </Tabs.Root>
   );
-}
+};

--- a/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
@@ -20,8 +20,6 @@ import {useNodeWithServerType} from '@wandb/weave/react';
 import {MOON_250} from '@wandb/weave/common/css/color.styles';
 import {useHistory} from 'react-router-dom';
 
-import * as Tabs from '../../Tabs';
-
 const CenterSpace = styled(LayoutElements.VSpace)`
   border: 1px solid ${MOON_250};
   box-shadow: 0px 8px 16px 0px #0e10140a;
@@ -333,30 +331,5 @@ export const HomeBoardPreview: React.FC<{
         navigateToExpression={navigateToExpression}
       />
     </HomePreviewSidebarTemplate>
-  );
-};
-
-export const HomePreviewTabs: React.FC<{
-  expr: Node;
-  navigateToExpression: NavigateToExpressionType;
-}> = ({expr, navigateToExpression}) => {
-  const [tabValue, setTabValue] = React.useState('Overview');
-
-  return (
-    <Tabs.Root value={tabValue} onValueChange={val => setTabValue(val)}>
-      <Tabs.List>
-        <Tabs.Trigger value="Overview">Overview</Tabs.Trigger>
-        <Tabs.Trigger value="Templates">Templates</Tabs.Trigger>
-        <Tabs.Trigger value="Boards">Boards</Tabs.Trigger>
-      </Tabs.List>
-      <Tabs.Content value="Overview">
-        <HomeExpressionPreviewParts
-          expr={expr}
-          navigateToExpression={navigateToExpression}
-        />
-      </Tabs.Content>
-      <Tabs.Content value="Templates">Templates</Tabs.Content>
-      <Tabs.Content value="Boards">Boards</Tabs.Content>
-    </Tabs.Root>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/HomeTopBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeTopBar.tsx
@@ -1,54 +1,14 @@
-import {voidNode} from '@wandb/weave/core';
-import moment from 'moment';
-import React, {useCallback, useState} from 'react';
-import getConfig from '../../../config';
-
+import React from 'react';
 import styled from 'styled-components';
-import {useWeaveContext} from '../../../context';
 import {IconWeaveLogo} from '../../Panel2/Icons';
-import {useNewPanelFromRootQueryCallback} from '../../Panel2/PanelRootBrowser/util';
-import {NavigateToExpressionType} from './common';
-import {Button} from '../../Button';
 
-export const HomeTopBar: React.FC<{
-  navigateToExpression: NavigateToExpressionType;
-  inJupyter: boolean;
-}> = props => {
-  const now = moment().format('YY_MM_DD_hh_mm_ss');
-  const inJupyter = props.inJupyter;
-  const defaultName = now;
-  const [newName] = useState('');
-  const weave = useWeaveContext();
-  const name = 'dashboard-' + (newName === '' ? defaultName : newName);
-  const makeNewDashboard = useNewPanelFromRootQueryCallback();
-  const {urlPrefixed} = getConfig();
-  const newDashboard = useCallback(() => {
-    makeNewDashboard(name, voidNode(), true, newDashExpr => {
-      if (inJupyter) {
-        const expStr = weave
-          .expToString(newDashExpr)
-          .replace(/\n+/g, '')
-          .replace(/\s+/g, '');
-        window.open(
-          urlPrefixed(`?exp=${encodeURIComponent(expStr)}`),
-          '_blank'
-        );
-      } else {
-        props.navigateToExpression(newDashExpr);
-      }
-    });
-  }, [inJupyter, makeNewDashboard, name, props, urlPrefixed, weave]);
+export const HomeTopBar: React.FC = () => {
   return (
     <TopBar>
       <TopBarLeft>
         <WeaveLogo />
         Weave
       </TopBarLeft>
-      <TopBarRight>
-        <Button onClick={newDashboard} icon="add-new">
-          New board
-        </Button>
-      </TopBarRight>
     </TopBar>
   );
 };
@@ -66,11 +26,6 @@ const TopBarLeft = styled.div`
   align-items: center;
   font-size: 18px;
   font-weight: 600;
-`;
-
-const TopBarRight = styled.div`
-  display: flex;
-  align-items: center;
 `;
 
 const WeaveLogo = styled(IconWeaveLogo)`

--- a/weave-js/src/components/PagePanelComponents/Home/LayoutElements.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/LayoutElements.tsx
@@ -1,4 +1,4 @@
-import { MOON_500 } from '@wandb/weave/common/css/color.styles';
+import {MOON_500} from '@wandb/weave/common/css/color.styles';
 import styled from 'styled-components';
 
 const STYLE_DEBUG = false;
@@ -82,12 +82,12 @@ export const HBlock = styled.div`
 `;
 HBlock.displayName = 'S.HBlock';
 
-export const BlockHeader = styled.div` 
+export const BlockHeader = styled.div`
   color: ${MOON_500};
   font-weight: 600;
   font-size: 14px;
   line-height: 24px;
-  
+
   display: flex;
   justify-content: space-between;
 `;

--- a/weave-js/src/components/PagePanelComponents/Home/LayoutElements.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/LayoutElements.tsx
@@ -1,3 +1,4 @@
+import { MOON_500 } from '@wandb/weave/common/css/color.styles';
 import styled from 'styled-components';
 
 const STYLE_DEBUG = false;
@@ -80,3 +81,14 @@ export const HBlock = styled.div`
   ${debugStyle}
 `;
 HBlock.displayName = 'S.HBlock';
+
+export const BlockHeader = styled.div` 
+  color: ${MOON_500};
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 24px;
+  
+  display: flex;
+  justify-content: space-between;
+`;
+BlockHeader.displayName = 'S.BlockHeader';


### PR DESCRIPTION
updates the headers in left nav and sidebar
moves the new board button
adds expand and copy action to sidebar

new
![Screenshot 2023-08-16 at 11 31 25 AM](https://github.com/wandb/weave/assets/25037002/c7985175-a5e0-4b0c-ae89-914d907c3667)

old
![Screenshot 2023-08-16 at 11 31 37 AM](https://github.com/wandb/weave/assets/25037002/0d161cda-bd23-4140-aba3-9a9e8611d79f)


