### PR TITLE
perf: implement unnest in arrow

### DIFF
--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -582,16 +582,6 @@ def unnest(self):
             arrow_obj = arrow_obj.append_column(tag_col_name, col_tags)
             arrow_obj = arrow_obj.append_column(col, col_values)
 
-    # todo: make this more efficient. we shouldn't have to convert back and forth
-    # from the arrow in-memory representation to pandas just to call the explode
-    # function. but there is no native pyarrow implementation of this
-
-    # This can replace int64 with float64! I believe it happens when we have nullable
-    # int. pandas represents nullability using nan.
-    # This requires us a hack in our AWL.validate function to allow float64 when
-    # the weave type is int.
-    # TODO: write an arrow based implementation, and remove the hack in validate.
-
     exploded_table = arrow_obj
     for column in list_cols:
         exploded_table = explode_table(exploded_table, column)

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -518,14 +518,14 @@ def explode_table(table: pa.Table, column: str) -> pa.Table:
     other_columns.remove(column)
     if len(other_columns) == 0:
         return pa.table({column: flattened})
-    else:
-        indices = pc.list_parent_indices(null_filled)
-        result = table.select(other_columns).take(indices)
-        result = result.append_column(
-            pa.field(column, table.schema.field(column).type.value_type),
-            flattened,
-        )
-        return result
+
+    indices = pc.list_parent_indices(null_filled)
+    result = table.select(other_columns).take(indices)
+    result = result.append_column(
+        pa.field(column, table.schema.field(column).type.value_type),
+        flattened,
+    )
+    return result
 
 
 @op(

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -511,6 +511,23 @@ def limit(self: ArrowWeaveList, limit: int):
     return self._limit(limit)
 
 
+def explode_table(table: pa.Table, column: str) -> pa.Table:
+    null_filled = pc.fill_null(table[column], [None])
+    flattened = pc.list_flatten(null_filled)
+    other_columns = list(table.schema.names)
+    other_columns.remove(column)
+    if len(other_columns) == 0:
+        return pa.table({column: flattened})
+    else:
+        indices = pc.list_parent_indices(null_filled)
+        result = table.select(other_columns).take(indices)
+        result = result.append_column(
+            pa.field(column, table.schema.field(column).type.value_type),
+            flattened,
+        )
+        return result
+
+
 @op(
     name="ArrowWeaveList-unnest",
     input_type={"self": ArrowWeaveListType(types.TypedDict({}))},
@@ -574,9 +591,10 @@ def unnest(self):
     # This requires us a hack in our AWL.validate function to allow float64 when
     # the weave type is int.
     # TODO: write an arrow based implementation, and remove the hack in validate.
-    exploded_table = pa.Table.from_pandas(
-        df=arrow_obj.to_pandas().explode(list_cols), preserve_index=False
-    )
+
+    exploded_table = arrow_obj
+    for column in list_cols:
+        exploded_table = explode_table(exploded_table, column)
 
     # Reconstruct the tagged list columns
     for col in exploded_table.column_names:


### PR DESCRIPTION
Implements unnest in arrow following https://github.com/apache/arrow/issues/27923#issuecomment-1378008415. 

Allows us to avoid breaking out to pandas in unnest. 