### PR TITLE
fix: fix handling of multiple list columns in awl.unnest()

### DIFF
--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -547,16 +547,14 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
         raise ValueError("Cannot explode table with no list columns")
 
     result = table.select(other_columns).take(indices)
-    """
-    result = result.append_column(
-        pa.field(column, table.schema.field(column).type.value_type),
-        flattened,
-    )
 
-
+    for column in list_columns:
+        result = result.append_column(
+            pa.field(column, table.schema.field(column).type.value_type),
+            flattened_list_columns[column],
+        )
 
     return result
-    """
 
 
 @op(

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -511,15 +511,41 @@ def limit(self: ArrowWeaveList, limit: int):
     return self._limit(limit)
 
 
-def explode_table(table: pa.Table, column: str) -> pa.Table:
-    null_filled = pc.fill_null(table[column], [None])
-    flattened = pc.list_flatten(null_filled)
+def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
     other_columns = list(table.schema.names)
-    other_columns.remove(column)
-    if len(other_columns) == 0:
-        return pa.table({column: flattened})
 
-    indices = pc.list_parent_indices(null_filled)
+    flattened_list_columns: dict[str, pa.ChunkedArray] = {}
+
+    if len(list_columns) == 0:
+        return table
+
+    first_column = list_columns[0]
+    value_lengths_0 = table[first_column].combine_chunks().value_lengths()
+
+    # only need to calculate this once since all the list columns should have the same shape
+    # if they don't, then we raise an error below
+    indices: typing.Optional[pa.Array] = None
+
+    for column in list_columns:
+        value_lengths = table[column].combine_chunks().value_lengths()
+        if not pc.equals(value_lengths, value_lengths_0):
+            raise ValueError(
+                f"Cannot explode table with list columns of different shapes: {value_lengths} != {value_lengths_0}"
+            )
+        null_filled = pc.fill_null(table[column], [None])
+        flattened = pc.list_flatten(null_filled)
+        other_columns.remove(column)
+        flattened_list_columns[column] = flattened
+
+        if indices is None:
+            indices = pc.list_parent_indices(null_filled)
+
+    if len(other_columns) == 0:
+        return pa.table(flattened_list_columns)
+
+    if indices is None:
+        raise ValueError("Cannot explode table with no list columns")
+
     result = table.select(other_columns).take(indices)
     result = result.append_column(
         pa.field(column, table.schema.field(column).type.value_type),
@@ -582,9 +608,7 @@ def unnest(self):
             arrow_obj = arrow_obj.append_column(tag_col_name, col_tags)
             arrow_obj = arrow_obj.append_column(col, col_values)
 
-    exploded_table = arrow_obj
-    for column in list_cols:
-        exploded_table = explode_table(exploded_table, column)
+    exploded_table = explode_table(exploded_table, list_cols)
 
     # Reconstruct the tagged list columns
     for col in exploded_table.column_names:

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -519,7 +519,6 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
     if len(list_columns) == 0:
         return table
 
-    """
     first_column = list_columns[0]
     value_lengths_0 = table[first_column].combine_chunks().value_lengths()
 
@@ -527,6 +526,7 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
     # if they don't, then we raise an error below
     indices: typing.Optional[pa.Array] = None
 
+    """
     for column in list_columns:
         value_lengths = table[column].combine_chunks().value_lengths()
         if not pc.equals(value_lengths, value_lengths_0):

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -552,6 +552,7 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
         pa.field(column, table.schema.field(column).type.value_type),
         flattened,
     )
+
     return result
     """
 

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -546,12 +546,14 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
     if indices is None:
         raise ValueError("Cannot explode table with no list columns")
 
-    """
     result = table.select(other_columns).take(indices)
+    """
     result = result.append_column(
         pa.field(column, table.schema.field(column).type.value_type),
         flattened,
     )
+
+
 
     return result
     """

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -526,7 +526,6 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
     # if they don't, then we raise an error below
     indices: typing.Optional[pa.Array] = None
 
-    """
     for column in list_columns:
         value_lengths = table[column].combine_chunks().value_lengths()
         if not pc.equals(value_lengths, value_lengths_0):
@@ -547,6 +546,7 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
     if indices is None:
         raise ValueError("Cannot explode table with no list columns")
 
+    """
     result = table.select(other_columns).take(indices)
     result = result.append_column(
         pa.field(column, table.schema.field(column).type.value_type),

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -528,7 +528,7 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
 
     for column in list_columns:
         value_lengths = table[column].combine_chunks().value_lengths()
-        if not pc.equals(value_lengths, value_lengths_0):
+        if not pc.equal(value_lengths, value_lengths_0):
             raise ValueError(
                 f"Cannot explode table with list columns of different shapes: {value_lengths} != {value_lengths_0}"
             )
@@ -611,7 +611,7 @@ def unnest(self):
             arrow_obj = arrow_obj.append_column(tag_col_name, col_tags)
             arrow_obj = arrow_obj.append_column(col, col_values)
 
-    exploded_table = explode_table(exploded_table, list_cols)
+    exploded_table = explode_table(arrow_obj, list_cols)
 
     # Reconstruct the tagged list columns
     for col in exploded_table.column_names:

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -519,6 +519,7 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
     if len(list_columns) == 0:
         return table
 
+    """
     first_column = list_columns[0]
     value_lengths_0 = table[first_column].combine_chunks().value_lengths()
 
@@ -552,6 +553,7 @@ def explode_table(table: pa.Table, list_columns: list[str]) -> pa.Table:
         flattened,
     )
     return result
+    """
 
 
 @op(

--- a/weave/tests/test_arrow.py
+++ b/weave/tests/test_arrow.py
@@ -626,6 +626,36 @@ def test_arrow_unnest():
     ]
 
 
+def test_arrow_unnest_two_list_cols():
+    data = arrow.to_arrow(
+        [
+            {"a": [1, 2, 3], "b": "c", "c": ["a", "b", "c"]},
+            {"a": [4, 5, 6], "b": "d", "c": ["d", "e", "f"]},
+        ]
+    )
+    assert weave.type_of(data) == arrow.ArrowWeaveListType(
+        types.TypedDict(
+            {
+                "a": types.List(types.Int()),
+                "b": types.String(),
+                "c": types.List(types.String()),
+            }
+        )
+    )
+    unnest_node = weave.weave(data).unnest()
+    assert unnest_node.type == arrow.ArrowWeaveListType(
+        types.TypedDict({"a": types.Int(), "b": types.String(), "c": types.String()})
+    )
+    assert weave.use(weave.weave(data).unnest()).to_pylist_raw() == [
+        {"a": 1, "b": "c", "c": "a"},
+        {"a": 2, "b": "c", "c": "b"},
+        {"a": 3, "b": "c", "c": "c"},
+        {"a": 4, "b": "d", "c": "d"},
+        {"a": 5, "b": "d", "c": "e"},
+        {"a": 6, "b": "d", "c": "f"},
+    ]
+
+
 def test_arrow_nullable_concat():
     ca1 = pa.chunked_array([[1, 2], [3, 4]])
     ca2 = pa.compute.add(ca1, 1)


### PR DESCRIPTION
Fixes an issue where multiple list columns were unnested individually in `awl.unnest()`. As an illustration of this bug, calling unnest on 

```
     [
            {"a": [1, 2, 3], "b": "c", "c": ["a", "b", "c"]},
            {"a": [4, 5, 6], "b": "d", "c": ["d", "e", "f"]},
        ]
```

would yield

```
     [
{'a': 1, 'b': 'c', 'c': 'a'},
{'a': 1, 'b': 'c', 'c': 'b'},
{'a': 1, 'b': 'c', 'c': 'c'},
{'a': 2, 'b': 'c', 'c': 'a'},
{'a': 2, 'b': 'c', 'c': 'b'},
{'a': 2, 'b': 'c', 'c': 'c'},
{'a': 3, 'b': 'c', 'c': 'a'},
{'a': 3, 'b': 'c', 'c': 'b'},
{'a': 3, 'b': 'c', 'c': 'c'},
{'a': 4, 'b': 'd', 'c': 'd'},
{'a': 4, 'b': 'd', 'c': 'e'},
{'a': 4, 'b': 'd', 'c': 'f'},
{'a': 5, 'b': 'd', 'c': 'd'},
{'a': 5, 'b': 'd', 'c': 'e'},
{'a': 5, 'b': 'd', 'c': 'f'},
{'a': 6, 'b': 'd', 'c': 'd'},
{'a': 6, 'b': 'd', 'c': 'e'},
{'a': 6, 'b': 'd', 'c': 'f'},
]
```

instead of 

```
[
        {"a": 1, "b": "c", "c": "a"},
        {"a": 2, "b": "c", "c": "b"},
        {"a": 3, "b": "c", "c": "c"},
        {"a": 4, "b": "d", "c": "d"},
        {"a": 5, "b": "d", "c": "e"},
        {"a": 6, "b": "d", "c": "f"},
    ]

```

This PR fixes this issue and adds a test. 