### PR TITLE
chore(weave): Introduce history.count optimization

### DIFF
--- a/weave/ops_domain/run_ops.py
+++ b/weave/ops_domain/run_ops.py
@@ -134,6 +134,14 @@ gql_prop_op(
     types.Timestamp(),
 )
 
+gql_prop_op(
+    "run-historyLineCount",
+    wdt.RunType,
+    "historyLineCount",
+    types.Number(),
+    hidden=True,
+)
+
 
 def config_to_values(config: dict) -> dict:
     """

--- a/weave/ops_domain/wandb_domain_gql.py
+++ b/weave/ops_domain/wandb_domain_gql.py
@@ -42,6 +42,7 @@ def gql_prop_op(
     input_type: weave_types.Type,
     prop_name: str,
     output_type: weave_types.Type,
+    hidden: bool = False,
 ):
     first_arg_name = input_type.name
 
@@ -63,6 +64,7 @@ def gql_prop_op(
         ),
         input_type={first_arg_name: input_type},
         output_type=output_type,
+        hidden=hidden,
     )(gql_property_getter_op_fn)
 
 

--- a/weave/tests/test_wb_end_to_end.py
+++ b/weave/tests/test_wb_end_to_end.py
@@ -1,5 +1,6 @@
 import weave
 import wandb
+from weave import compile
 
 
 # Example of end to end integration test
@@ -75,3 +76,22 @@ def test_run_histories(user_by_api_key_in_env):
 
     # Runs return in reverse chronological order
     assert history == [2, 1]
+
+
+# Example of end to end integration test
+def test_run_history_count(user_by_api_key_in_env):
+    run = wandb.init(project="project_exists")
+    run.log({"a": 1})
+    run.log({"a": 2})
+    run.finish()
+
+    run_node = weave.ops.project(run.entity, run.project).run(run.id)
+    h_count_node = run_node.history().count()
+    history_count = weave.use(h_count_node)
+    assert history_count == 2
+
+    compiled = compile.compile([h_count_node])
+    assert compiled[0].from_op.name == "run-historyLineCount"
+
+    run_history_lines = weave.use(run_node.historyLineCount())
+    assert run_history_lines == 2


### PR DESCRIPTION
The first of it's kind: an op re-write optimization. Rewrites `run.history.count` to `run.historyLineCount` which is much faster since it is just a quick lookup for gorilla!