### PR TITLE
feat: Visual filter editor

### DIFF
--- a/examples/monitoring/dev/openai_monitoring_board_demo.ipynb
+++ b/examples/monitoring/dev/openai_monitoring_board_demo.ipynb
@@ -85,7 +85,7 @@
     "                     'api_key': 'sk-U4...yK7z',\n",
     "                     'username': pred['username']\n",
     "                 },\n",
-    "                 metrics={\n",
+    "                 summary={\n",
     "                     'prompt_tokens': pred['prompt_tokens'],\n",
     "                     'completion_tokens': pred['completion_tokens'],\n",
     "                     'total_tokens': pred['prompt_tokens'] + pred['completion_tokens']\n",

--- a/weave-js/src/components/Panel2/PanelDropdown.tsx
+++ b/weave-js/src/components/Panel2/PanelDropdown.tsx
@@ -94,22 +94,24 @@ export const PanelDropdown: React.FC<PanelDropdownProps> = props => {
   }, [choices]);
 
   return (
-    <ModifiedDropdown
-      value={chosen}
-      onChange={(e, {value}) => {
-        if (isMultiple) {
-          setVal({val: constNodeUnsafe(config.choices.type, value)});
-        } else if (value != null) {
-          setVal({val: constString(value as string)});
-        } else {
-          setVal({val: constNone()});
-        }
-      }}
-      options={options}
-      selection
-      multiple={isMultiple}
-      floating
-    />
+    <div style={{paddingLeft: 16}}>
+      <ModifiedDropdown
+        value={chosen}
+        onChange={(e, {value}) => {
+          if (isMultiple) {
+            setVal({val: constNodeUnsafe(config.choices.type, value)});
+          } else if (value != null) {
+            setVal({val: constString(value as string)});
+          } else {
+            setVal({val: constNone()});
+          }
+        }}
+        options={options}
+        selection
+        multiple={isMultiple}
+        floating
+      />
+    </div>
   );
 };
 

--- a/weave-js/src/components/Panel2/PanelFilterEditor.tsx
+++ b/weave-js/src/components/Panel2/PanelFilterEditor.tsx
@@ -27,7 +27,7 @@ import {
   opBooleanNotEqual,
   constNumber,
   constBoolean,
-  opLimit,
+  // opLimit,
 } from '@wandb/weave/core';
 import * as _ from 'lodash';
 import React, {useCallback, useMemo, useState} from 'react';
@@ -38,6 +38,7 @@ import * as Panel2 from './panel';
 import {PanelContextProvider} from './PanelContext';
 import {Button, Popup} from 'semantic-ui-react';
 import ModifiedDropdown from '@wandb/weave/common/components/elements/ModifiedDropdown';
+import LinkButton from '@wandb/weave/common/components/LinkButton';
 
 const inputType = {
   type: 'function' as const,
@@ -160,21 +161,31 @@ const SingleFilterVisualEditor: React.FC<{
   const opChoices = getOpChoices(simpleKeyType);
   const opOptions = opChoices.map(key => ({text: key, value: key, key}));
 
+  // const valueQuery =
+  // TODO: opLimit is broken in weave python when we have an ArrowWeaveList...
+  // I think because we don't have opUnique?
+  //   key != null
+  //     ? opLimit({
+  //         arr: opUnique({
+  //           arr: opPick({obj: props.listNode, key: constString(key)}),
+  //         }),
+  //         limit: constNumber(500),
+  //       })
+  //     : voidNode();
   const valueQuery =
     key != null
-      ? opLimit({
-          arr: opUnique({
-            arr: opPick({obj: props.listNode, key: constString(key)}),
-          }),
-          limit: constNumber(500),
+      ? opUnique({
+          arr: opPick({obj: props.listNode, key: constString(key)}),
         })
       : voidNode();
   const valueChoices = useNodeValue(valueQuery).result ?? [];
-  const valueOptions = valueChoices.map((value: boolean | string | number) => ({
-    text: value.toString(),
-    value: value,
-    key: value.toString(),
-  }));
+  const valueOptions = valueChoices
+    .filter((value: any) => value != null)
+    .map((value: boolean | string | number) => ({
+      text: value.toString(),
+      value: value,
+      key: value.toString(),
+    }));
 
   const curClause: VisualClauseWorkingState = {key, simpleKeyType, op, value};
   const valid = visualClauseIsValid(curClause);
@@ -580,12 +591,16 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
             open={editingFilterIndex === -1}
             trigger={
               <div>
-                <button
+                {/* TODO: this LinkButton is really bad, it's just a span. 
+                    Use something better
+                */}
+                <LinkButton
+                  style={{cursor: 'pointer'}}
                   onClick={() => {
                     setEditingFilterIndex(-1);
                   }}>
                   + Add filter
-                </button>
+                </LinkButton>
               </div>
             }
             content={

--- a/weave-js/src/components/Panel2/PanelFilterEditor.tsx
+++ b/weave-js/src/components/Panel2/PanelFilterEditor.tsx
@@ -5,14 +5,39 @@ import {
   varNode,
   voidNode,
   Node,
+  opStringEqual,
+  constString,
+  opIndex,
+  opPick,
+  pickSuggestions,
+  opUnique,
+  NodeOrVoidNode,
+  opAnd,
+  isAssignableTo,
+  maybe,
+  Type,
+  opStringNotEqual,
+  opNumberEqual,
+  opNumberNotEqual,
+  opNumberLess,
+  opNumberLessEqual,
+  opNumberGreater,
+  opNumberGreaterEqual,
+  opBooleanEqual,
+  opBooleanNotEqual,
+  constNumber,
+  constBoolean,
+  opLimit,
 } from '@wandb/weave/core';
 import * as _ from 'lodash';
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback, useMemo, useState} from 'react';
 
 import {WeaveExpression} from '../../panel/WeaveExpression';
 import {useMutation, useNodeValue} from '../../react';
 import * as Panel2 from './panel';
 import {PanelContextProvider} from './PanelContext';
+import {Button, Popup} from 'semantic-ui-react';
+import ModifiedDropdown from '@wandb/weave/common/components/elements/ModifiedDropdown';
 
 const inputType = {
   type: 'function' as const,
@@ -28,14 +53,413 @@ type PanelFilterEditorProps = Panel2.PanelProps<
   PanelFilterEditorConfig
 >;
 
+interface VisualClauseString {
+  key: string;
+  simpleKeyType: 'string';
+  op: '=' | '!=';
+  value: string;
+}
+interface VisualClauseBoolean {
+  key: string;
+  simpleKeyType: 'boolean';
+  op: '=' | '!=';
+  value: boolean;
+}
+
+interface VisualClauseNumber {
+  key: string;
+  simpleKeyType: 'number';
+  op: '=' | '!=' | '<' | '<=' | '>' | '>=';
+  value: number;
+}
+
+type VisualClause =
+  | VisualClauseString
+  | VisualClauseBoolean
+  | VisualClauseNumber;
+
+interface VisualClauseWorkingState {
+  key: string | undefined;
+  simpleKeyType: 'number' | 'string' | 'boolean' | 'other';
+  op: string | undefined;
+  value: string | number | boolean | undefined;
+}
+
+const visualClauseIsValid = (
+  clause: VisualClauseWorkingState
+): clause is VisualClause => {
+  if (clause.key == null || clause.op == null) {
+    return false;
+  }
+  if (clause.simpleKeyType === 'number' && typeof clause.value !== 'number') {
+    return false;
+  }
+  if (clause.simpleKeyType === 'string' && typeof clause.value !== 'string') {
+    return false;
+  }
+  if (clause.simpleKeyType === 'boolean' && typeof clause.value !== 'boolean') {
+    return false;
+  }
+  return true;
+};
+
+const getSimpleKeyType = (keyType: Type) => {
+  return isAssignableTo(keyType, maybe('string'))
+    ? 'string'
+    : isAssignableTo(keyType, maybe('number'))
+    ? 'number'
+    : isAssignableTo(keyType, maybe('boolean'))
+    ? 'boolean'
+    : 'other';
+};
+
+const getOpChoices = (
+  simpleKeyType: 'string' | 'number' | 'boolean' | 'other'
+) => {
+  return simpleKeyType === 'boolean' || simpleKeyType === 'string'
+    ? ['=', '!=']
+    : simpleKeyType === 'number'
+    ? ['=', '!=', '<', '<=', '>', '>=']
+    : [];
+};
+
+const SingleFilterVisualEditor: React.FC<{
+  listNode: Node;
+  clause: VisualClause | null;
+  onCancel: () => void;
+  onOK: (clause: VisualClause) => void;
+}> = props => {
+  const defaultKey = props.clause?.key;
+  const defaultOp = props.clause?.op;
+  const defaultValue = props.clause?.value;
+
+  const listItem = opIndex({
+    arr: props.listNode,
+    index: varNode('number', 'n'),
+  });
+  const keyChoices = pickSuggestions(listItem.type).filter(
+    k =>
+      getSimpleKeyType(opPick({obj: listItem, key: constString(k)}).type) !==
+      'other'
+  );
+  const keyOptions = keyChoices.map(key => ({text: key, value: key, key}));
+
+  const [key, setKey] = useState<string | undefined>(
+    defaultKey ?? keyChoices[0]
+  );
+  const [op, setOp] = useState<string | undefined>(defaultOp);
+  const [value, setValue] = useState<any | undefined>(defaultValue);
+
+  const simpleKeyType = getSimpleKeyType(
+    opPick({
+      obj: listItem,
+      key: constString(key ?? ''),
+    }).type
+  );
+
+  const opChoices = getOpChoices(simpleKeyType);
+  const opOptions = opChoices.map(key => ({text: key, value: key, key}));
+
+  const valueQuery =
+    key != null
+      ? opLimit({
+          arr: opUnique({
+            arr: opPick({obj: props.listNode, key: constString(key)}),
+          }),
+          limit: constNumber(500),
+        })
+      : voidNode();
+  const valueChoices = useNodeValue(valueQuery).result ?? [];
+  const valueOptions = valueChoices.map((value: boolean | string | number) => ({
+    text: value.toString(),
+    value: value,
+    key: value.toString(),
+  }));
+
+  const curClause: VisualClauseWorkingState = {key, simpleKeyType, op, value};
+  const valid = visualClauseIsValid(curClause);
+
+  return (
+    <div>
+      <ModifiedDropdown
+        value={key}
+        onChange={(e, {value}) => {
+          const newKey = value as string;
+          const simpleKeyType = getSimpleKeyType(
+            opPick({
+              obj: listItem,
+              key: constString(newKey),
+            }).type
+          );
+          const opChoices = getOpChoices(simpleKeyType);
+          setKey(value as string);
+          setOp(opChoices[0]);
+          setValue(undefined);
+        }}
+        options={keyOptions}
+        selection
+      />
+      <ModifiedDropdown
+        value={op}
+        onChange={(e, {value}) => setOp(value as string)}
+        options={opOptions}
+        selection
+      />
+      <ModifiedDropdown
+        value={value}
+        onChange={(e, {value}) => {
+          setValue(value);
+        }}
+        options={valueOptions}
+        selection
+      />
+      <Button onClick={props.onCancel}>Cancel</Button>
+      <Button
+        disabled={!valid}
+        onClick={() => {
+          if (valid) {
+            props.onOK(curClause);
+          } else {
+            // Shouldn't really happen since we filter above.
+            props.onCancel();
+          }
+        }}>
+        OK
+      </Button>
+    </div>
+  );
+};
+
+const clauseNodeToVisual = (clause: Node): VisualClause | null => {
+  if (clause.nodeType !== 'output') {
+    return null;
+  }
+  const op = clause.fromOp;
+  let opString;
+  if (['string-equal', 'boolean-equal', 'number-equal'].includes(op.name)) {
+    opString = '=';
+  } else if (
+    ['string-notEqual', 'boolean-notEqual', 'number-notEqual'].includes(op.name)
+  ) {
+    opString = '!=';
+  } else if (op.name === 'number-less') {
+    opString = '<';
+  } else if (op.name === 'number-lessEqual') {
+    opString = '<=';
+  } else if (op.name === 'number-greater') {
+    opString = '>';
+  } else if (op.name === 'number-greaterEqual') {
+    opString = '>=';
+  } else {
+    return null;
+  }
+  const lhs = op.inputs.lhs;
+  if (lhs.nodeType !== 'output') {
+    return null;
+  }
+  if (lhs.fromOp.name !== 'pick') {
+    return null;
+  }
+  const simpleKeyType = getSimpleKeyType(lhs.type);
+  if (simpleKeyType === 'other') {
+    return null;
+  }
+  if (lhs.fromOp.inputs.key.nodeType !== 'const') {
+    return null;
+  }
+  const key = lhs.fromOp.inputs.key.val;
+  const rhs = op.inputs.rhs;
+  if (rhs.nodeType !== 'const') {
+    return null;
+  }
+  const value = rhs.val;
+  return {key, simpleKeyType, op: opString as any, value};
+};
+
+const filterExpressionToVisualClauses = (
+  expr: NodeOrVoidNode
+): VisualClause[] | null => {
+  if (expr.nodeType === 'void') {
+    return [];
+  }
+  if (expr.nodeType === 'const' && expr.val === true) {
+    return [];
+  }
+  if (expr.nodeType !== 'output') {
+    return null;
+  }
+  if (expr.fromOp.name !== 'and') {
+    const singleVisualClause = clauseNodeToVisual(expr);
+    if (singleVisualClause == null) {
+      return null;
+    }
+    return [singleVisualClause];
+  }
+  const lhs = filterExpressionToVisualClauses(expr.fromOp.inputs.lhs);
+  if (lhs == null) {
+    return null;
+  }
+  const rhs = filterExpressionToVisualClauses(expr.fromOp.inputs.rhs);
+  if (rhs == null) {
+    return null;
+  }
+  return [...lhs, ...rhs];
+};
+
+const visualClausesToFilterExpression = (
+  clauses: VisualClause[],
+  listItemType: Type
+) => {
+  return clauses.reduce((expr, visualClause) => {
+    const keyNode = opPick({
+      obj: varNode(listItemType, 'row'),
+      key: constString(visualClause.key),
+    });
+    let compOp;
+    let valueNode;
+    if (visualClause.simpleKeyType === 'string') {
+      if (visualClause.op === '=') {
+        compOp = opStringEqual;
+      } else if (visualClause.op === '!=') {
+        compOp = opStringNotEqual;
+      }
+      valueNode = constString(visualClause.value);
+    } else if (visualClause.simpleKeyType === 'number') {
+      if (visualClause.op === '=') {
+        compOp = opNumberEqual;
+      } else if (visualClause.op === '!=') {
+        compOp = opNumberNotEqual;
+      } else if (visualClause.op === '<') {
+        compOp = opNumberLess;
+      } else if (visualClause.op === '<=') {
+        compOp = opNumberLessEqual;
+      } else if (visualClause.op === '>') {
+        compOp = opNumberGreater;
+      } else if (visualClause.op === '>=') {
+        compOp = opNumberGreaterEqual;
+      }
+      valueNode = constNumber(visualClause.value);
+    } else if (visualClause.simpleKeyType === 'boolean') {
+      if (visualClause.op === '=') {
+        compOp = opBooleanEqual;
+      } else if (visualClause.op === '!=') {
+        compOp = opBooleanNotEqual;
+      }
+      valueNode = constBoolean(visualClause.value);
+    }
+    if (compOp == null) {
+      throw new Error('Invalid visual clause');
+    }
+    const clause = compOp({
+      lhs: keyNode,
+      rhs: valueNode as any,
+    });
+    if (expr.nodeType === 'const' && expr.val === true) {
+      return clause;
+    }
+    return opAnd({
+      lhs: expr,
+      rhs: clause,
+    });
+  }, constNodeUnsafe('boolean', true) as Node);
+};
+
+const addVisualClause = (
+  clauses: VisualClause[],
+  newClause: VisualClause
+): VisualClause[] => {
+  return [...clauses, newClause];
+};
+
+const setVisualClauseIndex = (
+  clauses: VisualClause[],
+  index: number,
+  newClause: VisualClause
+): VisualClause[] => {
+  return [...clauses.slice(0, index), newClause, ...clauses.slice(index + 1)];
+};
+
+const removeVisualClause = (
+  clauses: VisualClause[],
+  index: number
+): VisualClause[] => {
+  return [...clauses.slice(0, index), ...clauses.slice(index + 1)];
+};
+
+const FilterPill = (props: {
+  clause: VisualClause;
+  onClick: () => void;
+  onRemove: () => void;
+}) => {
+  const {clause} = props;
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        borderRadius: 8,
+        backgroundColor: '#eee',
+        padding: '4px 16px',
+        cursor: 'pointer',
+        position: 'relative',
+      }}
+      onClick={props.onClick}>
+      <div style={{marginRight: 4}}>{clause.key}</div>
+      <div style={{marginRight: 4}}>{clause.op}</div>
+      <div>{clause.value}</div>
+    </div>
+  );
+};
+
+const FilterPillBlock = (props: {
+  clause: VisualClause;
+  onClick: () => void;
+  onRemove: () => void;
+}) => {
+  const [hover, setHover] = React.useState(false);
+  return (
+    <div
+      style={{marginBottom: 4, display: 'flex', alignItems: 'center'}}
+      onMouseOver={() => setHover(true)}
+      onMouseOut={() => setHover(false)}>
+      <FilterPill
+        clause={props.clause}
+        onClick={props.onClick}
+        onRemove={props.onRemove}
+      />
+      <div
+        style={{
+          display: hover ? 'block' : 'none',
+          marginLeft: 8,
+          cursor: 'pointer',
+        }}
+        onClick={props.onRemove}>
+        x
+      </div>
+    </div>
+  );
+};
+
 export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
+  const listItem = opIndex({
+    arr: props.config!.node,
+    index: varNode('number', 'n'),
+  });
   const valueNode = props.input;
   const valueQuery = useNodeValue(valueNode, {callSite: 'PanelFilterEditor'});
   const value = valueQuery.loading
     ? constFunction({}, () => voidNode() as any)
     : valueQuery.result;
   const setVal = useMutation(valueNode, 'set');
-  // const [mode, setMode] = React.useState<'visual' | 'expression'>('visual');
+  const [mode, setMode] = React.useState<'visual' | 'expression'>('visual');
+  const [editingFilterIndex, setEditingFilterIndex] = React.useState<
+    number | null
+  >(null);
+
+  const visualClauses =
+    value.nodeType === 'const'
+      ? filterExpressionToVisualClauses(value.val)
+      : null;
+  const actualMode = visualClauses == null ? 'expression' : mode;
 
   if (!isFunctionLiteral(value)) {
     throw new Error('Expected function literal');
@@ -72,6 +496,14 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
     [setVal, inputTypes]
   );
 
+  const updateValFromVisualClauses = useCallback(
+    (clauses: VisualClause[]) => {
+      const newExpr = visualClausesToFilterExpression(clauses, listItem.type);
+      updateVal(newExpr);
+    },
+    [listItem.type, updateVal]
+  );
+
   const paramVars = useMemo(
     () => _.mapValues(inputTypes, (type, name) => varNode(type, name)),
     [inputTypes]
@@ -82,10 +514,96 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
   }
 
   return (
-    <div style={{width: '100%', height: '100%'}}>
-      <PanelContextProvider newVars={paramVars}>
-        <WeaveExpression expr={value.val} setExpression={updateVal} noBox />
-      </PanelContextProvider>
+    <div style={{width: '100%', height: '100%', paddingLeft: 16}}>
+      <div style={{display: 'flex', alignItems: 'center'}}>
+        <div
+          style={{
+            marginRight: 8,
+            color: visualClauses == null ? '#aaa' : undefined,
+            textDecoration: actualMode === 'visual' ? 'underline' : undefined,
+            cursor: 'pointer',
+          }}
+          onClick={() => visualClauses != null && setMode('visual')}>
+          visual
+        </div>
+        <div> | </div>
+        <div
+          style={{
+            marginLeft: 8,
+            textDecoration:
+              actualMode === 'expression' ? 'underline' : undefined,
+            cursor: 'pointer',
+          }}
+          onClick={() => setMode('expression')}>
+          expression
+        </div>
+      </div>
+      {mode === 'expression' || visualClauses == null ? (
+        <PanelContextProvider newVars={paramVars}>
+          <WeaveExpression expr={value.val} setExpression={updateVal} noBox />
+        </PanelContextProvider>
+      ) : (
+        <div>
+          {visualClauses.map((clause, i) => (
+            <Popup
+              key={i}
+              position="right center"
+              trigger={
+                <FilterPillBlock
+                  clause={clause}
+                  onClick={() => setEditingFilterIndex(0)}
+                  onRemove={() => {
+                    updateValFromVisualClauses(
+                      removeVisualClause(visualClauses, i)
+                    );
+                  }}
+                />
+              }
+              open={editingFilterIndex === 0}
+              content={
+                <SingleFilterVisualEditor
+                  listNode={props.config!.node}
+                  clause={clause}
+                  onCancel={() => setEditingFilterIndex(null)}
+                  onOK={newClause => {
+                    setEditingFilterIndex(null);
+                    updateValFromVisualClauses(
+                      setVisualClauseIndex(visualClauses, i, newClause)
+                    );
+                  }}
+                />
+              }
+            />
+          ))}
+          <Popup
+            position="right center"
+            open={editingFilterIndex === -1}
+            trigger={
+              <div>
+                <button
+                  onClick={() => {
+                    setEditingFilterIndex(-1);
+                  }}>
+                  + Add filter
+                </button>
+              </div>
+            }
+            content={
+              <SingleFilterVisualEditor
+                listNode={props.config!.node}
+                clause={null}
+                onCancel={() => setEditingFilterIndex(null)}
+                onOK={newClause => {
+                  setEditingFilterIndex(null);
+                  updateValFromVisualClauses(
+                    addVisualClause(visualClauses, newClause)
+                  );
+                }}
+              />
+            }
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/weave-js/src/components/Panel2/PanelFilterEditor.tsx
+++ b/weave-js/src/components/Panel2/PanelFilterEditor.tsx
@@ -212,8 +212,8 @@ const SingleFilterVisualEditor: React.FC<{
     <div>
       <ModifiedDropdown
         value={key}
-        onChange={(e, {value}) => {
-          const newKey = value as string;
+        onChange={(e, {value: k}) => {
+          const newKey = k as string;
           const newSimpleKeyType = getSimpleKeyType(
             opPick({
               obj: listItem,
@@ -221,7 +221,7 @@ const SingleFilterVisualEditor: React.FC<{
             }).type
           );
           const newOpChoices = getOpChoices(newSimpleKeyType);
-          setKey(value as string);
+          setKey(newKey);
           setOp(newOpChoices[0]);
           setValue(undefined);
         }}

--- a/weave-js/src/components/Panel2/PanelFilterEditor.tsx
+++ b/weave-js/src/components/Panel2/PanelFilterEditor.tsx
@@ -161,7 +161,7 @@ const SingleFilterVisualEditor: React.FC<{
       getSimpleKeyType(opPick({obj: listItem, key: constString(k)}).type) !==
       'other'
   );
-  const keyOptions = keyChoices.map(key => ({text: key, value: key, key}));
+  const keyOptions = keyChoices.map(k => ({text: k, value: k, k}));
 
   const [key, setKey] = useState<string | undefined>(
     defaultKey ?? keyChoices[0]
@@ -177,7 +177,7 @@ const SingleFilterVisualEditor: React.FC<{
   );
 
   const opChoices = getOpChoices(simpleKeyType);
-  const opOptions = opChoices.map(key => ({text: key, value: key, key}));
+  const opOptions = opChoices.map(k => ({text: k, value: k, k}));
 
   // const valueQuery =
   // TODO: opLimit is broken in weave python when we have an ArrowWeaveList...
@@ -198,11 +198,11 @@ const SingleFilterVisualEditor: React.FC<{
       : voidNode();
   const valueChoices = useNodeValue(valueQuery).result ?? [];
   const valueOptions = valueChoices
-    .filter((value: any) => value != null)
-    .map((value: boolean | string | number) => ({
-      text: value.toString(),
-      value: value,
-      key: value.toString(),
+    .filter((v: any) => v != null)
+    .map((v: boolean | string | number) => ({
+      text: v.toString(),
+      value: v,
+      key: v.toString(),
     }));
 
   const curClause: VisualClauseWorkingState = {key, simpleKeyType, op, value};
@@ -214,15 +214,15 @@ const SingleFilterVisualEditor: React.FC<{
         value={key}
         onChange={(e, {value}) => {
           const newKey = value as string;
-          const simpleKeyType = getSimpleKeyType(
+          const newSimpleKeyType = getSimpleKeyType(
             opPick({
               obj: listItem,
               key: constString(newKey),
             }).type
           );
-          const opChoices = getOpChoices(simpleKeyType);
+          const newOpChoices = getOpChoices(newSimpleKeyType);
           setKey(value as string);
-          setOp(opChoices[0]);
+          setOp(newOpChoices[0]);
           setValue(undefined);
         }}
         options={keyOptions}
@@ -230,13 +230,13 @@ const SingleFilterVisualEditor: React.FC<{
       />
       <ModifiedDropdown
         value={op}
-        onChange={(e, {value}) => {
-          if (value === 'in') {
+        onChange={(e, {value: v}) => {
+          if (v === 'in') {
             setValue([]);
           } else {
             setValue(undefined);
           }
-          setOp(value as string);
+          setOp(v as string);
         }}
         options={opOptions}
         selection
@@ -252,8 +252,8 @@ const SingleFilterVisualEditor: React.FC<{
         <ModifiedDropdown
           value={value}
           multiple={op === 'in'}
-          onChange={(e, {value}) => {
-            setValue(value);
+          onChange={(e, {value: v}) => {
+            setValue(v);
           }}
           options={valueOptions}
           selection
@@ -280,7 +280,7 @@ const clauseNodeToVisualStringIn = (
   clause: Node
 ): VisualClauseStringIn | null => {
   const inValues: string[] = [];
-  let key: string | undefined = undefined;
+  let key: string | undefined;
   const addClauseValue = (node: Node) => {
     const singleClause = clauseNodeToVisual(node);
     if (singleClause == null) {

--- a/weave/panels/panel_filter_editor.py
+++ b/weave/panels/panel_filter_editor.py
@@ -27,4 +27,4 @@ class FilterEditor(panel.Panel):
         if self.config is None:
             self.config = FilterEditorConfig()
         if "node" in options:
-            self.node = options["node"]
+            self.config.node = options["node"]


### PR DESCRIPTION
FilterEditor component now has a visual mode, we use it in the openai monitoring board.

Features:
- Let's you visually construct an AND of filters for string, number and boolean keys in the input list.
- Switch between visual editing and expression editing (for more complex queries)
- Suggestions for keys and string values
- Supports string in filters.

Underlying state is stored as a Weave node.

Will need a design pass, but not blocking, let me get the rest of the board cleanup/features in first. 

<img width="1370" alt="image" src="https://github.com/wandb/weave/assets/499383/9c4721fd-ca0d-4cc3-865c-c6aee1a9bedf">
