### PR TITLE
chore(weave): AWL.keys.flatten.unique optimization

### DIFF
--- a/weave/compile.py
+++ b/weave/compile.py
@@ -87,39 +87,6 @@ def _quote_node(node: graph.Node) -> graph.Node:
     return weave_internal.const(node)
 
 
-def _node_simplification(node: graph.Node) -> typing.Optional[graph.OutputNode]:
-    if isinstance(node, graph.OutputNode) and node.from_op.name == "count":
-        arr_node = node.from_op.inputs["arr"]
-        if isinstance(arr_node, graph.OutputNode) and arr_node.from_op.name.startswith(
-            "run-history"
-        ):
-            run_node = arr_node.from_op.inputs["run"]
-            return graph.OutputNode(
-                node.type,
-                "run-historyLineCount",
-                {"run": run_node},
-            )
-    elif isinstance(node, graph.OutputNode) and node.from_op.name == "unique":
-        arr_node = node.from_op.inputs["arr"]
-        if (
-            isinstance(arr_node, graph.OutputNode)
-            and arr_node.from_op.name == "ArrowWeaveList-flatten"
-        ):
-            arr_node_2 = arr_node.from_op.inputs["arr"]
-            if (
-                isinstance(arr_node_2, graph.OutputNode)
-                and arr_node_2.from_op.name == "ArrowWeaveListTypedDict-keys"
-            ):
-                awl_node = arr_node_2.from_op.inputs["self"]
-                return graph.OutputNode(
-                    node.type,
-                    "ArrowWeaveListTypedDict-columnNames",
-                    {"self": awl_node},
-                )
-
-    return None
-
-
 def _dispatch_map_fn_refining(node: graph.Node) -> typing.Optional[graph.OutputNode]:
     if isinstance(node, graph.OutputNode):
         from_op = node.from_op
@@ -237,6 +204,45 @@ def _simple_optimizations(node: graph.Node) -> typing.Optional[graph.Node]:
             and not rhs.from_op.inputs
         ):
             return lhs
+    elif isinstance(node, graph.OutputNode) and node.from_op.name == "count":
+        # When the graph is `run.history.count`, we can avoid the more costly
+        # loading of all run history and instead directly fetch the history
+        # count from the server by reducing to `run.historyLineCount` which
+        # compiles to a single gql edge. This is particularly helpful when
+        # loading StreamTables backed by runs. It helps with the client-side
+        # map refinement, table row count, and with logic that is conditioned
+        # on empty tables
+        arr_node = node.from_op.inputs["arr"]
+        if isinstance(arr_node, graph.OutputNode) and arr_node.from_op.name.startswith(
+            "run-history"
+        ):
+            run_node = arr_node.from_op.inputs["run"]
+            return graph.OutputNode(
+                node.type,
+                "run-historyLineCount",
+                {"run": run_node},
+            )
+    elif isinstance(node, graph.OutputNode) and node.from_op.name == "unique":
+        # When the graph is `awl.keys.flatten.unique`, the user is really
+        # asking for the columnNames. This can be reduced to a simple `awl.columnNames`
+        # which is extremely fast as it is simply the property types of the list!
+        #
+        # Note: we cannot perform such optimization on pure lists because we don't have
+        # a way to operate on the type of the node itself.
+        arr_node = node.from_op.inputs["arr"]
+        if (
+            isinstance(arr_node, graph.OutputNode)
+            and arr_node.from_op.name == "ArrowWeaveList-flatten"
+        ):
+            arr_node_2 = arr_node.from_op.inputs["arr"]
+            if (
+                isinstance(arr_node_2, graph.OutputNode)
+                and arr_node_2.from_op.name == "ArrowWeaveListTypedDict-keys"
+            ):
+                awl_node = arr_node_2.from_op.inputs["self"]
+                return graph.OutputNode(
+                    node.type, "ArrowWeaveListTypedDict-columnNames", {"self": awl_node}
+                )
     return None
 
 
@@ -510,13 +516,6 @@ def compile_quote(
     return graph.map_nodes_full(nodes, _quote_nodes_map_fn, on_error)
 
 
-def compile_node_simplification(
-    nodes: typing.List[graph.Node],
-    on_error: graph.OnErrorFnType = None,
-) -> typing.List[graph.Node]:
-    return graph.map_nodes_full(nodes, _node_simplification, on_error)
-
-
 def compile_refine(
     nodes: typing.List[graph.Node],
     on_error: graph.OnErrorFnType = None,
@@ -677,9 +676,6 @@ def _compile(
     with tracer.trace("compile:fix_calls"):
         results = results.batch_map(_track_errors(compile_fix_calls))
 
-    with tracer.trace("compile:simple_optimizations"):
-        results = results.batch_map(_track_errors(compile_simple_optimizations))
-
     with tracer.trace("compile:lambda_uniqueness"):
         results = results.batch_map(_track_errors(compile_lambda_uniqueness))
 
@@ -725,8 +721,10 @@ def _compile(
     with tracer.trace("compile:node_ops"):
         results = results.batch_map(_track_errors(compile_node_ops))
 
-    with tracer.trace("compile:node_simplification"):
-        results = results.batch_map(_track_errors(compile_node_simplification))
+    with tracer.trace("compile:simple_optimizations"):
+        # Simple Optimizations should happen after `node_ops` to ensure we operate on
+        # the expanded nodes.
+        results = results.batch_map(_track_errors(compile_simple_optimizations))
 
     # Now that we have the correct calls, we can do our forward-looking pushdown
     # optimizations. These do not depend on having correct types in the graph.

--- a/weave/compile.py
+++ b/weave/compile.py
@@ -209,9 +209,9 @@ def _simple_optimizations(node: graph.Node) -> typing.Optional[graph.Node]:
         # loading of all run history and instead directly fetch the history
         # count from the server by reducing to `run.historyLineCount` which
         # compiles to a single gql edge. This is particularly helpful when
-        # loading StreamTables backed by runs. It helps with the client-side
-        # map refinement, table row count, and with logic that is conditioned
-        # on empty tables
+        # loading StreamTables backed by runs. It helps with the client-side map
+        # refinement, table row count, and with logic that is conditioned on
+        # empty tables
         arr_node = node.from_op.inputs["arr"]
         if isinstance(arr_node, graph.OutputNode) and arr_node.from_op.name.startswith(
             "run-history"
@@ -223,12 +223,13 @@ def _simple_optimizations(node: graph.Node) -> typing.Optional[graph.Node]:
                 {"run": run_node},
             )
     elif isinstance(node, graph.OutputNode) and node.from_op.name == "unique":
-        # When the graph is `awl.keys.flatten.unique`, the user is really
-        # asking for the columnNames. This can be reduced to a simple `awl.columnNames`
-        # which is extremely fast as it is simply the property types of the list!
+        # When the graph is `awl.keys.flatten.unique`, the user is really asking
+        # for the columnNames. This can be reduced to a simple `awl.columnNames`
+        # which is extremely fast as it is simply the property types of the
+        # list!
         #
-        # Note: we cannot perform such optimization on pure lists because we don't have
-        # a way to operate on the type of the node itself.
+        # Note: we cannot perform such optimization on pure lists because we
+        # don't have a way to operate on the type of the node itself.
         arr_node = node.from_op.inputs["arr"]
         if (
             isinstance(arr_node, graph.OutputNode)

--- a/weave/compile.py
+++ b/weave/compile.py
@@ -113,7 +113,7 @@ def _node_simplification(node: graph.Node) -> typing.Optional[graph.OutputNode]:
                 awl_node = arr_node_2.from_op.inputs["self"]
                 return graph.OutputNode(
                     node.type,
-                    "ArrowWeaveListTypedDict-propertyTypes",
+                    "ArrowWeaveListTypedDict-columnNames",
                     {"self": awl_node},
                 )
 

--- a/weave/ops_arrow/dict.py
+++ b/weave/ops_arrow/dict.py
@@ -422,12 +422,12 @@ def keys(self):
 
 
 @op(
-    name="ArrowWeaveListTypedDict-propertyTypes",
+    name="ArrowWeaveListTypedDict-columnNames",
     hidden=True,
     input_type={"self": ArrowWeaveListType(types.TypedDict({}))},
     output_type=lambda input_types: ArrowWeaveListType(types.String()),
 )
-def propertyTypes(self):
+def columnNames(self):
     return convert.to_arrow(
         list(self.object_type.property_types.keys()),
         types.List(types.String()),

--- a/weave/ops_arrow/dict.py
+++ b/weave/ops_arrow/dict.py
@@ -417,7 +417,7 @@ def awl_projection_2d(
 def keys(self):
     keys = list(self.object_type.property_types.keys())
     return convert.to_arrow(
-        keys * len(self), types.List(types.String()), self._artifact
+        [keys] * len(self), types.List(types.List(types.String())), self._artifact
     )
 
 
@@ -425,7 +425,11 @@ def keys(self):
     name="ArrowWeaveListTypedDict-propertyTypes",
     hidden=True,
     input_type={"self": ArrowWeaveListType(types.TypedDict({}))},
-    output_type=lambda input_types: types.List(types.String()),
+    output_type=lambda input_types: ArrowWeaveListType(types.String()),
 )
 def propertyTypes(self):
-    return list(self.object_type.property_types.keys())
+    return convert.to_arrow(
+        list(self.object_type.property_types.keys()),
+        types.List(types.String()),
+        self._artifact,
+    )

--- a/weave/ops_arrow/dict.py
+++ b/weave/ops_arrow/dict.py
@@ -13,6 +13,7 @@ from ..language_features.tagging import (
     process_opdef_output_type,
 )
 from .arrow_tags import direct_add_arrow_tags
+from . import convert
 
 from .constructors import (
     vectorized_container_constructor_preprocessor,
@@ -406,3 +407,25 @@ def awl_projection_2d(
         ),
         table._artifact,
     )
+
+
+@op(
+    name="ArrowWeaveListTypedDict-keys",
+    input_type={"self": ArrowWeaveListType(types.TypedDict({}))},
+    output_type=lambda input_types: ArrowWeaveListType(types.List(types.String())),
+)
+def keys(self):
+    keys = list(self.object_type.property_types.keys())
+    return convert.to_arrow(
+        keys * len(self), types.List(types.String()), self._artifact
+    )
+
+
+@op(
+    name="ArrowWeaveListTypedDict-propertyTypes",
+    hidden=True,
+    input_type={"self": ArrowWeaveListType(types.TypedDict({}))},
+    output_type=lambda input_types: types.List(types.String()),
+)
+def propertyTypes(self):
+    return list(self.object_type.property_types.keys())

--- a/weave/ops_domain/run_ops.py
+++ b/weave/ops_domain/run_ops.py
@@ -134,6 +134,14 @@ gql_prop_op(
     types.Timestamp(),
 )
 
+gql_prop_op(
+    "run-historyLineCount",
+    wdt.RunType,
+    "historyLineCount",
+    types.Number(),
+    hidden=True,
+)
+
 
 def config_to_values(config: dict) -> dict:
     """

--- a/weave/ops_domain/wandb_domain_gql.py
+++ b/weave/ops_domain/wandb_domain_gql.py
@@ -42,6 +42,7 @@ def gql_prop_op(
     input_type: weave_types.Type,
     prop_name: str,
     output_type: weave_types.Type,
+    hidden: bool = False,
 ):
     first_arg_name = input_type.name
 
@@ -63,6 +64,7 @@ def gql_prop_op(
         ),
         input_type={first_arg_name: input_type},
         output_type=output_type,
+        hidden=hidden,
     )(gql_property_getter_op_fn)
 
 

--- a/weave/tests/test_arrow.py
+++ b/weave/tests/test_arrow.py
@@ -1768,3 +1768,19 @@ def test_flatten_handles_tagged_lists():
         }
         for i in expected
     ]
+
+
+def test_keys_ops():
+    awl = arrow.to_arrow([{"a": 1}, {"a": 1, "b": 2, "c": 2}, {"c": 3}])
+    node = weave.save(awl)
+    keys_node = node.keys()
+    # Unfortunately, we lose specific info about key presence in AWL.
+    assert weave.use(keys_node).to_pylist_raw() == [
+        ["a", "b", "c"],
+        ["a", "b", "c"],
+        ["a", "b", "c"],
+    ]
+
+    all_keys_node = keys_node.flatten().unique()
+
+    assert weave.use(all_keys_node).to_pylist_raw() == ["a", "b", "c"]

--- a/weave/tests/test_wb_end_to_end.py
+++ b/weave/tests/test_wb_end_to_end.py
@@ -1,5 +1,6 @@
 import weave
 import wandb
+from weave import compile
 
 
 # Example of end to end integration test
@@ -75,3 +76,22 @@ def test_run_histories(user_by_api_key_in_env):
 
     # Runs return in reverse chronological order
     assert history == [2, 1]
+
+
+# Example of end to end integration test
+def test_run_history_count(user_by_api_key_in_env):
+    run = wandb.init(project="project_exists")
+    run.log({"a": 1})
+    run.log({"a": 2})
+    run.finish()
+
+    run_node = weave.ops.project(run.entity, run.project).run(run.id)
+    h_count_node = run_node.history().count()
+    history_count = weave.use(h_count_node)
+    assert history_count == 2
+
+    compiled = compile.compile([h_count_node])
+    assert compiled[0].from_op.name == "run-historyLineCount"
+
+    run_history_lines = weave.use(run_node.historyLineCount())
+    assert run_history_lines == 2


### PR DESCRIPTION
This pattern is used in the OpenAI dash and causes us to bail out of weave. Building off of https://github.com/wandb/weave/pull/381 we add an optimization to compile this op chain to an efficient representation

When loading an OAI dash of 50k rows, this one step typically costs 5 seconds. With this change it is down to 126 nanoseconds!!