### PR TITLE
feat: Clean varbar

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -201,6 +201,7 @@ export interface ChildPanelProps {
   prefixHeader?: JSX.Element;
   prefixButtons?: JSX.Element;
   allowedPanels?: string[];
+  overflowVisible?: boolean;
   config: ChildPanelConfig | undefined;
   updateConfig: (newConfig: ChildPanelFullConfig) => void;
   updateConfig2?: (change: (oldConfig: any) => any) => void;
@@ -567,7 +568,21 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       data-weavepath={props.pathEl ?? 'root'}
       onMouseEnter={() => setHoverPanel(true)}
       onMouseLeave={() => setHoverPanel(false)}>
-      {(props.controlBar === 'titleBar' || props.controlBar === 'editable') && (
+      {props.controlBar === 'titleBar' && (
+        <div
+          style={{
+            fontWeight: 'bold',
+            padding: '0 16px 8px',
+            lineHeight: '20px',
+            marginTop: 16,
+          }}>
+          {props.pathEl != null &&
+            props.pathEl
+              .replace(/_/g, ' ')
+              .replace(/\b\w/g, char => char.toUpperCase())}
+        </div>
+      )}
+      {props.controlBar === 'editable' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
             {props.prefixHeader}
@@ -644,14 +659,12 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
           </EditorBarContent>
         </Styles.EditorBar>
       )}
-      <PanelContainer>
+      <PanelContainer overflowVisible={props.overflowVisible}>
         <PanelContextProvider
           newVars={newVars}
           handleVarEvent={handleVarEvent}
           newPath={props.pathEl}>
-          {props.controlBar === 'titleBar' &&
-          isChildPanelFullConfig(props.config) &&
-          curPanelId === 'Expression' ? (
+          {props.controlBar === 'titleBar' && curPanelId === 'Expression' ? (
             <div style={{paddingLeft: 16, paddingRight: 16}}>
               <WeaveExpression
                 expr={panelInputExpr}
@@ -995,10 +1008,9 @@ const EditorIcons = styled.div<{visible: boolean}>`
   visibility: ${p => (p.visible ? `visible` : `hidden`)};
 `;
 
-const PanelContainer = styled.div`
+const PanelContainer = styled.div<{overflowVisible?: boolean}>`
   flex-grow: 1;
-  // TODO
-  overflow-y: auto;
+  overflow-y: ${p => (p.overflowVisible ? 'visible' : 'auto')};
 `;
 
 type ElementWidth<T> = {

--- a/weave-js/src/components/Panel2/PanelFilterEditor.tsx
+++ b/weave-js/src/components/Panel2/PanelFilterEditor.tsx
@@ -677,7 +677,7 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
           {visualClauses.map((clause, i) => (
             <Popup
               key={i}
-              position="right center"
+              position="left center"
               trigger={
                 <FilterPillBlock
                   clause={clause}
@@ -689,6 +689,7 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
                   }}
                 />
               }
+              onClose={() => setEditingFilterIndex(null)}
               open={editingFilterIndex === i}
               content={
                 <SingleFilterVisualEditor
@@ -706,10 +707,11 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
             />
           ))}
           <Popup
-            position="right center"
+            position="left center"
+            onClose={() => setEditingFilterIndex(null)}
             open={editingFilterIndex === -1}
             trigger={
-              <div>
+              <div style={{marginTop: 8}}>
                 {/* TODO: this LinkButton is really bad, it's just a span. 
                     Use something better
                 */}

--- a/weave-js/src/components/Panel2/PanelFilterEditor.tsx
+++ b/weave-js/src/components/Panel2/PanelFilterEditor.tsx
@@ -678,6 +678,11 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
             <Popup
               key={i}
               position="left center"
+              popperModifiers={{
+                preventOverflow: {
+                  boundariesElement: 'offsetParent',
+                },
+              }}
               trigger={
                 <FilterPillBlock
                   clause={clause}
@@ -689,6 +694,7 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
                   }}
                 />
               }
+              on="click"
               onClose={() => setEditingFilterIndex(null)}
               open={editingFilterIndex === i}
               content={
@@ -708,6 +714,12 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
           ))}
           <Popup
             position="left center"
+            popperModifiers={{
+              preventOverflow: {
+                boundariesElement: 'offsetParent',
+              },
+            }}
+            on="click"
             onClose={() => setEditingFilterIndex(null)}
             open={editingFilterIndex === -1}
             trigger={

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -576,10 +576,7 @@ export const PanelGroupItem: React.FC<{
   // correctly. For example, without this PanelDropdown renders its dropdown menu
   // within the parent, creating a scrollbar.
   let overflowVisible = false;
-  if (
-    (config.layoutMode === 'vertical' || config.layoutMode === 'horizontal') &&
-    !config.equalSize
-  ) {
+  if (config.layoutMode === 'vertical' && !config.equalSize) {
     overflowVisible = true;
   }
   return (

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -572,11 +572,22 @@ export const PanelGroupItem: React.FC<{
   } else {
     controlBar = 'editable';
   }
+  // This makes it so controls in the varbar can overflow the parent container
+  // correctly. For example, without this PanelDropdown renders its dropdown menu
+  // within the parent, creating a scrollbar.
+  let overflowVisible = false;
+  if (
+    (config.layoutMode === 'vertical' || config.layoutMode === 'horizontal') &&
+    !config.equalSize
+  ) {
+    overflowVisible = true;
+  }
   return (
     <PanelContextProvider
       newVars={siblingVars}
       handleVarEvent={handleSiblingVarEvent}>
       <ChildPanel
+        overflowVisible={overflowVisible}
         allowedPanels={config.allowedPanels}
         pathEl={'' + name}
         config={item}

--- a/weave/panels/panel_board.py
+++ b/weave/panels/panel_board.py
@@ -49,7 +49,7 @@ def varbar(editable=True, items=None) -> panel_group.Group:
                 "DateRange",
                 "FilterEditor",
             ],
-            enableAddPanel=True,
+            enableAddPanel=editable,
             childNameBase="var",
         ),
         items=items,

--- a/weave/panels_py/panel_openai_monitor.py
+++ b/weave/panels_py/panel_openai_monitor.py
@@ -131,17 +131,17 @@ def board(
     ### Varbar
 
     # Add the input node as raw data
-    varbar = panel_board.varbar()
+    varbar = panel_board.varbar(editable=False)
 
-    dataset = varbar.add("dataset", input_node)
+    source_data = varbar.add("source_data", input_node)
 
     # Setup date range variables:
     ## 1. raw_data_range is derived from raw_data
     dataset_range = varbar.add(
         "dataset_range",
         weave.ops.make_list(
-            a=dataset[timestamp_col_name].min(),
-            b=dataset[timestamp_col_name].max(),
+            a=source_data[timestamp_col_name].min(),
+            b=source_data[timestamp_col_name].max(),
         ),
         hidden=True,
     )
@@ -151,8 +151,8 @@ def board(
 
     ## 2.b: Setup a date picker to set the user_zoom_range
     varbar.add(
-        "date_picker",
-        weave.panels.DateRange(user_zoom_range, domain=dataset[timestamp_col_name]),
+        "time_range",
+        weave.panels.DateRange(user_zoom_range, domain=source_data[timestamp_col_name]),
     )
 
     ## 3. bin_range is derived from user_zoom_range and raw_data_range. This is
@@ -183,7 +183,7 @@ def board(
 
     window_data = varbar.add(
         "window_data",
-        dataset.filter(
+        source_data.filter(
             lambda row: weave.ops.Boolean.bool_and(
                 row[timestamp_col_name] >= bin_range[0],
                 row[timestamp_col_name] <= bin_range[1],
@@ -199,26 +199,28 @@ def board(
         ),
         hidden=True,
     )
-    filter_editor = varbar.add(
-        "filter_editor",
+    filters = varbar.add(
+        "filters",
         weave.panels.FilterEditor(filter_fn, node=window_data),
     )
 
-    filtered_data = varbar.add("filtered_data", dataset.filter(filter_fn), hidden=True)
+    filtered_data = varbar.add(
+        "filtered_data", source_data.filter(filter_fn), hidden=True
+    )
 
     filtered_window_data = varbar.add(
         "filtered_window_data", window_data.filter(filter_fn), hidden=True
     )
 
     groupby = varbar.add("groupby", "output.model", hidden=True)
-    groupby_dropdown = varbar.add(
-        "groupby_dropdown",
+    grouping = varbar.add(
+        "grouping",
         weave.panels.Dropdown(
             groupby,
             choices=weave.ops.List.concat(
                 weave.ops.make_list(
                     a=weave_internal.const(["output.model"]),
-                    b=dataset["attributes"]
+                    b=source_data["attributes"]
                     .keys()
                     .flatten()
                     .unique()


### PR DESCRIPTION
- Render variable name as a bold title when editable=False for varbar
- Remove edit and ... menu controls from varbar when editable=False
- Remove new panel button from varbar when editable=False
- Fix overflow for vertical/horizontal group layout child panels, so controls can correct expand out of parent (like Dropdown)

![image](https://github.com/wandb/weave/assets/499383/62e03c3f-3f51-41d5-a21c-3408915a84ab)
