### PR TITLE
feat: Cleaner board UX

### DIFF
--- a/weave-js/src/common/css/color.styles.ts
+++ b/weave-js/src/common/css/color.styles.ts
@@ -233,3 +233,25 @@ export const NEW_BLUES = {
   BLUE_650,
   BLUE_700,
 };
+
+// Don't know if we ultimately want this here. This is copied from
+// color.ts runColorDict in the W&B code.
+
+export const WB_RUN_COLORS = [
+  '#E87B9F',
+  '#A12864',
+  '#DA4C4C',
+  '#F0B899',
+  '#E57439',
+  '#EDB732',
+  '#A0C75C',
+  '#479A5F',
+  '#87CEBF',
+  '#229487',
+  '#5BC5DB',
+  '#5387DD',
+  '#7D54B2',
+  '#C565C7',
+  '#A46750',
+  '#A1A9AD',
+];

--- a/weave-js/src/common/css/color.styles.ts
+++ b/weave-js/src/common/css/color.styles.ts
@@ -235,23 +235,23 @@ export const NEW_BLUES = {
 };
 
 // Don't know if we ultimately want this here. This is copied from
-// color.ts runColorDict in the W&B code.
+// color.ts runColorDict in the W&B code. But I reordered them.
 
 export const WB_RUN_COLORS = [
+  '#5387DD',
   '#E87B9F',
-  '#A12864',
   '#DA4C4C',
+  '#A0C75C',
   '#F0B899',
   '#E57439',
   '#EDB732',
-  '#A0C75C',
-  '#479A5F',
   '#87CEBF',
   '#229487',
-  '#5BC5DB',
-  '#5387DD',
   '#7D54B2',
   '#C565C7',
   '#A46750',
   '#A1A9AD',
+  '#5BC5DB',
+  '#A12864',
+  '#479A5F',
 ];

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -505,6 +505,12 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
   );
 };
 
+const varNameToTitle = (varName: string) => {
+  return varName
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase());
+};
+
 // This is the standard way to render subpanels. We should migrate
 // other cases to this (Table cell, SelectPanel in Facet, and probably
 // PanelExpression and PanelRootQuery)
@@ -576,86 +582,89 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
             lineHeight: '20px',
             marginTop: 16,
           }}>
-          {props.pathEl != null &&
-            props.pathEl
-              .replace(/_/g, ' ')
-              .replace(/\b\w/g, char => char.toUpperCase())}
+          {props.pathEl != null && varNameToTitle(props.pathEl)}
         </div>
       )}
       {props.controlBar === 'editable' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
-            {props.prefixHeader}
-            {props.pathEl != null && (
-              <EditorPath>
-                <ValidatingTextInput
-                  dataTest="panel-expression-path"
-                  onCommit={props.updateName ?? (() => {})}
-                  validateInput={validateName}
-                  initialValue={props.pathEl}
-                  maxWidth={
-                    editorBarWidth != null ? editorBarWidth / 3 : undefined
-                  }
-                  maxLength={24}
-                />{' '}
-                {props.controlBar === 'editable' && '= '}
-              </EditorPath>
-            )}
-            {props.controlBar === 'editable' &&
-              curPanelId !== 'Expression' &&
-              curPanelId !== 'RootBrowser' && (
-                <PanelNameEditor
-                  value={curPanelId ?? ''}
-                  autocompleteOptions={panelOptions}
-                  setValue={handlePanelChange}
-                />
-              )}
-            {props.controlBar === 'editable' ? (
-              <EditorExpression data-test="panel-expression-expression">
-                <WeaveExpression
-                  expr={panelInputExpr}
-                  setExpression={updateExpression}
-                  noBox
-                  truncate={!expressionFocused}
-                  onFocus={onFocusExpression}
-                  onBlur={onBlurExpression}
-                />
-              </EditorExpression>
+            {!hoverPanel ? (
+              props.pathEl != null && varNameToTitle(props.pathEl)
             ) : (
-              <div style={{width: '100%'}} />
+              <>
+                {props.prefixHeader}
+                {props.pathEl != null && (
+                  <EditorPath>
+                    <ValidatingTextInput
+                      dataTest="panel-expression-path"
+                      onCommit={props.updateName ?? (() => {})}
+                      validateInput={validateName}
+                      initialValue={props.pathEl}
+                      maxWidth={
+                        editorBarWidth != null ? editorBarWidth / 3 : undefined
+                      }
+                      maxLength={24}
+                    />{' '}
+                    {props.controlBar === 'editable' && '= '}
+                  </EditorPath>
+                )}
+                {props.controlBar === 'editable' &&
+                  curPanelId !== 'Expression' &&
+                  curPanelId !== 'RootBrowser' && (
+                    <PanelNameEditor
+                      value={curPanelId ?? ''}
+                      autocompleteOptions={panelOptions}
+                      setValue={handlePanelChange}
+                    />
+                  )}
+                {props.controlBar === 'editable' ? (
+                  <EditorExpression data-test="panel-expression-expression">
+                    <WeaveExpression
+                      expr={panelInputExpr}
+                      setExpression={updateExpression}
+                      noBox
+                      truncate={!expressionFocused}
+                      onFocus={onFocusExpression}
+                      onBlur={onBlurExpression}
+                    />
+                  </EditorExpression>
+                ) : (
+                  <div style={{width: '100%'}} />
+                )}
+                <EditorIcons visible={hoverPanel || isMenuOpen}>
+                  {props.prefixButtons}
+                  <Tooltip
+                    position="top center"
+                    trigger={
+                      <Button
+                        variant="ghost"
+                        size="small"
+                        icon="pencil-edit"
+                        onClick={() => setInspectingPanel(props.pathEl ?? '')}
+                      />
+                    }>
+                    Open panel editor
+                  </Tooltip>
+                  <OutlineItemPopupMenu
+                    config={fullConfig}
+                    localConfig={getConfigForPath(fullConfig, fullPath)}
+                    path={fullPath}
+                    updateConfig={updateConfig}
+                    updateConfig2={updateConfig2}
+                    trigger={
+                      <Button
+                        variant="ghost"
+                        size="small"
+                        icon="overflow-horizontal"
+                      />
+                    }
+                    onOpen={() => setIsMenuOpen(true)}
+                    onClose={() => setIsMenuOpen(false)}
+                    isOpen={isMenuOpen}
+                  />
+                </EditorIcons>
+              </>
             )}
-            <EditorIcons visible={hoverPanel || isMenuOpen}>
-              {props.prefixButtons}
-              <Tooltip
-                position="top center"
-                trigger={
-                  <Button
-                    variant="ghost"
-                    size="small"
-                    icon="pencil-edit"
-                    onClick={() => setInspectingPanel(props.pathEl ?? '')}
-                  />
-                }>
-                Open panel editor
-              </Tooltip>
-              <OutlineItemPopupMenu
-                config={fullConfig}
-                localConfig={getConfigForPath(fullConfig, fullPath)}
-                path={fullPath}
-                updateConfig={updateConfig}
-                updateConfig2={updateConfig2}
-                trigger={
-                  <Button
-                    variant="ghost"
-                    size="small"
-                    icon="overflow-horizontal"
-                  />
-                }
-                onOpen={() => setIsMenuOpen(true)}
-                onClose={() => setIsMenuOpen(false)}
-                isOpen={isMenuOpen}
-              />
-            </EditorIcons>
           </EditorBarContent>
         </Styles.EditorBar>
       )}

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -581,6 +581,9 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
             padding: '0 16px 8px',
             lineHeight: '20px',
             marginTop: 16,
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+            overflow: 'hidden',
           }}>
           {props.pathEl != null && varNameToTitle(props.pathEl)}
         </div>
@@ -589,7 +592,16 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
             {!hoverPanel ? (
-              props.pathEl != null && varNameToTitle(props.pathEl)
+              props.pathEl != null && (
+                <div
+                  style={{
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                    overflow: 'hidden',
+                  }}>
+                  {varNameToTitle(props.pathEl)}
+                </div>
+              )
             ) : (
               <>
                 {props.prefixHeader}

--- a/weave-js/src/components/Panel2/KeyValTable.tsx
+++ b/weave-js/src/components/Panel2/KeyValTable.tsx
@@ -1,9 +1,13 @@
 import * as globals from '@wandb/weave/common/css/globals.styles';
 import styled from 'styled-components';
 
-export const Table = styled.table``;
+export const Table = styled.table`
+  font-size: 13px;
+`;
 export const Row = styled.tr``;
 export const Key = styled.td`
+  white-space: nowrap;
+  text-overflow: ellipsis;
   vertical-align: top;
   padding: 0 !important;
   color: ${globals.gray500};

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -3496,6 +3496,15 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
 
   const loaderComp = <Panel2Loader />;
 
+  // Hardcode plot colors for now.
+  if (vegaSpec.encoding.color == null) {
+    vegaSpec.encoding.color = {};
+  }
+  if (vegaSpec.encoding.color.scale == null) {
+    vegaSpec.encoding.color.scale = {};
+  }
+  vegaSpec.encoding.color.scale.range = globals.WB_RUN_COLORS;
+
   return (
     <div
       data-test="panel-plot-2-wrapper"

--- a/weave-js/src/components/Sidebar/Inspector.tsx
+++ b/weave-js/src/components/Sidebar/Inspector.tsx
@@ -26,7 +26,8 @@ export const Container = styled.div<{active: boolean}>`
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2); 
   */
   width: ${p => (p.active ? WIDTH_PX : 0)}px;
-  transition: width 0.3s;
+  // Don't do this, it makes open and closing the inspector janky
+  // transition: width 0.3s;
 `;
 
 export const Content = styled.div`

--- a/weave-js/src/components/WeavePanelBank/PBSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PBSection.tsx
@@ -102,7 +102,11 @@ export const PBSection: React.FC<PBSectionProps> = props => {
               <div className="panel-bank__section">
                 {!inJupyter && groupPath != null && handleAddPanel != null && (
                   <ActionBar ref={actionBarRef}>
-                    <Tooltip
+                    {/* This opens the editor at the outline level on the main board.
+                    The button was always shown on the page, but it leads to a kind
+                    of confusing place, so I'm just disabling it. */}
+
+                    {/* <Tooltip
                       position="bottom right"
                       trigger={
                         <Button
@@ -112,7 +116,7 @@ export const PBSection: React.FC<PBSectionProps> = props => {
                         />
                       }>
                       Open panel editor
-                    </Tooltip>
+                    </Tooltip> */}
                     {enableAddPanel && (
                       <Button
                         variant="ghost"

--- a/weave-js/src/components/WeavePanelBank/PBSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PBSection.tsx
@@ -29,12 +29,10 @@ import {
 import {IconAddNew as IconAddNewUnstyled} from '../Panel2/Icons';
 import {inJupyterCell} from '../PagePanelComponents/util';
 import {useScrollbarVisibility} from '../../core/util/scrollbar';
-import {Tooltip} from '../Tooltip';
 import {
   useGetPanelIsHoveredByGroupPath,
   useGetPanelIsHoveredInOutlineByGroupPath,
   useSelectedPath,
-  useSetInspectingPanel,
   useSetPanelIsHovered,
 } from '../Panel2/PanelInteractContext';
 import {Button} from '../Button';
@@ -55,7 +53,6 @@ export const PBSection: React.FC<PBSectionProps> = props => {
   const {config, groupPath, enableAddPanel, updateConfig2, handleAddPanel} =
     props;
   const selectedPath = useSelectedPath();
-  const setInspectingPanel = useSetInspectingPanel();
   const getPanelIsHovered = useGetPanelIsHoveredByGroupPath(groupPath ?? []);
   const getPanelIsHoveredInOutline = useGetPanelIsHoveredInOutlineByGroupPath(
     groupPath ?? []

--- a/weave-js/src/components/WeavePanelBank/PBSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PBSection.tsx
@@ -22,6 +22,7 @@ import {
   GRAY_350,
   GRAY_400,
   GRAY_500,
+  MOON_50,
   PANEL_HOVERED_SHADOW,
   SCROLLBAR_STYLES,
   WHITE,
@@ -72,7 +73,11 @@ export const PBSection: React.FC<PBSectionProps> = props => {
   const addPanelBarRef = useRef<HTMLDivElement | null>(null);
   return (
     <DragDropProvider>
-      <div className="panel-bank" style={{height: '100%'}}>
+      <div
+        className="panel-bank"
+        // We set the background color for the main area of the board here
+        // for now... Maybe this will work for all uses of PB in Weave
+        style={{height: '100%', backgroundColor: MOON_50}}>
         <Measure
           bounds
           onResize={contentRect => {

--- a/weave-js/src/core/hl.ts
+++ b/weave-js/src/core/hl.ts
@@ -1010,6 +1010,12 @@ function simpleArgsString(args: EditingOpInputs, opStore: OpStore): string {
 function simpleOpString(op: EditingOp, opStore: OpStore): string {
   const argNames = Object.keys(op.inputs);
   const argValues = Object.values(op.inputs);
+  if (op.name.endsWith('bin')) {
+    // Bin ops like timestamp-bin produce really ugly strings. Simplify by not showing the rhs
+    // argument. This makes default plot legends that are binned by timestamp much nicer.
+    return `${simpleNodeString(argValues[0], opStore)} bin`;
+  }
+
   if (isUnaryOp(op, opStore)) {
     return `${opSymbol(op, opStore)}${simpleNodeString(argValues[0], opStore)}`;
   }

--- a/weave/panels_py/panel_autoboard.py
+++ b/weave/panels_py/panel_autoboard.py
@@ -61,7 +61,6 @@ def timeseries(
         label=lambda row: row[groupby_key],
         groupby_dims=["x", "label"],
         mark="line",
-        no_legend=True,
         domain_x=x_domain,
     )
 

--- a/weave/panels_py/panel_autoboard.py
+++ b/weave/panels_py/panel_autoboard.py
@@ -47,15 +47,17 @@ def timeseries(
 ) -> weave.Panel:
     x_axis_type = input_node[x_axis_key].type.object_type  # type: ignore
     if weave.types.optional(weave.types.Timestamp()).assign_type(x_axis_type):
+        x_title = ""
         bin_fn = weave.ops.timestamp_bins_nice
     elif weave.types.optional(weave.types.Number()).assign_type(x_axis_type):
+        x_title = x_axis_key
         bin_fn = weave.ops.numbers_bins_equal
     else:
         raise ValueError(f"Unsupported type for x_axis_key {x_axis_key}: {x_axis_type}")
     return weave.panels.Plot(
         input_node,
         x=lambda row: row[x_axis_key].bin(bin_fn(bin_domain_node, 100))["start"],
-        x_title=x_axis_key,
+        x_title=x_title,
         y=y_expr,
         y_title=y_title,
         label=lambda row: row[groupby_key],
@@ -105,15 +107,17 @@ def timeseries_sum_bar(
 ) -> weave.Panel:
     x_axis_type = input_node[x_axis_key].type.object_type  # type: ignore
     if weave.types.optional(weave.types.Timestamp()).assign_type(x_axis_type):
+        x_title = ""
         bin_fn = weave.ops.timestamp_bins_nice
     elif weave.types.optional(weave.types.Number()).assign_type(x_axis_type):
+        x_title = x_axis_key
         bin_fn = weave.ops.numbers_bins_equal
     else:
         raise ValueError(f"Unsupported type for x_axis_key {x_axis_key}: {x_axis_type}")
     return weave.panels.Plot(
         input_node,
         x=lambda row: row[x_axis_key].bin(bin_fn(bin_domain_node, n_bins)),
-        x_title=x_axis_key,
+        x_title=x_title,
         y=lambda row: row[y_axis_key].sum(),
         y_title="sum_" + y_axis_key,
         label=lambda row: row[groupby_key],
@@ -134,15 +138,17 @@ def timeseries_count_bar(
 ) -> weave.Panel:
     x_axis_type = input_node[x_axis_key].type.object_type  # type: ignore
     if weave.types.optional(weave.types.Timestamp()).assign_type(x_axis_type):
+        x_title = ""
         bin_fn = weave.ops.timestamp_bins_nice
     elif weave.types.optional(weave.types.Number()).assign_type(x_axis_type):
+        x_title = x_axis_key
         bin_fn = weave.ops.numbers_bins_equal
     else:
         raise ValueError(f"Unsupported type for x_axis_key {x_axis_key}: {x_axis_type}")
     return weave.panels.Plot(
         input_node,
         x=lambda row: row[x_axis_key].bin(bin_fn(bin_domain_node, n_bins)),
-        x_title=x_axis_key,
+        x_title=x_title,
         y=lambda row: row.count(),
         label=lambda row: row[groupby_key],
         groupby_dims=["x", "label"],

--- a/weave/panels_py/panel_openai_monitor.py
+++ b/weave/panels_py/panel_openai_monitor.py
@@ -284,24 +284,24 @@ def board(
     )
 
     overview_tab.add(
-        "avg cost per req",
+        "avg_cost_per_req",
         cost(filtered_window_data).avg(),  # type: ignore
-        layout=weave.panels.GroupPanelLayout(x=0, y=height * 2, w=6, h=height),
+        layout=weave.panels.GroupPanelLayout(x=0, y=height * 2, w=6, h=3),
     )
     overview_tab.add(
-        "avg prompt tokens per req",
+        "avg_prompt_tokens_per_req",
         filtered_window_data["summary.prompt_tokens"].avg(),  # type: ignore
-        layout=weave.panels.GroupPanelLayout(x=6, y=height * 2, w=6, h=height),
+        layout=weave.panels.GroupPanelLayout(x=6, y=height * 2, w=6, h=3),
     )
     overview_tab.add(
-        "avg completion tokens per req",
+        "avg_completion_tokens_per_req",
         filtered_window_data["summary.completion_tokens"].avg(),  # type: ignore
-        layout=weave.panels.GroupPanelLayout(x=12, y=height * 2, w=6, h=height),
+        layout=weave.panels.GroupPanelLayout(x=12, y=height * 2, w=6, h=3),
     )
     overview_tab.add(
-        "avg total tokens per req",
+        "avg_total_tokens_per_req",
         filtered_window_data["summary.total_tokens"].avg(),  # type: ignore
-        layout=weave.panels.GroupPanelLayout(x=18, y=height * 2, w=6, h=height),
+        layout=weave.panels.GroupPanelLayout(x=18, y=height * 2, w=6, h=3),
     ),
 
     # Show a plot for each attribute.
@@ -337,7 +337,7 @@ def board(
     requests_table_var = overview_tab.add(
         "table",
         requests_table,
-        layout=weave.panels.GroupPanelLayout(x=0, y=15, w=24, h=8),
+        layout=weave.panels.GroupPanelLayout(x=0, y=13, w=24, h=8),
     )
     overview_tab.add(
         "input",
@@ -345,12 +345,12 @@ def board(
             requests_table_var.active_data()["inputs.messages"],
             columns=[lambda row: row["role"], lambda row: row["content"]],
         ),
-        layout=weave.panels.GroupPanelLayout(x=0, y=23, w=12, h=8),
+        layout=weave.panels.GroupPanelLayout(x=0, y=21, w=12, h=8),
     )
     overview_tab.add(
         "output",
         requests_table_var.active_row(),
-        layout=weave.panels.GroupPanelLayout(x=12, y=23, w=12, h=8),
+        layout=weave.panels.GroupPanelLayout(x=12, y=21, w=12, h=8),
     )
 
     # attributes_tab = weave.panels.Group(layoutMode="grid")


### PR DESCRIPTION
Now we only show the variable name converted to a title format on panels by default. When you mouse over, you get the whole editor bar as it was.

Also shrunk the height of the metric panels in the openai board from 5 to 3, which looks nicer.

Other changes:
- 13px font size for KeyValTable so PanelObject matches PanelTable
- Modified simpleOpString to produce a much simpler string when we are using binning operations, improving PanelPlot legend
- Removed the edit button next to "New Panel", it was always present onscreen, and opens to the outline editor which seems confusing.
- Made sure there are no underscores in variables names in the openai board
- Background color for main section of board is now a very light gray
- Use W&B run color scheme for PanelPlot colors
- Don't show "timestamp" for x-axis label, no need for it

![Uploading image.png…]()
