### PR TITLE
chore(weave): Stop browser actions from rerendering everytime

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -350,7 +350,15 @@ const CenterProjectBoardsBrowser: React.FC<
         },
       ],
     ];
-  }, [props, history, params.entity, params.project, params.assetType]);
+  }, [
+    history,
+    params.entity,
+    params.project,
+    params.assetType,
+    props.entityName,
+    props.projectName,
+    props.navigateToExpression,
+  ]);
 
   const sidebarActions = useMemo(
     () =>
@@ -551,8 +559,8 @@ const CenterProjectTablesBrowser: React.FC<
 
   const browserActions: Array<
     CenterBrowserActionType<(typeof browserData)[number]>
-  > = useMemo(() => {
-    return [
+  > = useMemo(
+    () => [
       [
         // Home Page TODO: Enable awesome previews
         {
@@ -627,8 +635,16 @@ const CenterProjectTablesBrowser: React.FC<
           },
         },
       ],
-    ];
-  }, [props, weave, history, makeBoardFromNode, navigateToExpression]);
+    ],
+    [
+      props.entityName,
+      props.projectName,
+      weave,
+      history,
+      makeBoardFromNode,
+      navigateToExpression,
+    ]
+  );
 
   const sidebarActions = useMemo(
     () =>

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -284,7 +284,7 @@ const rowToExpression = (
 
 const CenterProjectBoardsBrowser: React.FC<
   CenterProjectBrowserInnerPropsType
-> = props => {
+> = ({entityName, projectName, setPreviewNode, navigateToExpression}) => {
   const history = useHistory();
   const params = useParams<HomeParams>();
   const browserTitle = 'Boards';
@@ -297,7 +297,7 @@ const CenterProjectBoardsBrowser: React.FC<
     );
   }, [params.entity, params.project, params.preview, browserTitle]);
 
-  const boards = query.useProjectBoards(props.entityName, props.projectName);
+  const boards = query.useProjectBoards(entityName, projectName);
   const browserData = useMemo(() => {
     return boards.result.map(b => ({
       _id: b.name,
@@ -308,8 +308,6 @@ const CenterProjectBoardsBrowser: React.FC<
     }));
   }, [boards]);
 
-  const {setPreviewNode, navigateToExpression} = props;
-
   const browserActions: Array<
     CenterBrowserActionType<(typeof browserData)[number]>
   > = useMemo(() => {
@@ -319,7 +317,7 @@ const CenterProjectBoardsBrowser: React.FC<
           icon: IconOpenNewTab,
           label: 'Open board',
           onClick: row => {
-            props.navigateToExpression(
+            navigateToExpression(
               rowToExpression(params.entity!, params.project!, row._id)
             );
           },
@@ -344,7 +342,7 @@ const CenterProjectBoardsBrowser: React.FC<
           icon: IconDelete,
           label: 'Delete board',
           onClick: row => {
-            const uri = `wandb-artifact:///${props.entityName}/${props.projectName}/${row._id}:latest/obj`;
+            const uri = `wandb-artifact:///${entityName}/${projectName}/${row._id}:latest/obj`;
             setDeletingId(uri);
           },
         },
@@ -355,9 +353,9 @@ const CenterProjectBoardsBrowser: React.FC<
     params.entity,
     params.project,
     params.assetType,
-    props.entityName,
-    props.projectName,
-    props.navigateToExpression,
+    entityName,
+    projectName,
+    navigateToExpression,
   ]);
 
   const sidebarActions = useMemo(
@@ -424,26 +422,26 @@ const CenterProjectBoardsBrowser: React.FC<
       allowSearch
       title={browserTitle}
       selectedRowId={params.preview}
-      setPreviewNode={props.setPreviewNode}
+      setPreviewNode={setPreviewNode}
       deletingId={deletingId}
       setDeletingId={setDeletingId}
       deleteTypeString="board"
-      noDataCTA={`No Weave boards found for project: ${props.entityName}/${props.projectName}`}
+      noDataCTA={`No Weave boards found for project: ${entityName}/${projectName}`}
       breadcrumbs={[
         {
           key: 'entity',
-          text: props.entityName,
+          text: entityName,
           onClick: () => {
-            props.setPreviewNode(undefined);
-            history.push(urlEntity(props.entityName));
+            setPreviewNode(undefined);
+            history.push(urlEntity(entityName));
           },
         },
         {
           key: 'project',
-          text: props.projectName,
+          text: projectName,
           onClick: () => {
-            props.setPreviewNode(undefined);
-            history.push(urlProject(props.entityName, props.projectName));
+            setPreviewNode(undefined);
+            history.push(urlProject(entityName, projectName));
           },
         },
       ]}
@@ -502,7 +500,7 @@ const tableRowToNode = (
 
 const CenterProjectTablesBrowser: React.FC<
   CenterProjectBrowserInnerPropsType
-> = props => {
+> = ({entityName, projectName, setPreviewNode, navigateToExpression}) => {
   const history = useHistory();
   const params = useParams<HomeParams>();
   const weave = useWeaveContext();
@@ -519,14 +517,8 @@ const CenterProjectTablesBrowser: React.FC<
     }
   }, [params.entity, params.project, params.preview, browserTitle]);
 
-  const runStreams = query.useProjectRunStreams(
-    props.entityName,
-    props.projectName
-  );
-  const loggedTables = query.useProjectRunLoggedTables(
-    props.entityName,
-    props.projectName
-  );
+  const runStreams = query.useProjectRunStreams(entityName, projectName);
+  const loggedTables = query.useProjectRunLoggedTables(entityName, projectName);
   const isLoading = runStreams.loading || loggedTables.loading;
   const browserData = useMemo(() => {
     if (isLoading) {
@@ -555,8 +547,6 @@ const CenterProjectTablesBrowser: React.FC<
     return combined;
   }, [isLoading, loggedTables.result, runStreams.result]);
 
-  const {setPreviewNode, navigateToExpression} = props;
-
   const browserActions: Array<
     CenterBrowserActionType<(typeof browserData)[number]>
   > = useMemo(
@@ -568,12 +558,7 @@ const CenterProjectTablesBrowser: React.FC<
           label: 'Table overview',
           onClick: row => {
             history.push(
-              urlProjectAssetPreview(
-                props.entityName,
-                props.projectName,
-                'table',
-                row._id
-              )
+              urlProjectAssetPreview(entityName, projectName, 'table', row._id)
             );
           },
         },
@@ -581,13 +566,8 @@ const CenterProjectTablesBrowser: React.FC<
           icon: IconFullScreenModeExpand,
           label: 'Preview table',
           onClick: row => {
-            props.navigateToExpression(
-              tableRowToNode(
-                row.kind,
-                props.entityName,
-                props.projectName,
-                row._id
-              )
+            navigateToExpression(
+              tableRowToNode(row.kind, entityName, projectName, row._id)
             );
           },
         },
@@ -597,8 +577,8 @@ const CenterProjectTablesBrowser: React.FC<
           onClick: row => {
             const node = tableRowToNode(
               row.kind,
-              props.entityName,
-              props.projectName,
+              entityName,
+              projectName,
               row._id
             );
             const copyText = weave.expToString(node);
@@ -615,8 +595,8 @@ const CenterProjectTablesBrowser: React.FC<
           onClick: row => {
             const node = tableRowToNode(
               row.kind,
-              props.entityName,
-              props.projectName,
+              entityName,
+              projectName,
               row._id
             );
             makeBoardFromNode(SEED_BOARD_OP_NAME, node, newDashExpr => {
@@ -630,15 +610,15 @@ const CenterProjectTablesBrowser: React.FC<
           icon: IconDelete,
           label: 'Delete table',
           onClick: row => {
-            const uri = `wandb-artifact:///${props.entityName}/${props.projectName}/${row._id}:latest/obj`;
+            const uri = `wandb-artifact:///${entityName}/${projectName}/${row._id}:latest/obj`;
             setDeletingId(uri);
           },
         },
       ],
     ],
     [
-      props.entityName,
-      props.projectName,
+      entityName,
+      projectName,
       weave,
       history,
       makeBoardFromNode,
@@ -708,22 +688,22 @@ const CenterProjectTablesBrowser: React.FC<
         deletingId={deletingId}
         setDeletingId={setDeletingId}
         deleteTypeString="table"
-        noDataCTA={`No Weave tables found for project: ${props.entityName}/${props.projectName}`}
+        noDataCTA={`No Weave tables found for project: ${entityName}/${projectName}`}
         breadcrumbs={[
           {
             key: 'entity',
-            text: props.entityName,
+            text: entityName,
             onClick: () => {
-              props.setPreviewNode(undefined);
-              history.push(urlEntity(props.entityName));
+              setPreviewNode(undefined);
+              history.push(urlEntity(entityName));
             },
           },
           {
             key: 'project',
-            text: props.projectName,
+            text: projectName,
             onClick: () => {
-              props.setPreviewNode(undefined);
-              history.push(urlProject(props.entityName, props.projectName));
+              setPreviewNode(undefined);
+              history.push(urlProject(entityName, projectName));
             },
           },
         ]}


### PR DESCRIPTION
passing in the destructured props, vs props stops it

![screenshot_2023-08-17_at_10 26 40_pm_720](https://github.com/wandb/weave/assets/25037002/0e58cc18-ddfb-40b0-84b8-d5d78e5c8982)

