### PR TITLE
feat: cond op, with_columns op, openai cost calculation

### DIFF
--- a/examples/monitoring/dev/openai_monitoring_board_demo.ipynb
+++ b/examples/monitoring/dev/openai_monitoring_board_demo.ipynb
@@ -40,24 +40,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "345a1b0a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "preds = random_predictions()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "93653c45",
    "metadata": {},
    "outputs": [],
    "source": [
+    "preds = random_predictions(100)\n",
+    "\n",
     "# Convert synthetic data into the format used by the weave.monitoring.openai integration\n",
     "\n",
-    "spans = []\n",
-    "for pred in preds:\n",
+    "# convert model_version in the synthetic data to an openai model version\n",
+    "# this makes it so that there's a new API key that has appeared in our logs recently, and that key\n",
+    "# has started using gpt-4 which makes a cost spike\n",
+    "versions = sorted(preds.column('model_version').unique())\n",
+    "version_map = {}\n",
+    "for i, v in enumerate(reversed(versions)):\n",
+    "    api_key = 'sk-U4...yK7z'\n",
+    "    model = 'gpt-3.5-turbo-0613'\n",
+    "    if i == 1 or i == 2:\n",
+    "        # second and third most recent versions use a different api key\n",
+    "        api_key = 'sk-U9...a22c'\n",
+    "    if i == 1:\n",
+    "        # second most recent version uses gpt-4\n",
+    "        model = 'gpt-4-0613'\n",
+    "    version_map[v] = (api_key, model)\n",
+    "    \n",
+    "spans = [] \n",
+    "for i, pred in enumerate(preds):\n",
+    "    api_key, model = version_map[pred['model_version']]\n",
+    "    latency_mult = 1\n",
+    "    if model == 'gpt-4-0613':\n",
+    "        latency_mult = 3\n",
     "    span = monitor.Span('openai.api_resources.chat_completion.type.create',\n",
     "                 inputs={\n",
     "                     'messages':[\n",
@@ -68,7 +80,7 @@
     "                     'id': 'chatcmpl-%s' % uuid.uuid4(),\n",
     "                     'object': 'chat.completion',\n",
     "                     'created': pred['timestamp'].timestamp(),\n",
-    "                     'model': 'gpt-3.5-turbo-0613',\n",
+    "                     'model': model,\n",
     "                     'choices': [\n",
     "                         {\n",
     "                             'index': 0,\n",
@@ -82,16 +94,16 @@
     "\n",
     "                 },\n",
     "                 attributes={\n",
-    "                     'api_key': 'sk-U4...yK7z',\n",
+    "                     'api_key': api_key,\n",
     "                     'username': pred['username']\n",
     "                 },\n",
     "                 summary={\n",
     "                     'prompt_tokens': pred['prompt_tokens'],\n",
     "                     'completion_tokens': pred['completion_tokens'],\n",
-    "                     'total_tokens': pred['prompt_tokens'] + pred['completion_tokens']\n",
+    "                     'total_tokens': (pred['prompt_tokens'] + pred['completion_tokens'])\n",
     "                 })\n",
     "    span.start_time = pred['timestamp']\n",
-    "    span.end_time = pred['timestamp'] + timedelta(seconds=pred['latency'])\n",
+    "    span.end_time = pred['timestamp'] + timedelta(seconds=pred['latency'] * latency_mult)\n",
     "    spans.append({'timestamp': pred['timestamp'], **span.asdict()})"
    ]
   },
@@ -114,18 +126,6 @@
    "outputs": [],
    "source": [
     "oai_data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f8121474",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Visualize the table\n",
-    "from weave import weave_internal\n",
-    "weave.use(oai_data['attributes'].keys().flatten().unique().map(lambda k: weave_internal.const('attribute.') + k))"
    ]
   },
   {

--- a/perf_notebooks/case_when v if_then_else.ipynb
+++ b/perf_notebooks/case_when v if_then_else.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8571663c",
+   "metadata": {},
+   "source": [
+    "Explores a case_when based conditional performance v a short-circuiting if_then_else\n",
+    "implementation, as discussed in this PR: https://github.com/wandb/weave/pull/406#discussion_r1299238062"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f5ba866b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import timeit\n",
+    "import numpy as np\n",
+    "import pyarrow as pa\n",
+    "import pyarrow.compute as pc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "8174a151",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def if_then_else(arr, if_fn, then_fn, else_fn):\n",
+    "    case = if_fn(arr)\n",
+    "    case_inverted = pc.invert(case)\n",
+    "    filt_true = pc.filter(arr, case)\n",
+    "    filt_false = pc.filter(arr, case_inverted)\n",
+    "    true_result = then_fn(filt_true)\n",
+    "    false_result = else_fn(filt_false)\n",
+    "    new_arr = pc.replace_with_mask(arr, case, true_result)\n",
+    "    new_arr = pc.replace_with_mask(new_arr, case_inverted, false_result)\n",
+    "    return new_arr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "c947dc17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cond_if_then_else(arr, case_fns, result_fns):\n",
+    "    result_arr = arr\n",
+    "    then_fn = result_fns[0]\n",
+    "    \n",
+    "    # have to do this because of variable capture\n",
+    "    def make_else(ef):\n",
+    "        return lambda arr: if_then_else(arr, case_fns[i-1], result_fns[i-1], ef)\n",
+    "    \n",
+    "    else_fn = result_fns[-1]\n",
+    "    for i in range(len(result_fns) - 1, 1, -1):\n",
+    "        else_fn = make_else(else_fn)\n",
+    "    return if_then_else(arr, case_fns[0], result_fns[0], else_fn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "76bc84b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cond(arr, case_fns, result_fns):\n",
+    "    cases = [case_fn(arr) for case_fn in case_fns]\n",
+    "    case_names = ['%s' % i for i in range(len(case_fns))]\n",
+    "    results = [result_fn(arr) for result_fn in result_fns]\n",
+    "    return pc.case_when(\n",
+    "        pa.StructArray.from_arrays(cases, names=case_names),\n",
+    "        *results\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "9efe23bf",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cond_args = {\n",
+    "    'case_fns': [lambda arr: pc.greater(arr, 0.9), lambda arr: pc.greater(arr, 0.25)],\n",
+    "    'result_fns': [lambda arr: pc.add(arr, 50), lambda arr: pc.subtract(arr, 5), lambda arr: pc.add(arr, 5)]\n",
+    "}\n",
+    "# cond_res = cond(arr, **cond_args)\n",
+    "# if_res = cond_if_then_else(arr, **cond_args)\n",
+    "# cond_res == if_res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "26373d9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_cases = 100\n",
+    "def make_case(i):\n",
+    "    # With this variant, we eliminate most of the options during the first step. Should be very\n",
+    "    # favorable to the if_then_else variant\n",
+    "    # return lambda arr: pc.greater(arr, (i / n_cases))\n",
+    "    \n",
+    "    # The \"1 -\" version means we only eliminate a fraction of the options at each step in our\n",
+    "    # tree.\n",
+    "    return lambda arr: pc.greater(arr, 1 - (i / n_cases))\n",
+    "def make_result(i):\n",
+    "    return lambda arr: pc.add(arr, i)\n",
+    "cond_args = {\n",
+    "    'case_fns': [make_case(i) for i in range(n_cases)],\n",
+    "    'result_fns': [make_result(i) for i in range(n_cases + 1)]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "id": "17757341",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "COND RES 0.23255444579999676\n",
+      "IFTH RES 0.18101482080001005\n"
+     ]
+    }
+   ],
+   "source": [
+    "n_trials = 10\n",
+    "arr = np.random.rand(1000000)\n",
+    "cond_res = timeit.timeit(lambda: cond(arr, **cond_args), number=n_trials) / n_trials\n",
+    "print(\"COND RES\", cond_res)\n",
+    "cond_if_then_else_res = timeit.timeit(lambda: cond_if_then_else(arr, **cond_args), number=n_trials) / n_trials\n",
+    "print(\"IFTH RES\", cond_if_then_else_res)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/weave-js/src/core/ops/domain/local.ts
+++ b/weave-js/src/core/ops/domain/local.ts
@@ -736,7 +736,7 @@ const _withColumnType = (
   newColType: Type
 ): Type => {
   if (curType == null || !isTypedDict(curType)) {
-    throw new Error('invalid type');
+    curType = typedDict({});
   }
   const path = splitEscapedString(key);
   const propertyTypes = {...curType.propertyTypes} as {[key: string]: Type};

--- a/weave-js/src/core/ops/domain/local.ts
+++ b/weave-js/src/core/ops/domain/local.ts
@@ -730,7 +730,7 @@ export const opCond = makeOp({
   },
 });
 
-const _withColumnType = (
+const withColumnType = (
   curType: Type | undefined,
   key: string,
   newColType: Type
@@ -741,10 +741,10 @@ const _withColumnType = (
   const path = splitEscapedString(key);
   const propertyTypes = {...curType.propertyTypes} as {[key: string]: Type};
   if (path.length > 1) {
-    return _withColumnType(
+    return withColumnType(
       curType,
       path[0],
-      _withColumnType(
+      withColumnType(
         propertyTypes[path[0]],
         path.slice(1).join('.'),
         newColType
@@ -761,7 +761,7 @@ const _withColumnType = (
   return typedDict(propertyTypes);
 };
 
-const _withColumnsOutputType = (selfType: ListType, colsType: Type) => {
+const withColumnsOutputType = (selfType: ListType, colsType: Type) => {
   if (!isTypedDict(colsType)) {
     throw new Error('invalid');
   }
@@ -771,7 +771,7 @@ const _withColumnsOutputType = (selfType: ListType, colsType: Type) => {
     if (v == null || !isList(v)) {
       throw new Error('invalid ');
     }
-    objType = _withColumnType(objType, k, v.objectType);
+    objType = withColumnType(objType, k, v.objectType);
   }
   return list(objType);
 };
@@ -798,7 +798,7 @@ export const opWithColumns = makeOp({
     },
   },
   returnType: inputNodes => {
-    return _withColumnsOutputType(inputNodes.self.type, inputNodes.cols.type);
+    return withColumnsOutputType(inputNodes.self.type, inputNodes.cols.type);
   },
 });
 

--- a/weave-js/src/core/ops/domain/local.ts
+++ b/weave-js/src/core/ops/domain/local.ts
@@ -15,6 +15,7 @@ import {
   isSimpleTypeShape,
   isTaggedValue,
   isTypedDict,
+  isTypedDictLike,
   isUnion,
   list,
   maybe,
@@ -22,6 +23,7 @@ import {
   taggedValue,
   Type,
   typedDict,
+  typedDictPropertyTypes,
   union,
   unionObjectTypeAttrTypes,
 } from '../../model';
@@ -700,8 +702,8 @@ export const opCrossProduct = makeOp({
   },
 });
 
-export const opCond2 = makeOp({
-  name: 'op-cond2',
+export const opCond = makeOp({
+  name: 'op-cond',
   renderInfo: {
     type: 'function',
   },
@@ -709,17 +711,22 @@ export const opCond2 = makeOp({
   argDescriptions: {},
   returnValueDescription: 'hello',
   argTypes: {
-    conds: {
+    cases: {
       type: 'dict',
       objectType: 'boolean',
     },
     results: {
-      type: 'list',
+      type: 'dict',
       objectType: 'any',
     },
   },
   returnType: inputNodes => {
-    return maybe(inputNodes.results.type.objectType);
+    if (!isTypedDictLike(inputNodes.results.type)) {
+      throw new Error('unexpected type in opCond');
+    }
+    return maybe(
+      union(Object.values(typedDictPropertyTypes(inputNodes.results.type)))
+    );
   },
 });
 

--- a/weave/compile.py
+++ b/weave/compile.py
@@ -554,6 +554,13 @@ def compile_merge_by_node_id(
 def _node_ops(node: graph.Node) -> typing.Optional[graph.Node]:
     if not isinstance(node, graph.OutputNode):
         return None
+
+    # weavified ops are expanded here.
+    op_def = registry_mem.memory_registry.get_op(node.from_op.name)
+    if op_def.weave_fn is not None:
+        return weave_internal.call_fn(op_def.weave_fn, node.from_op.inputs)
+
+    # otherwise we expand this hard-coded list
     if node.from_op.name not in [
         "RunChain-history",
         "panel_table-active_data",

--- a/weave/decorator_op.py
+++ b/weave/decorator_op.py
@@ -21,6 +21,10 @@ def op(
     *,  # Marks the rest of the arguments as keyword-only.
     plugins=None,
     mutation=False,
+    # If True, the op will be weavified, ie it's resolver will be stored as a Weave
+    # op graph. The compile node_ops pass will expand the node to the weavified
+    # version, instead of executing the original python resolver body.
+    weavify=False,
 ):
     """Decorator for declaring an op.
 
@@ -63,6 +67,10 @@ def op(
             mutation=mutation,
             _decl_locals=inspect.currentframe().f_back.f_locals,
         )
+        if weavify:
+            from .weavify import op_to_weave_fn
+
+            op.weave_fn = op_to_weave_fn(op)
 
         op_version = registry_mem.memory_registry.register_op(op)
 

--- a/weave/ops_arrow/boolean.py
+++ b/weave/ops_arrow/boolean.py
@@ -112,6 +112,7 @@ def _cond_output_type(input_type):
     output_type=_cond_output_type,
 )
 def awl_cond(cases, results):
+    # Will crash if results are not of the same type.
     if isinstance(results, ArrowWeaveList):
         result_values = [
             results._arrow_data.field(i) for i in range(len(results._arrow_data.type))

--- a/weave/ops_arrow/dict.py
+++ b/weave/ops_arrow/dict.py
@@ -437,7 +437,7 @@ def columnNames(self):
 
 def _with_column_type(cur_type: types.Type, key: str, new_col_type: types.Type):
     if not isinstance(cur_type, types.TypedDict):
-        raise ValueError("invalid type ", cur_type)
+        cur_type = types.TypedDict()
     path = _dict_utils.split_escaped_string(key)
 
     property_types = {**cur_type.property_types}
@@ -467,7 +467,8 @@ def _with_columns_output_type(input_type):
     new_col_types = input_type["cols"]
     obj_type = input_type["self"].object_type
     for k, v in new_col_types.property_types.items():
-        print("K V", k, v)
+        # added column type is optional, because we may need to extend with None
+        # if it is too short.
         obj_type = _with_column_type(obj_type, k, v.object_type)
     return ArrowWeaveListType(obj_type)
 
@@ -481,5 +482,8 @@ def _with_columns_output_type(input_type):
     },
     output_type=_with_columns_output_type,
 )
-def with_column(self, cols):
+def with_columns(self, cols):
+    for col_val in cols.values():
+        if len(self) != len(col_val):
+            return None
     return self.with_columns(cols)

--- a/weave/ops_arrow/list_.py
+++ b/weave/ops_arrow/list_.py
@@ -13,6 +13,7 @@ from .. import ref_base
 from .. import weave_types as types
 from .. import box
 from .. import weave_internal
+from ..ops_primitives import _dict_utils
 from .. import errors
 from .. import graph
 from ..language_features.tagging import (
@@ -567,6 +568,42 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
         self._validate_weave_type()
         self._validate_arrow_data()
         self._invalid_reason = None
+
+    def with_column(self, key: str, val: "ArrowWeaveList"):
+        if not isinstance(self.object_type, types.TypedDict):
+            raise ValueError("must add to TypedDict")
+
+        path = _dict_utils.split_escaped_string(key)
+
+        if len(path) > 1:
+            return self.with_column(
+                path[0], self.column(path[0]).with_column(".".join(path[1:]), val)
+            )
+
+        col_names = list(self.object_type.property_types.keys())
+        col_data = [self._arrow_data.field(i) for i in range(len(col_names))]
+        property_types = {**self.object_type.property_types}
+        try:
+            key_index = col_names.index(key)
+        except ValueError:
+            key_index = None
+        if key_index is not None:
+            property_types.pop(key)
+            col_names.pop(key_index)
+            col_data.pop(key_index)
+        col_names.append(key)
+        col_data.append(val._arrow_data)
+        property_types[key] = val.object_type
+        return ArrowWeaveList(
+            pa.StructArray.from_arrays(col_data, names=col_names),
+            types.TypedDict(property_types),
+            self._artifact,
+        )
+
+    def with_columns(self, cols: dict[str, "ArrowWeaveList"]):
+        for k, v in cols.items():
+            self = self.with_column(k, v)
+        return self
 
     def map_column(
         self,
@@ -1270,6 +1307,13 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
             property_types[name],
             self._artifact,
             invalid_reason=self._invalid_reason,
+        )
+
+    def unique(self) -> "ArrowWeaveList":
+        return ArrowWeaveList(
+            pa.compute.unique(self._arrow_data),
+            types.split_none(self.object_type)[1],
+            self._artifact,
         )
 
     def tagged_value_tag(self) -> "ArrowWeaveListGeneric[types.TypedDict]":

--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -676,7 +676,7 @@ def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
     from .. import graph_debug
 
     vecced = vectorize(_ensure_variadic_fn(fn, awl.object_type))
-    logging.info("Vectorizing. Vectorized: %s", fn)
+    logging.info("Vectorizing. Vectorized: %s", vecced)
     called = _call_vectorized_fn_node_maybe_awl(awl, vecced)
     # print("CALLED ", called)
     return _call_and_ensure_awl(awl, called)

--- a/weave/ops_primitives/boolean.py
+++ b/weave/ops_primitives/boolean.py
@@ -41,3 +41,11 @@ def none_coalesce(lhs: typing.Any, rhs: typing.Any):
     if isinstance(lhs, list) and isinstance(rhs, list):
         return [l or r for l, r in zip(lhs, rhs)]
     return lhs or rhs
+
+
+@op(output_type=lambda input_type: types.optional(input_type["results"].object_type))
+def cond(cases: dict[str, bool], results: list[typing.Any]):
+    for c, r in zip(cases.values(), results):
+        if c:
+            return r
+    return None

--- a/weave/panels_py/panel_openai_monitor.py
+++ b/weave/panels_py/panel_openai_monitor.py
@@ -110,19 +110,22 @@ board_name = "py_board-" + BOARD_ID
 
 
 def cost(row: dispatch.RuntimeOutputNode) -> dispatch.RuntimeOutputNode:
-    return weave.ops.cond(
-        weave.ops.dict_(
-            a=row["output.model"] == "gpt-3.5-turbo-0613",
-            b=row["output.model"] == "gpt-4-0613",
-        ),
-        weave.ops.make_list(
-            # gpt-3.5-turbo-0613
-            a=row["summary.prompt_tokens"] * 0.0015e-3
-            + row["summary.completion_tokens"] * 0.002e-3,
-            # gpt-4-0613
-            b=row["summary.prompt_tokens"] * 0.03e-3
-            + row["summary.completion_tokens"] * 0.06e-3,
-        ),
+    return (
+        weave.ops.case(
+            [
+                {
+                    "when": row["output.model"] == "gpt-3.5-turbo-0613",
+                    "then": row["summary.prompt_tokens"] * 0.0015
+                    + row["summary.completion_tokens"] * 0.002,
+                },
+                {
+                    "when": row["output.model"] == "gpt-4-0613",
+                    "then": row["summary.prompt_tokens"] * 0.03
+                    + row["summary.completion_tokens"] * 0.06,
+                },
+            ]
+        )
+        / 1000
     )
 
 

--- a/weave/tests/test_cond.py
+++ b/weave/tests/test_cond.py
@@ -3,16 +3,114 @@ from weave import ops_arrow
 
 
 def test_cond_basic():
-    assert weave.use(weave.ops.cond({"a": True}, [5])) == 5
-    assert weave.use(weave.ops.cond({"a": False}, [5])) == None
-    assert weave.use(weave.ops.cond({"a": False, "b": True}, [5, 6])) == 6
+    assert weave.use(weave.ops.cond({"a": True}, {"a": 5})) == 5
+    assert weave.use(weave.ops.cond({"a": False}, {"a": 5})) == None
+    assert weave.use(weave.ops.cond({"a": False, "b": True}, {"a": 5, "b": 6})) == 6
 
 
-def test_cond_vector():
+def test_cond_mapped_vector():
     conds = weave.save(
         ops_arrow.to_arrow(
             [{"a": True, "b": False}, {"a": False, "b": False}, {"a": False, "b": True}]
         ),
         "conds",
     )
-    assert weave.use(conds.cond([5, 6])).to_pylist_raw() == [5, None, 6]
+    assert weave.use(conds.cond({"a": 5, "b": 6})).to_pylist_raw() == [5, None, 6]
+
+
+def test_cond_mapped_vector_arr_value():
+    conds = weave.save(
+        ops_arrow.to_arrow(
+            [{"a": True, "b": False}, {"a": False, "b": False}, {"a": False, "b": True}]
+        ),
+        "conds",
+    )
+    assert weave.use(conds.cond({"a": [1, 2], "b": [5, 6]})).to_pylist_raw() == [
+        [1, 2],
+        None,
+        [5, 6],
+    ]
+
+
+def test_cond_vector():
+    conds = weave.save(
+        ops_arrow.to_arrow(
+            [
+                {"a": True, "b": False, "val_a": 5, "val_b": 6},
+                {"a": False, "b": False, "val_a": 7, "val_b": 8},
+                {"a": False, "b": True, "val_a": 9, "val_b": 10},
+            ]
+        ),
+        "conds",
+    )
+    assert weave.use(
+        conds.map(
+            lambda row: weave.ops.cond(
+                weave.ops.dict_(**{"a": row["a"], "b": row["b"]}),
+                weave.ops.dict_(**{"a": row["val_a"], "b": row["val_b"]}),
+            )
+        )
+    ).to_pylist_raw() == [5, None, 10]
+
+
+def test_cond_vector_arr_value():
+    conds = weave.save(
+        ops_arrow.to_arrow(
+            [
+                {"a": True, "b": False, "val_a": [1, 2], "val_b": [3, 4]},
+                {"a": False, "b": False, "val_a": [5, 6], "val_b": [7, 8]},
+                {"a": False, "b": True, "val_a": [9, 10], "val_b": [11, 12]},
+            ]
+        ),
+        "conds",
+    )
+    assert weave.use(
+        conds.map(
+            lambda row: weave.ops.cond(
+                weave.ops.dict_(**{"a": row["a"], "b": row["b"]}),
+                weave.ops.dict_(**{"a": row["val_a"], "b": row["val_b"]}),
+            )
+        )
+    ).to_pylist_raw() == [[1, 2], None, [11, 12]]
+
+
+def test_cond_vector_mixed():
+    conds = weave.save(
+        ops_arrow.to_arrow(
+            [
+                {"a": True, "b": False, "val_a": 1, "val_b": 4},
+                {"a": False, "b": False, "val_a": 2, "val_b": 5},
+                {"a": False, "b": True, "val_a": 3, "val_b": 6},
+            ]
+        ),
+        "conds",
+    )
+    assert weave.use(
+        conds.map(
+            lambda row: weave.ops.cond(
+                weave.ops.dict_(**{"a": row["a"], "b": row["b"]}),
+                weave.ops.dict_(**{"a": row["val_a"], "b": 99}),
+            )
+        )
+    ).to_pylist_raw() == [1, None, 99]
+
+
+def test_cond_vector_mixed_arr_value():
+    conds = weave.save(
+        ops_arrow.to_arrow(
+            [
+                {"a": True, "b": False, "val_a": [1, 2], "val_b": [3, 4]},
+                {"a": False, "b": False, "val_a": [5, 6], "val_b": [7, 8]},
+                {"a": False, "b": True, "val_a": [9, 10], "val_b": [11, 12]},
+            ]
+        ),
+        "conds",
+    )
+    assert weave.use(
+        conds.map(
+            lambda row: weave.ops.cond(
+                weave.ops.dict_(**{"a": row["a"], "b": row["b"]}),
+                weave.ops.dict_(**{"a": row["val_a"], "b": [99, 100]}),
+            )
+        )
+    ).to_pylist_raw() == [[1, 2], None, [99, 100]]

--- a/weave/tests/test_cond.py
+++ b/weave/tests/test_cond.py
@@ -1,0 +1,18 @@
+import weave
+from weave import ops_arrow
+
+
+def test_cond_basic():
+    assert weave.use(weave.ops.cond({"a": True}, [5])) == 5
+    assert weave.use(weave.ops.cond({"a": False}, [5])) == None
+    assert weave.use(weave.ops.cond({"a": False, "b": True}, [5, 6])) == 6
+
+
+def test_cond_vector():
+    conds = weave.save(
+        ops_arrow.to_arrow(
+            [{"a": True, "b": False}, {"a": False, "b": False}, {"a": False, "b": True}]
+        ),
+        "conds",
+    )
+    assert weave.use(conds.cond([5, 6])).to_pylist_raw() == [5, None, 6]

--- a/weave/tests/test_with_columns.py
+++ b/weave/tests/test_with_columns.py
@@ -1,0 +1,68 @@
+import weave
+from weave import ops_arrow
+
+
+def test_with_columns_basic():
+    t = weave.save(
+        ops_arrow.to_arrow([{"a": 5, "b": 6, "d": {"y": 9}}, {"a": 7, "d": {"y": 11}}])
+    )
+    result_node = t.with_columns(
+        {
+            # should insert entries into d
+            "d.x": ops_arrow.to_arrow([1, 2]),
+            # should overwrite existing a
+            "a": ops_arrow.to_arrow([-1, -2]),
+        }
+    )
+    result = weave.use(result_node)
+    assert result_node.type == ops_arrow.ArrowWeaveListType(
+        weave.types.TypedDict(
+            {
+                "b": weave.types.optional(weave.types.Int()),
+                "d": weave.types.TypedDict(
+                    {"y": weave.types.Int(), "x": weave.types.Int()}
+                ),
+                "a": weave.types.Int(),
+            }
+        )
+    )
+    assert result.to_pylist_tagged() == [
+        {"b": 6, "d": {"y": 9, "x": 1}, "a": -1},
+        {"b": None, "d": {"y": 11, "x": 2}, "a": -2},
+    ]
+
+
+def test_with_columns_non_dict():
+    t = weave.save(
+        ops_arrow.to_arrow([{"a": 5, "b": 6, "d": {"y": 9}}, {"a": 7, "d": {"y": 11}}])
+    )
+    result_node = t.with_columns(
+        {
+            # a should be replaced with dict
+            "a.x": ops_arrow.to_arrow([1, 2]),
+        }
+    )
+    result = weave.use(result_node)
+    assert result_node.type == ops_arrow.ArrowWeaveListType(
+        weave.types.TypedDict(
+            {
+                "b": weave.types.optional(weave.types.Int()),
+                "d": weave.types.TypedDict({"y": weave.types.Int()}),
+                "a": weave.types.TypedDict({"x": weave.types.Int()}),
+            }
+        )
+    )
+    assert result.to_pylist_tagged() == [
+        {"b": 6, "d": {"y": 9}, "a": {"x": 1}},
+        {"b": None, "d": {"y": 11}, "a": {"x": 2}},
+    ]
+
+
+def test_with_columns_length_mismatch():
+    t = weave.save(
+        ops_arrow.to_arrow([{"a": 5, "b": 6, "d": {"y": 9}}, {"a": 7, "d": {"y": 11}}])
+    )
+    result = weave.use(t.with_columns({"a": ops_arrow.to_arrow([1])}))
+    assert result == None
+    result = weave.use(t.with_columns({"a": ops_arrow.to_arrow([1, 2, 3])}))
+    assert result == None

--- a/weave/weavejs_fixes.py
+++ b/weave/weavejs_fixes.py
@@ -46,11 +46,11 @@ def _convert_specific_opname_to_generic_opname(
     elif name == "ArrowWeaveList-map":
         return "map", {"arr": inputs["self"], "mapFn": inputs["map_fn"]}
     elif name == "ArrowWeaveListString-equal":
-        return "number-mult", {"lhs": inputs["self"], "rhs": inputs["other"]}
+        return "number-equal", {"lhs": inputs["self"], "rhs": inputs["other"]}
     elif name == "ArrowWeaveListNumber-mult":
         return "number-mult", {"lhs": inputs["self"], "rhs": inputs["other"]}
     elif name == "ArrowWeaveListNumber-add":
-        return "number-mult", {"lhs": inputs["self"], "rhs": inputs["other"]}
+        return "number-add", {"lhs": inputs["self"], "rhs": inputs["other"]}
     elif name == "ArrowWeaveListNumber-min":
         return "numbers-min", {"numbers": inputs["self"]}
     elif name == "ArrowWeaveListNumber-max":

--- a/weave/weavejs_fixes.py
+++ b/weave/weavejs_fixes.py
@@ -45,7 +45,11 @@ def _convert_specific_opname_to_generic_opname(
         return "limit", {"arr": inputs["self"], "limit": inputs["limit"]}
     elif name == "ArrowWeaveList-map":
         return "map", {"arr": inputs["self"], "mapFn": inputs["map_fn"]}
+    elif name == "ArrowWeaveListString-equal":
+        return "number-mult", {"lhs": inputs["self"], "rhs": inputs["other"]}
     elif name == "ArrowWeaveListNumber-mult":
+        return "number-mult", {"lhs": inputs["self"], "rhs": inputs["other"]}
+    elif name == "ArrowWeaveListNumber-add":
         return "number-mult", {"lhs": inputs["self"], "rhs": inputs["other"]}
     elif name == "ArrowWeaveListNumber-min":
         return "numbers-min", {"numbers": inputs["self"]}


### PR DESCRIPTION
This gives us the ability to derive the correct OpenAI API cost. Everything is vectorized.

To do this, I added two new ops, which are both major pieces of new functionality.

One is "cond". Here's an example of it's usage:
```
def cost(row: dispatch.RuntimeOutputNode) -> dispatch.RuntimeOutputNode:
    return weave.ops.cond(
        weave.ops.dict_(
            a=row["output.model"] == "gpt-3.5-turbo-0613",
            b=row["output.model"] == "gpt-4-0613",
        ),
        weave.ops.make_list(
            # gpt-3.5-turbo-0613
            a=row["summary.prompt_tokens"] * 0.0015e-3
            + row["summary.completion_tokens"] * 0.002e-3,
            # gpt-4-0613
            b=row["summary.prompt_tokens"] * 0.03e-3
            + row["summary.completion_tokens"] * 0.06e-3,
        ),
    )
```

This formulation matches arrow's case_when. I don't love this because you have to write the cases in the first argument, and the resulting values in the second argument, so they are separated. I am still considering if there is a better way to do it. This way is amenable to vectorization.

Also adds the with_columns op, which allows you to add potentially nested columns to a table. Example usage:
```
    augmented_data = varbar.add(
        "augmented_data",
        source_data.with_columns(
            weave.ops.dict_(**{"summary.cost": source_data.map(lambda row: cost(row))})
        ),
        hidden=True,
    )
```

TODOs:
- Implement with_columns for non-AWL?
- with_columns throws errors in a bunch of unhandled, need to remove those.
- Decide if the cond formulation is ok, or do something else
- I'm not handling the output type functions well in python or js, they are brittle
- The vectorized cond op does funky type detection for the second argument. It's incorrect, means we can't use conds with lists as values.
- Complete the OpenAI cost function when the above is stable. Consider making it an op.

