### PR TITLE
feat: LLM board: Sort the table by timestamp (most recent first)

### DIFF
--- a/weave/panels/panel_table.py
+++ b/weave/panels/panel_table.py
@@ -133,10 +133,20 @@ class Table(panel.Panel, codifiable_value_mixin.CodifiableValueMixin):
         return f"""weave.panels.panel_table.Table({codify.object_to_code_no_format(self.input_node)}, {param_str})"""
 
     def add_column(
-        self, select_expr: typing.Callable, name: typing.Optional[str] = None
-    ) -> None:
+        self,
+        select_expr: typing.Callable,
+        name: typing.Optional[str] = None,
+        groupby: bool = False,
+        sort_dir: typing.Optional[str] = None,
+    ) -> str:
         config = typing.cast(TableConfig, self.config)
-        config.tableState.add_column(select_expr, name)
+        return config.tableState.add_column(
+            select_expr, name, groupby=groupby, sort_dir=sort_dir
+        )
+
+    def enable_sort(self, col_id: str, dir: typing.Optional[str] = "asc") -> None:
+        config = typing.cast(TableConfig, self.config)
+        config.tableState.enable_sort(col_id, dir=dir)
 
 
 def _get_composite_group_key(self: typing.Union[Table, Query]) -> str:

--- a/weave/panels/table_state.py
+++ b/weave/panels/table_state.py
@@ -117,6 +117,7 @@ class TableState:
         name="",
         panel_def: typing.Optional[PanelDef] = None,
         groupby: bool = False,
+        sort_dir: typing.Optional[str] = None,
     ):
         col_id = self._new_col_id()
         if panel_def is None:
@@ -127,6 +128,8 @@ class TableState:
         if groupby:
             self.enable_groupby(col_id)
         self.update_col(col_id, select_expr)
+        if sort_dir:
+            self.enable_sort(col_id, dir=sort_dir)
         return col_id
 
     def set_groupby(self, col_ids):

--- a/weave/panels_py/panel_openai_monitor.py
+++ b/weave/panels_py/panel_openai_monitor.py
@@ -321,10 +321,11 @@ def board(
     requests_table = panels.Table(filtered_window_data)  # type: ignore
     requests_table.add_column(lambda row: row["output.model"], "Model")
     requests_table.add_column(
-        lambda row: row["inputs.messages"][-1]["content"], "Message"
+        lambda row: row["inputs.messages"][-1]["content"], "inputs.messages[-1].content"
     )
     requests_table.add_column(
-        lambda row: row["output.choices"][-1]["message.content"], "Completion"
+        lambda row: row["output.choices"][-1]["message.content"],
+        "output.choices[-1].message.content",
     )
     requests_table.add_column(lambda row: row["summary.prompt_tokens"], "Prompt Tokens")
     requests_table.add_column(
@@ -332,7 +333,9 @@ def board(
     )
     requests_table.add_column(lambda row: row["summary.total_tokens"], "Total Tokens")
     requests_table.add_column(lambda row: row["summary.latency_s"], "Latency")
-    requests_table.add_column(lambda row: row["timestamp"], "Timestamp")
+    requests_table.add_column(
+        lambda row: row["timestamp"], "Timestamp", sort_dir="desc"
+    )
 
     requests_table_var = overview_tab.add(
         "table",


### PR DESCRIPTION
- Add the ability to specify sorting when add a table column
LLM board
- Sorts the table by timestamp (most recent first)
- Changes a couple column names to make it more clear that we've captured all of the data but are only showing the last input and output messages.