### PR TITLE
chore: include browse in printed URL

### DIFF
--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -183,7 +183,7 @@ class _StreamTableSync:
             self._artifact.set_file_pusher(self._lite_run.pusher)
         if print_url:
             base_url = environment.weave_server_url()
-            url = f"{base_url}/wandb/{self._entity_name}/{self._project_name}/table/{self._table_name}"
+            url = f"{base_url}/browse/wandb/{self._entity_name}/{self._project_name}/table/{self._table_name}"
             printer = get_printer(_get_python_type() != "python")
             printer.display(f'{printer.emoji("star")} View data at {printer.link(url)}')
         return self._weave_stream_table


### PR DESCRIPTION
Printed link should have browse after changing URL structure in https://github.com/wandb/weave/pull/353