### PR TITLE
fix(ui): Fix overflow-vertical icon fill

### DIFF
--- a/weave-js/src/assets/icons/icon-overflow-vertical.svg
+++ b/weave-js/src/assets/icons/icon-overflow-vertical.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-<circle cx="12" cy="5" r="1.5" fill="#373A3D"/>
-<circle cx="12" cy="12" r="1.5" fill="#373A3D"/>
-<circle cx="12" cy="19" r="1.5" fill="#373A3D"/>
+<circle cx="12" cy="5" r="1.5" />
+<circle cx="12" cy="12" r="1.5" />
+<circle cx="12" cy="19" r="1.5" />
 </svg>


### PR DESCRIPTION
the fill of each individual dot in `icon-overflow-vertical` was hard-coded instead of using `currentColor`