### PR TITLE
fix: use last child for positioning EE popup instead of first

### DIFF
--- a/weave-js/src/panel/WeaveExpression/hooks.ts
+++ b/weave-js/src/panel/WeaveExpression/hooks.ts
@@ -451,8 +451,9 @@ export const useSuggestionVisualState = ({
     trace(`SuggestionVisualState: showing`);
     element.style.opacity = '1';
 
-    const editorRootEl = ReactEditor.toDOMNode(editor, editor.children[0]);
-    computePosition(editorRootEl, element, {
+    const lastChild = editor.children[editor.children.length - 1];
+    const lastChildNode = ReactEditor.toDOMNode(editor, lastChild);
+    computePosition(lastChildNode, element, {
       placement: 'bottom-start',
       middleware: [
         offset(4),


### PR DESCRIPTION
When you have entered newlines in the expression editor (shift+return, not wrapped lines) the popup was not getting positioned properly.

Before: 
<img width="377" alt="Screenshot 2023-08-23 at 11 21 28 AM" src="https://github.com/wandb/weave/assets/112953339/ca762e76-4582-4a95-87e8-598fc6d6a247">

After:
<img width="365" alt="Screenshot 2023-08-23 at 11 21 41 AM" src="https://github.com/wandb/weave/assets/112953339/dfb56479-e1c7-466f-ac74-4a09291df417">
