### PR TITLE
fix: hide panel editor bar rather than omitting it on mouseleave

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -541,7 +541,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     [frame]
   );
 
-  const [hoverPanel, setHoverPanel] = useState(false);
+  const [isHoverPanel, setIsHoverPanel] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const [expressionFocused, setExpressionFocused] = useState(false);
@@ -571,8 +571,8 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
   ) : (
     <Styles.Main
       data-weavepath={props.pathEl ?? 'root'}
-      onMouseEnter={() => setHoverPanel(true)}
-      onMouseLeave={() => setHoverPanel(false)}>
+      onMouseEnter={() => setIsHoverPanel(true)}
+      onMouseLeave={() => setIsHoverPanel(false)}>
       {props.controlBar === 'titleBar' && (
         <div
           style={{
@@ -590,92 +590,84 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       {props.controlBar === 'editable' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
-            {!hoverPanel ? (
-              props.pathEl != null && (
-                <div
-                  style={{
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                    overflow: 'hidden',
-                  }}>
-                  {varNameToTitle(props.pathEl)}
-                </div>
-              )
-            ) : (
-              <>
-                {props.prefixHeader}
-                {props.pathEl != null && (
-                  <EditorPath>
-                    <ValidatingTextInput
-                      dataTest="panel-expression-path"
-                      onCommit={props.updateName ?? (() => {})}
-                      validateInput={validateName}
-                      initialValue={props.pathEl}
-                      maxWidth={
-                        editorBarWidth != null ? editorBarWidth / 3 : undefined
-                      }
-                      maxLength={24}
-                    />{' '}
-                    {props.controlBar === 'editable' && '= '}
-                  </EditorPath>
-                )}
-                {props.controlBar === 'editable' &&
-                  curPanelId !== 'Expression' &&
-                  curPanelId !== 'RootBrowser' && (
-                    <PanelNameEditor
-                      value={curPanelId ?? ''}
-                      autocompleteOptions={panelOptions}
-                      setValue={handlePanelChange}
-                    />
-                  )}
-                {props.controlBar === 'editable' ? (
-                  <EditorExpression data-test="panel-expression-expression">
-                    <WeaveExpression
-                      expr={panelInputExpr}
-                      setExpression={updateExpression}
-                      noBox
-                      truncate={!expressionFocused}
-                      onFocus={onFocusExpression}
-                      onBlur={onBlurExpression}
-                    />
-                  </EditorExpression>
-                ) : (
-                  <div style={{width: '100%'}} />
-                )}
-                <EditorIcons visible={hoverPanel || isMenuOpen}>
-                  {props.prefixButtons}
-                  <Tooltip
-                    position="top center"
-                    trigger={
-                      <Button
-                        variant="ghost"
-                        size="small"
-                        icon="pencil-edit"
-                        onClick={() => setInspectingPanel(props.pathEl ?? '')}
-                      />
-                    }>
-                    Open panel editor
-                  </Tooltip>
-                  <OutlineItemPopupMenu
-                    config={fullConfig}
-                    localConfig={getConfigForPath(fullConfig, fullPath)}
-                    path={fullPath}
-                    updateConfig={updateConfig}
-                    updateConfig2={updateConfig2}
-                    trigger={
-                      <Button
-                        variant="ghost"
-                        size="small"
-                        icon="overflow-horizontal"
-                      />
-                    }
-                    onOpen={() => setIsMenuOpen(true)}
-                    onClose={() => setIsMenuOpen(false)}
-                    isOpen={isMenuOpen}
-                  />
-                </EditorIcons>
-              </>
+            {!isHoverPanel && props.pathEl != null && (
+              <EditorBarTitleOnly>
+                {varNameToTitle(props.pathEl)}
+              </EditorBarTitleOnly>
             )}
+            <EditorBarHover isHovered={isHoverPanel}>
+              {props.prefixHeader}
+              {props.pathEl != null && (
+                <EditorPath>
+                  <ValidatingTextInput
+                    dataTest="panel-expression-path"
+                    onCommit={props.updateName ?? (() => {})}
+                    validateInput={validateName}
+                    initialValue={props.pathEl}
+                    maxWidth={
+                      editorBarWidth != null ? editorBarWidth / 3 : undefined
+                    }
+                    maxLength={24}
+                  />{' '}
+                  {props.controlBar === 'editable' && '= '}
+                </EditorPath>
+              )}
+              {props.controlBar === 'editable' &&
+                curPanelId !== 'Expression' &&
+                curPanelId !== 'RootBrowser' && (
+                  <PanelNameEditor
+                    value={curPanelId ?? ''}
+                    autocompleteOptions={panelOptions}
+                    setValue={handlePanelChange}
+                  />
+                )}
+              {props.controlBar === 'editable' ? (
+                <EditorExpression data-test="panel-expression-expression">
+                  <WeaveExpression
+                    expr={panelInputExpr}
+                    setExpression={updateExpression}
+                    noBox
+                    truncate={!expressionFocused}
+                    onFocus={onFocusExpression}
+                    onBlur={onBlurExpression}
+                  />
+                </EditorExpression>
+              ) : (
+                <div style={{width: '100%'}} />
+              )}
+              <EditorIcons visible={isHoverPanel || isMenuOpen}>
+                {props.prefixButtons}
+                <Tooltip
+                  position="top center"
+                  trigger={
+                    <Button
+                      variant="ghost"
+                      size="small"
+                      icon="pencil-edit"
+                      onClick={() => setInspectingPanel(props.pathEl ?? '')}
+                    />
+                  }>
+                  Open panel editor
+                </Tooltip>
+                <OutlineItemPopupMenu
+                  config={fullConfig}
+                  localConfig={getConfigForPath(fullConfig, fullPath)}
+                  path={fullPath}
+                  updateConfig={updateConfig}
+                  updateConfig2={updateConfig2}
+                  trigger={
+                    <Button
+                      variant="ghost"
+                      size="small"
+                      icon="overflow-horizontal"
+                    />
+                  }
+                  onOpen={() => setIsMenuOpen(true)}
+                  onClose={() => setIsMenuOpen(false)}
+                  isOpen={isMenuOpen}
+                />
+              </EditorIcons>
+            </EditorBarHover>
           </EditorBarContent>
         </Styles.EditorBar>
       )}
@@ -997,8 +989,6 @@ export const useChildPanelProps = (
 };
 
 const EditorBarContent = styled.div`
-  display: flex;
-  align-items: flex-start;
   width: calc(100% + 16px);
   flex-shrink: 0;
   position: relative;
@@ -1007,6 +997,21 @@ const EditorBarContent = styled.div`
   border-bottom: 1px solid ${GRAY_350};
   line-height: 20px;
 `;
+
+const EditorBarTitleOnly = styled.div`
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
+EditorBarTitleOnly.displayName = 'S.EditorBarTitleOnly';
+
+// If the mouse leaves the panel we want to keep these contents (e.g. unsubmitted
+// expression editor state) but just hide them.
+const EditorBarHover = styled.div<{isHovered: boolean}>`
+  display: ${props => (props.isHovered ? 'flex' : 'none')};
+  align-items: flex-start;
+`;
+EditorBarHover.displayName = 'S.EditorBarHover';
 
 const EditorPath = styled.div`
   white-space: nowrap;

--- a/weave-js/src/components/WeavePanelBank/PBSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PBSection.tsx
@@ -240,6 +240,7 @@ export const getSectionConfig = (
 const Sections = styled.div`
   ${SCROLLBAR_STYLES}
 `;
+Sections.displayName = 'S.Sections';
 
 const ActionBar = styled.div`
   height: 48px;
@@ -248,6 +249,7 @@ const ActionBar = styled.div`
   justify-content: flex-end;
   align-items: center;
 `;
+ActionBar.displayName = 'S.ActionBar';
 
 const AddPanelBar = styled.div`
   height: 48px;
@@ -260,6 +262,7 @@ const AddPanelBar = styled.div`
   font-weight: 600;
   color: ${GRAY_500};
 `;
+AddPanelBar.displayName = 'S.AddPanelBar';
 
 const AddPanelBarContainer = styled.div`
   padding: 8px 32px 16px;
@@ -269,12 +272,14 @@ const AddPanelBarContainer = styled.div`
     opacity: 0;
   }
 `;
+AddPanelBarContainer.displayName = 'S.AddPanelBarContainer';
 
 const IconAddNew = styled(IconAddNewUnstyled)<{$marginRight?: number}>`
   width: 18px;
   height: 18px;
   margin-right: ${p => p.$marginRight ?? 8}px;
 `;
+IconAddNew.displayName = 'S.IconAddNew';
 
 const EditablePanel = styled.div<{isFocused: boolean; isHovered: boolean}>`
   &&&&& {
@@ -299,3 +304,4 @@ const EditablePanel = styled.div<{isFocused: boolean; isHovered: boolean}>`
       `}
   }
 `;
+EditablePanel.displayName = 'S.EditablePanel';


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-15202

I recommend turning on "Hide whitespace" in the diff view.

A recent change toggles between a title-only view and an editor bar when you mouse enter/leave a panel. It was taking the editor bar out of the component tree entirely when not over the panel, which causes the expression editor to lose any unsubmitted state. This PR changes it to just `display: none` the contents instead.
