### PR TITLE
chore(dev): use wandbmachine github user to push to master

### DIFF
--- a/.github/workflows/upload-assets.yaml
+++ b/.github/workflows/upload-assets.yaml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          token: {{ secrets.WANDBMACHINE_GITHUB_TOKEN }}
           fetch-depth: 0
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
the default token cannot bypass branch protections so I need to use this specific user.