### PR TITLE
fix(weave): Enable pinning columns

### DIFF
--- a/weave/panels/panel_table.py
+++ b/weave/panels/panel_table.py
@@ -17,6 +17,7 @@ class TableConfig:
     tableState: table_state.TableState
     rowSize: int = dataclasses.field(default_factory=lambda: 1)
     pinnedRows: dict[str, list[int]] = dataclasses.field(default_factory=dict)
+    pinnedColumns: list[str] = dataclasses.field(default_factory=list)
     activeRowForGrouping: dict[str, int] = dataclasses.field(default_factory=dict)
 
 


### PR DESCRIPTION
pinnedColumns did not exist on the config, so pinned columns did not work

https://wandb.atlassian.net/browse/WB-15228
https://wandb.atlassian.net/browse/WB-15043

before

https://github.com/wandb/weave/assets/25037002/1c8d50d4-9ef2-4a8e-82e3-796ab1c55db1

after

https://github.com/wandb/weave/assets/25037002/7d24ca42-a3c6-4694-900d-2dce2af599c0

