### PR TITLE
chore: use destructive variant for board deletion button

### DIFF
--- a/weave-js/src/components/PagePanelComponents/DeleteActionModal.tsx
+++ b/weave-js/src/components/PagePanelComponents/DeleteActionModal.tsx
@@ -25,16 +25,22 @@ export const DeleteActionModal = ({
       closeOnDimmerClick={false}
       size="small">
       <Modal.Content>
-        <M.Title>{`Are you sure you want to delete this ${deleteTypeString}?`}</M.Title>
+        <M.Title>
+          Are you sure you want to delete this {deleteTypeString}?
+        </M.Title>
         <M.Description>
-          {`Warning - this is a permanent action - it will break any links
-          referencing this ${deleteTypeString}.`}
+          Warning - this is a permanent action - it will break any links
+          referencing this {deleteTypeString}.
         </M.Description>
         <M.Buttons>
-          <Button disabled={acting} onClick={onDelete}>
+          <Button
+            variant="destructive"
+            size="large"
+            disabled={acting}
+            onClick={onDelete}>
             {`Delete ${deleteTypeString}`}
           </Button>
-          <Button variant="ghost" onClick={onClose}>
+          <Button variant="ghost" size="large" onClick={onClose}>
             Cancel
           </Button>
         </M.Buttons>


### PR DESCRIPTION
Button size large to align with design spec.

Before:
<img width="738" alt="Screenshot 2023-08-25 at 11 39 00 AM" src="https://github.com/wandb/weave/assets/112953339/474a32f9-21bf-4341-8948-69619af55878">

After:
<img width="750" alt="Screenshot 2023-08-25 at 11 38 45 AM" src="https://github.com/wandb/weave/assets/112953339/bfe136f5-f66c-465e-bbb3-a09cc98cee5b">
