### PR TITLE
chore: replace pre-commit hooks with pre-push hooks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-container:
     name: Build test container
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: [self-hosted, builder]
     # runs-on: ubuntu-latest
     env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 default_install_hook_types: [pre-push]
+default_stages: [pre-push]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,5 @@ repos:
       - id: jupyter-nb-clear-output
         name: jupyter-nb-clear-output
         files: ^examples/.*\.ipynb$
-        stages: [commit]
         language: system
         entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,4 @@
 default_install_hook_types: [pre-push]
-default_stages: [push]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_install_hook_types: [pre-push]
+default_stages: [push]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.275

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-default_install_hook_types: [pre-push]
 default_stages: [pre-push]
 
 repos:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 types-requests>=2.28.11.8
 types-setuptools>=65.7.0.3
-pre-commit>=3.0.2
+pre-commit>=3.3.3
 black==22.3.0
 types-aiofiles>=22.1.0.6
 types-all>=1.0.0


### PR DESCRIPTION
Updates our pre-commit hooks to run before pushing to github instead of on commit, following a discussion from office hours on Wednesday. 