### PR TITLE
chore: update error boundary and display

### DIFF
--- a/weave-js/src/components/ErrorBoundary.tsx
+++ b/weave-js/src/components/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import React, {Component, ErrorInfo, ReactNode} from 'react';
+import {ErrorPanel} from './ErrorPanel';
+
+type Props = {
+  children?: ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+  };
+
+  public static getDerivedStateFromError(_: Error): State {
+    return {hasError: true};
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // TODO: Log to error reporting service?
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return <ErrorPanel />;
+    }
+
+    return this.props.children;
+  }
+}

--- a/weave-js/src/components/ErrorPanel.tsx
+++ b/weave-js/src/components/ErrorPanel.tsx
@@ -1,0 +1,134 @@
+import React, {forwardRef, useEffect, useRef, useState} from 'react';
+import styled from 'styled-components';
+import {MOON_300, MOON_600, hexToRGB} from '../common/css/globals.styles';
+import {Tooltip} from './Tooltip';
+import {Icon} from './Icon';
+
+const DEFAULT_TITLE = 'Something went wrong.';
+const DEFAULT_SUBTITLE = 'Please check the panel configuration for errors.';
+const DEFAULT_SUBTITLE2 = 'Thank you for your patience while Weave is in beta.';
+
+type ErrorPanelProps = {
+  title?: string;
+  subtitle?: string;
+  subtitle2?: string;
+};
+
+export const Centered = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+Centered.displayName = 'S.Centered';
+
+export const Circle = styled.div<{$size: number; $hoverHighlight: boolean}>`
+  border-radius: 50%;
+  width: ${props => props.$size}px;
+  height: ${props => props.$size}px;
+  background-color: ${hexToRGB(MOON_300, 0.48)};
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &:hover {
+    background-color: ${props =>
+      props.$hoverHighlight ? hexToRGB(MOON_300, 0.64) : undefined};
+  }
+`;
+Circle.displayName = 'Circle';
+
+export const Large = styled.div`
+  width: fit-content;
+  text-align: center;
+  margin: 0 auto;
+`;
+Large.displayName = 'Large';
+
+export const Title = styled.div`
+  color: ${MOON_600};
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 140%;
+  margin: 16px 0 8px 0;
+`;
+Title.displayName = 'Title';
+
+export const Subtitle = styled.div`
+  color: ${MOON_600};
+  font-size: 15px;
+`;
+Subtitle.displayName = 'Subtitle';
+
+export const ErrorPanelSmall = ({
+  title,
+  subtitle,
+  subtitle2,
+}: ErrorPanelProps) => {
+  const titleStr = title ?? DEFAULT_TITLE;
+  const subtitleStr = subtitle ?? DEFAULT_SUBTITLE;
+  const subtitle2Str = subtitle2 ?? DEFAULT_SUBTITLE2;
+  return (
+    <Tooltip
+      position="top center"
+      trigger={
+        <Circle $size={22} $hoverHighlight={true}>
+          <Icon name="warning-alt" width={16} height={16} />
+        </Circle>
+      }>
+      <b>{titleStr}</b> {subtitleStr} {subtitle2Str}
+    </Tooltip>
+  );
+};
+
+export const ErrorPanelLarge = forwardRef<HTMLDivElement, ErrorPanelProps>(
+  ({title, subtitle, subtitle2}, ref) => {
+    const titleStr = title ?? DEFAULT_TITLE;
+    const subtitleStr = subtitle ?? DEFAULT_SUBTITLE;
+    const subtitle2Str = subtitle2 ?? DEFAULT_SUBTITLE2;
+    return (
+      <Large ref={ref}>
+        <Circle $size={40} $hoverHighlight={false}>
+          <Icon name="warning-alt" width={24} height={24} />
+        </Circle>
+        <Title>{titleStr}</Title>
+        <Subtitle>{subtitleStr}</Subtitle>
+        <Subtitle>{subtitle2Str}</Subtitle>
+      </Large>
+    );
+  }
+);
+
+export const ErrorPanel = (props: ErrorPanelProps) => {
+  const thisRef = useRef<HTMLDivElement | null>(null);
+  const largeRef = useRef<HTMLDivElement | null>(null);
+  const [mode, setMode] = useState('measure');
+
+  useEffect(() => {
+    const thisW = thisRef.current?.clientWidth ?? 0;
+    const thisH = thisRef.current?.clientHeight ?? 0;
+    const largeW = largeRef.current?.clientWidth ?? 0;
+    const largeH = largeRef.current?.clientHeight ?? 0;
+    const largeFits = thisW >= largeW && thisH >= largeH;
+    setMode(largeFits ? 'large' : 'small');
+  }, []);
+
+  return (
+    <div ref={thisRef} style={{height: '100%'}}>
+      {mode === 'large' ? (
+        <Centered>
+          <ErrorPanelLarge {...props} ref={largeRef} />
+        </Centered>
+      ) : mode === 'small' ? (
+        <Centered>
+          <ErrorPanelSmall {...props} />
+        </Centered>
+      ) : (
+        <div style={{visibility: 'hidden'}}>
+          <ErrorPanelLarge {...props} ref={largeRef} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/weave-js/src/components/Panel2/PanelComp.tsx
+++ b/weave-js/src/components/Panel2/PanelComp.tsx
@@ -27,8 +27,8 @@ import {usePanelContext} from './PanelContext';
 import {PanelExportUpdaterContext} from './PanelExportContext';
 import * as PanelLib from './panellib/libpanel';
 import * as TSTypeWithPath from './tsTypeWithPath';
-import {WeaveMessage} from './WeaveMessage';
 import {HOVER_DELAY_MS} from './Tooltip';
+import {ErrorPanel} from '../ErrorPanel';
 
 class PanelCompErrorBoundary extends React.Component<
   {
@@ -79,12 +79,7 @@ class PanelCompErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      return (
-        <WeaveMessage>
-          {this.state.customMessage ||
-            'Something went wrong. Check the javascript console.'}
-        </WeaveMessage>
-      );
+      return <ErrorPanel title={this.state.customMessage} />;
     }
 
     return this.props.children;

--- a/weave-js/src/components/Panel2/WeaveMessage.tsx
+++ b/weave-js/src/components/Panel2/WeaveMessage.tsx
@@ -13,6 +13,7 @@ const WeaveMessageWrapper = styled.div`
   align-content: space-around;
   justify-content: space-around;
 `;
+WeaveMessageWrapper.displayName = 'S.WeaveMessageWrapper';
 
 const WeaveMessageBody = styled.div`
   background: ${globals.errorBackground};
@@ -22,6 +23,7 @@ const WeaveMessageBody = styled.div`
     margin-bottom: 8px;
   }
 `;
+WeaveMessageBody.displayName = 'S.WeaveMessageBody';
 
 export const WeaveMessage: React.FC = ({children}) => {
   return (


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-14135

The current error indicator doesn't adapt to its available space, which can lead to the message appearing cropped or other visual problems. This PR adds an ErrorPanel that determines whether it has space to display a full size message, and if not, instead shows just an icon with a tooltip.

Before:

<img width="564" alt="Screenshot 2023-08-25 at 9 38 48 PM" src="https://github.com/wandb/weave/assets/112953339/da28aae9-d4ee-4847-904c-756386f266a1">
<img width="175" alt="Screenshot 2023-08-25 at 9 39 11 PM" src="https://github.com/wandb/weave/assets/112953339/ff499e22-55b3-46cb-bd5b-0500af50c303">
<img width="400" alt="Screenshot 2023-08-25 at 9 39 03 PM" src="https://github.com/wandb/weave/assets/112953339/5f81811e-b43a-470d-8a6a-95f6f1a21027">

After:

<img width="406" alt="Screenshot 2023-08-25 at 9 40 25 PM" src="https://github.com/wandb/weave/assets/112953339/68644582-bd41-4775-913d-14678e4453ec">
<img width="167" alt="Screenshot 2023-08-25 at 9 40 06 PM" src="https://github.com/wandb/weave/assets/112953339/91bb7798-8528-4cea-b864-ebf69a9c08d9">
<img width="228" alt="Screenshot 2023-08-25 at 9 40 13 PM" src="https://github.com/wandb/weave/assets/112953339/c97dc1eb-a604-421c-8f4a-3ab7c4fb7e5a">
<img width="343" alt="Screenshot 2023-08-25 at 9 39 58 PM" src="https://github.com/wandb/weave/assets/112953339/0399fcbe-4a47-4422-ab78-a47c6cd2dc16">
