### PR TITLE
fix: add ttlDurationSeconds to schema

### DIFF
--- a/weave/ops_domain/wb_schema.gql
+++ b/weave/ops_domain/wb_schema.gql
@@ -513,6 +513,7 @@ type Artifact {
   ): RunConnection!
   currentManifest: ArtifactManifest
   historyStep: Int64
+  ttlDurationSeconds: Int64!
 }
 
 type ArtifactManifestConnection {


### PR DESCRIPTION
Fixes internal sentry issue https://weights-biases.sentry.io/issues/4431714471/?referrer=slack&alert_rule_id=12726589&alert_type=issue