### PR TITLE
perf: Dedupe rendundant ops after expansion.

### DIFF
--- a/weave/execute_fast.py
+++ b/weave/execute_fast.py
@@ -79,7 +79,8 @@ def _resolve_static_branches(map_fn):
         if all(isinstance(v, graph.ConstNode) for v in inputs.values()):
             call_node = graph.OutputNode(map_fn.type, map_fn.from_op.name, inputs)
 
-            with compile._compiling():
+            # Don't compile here, we've already compiled.
+            with compile.disable_compile():
                 res = weave_internal.use(call_node)
             result_store[map_fn] = res
             return graph.ConstNode(map_fn.type, res)

--- a/weave/execute_fast.py
+++ b/weave/execute_fast.py
@@ -78,7 +78,9 @@ def _resolve_static_branches(map_fn):
 
         if all(isinstance(v, graph.ConstNode) for v in inputs.values()):
             call_node = graph.OutputNode(map_fn.type, map_fn.from_op.name, inputs)
-            res = weave_internal.use(call_node)
+
+            with compile._compiling():
+                res = weave_internal.use(call_node)
             result_store[map_fn] = res
             return graph.ConstNode(map_fn.type, res)
         return graph.OutputNode(map_fn.type, map_fn.from_op.name, inputs)

--- a/weave/graph.py
+++ b/weave/graph.py
@@ -465,17 +465,15 @@ def is_open(node: Node) -> bool:
     return len(filter_nodes_top_level([node], lambda n: isinstance(n, VarNode))) > 0
 
 
-def _all_nodes(node: Node) -> set[Node]:
-    if not isinstance(node, OutputNode):
-        return set((node,))
-    res: set[Node] = set((node,))
-    for input in node.from_op.inputs.values():
-        res.update(_all_nodes(input))
-    return res
-
-
 def count(node: Node) -> int:
-    return len(_all_nodes(node))
+    counter = 0
+
+    def inc(n: Node) -> None:
+        nonlocal counter
+        counter += 1
+
+    map_nodes_full([node], inc)
+    return counter
 
 
 def _linearize(node: OutputNode) -> list[OutputNode]:

--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -609,7 +609,7 @@ def _call_and_ensure_awl(
 ) -> ArrowWeaveList:
     from .. import compile
 
-    with compile._compiling():
+    with compile.disable_compile():
         res = use(called)
     # Since it is possible that the result of `use` bails out of arrow due to a
     # mismatch in the types / op support. This is most likely due to gap in the

--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -607,7 +607,10 @@ def vectorize(
 def _call_and_ensure_awl(
     awl: ArrowWeaveList, called: graph.OutputNode
 ) -> ArrowWeaveList:
-    res = use(called)
+    from .. import compile
+
+    with compile._compiling():
+        res = use(called)
     # Since it is possible that the result of `use` bails out of arrow due to a
     # mismatch in the types / op support. This is most likely due to gap in the
     # implementation of vectorized ops. However, there are cases where it is
@@ -674,6 +677,9 @@ def _ensure_variadic_fn(
 
 
 def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
+    import time
+
+    start_time = time.time()
     logging.info("Vectorizing: %s", fn)
     from .. import execute_fast
 
@@ -684,5 +690,9 @@ def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
     vecced = vectorize(_ensure_variadic_fn(fn, awl.object_type))
     logging.info("Vectorizing. Vectorized: %s", vecced)
     called = _call_vectorized_fn_node_maybe_awl(awl, vecced)
+    vec_time = time.time()
     # print("CALLED ", called)
-    return _call_and_ensure_awl(awl, called)
+    res = _call_and_ensure_awl(awl, called)
+    res_time = time.time()
+    print("VEC TIMES", vec_time - start_time, res_time - vec_time)
+    return res

--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -677,9 +677,6 @@ def _ensure_variadic_fn(
 
 
 def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
-    import time
-
-    start_time = time.time()
     logging.info("Vectorizing: %s", fn)
     from .. import execute_fast
 
@@ -690,9 +687,4 @@ def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
     vecced = vectorize(_ensure_variadic_fn(fn, awl.object_type))
     logging.info("Vectorizing. Vectorized: %s", vecced)
     called = _call_vectorized_fn_node_maybe_awl(awl, vecced)
-    vec_time = time.time()
-    # print("CALLED ", called)
-    res = _call_and_ensure_awl(awl, called)
-    res_time = time.time()
-    print("VEC TIMES", vec_time - start_time, res_time - vec_time)
-    return res
+    return _call_and_ensure_awl(awl, called)

--- a/weave/ops_domain/run_history/history_op_common.py
+++ b/weave/ops_domain/run_history/history_op_common.py
@@ -371,7 +371,7 @@ def process_history_awl_tables(tables: list[ArrowWeaveList]):
 
 def concat_awls(awls: list[ArrowWeaveList]):
     list = make_list(**{str(i): table for i, table in enumerate(awls)})
-    with compile._compiling():
+    with compile.disable_compile():
         return use(concat(list))
 
 

--- a/weave/ops_domain/run_history/history_op_common.py
+++ b/weave/ops_domain/run_history/history_op_common.py
@@ -371,7 +371,8 @@ def process_history_awl_tables(tables: list[ArrowWeaveList]):
 
 def concat_awls(awls: list[ArrowWeaveList]):
     list = make_list(**{str(i): table for i, table in enumerate(awls)})
-    return use(concat(list))
+    with compile._compiling():
+        return use(concat(list))
 
 
 def awl_to_pa_table(awl: ArrowWeaveList):

--- a/weave/ops_primitives/type.py
+++ b/weave/ops_primitives/type.py
@@ -20,7 +20,7 @@ def _cast_output_type(input_type):
 # This is not yet supported in js. The right argument needs to be Const,
 # but we don't have a way to construct const objects in js yet.
 @op(
-    input_type={"to_type": types.Const(types.Type(), types.NoneType())},
+    input_type={"to_type": types.Const(types.Type(), None)},
     output_type=_cast_output_type,
 )
 def cast(obj: typing.Any, to_type):

--- a/weave/serialize.py
+++ b/weave/serialize.py
@@ -94,8 +94,7 @@ def _is_lambda(node: graph.Node):
 
 @memo.memo
 def node_id(node: graph.Node):
-    # hashable = {"type": node.type.to_dict()}
-    hashable = {}
+    hashable: dict[str, typing.Any] = {}
     if isinstance(node, graph.OutputNode):
         hashable["op_name"] = node.from_op.name
         hashable["inputs"] = {
@@ -103,6 +102,8 @@ def node_id(node: graph.Node):
             for arg_name, arg_node in node.from_op.inputs.items()
         }
     elif isinstance(node, graph.VarNode):
+        # Must include type here, Const and OutputNode types can
+        # be inferred from the graph, but VarNode types cannot.
         hashable["type"] = node.type.to_dict()
         hashable["name"] = node.name
     elif isinstance(node, graph.ConstNode):

--- a/weave/serialize.py
+++ b/weave/serialize.py
@@ -94,24 +94,22 @@ def _is_lambda(node: graph.Node):
 
 @memo.memo
 def node_id(node: graph.Node):
-    hashable = {"type": node.type.to_dict()}
+    # hashable = {"type": node.type.to_dict()}
+    hashable = {}
     if isinstance(node, graph.OutputNode):
         hashable["op_name"] = node.from_op.name
         hashable["inputs"] = {
             arg_name: node_id(arg_node)
-            if not _is_lambda(arg_node)
-            else json.dumps(arg_node.to_json())
             for arg_name, arg_node in node.from_op.inputs.items()
         }
     elif isinstance(node, graph.VarNode):
-        # Ensure we don't share var nodes. That's invalid!
-        hashable["name"] = str(random.random())
+        hashable["type"] = node.type.to_dict()
+        hashable["name"] = node.name
     elif isinstance(node, graph.ConstNode):
         if isinstance(node.val, graph.OutputNode) or isinstance(
             node.val, graph.VarNode
         ):
-            # Ensure we don't share function nodes. That's invalid!
-            hashable["val"] = str(random.random())
+            hashable["val"] = {"lambda": True, "body": node_id(node.val)}
         else:
             hashable["val"] = storage.to_python(node.val)
     else:

--- a/weave/tests/test_arrow.py
+++ b/weave/tests/test_arrow.py
@@ -1054,7 +1054,12 @@ def test_arrow_concat_degenerate_types():
 @pytest.mark.parametrize("li", lath.ListInterfaces)
 def test_arrow_timestamp_conversion(li):
     dates = [
-        datetime.datetime(2020, 1, 2, 3, 4, 5),
+        # Ensure these two are actually different date times! The timezone is utc in
+        # our ci environment, so serializing these results in the same thing if the
+        # timestamps match. We use the serialized representation for graph deduplication,
+        # meaning we end up with the same node for both of these, which breaks the test
+        # (but not the actual behavior of the code).
+        datetime.datetime(2020, 1, 2, 3, 4, 6),
         datetime.datetime(2020, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc),
     ]
     utc_dates = [d.astimezone(datetime.timezone.utc) for d in dates]

--- a/weave/tests/test_compile.py
+++ b/weave/tests/test_compile.py
@@ -164,17 +164,6 @@ def test_optimize_merge_empty_dict():
     )
 
 
-def count_nodes(node: graph.Node) -> int:
-    counter = 0
-
-    def inc(n: graph.Node):
-        nonlocal counter
-        counter += 1
-
-    weave.graph.map_nodes_full([node], inc)
-    return counter
-
-
 def test_compile_lambda_uniqueness():
     list_node_1 = weave.ops.make_list(a=make_const_node(weave.types.Number(), 1))
     list_node_2 = weave.ops.make_list(a=make_const_node(weave.types.Number(), 2))
@@ -190,13 +179,15 @@ def test_compile_lambda_uniqueness():
     # combined node contains 1 node, x1 = 1
     # concat node contains 1 node, x1 = 1
     # total = 12
-    assert count_nodes(concatted) == 12
+    assert graph.count(concatted) == 12
 
     # However, after lambda compilation, we should get
-    # 3 more nodes (new row, add, and fn), creating
-    # a total of 15 nodes
+    # 3 more nodes (new row, add, and fn), but lose one
+    # because we dedupe the const "1", for a total of
+    # 14 nodes
     compiled = compile.compile([concatted])[0]
-    assert count_nodes(compiled) == 15
+
+    assert graph.count(compiled) == 14
 
 
 # We actually don't want this to work because it would require

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -140,8 +140,7 @@ def list_ops():
     with wandb_api.from_environment():
         # TODO: this is super slow.
         if not environment.wandb_production():
-            pass
-            # registry_mem.memory_registry.load_saved_ops()
+            registry_mem.memory_registry.load_saved_ops()
         if (
             ops_cache is None
             or ops_cache["updated_at"] < registry_mem.memory_registry.updated_at()

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -140,7 +140,8 @@ def list_ops():
     with wandb_api.from_environment():
         # TODO: this is super slow.
         if not environment.wandb_production():
-            registry_mem.memory_registry.load_saved_ops()
+            pass
+            # registry_mem.memory_registry.load_saved_ops()
         if (
             ops_cache is None
             or ops_cache["updated_at"] < registry_mem.memory_registry.updated_at()


### PR DESCRIPTION
This also improves node_id performance by a lot, which is used in deserialize, by not calculating hashes of types on all nodes which can be quite large. So deserialize performance improves a lot here too.

The node_ops compile pass expands nodes, potentially producing a bunch more ops, that can be duplicates of others that we already have in the graph. This was causing a lot of extra execution on the LLM monitoring board. On the dev board using 100 as the argument to random_predictions, this takes the execution time of the largest query from 2.3s to 1.3s.