### PR TITLE
perf: Don't keep tags on StreamTable

### DIFF
--- a/weave/language_features/tagging/opdef_util.py
+++ b/weave/language_features/tagging/opdef_util.py
@@ -35,6 +35,7 @@ def should_flow_tags(op_def: "OpDef.OpDef") -> bool:
         not op_def_consumes_tags(op_def)
         and len(named_args) > 0
         and not isinstance(named_args[0].type, types.Function)
+        and not op_def.name.endswith("dropTags")
     )
 
 

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -966,3 +966,21 @@ def flatten(arr):
         flatten_return_object_type(arr.object_type),
         arr._artifact,
     )
+
+
+def _drop_tags_output_type(input_type):
+    from ..op_def import map_type
+
+    return map_type(
+        input_type["arr"],
+        lambda t: isinstance(t, tagged_value_type.TaggedValueType) and t.value or t,
+    )
+
+
+@op(
+    name="ArrowWeaveList-dropTags",
+    input_type={"arr": ArrowWeaveListType()},
+    output_type=_drop_tags_output_type,
+)
+def drop_tags(arr):
+    return arr.without_tags()

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -981,6 +981,7 @@ def _drop_tags_output_type(input_type):
     name="ArrowWeaveList-dropTags",
     input_type={"arr": ArrowWeaveListType()},
     output_type=_drop_tags_output_type,
+    hidden=True,
 )
 def drop_tags(arr):
     return arr.without_tags()

--- a/weave/ops_domain/stream_table_ops.py
+++ b/weave/ops_domain/stream_table_ops.py
@@ -13,6 +13,7 @@ def _get_history_node(stream_table: StreamTableType):
             project(stream_table.entity_name, stream_table.project_name)
             .run(stream_table.table_name)
             .history3()
+            .dropTags()
         )
 
 


### PR DESCRIPTION
There are too many perf problems with Tags currently (we tag the output of history with Run, which includes the entire gql result, which includes the liveSet, which causes perf problems on downstream arrow nodes)