### PR TITLE
fix: variables to determine which warning to show are swapped in artifact file viewer

### DIFF
--- a/weave-js/src/components/Panel2/PanelFileText/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelFileText/Component.tsx
@@ -48,8 +48,8 @@ const PanelFileTextRenderInner: React.FC<PanelFileTextProps> = props => {
     return <div></div>;
   }
 
-  const truncatedTotalLines = processedResults?.truncatedLineLength;
-  const truncatedLineLength = processedResults?.truncatedTotalLines;
+  const truncatedTotalLines = processedResults?.truncatedTotalLines;
+  const truncatedLineLength = processedResults?.truncatedLineLength;
   const text = processedResults?.text;
   const language = languageFromFileName(fileExtension);
 


### PR DESCRIPTION
Internal Slack thread: https://weightsandbiases.slack.com/archives/C04MNBGJDBN/p1693319020965789?thread_ts=1693265406.551939&cid=C04MNBGJDBN