### PR TITLE
fix: unwrap tagged type to get artifact file extension

### DIFF
--- a/weave-js/src/components/Panel2/PanelFileText/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelFileText/Component.tsx
@@ -1,4 +1,5 @@
 import * as Op from '@wandb/weave/core';
+import {isFile, taggableValue} from '@wandb/weave/core';
 import numeral from 'numeral';
 import Prism from 'prismjs';
 import React, {useEffect, useMemo, useRef} from 'react';
@@ -23,9 +24,9 @@ const PanelFileTextRenderInner: React.FC<PanelFileTextProps> = props => {
   });
 
   const fileNode = props.input;
-  const unwrappedType = Op.taggableValue(fileNode.type);
+  const unwrappedType = taggableValue(fileNode.type);
   const fileExtension =
-    Op.isFile(unwrappedType) && unwrappedType.extension
+    isFile(unwrappedType) && unwrappedType.extension
       ? unwrappedType.extension
       : '';
 

--- a/weave-js/src/components/Panel2/PanelFileText/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelFileText/Component.tsx
@@ -23,7 +23,11 @@ const PanelFileTextRenderInner: React.FC<PanelFileTextProps> = props => {
   });
 
   const fileNode = props.input;
-  const fileExtension = fileNode.type.extension;
+  const unwrappedType = Op.taggableValue(fileNode.type);
+  const fileExtension =
+    Op.isFile(unwrappedType) && unwrappedType.extension
+      ? unwrappedType.extension
+      : '';
 
   const contentsNode = useMemo(
     () => Op.opFileContents({file: props.input}),


### PR DESCRIPTION
Fixes file extension extraction, which in turn makes syntax highlighting and JSON re-indentation etc. work.

Before:
<img width="1384" alt="Screenshot 2023-08-29 at 10 33 24 AM" src="https://github.com/wandb/weave/assets/112953339/cb756860-ba68-4151-be48-f6825642c598">

After:
<img width="1377" alt="Screenshot 2023-08-29 at 10 32 16 AM" src="https://github.com/wandb/weave/assets/112953339/25695685-4550-438d-bc81-6f0808439b19">
