### PR TITLE
chore: styling tweaks from design

### DIFF
--- a/weave-js/src/common/css/SemanticOverride.less
+++ b/weave-js/src/common/css/SemanticOverride.less
@@ -7,4 +7,9 @@
 }
 .ui.modal {
   box-shadow: 0px 24px 48px 0px rgba(24, 27, 31, 0.16);
+  border-radius: 8px;
+}
+
+.ui.modal > :first-child:not(.icon) {
+  border-radius: 8px;
 }

--- a/weave-js/src/components/ErrorPanel.tsx
+++ b/weave-js/src/components/ErrorPanel.tsx
@@ -58,6 +58,7 @@ Title.displayName = 'Title';
 export const Subtitle = styled.div`
   color: ${MOON_600};
   font-size: 15px;
+  line-height: 140%;
 `;
 Subtitle.displayName = 'Subtitle';
 
@@ -74,7 +75,7 @@ export const ErrorPanelSmall = ({
       position="top center"
       trigger={
         <Circle $size={22} $hoverHighlight={true}>
-          <Icon name="warning-alt" width={16} height={16} />
+          <Icon name="warning" width={16} height={16} />
         </Circle>
       }>
       <b>{titleStr}</b> {subtitleStr} {subtitle2Str}
@@ -90,7 +91,7 @@ export const ErrorPanelLarge = forwardRef<HTMLDivElement, ErrorPanelProps>(
     return (
       <Large ref={ref}>
         <Circle $size={40} $hoverHighlight={false}>
-          <Icon name="warning-alt" width={24} height={24} />
+          <Icon name="warning" width={24} height={24} />
         </Circle>
         <Title>{titleStr}</Title>
         <Subtitle>{subtitleStr}</Subtitle>


### PR DESCRIPTION
* Corners more rounded in modals
* Use circular instead of triangular warning icon
* Tighten error panel subtitle line height

<img width="680" alt="Screenshot 2023-08-29 at 1 23 21 PM" src="https://github.com/wandb/weave/assets/112953339/2bbb0f0a-a4b2-4b38-b581-f74324a199e5">
<img width="738" alt="Screenshot 2023-08-29 at 1 22 49 PM" src="https://github.com/wandb/weave/assets/112953339/1bf7bf3d-9d0d-421e-b51c-ebe0fc8c4376">
