### PR TITLE
chore: UI updates

### DIFF
--- a/weave-js/src/components/PagePanel.tsx
+++ b/weave-js/src/components/PagePanel.tsx
@@ -514,17 +514,6 @@ export const PageContent: FC<PageContentProps> = props => {
         }}>
         <ChildPanel
           controlBar={!isPanel && !props.previewMode ? 'editable' : 'off'}
-          prefixHeader={
-            inJupyter ? (
-              <Icon
-                style={{cursor: 'pointer', color: '#555'}}
-                name="home"
-                onClick={goHome}
-              />
-            ) : (
-              <></>
-            )
-          }
           prefixButtons={
             <>
               {inJupyter && (

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -576,57 +576,56 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       {controlBar !== 'off' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
-            {props.controlBar === 'titleBar' || !isHoverPanel ? (
+            {(props.controlBar === 'titleBar' || !isHoverPanel) &&
               props.pathEl != null && (
                 <EditorBarTitleOnly>
                   {varNameToTitle(props.pathEl)}
                 </EditorBarTitleOnly>
-              )
-            ) : (
-              <EditorBarHover isHovered={isHoverPanel}>
-                {/* Variable name */}
-                {props.pathEl != null && (
-                  <EditorPath>
-                    <ValidatingTextInput
-                      dataTest="panel-expression-path"
-                      onCommit={props.updateName ?? (() => {})}
-                      validateInput={validateName}
-                      initialValue={props.pathEl}
-                      maxWidth={
-                        editorBarWidth != null ? editorBarWidth / 3 : undefined
-                      }
-                      maxLength={24}
-                    />{' '}
-                    {controlBar === 'editable'}
-                  </EditorPath>
+              )}
+            <EditorBarHover
+              show={props.controlBar !== 'titleBar' && isHoverPanel}>
+              {/* Variable name */}
+              {props.pathEl != null && (
+                <EditorPath>
+                  <ValidatingTextInput
+                    dataTest="panel-expression-path"
+                    onCommit={props.updateName ?? (() => {})}
+                    validateInput={validateName}
+                    initialValue={props.pathEl}
+                    maxWidth={
+                      editorBarWidth != null ? editorBarWidth / 3 : undefined
+                    }
+                    maxLength={24}
+                  />{' '}
+                  {controlBar === 'editable'}
+                </EditorPath>
+              )}
+              {/* Panel picker */}
+              {controlBar === 'editable' &&
+                curPanelId !== 'Expression' &&
+                curPanelId !== 'RootBrowser' && (
+                  <PanelNameEditor
+                    value={curPanelId ?? ''}
+                    autocompleteOptions={panelOptions}
+                    setValue={handlePanelChange}
+                  />
                 )}
-                {/* Panel picker */}
-                {controlBar === 'editable' &&
-                  curPanelId !== 'Expression' &&
-                  curPanelId !== 'RootBrowser' && (
-                    <PanelNameEditor
-                      value={curPanelId ?? ''}
-                      autocompleteOptions={panelOptions}
-                      setValue={handlePanelChange}
-                    />
-                  )}
-                {/* Expression */}
-                {controlBar === 'editable' ? (
-                  <EditorExpression data-test="panel-expression-expression">
-                    <WeaveExpression
-                      expr={panelInputExpr}
-                      setExpression={updateExpression}
-                      noBox
-                      truncate={!expressionFocused}
-                      onFocus={onFocusExpression}
-                      onBlur={onBlurExpression}
-                    />
-                  </EditorExpression>
-                ) : (
-                  <div style={{width: '100%'}} />
-                )}
-              </EditorBarHover>
-            )}
+              {/* Expression */}
+              {controlBar === 'editable' ? (
+                <EditorExpression data-test="panel-expression-expression">
+                  <WeaveExpression
+                    expr={panelInputExpr}
+                    setExpression={updateExpression}
+                    noBox
+                    truncate={!expressionFocused}
+                    onFocus={onFocusExpression}
+                    onBlur={onBlurExpression}
+                  />
+                </EditorExpression>
+              ) : (
+                <div style={{width: '100%'}} />
+              )}
+            </EditorBarHover>
             {/* Control buttons */}
             <EditorIcons
               visible={!props.noEditorIcons && (isHoverPanel || isMenuOpen)}>
@@ -1005,8 +1004,8 @@ EditorBarTitleOnly.displayName = 'S.EditorBarTitleOnly';
 
 // If the mouse leaves the panel we want to keep these contents (e.g. unsubmitted
 // expression editor state) but just hide them.
-const EditorBarHover = styled.div<{isHovered: boolean}>`
-  display: ${props => (props.isHovered ? 'flex' : 'none')};
+const EditorBarHover = styled.div<{show: boolean}>`
+  display: ${props => (props.show ? 'flex' : 'none')};
   align-items: flex-start;
   flex-grow: 1;
 `;

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -597,7 +597,6 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
                     }
                     maxLength={24}
                   />{' '}
-                  {controlBar === 'editable'}
                 </EditorPath>
               )}
               {/* Panel picker */}

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -626,39 +626,40 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
               )}
             </EditorBarHover>
             {/* Control buttons */}
-            <EditorIcons
-              visible={!props.noEditorIcons && (isHoverPanel || isMenuOpen)}>
-              {props.prefixButtons}
-              <Tooltip
-                position="top center"
-                trigger={
-                  <Button
-                    variant="ghost"
-                    size="small"
-                    icon="pencil-edit"
-                    onClick={() => setInspectingPanel(props.pathEl ?? '')}
-                  />
-                }>
-                Open panel editor
-              </Tooltip>
-              <OutlineItemPopupMenu
-                config={fullConfig}
-                localConfig={getConfigForPath(fullConfig, fullPath)}
-                path={fullPath}
-                updateConfig={updateConfig}
-                updateConfig2={updateConfig2}
-                trigger={
-                  <Button
-                    variant="ghost"
-                    size="small"
-                    icon="overflow-horizontal"
-                  />
-                }
-                onOpen={() => setIsMenuOpen(true)}
-                onClose={() => setIsMenuOpen(false)}
-                isOpen={isMenuOpen}
-              />
-            </EditorIcons>
+            {!props.noEditorIcons && (
+              <EditorIcons visible={isHoverPanel || isMenuOpen}>
+                {props.prefixButtons}
+                <Tooltip
+                  position="top center"
+                  trigger={
+                    <Button
+                      variant="ghost"
+                      size="small"
+                      icon="pencil-edit"
+                      onClick={() => setInspectingPanel(props.pathEl ?? '')}
+                    />
+                  }>
+                  Open panel editor
+                </Tooltip>
+                <OutlineItemPopupMenu
+                  config={fullConfig}
+                  localConfig={getConfigForPath(fullConfig, fullPath)}
+                  path={fullPath}
+                  updateConfig={updateConfig}
+                  updateConfig2={updateConfig2}
+                  trigger={
+                    <Button
+                      variant="ghost"
+                      size="small"
+                      icon="overflow-horizontal"
+                    />
+                  }
+                  onOpen={() => setIsMenuOpen(true)}
+                  onClose={() => setIsMenuOpen(false)}
+                  isOpen={isMenuOpen}
+                />
+              </EditorIcons>
+            )}
           </EditorBarContent>
         </Styles.EditorBar>
       )}

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -583,13 +583,28 @@ export const PanelGroupItem: React.FC<{
   );
 
   let controlBar: ChildPanelProps['controlBar'] = 'off';
-  if (config.layoutMode === 'layer' || !config.showExpressions) {
+  if (
+    config.layoutMode === 'layer' ||
+    config.layoutMode === 'tab' ||
+    // Hardcode off off for Board top level items
+    name === 'sidebar' ||
+    name === 'varbar' ||
+    name === 'main'
+  ) {
     controlBar = 'off';
-  } else if (config.showExpressions === 'titleBar') {
+  } else if (
+    config.layoutMode === 'vertical' ||
+    config.layoutMode === 'horizontal' ||
+    config.layoutMode === 'section'
+  ) {
     controlBar = 'titleBar';
-  } else {
+  } else if (config.layoutMode === 'grid' || config.layoutMode === 'flow') {
     controlBar = 'editable';
   }
+  // We use enableAddPanel to mean the Group children are editable. If not editable,
+  const editable = !!config.enableAddPanel;
+  // If not editable, we don't want to show the editor icons in the ControlBar
+  const noEditorIcons = !editable;
   // This makes it so controls in the varbar can overflow the parent container
   // correctly. For example, without this PanelDropdown renders its dropdown menu
   // within the parent, creating a scrollbar.
@@ -602,6 +617,7 @@ export const PanelGroupItem: React.FC<{
       newVars={siblingVars}
       handleVarEvent={handleSiblingVarEvent}>
       <ChildPanel
+        noEditorIcons={noEditorIcons}
         overflowVisible={overflowVisible}
         allowedPanels={config.allowedPanels}
         pathEl={'' + name}

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -30,8 +30,8 @@ import {
 import {Draft, produce} from 'immer';
 import * as _ from 'lodash';
 import React, {useCallback, useMemo} from 'react';
-import {Button} from 'semantic-ui-react';
-import {Button as NewButton} from '../Button';
+import {Button as OldButton} from 'semantic-ui-react';
+import {Button} from '../Button';
 import styled, {css} from 'styled-components';
 
 import {IdObj, PanelBankSectionConfig} from '../WeavePanelBank/panelbank';
@@ -87,7 +87,7 @@ interface PanelInfo {
 }
 export interface PanelGroupConfig {
   // Determines how to lay out children, and also how to render each child's ControlBar
-  // (ie whether ControlBar is off, or show's the title only, or a fully editable var name, panel
+  // (ie whether ControlBar is off, or shows the title only, or a fully editable var name, panel
   // id, and expression).
   layoutMode: (typeof LAYOUT_MODES)[number];
   // Determines if we use equal sizing for horizontal and vertical layouts.
@@ -591,9 +591,9 @@ export const PanelGroupConfigComponent: React.FC<PanelGroupProps> = props => {
         </ConfigPanel.ChildConfigContainer>
       </ConfigPanel.ConfigSection>
       <ConfigPanel.ConfigSection>
-        <Button size="mini" onClick={handleAddPanel}>
+        <OldButton size="mini" onClick={handleAddPanel}>
           Add Child
-        </Button>
+        </OldButton>
       </ConfigPanel.ConfigSection>
     </>
   );
@@ -674,7 +674,7 @@ export const PanelGroupItem: React.FC<{
   if (
     config.layoutMode === 'layer' ||
     config.layoutMode === 'tab' ||
-    // Hardcode off off for Board top level items
+    // Hardcode off for Board top level items
     name === 'sidebar' ||
     name === 'varbar' ||
     name === 'main'
@@ -689,7 +689,7 @@ export const PanelGroupItem: React.FC<{
   } else if (config.layoutMode === 'grid' || config.layoutMode === 'flow') {
     controlBar = 'editable';
   }
-  // We use enableAddPanel to mean the Group children are editable. If not editable,
+  // We use enableAddPanel to mean the Group children are editable.
   const editable = !!config.enableAddPanel;
   // If not editable, we don't want to show the editor icons in the ControlBar
   const noEditorIcons = !editable;
@@ -901,9 +901,9 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
         }}>
         {!inJupyter && config.enableAddPanel && (
           <ActionBar>
-            <NewButton variant="ghost" onClick={handleAddPanel} icon="add-new">
+            <Button variant="ghost" onClick={handleAddPanel} icon="add-new">
               New panel
-            </NewButton>
+            </Button>
           </ActionBar>
         )}
         <PBSection
@@ -984,9 +984,9 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
             <IconAddNew />
           </AddVarButton>
         ) : (
-          <Button onClick={handleAddPanel} size="tiny">
+          <OldButton onClick={handleAddPanel} size="tiny">
             Add {props.config?.childNameBase ?? 'panel'}
-          </Button>
+          </OldButton>
         ))}
     </Group>
   );

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -872,7 +872,6 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
           groupPath={groupPath}
           updateConfig2={updateGridConfig2}
           renderPanel={renderSectionPanel}
-          handleAddPanel={config.enableAddPanel ? handleAddPanel : undefined}
         />
         {config.enableAddPanel != null && (
           <AddPanelBarContainer ref={addPanelBarRef}>

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -55,6 +55,7 @@ import {
 // import {inJupyterCell} from '../PagePanelComponents/util';
 import {useUpdateConfig2} from './PanelComp';
 import {replaceChainRoot} from '@wandb/weave/core/mutate';
+import {inJupyterCell} from '../PagePanelComponents/util';
 
 const LAYOUT_MODES = [
   'horizontal' as const,
@@ -851,6 +852,8 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
   const isVarBar = _.isEqual(groupPath, [`sidebar`]);
   const isMain = _.isEqual(groupPath, [`main`]);
 
+  const inJupyter = inJupyterCell();
+
   if (config.layoutMode === 'grid' || config.layoutMode === 'flow') {
     return (
       <div
@@ -859,7 +862,7 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
           height: !isMain ? '100%' : undefined,
           backgroundColor: isMain ? MOON_50 : undefined,
         }}>
-        {config.enableAddPanel && (
+        {!inJupyter && config.enableAddPanel && (
           <ActionBar>
             <NewButton variant="ghost" onClick={handleAddPanel} icon="add-new">
               New panel
@@ -873,7 +876,7 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
           updateConfig2={updateGridConfig2}
           renderPanel={renderSectionPanel}
         />
-        {config.enableAddPanel != null && (
+        {!inJupyter && config.enableAddPanel != null && (
           <AddPanelBarContainer ref={addPanelBarRef}>
             <AddPanelBar onClick={handleAddPanel}>
               <IconAddNew />

--- a/weave-js/src/components/WeavePanelBank/PBSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PBSection.tsx
@@ -8,7 +8,7 @@ import {
 } from '@wandb/weave/common/containers/DragDropContainer';
 import {produce} from 'immer';
 import * as _ from 'lodash';
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useState} from 'react';
 import Measure from 'react-measure';
 
 import {IdObj, PANEL_BANK_PADDING, PanelBankSectionConfig} from './panelbank';
@@ -18,17 +18,13 @@ import {PanelBankGridSection} from './PanelBankGridSection';
 import styled, {css} from 'styled-components';
 import {
   BORDER_COLOR_FOCUSED,
-  GRAY_25,
   GRAY_350,
   GRAY_400,
-  GRAY_500,
-  MOON_50,
   PANEL_HOVERED_SHADOW,
   SCROLLBAR_STYLES,
   WHITE,
 } from '../../common/css/globals.styles';
 import {IconAddNew as IconAddNewUnstyled} from '../Panel2/Icons';
-import {inJupyterCell} from '../PagePanelComponents/util';
 import {useScrollbarVisibility} from '../../core/util/scrollbar';
 import {
   useGetPanelIsHoveredByGroupPath,
@@ -36,28 +32,19 @@ import {
   useSelectedPath,
   useSetPanelIsHovered,
 } from '../Panel2/PanelInteractContext';
-import {Button} from '../Button';
 
 interface PBSectionProps {
   mode: 'grid' | 'flow';
   config: PanelBankSectionConfig;
   groupPath?: string[];
-  enableAddPanel?: boolean;
   updateConfig2: (
     fn: (config: PanelBankSectionConfig) => PanelBankSectionConfig
   ) => void;
   renderPanel: (panelRef: IdObj) => React.ReactNode;
-  handleAddPanel?: () => void;
 }
 
 export const PBSection: React.FC<PBSectionProps> = props => {
-  const {
-    config,
-    groupPath,
-    enableAddPanel,
-    updateConfig2,
-    handleAddPanel: addPanel,
-  } = props;
+  const {config, groupPath, updateConfig2} = props;
   const selectedPath = useSelectedPath();
   const getPanelIsHovered = useGetPanelIsHoveredByGroupPath(groupPath ?? []);
   const getPanelIsHoveredInOutline = useGetPanelIsHoveredInOutlineByGroupPath(
@@ -68,37 +55,16 @@ export const PBSection: React.FC<PBSectionProps> = props => {
   const [panelBankHeight, setPanelBankHeight] = useState(0);
   const PanelBankSectionComponent =
     props.mode === 'grid' ? PanelBankGridSection : PanelBankFlowSection;
-  const inJupyter = inJupyterCell();
   const {
     visible: sectionsScrollbarVisible,
     onScroll: onSectionsScroll,
     onMouseMove: onSectionsMouseMove,
   } = useScrollbarVisibility();
-  const actionBarRef = useRef<HTMLDivElement | null>(null);
-  const addPanelBarRef = useRef<HTMLDivElement | null>(null);
-
   // On add panel, scroll to the new panel
-  const [shouldScrollToNewPanel, setShouldScrollToNewPanel] = useState(false);
-  const handleAddPanel = useCallback(() => {
-    addPanel?.();
-    setShouldScrollToNewPanel(true);
-  }, [addPanel, setShouldScrollToNewPanel]);
-  useEffect(() => {
-    if (shouldScrollToNewPanel && addPanelBarRef.current) {
-      addPanelBarRef.current.scrollIntoView({
-        behavior: 'smooth',
-      });
-      setShouldScrollToNewPanel(false);
-    }
-  }, [shouldScrollToNewPanel, setShouldScrollToNewPanel, addPanelBarRef]);
 
   return (
     <DragDropProvider>
-      <div
-        className="panel-bank"
-        // We set the background color for the main area of the board here
-        // for now... Maybe this will work for all uses of PB in Weave
-        style={{height: '100%', backgroundColor: MOON_50}}>
+      <div className="panel-bank" style={{height: '100%'}}>
         <Measure
           bounds
           onResize={contentRect => {
@@ -109,9 +75,7 @@ export const PBSection: React.FC<PBSectionProps> = props => {
             );
             setPanelBankHeight(
               contentRect.bounds
-                ? contentRect.bounds.height -
-                    (actionBarRef.current?.offsetHeight ?? 0) -
-                    (addPanelBarRef.current?.offsetHeight ?? 0)
+                ? contentRect.bounds.height - PANEL_BANK_PADDING * 2
                 : 0
             );
           }}>
@@ -123,33 +87,6 @@ export const PBSection: React.FC<PBSectionProps> = props => {
               onScroll={onSectionsScroll}
               onMouseMove={onSectionsMouseMove}>
               <div className="panel-bank__section">
-                {!inJupyter && groupPath != null && handleAddPanel != null && (
-                  <ActionBar ref={actionBarRef}>
-                    {/* This opens the editor at the outline level on the main board.
-                    The button was always shown on the page, but it leads to a kind
-                    of confusing place, so I'm just disabling it. */}
-
-                    {/* <Tooltip
-                      position="bottom right"
-                      trigger={
-                        <Button
-                          variant="ghost"
-                          icon="pencil-edit"
-                          onClick={() => setInspectingPanel(groupPath)}
-                        />
-                      }>
-                      Open panel editor
-                    </Tooltip> */}
-                    {enableAddPanel && (
-                      <Button
-                        variant="ghost"
-                        onClick={handleAddPanel}
-                        icon="add-new">
-                        New panel
-                      </Button>
-                    )}
-                  </ActionBar>
-                )}
                 <PanelBankSectionComponent
                   panelBankWidth={panelBankWidth}
                   panelBankHeight={panelBankHeight}
@@ -204,14 +141,6 @@ export const PBSection: React.FC<PBSectionProps> = props => {
                     console.log('MOVE BETWEEN SECTIONS');
                   }}
                 />
-                {handleAddPanel != null && !inJupyter && (
-                  <AddPanelBarContainer ref={addPanelBarRef}>
-                    <AddPanelBar onClick={handleAddPanel}>
-                      <IconAddNew />
-                      New panel
-                    </AddPanelBar>
-                  </AddPanelBarContainer>
-                )}
               </div>
             </Sections>
           )}
@@ -271,29 +200,6 @@ const ActionBar = styled.div`
   align-items: center;
 `;
 ActionBar.displayName = 'S.ActionBar';
-
-const AddPanelBar = styled.div`
-  height: 48px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
-  border-radius: 6px;
-  background-color: ${GRAY_25};
-  font-weight: 600;
-  color: ${GRAY_500};
-`;
-AddPanelBar.displayName = 'S.AddPanelBar';
-
-const AddPanelBarContainer = styled.div`
-  padding: 8px 32px 16px;
-
-  transition: opacity 0.3s;
-  &:not(:hover) {
-    opacity: 0;
-  }
-`;
-AddPanelBarContainer.displayName = 'S.AddPanelBarContainer';
 
 const IconAddNew = styled(IconAddNewUnstyled)<{$marginRight?: number}>`
   width: 18px;

--- a/weave-js/src/components/WeavePanelBank/PanelBank.less
+++ b/weave-js/src/components/WeavePanelBank/PanelBank.less
@@ -165,7 +165,6 @@
       display: flex;
       flex-direction: column;
       height: 100%;
-      overflow: auto;
     }
     &__section {
       height: 100%;


### PR DESCRIPTION
- Fix default blank board to have actual working VarBar again! We always render expressions below the title row in VarBar now
- Clean up how panel configuration is used in PanelGroup and ChildPanel (see new comments in PanelGroup)
- Remove "=" in ControlBar (var = Panel expr)
- Factor Add panel buttons out of PanelBank and into PanelGroup, so if you add a Flow/Grid section to within another panel, we do something reasonable.