### PR TITLE
chore(weave): Cleanup various memory leaks

### DIFF
--- a/weave-js/src/common/util/hooks.ts
+++ b/weave-js/src/common/util/hooks.ts
@@ -258,7 +258,7 @@ export function useIsMounted() {
   // function will be a stable reference across renders, so it is safe to use in
   // dependencies. This is useful to use in callbacks for example to check if a
   // component is still mounted before updating state. Stylistically, I think it
-  // is more readible to maintain mount state near the useEffect that uses it.
+  // is more readable to maintain mount state near the useEffect that uses it.
   // However, with non-useEffect hooks, we sometimes want to check if a
   // component is mounted before updating state. In those cases, we can use this
   // hook.

--- a/weave-js/src/common/util/hooks.ts
+++ b/weave-js/src/common/util/hooks.ts
@@ -254,6 +254,14 @@ export const useUpdatingState = <T extends any>(initialValue: T) => {
 };
 
 export function useIsMounted() {
+  // This hook exposes a method to check if a component is mounted. The returned
+  // function will be a stable reference across renders, so it is safe to use in
+  // dependencies. This is useful to use in callbacks for example to check if a
+  // component is still mounted before updating state. Stylistically, I think it
+  // is more readible to maintain mount state near the useEffect that uses it.
+  // However, with non-useEffect hooks, we sometimes want to check if a
+  // component is mounted before updating state. In those cases, we can use this
+  // hook.
   const isMountedRef = useRef(false);
   useEffect(() => {
     isMountedRef.current = true;

--- a/weave-js/src/common/util/hooks.ts
+++ b/weave-js/src/common/util/hooks.ts
@@ -252,3 +252,14 @@ export const useUpdatingState = <T extends any>(initialValue: T) => {
 
   return [state, setState] as const;
 };
+
+export function useIsMounted() {
+  const isMountedRef = useRef(false);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+  return useCallback(() => isMountedRef.current, []);
+}

--- a/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
@@ -420,8 +420,8 @@ const OverviewTab = ({
                           recommendedTemplateInfo.op_name,
                           refinedExpression.result as any,
                           newDashExpr => {
-                            navigateToExpression(newDashExpr);
                             setIsGenerating(false);
+                            navigateToExpression(newDashExpr);
                           }
                         );
                       }}
@@ -442,8 +442,8 @@ const OverviewTab = ({
                     SEED_BOARD_OP_NAME,
                     refinedExpression.result as any,
                     newDashExpr => {
-                      navigateToExpression(newDashExpr);
                       setIsGenerating(false);
+                      navigateToExpression(newDashExpr);
                     }
                   );
                 }}
@@ -510,8 +510,8 @@ const TemplateTab = ({
               recommendedTemplateInfo.op_name,
               refinedExpression.result as any,
               newDashExpr => {
-                navigateToExpression(newDashExpr);
                 setIsGenerating(false);
+                navigateToExpression(newDashExpr);
               }
             );
           }}
@@ -540,8 +540,8 @@ const TemplateTab = ({
                 template.op_name,
                 refinedExpression.result as any,
                 newDashExpr => {
-                  navigateToExpression(newDashExpr);
                   setIsGenerating(false);
+                  navigateToExpression(newDashExpr);
                 }
               );
             }}

--- a/weave-js/src/components/PagePanelComponents/util.ts
+++ b/weave-js/src/components/PagePanelComponents/util.ts
@@ -2,7 +2,7 @@ import getConfig from '../../config';
 import {getCookie} from '@wandb/weave/common/util/cookie';
 import {NodeOrVoidNode, Type, isAssignableTo} from '@wandb/weave/core';
 import fetch from 'isomorphic-unfetch';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 export const REMOTE_URI_PREFIX = 'wandb-artifact:///';
 export const LOCAL_URI_PREFIX = 'local-artifact:///';
@@ -32,6 +32,8 @@ export const useIsAuthenticated = (skip: boolean = false) => {
   const [isAuth, setIsAuth] = useState<boolean | undefined>(undefined);
   const anonApiKey = getCookie('anon_api_key');
 
+  const isMounted = useRef(true);
+
   useEffect(() => {
     if (skip) {
       setIsAuth(false);
@@ -50,6 +52,9 @@ export const useIsAuthenticated = (skip: boolean = false) => {
       },
     })
       .then(res => {
+        if (!isMounted.current) {
+          return;
+        }
         if (res.status !== 200) {
           setIsAuth(false);
           return;
@@ -58,12 +63,22 @@ export const useIsAuthenticated = (skip: boolean = false) => {
         }
       })
       .then(json => {
+        if (!isMounted.current) {
+          return;
+        }
         const auth = !!(json?.authenticated ?? false);
         setIsAuth(auth);
       })
       .catch(err => {
+        if (!isMounted.current) {
+          return;
+        }
         setIsAuth(false);
       });
+
+    return () => {
+      isMounted.current = false;
+    }
   }, [anonApiKey, skip]);
   return isAuth;
 };

--- a/weave-js/src/components/PagePanelComponents/util.ts
+++ b/weave-js/src/components/PagePanelComponents/util.ts
@@ -78,7 +78,7 @@ export const useIsAuthenticated = (skip: boolean = false) => {
 
     return () => {
       isMounted.current = false;
-    }
+    };
   }, [anonApiKey, skip]);
   return isAuth;
 };

--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -253,7 +253,7 @@ const usePanelPanelCommon = (props: PanelPanelProps) => {
   // Fortunately the Weave backend requests for these two parallel initializations
   // are deduped.
   // TODO: fix, this should really be the true UI root.
-
+  const isMounted = useRef(true);
   useEffect(() => {
     if (initialLoading && !panelQuery.loading) {
       const doLoad = async () => {
@@ -296,14 +296,18 @@ const usePanelPanelCommon = (props: PanelPanelProps) => {
         // console.log('ORIG', loadedPanel);
         // console.log('REFINED', refined);
         // console.log('DIFF', difference(loadedPanel, refined));
-        dispatch({type: 'setConfig', newConfig: refined});
+        if (isMounted.current) {
+          dispatch({type: 'setConfig', newConfig: refined});
+        }
       };
       if (!loaded.current) {
         loaded.current = true;
         doLoad();
       }
-      return;
     }
+    return () => {
+      isMounted.current = false;
+    };
   }, [
     initialLoading,
     panelQuery.loading,

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -137,6 +137,7 @@ import {
 import styled from 'styled-components';
 import {PopupMenu, Section} from '../../Sidebar/PopupMenu';
 import {Option} from '@wandb/weave/common/util/uihelpers';
+import {useIsMounted} from '@wandb/weave/common/util/hooks';
 
 const recordEvent = makeEventRecorder('Plot');
 
@@ -1970,6 +1971,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
     updateConfig: propsUpdateConfig,
     updateConfig2: propsUpdateConfig2,
   } = props;
+  const isMounted = useIsMounted();
 
   const [brushMode, setBrushMode] = useState<BrushMode>('zoom');
 
@@ -3393,6 +3395,9 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
 
   const handleTooltip = useCallback(
     (toolTipHandler: any, event: any, item: any, value: any) => {
+      if (!isMounted()) {
+        return;
+      }
       let {x, y}: {x?: number; y?: number} = {};
 
       if (value == null) {
@@ -3416,7 +3421,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
         setTooltipPos({x, y, value});
       }
     },
-    [setTooltipPos]
+    [isMounted]
   );
 
   const isLineTooltip = useMemo(

--- a/weave-js/src/panel/WeaveExpression/hooks.ts
+++ b/weave-js/src/panel/WeaveExpression/hooks.ts
@@ -199,8 +199,22 @@ export const useWeaveExpressionState = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const [externalState, setExternalState] =
+  const [externalState, setExternalStateUnsafe] =
     React.useState<WeaveExpressionState>(internalState);
+
+  const isMounted = React.useRef(true);
+
+  React.useEffect(() => {
+    return () => {
+      isMounted.current = false;
+    };
+  }, [])
+
+  const setExternalState = React.useCallback<typeof setExternalStateUnsafe>((args) => {
+    if (isMounted.current) {
+      setExternalStateUnsafe(args);
+    }
+  }, [])
 
   const onChange = React.useCallback(
     (newValue: SlateNode[], newStack: Stack) => {

--- a/weave-js/src/panel/WeaveExpression/hooks.ts
+++ b/weave-js/src/panel/WeaveExpression/hooks.ts
@@ -25,6 +25,7 @@ import {usePanelContext} from '../../components/Panel2/PanelContext';
 import {WeaveExpressionState} from './state';
 import type {SuggestionProps, WeaveExpressionProps} from './types';
 import {getIndexForPoint, moveToNextMissingArg, trace} from './util';
+import { useIsMounted } from '@wandb/weave/common/util/hooks';
 
 // Provides the decorate callback to pass to Slate's Editable
 // component and implements syntax highlighting and styling
@@ -202,21 +203,19 @@ export const useWeaveExpressionState = (
   const [externalState, setExternalStateUnsafe] =
     React.useState<WeaveExpressionState>(internalState);
 
-  const isMounted = React.useRef(true);
-
-  React.useEffect(() => {
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
+  const isMounted = useIsMounted();
 
   const setExternalState = React.useCallback<typeof setExternalStateUnsafe>(
     args => {
-      if (isMounted.current) {
+      // setExternalState is used by `WeaveExpressionState` to update the
+      // external state. `WeaveExpressionState` is not aware of the component
+      // mount state, nor does it need to be. This check is here to prevent
+      // a state update from being applied after the component has unmounted.
+      if (isMounted()) {
         setExternalStateUnsafe(args);
       }
     },
-    []
+    [isMounted]
   );
 
   const onChange = React.useCallback(

--- a/weave-js/src/panel/WeaveExpression/hooks.ts
+++ b/weave-js/src/panel/WeaveExpression/hooks.ts
@@ -25,7 +25,7 @@ import {usePanelContext} from '../../components/Panel2/PanelContext';
 import {WeaveExpressionState} from './state';
 import type {SuggestionProps, WeaveExpressionProps} from './types';
 import {getIndexForPoint, moveToNextMissingArg, trace} from './util';
-import { useIsMounted } from '@wandb/weave/common/util/hooks';
+import {useIsMounted} from '@wandb/weave/common/util/hooks';
 
 // Provides the decorate callback to pass to Slate's Editable
 // component and implements syntax highlighting and styling

--- a/weave-js/src/panel/WeaveExpression/hooks.ts
+++ b/weave-js/src/panel/WeaveExpression/hooks.ts
@@ -208,13 +208,16 @@ export const useWeaveExpressionState = (
     return () => {
       isMounted.current = false;
     };
-  }, [])
+  }, []);
 
-  const setExternalState = React.useCallback<typeof setExternalStateUnsafe>((args) => {
-    if (isMounted.current) {
-      setExternalStateUnsafe(args);
-    }
-  }, [])
+  const setExternalState = React.useCallback<typeof setExternalStateUnsafe>(
+    args => {
+      if (isMounted.current) {
+        setExternalStateUnsafe(args);
+      }
+    },
+    []
+  );
 
   const onChange = React.useCallback(
     (newValue: SlateNode[], newStack: Stack) => {


### PR DESCRIPTION
When using the weave app, there are numerous interactions that result in mem leak errors from react. This is caused by attempting to update a component state after it is unmounted. This PR address a number of issues I found while using the app (making dashboards, templates, navigating back and forth, etc...):

1. Fixes `HomePreviewSidebar` to put the state update before the page change
2. Fixes `useIsAuthenticated` to respect mount state
3. Fixes `PanelPanel` refinement dispatch to respect mount state
4. Fixes `PanelPlot`'s `handleTooltip` to respect mount state.
5. Fixes `WeaveExpression/hooks.ts::useWeaveExpressionState` to respect mount state