### PR TITLE
fix: Return correct type for run-runtime (number instead of timedelta)

### DIFF
--- a/weave/gql_to_weave.py
+++ b/weave/gql_to_weave.py
@@ -109,7 +109,7 @@ def gql_type_to_weave_type(
         elif gql_type.name == "DateTime":
             t = types.Timestamp()
         elif gql_type.name == "Duration":
-            t = types.Int()  # duration is number of seconds
+            t = types.Number()  # duration is number of seconds
         else:
             raise ValueError(f"Unknown scalar type {gql_type.name}")
 

--- a/weave/gql_to_weave.py
+++ b/weave/gql_to_weave.py
@@ -109,7 +109,7 @@ def gql_type_to_weave_type(
         elif gql_type.name == "DateTime":
             t = types.Timestamp()
         elif gql_type.name == "Duration":
-            t = types.TimeDelta()
+            t = types.Int()  # duration is number of seconds
         else:
             raise ValueError(f"Unknown scalar type {gql_type.name}")
 

--- a/weave/mappers_arrow.py
+++ b/weave/mappers_arrow.py
@@ -346,16 +346,6 @@ class GQLHasKeysToArrowStruct(mappers_python.GQLClassWithKeysToPyDict):
         )
 
 
-class TimeDeltaToArrowTimeDelta(mappers.Mapper):
-    def result_type(self):
-        return pa.duration("ms")
-
-
-class ArrowTimeDeltaToTimeDelta(mappers.Mapper):
-    def apply(self, obj):
-        return obj
-
-
 def map_to_arrow_(
     type, mapper, artifact: artifact_base.Artifact, path=[], mapper_options=None
 ):
@@ -385,8 +375,6 @@ def map_to_arrow_(
         return StringToArrow(type, mapper, artifact, path)
     elif isinstance(type, types.Timestamp):
         return TimestampToArrowTimestamp(type, mapper, artifact, path)
-    elif isinstance(type, types.TimeDelta):
-        return TimeDeltaToArrowTimeDelta(type, mapper, artifact, path)
     elif isinstance(type, types.Function):
         return FunctionToArrowFunction(type, mapper, artifact, path)
     elif isinstance(type, types.NoneType):
@@ -424,8 +412,6 @@ def map_from_arrow_(type, mapper, artifact, path=[], mapper_options=None):
         return ArrowDateTimeToDateTime(type, mapper, artifact, path)
     elif isinstance(type, types.Function):
         return ArrowFunctionToFunction(type, mapper, artifact, path)
-    elif isinstance(type, types.TimeDelta):
-        return ArrowTimeDeltaToTimeDelta(type, mapper, artifact, path)
     elif isinstance(type, types.NoneType):
         return mappers_python.NoneToPyNone(type, mapper, artifact, path)
     elif isinstance(type, types.UnknownType):

--- a/weave/mappers_arrow.py
+++ b/weave/mappers_arrow.py
@@ -346,6 +346,16 @@ class GQLHasKeysToArrowStruct(mappers_python.GQLClassWithKeysToPyDict):
         )
 
 
+class TimeDeltaToArrowTimeDelta(mappers.Mapper):
+    def result_type(self):
+        return pa.duration("ms")
+
+
+class ArrowTimeDeltaToTimeDelta(mappers.Mapper):
+    def apply(self, obj):
+        return obj
+
+
 def map_to_arrow_(
     type, mapper, artifact: artifact_base.Artifact, path=[], mapper_options=None
 ):
@@ -375,6 +385,8 @@ def map_to_arrow_(
         return StringToArrow(type, mapper, artifact, path)
     elif isinstance(type, types.Timestamp):
         return TimestampToArrowTimestamp(type, mapper, artifact, path)
+    elif isinstance(type, types.TimeDelta):
+        return TimeDeltaToArrowTimeDelta(type, mapper, artifact, path)
     elif isinstance(type, types.Function):
         return FunctionToArrowFunction(type, mapper, artifact, path)
     elif isinstance(type, types.NoneType):
@@ -412,6 +424,8 @@ def map_from_arrow_(type, mapper, artifact, path=[], mapper_options=None):
         return ArrowDateTimeToDateTime(type, mapper, artifact, path)
     elif isinstance(type, types.Function):
         return ArrowFunctionToFunction(type, mapper, artifact, path)
+    elif isinstance(type, types.TimeDelta):
+        return ArrowTimeDeltaToTimeDelta(type, mapper, artifact, path)
     elif isinstance(type, types.NoneType):
         return mappers_python.NoneToPyNone(type, mapper, artifact, path)
     elif isinstance(type, types.UnknownType):

--- a/weave/mappers_gql.py
+++ b/weave/mappers_gql.py
@@ -17,8 +17,6 @@ from . import errors
 from . import weave_types as types
 from .partial_object import PartialObjectType
 
-from datetime import timedelta
-
 from . import gql_json_cache
 
 
@@ -82,12 +80,6 @@ class GQLConstToConst(mappers.Mapper):
         return obj
 
 
-class GQLTimeDeltaToTimeDelta(mappers.Mapper):
-    def apply(self, obj):
-        # duration is a number of seconds
-        return timedelta(seconds=obj)
-
-
 def map_from_gql_payload_(type, mapper, artifact, path=[], mapper_options=None):
     if isinstance(type, PartialObjectType):
         return DictToPyDict(type, mapper, artifact, path)
@@ -117,8 +109,6 @@ def map_from_gql_payload_(type, mapper, artifact, path=[], mapper_options=None):
         return GQLUnionToUnion(type, mapper, artifact, path)
     elif isinstance(type, types.Const):
         return GQLConstToConst(type, mapper, artifact, path)
-    elif isinstance(type, types.TimeDelta):
-        return GQLTimeDeltaToTimeDelta(type, mapper, artifact, path)
     raise errors.WeaveValueError(f"Unknown type {type}")
 
 

--- a/weave/ops_domain/run_ops.py
+++ b/weave/ops_domain/run_ops.py
@@ -409,7 +409,7 @@ def run_logged_artifact_version(
 
 @op(
     name="run-runtime",
-    input_type=wdt.RunType,
+    input_type={"run": wdt.RunType},
     output_type=types.Number(),
     plugins=wb_gql_op_plugin(lambda inputs, inner: "computeSeconds"),
 )
@@ -419,9 +419,9 @@ def run_runtime(run):
 
 @arrow_op(
     name="ArrowWeaveListRun-runtime",
-    input_type=ArrowWeaveListType(
-        wdt.RunType.with_keys({"runtime": types.TimeDelta()})
-    ),
+    input_type={
+        "arr": ArrowWeaveListType(wdt.RunType.with_keys({"runtime": types.TimeDelta()}))
+    },
     output_type=ArrowWeaveListType(types.Number()),
 )
 def awl_run_runtime(arr):

--- a/weave/ops_domain/run_ops.py
+++ b/weave/ops_domain/run_ops.py
@@ -36,10 +36,7 @@
 
 import json
 import typing
-import datetime
-import pyarrow as pa
 
-from pyarrow import compute as pc
 
 from .. import compile_table
 from ..input_provider import InputAndStitchProvider
@@ -55,13 +52,10 @@ from .wandb_domain_gql import (
     _make_alias,
 )
 
-from ..ops_arrow import ArrowWeaveListType, ArrowWeaveList
-
 
 from . import wb_util
 from .. import engine_trace
 from .run_history import history_op_common
-from ..decorator_arrow_op import arrow_op
 
 
 # Important to re-export ops
@@ -127,6 +121,13 @@ gql_prop_op(
     wdt.RunType,
     "historyKeys",
     types.Dict(types.String(), types.Any()),
+)
+
+runtime = gql_prop_op(
+    "run-runtime",
+    wdt.RunType,
+    "computeSeconds",
+    types.Number(),
 )
 
 gql_prop_op(
@@ -405,36 +406,3 @@ def run_logged_artifact_version(
 ) -> wdt.ArtifactVersion:
     alias = _make_alias(artifactVersionName, prefix="artifact")
     return wdt.ArtifactVersion.from_keys(run["project"][alias])
-
-
-@op(
-    name="run-runtime",
-    input_type={"run": wdt.RunType},
-    output_type=types.Number(),
-    plugins=wb_gql_op_plugin(lambda inputs, inner: "computeSeconds"),
-)
-def run_runtime(run):
-    return typing.cast(datetime.timedelta, run["computeSeconds"]).seconds
-
-
-@arrow_op(
-    name="ArrowWeaveListRun-runtime",
-    input_type={
-        "arr": ArrowWeaveListType(
-            wdt.RunType.with_keys({"computeSeconds": types.TimeDelta()})
-        )
-    },
-    output_type=ArrowWeaveListType(types.Number()),
-)
-def awl_run_runtime(arr):
-    indices = arr._arrow_data.indices
-    dictionary = arr._arrow_data.dictionary
-    seconds = pa.DictionaryArray.from_arrays(
-        indices, pc.divide(dictionary.field("computeSeconds").cast(pa.int64()), 1000)
-    )
-
-    return ArrowWeaveList(
-        seconds,
-        types.Number(),
-        arr._artifact,
-    )

--- a/weave/ops_domain/run_ops.py
+++ b/weave/ops_domain/run_ops.py
@@ -420,11 +420,21 @@ def run_runtime(run):
 @arrow_op(
     name="ArrowWeaveListRun-runtime",
     input_type={
-        "arr": ArrowWeaveListType(wdt.RunType.with_keys({"runtime": types.TimeDelta()}))
+        "arr": ArrowWeaveListType(
+            wdt.RunType.with_keys({"computeSeconds": types.TimeDelta()})
+        )
     },
     output_type=ArrowWeaveListType(types.Number()),
 )
 def awl_run_runtime(arr):
+    indices = arr._arrow_data.indices
+    dictionary = arr._arrow_data.dictionary
+    seconds = pa.DictionaryArray.from_arrays(
+        indices, pc.divide(dictionary.field("computeSeconds").cast(pa.int64()), 1000)
+    )
+
     return ArrowWeaveList(
-        pc.divide(arr._arrow_data.cast(pa.int64()), 1000), types.Number(), arr._artifact
+        seconds,
+        types.Number(),
+        arr._artifact,
     )

--- a/weave/tests/test_arrow_vectorizer.py
+++ b/weave/tests/test_arrow_vectorizer.py
@@ -1341,16 +1341,16 @@ def test_cant_vectorize_without_keys():
 
 def test_vectorize_run_runtime():
     runs = [
-        wdt.Run({"id": "A", "computeSeconds": datetime.timedelta(seconds=1)}),
-        wdt.Run({"id": "B", "computeSeconds": datetime.timedelta(seconds=2)}),
-        wdt.Run({"id": "C", "computeSeconds": datetime.timedelta(seconds=3)}),
+        wdt.Run({"id": "A", "computeSeconds": 1}),
+        wdt.Run({"id": "B", "computeSeconds": 2}),
+        wdt.Run({"id": "C", "computeSeconds": 3}),
     ]
 
     awl = arrow.to_arrow(runs)
     l = weave.save(awl)
 
     fn = weave_internal.define_fn(
-        {"x": awl.object_type}, lambda x: run_ops.run_runtime(x)
+        {"x": awl.object_type}, lambda x: run_ops.runtime(x)
     ).val
 
     vec_fn = arrow.vectorize(fn, strict=True)

--- a/weave/tests/test_arrow_vectorizer.py
+++ b/weave/tests/test_arrow_vectorizer.py
@@ -10,6 +10,8 @@ from .. import weave_internal
 from ..ops_primitives import dict_, list_
 from .. import errors
 
+import datetime
+
 from ..language_features.tagging import tag_store, tagged_value_type, make_tag_getter_op
 
 from .. import ops_arrow as arrow
@@ -1335,3 +1337,27 @@ def test_cant_vectorize_without_keys():
     # it finds a mapped list op, but not an AWL op
     assert "ArrowWeaveList" not in vec_fn.from_op.name
     assert "mapped" in vec_fn.from_op.name
+
+
+def test_vectorize_run_runtime():
+    runs = [
+        wdt.Run({"id": "A", "computeSeconds": datetime.timedelta(seconds=1)}),
+        wdt.Run({"id": "B", "computeSeconds": datetime.timedelta(seconds=2)}),
+        wdt.Run({"id": "C", "computeSeconds": datetime.timedelta(seconds=3)}),
+    ]
+
+    awl = arrow.to_arrow(runs)
+    l = weave.save(awl)
+
+    fn = weave_internal.define_fn(
+        {"x": awl.object_type}, lambda x: run_ops.run_runtime(x)
+    ).val
+
+    vec_fn = arrow.vectorize(fn, strict=True)
+
+    called = weave_internal.call_fn(vec_fn, {"x": l})
+    assert weave.use(called).to_pylist_notags() == [1, 2, 3]
+
+    # it finds an AWL op
+    assert "ArrowWeaveList" in vec_fn.from_op.name
+    assert "mapped" not in vec_fn.from_op.name


### PR DESCRIPTION
Fixes these internal sentry issues 

https://weights-biases.sentry.io/issues/4435792101
https://weights-biases.sentry.io/issues/4435792046

The GQL type of run-computeSeconds is Duration, which maps to a python type of `datetime.TimeDelta()`. Our gql_prop_op `run-runtime` had this typed as `types.Number()`, which was correct before #478 but not anymore. Here we explicitly rewrite the op to convert the duration to integer seconds, add arrow mappers to convert the timedelta to the correct arrow type, and add a vectorized special op to do the conversion to number using arrow compute functions. 

Adds a unit test.