### PR TITLE
chore: only import ecosystem in tests if needed

### DIFF
--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -10,7 +10,6 @@ import tempfile
 
 from weave.panels import table_state
 from . import context_state
-from . import weave_server
 from .tests import fixture_fakewandb
 from . import serialize
 from . import client
@@ -187,6 +186,8 @@ def fixed_random_seed():
 
 @pytest.fixture()
 def app():
+    from . import weave_server
+
     app = weave_server.make_app()
     app.config.update(
         {
@@ -229,6 +230,8 @@ class HttpServerTestClient:
 
 @pytest.fixture()
 def http_server_test_client(app):
+    from . import weave_server
+
     app = weave_server.make_app()
     flask_client = app.test_client()
     return HttpServerTestClient(flask_client)


### PR DESCRIPTION
There is a few second startup time to a single unit test in VScode right now because we import the ecosystem in conftest, in fixtures. This moves the import to inside the fixtures, so we only perform the input if we actually need to to run the tests at hand. 

This should make running one off local tests feel much snappier