### PR TITLE
chore: configure logs in test

### DIFF
--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -28,6 +28,8 @@ from _pytest.config import Config
 from _pytest.reports import TestReport
 from typing import Tuple, Optional
 
+logs.configure_logger()
+
 
 def pytest_report_teststatus(
     report: TestReport, config: Config


### PR DESCRIPTION
Fixes an issue where calls to logging.error in tests would raise an error due to the logger not being configured, obscuring the actual exception that was raised 