### PR TITLE
chore(weave): Allows editing of varbar names

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -563,7 +563,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     useElementWidth<HTMLDivElement>();
 
   const controlBar = props.controlBar ?? 'off';
-
+  const isVarNameEditable = !props.noEditorIcons;
   return curPanelId == null || handler == null ? (
     <div>
       No panel for type {defaultLanguageBinding.printType(panelInput.type)}
@@ -576,19 +576,12 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       {controlBar !== 'off' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
-            {((props.controlBar === 'titleBar' &&
-              curPanelId !== 'Expression') ||
-              !isHoverPanel) &&
-              props.pathEl != null && (
-                <EditorBarTitleOnly>
-                  {varNameToTitle(props.pathEl)}
-                </EditorBarTitleOnly>
-              )}
-            <EditorBarHover
-              show={
-                isHoverPanel &&
-                (props.controlBar !== 'titleBar' || curPanelId === 'Expression')
-              }>
+            {(isVarNameEditable || !isHoverPanel) && props.pathEl != null && (
+              <EditorBarTitleOnly>
+                {varNameToTitle(props.pathEl)}
+              </EditorBarTitleOnly>
+            )}
+            <EditorBarHover show={isHoverPanel && !isVarNameEditable}>
               {/* Variable name */}
               {props.pathEl != null && (
                 <EditorPath>

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -195,7 +195,7 @@ export const useChildPanelConfig = (
 };
 
 export interface ChildPanelProps {
-  noEditorIcons?: boolean;
+  editable?: boolean;
   controlBar?: 'off' | 'editable' | 'titleBar';
   passthroughUpdate?: boolean;
   pathEl?: string;
@@ -563,7 +563,9 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     useElementWidth<HTMLDivElement>();
 
   const controlBar = props.controlBar ?? 'off';
-  const isVarNameEditable = !props.noEditorIcons;
+  const isVarNameEditable = props.editable || controlBar === 'editable';
+  const noEditorIcons = !props.editable;
+
   return curPanelId == null || handler == null ? (
     <div>
       No panel for type {defaultLanguageBinding.printType(panelInput.type)}
@@ -624,7 +626,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
               )}
             </EditorBarHover>
             {/* Control buttons */}
-            {!props.noEditorIcons && (
+            {!noEditorIcons && (
               <EditorIcons visible={isHoverPanel || isMenuOpen}>
                 {props.prefixButtons}
                 <Tooltip

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -576,12 +576,19 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       {controlBar !== 'off' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
-            {!isHoverPanel && props.pathEl != null && (
-              <EditorBarTitleOnly>
-                {varNameToTitle(props.pathEl)}
-              </EditorBarTitleOnly>
-            )}
-            <EditorBarHover show={isHoverPanel}>
+            {((props.controlBar === 'titleBar' &&
+              curPanelId !== 'Expression') ||
+              !isHoverPanel) &&
+              props.pathEl != null && (
+                <EditorBarTitleOnly>
+                  {varNameToTitle(props.pathEl)}
+                </EditorBarTitleOnly>
+              )}
+            <EditorBarHover
+              show={
+                isHoverPanel &&
+                (props.controlBar !== 'titleBar' || curPanelId === 'Expression')
+              }>
               {/* Variable name */}
               {props.pathEl != null && (
                 <EditorPath>

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -576,14 +576,12 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       {controlBar !== 'off' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
-            {!isHoverPanel &&
-              props.pathEl != null && (
-                <EditorBarTitleOnly>
-                  {varNameToTitle(props.pathEl)}
-                </EditorBarTitleOnly>
-              )}
-            <EditorBarHover
-              show={isHoverPanel}>
+            {!isHoverPanel && props.pathEl != null && (
+              <EditorBarTitleOnly>
+                {varNameToTitle(props.pathEl)}
+              </EditorBarTitleOnly>
+            )}
+            <EditorBarHover show={isHoverPanel}>
               {/* Variable name */}
               {props.pathEl != null && (
                 <EditorPath>

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -1017,6 +1017,9 @@ const EditorPath = styled.div`
   margin-right: 8px;
 
   input {
+    :focus {
+      outline: none;
+    }
     font-family: inherit;
   }
 `;

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -564,7 +564,6 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
 
   const controlBar = props.controlBar ?? 'off';
   const isVarNameEditable = props.editable || controlBar === 'editable';
-  const noEditorIcons = !props.editable;
 
   return curPanelId == null || handler == null ? (
     <div>
@@ -626,7 +625,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
               )}
             </EditorBarHover>
             {/* Control buttons */}
-            {!noEditorIcons && (
+            {props.editable && (
               <EditorIcons visible={isHoverPanel || isMenuOpen}>
                 {props.prefixButtons}
                 <Tooltip

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -576,12 +576,12 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       {controlBar !== 'off' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
-            {(isVarNameEditable || !isHoverPanel) && props.pathEl != null && (
+            {(!isVarNameEditable || !isHoverPanel) && props.pathEl != null && (
               <EditorBarTitleOnly>
                 {varNameToTitle(props.pathEl)}
               </EditorBarTitleOnly>
             )}
-            <EditorBarHover show={isHoverPanel && !isVarNameEditable}>
+            <EditorBarHover show={isHoverPanel && isVarNameEditable}>
               {/* Variable name */}
               {props.pathEl != null && (
                 <EditorPath>

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -576,14 +576,14 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       {controlBar !== 'off' && (
         <Styles.EditorBar>
           <EditorBarContent className="edit-bar" ref={editorBarRef}>
-            {(props.controlBar === 'titleBar' || !isHoverPanel) &&
+            {!isHoverPanel &&
               props.pathEl != null && (
                 <EditorBarTitleOnly>
                   {varNameToTitle(props.pathEl)}
                 </EditorBarTitleOnly>
               )}
             <EditorBarHover
-              show={props.controlBar !== 'titleBar' && isHoverPanel}>
+              show={isHoverPanel}>
               {/* Variable name */}
               {props.pathEl != null && (
                 <EditorPath>

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -658,9 +658,9 @@ export const PanelGroupItem: React.FC<{
 
           // This updates the grid config with the new name, since we use names as ids
           // if we had unique ids, we wouldnt have to do this
-          if (config.gridConfig != null){
+          if (config.gridConfig != null) {
             const gridConfigIndex = config.gridConfig.panels.findIndex(
-              p => p.id === name  
+              p => p.id === name
             );
             if (gridConfigIndex !== -1) {
               draft.gridConfig.panels[gridConfigIndex].id = newName;

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -692,9 +692,8 @@ export const PanelGroupItem: React.FC<{
     controlBar = 'editable';
   }
   // We use enableAddPanel to mean the Group children are editable.
-  const editable = !!config.enableAddPanel;
   // If not editable, we don't want to show the editor icons in the ControlBar
-  const noEditorIcons = !editable;
+  const editable = !!config.enableAddPanel;
   // This makes it so controls in the varbar can overflow the parent container
   // correctly. For example, without this PanelDropdown renders its dropdown menu
   // within the parent, creating a scrollbar.
@@ -707,7 +706,7 @@ export const PanelGroupItem: React.FC<{
       newVars={siblingVars}
       handleVarEvent={handleSiblingVarEvent}>
       <ChildPanel
-        noEditorIcons={noEditorIcons}
+        editable={editable}
         overflowVisible={overflowVisible}
         allowedPanels={config.allowedPanels}
         pathEl={'' + name}

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -658,11 +658,13 @@ export const PanelGroupItem: React.FC<{
 
           // This updates the grid config with the new name, since we use names as ids
           // if we had unique ids, we wouldnt have to do this
-          const gridConfigIndex = config.gridConfig.panels.findIndex(
-            p => p.id === name
-          );
-          if (gridConfigIndex !== -1) {
-            draft.gridConfig.panels[gridConfigIndex].id = newName;
+          if (config.gridConfig != null){
+            const gridConfigIndex = config.gridConfig.panels.findIndex(
+              p => p.id === name  
+            );
+            if (gridConfigIndex !== -1) {
+              draft.gridConfig.panels[gridConfigIndex].id = newName;
+            }
           }
         })
       );


### PR DESCRIPTION
updates the titlebar check to include that if the panel is an expression(eg in the varbar) allow the name to be edited

https://github.com/wandb/weave/assets/25037002/70a14858-3d23-4514-8a15-602f5c3cb939

