### PR TITLE
fix: properly catch typeguard error in trace tree

### DIFF
--- a/weave/ops_domain/trace_tree.py
+++ b/weave/ops_domain/trace_tree.py
@@ -44,7 +44,7 @@ def _setattr_with_typeguard(obj: typing.Any, key: str, value: typing.Any) -> Non
 
     try:
         typeguard.check_type(value, hints[key])
-    except TypeError as e:
+    except typeguard.TypeCheckError as e:
         # warn
         logging.warning(
             f"Setting attribute {key} of {obj} to {value} failed typeguard check: {e}. Replacing with None."


### PR DESCRIPTION
Fixes this internal sentry issue https://weights-biases.sentry.io/issues/4443133957/?environment=prod&project=6620563&query=!error.type:WeaveReponsesDifferException+!error.type:WeaveTypescriptServiceError+!error.type:WeavePerformanceRegressionException+release:latest+stack.stack_level:0&referrer=issue-stream&sort=freq&statsPeriod=7d&stream_index=8.

We were catching the wrong error type in our new trace tree `_setattr_with_typeguard()`. This catches the correct one.