### PR TITLE
fix: hash constnode type to avoid collisions in deserialize in python

### DIFF
--- a/weave/serialize.py
+++ b/weave/serialize.py
@@ -113,6 +113,7 @@ def node_id(node: graph.Node):
             hashable["val"] = {"lambda": True, "body": node_id(node.val)}
         else:
             hashable["val"] = storage.to_python(node.val)
+        hashable["type"] = storage.to_python(node.type)
     else:
         raise errors.WeaveInternalError("invalid node encountered: %s" % node)
     hash = hashlib.md5()

--- a/weave/tests/test_compile.py
+++ b/weave/tests/test_compile.py
@@ -182,12 +182,12 @@ def test_compile_lambda_uniqueness():
     assert graph.count(concatted) == 12
 
     # However, after lambda compilation, we should get
-    # 3 more nodes (new row, add, and fn), but lose one
-    # because we dedupe the const "1", for a total of
-    # 14 nodes
+    # 3 more nodes (new row, add, and fn), the const 1
+    # is not deduped because in one case (inside the lambda function),
+    # it is an int and in the other, it is a number
     compiled = compile.compile([concatted])[0]
 
-    assert graph.count(compiled) == 14
+    assert graph.count(compiled) == 15
 
 
 # We actually don't want this to work because it would require


### PR DESCRIPTION
Related to #247. Fixes internal JIRA ticket https://wandb.atlassian.net/browse/WB-15389.

This is the python analog of the above bug #247. We were hashing parsed constnodes by value instead of by type and value, leading to collisions between nodes of different types that could affect dispatch. This PR fixes deserialize to hash constnodes by type and by value instead of just by value. 