### PR TITLE
fix: properly strip partialobject type from response payload before sending to JS

### DIFF
--- a/weave/tests/test_js_compat.py
+++ b/weave/tests/test_js_compat.py
@@ -28,4 +28,4 @@ def test_partialobject_type_stripping():
     type = types.TypeRegistry.type_of(instance)
     assert isinstance(type, partial_object.PartialObjectType)
     serialized = type.to_dict()
-    assert weavejs_fixes.remove_gql_haskeys_from_types(serialized) == "run"
+    assert weavejs_fixes.remove_partialobject_from_types(serialized) == "run"

--- a/weave/tests/test_js_compat.py
+++ b/weave/tests/test_js_compat.py
@@ -29,3 +29,1984 @@ def test_partialobject_type_stripping():
     assert isinstance(type, partial_object.PartialObjectType)
     serialized = type.to_dict()
     assert weavejs_fixes.remove_partialobject_from_types(serialized) == "run"
+
+
+def test_nested_partialobject_type_stripping():
+    input = {
+        "type": "tagged",
+        "tag": {
+            "type": "typedDict",
+            "propertyTypes": {
+                "project": {
+                    "type": "PartialObject",
+                    "keys": {
+                        "id": "string",
+                        "name": "string",
+                        "runs_b7f2f1441a601b3477d356429a493d05": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "edges": {
+                                    "type": "list",
+                                    "objectType": {
+                                        "type": "typedDict",
+                                        "propertyTypes": {
+                                            "node": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {
+                                                    "id": "string",
+                                                    "name": "string",
+                                                    "summaryMetrics": "string",
+                                                },
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                        },
+                    },
+                    "keyless_weave_type_class": "project",
+                }
+            },
+        },
+        "value": {
+            "type": "list",
+            "objectType": {
+                "type": "union",
+                "members": [
+                    {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "run": {
+                                    "type": "PartialObject",
+                                    "keys": {
+                                        "id": "string",
+                                        "name": "string",
+                                        "summaryMetrics": "string",
+                                    },
+                                    "keyless_weave_type_class": "run",
+                                }
+                            },
+                        },
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "epoch": "int",
+                                "_timestamp": "float",
+                                "samples_wf_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "val_mean_absolute_error": "float",
+                                "graph": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "sha256": "string",
+                                        "path": "string",
+                                        "size": "int",
+                                        "_type": "string",
+                                    },
+                                },
+                                "best_epoch": "int",
+                                "samples_wf_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "final_val_loss": "float",
+                                "_step": "int",
+                                "val_mae": "float",
+                                "_runtime": "float",
+                                "test_loss": "float",
+                                "samples_wf_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "mean_absolute_error": "float",
+                                "loss": "float",
+                                "GFLOPs": "int",
+                                "test_mae": "float",
+                                "val_loss": "float",
+                                "best_val_loss": "float",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "run": {
+                                    "type": "PartialObject",
+                                    "keys": {
+                                        "id": "string",
+                                        "name": "string",
+                                        "summaryMetrics": "string",
+                                    },
+                                    "keyless_weave_type_class": "run",
+                                }
+                            },
+                        },
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "_step": "int",
+                                "_runtime": "float",
+                                "samples_wf_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_timestamp": "float",
+                                "samples_wf_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "run": {
+                                    "type": "PartialObject",
+                                    "keys": {
+                                        "id": "string",
+                                        "name": "string",
+                                        "summaryMetrics": "string",
+                                    },
+                                    "keyless_weave_type_class": "run",
+                                }
+                            },
+                        },
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "samples_wf_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "best_val_loss": "float",
+                                "final_val_loss": "float",
+                                "graph": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "sha256": "string",
+                                        "path": "string",
+                                        "size": "int",
+                                        "_type": "string",
+                                    },
+                                },
+                                "best_epoch": "int",
+                                "_timestamp": "float",
+                                "samples_wf_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "val_mean_absolute_error": "float",
+                                "epoch": "int",
+                                "test_mae": "float",
+                                "val_loss": "float",
+                                "loss": "float",
+                                "_runtime": "float",
+                                "mean_absolute_error": "float",
+                                "samples_wf_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_step": "int",
+                                "val_mae": "float",
+                                "test_loss": "float",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "run": {
+                                    "type": "PartialObject",
+                                    "keys": {
+                                        "id": "string",
+                                        "name": "string",
+                                        "summaryMetrics": "string",
+                                    },
+                                    "keyless_weave_type_class": "run",
+                                }
+                            },
+                        },
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "samples_wf_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_runtime": "float",
+                                "test_mae": "float",
+                                "val_mae": "float",
+                                "test_loss": "float",
+                                "_timestamp": "float",
+                                "samples_wf_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "final_val_loss": "float",
+                                "_step": "int",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "run": {
+                                    "type": "PartialObject",
+                                    "keys": {
+                                        "id": "string",
+                                        "name": "string",
+                                        "summaryMetrics": "string",
+                                    },
+                                    "keyless_weave_type_class": "run",
+                                }
+                            },
+                        },
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "samples_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_timestamp": "float",
+                                "_step": "int",
+                                "_runtime": "float",
+                                "samples_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "run": {
+                                    "type": "PartialObject",
+                                    "keys": {
+                                        "id": "string",
+                                        "name": "string",
+                                        "summaryMetrics": "string",
+                                    },
+                                    "keyless_weave_type_class": "run",
+                                }
+                            },
+                        },
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "loss": "float",
+                                "GFLOPs": "int",
+                                "_runtime": "float",
+                                "samples_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "best_epoch": "int",
+                                "val_mean_absolute_error": "float",
+                                "test_loss": "float",
+                                "_step": "int",
+                                "epoch": "int",
+                                "graph": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "path": "string",
+                                        "size": "int",
+                                        "_type": "string",
+                                        "sha256": "string",
+                                    },
+                                },
+                                "val_loss": "float",
+                                "samples_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_timestamp": "float",
+                                "best_val_loss": "float",
+                                "final_val_loss": "float",
+                                "mean_absolute_error": "float",
+                                "val_mae": "float",
+                                "test_mae": "float",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "run": {
+                                    "type": "PartialObject",
+                                    "keys": {
+                                        "id": "string",
+                                        "name": "string",
+                                        "summaryMetrics": "string",
+                                    },
+                                    "keyless_weave_type_class": "run",
+                                }
+                            },
+                        },
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "_step": "int",
+                                "graph": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "path": "string",
+                                        "size": "int",
+                                        "_type": "string",
+                                        "sha256": "string",
+                                    },
+                                },
+                                "samples_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "val_mean_absolute_error": "float",
+                                "samples_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "final_val_loss": "float",
+                                "epoch": "int",
+                                "_runtime": "float",
+                                "test_mae": "float",
+                                "samples_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_timestamp": "float",
+                                "best_epoch": "int",
+                                "best_val_loss": "float",
+                                "loss": "float",
+                                "val_mae": "float",
+                                "val_loss": "float",
+                                "samples_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "test_loss": "float",
+                                "mean_absolute_error": "float",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "run": {
+                                    "type": "PartialObject",
+                                    "keys": {
+                                        "id": "string",
+                                        "name": "string",
+                                        "summaryMetrics": "string",
+                                    },
+                                    "keyless_weave_type_class": "run",
+                                }
+                            },
+                        },
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "val_mae": "float",
+                                "samples_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "test_loss": "float",
+                                "_timestamp": "float",
+                                "_step": "int",
+                                "_runtime": "float",
+                                "test_mae": "float",
+                                "samples_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "final_val_loss": "float",
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+    }
+
+    actual = weavejs_fixes.remove_partialobject_from_types(input)
+
+    expected = {
+        "type": "tagged",
+        "tag": {"type": "typedDict", "propertyTypes": {"project": "project"}},
+        "value": {
+            "type": "list",
+            "objectType": {
+                "type": "union",
+                "members": [
+                    {
+                        "type": "tagged",
+                        "tag": {"type": "typedDict", "propertyTypes": {"run": "run"}},
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "epoch": "int",
+                                "_timestamp": "float",
+                                "samples_wf_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "val_mean_absolute_error": "float",
+                                "graph": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "sha256": "string",
+                                        "path": "string",
+                                        "size": "int",
+                                        "_type": "string",
+                                    },
+                                },
+                                "best_epoch": "int",
+                                "samples_wf_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "final_val_loss": "float",
+                                "_step": "int",
+                                "val_mae": "float",
+                                "_runtime": "float",
+                                "test_loss": "float",
+                                "samples_wf_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "mean_absolute_error": "float",
+                                "loss": "float",
+                                "GFLOPs": "int",
+                                "test_mae": "float",
+                                "val_loss": "float",
+                                "best_val_loss": "float",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {"type": "typedDict", "propertyTypes": {"run": "run"}},
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "_step": "int",
+                                "_runtime": "float",
+                                "samples_wf_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_timestamp": "float",
+                                "samples_wf_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {"type": "typedDict", "propertyTypes": {"run": "run"}},
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "samples_wf_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "best_val_loss": "float",
+                                "final_val_loss": "float",
+                                "graph": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "sha256": "string",
+                                        "path": "string",
+                                        "size": "int",
+                                        "_type": "string",
+                                    },
+                                },
+                                "best_epoch": "int",
+                                "_timestamp": "float",
+                                "samples_wf_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "val_mean_absolute_error": "float",
+                                "epoch": "int",
+                                "test_mae": "float",
+                                "val_loss": "float",
+                                "loss": "float",
+                                "_runtime": "float",
+                                "mean_absolute_error": "float",
+                                "samples_wf_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_step": "int",
+                                "val_mae": "float",
+                                "test_loss": "float",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {"type": "typedDict", "propertyTypes": {"run": "run"}},
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "samples_wf_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_runtime": "float",
+                                "test_mae": "float",
+                                "val_mae": "float",
+                                "test_loss": "float",
+                                "_timestamp": "float",
+                                "samples_wf_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_wf_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "final_val_loss": "float",
+                                "_step": "int",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {"type": "typedDict", "propertyTypes": {"run": "run"}},
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "samples_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_timestamp": "float",
+                                "_step": "int",
+                                "_runtime": "float",
+                                "samples_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {"type": "typedDict", "propertyTypes": {"run": "run"}},
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "loss": "float",
+                                "GFLOPs": "int",
+                                "_runtime": "float",
+                                "samples_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "best_epoch": "int",
+                                "val_mean_absolute_error": "float",
+                                "test_loss": "float",
+                                "_step": "int",
+                                "epoch": "int",
+                                "graph": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "path": "string",
+                                        "size": "int",
+                                        "_type": "string",
+                                        "sha256": "string",
+                                    },
+                                },
+                                "val_loss": "float",
+                                "samples_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_timestamp": "float",
+                                "best_val_loss": "float",
+                                "final_val_loss": "float",
+                                "mean_absolute_error": "float",
+                                "val_mae": "float",
+                                "test_mae": "float",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {"type": "typedDict", "propertyTypes": {"run": "run"}},
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "_step": "int",
+                                "graph": {
+                                    "type": "typedDict",
+                                    "propertyTypes": {
+                                        "path": "string",
+                                        "size": "int",
+                                        "_type": "string",
+                                        "sha256": "string",
+                                    },
+                                },
+                                "samples_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "val_mean_absolute_error": "float",
+                                "samples_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "final_val_loss": "float",
+                                "epoch": "int",
+                                "_runtime": "float",
+                                "test_mae": "float",
+                                "samples_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "_timestamp": "float",
+                                "best_epoch": "int",
+                                "best_val_loss": "float",
+                                "loss": "float",
+                                "val_mae": "float",
+                                "val_loss": "float",
+                                "samples_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "test_loss": "float",
+                                "mean_absolute_error": "float",
+                            },
+                        },
+                    },
+                    {
+                        "type": "tagged",
+                        "tag": {"type": "typedDict", "propertyTypes": {"run": "run"}},
+                        "value": {
+                            "type": "typedDict",
+                            "propertyTypes": {
+                                "val_mae": "float",
+                                "samples_0": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_1": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_3": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "samples_4": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "test_loss": "float",
+                                "_timestamp": "float",
+                                "_step": "int",
+                                "_runtime": "float",
+                                "test_mae": "float",
+                                "samples_2": {
+                                    "type": "file",
+                                    "_base_type": {"type": "FileBase"},
+                                    "extension": "json",
+                                    "wbObjectType": {
+                                        "type": "table",
+                                        "_base_type": {"type": "Object"},
+                                        "_is_object": True,
+                                        "_rows": {
+                                            "type": "ArrowWeaveList",
+                                            "_base_type": {"type": "list"},
+                                            "objectType": {
+                                                "type": "typedDict",
+                                                "propertyTypes": {},
+                                            },
+                                        },
+                                    },
+                                },
+                                "final_val_loss": "float",
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+    }
+
+    assert actual == expected

--- a/weave/weavejs_fixes.py
+++ b/weave/weavejs_fixes.py
@@ -194,7 +194,7 @@ def remove_nan_and_inf(obj):
     return obj
 
 
-def remove_gql_haskeys_from_types(data):
+def remove_partialobject_from_types(data):
     """Convert weave-internal types like
 
     {"type":"PartialObject","keys":{"name":"string"},"keyless_weave_type_class":"project"}
@@ -208,7 +208,7 @@ def remove_gql_haskeys_from_types(data):
     # TODO: check this
 
     if isinstance(data, list):
-        return [remove_gql_haskeys_from_types(d) for d in data]
+        return [remove_partialobject_from_types(d) for d in data]
     elif isinstance(data, dict):
         for key in data:
             if key == "type":
@@ -224,5 +224,5 @@ def fixup_data(data):
     # response right now.
     # TODO: fix. Encode as string and then interpret in js side.
     data = remove_nan_and_inf(data)
-    data = remove_gql_haskeys_from_types(data)
+    data = remove_partialobject_from_types(data)
     return convert_specific_ops_to_generic_ops_data(data)

--- a/weave/weavejs_fixes.py
+++ b/weave/weavejs_fixes.py
@@ -210,10 +210,13 @@ def remove_partialobject_from_types(data):
     if isinstance(data, list):
         return [remove_partialobject_from_types(d) for d in data]
     elif isinstance(data, dict):
+        result = {}
         for key in data:
             if key == "type":
                 if data[key] == "PartialObject":
                     return data["keyless_weave_type_class"]
+            result[key] = remove_partialobject_from_types(data[key])
+        return result
     return data
 
 

--- a/weave/weavejs_fixes.py
+++ b/weave/weavejs_fixes.py
@@ -212,9 +212,8 @@ def remove_partialobject_from_types(data):
     elif isinstance(data, dict):
         result = {}
         for key in data:
-            if key == "type":
-                if data[key] == "PartialObject":
-                    return data["keyless_weave_type_class"]
+            if key == "type" and data[key] == "PartialObject":
+                return data["keyless_weave_type_class"]
             result[key] = remove_partialobject_from_types(data[key])
         return result
     return data


### PR DESCRIPTION
This PR fixes an issue where nested `PartialObject` types sent from python to JS in response to queries like `refine_summary_type` were not properly converted to the forms that JS expected, instead retaining their internal python representation. The reason for this was that the py -> js conversion was only going 1 level deep, so nested PartialObjects were being missed. Here we fix it by updating the function to recurse correctly. This fixes an issue where run colors were not working in panel plot. 

Before:

<img width="1257" alt="Screen Shot 2023-09-05 at 4 26 57 PM" src="https://github.com/wandb/weave/assets/2769632/3672929e-f235-4890-a917-8940ffc18a82">


After:

<img width="1250" alt="Screen Shot 2023-09-05 at 4 24 24 PM" src="https://github.com/wandb/weave/assets/2769632/b6808d58-5740-47c8-9b2a-6f6b76851963">

