### PR TITLE
chore(dev): fix publish script sha check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - run: |
           pip install build twine
           ./build_dist.py
-          if [[ -n "$(git status --porcelain)" ]]
+          if [[ -n "$(git status weave/frontend/sha1.txt --porcelain)" ]]
           then
             echo "::error cannot publish release, commited SHA does not match build SHA"
             exit 1


### PR DESCRIPTION
This checks that only the `sha1.txt` value is unchanged, if we check the entire git tree, the `index.html` file is currently not stable so it will change even if there is no material change in the code. This check makes it more stable.