### PR TITLE
analytics(weave): Make Sentry respect fingerprint & stack trace

### DIFF
--- a/weave/dispatch.py
+++ b/weave/dispatch.py
@@ -282,7 +282,7 @@ def get_op_for_inputs(name: str, kwargs: dict[str, types.Type]) -> op_def.OpDef:
     if not ops:
         logging.info('No ops found for "%s" with first arg "%s"', name, input_types[0])
         err = errors.WeaveDispatchError(
-            f'Cannot dispatch op "{name}"; no matching op found for first arg type: {input_types[0]}',
+            f'Cannot dispatch op "{name}"; no matching op found for first arg type: {input_types[0]}'
         )
         util.raise_exception_with_sentry_if_available(err, [name])
 

--- a/weave/dispatch.py
+++ b/weave/dispatch.py
@@ -111,8 +111,7 @@ def _subtype_sorting_ambiguity_resolution_rule_cmp(
     a_is_subtype = _op_args_is_subtype(b.input_type, a.input_type)
     if a_is_subtype and b_is_subtype:
         raise errors.WeaveDispatchError(
-            "Ambiguous ops %s, %s. Ops' input types are equivalent" % (a.name, b.name),
-            f"{a.name}, {b.name}"
+            "Ambiguous ops %s, %s. Ops' input types are equivalent" % (a.name, b.name)
         )
     if a_is_subtype:
         return -1
@@ -120,8 +119,7 @@ def _subtype_sorting_ambiguity_resolution_rule_cmp(
         return 1
     raise errors.WeaveDispatchError(
         "Ambiguous ops %s, %s. Ops' input types first arguments must be subset in one direction or the other."
-        % (a.name, b.name),
-        f"{a.name}, {b.name}"
+        % (a.name, b.name)
     )
 
 
@@ -240,16 +238,14 @@ def get_op_for_inputs(name: str, kwargs: dict[str, types.Type]) -> op_def.OpDef:
         ops = _get_ops_by_name(name)
         if not ops:
             err = errors.WeaveDispatchError(
-                f'Cannot dispatch op "{name}"; no matching op found',
-                name
+                f'Cannot dispatch op "{name}"; no matching op found'
             )
-            util.raise_exception_with_sentry_if_available(err)
+            util.raise_exception_with_sentry_if_available(err, [name])
         elif len(ops) > 1:
             err = errors.WeaveDispatchError(
-                f'Cannot dispatch zero-arg op "{name}"; multiple matching ops found',
-                name
+                f'Cannot dispatch zero-arg op "{name}"; multiple matching ops found'
             )
-            util.raise_exception_with_sentry_if_available(err)
+            util.raise_exception_with_sentry_if_available(err, [name])
         return ops[0]
 
     if (
@@ -287,19 +283,17 @@ def get_op_for_inputs(name: str, kwargs: dict[str, types.Type]) -> op_def.OpDef:
         logging.info('No ops found for "%s" with first arg "%s"', name, input_types[0])
         err = errors.WeaveDispatchError(
             f'Cannot dispatch op "{name}"; no matching op found for first arg type: {input_types[0]}',
-            name
         )
-        util.raise_exception_with_sentry_if_available(err)
+        util.raise_exception_with_sentry_if_available(err, [name])
 
     final_ops = _dispatch_remaining_args(
         ops, dict(zip(input_keys[1:], input_types[1:]))
     )
     if not final_ops:
         err = errors.WeaveDispatchError(
-            f'Cannot dispatch op "{name}"; ops {ops} matched first arg type, but no matching ops found for remaining arg types: {input_types[1:]}',
-            name
+            f'Cannot dispatch op "{name}"; ops {ops} matched first arg type, but no matching ops found for remaining arg types: {input_types[1:]}'
         )
-        util.raise_exception_with_sentry_if_available(err)
+        util.raise_exception_with_sentry_if_available(err, [name])
 
     return _resolve_op_ambiguity(final_ops, input_types[0])
 
@@ -357,10 +351,9 @@ class BoundPotentialOpDefs:
                 ops = self.potential_ops
             else:
                 err = errors.WeaveDispatchError(
-                    f'Cannot dispatch choose op from "{self.potential_ops}"; no matching op found',
-                    str(self.potential_ops)
+                    f'Cannot dispatch choose op from "{self.potential_ops}"; no matching op found'
                 )
-                util.raise_exception_with_sentry_if_available(err)
+                util.raise_exception_with_sentry_if_available(err, [str(self.potential_ops)])
         op = _resolve_op_ambiguity(ops, input_types[0])
         params = op.input_type.create_param_dict([self.self_node] + list(args), kwargs)
         return op(**params)
@@ -414,8 +407,7 @@ class DispatchMixin:
         if possible_prop_node is not None:
             return possible_prop_node
         raise errors.WeaveDispatchError(
-            'No ops called "%s" available on type "%s"' % (attr, node_self.type),
-            attr
+            'No ops called "%s" available on type "%s"' % (attr, node_self.type)
         )
 
     # This implementation is not directly inside of __getattr__ so that
@@ -451,8 +443,7 @@ class DispatchMixin:
             else:
                 raise errors.WeaveDispatchError(
                     'No attributes called "%s" available on Object "%s"'
-                    % (attr, node_self.type),
-                    attr
+                    % (attr, node_self.type)
                 )
         return None
 

--- a/weave/errors.py
+++ b/weave/errors.py
@@ -14,7 +14,7 @@ class WeaveBaseError(Exception):
         return self._fingerprint
 
     @fingerprint.setter
-    def fingerprint(self, value: Iterable) -> None:
+    def fingerprint(self, value: Optional[Iterable]) -> None:
         self._fingerprint = value
     
 

--- a/weave/errors.py
+++ b/weave/errors.py
@@ -4,18 +4,20 @@ class WeaveUnmergableArtifactsError(Exception):
     pass
 
 
-class WeaveBaseError(Exception):
-    def __init__(self, message: Optional[str] = None) -> None:
-        super().__init__(message)
-        self._fingerprint = None
-    
+class WeaveFingerprintErrorMixin():
     @property
     def fingerprint(self) -> Optional[Iterable]:
+        if not hasattr(self, "_fingerprint"):
+            self._fingerprint = None
         return self._fingerprint
 
     @fingerprint.setter
     def fingerprint(self, value: Optional[Iterable]) -> None:
         self._fingerprint = value
+
+
+class WeaveBaseError(Exception, WeaveFingerprintErrorMixin):
+    pass
     
 
 class WeaveBaseWarning(Warning):

--- a/weave/errors.py
+++ b/weave/errors.py
@@ -1,9 +1,20 @@
+from typing import Optional
+
 class WeaveUnmergableArtifactsError(Exception):
     pass
 
 
 class WeaveBaseError(Exception):
-    pass
+    def __init__(self, message: str, fingerprint: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.fingerprint = fingerprint
+
+    
+    def __str__(self) -> str:
+        message = super().__str__()
+        if self.fingerprint:
+            return f"{message} __fp:{self.fingerprint}"
+        return message
 
 
 class WeaveBaseWarning(Warning):

--- a/weave/errors.py
+++ b/weave/errors.py
@@ -1,21 +1,22 @@
-from typing import Optional
+from typing import Optional, Iterable
 
 class WeaveUnmergableArtifactsError(Exception):
     pass
 
 
 class WeaveBaseError(Exception):
-    def __init__(self, message: str, fingerprint: Optional[str] = None) -> None:
+    def __init__(self, message: str) -> None:
         super().__init__(message)
-        self.fingerprint = fingerprint
-
+        self._fingerprint = None
     
-    def __str__(self) -> str:
-        message = super().__str__()
-        if self.fingerprint:
-            return f"{message} __fp:{self.fingerprint}"
-        return message
+    @property
+    def fingerprint(self) -> Optional[Iterable]:
+        return self._fingerprint
 
+    @fingerprint.setter
+    def fingerprint(self, value: Iterable) -> None:
+        self._fingerprint = value
+    
 
 class WeaveBaseWarning(Warning):
     pass

--- a/weave/errors.py
+++ b/weave/errors.py
@@ -5,7 +5,7 @@ class WeaveUnmergableArtifactsError(Exception):
 
 
 class WeaveBaseError(Exception):
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: Optional[str] = None) -> None:
         super().__init__(message)
         self._fingerprint = None
     

--- a/weave/util.py
+++ b/weave/util.py
@@ -21,7 +21,7 @@ def init_sentry():
     except ImportError:
         return
     # Disable logs going to Sentry. Its slow
-    sentry_sdk.init(integrations=[LoggingIntegration(level=None)])
+    sentry_sdk.init(integrations=[LoggingIntegration(level=None, event_level=None)])
 
 
 def raise_exception_with_sentry_if_available(

--- a/weave/util.py
+++ b/weave/util.py
@@ -4,7 +4,6 @@ import socket
 import string
 import gc, inspect
 import ipynbname
-import re
 import typing
 
 sentry_inited = False

--- a/weave/util.py
+++ b/weave/util.py
@@ -9,22 +9,6 @@ import typing
 
 sentry_inited = False
 
-def before_send(event, hint):
-    if 'exception' in event:
-        exceptions = event['exception'].get('values', [])
-        if exceptions:
-            # Grab the first exception and extract fingerprint if it exists
-            exc_info = exceptions[0]
-            message = exc_info.get('value', '')
-            match = re.search(r'__fp:([\w]+)', message)
-            if match:
-                fingerprint = match.group(1)
-                new_message = re.sub(r'__fp:[\w]+', '', message).strip()
-                event['fingerprint'] = [fingerprint]
-                exc_info['value'] = new_message
-    return event
-
-
 def init_sentry():
     global sentry_inited
     if sentry_inited:
@@ -37,36 +21,17 @@ def init_sentry():
     except ImportError:
         return
     # Disable logs going to Sentry. Its slow
-    sentry_sdk.init(integrations=[LoggingIntegration(level=None, event_level=None)], before_send=before_send)
+    sentry_sdk.init(integrations=[LoggingIntegration(level=None, event_level=None)])
 
 
 def raise_exception_with_sentry_if_available(
-    err: Exception
+    err: Exception,
+    fingerprint: typing.Any
 ) -> typing.NoReturn:
     init_sentry()
-    try:
-        import sentry_sdk
-    except ImportError:
-        raise err
+    if hasattr(err, 'fingerprint'):
+        err.fingerprint = fingerprint
     raise err
-
-    # Note: It seems like you only get one or the other with Sentry: either the fingerprint
-    # or the full stack trace. If you set the fingerprint and explicitly capture it, 
-    # the stack trace gets dropped. This seems to happen even if you use the `fingerprint`
-    # arg in `capture_exception` or raise the error & catch it before capturing it in Sentry.
-    # I also tried raising outside of the with block with the same results. 
-    # So instead, we attach the fingerprint in the before_send hook at sentry init. 
-    # I'm leaving the code block below as a record of what was tried with Sentry's APIs,
-    # since it's not intuitive that it doesn't work. 
-    # else:
-    #     with sentry_sdk.push_scope() as scope:
-    #         scope.fingerprint = fingerprint
-    #         scope.set_extra("manual_traceback", tb_str)
-    #         # I (Tim) don't think we need to explicitly capture the exception
-    #         # here, since we're raising it anyway. Explicitly capturing it
-    #         # ends dropping the stack trace in Sentry.
-    #         # sentry_sdk.capture_exception(err)
-    #         raise err
 
 
 def capture_exception_with_sentry_if_available(
@@ -79,7 +44,10 @@ def capture_exception_with_sentry_if_available(
         pass
     else:
         with sentry_sdk.push_scope() as scope:
-            scope.fingerprint = fingerprint
+            if fingerprint:
+                scope.fingerprint = fingerprint
+            elif hasattr(err, "fingerprint"):
+                scope.fingerprint = err.fingerprint
             return sentry_sdk.capture_exception(err)
     return None
 


### PR DESCRIPTION
JIRA: https://wandb.atlassian.net/browse/WB-14243

We set the fingerprint on the error if possible in `raise_exception_with_sentry_if_available`. The error will get bubbled up to `capture_exception_with_sentry_if_available` which will use the fingerprint from the error if it exists. 

You can see the stack trace and custom fingerprint being set below when I test it locally by calling `[].throwError()`. 

# Sentry screenshots

![Screen Shot 2023-09-06 at 5 42 29 PM](https://github.com/wandb/weave/assets/8609620/f439d460-b892-4fb1-bcb9-3a067acccca2)

![Screen Shot 2023-09-06 at 5 42 09 PM](https://github.com/wandb/weave/assets/8609620/98d5509e-d046-41cf-95d1-7cf0edac0fa3)


