### PR TITLE
chore: make sure linting runs in CI and run it locally 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,7 +49,7 @@ jobs:
     container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test:${{ github.sha }}
     steps:
       - uses: actions/checkout@v2
-      - run: source /root/venv/bin/activate && pre-commit run --all-files
+      - run: source /root/venv/bin/activate && pre-commit run --hook-stage=pre-push --all-files
       - name: Show changes if pre-commit fails
         if: failure()
         run: |

--- a/weave/dispatch.py
+++ b/weave/dispatch.py
@@ -353,7 +353,9 @@ class BoundPotentialOpDefs:
                 err = errors.WeaveDispatchError(
                     f'Cannot dispatch choose op from "{self.potential_ops}"; no matching op found'
                 )
-                util.raise_exception_with_sentry_if_available(err, [str(self.potential_ops)])
+                util.raise_exception_with_sentry_if_available(
+                    err, [str(self.potential_ops)]
+                )
         op = _resolve_op_ambiguity(ops, input_types[0])
         params = op.input_type.create_param_dict([self.self_node] + list(args), kwargs)
         return op(**params)

--- a/weave/util.py
+++ b/weave/util.py
@@ -9,6 +9,7 @@ from .errors import WeaveFingerprintErrorMixin
 
 sentry_inited = False
 
+
 def init_sentry():
     global sentry_inited
     if sentry_inited:
@@ -25,8 +26,7 @@ def init_sentry():
 
 
 def raise_exception_with_sentry_if_available(
-    err: Exception,
-    fingerprint: typing.Any
+    err: Exception, fingerprint: typing.Any
 ) -> typing.NoReturn:
     init_sentry()
     if isinstance(err, WeaveFingerprintErrorMixin):


### PR DESCRIPTION
Since #472, linting checks have not been running in CI. This PR fixes that, and runs them locally to ensure that they pass on this commit. 