### PR TITLE
chore: add an error boundary

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Home.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Home.tsx
@@ -31,6 +31,7 @@ import {
   urlRecentTables,
 } from '../../../urls';
 import getConfig from '../../../config';
+import {ErrorBoundary} from '../../ErrorBoundary';
 
 const CenterSpace = styled(LayoutElements.VSpace)`
   border: 1px solid ${MOON_250};
@@ -143,7 +144,6 @@ const HomeComp: FC<HomeProps> = props => {
                   props.browserType === 'wandb' && params.entity === entity,
                 to: urlEntity(entity),
                 onClick: () => {
-                  console.log('setpreview node undefined');
                   setPreviewNode(undefined);
                   history.push(urlEntity(entity));
                 },
@@ -265,24 +265,26 @@ const HomeComp: FC<HomeProps> = props => {
         {/* Center Content */}
         {!loading && (
           <CenterSpace>
-            {props.browserType === 'recent' ? (
-              // This should never come up
-              <Placeholder />
-            ) : props.browserType === 'wandb' ? (
-              <CenterEntityBrowser
-                navigateToExpression={navigateToExpression}
-                setPreviewNode={setPreviewNode}
-                entityName={params.entity ?? ''}
-              />
-            ) : props.browserType === 'local' ? (
-              <CenterLocalBrowser
-                navigateToExpression={navigateToExpression}
-                setPreviewNode={setPreviewNode}
-              />
-            ) : (
-              // This should never come up
-              <Placeholder />
-            )}
+            <ErrorBoundary key={pathname}>
+              {props.browserType === 'recent' ? (
+                // This should never come up
+                <Placeholder />
+              ) : props.browserType === 'wandb' ? (
+                <CenterEntityBrowser
+                  navigateToExpression={navigateToExpression}
+                  setPreviewNode={setPreviewNode}
+                  entityName={params.entity ?? ''}
+                />
+              ) : props.browserType === 'local' ? (
+                <CenterLocalBrowser
+                  navigateToExpression={navigateToExpression}
+                  setPreviewNode={setPreviewNode}
+                />
+              ) : (
+                // This should never come up
+                <Placeholder />
+              )}
+            </ErrorBoundary>
           </CenterSpace>
         )}
         {/* Right Bar */}


### PR DESCRIPTION
Wrap main browser panel in ErrorBoundary so you can attempt to navigate after an error.

Before:
![image](https://github.com/wandb/weave/assets/112953339/bfb875e6-51a0-46cc-a55a-99e915fdd9b1)

After:
![image](https://github.com/wandb/weave/assets/112953339/b7b8e672-64a0-408c-8945-d556c8d127e6)
