### PR TITLE
analytics(weave): Tagging pageview analytics with pageName

### DIFF
--- a/weave-js/src/components/PagePanel.tsx
+++ b/weave-js/src/components/PagePanel.tsx
@@ -127,7 +127,7 @@ function useEnablePageAnalytics() {
       if (pathRef.current !== currentPath) {
         let pageName = '';
         if (location.search.includes('exp=get')) {
-          pageName = 'WeaveBoardOrTable';
+          pageName = 'WeaveGetExpression';
         } else if (location.pathname.includes('/browse')) {
           pageName = 'WeaveBrowser';
         }

--- a/weave-js/src/components/PagePanel.tsx
+++ b/weave-js/src/components/PagePanel.tsx
@@ -120,21 +120,23 @@ function useEnablePageAnalytics() {
   const pathRef = useRef('');
   const {urlPrefixed, backendWeaveViewerUrl} = getConfig();
 
-  const trackOnPathDiff = useCallback((location: any, options: any) => {
-    const currentPath = `${location.pathname}${location.search}`;
-    const fullURL = `${window.location.protocol}//${window.location.host}${location.pathname}${location.search}${location.hash}`;
-    if (pathRef.current !== currentPath) {
-      let pageName = "";
-      if (location.search.includes("exp=get")) {
-        pageName = "WeaveBoardOrTable"
+  const trackOnPathDiff = useCallback(
+    (location: any, options: any) => {
+      const currentPath = `${location.pathname}${location.search}`;
+      const fullURL = `${window.location.protocol}//${window.location.host}${location.pathname}${location.search}${location.hash}`;
+      if (pathRef.current !== currentPath) {
+        let pageName = '';
+        if (location.search.includes('exp=get')) {
+          pageName = 'WeaveBoardOrTable';
+        } else if (location.pathname.includes('/browse')) {
+          pageName = 'WeaveBrowser';
+        }
+        trackPage({url: fullURL, pageName}, options);
+        pathRef.current = currentPath;
       }
-      else if (location.pathname.includes("/browse")) {
-        pageName = "WeaveBrowser"
-      } 
-      trackPage({url: fullURL, pageName}, options);
-      pathRef.current = currentPath;
-    }
-  }, [pathRef])
+    },
+    [pathRef]
+  );
 
   // fetch user
   useEffect(() => {
@@ -176,11 +178,11 @@ function useEnablePageAnalytics() {
     };
 
     const unlisten = history.listen(location => {
-      trackOnPathDiff(location, options)
+      trackOnPathDiff(location, options);
     });
 
     // Track initial page view
-    trackOnPathDiff(history.location, options)
+    trackOnPathDiff(history.location, options);
 
     return () => {
       unlisten();

--- a/weave-js/src/components/PagePanel.tsx
+++ b/weave-js/src/components/PagePanel.tsx
@@ -120,6 +120,22 @@ function useEnablePageAnalytics() {
   const pathRef = useRef('');
   const {urlPrefixed, backendWeaveViewerUrl} = getConfig();
 
+  const trackOnPathDiff = useCallback((location: any, options: any) => {
+    const currentPath = `${location.pathname}${location.search}`;
+    const fullURL = `${window.location.protocol}//${window.location.host}${location.pathname}${location.search}${location.hash}`;
+    if (pathRef.current !== currentPath) {
+      let pageName = "";
+      if (location.search.includes("exp=get")) {
+        pageName = "WeaveBoardOrTable"
+      }
+      else if (location.pathname.includes("/browse")) {
+        pageName = "WeaveBrowser"
+      } 
+      trackPage({url: fullURL, pageName}, options);
+      pathRef.current = currentPath;
+    }
+  }, [pathRef])
+
   // fetch user
   useEffect(() => {
     const anonApiKey = getCookie('anon_api_key');
@@ -159,28 +175,17 @@ function useEnablePageAnalytics() {
       },
     };
 
-    // TODO: Make this DRY-er
     const unlisten = history.listen(location => {
-      const currentPath = `${location.pathname}${location.search}`;
-      const fullURL = `${window.location.protocol}//${window.location.host}${location.pathname}${location.search}${location.hash}`;
-      if (pathRef.current !== currentPath) {
-        trackPage({url: fullURL}, options);
-        pathRef.current = currentPath;
-      }
+      trackOnPathDiff(location, options)
     });
 
     // Track initial page view
-    const initialPath = `${history.location.pathname}${history.location.search}`;
-    const entireURL = `${window.location.protocol}//${window.location.host}${history.location.pathname}${history.location.search}${history.location.hash}`;
-    if (pathRef.current !== initialPath) {
-      trackPage({url: entireURL}, options);
-      pathRef.current = initialPath;
-    }
+    trackOnPathDiff(history.location, options)
 
     return () => {
       unlisten();
     };
-  }, [history]);
+  }, [history, trackOnPathDiff]);
 }
 
 // Simple function that forces rerender when URL changes.


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15502

URL is not present as a property in the analytics whitelist. Even if it was, it would be anonymized to hide PII (`entity` and `project` are examples of PII properties in the whitelist). 

PageName does exist and it's not anonymized. So we use it as a tag on page view events from enterprise customers. It currently holds one of two values: `WeaveBrowser` or `WeaveBoardOrTable` (or the empty string for all other URLs).  

