### PR TITLE
refactor(wir): Allow more modes in PanelInteractContext

### DIFF
--- a/weave-js/src/components/PagePanel.tsx
+++ b/weave-js/src/components/PagePanel.tsx
@@ -41,13 +41,13 @@ import {
 } from './Panel2/PanelGroup';
 import {
   PanelInteractContextProvider,
-  useCloseEditor,
-  useEditorIsOpen,
-  useSetInspectingPanel,
+  useCloseDrawer,
+  usePanelInteractMode,
+  useSetInteractingPanel,
 } from './Panel2/PanelInteractContext';
 import {useUpdateServerPanel} from './Panel2/PanelPanel';
 import {PanelRenderedConfigContextProvider} from './Panel2/PanelRenderedConfigContext';
-import Inspector from './Sidebar/Inspector';
+import PanelInteractDrawer from './Sidebar/PanelInteractDrawer';
 import {useWeaveAutomation} from './automation';
 import {consoleLog} from '../util';
 import {trackPage} from '../util/events';
@@ -456,7 +456,7 @@ type PageContentProps = {
 export const PageContent: FC<PageContentProps> = props => {
   const {config, updateConfig, updateConfig2, goHome} = props;
   const weave = useWeaveContext();
-  const editorIsOpen = useEditorIsOpen();
+  const panelInteractMode = usePanelInteractMode();
   const inJupyter = inJupyterCell();
   const {urlPrefixed} = getConfig();
 
@@ -538,18 +538,19 @@ export const PageContent: FC<PageContentProps> = props => {
           updateConfig2={updateConfig2}
         />
       </div>
-      <Inspector active={editorIsOpen}>
-        <ChildPanelConfigComp
-          // pathEl={CHILD_NAME}
-          config={config}
-          updateConfig={updateConfig}
-          updateConfig2={updateConfig2}
-        />
-      </Inspector>
+      <PanelInteractDrawer active={panelInteractMode !== null}>
+        {panelInteractMode === 'config' && (
+          <ChildPanelConfigComp
+            config={config}
+            updateConfig={updateConfig}
+            updateConfig2={updateConfig2}
+          />
+        )}
+      </PanelInteractDrawer>
       {inJupyter && (
         <JupyterPageControls
           {...props}
-          reveal={showJupyterControls && !editorIsOpen}
+          reveal={showJupyterControls && panelInteractMode === null}
           goHome={goHome}
           openNewTab={openNewTab}
           maybeUri={maybeUri}
@@ -576,9 +577,9 @@ const JupyterPageControls: React.FC<
   const [hoverText, setHoverText] = useState('');
   // TODO(fix): Hiding code export temporarily as it is partially broken
   // const {copyStatus, onCopy} = useCopyCodeFromURI(props.maybeUri);
-  const setInspectingPanel = useSetInspectingPanel();
-  const closeEditor = useCloseEditor();
-  const editorIsOpen = useEditorIsOpen();
+  const setInteractingPanel = useSetInteractingPanel();
+  const closeDrawer = useCloseDrawer();
+  const panelInteractMode = usePanelInteractMode();
   const updateInput = useCallback(
     (newInput: NodeOrVoidNode) => {
       props.updateConfig2(oldConfig => {
@@ -662,10 +663,10 @@ const JupyterPageControls: React.FC<
         </JupyterControlsIcon>
       )}
 
-      {editorIsOpen ? (
+      {panelInteractMode !== null ? (
         <JupyterControlsIcon
           onClick={() => {
-            closeEditor();
+            closeDrawer();
             setHoverText('Edit configuration');
           }}
           onMouseEnter={e => {
@@ -679,7 +680,7 @@ const JupyterPageControls: React.FC<
       ) : (
         <JupyterControlsIcon
           onClick={() => {
-            setInspectingPanel(['']);
+            setInteractingPanel('config', ['']);
             setHoverText('Close configuration editor');
           }}
           onMouseEnter={e => {

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -52,10 +52,10 @@ import {
 } from './PanelContext';
 import * as Styles from './PanelExpression/styles';
 import {
-  useCloseEditor,
+  useCloseDrawer,
   usePanelInputExprIsHighlightedByPath,
   useSelectedPath,
-  useSetInspectingChildPanel,
+  useSetInteractingChildPanel,
   useSetPanelInputExprIsHighlighted,
 } from './PanelInteractContext';
 import PanelNameEditor from './PanelNameEditor';
@@ -461,7 +461,7 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
     [panelInputExpr.type]
   );
 
-  const setInspectingPanel = useSetInspectingChildPanel();
+  const setInteractingPanel = useSetInteractingChildPanel();
 
   return useMemo(
     () => ({
@@ -481,7 +481,7 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
       updatePanelConfig,
       updatePanelConfig2,
       updatePanelInput,
-      setInspectingPanel,
+      setInteractingPanel,
     }),
     [
       curPanelId,
@@ -500,7 +500,7 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
       updatePanelConfig,
       updatePanelConfig2,
       updatePanelInput,
-      setInspectingPanel,
+      setInteractingPanel,
     ]
   );
 };
@@ -528,11 +528,11 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     updatePanelConfig,
     updatePanelConfig2,
     updatePanelInput,
-    setInspectingPanel,
+    setInteractingPanel,
   } = useChildPanelCommon(props);
 
   const {frame} = usePanelContext();
-  const closeEditor = useCloseEditor();
+  const closeDrawer = useCloseDrawer();
 
   const validateName = useCallback(
     (newName: string) => {
@@ -637,7 +637,9 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
                       variant="ghost"
                       size="small"
                       icon="pencil-edit"
-                      onClick={() => setInspectingPanel(props.pathEl ?? '')}
+                      onClick={() =>
+                        setInteractingPanel('config', props.pathEl ?? '')
+                      }
                     />
                   }>
                   Open panel editor
@@ -658,7 +660,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
                   onOpen={() => setIsMenuOpen(true)}
                   onClose={() => setIsMenuOpen(false)}
                   isOpen={isMenuOpen}
-                  goBackToOutline={closeEditor}
+                  goBackToOutline={closeDrawer}
                 />
               </EditorIcons>
             )}

--- a/weave-js/src/components/Panel2/PanelInteractContext.tsx
+++ b/weave-js/src/components/Panel2/PanelInteractContext.tsx
@@ -10,9 +10,11 @@ interface PanelInteractState {
   highlightInputExpr?: boolean;
 }
 
+type PanelInteractMode = 'config' | 'export-report' | null;
+
 export interface PanelInteractContextState {
   // State is stored by panel path. panel path is managed by PanelContext.
-  editorSidebarOpen: boolean;
+  panelInteractMode: PanelInteractMode;
   selectedPath: string[];
   panelState: {[pathString: string]: PanelInteractState};
 }
@@ -34,7 +36,7 @@ export const PanelInteractContextProvider: React.FC<{}> = React.memo(
   ({children}) => {
     const [state, setState] = useState<PanelInteractContextState>({
       selectedPath: [],
-      editorSidebarOpen: false,
+      panelInteractMode: null,
       panelState: {},
     });
 
@@ -157,13 +159,13 @@ export const useSetPanelIsHoveredInOutline = () => {
   );
 };
 
-export const useSetInspectingPanel = () => {
+export const useSetInteractingPanel = () => {
   const {setState} = usePanelInteractContext();
   return useCallback(
-    (path: string[]) => {
+    (mode: PanelInteractMode, path: string[]) => {
       setState(prevState => ({
         ...prevState,
-        editorSidebarOpen: true,
+        panelInteractMode: mode,
         selectedPath: path,
       }));
     },
@@ -171,30 +173,30 @@ export const useSetInspectingPanel = () => {
   );
 };
 
-export const useSetInspectingChildPanel = () => {
-  const setInspectingPanel = useSetInspectingPanel();
+export const useSetInteractingChildPanel = () => {
+  const setInteractingPanel = useSetInteractingPanel();
   const {path} = usePanelContext();
   return useCallback(
-    (childPath: string) => {
-      setInspectingPanel(path.concat([childPath]));
+    (mode: PanelInteractMode, childPath: string) => {
+      setInteractingPanel(mode, path.concat([childPath]));
     },
-    [path, setInspectingPanel]
+    [path, setInteractingPanel]
   );
 };
 
-export const useCloseEditor = () => {
+export const useCloseDrawer = () => {
   const {setState} = usePanelInteractContext();
   return useCallback(() => {
     setState(prevState => ({
       ...prevState,
-      editorSidebarOpen: false,
+      panelInteractMode: null,
     }));
   }, [setState]);
 };
 
-export const useEditorIsOpen = () => {
+export const usePanelInteractMode = () => {
   const {state} = usePanelInteractContext();
-  return state.editorSidebarOpen;
+  return state.panelInteractMode;
 };
 
 export const useSelectedPath = () => {

--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -32,9 +32,9 @@ import {PanelContextProvider, usePanelContext} from './PanelContext';
 import {fixChildData} from './PanelGroup';
 import {toWeaveType} from './toWeaveType';
 import {
-  useCloseEditor,
+  useCloseDrawer,
   useSelectedPath,
-  useSetInspectingPanel,
+  useSetInteractingPanel,
 } from './PanelInteractContext';
 import {useSetPanelRenderedConfig} from './PanelRenderedConfigContext';
 import {OutlineItemPopupMenu} from '../Sidebar/OutlineItemPopupMenu';
@@ -302,7 +302,7 @@ export function usePanelRootContext(id: string) {
 const usePanelPanelCommon = (props: PanelPanelProps) => {
   const weave = useWeaveContext();
   const selectedPanel = useSelectedPath();
-  const setSelectedPanel = useSetInspectingPanel();
+  const setInteractingPanel = useSetInteractingPanel();
   // const panelConfig = props.config;
 
   // TODO: this is not the right ID to use!!! The expression string changes when the panel
@@ -341,7 +341,7 @@ const usePanelPanelCommon = (props: PanelPanelProps) => {
     loading: initialLoading,
     panelConfig,
     selectedPanel,
-    setSelectedPanel,
+    setInteractingPanel,
     panelUpdateConfig,
     panelUpdateConfig2,
   };
@@ -352,12 +352,12 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
     loading,
     panelConfig,
     selectedPanel,
-    setSelectedPanel,
+    setInteractingPanel,
     panelUpdateConfig,
     panelUpdateConfig2,
   } = usePanelPanelCommon(props);
 
-  const closeEditor = useCloseEditor();
+  const closeDrawer = useCloseDrawer();
   const {
     visible: bodyScrollbarVisible,
     onScroll: onBodyScroll,
@@ -380,8 +380,8 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
   );
 
   const goBackToOutline = useCallback(() => {
-    setSelectedPanel([``]);
-  }, [setSelectedPanel]);
+    setInteractingPanel('config', ['']);
+  }, [setInteractingPanel]);
 
   if (loading) {
     return <Panel2Loader />;
@@ -404,7 +404,7 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
                 icon="close"
                 variant="ghost"
                 size="small"
-                onClick={closeEditor}
+                onClick={closeDrawer}
               />
             </SidebarConfig.HeaderTopRight>
           </SidebarConfig.HeaderTop>
@@ -413,7 +413,7 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
           config={panelConfig}
           updateConfig={panelUpdateConfig}
           updateConfig2={panelUpdateConfig2}
-          setSelected={setSelectedPanel}
+          setSelected={path => setInteractingPanel('config', path)}
           selected={selectedPanel}
         />
       </SidebarConfig.Container>
@@ -453,7 +453,7 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
               icon="close"
               variant="ghost"
               size="small"
-              onClick={closeEditor}
+              onClick={closeDrawer}
             />
           </SidebarConfig.HeaderTopRight>
         </SidebarConfig.HeaderTop>

--- a/weave-js/src/components/Sidebar/PanelInteractDrawer.tsx
+++ b/weave-js/src/components/Sidebar/PanelInteractDrawer.tsx
@@ -1,9 +1,13 @@
+import {MOON_250} from '@wandb/weave/common/css/color.styles';
 import React from 'react';
 import styled from 'styled-components';
 
-type InspectorProps = {active: boolean};
+type PanelInteractDrawerProps = {active: boolean};
 
-export const Inspector: React.FC<InspectorProps> = ({active, children}) => {
+export const PanelInteractDrawer: React.FC<PanelInteractDrawerProps> = ({
+  active,
+  children,
+}) => {
   return (
     <Container active={active} data-test="weave-sidebar">
       <Content>{children}</Content>
@@ -11,7 +15,7 @@ export const Inspector: React.FC<InspectorProps> = ({active, children}) => {
   );
 };
 
-export default Inspector;
+export default PanelInteractDrawer;
 
 const WIDTH_PX = 328;
 
@@ -19,14 +23,14 @@ export const Container = styled.div<{active: boolean}>`
   flex-shrink: 0;
   font-size: 15px;
   overflow: hidden;
-  border-left: ${p => (p.active ? '1px solid #e5e5e5' : 'none')};
+  border-left: ${p => (p.active ? `1px solid ${MOON_250}` : 'none')};
   // Alternative to the border:
   /* 
   z-index: 1;
   box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2); 
   */
   width: ${p => (p.active ? WIDTH_PX : 0)}px;
-  // Don't do this, it makes open and closing the inspector janky
+  // Don't do this, it makes open and closing the drawer janky
   // transition: width 0.3s;
 `;
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15451

No user-facing changes, just renames a bunch of things and updates `editorIsOpen: boolean` to `panelInteractMode: enum` in `PanelInteractContext`

Regression spot checks for "edit panel" experience:

https://github.com/wandb/weave/assets/17016170/fd6a4638-01be-4daf-8463-6949d23e08ed



