### PR TITLE
fix: Move setting bytes_read_to_arrow out of finally block

### DIFF
--- a/weave/execute.py
+++ b/weave/execute.py
@@ -375,11 +375,12 @@ def execute_forward(fg: forward_graph.ForwardGraph, no_cache=False) -> ExecuteSt
                         }
                     finally:
                         if span is not None:
-                            span.set_tag(
-                                "bytes_read_to_arrow", report["bytes_read_to_arrow"]
-                            )
-
                             span.finish()
+
+                    if span is not None:
+                        span.set_tag(
+                            "bytes_read_to_arrow", report["bytes_read_to_arrow"]
+                        )
 
                     stats.add_node(
                         forward_node.node,


### PR DESCRIPTION
Fixes internal sentry issue https://weights-biases.sentry.io/issues/4473321899/?referrer=slack&notification_uuid=c9637b87-cf47-454e-ba30-d6f76e134df6&alert_rule_id=12726589&alert_type=issue