### PR TITLE
chore: track table rows in bytes read to arrow

### DIFF
--- a/weave/op_policy.py
+++ b/weave/op_policy.py
@@ -40,7 +40,7 @@ CACHE_OP_NAMES = [
     "gqlroot-wbgqlquery",
 ] + CACHE_AND_PARALLEL_OP_NAMES
 
-ARROW_FS_OPS = ["run-history3", "run-history3_with_columns"]
+ARROW_FS_OPS = ["run-history3", "run-history3_with_columns", "table-rows"]
 
 
 # history ops are parallelized by derive_op only, in a custom way


### PR DESCRIPTION
Implements a comment from @tssweeney, tracks table-rows in `bytes_read_to_arrow`. 

