### PR TITLE
chore: fix dev mode validateDOMNesting warning

### DIFF
--- a/weave-js/src/components/Panel2/KeyValTable.tsx
+++ b/weave-js/src/components/Panel2/KeyValTable.tsx
@@ -1,11 +1,28 @@
 import * as globals from '@wandb/weave/common/css/globals.styles';
 import styled from 'styled-components';
 
-export const Table = styled.table`
+export const Table = styled.div`
   font-size: 13px;
+  display: table;
+  padding: 2px;
 `;
-export const Row = styled.tr``;
-export const Key = styled.td`
+Table.displayName = 'S.Table';
+
+export const Rows = styled.div`
+  margin-top: 2px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+Rows.displayName = 'S.Rows';
+
+export const Row = styled.div`
+  display: flex;
+  gap: 2px;
+`;
+Row.displayName = 'S.Row';
+
+export const Key = styled.div`
   white-space: nowrap;
   text-overflow: ellipsis;
   vertical-align: top;
@@ -13,12 +30,16 @@ export const Key = styled.td`
   color: ${globals.gray500};
   width: 100px;
 `;
-export const Val = styled.td`
+Key.displayName = 'S.Key';
+
+export const Val = styled.div`
   padding: 0 !important;
 `;
+Val.displayName = 'S.Val';
 
-export const InputUpdateLink = styled.div`
+export const InputUpdateLink = styled.span`
   cursor: pointer;
   text-decoration: underline;
   text-decoration-style: dotted;
 `;
+InputUpdateLink.displayName = 'S.InputUpdateLink';

--- a/weave-js/src/components/Panel2/PanelObject.tsx
+++ b/weave-js/src/components/Panel2/PanelObject.tsx
@@ -252,7 +252,7 @@ export const PanelObject: React.FC<PanelObjectProps> = props => {
           {props.input.type.type}
         </div>
       )}
-      {expanded && <tbody>{keyChildren}</tbody>}
+      {expanded && <KeyValTable.Rows>{keyChildren}</KeyValTable.Rows>}
     </KeyValTable.Table>
   );
 };


### PR DESCRIPTION
Fixes this development mode warning by using divs styled to match existing table instead of an actual table element.

<img width="692" alt="Screenshot 2023-09-13 at 4 15 49 PM" src="https://github.com/wandb/weave/assets/112953339/7579df84-800b-433e-8872-a00157766f2a">
