### PR TITLE
chore: change logged table expression to use get op

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -17,13 +17,10 @@ import {
   callOpVeryUnsafe,
   constString,
   list,
-  opArtifactMembershipArtifactVersion,
-  opArtifactMembershipForAlias,
   opArtifactVersionFile,
   opFileTable,
   opGet,
   opIsNone,
-  opProjectArtifact,
   opRootProject,
   opTableRows,
   typedDict,
@@ -472,24 +469,17 @@ const tableRowToNode = (
       list(typedDict({}))
     ) as any;
   } else {
-    // This is a  hacky here. Would be nice to have better mapping
+    // This is a hack. Would be nice to have better mapping
+    // Note that this will not work for tables with spaces in their name
+    // as we strip the space out to make the artifact name.
     const artNameParts = artName.split('-', 3);
     const tableName = artNameParts[artNameParts.length - 1] + '.table.json';
+
+    const uri = `wandb-artifact:///${entityName}/${projectName}/${artName}:latest`;
     newExpr = opTableRows({
       table: opFileTable({
         file: opArtifactVersionFile({
-          artifactVersion: opArtifactMembershipArtifactVersion({
-            artifactMembership: opArtifactMembershipForAlias({
-              artifact: opProjectArtifact({
-                project: opRootProject({
-                  entityName: constString(entityName),
-                  projectName: constString(projectName),
-                }),
-                artifactName: constString(artName),
-              }),
-              aliasName: constString('latest'),
-            }),
-          }),
+          artifactVersion: opGet({uri: constString(uri)}),
           path: constString(tableName),
         }),
       }),


### PR DESCRIPTION
The goal here is to make the expression structure for logged tables more closely match the expression structure for stream tables, which in turn will let us simplify the UI logic for fetching the artifacts (boards) depending on the table.