### PR TITLE
feat(weave): add number of rows for ST in home page table

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -539,7 +539,7 @@ const CenterProjectTablesBrowser: React.FC<
       'created at': moment.utc(b.createdAt).local().calendar(),
       'created by': b.createdByUserName,
       // we use the # of steps in the run history to compute rows quickly. This works for stream tables
-      // because the table leverages run history. For logged tables, we must open to table in order to
+      // because the table leverages run history. For logged tables, we must open the table in order
       // to know the number of rows which is a much more expensive operation. Instead, we will just
       // display a dummy placeholder
       'number of rows': '-',

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -528,6 +528,7 @@ const CenterProjectTablesBrowser: React.FC<
       'updated at': moment.utc(b.createdByUpdatedAt).local().calendar(),
       'created at': moment.utc(b.createdAt).local().calendar(),
       'created by': b.createdByUserName,
+      'number of rows': b.numRows,
     }));
     const logged = loggedTables.result.map(b => ({
       _id: b.name,
@@ -537,6 +538,11 @@ const CenterProjectTablesBrowser: React.FC<
       'updated at': moment.utc(b.updatedAt).local().calendar(),
       'created at': moment.utc(b.createdAt).local().calendar(),
       'created by': b.createdByUserName,
+      // we use the # of steps in the run history to compute rows quickly. This works for stream tables
+      // because the table leverages run history. For logged tables, we must open to table in order to
+      // to know the number of rows which is a much more expensive operation. Instead, we will just
+      // display a dummy placeholder
+      'number of rows': '-',
     }));
     const combined = [...streams, ...logged];
     combined.sort((a, b) => b._updatedAt - a._updatedAt);
@@ -705,7 +711,14 @@ const CenterProjectTablesBrowser: React.FC<
         ]}
         loading={isLoading}
         filters={{kind: {placeholder: 'All table kinds'}}}
-        columns={['name', 'kind', 'updated at', 'created at', 'created by']}
+        columns={[
+          'name',
+          'kind',
+          'updated at',
+          'created at',
+          'created by',
+          'number of rows',
+        ]}
         data={browserData}
         actions={browserActions}
       />

--- a/weave-js/src/components/PagePanelComponents/Home/query.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/query.tsx
@@ -272,6 +272,15 @@ const opArtifactsBasicMetadata = ({artifacts}: {artifacts: w.Node}) => {
             artifactVersion: latestVersionNode,
           }),
         }),
+        numRows: w.callOpVeryUnsafe(
+          'run-historyLineCount',
+          {
+            run: w.opArtifactVersionCreatedBy({
+              artifactVersion: latestVersionNode,
+            }),
+          },
+          'number'
+        ) as any,
       } as any);
     }),
   });
@@ -314,6 +323,7 @@ export const useProjectRunStreams = (
     createdAt: number;
     updatedAt: number;
     createdByUpdatedAt: number;
+    numRows: number;
   }>;
   loading: boolean;
 } => {
@@ -341,6 +351,7 @@ export const useProjectRunLoggedTables = (
     createdAt: number;
     updatedAt: number;
     createdByUpdatedAt: number;
+    numRows: number;
   }>;
   loading: boolean;
 } => {


### PR DESCRIPTION
Add a new column for number of rows for stream tables:
<img width="2256" alt="image" src="https://github.com/wandb/weave/assets/1727691/10c5713d-e185-4f7b-a26e-d62ea9e79448">

Note: this does not work for logged tables so I display a `-` to indicate the information does not exist