### PR TITLE
fix: handle null initiator in artifact version created by user

### DIFF
--- a/weave/ops_domain/artifact_version_ops.py
+++ b/weave/ops_domain/artifact_version_ops.py
@@ -276,7 +276,8 @@ def artifact_version_created_by(
 def artifact_version_created_by_user(
     artifactVersion: wdt.ArtifactVersion,
 ) -> typing.Optional[wdt.User]:
-    if artifactVersion["createdBy"]["__typename"] == "User":
+    cb = artifactVersion["createdBy"]
+    if cb is not None and cb["__typename"] == "User":
         return wdt.User.from_keys(artifactVersion["createdBy"])
     return None
 


### PR DESCRIPTION
Related to #563. Handles the user case and fixes one of our top sentry issues, https://weights-biases.sentry.io/issues/4488342603.
