### PR TITLE
fix: coerce bin count to int in histogram

### DIFF
--- a/weave/ops_domain/wb_util.py
+++ b/weave/ops_domain/wb_util.py
@@ -84,7 +84,7 @@ def _process_run_dict_item(val, run_path: typing.Optional[RunPath] = None):
             if "packedBins" in val:
                 bins = []
                 bin_min = val["packedBins"]["min"]
-                for i in range(val["packedBins"]["count"]):
+                for i in range(int(val["packedBins"]["count"])):
                     bins.append(bin_min)
                     bin_min += val["packedBins"]["size"]
             else:


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-15607

Fixes an issue where we were not properly handling float values (e.g., 64.0) in our histogram deserialization path.  Solution: coerce to ints. 