### PR TITLE
fix: Unbox nones in pyarrow util.equal, util.not_equal

### DIFF
--- a/weave/ops_arrow/util.py
+++ b/weave/ops_arrow/util.py
@@ -36,6 +36,7 @@ def _eq_null_consumer_helper(
     lhs: pa.Array, rhs: typing.Union[pa.Array, pa.Scalar]
 ) -> typing.Tuple[pa.Array, pa.Array]:
     # consume nulls
+
     self_is_null = pc.is_null(lhs)
     other_is_null = pc.is_null(rhs)
     one_null = pc.xor(self_is_null, other_is_null)
@@ -45,6 +46,10 @@ def _eq_null_consumer_helper(
 
 
 def not_equal(lhs: pa.Array, rhs: typing.Union[pa.Array, pa.Scalar]) -> pa.Array:
+    # this unboxes the null scalar if it is boxed
+    if rhs == None:
+        rhs = None
+
     one_null, both_null = _eq_null_consumer_helper(lhs, rhs)
     result = pc.not_equal(lhs, rhs)
     result = pc.replace_with_mask(result, both_null, False)
@@ -53,6 +58,10 @@ def not_equal(lhs: pa.Array, rhs: typing.Union[pa.Array, pa.Scalar]) -> pa.Array
 
 
 def equal(lhs: pa.Array, rhs: typing.Union[pa.Array, pa.Scalar]) -> pa.Array:
+    # this unboxes the null scalar if it is boxed
+    if rhs == None:
+        rhs = None
+
     one_null, both_null = _eq_null_consumer_helper(lhs, rhs)
     result = pc.equal(lhs, rhs)
     result = pc.replace_with_mask(result, both_null, True)

--- a/weave/tests/test_arrow_vectorizer.py
+++ b/weave/tests/test_arrow_vectorizer.py
@@ -10,18 +10,21 @@ from .. import weave_internal
 from ..ops_primitives import dict_, list_
 from .. import errors
 
-import datetime
-
 from ..language_features.tagging import tag_store, tagged_value_type, make_tag_getter_op
 
 from .. import ops_arrow as arrow
 from ..ops_arrow import arraylist_ops
 from ..ops_arrow import convert_ops
+from ..ops_arrow import util
 
 from ..ops_domain import wb_domain_types as wdt
 
 from ..ops_domain import run_ops
 
+
+import pyarrow as pa
+
+from pyarrow import compute as pc
 
 string_ops_test_cases = [
     ("eq-scalar", lambda x: x == "bc", [True, False, False]),
@@ -1401,3 +1404,10 @@ def test_vectorize_run_runtime():
     # it finds an AWL op
     assert "ArrowWeaveList" in vec_fn.from_op.name
     assert "mapped" not in vec_fn.from_op.name
+
+
+def test_boxed_null_in_array_equal():
+    lhs = pa.array([1, None, 3])
+    rhs = box.box(None)
+    assert util.equal(lhs, rhs).to_pylist() == [False, True, False]
+    assert util.not_equal(lhs, rhs).to_pylist() == [True, False, True]


### PR DESCRIPTION
Fixes an issue where we were not unboxing nones properly in util.equal, util.not_equal, and adds a test. 

Internal JIRA: https://wandb.atlassian.net/browse/WB-15609
Internal Sentry: https://weights-biases.sentry.io/issues/4490051920