### PR TITLE
fix(wir): Fix minor report select issues

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ReportOption.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ReportOption.tsx
@@ -21,7 +21,9 @@ export const ReportOptionComp = ({optionData, children}: ReportOptionProps) => {
       )}
       <div className="mx-8 flex grow flex-col p-0 text-base leading-6">
         <p>{children}</p>
-        <p className="mt-4 text-sm text-moon-500">{optionData.projectName}</p>
+        {!!optionData.projectName && (
+          <p className="mt-4 text-sm text-moon-500">{optionData.projectName}</p>
+        )}
       </div>
     </div>
   );

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
@@ -109,7 +109,7 @@ export const ReportSelection = ({
       const foundEntity = entities.result.find(
         (item: EntityOption) => item.name === entityName
       );
-      setSelectedEntity(foundEntity);
+      setSelectedEntity(foundEntity ?? entities.result[0]);
     }
   }, [entityName, entities, setSelectedEntity]);
 
@@ -155,7 +155,7 @@ export const ReportSelection = ({
         isSearchable
       />
       <label
-        htmlFor="destination-report"
+        htmlFor="report-selector"
         className="mb-4 block font-semibold text-moon-800">
         Destination report
       </label>

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
@@ -171,9 +171,7 @@ export const ReportSelection = ({
             className="mb-16"
             id="report-selector"
             isLoading={reports.loading}
-            isDisabled={
-              entities.loading || reports.loading || reports.result.length === 1
-            }
+            isDisabled={entities.loading || reports.loading}
             options={groupedReportOptions}
             placeholder={!reports.loading && 'Select a report...'}
             getOptionLabel={option => option.name}


### PR DESCRIPTION
before:

1. report select is disabled if there's only 1 report in the selected entity
2. "New report" option text slightly misaligned
3. awkward state for unpublished boards (because entity name is not in url)

<img width="368" alt="Screen Shot 2023-09-20 at 9 05 31 AM" src="https://github.com/wandb/weave/assets/17016170/1913b278-6abd-4622-beab-c097dea955f7">
<img width="340" alt="Screen Shot 2023-09-20 at 9 05 41 AM" src="https://github.com/wandb/weave/assets/17016170/c2b47f83-bc72-4163-9da5-f6309216ffa2">

<img width="1360" alt="Screen Shot 2023-09-20 at 9 45 15 AM" src="https://github.com/wandb/weave/assets/17016170/a3486018-5065-406f-9bd8-c54cc88ba9d9">


after:

<img width="365" alt="Screen Shot 2023-09-20 at 9 05 12 AM" src="https://github.com/wandb/weave/assets/17016170/3dd5eddf-a396-4032-b2b4-f11012513630">

<img width="1362" alt="Screen Shot 2023-09-20 at 9 48 15 AM" src="https://github.com/wandb/weave/assets/17016170/96c603b5-49a9-44d5-a416-bc5ac303a848">

