### PR TITLE
feat(wir): Compute slate node for report export

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
@@ -8,14 +8,21 @@ import {useCloseDrawer, useSelectedPath} from '../PanelInteractContext';
 import {ReportSelection} from './ReportSelection';
 import {ChildPanelFullConfig} from '../ChildPanel';
 import {EntityOption, ProjectOption, ReportOption} from './utils';
+import {useNodeValue} from '@wandb/weave/react';
+import {computeReportSlateNode} from './computeReportSlateNode';
 
 type ChildPanelExportReportProps = {
+  /**
+   * "root" config of the board, which points to the artifact that contains
+   * the "full" config with actual details about all the sub-panels within
+   */
   rootConfig: ChildPanelFullConfig;
 };
 
 export const ChildPanelExportReport = ({
   rootConfig,
 }: ChildPanelExportReportProps) => {
+  const {result: fullConfig} = useNodeValue(rootConfig.input_node);
   const selectedPath = useSelectedPath();
   const closeDrawer = useCloseDrawer();
 
@@ -30,10 +37,16 @@ export const ChildPanelExportReport = ({
   );
 
   const onAddPanel = () => {
+    const slateNode = computeReportSlateNode(fullConfig, selectedPath);
     // TODO - this will be replaced with correct add panel implementation later on
-    alert(
-      `Report id: ${selectedReport?.id} \nReport name: ${selectedReport?.name} \nEntity name: ${selectedEntity?.name} \nProject name: ${selectedProject?.name}`
-    );
+    alert(`
+      Report id: ${selectedReport?.id}
+      Report name: ${selectedReport?.name}
+      Entity name: ${selectedEntity?.name}
+      Project name: ${selectedProject?.name}
+      Slate node: logged in dev console
+    `);
+    console.log('Slate node to be added:', slateNode);
   };
 
   return (

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
@@ -1,0 +1,65 @@
+import {voidNode} from '@wandb/weave/core';
+import {ChildPanelFullConfig} from '../ChildPanel';
+import {getConfigForPath} from '../panelTree';
+
+type WeavePanelSlateNode = {
+  type: 'weave-panel';
+  /**
+   * A weave-panel slate node in a report is a "void element", which
+   * requires an empty child text node. See:
+   * https://docs.slatejs.org/api/nodes/element#rendering-void-elements
+   */
+  children: [{text: ''}];
+  /** Slate node config, passed to RootQueryPanel in core */
+  config: {
+    isWeave1Panel: true;
+    /** Weave child panel config */
+    panelConfig: ChildPanelFullConfig;
+  };
+};
+
+/**
+ * Given a full child panel config and the path to a target panel,
+ * get the target config and map it into a slate node that can be
+ * displayed in a report
+ *
+ * @param fullConfig - config containing the target panel
+ * @param targetPath - path to the target panel
+ */
+export const computeReportSlateNode = (
+  fullConfig: ChildPanelFullConfig,
+  targetPath: string[]
+): WeavePanelSlateNode => {
+  const targetConfig = getConfigForPath(fullConfig, targetPath);
+
+  return {
+    type: 'weave-panel',
+    children: [{text: ''}],
+    config: {
+      isWeave1Panel: true,
+      panelConfig: {
+        id: 'Panel',
+        config: undefined,
+        input_node: {
+          nodeType: 'const',
+          type: {type: 'Panel'},
+          val: {
+            id: 'Group',
+            input_node: voidNode(),
+            config: {
+              items: {
+                panel: targetConfig,
+              },
+              disableDeletePanel: true,
+              enableAddPanel: true, // actually means "is editable"
+              layoutMode: 'vertical',
+              showExpressions: true,
+            },
+            vars: {},
+          },
+        },
+        vars: {},
+      },
+    },
+  };
+};


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15492

testing: copy the computed slate node config and manually add it into a report. with [this change](https://github.com/wandb/core/pull/17121) merged, the panel at least gets rendered, even if not yet editable


https://github.com/wandb/weave/assets/17016170/3d451414-bc81-49e2-9ab5-19cc853757fe

