### PR TITLE
fix(weave): Adding panel in Jupyter cell causes crash

### DIFF
--- a/weave-js/src/components/PagePanel.tsx
+++ b/weave-js/src/components/PagePanel.tsx
@@ -33,7 +33,6 @@ import {
 import {ChildPanelExportReport} from './Panel2/ChildPanelExportReport/ChildPanelExportReport';
 import {themes} from './Panel2/Editor.styles';
 import {
-  IconAddNew,
   IconClose,
   IconHome,
   IconOpenNewTab,
@@ -41,16 +40,11 @@ import {
 } from './Panel2/Icons';
 import * as Styles from './Panel2/PanelExpression/styles';
 import {
-  PANEL_GROUP_DEFAULT_CONFIG,
-  addPanelToGroupConfig,
-} from './Panel2/PanelGroup';
-import {
   PanelInteractContextProvider,
   useCloseDrawer,
   usePanelInteractMode,
   useSetInteractingPanel,
 } from './Panel2/PanelInteractContext';
-import {useUpdateServerPanel} from './Panel2/PanelPanel';
 import {PanelRenderedConfigContextProvider} from './Panel2/PanelRenderedConfigContext';
 import PanelInteractDrawer from './Sidebar/PanelInteractDrawer';
 import {useWeaveAutomation} from './automation';
@@ -591,65 +585,6 @@ const JupyterPageControls: React.FC<
   const setInteractingPanel = useSetInteractingPanel();
   const closeDrawer = useCloseDrawer();
   const panelInteractMode = usePanelInteractMode();
-  const updateInput = useCallback(
-    (newInput: NodeOrVoidNode) => {
-      props.updateConfig2(oldConfig => {
-        return {
-          ...oldConfig,
-          input_node: newInput,
-        };
-      });
-    },
-    [props]
-  );
-  const updateConfigForPanelNode = useUpdateServerPanel(
-    props.config.input_node,
-    updateInput
-  );
-  const addPanelToPanel = useCallback(() => {
-    if (props.isPanel) {
-      props.updateConfig2(oldConfig => {
-        // props.updateConfig2(oldConfig => {
-        let newInnerPanelConfig: ChildPanelFullConfig;
-        if (props.isGroup) {
-          newInnerPanelConfig = {
-            ...oldConfig.config,
-            config: addPanelToGroupConfig(
-              oldConfig.config.config,
-              [''],
-              'panel'
-            ),
-          };
-        } else {
-          newInnerPanelConfig = {
-            config: addPanelToGroupConfig(
-              addPanelToGroupConfig(
-                PANEL_GROUP_DEFAULT_CONFIG(),
-                undefined,
-                'panel',
-                oldConfig.config
-              ),
-              [''],
-              'panel'
-            ),
-            id: 'Group',
-            input_node: {
-              nodeType: 'void',
-              type: 'invalid',
-            },
-            vars: {},
-          };
-        }
-
-        updateConfigForPanelNode(newInnerPanelConfig);
-
-        return {
-          ...oldConfig,
-          config: newInnerPanelConfig,
-        };
-      });
-    }
-  }, [props, updateConfigForPanelNode]);
 
   return (
     <JupyterControlsMain
@@ -660,19 +595,6 @@ const JupyterPageControls: React.FC<
       <JupyterControlsHelpText active={hoverText !== ''}>
         {hoverText}
       </JupyterControlsHelpText>
-
-      {props.isPanel && (
-        <JupyterControlsIcon
-          onClick={addPanelToPanel}
-          onMouseEnter={e => {
-            setHoverText('Add new panel');
-          }}
-          onMouseLeave={e => {
-            setHoverText('');
-          }}>
-          <IconAddNew />
-        </JupyterControlsIcon>
-      )}
 
       {panelInteractMode !== null ? (
         <JupyterControlsIcon


### PR DESCRIPTION
JIRA ticket: https://wandb.atlassian.net/browse/WB-15599

### Problem
In the notebook cell, we render PagePanel --> JupyterPageControls --> PanelGroup. This "Add new panel" button exists on the Jupyter component and clicking on it tries to modify the config defined in PagePanel. This fails because config.config is undefined.

![Screen Shot 2023-09-20 at 12 14 33 PM](https://github.com/wandb/weave/assets/8609620/16cf740f-6148-44f0-8052-1940f5d3be8c)

In the dashboard view, the "Add new panel" button exists inside PanelGroup and never touches the PagePanel config. It only controls the PanelGroup config which are totally different configs.

![Screen Shot 2023-09-20 at 12 16 48 PM](https://github.com/wandb/weave/assets/8609620/bee5479b-7f95-4047-a7c0-2360ac459fc9)

### Solution
We need the button in the Jupyter cell (under PagePanel) to modify the PanelGroup config in its descendant component tree. Making this work would be difficult, given the way we render components. 

As per @shawnlewis's recommendation, I'm going to remove this button and associated logic from the JupyterPageControls component. We can tell users to open in fullscreen (new tab) and adding a panel there. It would make for a better UX since each cell in Jupyter has pretty small real estate anyways. 


