### PR TITLE
fix: Use gql retry in artifact path

### DIFF
--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -193,12 +193,13 @@ def _collection_and_alias_id_mapping_to_uri(
     }
     """
     )
-    res = wandb_client_api.wandb_public_api().client.execute(
+    res = wandb_client_api._query_with_retry(
         query,
         variable_values={
             "id": client_collection_id,
             "aliasName": alias_name,
         },
+        num_timeout_retries=1,
     )
     collection = res["artifactCollection"]
 

--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -193,7 +193,7 @@ def _collection_and_alias_id_mapping_to_uri(
     }
     """
     )
-    res = wandb_client_api._query_with_retry(
+    res = wandb_client_api.query_with_retry(
         query,
         variables={
             "id": client_collection_id,

--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -153,8 +153,7 @@ def _collection_and_alias_id_mapping_to_uri(
     client_collection_id: str, alias_name: str
 ) -> ReadClientArtifactURIResult:
     is_deleted = False
-    query = wb_public.gql(
-        """
+    query = """
     query ArtifactVersionFromIdAlias(
         $id: ID!,
         $aliasName: String!
@@ -192,7 +191,7 @@ def _collection_and_alias_id_mapping_to_uri(
         }
     }
     """
-    )
+
     res = wandb_client_api.query_with_retry(
         query,
         variables={

--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -195,7 +195,7 @@ def _collection_and_alias_id_mapping_to_uri(
     )
     res = wandb_client_api._query_with_retry(
         query,
-        variable_values={
+        variables={
             "id": client_collection_id,
             "aliasName": alias_name,
         },

--- a/weave/wandb_client_api.py
+++ b/weave/wandb_client_api.py
@@ -29,7 +29,7 @@ def assert_wandb_authenticated() -> None:
         )
 
 
-def _query_with_retry(
+def query_with_retry(
     query_str: str,
     variables: dict[str, typing.Any] = {},
     num_timeout_retries: int = 0,
@@ -52,7 +52,7 @@ def _query_with_retry(
 
 def introspect_server_schema(num_timeout_retries: int = 0) -> GraphQLSchema:
     introspection_query = graphql.get_introspection_query()
-    payload = _query_with_retry(introspection_query, {}, num_timeout_retries)
+    payload = query_with_retry(introspection_query, {}, num_timeout_retries)
     return graphql.build_client_schema(payload)
 
 
@@ -61,7 +61,7 @@ def wandb_gql_query(
     variables: dict[str, typing.Any] = {},
     num_timeout_retries: int = 0,
 ) -> typing.Any:
-    return _query_with_retry(query_str, variables, num_timeout_retries)
+    return query_with_retry(query_str, variables, num_timeout_retries)
 
 
 def set_wandb_thread_local_api_settings(


### PR DESCRIPTION
Uses GQL retry logic in wbroot_gqlquery op in our artifact path. Should reduce incidence of artifact queries timing out due to GQL. 

Internal Sentry: https://weights-biases.sentry.io/issues/3913896763
Internal JIRA: https://wandb.atlassian.net/browse/WB-15640