### PR TITLE
fix: handle artifacts that were never uploaded

### DIFF
--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -6,6 +6,7 @@ import functools
 import tempfile
 import typing
 import requests
+import logging
 
 from wandb import Artifact
 from wandb.apis import public as wb_public
@@ -205,9 +206,13 @@ def _collection_and_alias_id_mapping_to_uri(
     except requests.exceptions.HTTPError as e:
         if e.response.status_code == 400:
             # This is a special case: the client id corresponds to an artifact that was
-            # never uploaded, so the client id doesn't exist in gorilla.
+            # never uploaded, so the client id doesn't exist in the W&B server.
 
             collection = None
+            logging.warn(
+                f"Artifact collection with client id {client_collection_id} not present in W&B server."
+            )
+
         else:
             raise e
     else:

--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -5,6 +5,7 @@ import os
 import functools
 import tempfile
 import typing
+import requests
 
 from wandb import Artifact
 from wandb.apis import public as wb_public
@@ -192,19 +193,29 @@ def _collection_and_alias_id_mapping_to_uri(
     }
     """
 
-    res = wandb_client_api.query_with_retry(
-        query,
-        variables={
-            "id": client_collection_id,
-            "aliasName": alias_name,
-        },
-        num_timeout_retries=1,
-    )
-    collection = res["artifactCollection"]
+    try:
+        res = wandb_client_api.query_with_retry(
+            query,
+            variables={
+                "id": client_collection_id,
+                "aliasName": alias_name,
+            },
+            num_timeout_retries=1,
+        )
+    except requests.exceptions.HTTPError as e:
+        if e.response.status_code == 400:
+            # This is a special case: the client id corresponds to an artifact that was
+            # never uploaded, so the client id doesn't exist in gorilla.
+
+            collection = None
+        else:
+            raise e
+    else:
+        collection = res["artifactCollection"]
 
     if collection is None:
         # Note: deleted collections are still returned by the API (with state=DELETED)
-        # So a missing collection is a real error.
+        # So a missing collection is a real error (unless it was never uploaded)
         raise errors.WeaveArtifactCollectionNotFound(
             f"Could not find artifact collection with client id {client_collection_id}"
         )


### PR DESCRIPTION
Handles artifacts that were never uploaded the same way that deleted artifacts are handled, addressing internal sentry issue https://weights-biases.sentry.io/issues/3933057442/?referrer=slack.