### PR TITLE
feat: improve panel selection

### DIFF
--- a/weave-js/src/components/Panel2/PanelInteractContext.tsx
+++ b/weave-js/src/components/Panel2/PanelInteractContext.tsx
@@ -159,6 +159,19 @@ export const useSetPanelIsHoveredInOutline = () => {
   );
 };
 
+export const useSetSelectedPanel = () => {
+  const {setState} = usePanelInteractContext();
+  return useCallback(
+    (path: string[]) => {
+      setState(prevState => ({
+        ...prevState,
+        selectedPath: path,
+      }));
+    },
+    [setState]
+  );
+};
+
 export const useSetInteractingPanel = () => {
   const {setState} = usePanelInteractContext();
   return useCallback(


### PR DESCRIPTION
Internal Jira: 
https://wandb.atlassian.net/browse/WB-15644
https://wandb.atlassian.net/browse/WB-14310

Selects panel on click, keeping the expression editor and other buttons shown while panel is selected. Can click on background or elsewhere to clear selection.

This is a usability fix, as it was too easy for minor mouse movements to hide the expression editor while people were using it.