### PR TITLE
fix(wir): Allow multiple panels on one report

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -89,11 +89,11 @@ const allowPanel = (stackId: string) => {
   );
 };
 
-export interface ChildPanelFullConfig {
+export interface ChildPanelFullConfig<C = any> {
   vars: Frame;
   input_node: NodeOrVoidNode;
   id: string;
-  config: any;
+  config: C;
 }
 
 export type ChildPanelConfig =

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
@@ -1,4 +1,5 @@
 import {voidNode} from '@wandb/weave/core';
+import {v4 as uuid} from 'uuid';
 import {ChildPanelFullConfig} from '../ChildPanel';
 import {getConfigForPath} from '../panelTree';
 
@@ -13,8 +14,14 @@ type WeavePanelSlateNode = {
   /** Slate node config, passed to RootQueryPanel in core */
   config: {
     isWeave1Panel: true;
-    /** Weave child panel config */
-    panelConfig: ChildPanelFullConfig;
+    /** Packaged PanelPanel config */
+    panelConfig: ChildPanelFullConfig<{
+      /**
+       * Unique documentId is required because multiple
+       * panels could be exported to the same report.
+       */
+      documentId: string;
+    }>;
   };
 };
 
@@ -39,7 +46,9 @@ export const computeReportSlateNode = (
       isWeave1Panel: true,
       panelConfig: {
         id: 'Panel',
-        config: undefined,
+        config: {
+          documentId: uuid(),
+        },
         input_node: {
           nodeType: 'const',
           type: {type: 'Panel'},

--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -54,7 +54,13 @@ import produce from 'immer';
 const inputType = {type: 'Panel' as const};
 type PanelPanelProps = Panel2.PanelProps<
   typeof inputType,
-  ChildPanelFullConfig
+  {
+    /**
+     * Unique identifier for a PanelPanel. Required if multiple
+     * PanelPanels are rendered in a single PanelRootContext.
+     */
+    documentId?: string;
+  }
 >;
 
 // There is a single reducer, stored in a single global context.
@@ -305,12 +311,13 @@ const usePanelPanelCommon = (props: PanelPanelProps) => {
   const setInteractingPanel = useSetInteractingPanel();
   // const panelConfig = props.config;
 
-  // TODO: this is not the right ID to use!!! The expression string changes when the panel
+  // TODO: props.input is not the right default ID to use!!! The expression string changes when the panel
   // is renamed or published. Need to figure out how to get an ID shared across the Render
   // and Config components here... this probably something simple to do.
   // The path through the React tree... could work. Then panel path? Idk
+  const documentId = props.config?.documentId ?? weave.expToString(props.input);
 
-  const {state, dispatch} = usePanelRootContext(weave.expToString(props.input));
+  const {state, dispatch} = usePanelRootContext(documentId);
   const initialLoading = state == null;
   const panelConfig = state?.root;
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15547

before - if there multiple weave panels are added to the same report, their state is synced

https://github.com/wandb/weave/assets/17016170/62120e75-c610-404c-8f7a-82c588124438

after - each panel displays own state & can be edited individually


https://github.com/wandb/weave/assets/17016170/6433b190-4246-49eb-a803-ede1ee7820d5

(tested with [this branch](https://github.com/wandb/core/compare/master...connie/report-child-panel-edit?expand=1&w=1) in core - not quite ready for review yet but will be soon)