### PR TITLE
feat(wir): Track selected documentId in PanelInteractContext

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -998,7 +998,7 @@ const EditorBarContent = styled.div`
   flex-shrink: 0;
   position: relative;
   left: -8px;
-  padding: 0 16px 8px;
+  padding: 2px 16px 8px;
   border-bottom: 1px solid ${GRAY_350};
   line-height: 20px;
   display: flex;

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -556,6 +556,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
   }, []);
 
   const {
+    documentId,
     config: fullConfig,
     updateConfig,
     updateConfig2,
@@ -641,7 +642,11 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
                       size="small"
                       icon="pencil-edit"
                       onClick={() =>
-                        setInteractingPanel('config', props.pathEl ?? '')
+                        setInteractingPanel(
+                          'config',
+                          props.pathEl ?? '',
+                          documentId
+                        )
                       }
                     />
                   }>

--- a/weave-js/src/components/Panel2/PanelInteractContext.tsx
+++ b/weave-js/src/components/Panel2/PanelInteractContext.tsx
@@ -15,6 +15,11 @@ type PanelInteractMode = 'config' | 'export-report' | null;
 export interface PanelInteractContextState {
   // State is stored by panel path. panel path is managed by PanelContext.
   panelInteractMode: PanelInteractMode;
+  /**
+   * Unique ID of the selected root panel. Required if
+   * multiple root panels share one interact drawer.
+   */
+  selectedDocumentId?: string;
   selectedPath: string[];
   panelState: {[pathString: string]: PanelInteractState};
 }
@@ -162,11 +167,12 @@ export const useSetPanelIsHoveredInOutline = () => {
 export const useSetInteractingPanel = () => {
   const {setState} = usePanelInteractContext();
   return useCallback(
-    (mode: PanelInteractMode, path: string[]) => {
+    (mode: PanelInteractMode, path: string[], documentId?: string) => {
       setState(prevState => ({
         ...prevState,
         panelInteractMode: mode,
         selectedPath: path,
+        selectedDocumentId: documentId,
       }));
     },
     [setState]
@@ -177,8 +183,8 @@ export const useSetInteractingChildPanel = () => {
   const setInteractingPanel = useSetInteractingPanel();
   const {path} = usePanelContext();
   return useCallback(
-    (mode: PanelInteractMode, childPath: string) => {
-      setInteractingPanel(mode, path.concat([childPath]));
+    (mode: PanelInteractMode, childPath: string, documentId?: string) => {
+      setInteractingPanel(mode, path.concat([childPath]), documentId);
     },
     [path, setInteractingPanel]
   );
@@ -197,6 +203,11 @@ export const useCloseDrawer = () => {
 export const usePanelInteractMode = () => {
   const {state} = usePanelInteractContext();
   return state.panelInteractMode;
+};
+
+export const useSelectedDocumentId = () => {
+  const {state} = usePanelInteractContext();
+  return state.selectedDocumentId;
 };
 
 export const useSelectedPath = () => {

--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -346,6 +346,7 @@ const usePanelPanelCommon = (props: PanelPanelProps) => {
   return {
     dispatch,
     loading: initialLoading,
+    documentId,
     panelConfig,
     selectedPanel,
     setInteractingPanel,
@@ -491,6 +492,7 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
 export const PanelPanel: React.FC<PanelPanelProps> = props => {
   const {
     loading,
+    documentId,
     panelConfig,
     panelUpdateConfig,
     panelUpdateConfig2,
@@ -589,6 +591,7 @@ export const PanelPanel: React.FC<PanelPanelProps> = props => {
         justifyContent: 'space-around',
       }}>
       <PanelPanelContextProvider
+        documentId={documentId}
         config={panelConfig}
         updateConfig={panelUpdateConfig}
         updateConfig2={panelUpdateConfig2}>

--- a/weave-js/src/components/Panel2/PanelPanelContextProvider.tsx
+++ b/weave-js/src/components/Panel2/PanelPanelContextProvider.tsx
@@ -2,6 +2,8 @@ import React, {useContext} from 'react';
 import {ChildPanelConfig, ChildPanelFullConfig} from './ChildPanel';
 
 export interface PanelPanelContextValue {
+  /** Unique ID of the root PanelPanel, if available */
+  documentId?: string;
   config: ChildPanelFullConfig;
   updateConfig: (config: ChildPanelFullConfig) => void;
   updateConfig2: (
@@ -25,24 +27,20 @@ export const PanelPanelContext = React.createContext<PanelPanelContextValue>({
   updateConfig2: () => {},
 });
 
-export const PanelPanelContextProvider: React.FC<{
-  config: ChildPanelFullConfig;
-  updateConfig: (config: ChildPanelFullConfig) => void;
-  updateConfig2: (
-    change: (oldConfig: ChildPanelConfig) => ChildPanelFullConfig
-  ) => void;
-}> = React.memo(({config, updateConfig, updateConfig2, children}) => {
-  return (
-    <PanelPanelContext.Provider
-      value={{
-        config,
-        updateConfig,
-        updateConfig2,
-      }}>
-      {children}
-    </PanelPanelContext.Provider>
-  );
-});
+export const PanelPanelContextProvider: React.FC<PanelPanelContextValue> =
+  React.memo(({documentId, config, updateConfig, updateConfig2, children}) => {
+    return (
+      <PanelPanelContext.Provider
+        value={{
+          documentId,
+          config,
+          updateConfig,
+          updateConfig2,
+        }}>
+        {children}
+      </PanelPanelContext.Provider>
+    );
+  });
 
 export const usePanelPanelContext = () => {
   const context = useContext(PanelPanelContext);


### PR DESCRIPTION
Multiple PanelPanel documents may share 1 PanelInteractContext in a report. When a ChildPanel is selected for interaction, we need to track its root document ID so the report knows which panel is being interacted with.

Required to support [this change](https://github.com/wandb/core/commit/550f33f4817f52372abf78ab8222ab039252ef4c#diff-1fbc6ee517b197cc9f11b39e62c031feef371075f4cd4a95d298291318b650cfL136) so that the selected panel is set only when the "edit" button is clicked (rather than on click anywhere on the panel)