### PR TITLE
fix(wir): Allow updates on panels exported to reports

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -281,10 +281,8 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
 
   const updateExpression = useCallback(
     (newExpression: NodeOrVoidNode) => {
-      if (
-        weave.expToString(newExpression) === weave.expToString(panelInputExpr)
-      ) {
-        // If expression strings match, no update. This prevents glitching
+      if (weave.isExpLogicallyEqual(newExpression, panelInputExpr)) {
+        // If expressions match, no update. This prevents glitching
         // when types change (which I think happens in panel composition
         // due to inconsistency between client and server detected types).
         // I don't think we have a case for updating just the type of

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
@@ -2,6 +2,7 @@ import {voidNode} from '@wandb/weave/core';
 import {v4 as uuid} from 'uuid';
 import {ChildPanelFullConfig} from '../ChildPanel';
 import {getConfigForPath} from '../panelTree';
+import {toWeaveType} from '../toWeaveType';
 
 type WeavePanelSlateNode = {
   type: 'weave-panel';
@@ -38,6 +39,20 @@ export const computeReportSlateNode = (
   targetPath: string[]
 ): WeavePanelSlateNode => {
   const targetConfig = getConfigForPath(fullConfig, targetPath);
+  const inputNodeVal = {
+    id: 'Group',
+    input_node: voidNode(),
+    config: {
+      items: {
+        panel: targetConfig,
+      },
+      disableDeletePanel: true,
+      enableAddPanel: true, // actually means "is editable"
+      layoutMode: 'vertical',
+      showExpressions: true,
+    },
+    vars: {},
+  };
 
   return {
     type: 'weave-panel',
@@ -51,21 +66,8 @@ export const computeReportSlateNode = (
         },
         input_node: {
           nodeType: 'const',
-          type: {type: 'Panel'},
-          val: {
-            id: 'Group',
-            input_node: voidNode(),
-            config: {
-              items: {
-                panel: targetConfig,
-              },
-              disableDeletePanel: true,
-              enableAddPanel: true, // actually means "is editable"
-              layoutMode: 'vertical',
-              showExpressions: true,
-            },
-            vars: {},
-          },
+          type: toWeaveType(inputNodeVal),
+          val: inputNodeVal,
         },
         vars: {},
       },

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -2151,7 +2151,7 @@ const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
     (dimName: 'x' | 'y') => {
       return (newVal: Node) => {
         const currDomain = configRef.current.signals.domain[dimName];
-        if (weave.expToString(newVal) !== weave.expToString(currDomain)) {
+        if (!weave.isExpLogicallyEqual(newVal, currDomain)) {
           updateConfig2((oldConfig: PlotConfig) => {
             return {
               ...oldConfig,

--- a/weave-js/src/components/Panel2/toWeaveType.tsx
+++ b/weave-js/src/components/Panel2/toWeaveType.tsx
@@ -128,6 +128,7 @@ export function toWeaveType(o: any): any {
       type: curPanelId,
       id: 'string',
       _is_object: true,
+      _base_type: {type: 'Panel'},
       vars: {
         type: 'typedDict',
         propertyTypes: _.mapValues(o.vars, toWeaveType),

--- a/weave-js/src/core/model/graph/typeHelpers.ts
+++ b/weave-js/src/core/model/graph/typeHelpers.ts
@@ -1,6 +1,6 @@
 import {has} from '../../util/has';
 import {isAssignableTo} from '../helpers';
-import type {Type} from '../types';
+import type {ObjectType, Type} from '../types';
 import type {
   BaseNode,
   ConstNode,
@@ -63,6 +63,16 @@ export function isConstNodeWithType<T extends Type>(
   type: T
 ): constNode is ConstNode<T> {
   return isAssignableTo(constNode.type, type);
+}
+
+export function isConstNodeWithObjectType(
+  maybeNode: any
+): maybeNode is ConstNode<ObjectType> {
+  return (
+    isConstNode(maybeNode) &&
+    has('_is_object', maybeNode.type) &&
+    maybeNode.type._is_object === true
+  );
 }
 
 export const outputTypeIsType = (

--- a/weave-js/src/core/model/graph/typeHelpers.ts
+++ b/weave-js/src/core/model/graph/typeHelpers.ts
@@ -1,6 +1,6 @@
 import {has} from '../../util/has';
 import {isAssignableTo} from '../helpers';
-import type {ObjectType, Type} from '../types';
+import type {Type} from '../types';
 import type {
   BaseNode,
   ConstNode,
@@ -67,7 +67,7 @@ export function isConstNodeWithType<T extends Type>(
 
 export function isConstNodeWithObjectType(
   maybeNode: any
-): maybeNode is ConstNode<ObjectType> {
+): maybeNode is ConstNode<Type> {
   return (
     isConstNode(maybeNode) &&
     has('_is_object', maybeNode.type) &&

--- a/weave-js/src/core/model/types.ts
+++ b/weave-js/src/core/model/types.ts
@@ -66,7 +66,7 @@ interface ObjectTypeAttrs {
 }
 interface ObjectTypeBase {
   type: string;
-  is_object: true;
+  _is_object: true;
   _base_type: Type;
 }
 export type ObjectType = ObjectTypeBase & ObjectTypeAttrs;

--- a/weave-js/src/core/model/types.ts
+++ b/weave-js/src/core/model/types.ts
@@ -423,6 +423,7 @@ export type ComplexType =
   | PanelType
   | PanelSubType
   | NewImage
+  | ObjectType
   // End Weave Python additions
   | HistogramType
   | TypedDictType

--- a/weave-js/src/core/model/types.ts
+++ b/weave-js/src/core/model/types.ts
@@ -423,7 +423,6 @@ export type ComplexType =
   | PanelType
   | PanelSubType
   | NewImage
-  | ObjectType
   // End Weave Python additions
   | HistogramType
   | TypedDictType

--- a/weave-js/src/core/weave.ts
+++ b/weave-js/src/core/weave.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import callFunction, {callOpVeryUnsafe, dereferenceAllVars} from './callers';
 import {Client} from './client';
 import {
@@ -15,6 +16,7 @@ import {
   EditingOpInputs,
   Frame,
   isAssignableTo,
+  isConstNodeWithObjectType,
   Node,
   NodeOrVoidNode,
   OutputNode,
@@ -98,6 +100,18 @@ export class Weave implements WeaveInterface {
 
   expToString(node: EditingNode, indent: number | null = 0): string {
     return this.languageBinding.printGraph(node, indent);
+  }
+
+  isExpLogicallyEqual(node1: NodeOrVoidNode, node2: NodeOrVoidNode): boolean {
+    const isExpStringEqual =
+      this.expToString(node1) === this.expToString(node2);
+    if (!isExpStringEqual) {
+      return false;
+    }
+    if (isConstNodeWithObjectType(node1) && isConstNodeWithObjectType(node2)) {
+      return _.isEqual(node1.val, node2.val);
+    }
+    return true;
   }
 
   nodeIsExecutable(node: EditingNode): node is NodeOrVoidNode {

--- a/weave-js/src/core/weave.ts
+++ b/weave-js/src/core/weave.ts
@@ -102,15 +102,25 @@ export class Weave implements WeaveInterface {
     return this.languageBinding.printGraph(node, indent);
   }
 
+  /**
+   * Determines whether the expressions represented by two nodes are logically
+   * equivalent. This is used on panel updates to check if the input expression
+   * has actually changed.
+   */
   isExpLogicallyEqual(node1: NodeOrVoidNode, node2: NodeOrVoidNode): boolean {
-    const isExpStringEqual =
-      this.expToString(node1) === this.expToString(node2);
-    if (!isExpStringEqual) {
+    // If string representations don't match, the values are definitely different
+    if (this.expToString(node1) !== this.expToString(node2)) {
       return false;
     }
+
+    // Even if the string representations *do* match, the nodes may be objects that
+    // aren't actually equal. For const nodes with `_is_object: true`, `expToString`
+    // obfuscates the actual node value and returns a simple string based on the node
+    // type, e.g. "<Group>" or "<Object>". In this case, we need a deep equality check.
     if (isConstNodeWithObjectType(node1) && isConstNodeWithObjectType(node2)) {
       return _.isEqual(node1.val, node2.val);
     }
+
     return true;
   }
 


### PR DESCRIPTION
Figuring out this issue was quite an adventure, and I'm not 100% confident I landed on the correct solution. Made a couple of looms to walk through what I did - let me know what you think! (PS sorry about the poor video quality)

Initial issue with input type:
https://www.loom.com/share/63150218dd71484e9eeec431c9c4efbe

Follow-up issue with update handler:
https://www.loom.com/share/c6b228f522f34471b0ba28ccc9ae0da7
--> after discussing with Tim, we've decided on a different approach. Instead of updating the "exp to string" logic, we're modifying the "is expression unchanged" check with additional logic that handles `_is_object` const nodes
