### PR TITLE
chore(weave): Expose current WB TraceTree Data in Weave1 (Part 1)

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -15,7 +15,6 @@ import moment from 'moment';
 import {
   Node,
   callOpVeryUnsafe,
-  constFunction,
   constString,
   list,
   opArtifactVersionFile,
@@ -23,7 +22,6 @@ import {
   opFileTable,
   opGet,
   opIsNone,
-  opMap,
   opPick,
   opProjectRuns,
   opRootProject,
@@ -49,7 +47,6 @@ import {
   urlProjectAssetPreview,
   urlProjectAssets,
 } from '../../../urls';
-import {SpanWeaveType} from '../../Panel2/PanelTraceTree/util';
 
 type CenterEntityBrowserPropsType = {
   entityName: string;

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -228,8 +228,8 @@ const CenterProjectBrowserInner: React.FC<
         ? []
         : [
             {
-              _id: 'legacy_trace',
-              'asset type': 'Legacy Traces',
+              _id: 'runs_trace',
+              'asset type': 'Run Logged Traces',
               count: assetCounts.result.legacyTracesCount ?? 0,
             },
           ]),
@@ -493,7 +493,7 @@ const CenterProjectLegacyTracesBrowser: React.FC<
 > = ({entityName, projectName, setPreviewNode, navigateToExpression}) => {
   const history = useHistory();
   const params = useParams<HomeParams>();
-  const browserTitle = 'Legacy Traces';
+  const browserTitle = 'Run logged Traces';
   const weave = useWeaveContext();
   useEffect(() => {
     setDocumentTitle(
@@ -599,7 +599,7 @@ const CenterProjectLegacyTracesBrowser: React.FC<
         allowSearch
         title={browserTitle}
         selectedRowId={params.preview}
-        noDataCTA={`No legacy traces found for project: ${entityName}/${projectName}`}
+        noDataCTA={`No run logged traces found for project: ${entityName}/${projectName}`}
         breadcrumbs={[
           {
             key: 'entity',

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -493,7 +493,7 @@ const CenterProjectLegacyTracesBrowser: React.FC<
 > = ({entityName, projectName, setPreviewNode, navigateToExpression}) => {
   const history = useHistory();
   const params = useParams<HomeParams>();
-  const browserTitle = 'Run logged Traces';
+  const browserTitle = 'Run Logged Traces';
   const weave = useWeaveContext();
   useEffect(() => {
     setDocumentTitle(
@@ -573,7 +573,6 @@ const CenterProjectLegacyTracesBrowser: React.FC<
           setPreviewNode={setPreviewNode}>
           <HomeExpressionPreviewParts
             expr={expr}
-            generatorAllowList={['py_board-trace_monitor']}
             navigateToExpression={navigateToExpression}
           />
         </HomePreviewSidebarTemplate>

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -180,7 +180,7 @@ const CenterProjectBrowser: React.FC<CenterProjectBrowserPropsType> = props => {
     return <CenterProjectBoardsBrowser {...props} />;
   } else if (params.assetType === 'table') {
     return <CenterProjectTablesBrowser {...props} />;
-  } else if (params.assetType === 'legacy_trace') {
+  } else if (params.assetType === 'run_logged_trace') {
     return <CenterProjectLegacyTracesBrowser {...props} />;
   } else {
     return <>Not implemented</>;
@@ -228,7 +228,7 @@ const CenterProjectBrowserInner: React.FC<
         ? []
         : [
             {
-              _id: 'runs_trace',
+              _id: 'run_logged_trace',
               'asset type': 'Run Logged Traces',
               count: assetCounts.result.legacyTracesCount ?? 0,
             },
@@ -525,7 +525,7 @@ const CenterProjectLegacyTracesBrowser: React.FC<
               urlProjectAssetPreview(
                 entityName,
                 projectName,
-                'legacy_trace',
+                'run_logged_trace',
                 row._id
               )
             );

--- a/weave-js/src/components/PagePanelComponents/Home/query.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/query.tsx
@@ -186,7 +186,7 @@ const opProjectLoggedTableCount = ({project}: {project: w.Node}) => {
 const opProjectHistoryType = ({project}: {project: w.Node}) => {
   return w.callOpVeryUnsafe(
     'refine_history3_type',
-    {run: w.opProjectRuns({project: project})},
+    {run: w.opProjectRuns({project})},
     'type'
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/query.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/query.tsx
@@ -117,6 +117,7 @@ export const useProjectAssetCount = (
     boardCount: number;
     runStreamCount: number;
     loggedTableCount: number;
+    legacyTracesCount: number;
   };
   loading: boolean;
 } => {
@@ -128,24 +129,43 @@ export const useProjectAssetCount = (
     boardCount: opProjectBoardCount({project: projectNode}),
     runStreamCount: opProjectRunStreamCount({project: projectNode}),
     loggedTableCount: opProjectLoggedTableCount({project: projectNode}),
+    projectHistoryType: opProjectHistoryType({project: projectNode}),
   } as any);
   const compositeValue = useNodeValue(compositeNode);
 
-  return useMemo(
-    () => ({
-      result: compositeValue.result ?? {
-        boardCount: 0,
-        runStreamCount: 0,
-        loggedTableCount: 0,
-      },
+  return useMemo(() => {
+    let result = {
+      boardCount: 0,
+      runStreamCount: 0,
+      loggedTableCount: 0,
+      legacyTracesCount: 0,
+    };
+    if (compositeValue.result != null) {
+      const keys = projectHistoryTypeToLegacyTraceKeys(
+        compositeValue.result.projectHistoryType as w.Type
+      );
+
+      result = {
+        ...compositeValue.result,
+        legacyTracesCount: keys.length,
+      } as {
+        boardCount: number;
+        runStreamCount: number;
+        loggedTableCount: number;
+        legacyTracesCount: number;
+      };
+    }
+
+    return {
+      result,
       loading: compositeValue.loading,
-    }),
-    [compositeValue.loading, compositeValue.result]
-  ) as {
+    };
+  }, [compositeValue.loading, compositeValue.result]) as {
     result: {
       boardCount: number;
       runStreamCount: number;
       loggedTableCount: number;
+      legacyTracesCount: number;
     };
     loading: boolean;
   };
@@ -161,6 +181,14 @@ const opProjectRunStreamCount = ({project}: {project: w.Node}) => {
 
 const opProjectLoggedTableCount = ({project}: {project: w.Node}) => {
   return w.opCount({arr: opProjectRunLoggedTableArtifacts({project})});
+};
+
+const opProjectHistoryType = ({project}: {project: w.Node}) => {
+  return w.callOpVeryUnsafe(
+    'refine_history3_type',
+    {run: w.opProjectRuns({project: project})},
+    'type'
+  );
 };
 
 const projectBoardsNode = (entityName: string, projectName: string) => {
@@ -311,6 +339,76 @@ export const useProjectBoards = (
     }),
     [artifactDetailsValue.loading, artifactDetailsValue.result]
   );
+};
+
+export const useProjectLegacyTraces = (
+  entityName: string,
+  projectName: string
+): {
+  result: Array<{
+    name: string;
+  }>;
+  loading: boolean;
+} => {
+  const projectNode = w.opRootProject({
+    entityName: w.constString(entityName),
+    projectName: w.constString(projectName),
+  });
+  const historyTypeNode = opProjectHistoryType({project: projectNode});
+  const historyTypeValue = useNodeValue(historyTypeNode as w.Node);
+  return useMemo(() => {
+    const keys =
+      historyTypeValue.result == null
+        ? []
+        : projectHistoryTypeToLegacyTraceKeys(
+            historyTypeValue.result as w.Type
+          );
+    return {
+      result: keys.map(key => ({
+        name: key,
+      })),
+      loading: historyTypeValue.loading,
+    };
+  }, [historyTypeValue.loading, historyTypeValue.result]);
+};
+
+const projectHistoryTypeToLegacyTraceKeys = (
+  projectHistoryType: w.Type
+): string[] => {
+  if (w.isTaggedValue(projectHistoryType)) {
+    projectHistoryType = projectHistoryType.value;
+    if (w.isList(projectHistoryType)) {
+      projectHistoryType = projectHistoryType.objectType;
+      if (w.isTaggedValue(projectHistoryType)) {
+        projectHistoryType = projectHistoryType.value;
+        if (
+          !w.isSimpleTypeShape(projectHistoryType) &&
+          projectHistoryType.type === 'ArrowWeaveList'
+        ) {
+          projectHistoryType = projectHistoryType.objectType;
+          if (w.isTypedDict(projectHistoryType)) {
+            const legacyTraceKeys = Object.entries(
+              projectHistoryType.propertyTypes
+            )
+              .filter(([key, value]) => {
+                return (
+                  value != null &&
+                  w.isAssignableTo(
+                    value,
+                    w.maybe({
+                      type: 'wb_trace_tree',
+                    })
+                  )
+                );
+              })
+              .map(([key, value]) => key);
+            return legacyTraceKeys;
+          }
+        }
+      }
+    }
+  }
+  return [];
 };
 
 export const useProjectRunStreams = (


### PR DESCRIPTION
In this step, I introduce a new type that can be navigated to in the Weave Browser: `Legacy Trace` which maps the the data structure we see in W&B Workspaces. This simply makes the data available, but does not do the work to convert it to our new LLM board - that will be a followup.