### PR TITLE
chore(weave): 403 on send_local_file with no user, not 500

### DIFF
--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -373,7 +373,10 @@ def send_local_file(path):
     abspath = "/" / pathlib.Path(
         path
     )  # add preceding slash as werkzeug strips this by default and it is reappended below in send_from_directory
-    local_artifacts_path = pathlib.Path(filesystem.get_filesystem_dir()).absolute()
+    try:
+        local_artifacts_path = pathlib.Path(filesystem.get_filesystem_dir()).absolute()
+    except errors.WeaveAccessDeniedError:
+        abort(403)
     if local_artifacts_path not in list(abspath.parents):
         abort(403)
     return send_from_directory("/", path)


### PR DESCRIPTION
Makes trying to access a local file with no user set return 403 instead of 500. 