### PR TITLE
feat(weave): Templates re-design

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Home.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Home.tsx
@@ -1,4 +1,11 @@
-import React, {FC, memo, useCallback, useMemo, useState} from 'react';
+import React, {
+  FC,
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 import styled from 'styled-components';
 import {ChildPanelFullConfig} from '../../Panel2/ChildPanel';
@@ -10,7 +17,10 @@ import {
   IconUsersTeam,
   IconWeaveLogo,
 } from '../../Panel2/Icons';
-import {IconCategoryMultimodal} from '@wandb/weave/components/Icon';
+import {
+  IconCategoryMultimodal,
+  IconDocumentation,
+} from '@wandb/weave/components/Icon';
 import * as query from './query';
 import * as LayoutElements from './LayoutElements';
 import {CenterEntityBrowser} from './HomeCenterEntityBrowser';
@@ -36,6 +46,7 @@ import getConfig from '../../../config';
 import {ErrorBoundary} from '../../ErrorBoundary';
 import {useIsAuthenticated} from '@wandb/weave/context/WeaveViewerContext';
 import {HomeCenterTemplates} from './HomeCenterTemplates';
+import {useLocalStorage} from '../../../util/useLocalStorage';
 
 const CenterSpace = styled(LayoutElements.VSpace)`
   border: 1px solid ${MOON_250};
@@ -130,16 +141,21 @@ const HomeComp: FC<HomeProps> = props => {
     }
   }, [props.browserType, params.assetType, setPreviewNode, history]);
 
-  const gettingStartedSection = useMemo(() => {
+  const getStartedSection = useMemo(() => {
     return [
       {
-        title: `Getting Started`,
+        title: 'Get Started',
         items: [
           {
             icon: IconCategoryMultimodal,
-            label: `Board templates`,
+            label: 'Board templates',
             active: props.browserType === 'templates',
             to: urlTemplates(),
+          },
+          {
+            icon: IconDocumentation,
+            label: 'Documentation',
+            to: 'https://docs.wandb.ai/guides/weave',
           },
         ],
       },
@@ -233,11 +249,11 @@ const HomeComp: FC<HomeProps> = props => {
   const navSections = useMemo(() => {
     return [
       ...recentSection,
-      ...gettingStartedSection,
+      ...getStartedSection,
       ...wandbSection,
       ...localSection,
     ];
-  }, [localSection, recentSection, gettingStartedSection, wandbSection]);
+  }, [localSection, recentSection, getStartedSection, wandbSection]);
 
   const loading = userName.loading || isAuthenticated === undefined;
   const REDIRECT_RECENTS = [
@@ -265,6 +281,19 @@ const HomeComp: FC<HomeProps> = props => {
   let {pathname} = window.location;
   const basename = getConfig().PREFIX;
   pathname = pathname.substring(basename.length);
+
+  const [lastVisited, setLastVisited] = useLocalStorage<string>(
+    'lastVisited',
+    '/browse/templates'
+  );
+  useEffect(() => {
+    if (pathname === '/') {
+      history.push(lastVisited);
+    } else {
+      setLastVisited(pathname);
+    }
+  }, [history, lastVisited, setLastVisited, pathname]);
+
   if (!loading && REDIRECT_ANY.includes(pathname)) {
     // If we have Recent enabled, go for that!
     if (REDIRECT_RECENTS.includes(pathname)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Home.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Home.tsx
@@ -10,6 +10,7 @@ import {
   IconUsersTeam,
   IconWeaveLogo,
 } from '../../Panel2/Icons';
+import {IconCategoryMultimodal} from '@wandb/weave/components/Icon';
 import * as query from './query';
 import * as LayoutElements from './LayoutElements';
 import {CenterEntityBrowser} from './HomeCenterEntityBrowser';
@@ -29,11 +30,13 @@ import {
   urlLocalBoards,
   urlRecentBoards,
   urlRecentTables,
+  urlTemplates,
 } from '../../../urls';
 import getConfig from '../../../config';
 import {ErrorBoundary} from '../../ErrorBoundary';
 import {HomeFeaturedTemplates} from './HomeFeaturedTemplates';
 import {useIsAuthenticated} from '@wandb/weave/context/WeaveViewerContext';
+import {HomeCenterTemplates} from './HomeCenterTemplates';
 
 const CenterSpace = styled(LayoutElements.VSpace)`
   border: 1px solid ${MOON_250};
@@ -128,6 +131,22 @@ const HomeComp: FC<HomeProps> = props => {
     }
   }, [props.browserType, params.assetType, setPreviewNode, history]);
 
+  const gettingStartedSection = useMemo(() => {
+    return [
+      {
+        title: `Getting Started`,
+        items: [
+          {
+            icon: IconCategoryMultimodal,
+            label: `Board templates`,
+            active: props.browserType == 'templates',
+            to: urlTemplates(),
+          },
+        ],
+      },
+    ];
+  }, [props.browserType, setPreviewNode]);
+
   const wandbSection = useMemo(() => {
     return userEntities.result.length === 0
       ? ([] as any)
@@ -213,7 +232,12 @@ const HomeComp: FC<HomeProps> = props => {
   }, [isLocallyServed, props.browserType, setPreviewNode, history]);
 
   const navSections = useMemo(() => {
-    return [...recentSection, ...wandbSection, ...localSection];
+    return [
+      ...recentSection,
+      ...gettingStartedSection,
+      ...wandbSection,
+      ...localSection,
+    ];
   }, [localSection, recentSection, wandbSection]);
 
   const loading = userName.loading || isAuthenticated === undefined;
@@ -268,9 +292,6 @@ const HomeComp: FC<HomeProps> = props => {
       <LayoutElements.Block>
         <HomeTopBar />
       </LayoutElements.Block>
-      <LayoutElements.Block>
-        <HomeFeaturedTemplates setPreviewNode={setPreviewNode} />
-      </LayoutElements.Block>
       {/* Main Region */}
       <LayoutElements.HSpace
         style={{
@@ -289,6 +310,8 @@ const HomeComp: FC<HomeProps> = props => {
               {props.browserType === 'recent' ? (
                 // This should never come up
                 <Placeholder />
+              ) : props.browserType === 'templates' ? (
+                <HomeCenterTemplates setPreviewNode={setPreviewNode} />
               ) : props.browserType === 'wandb' ? (
                 <CenterEntityBrowser
                   navigateToExpression={navigateToExpression}

--- a/weave-js/src/components/PagePanelComponents/Home/Home.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Home.tsx
@@ -34,7 +34,6 @@ import {
 } from '../../../urls';
 import getConfig from '../../../config';
 import {ErrorBoundary} from '../../ErrorBoundary';
-import {HomeFeaturedTemplates} from './HomeFeaturedTemplates';
 import {useIsAuthenticated} from '@wandb/weave/context/WeaveViewerContext';
 import {HomeCenterTemplates} from './HomeCenterTemplates';
 
@@ -139,13 +138,13 @@ const HomeComp: FC<HomeProps> = props => {
           {
             icon: IconCategoryMultimodal,
             label: `Board templates`,
-            active: props.browserType == 'templates',
+            active: props.browserType === 'templates',
             to: urlTemplates(),
           },
         ],
       },
     ];
-  }, [props.browserType, setPreviewNode]);
+  }, [props.browserType]);
 
   const wandbSection = useMemo(() => {
     return userEntities.result.length === 0
@@ -238,7 +237,7 @@ const HomeComp: FC<HomeProps> = props => {
       ...wandbSection,
       ...localSection,
     ];
-  }, [localSection, recentSection, wandbSection]);
+  }, [localSection, recentSection, gettingStartedSection, wandbSection]);
 
   const loading = userName.loading || isAuthenticated === undefined;
   const REDIRECT_RECENTS = [

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterTemplates.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterTemplates.tsx
@@ -1,7 +1,6 @@
 import {SetPreviewNodeType} from './common';
 import React from 'react';
 import * as LayoutElements from './LayoutElements';
-import {Button} from 'semantic-ui-react';
 import {Node, Type, callOpVeryUnsafe} from '@wandb/weave/core';
 import {useNodeValue} from '@wandb/weave/react';
 import {Panel2Loader} from '../../Panel2/PanelComp';
@@ -9,11 +8,39 @@ import {Panel2Loader} from '../../Panel2/PanelComp';
 import {HomePreviewSidebarTemplate} from './HomePreviewSidebar';
 import {HomeFeaturedTemplateDrawer} from './HomeFeaturedTemplates';
 import {
-  WHITE,
-  TEAL_500,
   MOON_250,
   MOON_350,
+  MOON_500,
 } from '@wandb/weave/common/css/color.styles';
+import {Button} from '../../Button';
+import styled from 'styled-components';
+
+const Template = styled(LayoutElements.VStack)`
+  width: 332px;
+  height: 368px;
+  padding: 16px;
+  border-radius: 4px;
+  border: 1px solid ${MOON_250};
+  gap: 16px;
+  overflow-y: auto;
+  &:hover {
+    border: 1px solid ${MOON_350};
+    box-shadow: 0px 4px 8px 0px rgba(14, 16, 20, 0.04);
+  }
+`;
+Template.displayName = 'S.Template';
+
+const TemplateDescription = styled(LayoutElements.Block)`
+  overflow: hidden;
+  color: ${MOON_500};
+  text-overflow: ellipsis;
+  font-family: Source Sans Pro;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 140%;
+`;
+TemplateDescription.displayName = 'S.TemplateDescription';
 
 type TemplateType = {
   config_type: Type | null;
@@ -37,7 +64,8 @@ export const HomeCenterTemplates: React.FC<{
     return null;
   }
   return (
-    <LayoutElements.VBlock style={{padding: '32px', gap: '32px'}}>
+    <LayoutElements.VBlock
+      style={{padding: '32px', gap: '32px', height: '100%'}}>
       <LayoutElements.HBlock>
         <div style={{fontWeight: '600', fontSize: '24px'}}>Board templates</div>
       </LayoutElements.HBlock>
@@ -46,7 +74,8 @@ export const HomeCenterTemplates: React.FC<{
           <Panel2Loader />
         </LayoutElements.Block>
       ) : (
-        <LayoutElements.HStack style={{gap: '32px'}}>
+        <LayoutElements.HStack
+          style={{gap: '32px', flexWrap: 'wrap', overflow: 'auto'}}>
           {featuredTemplates.result.map((template: TemplateType, i: number) => (
             <TemplateCard
               key={template.op_name}
@@ -75,15 +104,7 @@ const TemplateCard: React.FC<{
   );
   const [isHover, setIsHover] = React.useState(false);
   return (
-    <LayoutElements.VStack
-      style={{
-        width: '300px',
-        height: '440px',
-        padding: '16px',
-        borderRadius: '4px',
-        border: `1px solid ${MOON_350}`,
-        gap: '16px',
-      }}
+    <Template
       onMouseEnter={() => {
         setIsHover(true);
       }}
@@ -91,7 +112,7 @@ const TemplateCard: React.FC<{
         setIsHover(false);
       }}>
       {template.thumbnail_url && (
-        <LayoutElements.Block style={{height: '150px'}}>
+        <LayoutElements.Block style={{height: '168px'}}>
           <img
             src={template.thumbnail_url}
             alt={template.display_name + ' thumbnail'}
@@ -107,25 +128,18 @@ const TemplateCard: React.FC<{
       <LayoutElements.Block style={{fontWeight: '600', fontSize: '18px'}}>
         {template.display_name}
       </LayoutElements.Block>
-      <LayoutElements.Block>{template.description}</LayoutElements.Block>
+      <TemplateDescription>{template.description}</TemplateDescription>
       <LayoutElements.Block style={{width: '100%', marginTop: 'auto'}}>
         {isHover && (
           <Button
-            style={{
-              width: '100%',
-              backgroundColor: `${TEAL_500}`,
-              color: `${WHITE}`,
-              borderRadius: '4px',
-              fontWeight: '600',
-              fontSize: '16px',
-            }}
+            className="w-full"
             onClick={() => {
-              setPreviewNode(node, '40%');
+              setPreviewNode(node, '35%');
             }}>
-            Use template
+            Try it out
           </Button>
         )}
       </LayoutElements.Block>
-    </LayoutElements.VStack>
+    </Template>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterTemplates.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterTemplates.tsx
@@ -1,0 +1,131 @@
+import {SetPreviewNodeType} from './common';
+import React from 'react';
+import * as LayoutElements from './LayoutElements';
+import {Button} from 'semantic-ui-react';
+import {Node, Type, callOpVeryUnsafe} from '@wandb/weave/core';
+import {useNodeValue} from '@wandb/weave/react';
+import {Panel2Loader} from '../../Panel2/PanelComp';
+
+import {HomePreviewSidebarTemplate} from './HomePreviewSidebar';
+import {HomeFeaturedTemplateDrawer} from './HomeFeaturedTemplates';
+import {
+  WHITE,
+  TEAL_500,
+  MOON_250,
+  MOON_350,
+} from '@wandb/weave/common/css/color.styles';
+
+type TemplateType = {
+  config_type: Type | null;
+  description: string;
+  display_name: string;
+  op_name: string;
+  instructions_md: string;
+  thumbnail_url?: string;
+};
+
+export const HomeCenterTemplates: React.FC<{
+  setPreviewNode: SetPreviewNodeType;
+}> = ({setPreviewNode}) => {
+  const featuredTemplatesNode = callOpVeryUnsafe(
+    'py_board-get_featured_board_templates',
+    {}
+  ) as Node;
+  const featuredTemplates = useNodeValue(featuredTemplatesNode);
+  if (featuredTemplates.result?.length === 0) {
+    // not expecting this to happen, but just in case
+    return null;
+  }
+  return (
+    <LayoutElements.VBlock style={{padding: '32px', gap: '32px'}}>
+      <LayoutElements.HBlock>
+        <div style={{fontWeight: '600', fontSize: '24px'}}>Board templates</div>
+      </LayoutElements.HBlock>
+      {featuredTemplates.loading ? (
+        <LayoutElements.Block>
+          <Panel2Loader />
+        </LayoutElements.Block>
+      ) : (
+        <LayoutElements.HStack style={{gap: '32px'}}>
+          {featuredTemplates.result.map((template: TemplateType, i: number) => (
+            <TemplateCard
+              key={template.op_name}
+              template={template}
+              setPreviewNode={setPreviewNode}
+            />
+          ))}
+        </LayoutElements.HStack>
+      )}
+    </LayoutElements.VBlock>
+  );
+};
+
+const TemplateCard: React.FC<{
+  template: TemplateType;
+  setPreviewNode: SetPreviewNodeType;
+}> = ({template, setPreviewNode}) => {
+  const node = (
+    <HomePreviewSidebarTemplate
+      title={template.display_name}
+      setPreviewNode={setPreviewNode}
+      isTemplate={true}
+      actions={[]}>
+      <HomeFeaturedTemplateDrawer template={template} />
+    </HomePreviewSidebarTemplate>
+  );
+  const [isHover, setIsHover] = React.useState(false);
+  return (
+    <LayoutElements.VStack
+      style={{
+        width: '300px',
+        height: '440px',
+        padding: '16px',
+        borderRadius: '4px',
+        border: `1px solid ${MOON_350}`,
+        gap: '16px',
+      }}
+      onMouseEnter={() => {
+        setIsHover(true);
+      }}
+      onMouseLeave={() => {
+        setIsHover(false);
+      }}>
+      {template.thumbnail_url && (
+        <LayoutElements.Block style={{height: '150px'}}>
+          <img
+            src={template.thumbnail_url}
+            alt={template.display_name + ' thumbnail'}
+            style={{
+              height: '100%',
+              width: '100%',
+              borderRadius: '4px',
+              border: `1px solid ${MOON_250}`,
+            }}
+          />
+        </LayoutElements.Block>
+      )}
+      <LayoutElements.Block style={{fontWeight: '600', fontSize: '18px'}}>
+        {template.display_name}
+      </LayoutElements.Block>
+      <LayoutElements.Block>{template.description}</LayoutElements.Block>
+      <LayoutElements.Block style={{width: '100%', marginTop: 'auto'}}>
+        {isHover && (
+          <Button
+            style={{
+              width: '100%',
+              backgroundColor: `${TEAL_500}`,
+              color: `${WHITE}`,
+              borderRadius: '4px',
+              fontWeight: '600',
+              fontSize: '16px',
+            }}
+            onClick={() => {
+              setPreviewNode(node, '40%');
+            }}>
+            Use template
+          </Button>
+        )}
+      </LayoutElements.Block>
+    </LayoutElements.VStack>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/HomeFeaturedTemplates.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeFeaturedTemplates.tsx
@@ -174,7 +174,7 @@ const TabContentWrapper = styled.div`
 `;
 TabContentWrapper.displayName = 'S.TabContentWrapper';
 
-const HomeFeaturedTemplateDrawer: React.FC<{
+export const HomeFeaturedTemplateDrawer: React.FC<{
   template: TemplateType;
 }> = ({template}) => {
   const [tabValue, setTabValue] = React.useState('Instructions');

--- a/weave-js/src/components/PagePanelComponents/Home/HomeFeaturedTemplates.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeFeaturedTemplates.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import * as LayoutElements from './LayoutElements';
-import {Button} from '../../Button';
-import {Node, Type, callOpVeryUnsafe} from '@wandb/weave/core';
-import {useNodeValue} from '@wandb/weave/react';
+import {Type} from '@wandb/weave/core';
 import * as Tabs from '@wandb/weave/components/Tabs';
 
-import {HomePreviewSidebarTemplate} from './HomePreviewSidebar';
-import {SetPreviewNodeType} from './common';
 import styled from 'styled-components';
 
 import ReactMarkdown from 'react-markdown';
@@ -15,7 +11,6 @@ import remarkGfm from 'remark-gfm';
 import './github-markdown-light.css';
 import {TargetBlank} from '@wandb/weave/common/util/links';
 import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter';
-import {Panel2Loader} from '../../Panel2/PanelComp';
 
 // This is considered a `hack` because I need to drop down to
 // access .tw-style, to give it a height 100%. When using tailwind
@@ -37,128 +32,6 @@ type TemplateType = {
   op_name: string;
   instructions_md: string;
   thumbnail_url?: string;
-};
-
-export const HomeFeaturedTemplates: React.FC<{
-  setPreviewNode: SetPreviewNodeType;
-}> = ({setPreviewNode}) => {
-  const featuredTemplatesNode = callOpVeryUnsafe(
-    'py_board-get_featured_board_templates',
-    {}
-  ) as Node;
-  const featuredTemplates = useNodeValue(featuredTemplatesNode);
-  if (featuredTemplates.result?.length === 0) {
-    // not expecting this to happen, but just in case
-    return null;
-  }
-  return (
-    <LayoutElements.VBlock
-      style={{
-        padding: '0px 12px 24px 12px',
-      }}>
-      <LayoutElements.HBlock>
-        <LayoutElements.BlockHeader
-          style={{
-            padding: '12px 12px',
-          }}>
-          FEATURED TEMPLATES
-        </LayoutElements.BlockHeader>
-      </LayoutElements.HBlock>
-      {featuredTemplates.loading ? (
-        <LayoutElements.Block style={{height: '166px'}}>
-          <Panel2Loader />
-        </LayoutElements.Block>
-      ) : (
-        <LayoutElements.HStack
-          style={{
-            gap: '16px',
-          }}>
-          {featuredTemplates.result.map((template: TemplateType, i: number) => (
-            <HomeFeaturedTemplateItem
-              key={template.op_name}
-              template={template}
-              setPreviewNode={setPreviewNode}
-            />
-          ))}
-        </LayoutElements.HStack>
-      )}
-    </LayoutElements.VBlock>
-  );
-};
-
-const HomeFeaturedTemplateItem: React.FC<{
-  template: TemplateType;
-  setPreviewNode: SetPreviewNodeType;
-}> = ({template, setPreviewNode}) => {
-  const node = (
-    <HomePreviewSidebarTemplate
-      title={template.display_name}
-      setPreviewNode={setPreviewNode}
-      isTemplate={true}
-      actions={[]}>
-      <HomeFeaturedTemplateDrawer template={template} />
-    </HomePreviewSidebarTemplate>
-  );
-
-  return (
-    <LayoutElements.HStack
-      style={{
-        border: '1px solid #E5E5E5',
-        borderRadius: '8px',
-        padding: '16px',
-        gap: '8px',
-      }}>
-      {template.thumbnail_url && (
-        <LayoutElements.Block
-          style={{
-            height: '132px',
-          }}>
-          <img
-            src={template.thumbnail_url}
-            alt={template.display_name + ' thumbnail'}
-            style={{
-              height: '100%',
-              borderRadius: '4px',
-              border: '2px solid #E5E5E5',
-            }}
-          />
-        </LayoutElements.Block>
-      )}
-      <LayoutElements.VStack
-        style={{
-          // gap: '8px',
-          flex: 1,
-          height: '132px',
-        }}>
-        <LayoutElements.HBlock
-          style={{
-            fontSize: '18px',
-            fontWeight: 800,
-          }}>
-          {template.display_name}
-        </LayoutElements.HBlock>
-        <LayoutElements.HStack
-          style={{
-            overflow: 'auto',
-          }}>
-          {template.description}
-        </LayoutElements.HStack>
-        <LayoutElements.HBlock
-          style={{
-            justifyContent: 'flex-end',
-          }}>
-          <Button
-            variant="secondary"
-            size="medium"
-            onClick={() => {
-              setPreviewNode(node, '40%');
-            }}>
-            Use template
-          </Button>
-        </LayoutElements.HBlock>
-      </LayoutElements.VStack>
-    </LayoutElements.HStack>
-  );
 };
 
 const TabContentWrapper = styled.div`

--- a/weave-js/src/components/PagePanelComponents/Home/HomeLeftNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeLeftNav.tsx
@@ -5,13 +5,13 @@ import {voidNode} from '@wandb/weave/core';
 import React, {useCallback, useState} from 'react';
 import styled from 'styled-components';
 import * as LayoutElements from './LayoutElements';
-import {Link} from 'react-router-dom';
 import moment from 'moment';
 
 import getConfig from '../../../config';
 import {useWeaveContext} from '../../../context';
 import {useNewPanelFromRootQueryCallback} from '../../Panel2/PanelRootBrowser/util';
 import {NavigateToExpressionType} from './common';
+import {Link} from '../../../common/util/links';
 
 const LeftNavItemBlock = styled(LayoutElements.HBlock)`
   margin: 0px 0px 0px 12px;
@@ -26,6 +26,7 @@ const LeftNavItemBlock = styled(LayoutElements.HBlock)`
     background-color: #f5f6f7;
   }
 `;
+LeftNavItemBlock.displayName = 'S.LeftNavItemBlock';
 
 const NewBoardButtonWrapper = styled.div`
   margin: 0px 24px 16px 24px;

--- a/weave-js/src/entrypoint.tsx
+++ b/weave-js/src/entrypoint.tsx
@@ -81,7 +81,7 @@ ReactDOM.render(
       <Route path={`/${URL_BROWSE}/${URL_RECENT}/:assetType?`}>
         <Main browserType={URL_RECENT} />
       </Route>
-      <Route path={[`/${URL_BROWSE}/${URL_WANDB}/templates/:templateName?`]}>
+      <Route path={[`/${URL_BROWSE}/${URL_TEMPLATES}/:templateName?`]}>
         <Main browserType={URL_TEMPLATES} />
       </Route>
       <Route

--- a/weave-js/src/entrypoint.tsx
+++ b/weave-js/src/entrypoint.tsx
@@ -8,7 +8,13 @@ import {onAppError} from './components/automation';
 import PagePanel from './components/PagePanel';
 import {WeaveMessage} from './components/Panel2/WeaveMessage';
 import {NotebookComputeGraphContextProvider} from './contextProviders';
-import {URL_BROWSE, URL_LOCAL, URL_RECENT, URL_WANDB} from './urls';
+import {
+  URL_BROWSE,
+  URL_LOCAL,
+  URL_TEMPLATES,
+  URL_RECENT,
+  URL_WANDB,
+} from './urls';
 import getConfig from './config';
 import {PanelRootContextProvider} from './components/Panel2/PanelPanel';
 import {WeaveViewerContextProvider} from './context/WeaveViewerContext';
@@ -74,6 +80,9 @@ ReactDOM.render(
     <Switch>
       <Route path={`/${URL_BROWSE}/${URL_RECENT}/:assetType?`}>
         <Main browserType={URL_RECENT} />
+      </Route>
+      <Route path={[`/${URL_BROWSE}/${URL_WANDB}/templates/:templateName?`]}>
+        <Main browserType={URL_TEMPLATES} />
       </Route>
       <Route
         path={[

--- a/weave-js/src/urls.ts
+++ b/weave-js/src/urls.ts
@@ -15,7 +15,7 @@ export function urlRecentTables(): string {
 }
 
 export function urlTemplates(): string {
-  return `/${URL_BROWSE}/${URL_WANDB}/templates`;
+  return `/${URL_BROWSE}/${URL_TEMPLATES}`;
 }
 
 export function urlEntity(entityName: string): string {

--- a/weave-js/src/urls.ts
+++ b/weave-js/src/urls.ts
@@ -2,6 +2,7 @@ export const URL_BROWSE = 'browse';
 export const URL_RECENT = 'recent';
 export const URL_WANDB = 'wandb';
 export const URL_LOCAL = 'local';
+export const URL_TEMPLATES = 'templates';
 
 export function urlRecent(): string {
   return `/${URL_BROWSE}/${URL_RECENT}/`;
@@ -11,6 +12,10 @@ export function urlRecentBoards(): string {
 }
 export function urlRecentTables(): string {
   return `${urlRecent()}table`;
+}
+
+export function urlTemplates(): string {
+  return `/${URL_BROWSE}/${URL_WANDB}/templates`;
 }
 
 export function urlEntity(entityName: string): string {

--- a/weave-js/src/util/localStorage.test.ts
+++ b/weave-js/src/util/localStorage.test.ts
@@ -1,0 +1,53 @@
+import {getStorage, safeLocalStorage} from './localStorage';
+
+describe('Localstorage w/ error handling', () => {
+  describe('feature detect local storage', () => {
+    test('true when available', () => {
+      // @ts-ignore
+      const storage = getStorage({
+        setItem: () => {},
+        removeItem: () => {},
+      });
+      expect(storage.isAvailable).toBe(true);
+    });
+    test('false when unavailable', () => {
+      // @ts-ignore
+      const storage = getStorage(null);
+      expect(storage.isAvailable).toBe(false);
+    });
+  });
+
+  test('localstorage works', () => {
+    safeLocalStorage.setItem('foo', 'bar');
+    expect(safeLocalStorage.getItem('foo')).toBe('bar');
+    safeLocalStorage.removeItem('foo');
+    expect(safeLocalStorage.getItem('foo')).toBe(null);
+    safeLocalStorage.setItem('foo1', 'bar');
+    safeLocalStorage.setItem('foo2', 'bar');
+    safeLocalStorage.clear();
+    expect(safeLocalStorage.getItem('foo1')).toBe(null);
+    expect(safeLocalStorage.getItem('foo2')).toBe(null);
+  });
+
+  test('clear should noop when not available', () => {
+    expect(() => {
+      safeLocalStorage.clear();
+    }).not.toThrow();
+  });
+
+  test('getItem should return null when not available', () => {
+    expect(safeLocalStorage.getItem('foo')).toBeNull();
+  });
+
+  test('removeItem should noop when not available', () => {
+    expect(() => {
+      safeLocalStorage.removeItem('foo');
+    }).not.toThrow();
+  });
+
+  test('setItem should noop when not available', () => {
+    expect(() => {
+      safeLocalStorage.setItem('foo', 'bar');
+    }).not.toThrow();
+  });
+});

--- a/weave-js/src/util/localStorage.ts
+++ b/weave-js/src/util/localStorage.ts
@@ -1,0 +1,99 @@
+// you can simulate this in Firefox by going to about:config in the nav bar and then
+// setting dom.storage.enabled to false.
+type MaybeStorage = Storage | null;
+
+export function detectStorage(storage: MaybeStorage) {
+  if (!storage) {
+    return false;
+  }
+
+  try {
+    storage.setItem('feature-detect-storage', '1');
+    storage.removeItem('feature-detect-storage');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export const clear = (storage: MaybeStorage) => () => {
+  try {
+    // @ts-ignore
+    storage.clear();
+  } catch (e) {
+    console.error(
+      'Error attempting to clear storage. Storage may not be available in this environment.'
+    );
+  }
+};
+
+export const getItem = (storage: MaybeStorage) => (key: string) => {
+  try {
+    // @ts-ignore
+    return storage.getItem(key);
+  } catch (e) {
+    console.error(
+      `Error attempting to retrieve item: "${key}" from storage. Storage may not be available in this environment.`
+    );
+    return null;
+  }
+};
+
+export const removeItem = (storage: MaybeStorage) => (key: string) => {
+  try {
+    // @ts-ignore
+    storage.removeItem(key);
+  } catch (e) {
+    console.error(
+      `Error attempting to remove item: "${key}" from storage. Storage may not be available in this environment.`
+    );
+  }
+};
+
+export const setItem =
+  (storage: MaybeStorage) => (key: string, value: string) => {
+    try {
+      // @ts-ignore
+      storage.setItem(key, value);
+    } catch (e) {
+      console.error(
+        `Error attempting to set item: "${key}" from storage. Storage may not be available in this environment.`
+      );
+    }
+  };
+
+export function getStorage(storage: Storage | null) {
+  return {
+    clear: clear(storage),
+    isAvailable: detectStorage(storage),
+    getItem: getItem(storage),
+    removeItem: removeItem(storage),
+    setItem: setItem(storage),
+  };
+}
+/**
+ * Safe wrappers around local storage
+ * LocalStorage will fail in certain environments (like private mode) and those
+ * failed operations should no-op instead of throwing errors.
+ *
+ * These functions work indentically to the standard localStorage API.
+ * ```
+ * import localStorage from './localStorage';
+ * localStorage.setItem('foo', 'bar');
+ * localStorage.getItem('foo');
+ * ```
+ */
+let windowLocalStorage: Storage | null = null;
+let windowSessionStorage: Storage | null = null;
+try {
+  // eslint-disable-next-line no-restricted-properties
+  windowLocalStorage = window?.localStorage;
+  // eslint-disable-next-line no-restricted-properties
+  windowSessionStorage = window?.sessionStorage;
+} catch (e) {
+  console.error(
+    'Error attempting to access window.localStorage. Storage may not be available in this environment.'
+  );
+}
+export const safeLocalStorage = getStorage(windowLocalStorage);
+export const safeSessionStorage = getStorage(windowSessionStorage);

--- a/weave-js/src/util/useLocalStorage.ts
+++ b/weave-js/src/util/useLocalStorage.ts
@@ -1,0 +1,43 @@
+// From https://usehooks.com/useLocalStorage/
+// Public domain per https://github.com/uidotdev/usehooks/blob/master/LICENSE
+
+import {useState} from 'react';
+
+import {safeLocalStorage} from './localStorage';
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+    try {
+      // Get from local storage by key
+      const item = safeLocalStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      safeLocalStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue] as const;
+}

--- a/weave/panels_py/panel_llm_monitor.py
+++ b/weave/panels_py/panel_llm_monitor.py
@@ -20,10 +20,10 @@ ops = weave.ops
 BOARD_ID = "llm_completions_monitor"
 
 # BOARD_DISPLAY_NAME is the name that will be displayed in the UI
-BOARD_DISPLAY_NAME = "Monitor OpenAI API"
+BOARD_DISPLAY_NAME = "Monitor OpenAI API usage"
 
 # BOARD_DESCRIPTION is the description that will be displayed in the UI
-BOARD_DESCRIPTION = "Use the OpenAI integration to track, monitor, & analyze API calls. LLM Engineers can better understand performance and quality; Admins can track trends and costs across entire organizations."
+BOARD_DESCRIPTION = "Use the OpenAI integration to track, monitor and analyze API calls. Understand performance and quality. Track trends and organization-wide costs."
 
 # BOARD_INPUT_WEAVE_TYPE is the weave type of the input node.
 BOARD_INPUT_WEAVE_TYPE = types.List(
@@ -440,5 +440,5 @@ template_registry.register(
     BOARD_DESCRIPTION,
     is_featured=True,
     instructions_md=instructions_md,
-    thumbnail_url="https://raw.githubusercontent.com/wandb/weave/master/docs/assets/full_board_view.png",
+    thumbnail_url="https://raw.githubusercontent.com/wandb/weave/master/docs/assets/monitor-open-ai-api-usage.png",
 )

--- a/weave/panels_py/panel_trace_monitor.py
+++ b/weave/panels_py/panel_trace_monitor.py
@@ -22,10 +22,10 @@ ops = weave.ops
 BOARD_ID = "trace_monitor"
 
 # BOARD_DISPLAY_NAME is the name that will be displayed in the UI
-BOARD_DISPLAY_NAME = "Trace Debug Board"
+BOARD_DISPLAY_NAME = "Trace an LLM pipeline"
 
 # BOARD_DESCRIPTION is the description that will be displayed in the UI
-BOARD_DESCRIPTION = "Systematically analyze traces from LLM chains, application, or any ML pipeline. Great for understanding complex LLM agent behavior, monitoring complex systems, and debugging ML pipelines."
+BOARD_DESCRIPTION = "Analyze traces from LLM chains, applications or any ML pipeline. Understand LLM agent behavior, monitor systems and debug ML pipelines."
 
 # BOARD_INPUT_WEAVE_TYPE is the weave type of the input node.
 
@@ -274,5 +274,5 @@ template_registry.register(
     BOARD_DESCRIPTION,
     is_featured=True,
     instructions_md=instructions_md,
-    thumbnail_url="https://raw.githubusercontent.com/wandb/weave/master/docs/assets/traces_debug_board.png",
+    thumbnail_url="https://raw.githubusercontent.com/wandb/weave/master/docs/assets/trace-an-llm-pipeline.png",
 )


### PR DESCRIPTION
Update of https://github.com/wandb/weave/pull/617 with some additional feedback from @joecloughley 

Internal Notion: https://www.notion.so/wandbai/Weave-Board-Templates-Design-3babd954cc514e4b8df951243249025b?pvs=4#b901fe23256c46f09dc6294d1598754f

Note that the local storage code in util was borrowed from core.

![image](https://github.com/wandb/weave/assets/112953339/6565b088-07f4-4a53-9367-88dcb56fd8d4)
