### PR TITLE
feat(weave): add openai completion api to monitoring sdk

### DIFF
--- a/weave/monitoring/openai.py
+++ b/weave/monitoring/openai.py
@@ -82,8 +82,10 @@ def openai_create_postprocess(span: monitor.SpanWithInputsAndOutput) -> typing.A
                 if "finish_reason" in choice_update:
                     choices[index]["finish_reason"] = choice_update["finish_reason"]
             yield item
-
+        
         if record is not None:
+            import pdb
+            pdb.set_trace()
             encoding = tiktoken.encoding_for_model(record["model"])
 
             prompt_tokens = (
@@ -116,9 +118,9 @@ def openai_create_postprocess(span: monitor.SpanWithInputsAndOutput) -> typing.A
 
 mon = monitor.default_monitor()
 
-monitored_create = mon.trace(
+monitored_create = lambda func: mon.trace(
     preprocess=openai_create_preprocess, postprocess=openai_create_postprocess
-)(openai.ChatCompletion.create)
+)(func)
 
 
 def message_from_stream(stream: typing.Generator) -> typing.Any:
@@ -140,4 +142,9 @@ def message_from_stream(stream: typing.Generator) -> typing.Any:
 class ChatCompletion:
     @staticmethod
     def create(**kwargs: typing.Any) -> typing.Any:
-        return monitored_create(**kwargs)
+        return monitored_create(openai.ChatCompletion.create)(**kwargs)
+
+class Completion:
+    @staticmethod
+    def create(**kwargs: typing.Any) -> typing.Any:
+        return monitored_create(openai.Completion.create)(**kwargs)

--- a/weave/monitoring/openai.py
+++ b/weave/monitoring/openai.py
@@ -157,9 +157,8 @@ def openai_create_postprocess(process_choice_fn: typing.Any, count_token_fn: typ
 
 mon = monitor.default_monitor()
 
-monitored_create = lambda openai_func, process_choice_fn, count_token_fn: mon.trace(
-    preprocess=openai_create_preprocess, postprocess=openai_create_postprocess(process_choice_fn, count_token_fn)
-)(openai_func)
+def monitored_create(openai_func, process_choice_fn, count_token_fn):
+    return mon.trace(preprocess=openai_create_preprocess, postprocess=openai_create_postprocess(process_choice_fn, count_token_fn))(openai_func)
 
 
 def message_from_stream(stream: typing.Generator) -> typing.Any:


### PR DESCRIPTION
Example table for Completion both with and without stream:
https://weave.wandb.ai/?exp=get%28%0A++++%22wandb-artifact%3A%2F%2F%2Fjzhao%2Fllmon-test%2Fopenai_completion_logs%3Alatest%2Fobj%22%29%0A++.rows

<img width="2554" alt="image" src="https://github.com/wandb/weave/assets/1727691/efd9a776-6275-49fd-9177-a15554545d03">

Example table for the original Chat completion:
https://weave.wandb.ai/?exp=get%28%0A++++%22wandb-artifact%3A%2F%2F%2Fjzhao%2Fllmon-test%2Fopenai_chat_completion_logs%3Alatest%2Fobj%22%29%0A++.rows

<img width="2557" alt="image" src="https://github.com/wandb/weave/assets/1727691/3304a031-3d38-4863-b5f0-563fb9055bc9">

One follow up is the monitoring board template does not work with the fields from the completion API by default. We discussed this offline and decided to ship the SDK changes first and fix the boards separately.

