### PR TITLE
chore: Clean up debug strings (node_expr_str) in weave python 

### DIFF
--- a/weave/graph.py
+++ b/weave/graph.py
@@ -230,10 +230,19 @@ def op_full_name(op: Op) -> str:
 
 
 def node_expr_str(node: Node) -> str:
+    from . import partial_object
+
     if isinstance(node, OutputNode):
         param_names = list(node.from_op.inputs.keys())
         if node.from_op.name == "dict":
             return "{%s}" % ", ".join(
+                (
+                    '"%s": %s' % (k, node_expr_str(n))
+                    for k, n in node.from_op.inputs.items()
+                )
+            )
+        elif node.from_op.name == "list":
+            return "[%s]" % ", ".join(
                 (
                     '"%s": %s' % (k, node_expr_str(n))
                     for k, n in node.from_op.inputs.items()
@@ -256,6 +265,24 @@ def node_expr_str(node: Node) -> str:
         elif node.from_op.name == "gqlroot-wbgqlquery":
             query_hash = "_query_"  # TODO: make a hash from the query for idenity
             return f"{node.from_op.friendly_name}({query_hash})"
+        elif node.from_op.name == "gqlroot-querytoobj":
+            const = node.from_op.inputs[param_names[2]]
+            try:
+                assert isinstance(const, ConstNode)
+                narrow_type = const.val
+                assert isinstance(narrow_type, partial_object.PartialObjectType)
+            except AssertionError:
+                return (
+                    f"{node_expr_str(node.from_op.inputs[param_names[0]])}."
+                    f"querytoobj({node_expr_str(node.from_op.inputs[param_names[1]])}, ?)"
+                )
+            else:
+                return (
+                    f"{node_expr_str(node.from_op.inputs[param_names[0]])}."
+                    f"querytoobj({node_expr_str(node.from_op.inputs[param_names[1]])},"
+                    f" {narrow_type.keyless_weave_type_class()})"
+                )
+
         elif all([not isinstance(n, OutputNode) for n in node.from_op.inputs.values()]):
             return "%s(%s)" % (
                 node.from_op.friendly_name,

--- a/weave/graph_debug.py
+++ b/weave/graph_debug.py
@@ -141,6 +141,7 @@ def node_expr_str_full(node: graph.Node) -> str:
             query_hash = "_query_"  # TODO: make a hash from the query for idenity
             return f"{node.from_op.friendly_name}({query_hash})"
         elif node.from_op.name == "gqlroot-querytoobj":
+            param_names = list(node.from_op.inputs.keys())            
             const = node.from_op.inputs[param_names[2]]
             try:
                 assert isinstance(const, graph.ConstNode)

--- a/weave/graph_debug.py
+++ b/weave/graph_debug.py
@@ -141,7 +141,7 @@ def node_expr_str_full(node: graph.Node) -> str:
             query_hash = "_query_"  # TODO: make a hash from the query for idenity
             return f"{node.from_op.friendly_name}({query_hash})"
         elif node.from_op.name == "gqlroot-querytoobj":
-            param_names = list(node.from_op.inputs.keys())            
+            param_names = list(node.from_op.inputs.keys())
             const = node.from_op.inputs[param_names[2]]
             try:
                 assert isinstance(const, graph.ConstNode)

--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -14,6 +14,8 @@ from .. import dispatch
 from .. import weave_internal
 from .. import weavify
 
+from .. import graph_debug
+
 from .arrow import ArrowWeaveListType
 from .list_ import ArrowWeaveList
 from . import arraylist_ops
@@ -693,14 +695,15 @@ def _ensure_variadic_fn(
 
 
 def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
-    logging.info("Vectorizing: %s", fn)
+    debug_str = graph_debug.node_expr_str_full(fn)
+    logging.info("Vectorizing: %s", debug_str)
     from .. import execute_fast
 
     fn = execute_fast._resolve_static_branches(fn)
-    logging.info("Vectorizing. Static branch resolution complete.: %s", fn)
-    from .. import graph_debug
+    logging.info("Vectorizing. Static branch resolution complete.: %s", debug_str)
 
     vecced = vectorize(_ensure_variadic_fn(fn, awl.object_type))
-    logging.info("Vectorizing. Vectorized: %s", vecced)
+    debug_str = graph_debug.node_expr_str_full(vecced)
+    logging.info("Vectorizing. Vectorized: %s", debug_str)
     called = _call_vectorized_fn_node_maybe_awl(awl, vecced)
     return _call_and_ensure_awl(awl, called)


### PR DESCRIPTION
This PR makes some changes to graph expression strings in Weave:

* It imports the partial_object module in graph.py and graph_debug.py. This is used for handling partial object types in graph node expressions.
* It adds better handling for gqlroot-querytoobj nodes in node_expr_str() and node_expr_str_full(). These expressions now show the narrow object type for the query if it is available, otherwise they show "?".
* In the vectorize module, it saves the node expression to a variable before logging it. This avoids calling node_expr_str_full() multiple times.

The main changes are adding support for printing gqlroot-querytoobj nodes with more detail about the narrow object type for the GraphQL query. The other changes improve logging and avoid duplicate work generating the node expression strings.

Overall this improves the logging and debugging of graph nodes during vectorization, especially for GraphQL query nodes by showing the loose object type if available.

---

Before: 

```
wbgqlquery(_query_).querytoobj("project_60b22529bc35484f7c50e94c4b5210a5", projectType({'id': 'String()', 'name': 'String()', 'run_3d9ea607ab62400b2cbd05b0797a4805': "TypedDict(property_types={'id': String(), 'name': String(), 'historyKeys': UnionType(members=[NoneType(), String()]), 'sampledParquetHistory': TypedDict(property_types={'liveData': String(), 'parquetUrls': List(object_type=String())}, not_required_keys=set()), 'project': TypedDict(property_types={'id': String(), 'name': String(), 'entity': TypedDict(property_types={'id': String(), 'name': String()}, not_required_keys=set())}, not_required_keys=set())}, not_required_keys=set())"}), "\n            project_60b22529bc35484f7c50e94c4b5210a5: project(name: \"otto\", entityName: \"l2k2\") {\n                \n        id\n        name\n    \n                \n            run_3d9ea607ab62400b2cbd05b0797a4805: run(name: \"test-runs\") {\n                \n        id\n        name\n    \n                \n    historyKeys\n    sampledParquetHistory: parquetHistory(liveKeys: [\"_step\", \"end_time_s\", \"status_code\", \"start_time_s\", \"inputs.args.duration\", \"inputs.args.location\", \"inputs.args.prompt\", \"name\", \"timestamp\", \"inputs.function_name\", \"inputs.args.topic\", \"_timestamp\", \"inputs.user_prompt\", \"inputs.args.question\", \"trace_id\", \"inputs.args.program\", \"span_id\", \"inputs.args.description\", \"_client_id\", \"summary.latency_s\"]) {\n        liveData\n        parquetUrls\n    }\n    \n        project {\n        id\n        name\n        entity {\n            id\n            name\n        }\n    }\n    \n    \n            }\n        \n            }\n        ").run("test-runs").history3_with_columns(["name", "_step", "trace_id", "timestamp", "end_time_s", "inputs", "span_id", "_timestamp", "summary", "_client_id", "status_code", "start_time_s"]).dropTags().groupby({"timestamp bin": row["timestamp"].bin(null.coalesce(wbgqlquery(_query_).querytoobj("project_60b22529bc35484f7c50e94c4b5210a5", projectType({'id': 'String()', 'name': 'String()', 'run_3d9ea607ab62400b2cbd05b0797a4805': "TypedDict(property_types={'id': String(), 'name': String(), 'historyKeys': UnionType(members=[NoneType(), String()]), 'sampledParquetHistory': TypedDict(property_types={'liveData': String(), 'parquetUrls': List(object_type=String())}, not_required_keys=set()), 'project': TypedDict(property_types={'id': String(), 'name': String(), 'entity': TypedDict(property_types={'id': String(), 'name': String()}, not_required_keys=set())}, not_required_keys=set())}, not_required_keys=set())"}), "\n            project_60b22529bc35484f7c50e94c4b5210a5: project(name: \"otto\", entityName: \"l2k2\") {\n                \n        id\n        name\n    \n                \n            run_3d9ea607ab62400b2cbd05b0797a4805: run(name: \"test-runs\") {\n                \n        id\n        name\n    \n                \n    historyKeys\n    sampledParquetHistory: parquetHistory(liveKeys: [\"_step\", \"end_time_s\", \"status_code\", \"start_time_s\", \"inputs.args.duration\", \"inputs.args.location\", \"inputs.args.prompt\", \"name\", \"timestamp\", \"inputs.function_name\", \"inputs.args.topic\", \"_timestamp\", \"inputs.user_prompt\", \"inputs.args.question\", \"trace_id\", \"inputs.args.program\", \"span_id\", \"inputs.args.description\", \"_client_id\", \"summary.latency_s\"]) {\n        liveData\n        parquetUrls\n    }\n    \n        project {\n        id\n        name\n        entity {\n            id\n            name\n        }\n    }\n    \n    \n            }\n        \n            }\n        ").run("test-runs").history3_with_columns(["name", "_step", "trace_id", "timestamp", "end_time_s", "inputs", "span_id", "_timestamp", "summary", "_client_id", "status_code", "start_time_s"]).dropTags()["timestamp"].min().list(wbgqlquery(_query_).querytoobj("project_60b22529bc35484f7c50e94c4b5210a5", projectType({'id': 'String()', 'name': 'String()', 'run_3d9ea607ab62400b2cbd05b0797a4805': "TypedDict(property_types={'id': String(), 'name': String(), 'historyKeys': UnionType(members=[NoneType(), String()]), 'sampledParquetHistory': TypedDict(property_types={'liveData': String(), 'parquetUrls': List(object_type=String())}, not_required_keys=set()), 'project': TypedDict(property_types={'id': String(), 'name': String(), 'entity': TypedDict(property_types={'id': String(), 'name': String()}, not_required_keys=set())}, not_required_keys=set())}, not_required_keys=set())"}), "\n            project_60b22529bc35484f7c50e94c4b5210a5: project(name: \"otto\", entityName: \"l2k2\") {\n                \n        id\n        name\n    \n                \n            run_3d9ea607ab62400b2cbd05b0797a4805: run(name: \"test-runs\") {\n                \n        id\n        name\n    \n                \n    historyKeys\n    sampledParquetHistory: parquetHistory(liveKeys: [\"_step\", \"end_time_s\", \"status_code\", \"start_time_s\", \"inputs.args.duration\", \"inputs.args.location\", \"inputs.args.prompt\", \"name\", \"timestamp\", \"inputs.function_name\", \"inputs.args.topic\", \"_timestamp\", \"inputs.user_prompt\", \"inputs.args.question\", \"trace_id\", \"inputs.args.program\", \"span_id\", \"inputs.args.description\", \"_client_id\", \"summary.latency_s\"]) {\n        liveData\n        parquetUrls\n    }\n    \n        project {\n        id\n        name\n        entity {\n            id\n            name\n        }\n    }\n    \n    \n            }\n        \n            }\n        ").run("test-runs").history3_with_columns(["name", "_step", "trace_id", "timestamp", "end_time_s", "inputs", "span_id", "_timestamp", "summary", "_client_id", "status_code", "start_time_s"]).dropTags()["timestamp"].max())).binsnice(150)), "row[groupby]": row[null]})
```

After:

```
wbgqlquery(_query_).querytoobj("project_60b22529bc35484f7c50e94c4b5210a5", projectType()).run("test-runs").history3_with_columns(["timestamp", "name", "_step", "_client_id", "span_id", "status_code", "summary", "end_time_s", "_timestamp", "start_time_s", "inputs", "trace_id"]).dropTags().groupby({"timestamp bin": row["timestamp"].bin(null.coalesce(["a": wbgqlquery(_query_).querytoobj("project_60b22529bc35484f7c50e94c4b5210a5", projectType()).run("test-runs").history3_with_columns(["timestamp", "name", "_step", "_client_id", "span_id", "status_code", "summary", "end_time_s", "_timestamp", "start_time_s", "inputs", "trace_id"]).dropTags()["timestamp"].min(), "b": wbgqlquery(_query_).querytoobj("project_60b22529bc35484f7c50e94c4b5210a5", projectType()).run("test-runs").history3_with_columns(["timestamp", "name", "_step", "_client_id", "span_id", "status_code", "summary", "end_time_s", "_timestamp", "start_time_s", "inputs", "trace_id"]).dropTags()["timestamp"].max()]).binsnice(150)), "row[groupby]": row[null]})
```