### PR TITLE
chore: support admin impersonation

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -158,11 +158,16 @@ def weave_wandb_cookie() -> typing.Optional[str]:
             raise errors.WeaveConfigurationError(
                 "WEAVE_WANDB_COOKIE should not be set in public mode."
             )
-        if os.path.exists(os.path.expanduser("~/.netrc")):
-            raise errors.WeaveConfigurationError(
-                "Please delete ~/.netrc while using WEAVE_WANDB_COOKIE to avoid using your credentials"
-            )
+        for netrc_file in ("~/.netrc", "~/_netrc"):
+            if os.path.exists(os.path.expanduser(netrc_file)):
+                raise errors.WeaveConfigurationError(
+                    f"Please delete {netrc_file} while using WEAVE_WANDB_COOKIE to avoid using your credentials"
+                )
     return cookie
+
+
+def weave_impersonated_username_cookie() -> typing.Optional[str]:
+    return os.environ.get("WEAVE_IMPERSONATED_USERNAME_COOKIE")
 
 
 def stack_dump_sighandler_enabled() -> bool:

--- a/weave/wandb_api.py
+++ b/weave/wandb_api.py
@@ -73,6 +73,9 @@ def init() -> typing.Optional[contextvars.Token[typing.Optional[WandbApiContext]
     if cookie:
         # This is a special case for testing. It should never be used in production.
         cookies = {"wandb": cookie}
+        impersonated_username = weave_env.weave_impersonated_username_cookie()
+        if impersonated_username:
+            cookies["impersonated_username"] = impersonated_username
         headers = {"use-admin-privileges": "true", "x-origin": "https://app.wandb.test"}
         return set_wandb_api_context("admin", None, headers, cookies)
     api_key = weave_env.weave_wandb_api_key()

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -117,6 +117,9 @@ def log_system_info():
     underscore_netrc_exists = os.path.exists(os.path.expanduser("~/_netrc"))
     WANDB_API_KEY = "REDACTED" if os.environ.get("WANDB_API_KEY") else None
     WEAVE_WANDB_COOKIE = "REDACTED" if os.environ.get("WEAVE_WANDB_COOKIE") else None
+    WEAVE_IMPERSONATED_USERNAME_COOKIE = os.environ.get(
+        "WEAVE_IMPERSONATED_USERNAME_COOKIE"
+    )
 
     logger.info("Network Config:")
     logger.info(f"  WEAVE_SERVER_URL    = {WEAVE_SERVER_URL}")
@@ -130,6 +133,9 @@ def log_system_info():
     logger.info(f"  ~/_netrc exists     = {underscore_netrc_exists}")
     logger.info(f"  WANDB_API_KEY       = {WANDB_API_KEY}")
     logger.info(f"  WEAVE_WANDB_COOKIE  = {WEAVE_WANDB_COOKIE}")
+    logger.info(
+        f"  WEAVE_IMPERSONATED_USERNAME_COOKIE = {WEAVE_IMPERSONATED_USERNAME_COOKIE}"
+    )
 
 
 def make_app():


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-15737

See also internal PR https://github.com/wandb/core/pull/17325 which updates the Weave auth documentation to explain usage.

Also adds an unrelated dev environment correctness check for `~/_netrc` in addition to `~/.netrc`.
