### PR TITLE
fix: scroll expression editor

### DIFF
--- a/weave-js/src/panel/WeaveExpression/styles.ts
+++ b/weave-js/src/panel/WeaveExpression/styles.ts
@@ -13,6 +13,9 @@ export const EditableContainer = styled.div<{
   display: flex;
   flex: 1 1 auto;
 
+  max-height: 80px;
+  overflow: auto;
+
   ${props =>
     !props.noBox &&
     css`


### PR DESCRIPTION
Fix for long expressions overlapping content in ugly way.

This solution does introduce some issues:
1. The suggestion panel not being positioned properly.
2. No visible indication when expression has been truncated (if browser is like Chrome and hides the scrollbar)
3. Scroll position isn't always properly updating as you edit or move keyboard focus around with arrows.

See loom for demonstration:
https://www.loom.com/share/6e490c6c6e7c4db3a0b45fa2002f5b38?sid=d2a8647f-9b44-4dac-b4e3-95fde6b2c0f2