### PR TITLE
feat: use default entity in streamtable construction when no entity specified

### DIFF
--- a/weave/tests/test_wb_stream_table.py
+++ b/weave/tests/test_wb_stream_table.py
@@ -7,6 +7,7 @@ import numpy as np
 from PIL import Image
 
 from weave import execute, context, gql_json_cache
+from weave import wandb_api
 
 
 def make_stream_table(*args, **kwargs):
@@ -107,7 +108,7 @@ def test_stream_table_entity_inference(user_by_api_key_in_env):
         st.log({"image": [1, 2, 3]})
     st.finish()
 
-    assert st._entity_name == "asd"
+    assert st._entity_name == wandb_api.get_wandb_api_sync().default_entity_name()
 
 
 def test_multi_writers_sequential(user_by_api_key_in_env):

--- a/weave/tests/test_wb_stream_table.py
+++ b/weave/tests/test_wb_stream_table.py
@@ -101,6 +101,15 @@ def test_stream_logging_image(user_by_api_key_in_env):
     assert isinstance(images[0], Image.Image)
 
 
+def test_stream_table_entity_inference(user_by_api_key_in_env):
+    st = make_stream_table("stream-tables/test_table-entity-inference")
+    for i in range(3):
+        st.log({"image": [1, 2, 3]})
+    st.finish()
+
+    assert st._entity_name == "asd"
+
+
 def test_multi_writers_sequential(user_by_api_key_in_env):
     st = make_stream_table(
         "test_table",

--- a/weave/wandb_api.py
+++ b/weave/wandb_api.py
@@ -188,6 +188,25 @@ class WandbApiAsync:
             return None
         return file["directUrl"]
 
+    VIEWER_DEFAULT_ENTITY_QUERY = gql.gql(
+        """
+        query DefaultEntity {
+            viewer {
+                defaultEntity {
+                    name
+                }
+            }
+        }        
+        """
+    )
+
+    async def default_entity_name(self) -> typing.Optional[str]:
+        try:
+            result = await self.query(self.VIEWER_DEFAULT_ENTITY_QUERY)
+        except gql.transport.exceptions.TransportQueryError as e:
+            return None
+        return result.get("viewer", {}).get("defaultEntity", {}).get("name", None)
+
 
 class WandbApi:
     def query(self, query: graphql.DocumentNode, **kwargs: typing.Any) -> typing.Any:
@@ -273,6 +292,25 @@ class WandbApi:
         if file is None:
             return None
         return file["directUrl"]
+
+    VIEWER_DEFAULT_ENTITY_QUERY = gql.gql(
+        """
+        query DefaultEntity {
+            viewer {
+                defaultEntity {
+                    name
+                }
+            }
+        }        
+        """
+    )
+
+    def default_entity_name(self) -> typing.Optional[str]:
+        try:
+            result = self.query(self.VIEWER_DEFAULT_ENTITY_QUERY)
+        except gql.transport.exceptions.TransportQueryError as e:
+            return None
+        return result.get("viewer", {}).get("defaultEntity", {}).get("name", None)
 
 
 async def get_wandb_api() -> WandbApiAsync:

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -14,6 +14,7 @@ import uuid
 from wandb.sdk.lib.paths import LogicalPath
 from wandb.sdk.lib.printer import get_printer
 from wandb.sdk.lib.ipython import _get_python_type
+from wandb.sdk.internal import internal_api
 
 
 from .wandb_lite_run import InMemoryLazyLiteRun
@@ -132,11 +133,12 @@ class _StreamTableSync:
             project_name = splits[1]
             table_name = splits[2]
 
-        # For now, we force the user to specify the entity and project
-        # technically, we could infer the entity from the API key, but
-        # that tends to confuse users.
         if entity_name is None or entity_name == "":
-            raise ValueError("Must specify entity_name")
+            # Use user's default entity
+            api = internal_api.Api()
+            entity_name = api.default_entity
+            if not entity_name:
+                raise ValueError("Entity not specified and no default entity found.")
         elif project_name is None or project_name == "":
             raise ValueError("Must specify project_name")
         elif table_name is None or table_name == "":

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -141,7 +141,8 @@ class _StreamTableSync:
                 raise ValueError(
                     "Entity not specified and no default entity found. Please specify entity_name or set default entity with `wandb login --entity <entity_name>`"
                 )
-        elif project_name is None or project_name == "":
+                
+        if project_name is None or project_name == "":
             raise ValueError("Must specify project_name")
         elif table_name is None or table_name == "":
             raise ValueError("Must specify table_name")

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -14,11 +14,10 @@ import uuid
 from wandb.sdk.lib.paths import LogicalPath
 from wandb.sdk.lib.printer import get_printer
 from wandb.sdk.lib.ipython import _get_python_type
-from wandb.sdk.internal import internal_api
-
 
 from .wandb_lite_run import InMemoryLazyLiteRun
 
+from .. import wandb_api
 from .. import runfiles_wandb
 from .. import storage
 from .. import weave_types
@@ -135,10 +134,13 @@ class _StreamTableSync:
 
         if entity_name is None or entity_name == "":
             # Use user's default entity
-            api = internal_api.Api()
-            entity_name = api.default_entity
-            if not entity_name:
-                raise ValueError("Entity not specified and no default entity found.")
+            api = wandb_api.get_wandb_api_sync()
+            entity_name = api.default_entity_name()
+            # get default entity
+            if entity_name is None or entity_name == "":
+                raise ValueError(
+                    "Entity not specified and no default entity found. Please specify entity_name or set default entity with `wandb login --entity <entity_name>`"
+                )
         elif project_name is None or project_name == "":
             raise ValueError("Must specify project_name")
         elif table_name is None or table_name == "":

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -141,7 +141,7 @@ class _StreamTableSync:
                 raise ValueError(
                     "Entity not specified and no default entity found. Please specify entity_name or set default entity with `wandb login --entity <entity_name>`"
                 )
-                
+
         if project_name is None or project_name == "":
             raise ValueError("Must specify project_name")
         elif table_name is None or table_name == "":


### PR DESCRIPTION
This PR adds support for initializing streamtables with just project/tablename, instead of requiring entity/project/tablename. The entity is calculated using the default entity from the current WB api context. 

Adds a test for this behavior.

Internal JIRA: https://wandb.atlassian.net/browse/WB-15768