### PR TITLE
fix: Use UTC ISO-ish format for timestamp display

### DIFF
--- a/weave-js/src/components/Panel2/PanelDateRange.tsx
+++ b/weave-js/src/components/Panel2/PanelDateRange.tsx
@@ -115,6 +115,14 @@ export function deltaStringToSeconds(timeString: string) {
   return timestamp * 1000;
 }
 
+// Convert timestamp to a string format that can be parsed by the Date constructor.
+// This is non-standard but tested to work in Chrome, Firefox, Safari.
+const formatTime = (timestamp: number): string => {
+  const date = new Date(timestamp);
+  const isoWithMillis = date.toISOString();
+  return isoWithMillis.replace('T', ' ').split('.')[0] + 'Z';
+};
+
 export const DateEditor: React.FC<{
   timestamp: number | null;
   onCommit: (newValue: number) => void;
@@ -124,8 +132,7 @@ export const DateEditor: React.FC<{
 }> = props => {
   const {timestamp} = props;
   const allowDelta = props.allowDelta && props.deltaFromOffset != null;
-  const dateS =
-    timestamp == null ? 'none' : new Date(timestamp).toLocaleString();
+  const dateS = timestamp == null ? 'none' : formatTime(timestamp);
   return (
     <ValidatingTextInput
       key={dateS}


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-15777

The DateRange control was using `toLocaleString`. This does not make it clear to the user what time zone is being used. Worse, it varies from browser to browser what date input formats can be parsed, and a non-US user was seeing parsing fail, without good UI feedback, for an input format it might seem was supported because we used it for output.

A longer term fix might involve fancier controls for date and timezone selection, but for now we display the timestamp in a format that can be parsed back (in tested browsers), is not ambiguous about timezone, and is less confusing about MM/DD vs. DD/MM ordering.

Before:
<img width="291" alt="Screenshot 2023-09-29 at 10 03 13 AM" src="https://github.com/wandb/weave/assets/112953339/f51d9aca-0926-423c-967f-82a07dba8194">

After:
<img width="293" alt="Screenshot 2023-09-29 at 10 07 51 AM" src="https://github.com/wandb/weave/assets/112953339/92cb4940-a947-4442-8872-e289b1853ca8">
