### PR TITLE
feat(wir): Create root documents registry in PanelInteractContext

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
@@ -4,7 +4,7 @@ import {ChildPanelFullConfig} from '../ChildPanel';
 import {getConfigForPath} from '../panelTree';
 import {toWeaveType} from '../toWeaveType';
 
-type WeavePanelSlateNode = {
+export type WeavePanelSlateNode = {
   type: 'weave-panel';
   /**
    * A weave-panel slate node in a report is a "void element", which


### PR DESCRIPTION
Adds a documents registry to `PanelInteractContext` so that all documents sharing a single `PanelInteractDrawer` are tracked in the context.

Required for https://github.com/wandb/core/pull/17251. Enables [this specific change](https://github.com/wandb/core/pull/17251/commits/7aa31e5b6c03fbea0ca70ea82cc6ac262b59edff) to better decouple the responsibilities of report page vs panel interact context