### PR TITLE
chore: check for _netrc too

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -158,10 +158,11 @@ def weave_wandb_cookie() -> typing.Optional[str]:
             raise errors.WeaveConfigurationError(
                 "WEAVE_WANDB_COOKIE should not be set in public mode."
             )
-        if os.path.exists(os.path.expanduser("~/.netrc")):
-            raise errors.WeaveConfigurationError(
-                "Please delete ~/.netrc while using WEAVE_WANDB_COOKIE to avoid using your credentials"
-            )
+        for netrc_file in ("~/.netrc", "~/_netrc"):
+            if os.path.exists(os.path.expanduser(netrc_file)):
+                raise errors.WeaveConfigurationError(
+                    f"Please delete {netrc_file} while using WEAVE_WANDB_COOKIE to avoid using your credentials"
+                )
     return cookie
 
 


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-15694 (partial)

A `_netrc` file can also cause problems. (It's the filename used on Windows.)
See https://github.com/psf/requests/blob/main/src/requests/utils.py
