### PR TITLE
chore(weave): Propagate if errors are server errors

### DIFF
--- a/weave-js/src/errors.ts
+++ b/weave-js/src/errors.ts
@@ -1,0 +1,1 @@
+export class UseNodeValueServerExecutionError extends Error {}

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -61,6 +61,7 @@ import {
   getChainRootVar,
   isConstructor,
 } from './core/mutate';
+import {UseNodeValueServerExecutionError} from './errors';
 // import {useTraceUpdate} from './common/util/hooks';
 
 /**
@@ -347,7 +348,8 @@ export const useNodeValue = <T extends Type>(
       const message =
         'Node execution failed (useNodeValue): ' + errorToText(error);
       console.error(message);
-      throw new Error(message);
+
+      throw new UseNodeValueServerExecutionError(message);
     }
     if (isConstNode(node)) {
       if (isFunction(node.type)) {


### PR DESCRIPTION
We need to be able to distinguish when a client-side error is due to the engine, or react code - this will help us to do that