### PR TITLE
fix(wir): Set documentId for PanelPanelConfig outline view

### DIFF
--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -358,6 +358,7 @@ const usePanelPanelCommon = (props: PanelPanelProps) => {
 export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
   const {
     loading,
+    documentId,
     panelConfig,
     selectedPanel,
     setInteractingPanel,
@@ -388,8 +389,8 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
   );
 
   const goBackToOutline = useCallback(() => {
-    setInteractingPanel('config', ['']);
-  }, [setInteractingPanel]);
+    setInteractingPanel('config', [''], documentId);
+  }, [documentId, setInteractingPanel]);
 
   if (loading) {
     return <Panel2Loader />;
@@ -422,7 +423,9 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
             config={panelConfig}
             updateConfig={panelUpdateConfig}
             updateConfig2={panelUpdateConfig2}
-            setSelected={path => setInteractingPanel('config', path)}
+            setSelected={path =>
+              setInteractingPanel('config', path, documentId)
+            }
             selected={selectedPanel}
           />
         </SidebarConfig.Body>


### PR DESCRIPTION
Problem: panel editor outline view doesn't work in report page

https://github.com/wandb/weave/assets/17016170/acb49614-26a9-4f47-afae-6d7652cd5c92

Solution: need to set selected doc id in `PanelInteractContext` when navigating to outline view

https://github.com/wandb/weave/assets/17016170/9a43e4c3-71e8-4144-92f6-e17e4363260a

Still works in boards too

https://github.com/wandb/weave/assets/17016170/6dbdb2a7-4fbf-4082-a6af-92cabf92fd53


