### PR TITLE
feat(wir): Support sticky PanelInteractDrawer

### DIFF
--- a/weave-js/src/components/Sidebar/PanelInteractDrawer.tsx
+++ b/weave-js/src/components/Sidebar/PanelInteractDrawer.tsx
@@ -2,14 +2,18 @@ import {MOON_250} from '@wandb/weave/common/css/color.styles';
 import React from 'react';
 import styled from 'styled-components';
 
-type PanelInteractDrawerProps = {active: boolean};
+type PanelInteractDrawerProps = {
+  active: boolean;
+  sticky?: boolean;
+};
 
 export const PanelInteractDrawer: React.FC<PanelInteractDrawerProps> = ({
   active,
   children,
+  sticky = false,
 }) => {
   return (
-    <Container active={active} data-test="weave-sidebar">
+    <Container active={active} sticky={sticky} data-test="weave-sidebar">
       <Content>{children}</Content>
     </Container>
   );
@@ -19,7 +23,7 @@ export default PanelInteractDrawer;
 
 const WIDTH_PX = 328;
 
-export const Container = styled.div<{active: boolean}>`
+export const Container = styled.div<{active: boolean; sticky: boolean}>`
   flex-shrink: 0;
   font-size: 15px;
   overflow: hidden;
@@ -32,6 +36,9 @@ export const Container = styled.div<{active: boolean}>`
   width: ${p => (p.active ? WIDTH_PX : 0)}px;
   // Don't do this, it makes open and closing the drawer janky
   // transition: width 0.3s;
+  height: ${p => (p.sticky ? '100vh' : undefined)};
+  position: ${p => (p.sticky ? 'sticky' : undefined)};
+  top: ${p => (p.sticky ? 0 : undefined)};
 `;
 
 export const Content = styled.div`


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15857

Problem: if `PanelInteractDrawer` is used with page contents that are long and scrollable (e.g. reports), the drawer contents may scroll out of view.

https://github.com/wandb/weave/assets/17016170/7c0d390c-7427-482a-86dc-a3ea2585d8e4

Solution: accept sticky prop to make drawer stick to the top as user scrolls (need to update core to use this prop: https://github.com/wandb/core/pull/17419)

https://github.com/wandb/weave/assets/17016170/37010d18-5b52-4f7a-8a00-2580b512f925

Drawer still works as expected in boards

https://github.com/wandb/weave/assets/17016170/e7806a11-e17b-4dbf-89bc-bc3ff3ca3a95
