### PR TITLE
chore(weave): Fix LLM Board to work for root-only-spans

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/query.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/query.tsx
@@ -90,7 +90,6 @@ export const useProjectsForEntityWithWeaveObject = (
   });
 
   const entityProjectNamesValue = useNodeValue(projectMetaNode);
-  console.log(entityProjectNamesValue);
 
   return useMemo(() => {
     // this filter step is done client side - very bad!
@@ -155,7 +154,7 @@ export const useProjectAssetCount = (
     projectHistoryType: opProjectHistoryType({project: projectNode}),
   } as any);
   const compositeValue = useNodeValue(compositeNode);
-  console.log('compositeValue', compositeValue);
+
   return useMemo(() => {
     let result = {
       boardCount: 0,
@@ -164,7 +163,6 @@ export const useProjectAssetCount = (
       legacyTracesCount: 0,
     };
     if (compositeValue.result != null) {
-      console.log(compositeValue.result.projectHistoryType);
       const keys = projectHistoryTypeToLegacyTraceKeys(
         compositeValue.result.projectHistoryType as w.Type
       );
@@ -380,7 +378,6 @@ export const useProjectLegacyTraces = (
   });
   const historyTypeNode = opProjectHistoryType({project: projectNode});
   const historyTypeValue = useNodeValue(historyTypeNode as w.Node);
-  console.log({historyTypeValue});
   return useMemo(() => {
     const keys =
       historyTypeValue.result == null

--- a/weave-js/src/components/Panel2/PanelTraceTree/util.ts
+++ b/weave-js/src/components/Panel2/PanelTraceTree/util.ts
@@ -67,6 +67,7 @@ export const SpanWeaveType = {
     'exception',
     'attributes',
     'summary',
+    'parent_id',
   ],
 };
 export const SpanWeaveWithTimestampType: Type = {

--- a/weave/panels/panel_trace.py
+++ b/weave/panels/panel_trace.py
@@ -20,7 +20,16 @@ span_typed_dict_type = weave.types.TypedDict(
         "timestamp": weave.types.optional(weave.types.Timestamp()),
     },
     not_required_keys=set(
-        ["status_code", "inputs", "output", "exception", "attributes", "summary"]
+        # parent_id is not required because it is None for root spans
+        [
+            "status_code",
+            "inputs",
+            "output",
+            "exception",
+            "attributes",
+            "summary",
+            "parent_id",
+        ]
     ),
 )
 


### PR DESCRIPTION
Working with customer example, I realized that we fail to recommend the if there are no parent_ids in the schema! This fixes that issue