### PR TITLE
chore(weave): Better cache handling on total error

### DIFF
--- a/weave-js/src/core/server/remoteHttp.ts
+++ b/weave-js/src/core/server/remoteHttp.ts
@@ -287,8 +287,10 @@ export class RemoteHttpServer implements Server {
         indexes.forEach(i => {
           const entry = nodeEntries[i];
           if (entry.retries >= this.opts.maxRetries) {
-            this.trace(`Cancelling node after ${entry.retries} retries`);
-            this.resolveNode(entry.node, null);
+            const message = `Cancelling node after ${entry.retries} retries`
+            this.trace(message);
+            this.rejectNode(entry.node, 
+              {message, traceback: []});
           } else {
             entry.state = 'waiting';
             entry.retries++;

--- a/weave-js/src/core/server/remoteHttp.ts
+++ b/weave-js/src/core/server/remoteHttp.ts
@@ -287,10 +287,9 @@ export class RemoteHttpServer implements Server {
         indexes.forEach(i => {
           const entry = nodeEntries[i];
           if (entry.retries >= this.opts.maxRetries) {
-            const message = `Cancelling node after ${entry.retries} retries`
+            const message = `Cancelling node after ${entry.retries} retries`;
             this.trace(message);
-            this.rejectNode(entry.node, 
-              {message, traceback: []});
+            this.rejectNode(entry.node, {message, traceback: []});
           } else {
             entry.state = 'waiting';
             entry.retries++;

--- a/weave-js/src/entrypoint.tsx
+++ b/weave-js/src/entrypoint.tsx
@@ -18,8 +18,11 @@ import {
 import getConfig from './config';
 import {PanelRootContextProvider} from './components/Panel2/PanelPanel';
 import {WeaveViewerContextProvider} from './context/WeaveViewerContext';
+import {LocalStorageBackedLRU} from './core/cache/localStorageBackedLRU';
 
 class ErrorBoundary extends React.Component<{}, {hasError: boolean}> {
+  private localStorageCache: LocalStorageBackedLRU;
+
   static getDerivedStateFromError(error: Error) {
     // Update state so the next render will show the fallback UI.
     return {hasError: true};
@@ -27,6 +30,7 @@ class ErrorBoundary extends React.Component<{}, {hasError: boolean}> {
   constructor(props: {}) {
     super(props);
     this.state = {hasError: false};
+    this.localStorageCache = new LocalStorageBackedLRU();
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
@@ -42,7 +46,12 @@ class ErrorBoundary extends React.Component<{}, {hasError: boolean}> {
 
   render() {
     if (this.state.hasError) {
-      // You can render any custom fallback UI
+      try {
+        // Here we blow away our local cache state since it's likely corrupted
+        this.localStorageCache.reset();
+      } catch (e) {
+        console.log(e);
+      }
       return (
         <WeaveMessage>
           Something went wrong. Check the javascript console.


### PR DESCRIPTION
Does 2 things:
1. When we timeout, we reject node and not resolve it... as a result of the current impl, we were returning `None` to node subscribers that did not expect `None` to be possible!
2. When we hit a full page crash (should rarely happen) - we should clear our cache so not to keep erroring