### PR TITLE
fix: migrate facet-selected to new-style autocall op

### DIFF
--- a/weave/compile.py
+++ b/weave/compile.py
@@ -841,6 +841,7 @@ def _node_ops(node: graph.Node) -> typing.Optional[graph.Node]:
         "panel_table-all_rows",
         "stream_table-rows",
         "panel_trace-active_span",
+        "Facet-selected",
     ]:
         return None
     new_node = typing.cast(graph.Node, weave_internal.use(node))

--- a/weave/panels/panel_facet.py
+++ b/weave/panels/panel_facet.py
@@ -4,6 +4,7 @@ import weave
 from .. import panel
 from . import table_state
 
+from .. import compile
 from .. import graph
 from .. import weave_internal
 
@@ -125,4 +126,5 @@ class Facet(panel.Panel):
                 ),
             ),
         )
-        return weave_internal.use(filtered)
+
+        return filtered

--- a/weave/panels/panel_facet.py
+++ b/weave/panels/panel_facet.py
@@ -4,7 +4,7 @@ import weave
 from .. import panel
 from . import table_state
 
-from .. import compile
+from .. import weave_types as types
 from .. import graph
 from .. import weave_internal
 
@@ -110,7 +110,9 @@ class Facet(panel.Panel):
         if self.config.selectedCell == None:
             from ..ops_arrow import list_
 
-            return list_.make_vec_none(0)
+            return weave_internal.make_const_node(
+                list_.ArrowWeaveListType(types.NoneType()), list_.make_vec_none(0)
+            )
         x_fn = self.config.table.columnSelectFunctions[self.config.dims.x]
         y_fn = self.config.table.columnSelectFunctions[self.config.dims.y]
         filtered = weave.ops.List.filter(


### PR DESCRIPTION
Fixes an issue where projection pushdown on the output of facet-selected was not being propagated to the facet input node in the resolver of facet-selected. Accomplishes this by transitioning facet-selected to a new style autocall op