### PR TITLE
chore(weave): Fix bad suggestions Part 1

### DIFF
--- a/weave-js/src/core/hl.ts
+++ b/weave-js/src/core/hl.ts
@@ -682,6 +682,9 @@ function isProducibleType(type: Type): boolean {
   if (isFunction(type)) {
     return isProducibleType(type.outputType);
   }
+  if (type === 'any') {
+    return false;
+  }
   const PRODUCIBLE_TYPES: Type[] = [
     'string',
     'number',
@@ -807,6 +810,9 @@ export function availableOpsForChain(node: Node, opStore: OpStore): OpDef[] {
     availableOps(supportedEngineForNode(node, opStore), opStore)
   ).filter(opDef => {
     if (isValidRootOp(opDef)) {
+      return false;
+    }
+    if (opDef.name.startsWith('panel-')) {
       return false;
     }
     const inputTypes = Object.values(opDef.inputTypes);
@@ -1056,6 +1062,9 @@ export const getPlaceholderArg = (
   argName: string
 ): EditingNode | null => {
   const argType = opDef.inputTypes[argName];
+  if (opDef.name.includes('merge')) {
+    console.log('merge placeholder arg', opDef.name, argName, argType);
+  }
   if (isAssignableTo('string', argType)) {
     return constString('');
   }

--- a/weave-js/src/core/hl.ts
+++ b/weave-js/src/core/hl.ts
@@ -1062,9 +1062,6 @@ export const getPlaceholderArg = (
   argName: string
 ): EditingNode | null => {
   const argType = opDef.inputTypes[argName];
-  if (opDef.name.includes('merge')) {
-    console.log('merge placeholder arg', opDef.name, argName, argType);
-  }
   if (isAssignableTo('string', argType)) {
     return constString('');
   }


### PR DESCRIPTION
I was watching some error cases and noticed that there are a number of `WeaveBadRequest` responses from server. Looking at the user journey - i noticed that the suggestions include `panel` ops as well as ops where the second arg is `any`. I simply don't suggest these cases because they are always going to get the user into a weird spot