### PR TITLE
refactor(wir): Use weave ID util instead of uuid

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
@@ -1,5 +1,4 @@
-import {voidNode} from '@wandb/weave/core';
-import {v4 as uuid} from 'uuid';
+import {ID, voidNode} from '@wandb/weave/core';
 import {ChildPanelFullConfig} from '../ChildPanel';
 import {getConfigForPath} from '../panelTree';
 import {toWeaveType} from '../toWeaveType';
@@ -62,7 +61,7 @@ export const computeReportSlateNode = (
       panelConfig: {
         id: 'Panel',
         config: {
-          documentId: uuid(),
+          documentId: ID(12),
         },
         input_node: {
           nodeType: 'const',


### PR DESCRIPTION
Related to: https://github.com/wandb/core/pull/17490/files

No functional impact to end users.

I noticed that core app actually doesn't have `uuid` as a dependency; it mostly uses the `ID` util from weave instead. Decided to update the logic for generating exported panel `documentId` for consistency.