### PR TITLE
perf: dont require key for vectorization

### DIFF
--- a/weave/ops_domain/wandb_domain_gql.py
+++ b/weave/ops_domain/wandb_domain_gql.py
@@ -87,9 +87,7 @@ def register_vectorized_gql_prop_op(
     assert isinstance(
         original_scalar_input_type, partial_object.PartialObjectTypeGeneratorType
     )
-    scalar_input_type = original_scalar_input_type.with_keys(
-        {prop_name: scalar_output_type}
-    )
+    scalar_input_type = original_scalar_input_type
 
     vectorized_op_name = "ArrowWeaveList" + scalar_op_name
     arrow_input_type = {first_arg_name: ArrowWeaveListType(scalar_input_type)}

--- a/weave/tests/test_arrow_vectorizer.py
+++ b/weave/tests/test_arrow_vectorizer.py
@@ -1361,27 +1361,6 @@ def test_vectorized_prop_op_gql_pick():
     ]
 
 
-def test_cant_vectorize_without_keys():
-    runs = [
-        wdt.Run({"id": "A", "key2": 1}),
-        wdt.Run({"id": "B", "key2": 1}),
-        wdt.Run({"id": "C", "key2": 1}),
-    ]
-    for run in runs:
-        tag_store.add_tags(run, {"mytag": "test" + run["id"]})
-    awl = arrow.to_arrow(runs)
-
-    fn = weave_internal.define_fn(
-        {"x": awl.object_type}, lambda x: run_ops.run_name(x)
-    ).val
-
-    vec_fn = arrow.vectorize(fn, strict=True)
-
-    # it finds a mapped list op, but not an AWL op
-    assert "ArrowWeaveList" not in vec_fn.from_op.name
-    assert "mapped" in vec_fn.from_op.name
-
-
 def test_vectorize_run_runtime():
     runs = [
         wdt.Run({"id": "A", "computeSeconds": 1}),


### PR DESCRIPTION
This PR removes the requirement that the input `ArrowWeaveListType(PartialObjectType())` to a vectorized GQL prop op have a specific key in order to dispatch the vectorized (instead of mapped) version. This prevents us breaking out to python in cases where we have a lambda function that does not have propagated GQL types. 

I dont think this requirement was ever needed in the first place, since if GQL domain compilation is working correctly we should always have the requisite keys available.