### PR TITLE
fix: fix attributeerror on default_entity_name

### DIFF
--- a/weave/wandb_api.py
+++ b/weave/wandb_api.py
@@ -205,7 +205,10 @@ class WandbApiAsync:
             result = await self.query(self.VIEWER_DEFAULT_ENTITY_QUERY)
         except gql.transport.exceptions.TransportQueryError as e:
             return None
-        return result.get("viewer", {}).get("defaultEntity", {}).get("name", None)
+        try:
+            return result.get("viewer", {}).get("defaultEntity", {}).get("name", None)
+        except AttributeError:
+            return None
 
 
 class WandbApi:


### PR DESCRIPTION
When we query for a default entity to initialize a streamtable, if `result` is `None` and we call `.get()` on it, it will raise an `AttributeError`. Here we return `None` in that case to fix. 