### PR TITLE
chore(weave): Fixes nullable created_by field on artifacts

### DIFF
--- a/weave/ops_domain/artifact_version_ops.py
+++ b/weave/ops_domain/artifact_version_ops.py
@@ -417,7 +417,7 @@ def _get_history_metrics(
     from .. import weave_internal
 
     created_by = artifactVersion["createdBy"]
-    if created_by["__typename"] != "Run":
+    if created_by == None or created_by["__typename"] != "Run":
         return {}
 
     run_name = created_by["name"]


### PR DESCRIPTION
The `artifact.created_by` field is allowed to be null, but we were not handling that correctly.