### PR TITLE
feat: allow formatting PanelNumber output

### DIFF
--- a/weave-js/src/components/Panel2/PanelNumber.tsx
+++ b/weave-js/src/components/Panel2/PanelNumber.tsx
@@ -20,7 +20,7 @@ const CustomFormatHelp = () => {
           style={{margin: 4}}
         />
       }
-      content="Supports a subset of Python's Format Specification Mini-Language. e.g. Value 1234 with format '+010,.1f' -> '+001,234.0'"
+      content="Syntax is inspired by Python's Format Specification Mini-Language. Supports precision, width with leading zeros, and commas for grouping. e.g. Value 1234 with format '+010,.1f' -> '+001,234.0'"
     />
   );
 };

--- a/weave-js/src/components/Panel2/PanelNumber.tsx
+++ b/weave-js/src/components/Panel2/PanelNumber.tsx
@@ -120,7 +120,10 @@ const inputType = {
   type: 'union' as const,
   members: ['none' as const, 'number' as const],
 };
-type PanelNumberProps = Panel2.PanelProps<typeof inputType>;
+type PanelNumberProps = Panel2.PanelProps<
+  typeof inputType,
+  {propFormat: string}
+>;
 type PanelNumberExtraProps = {
   textAlign?: 'left' | 'right' | 'center' | 'justify' | 'initial' | 'inherit';
 };

--- a/weave-js/src/core/util/number.test.ts
+++ b/weave-js/src/core/util/number.test.ts
@@ -19,26 +19,40 @@ const NUM_FRAC_FIFTH = 1 / 5;
 const NUM_FRAC_THIRD = 1 / 3;
 
 describe('formatNumber', () => {
-  it('matches Number.toString on Automatic or unrecognized format specified', () => {
-    for (const format of ['Automatic', 'Anything else']) {
-      expect(formatNumber(NUM_ZERO, format)).toEqual('0');
-      expect(formatNumber(NUM_NAN, format)).toEqual('NaN');
-      expect(formatNumber(NUM_INF_POS, format)).toEqual('Infinity');
-      expect(formatNumber(NUM_INF_NEG, format)).toEqual('-Infinity');
-      expect(formatNumber(NUM_INT_MAX, format)).toEqual('9007199254740991');
-      expect(formatNumber(NUM_INT_MIN, format)).toEqual('-9007199254740991');
-      expect(formatNumber(NUM_MAX, format)).toEqual('1.7976931348623157e+308');
-      expect(formatNumber(NUM_INT_POS, format)).toEqual('1234');
-      expect(formatNumber(NUM_INT_NEG, format)).toEqual('-1234');
-      expect(formatNumber(NUM_INT_BIG, format)).toEqual('100000000000000');
-      expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('1234.56789');
-      expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-1234.56789');
-      expect(formatNumber(NUM_FLOAT_BIG, format)).toEqual('1.234e+90');
-      expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('0.2');
-      expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual(
-        '0.3333333333333333'
-      );
-    }
+  it('formats Automatic to match previous behavior', () => {
+    const format = 'Automatic';
+    // Chosen to match integration tests.
+    expect(formatNumber(NUM_ZERO, format)).toEqual('0');
+    expect(formatNumber(NUM_NAN, format)).toEqual('NaN');
+    expect(formatNumber(NUM_INF_POS, format)).toEqual('Infinity');
+    expect(formatNumber(NUM_INF_NEG, format)).toEqual('-Infinity');
+    expect(formatNumber(NUM_INT_POS, format)).toEqual('1234');
+    expect(formatNumber(NUM_INT_NEG, format)).toEqual('-1234');
+    expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('1234.568');
+    expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-1234.568');
+    expect(formatNumber(NUM_FLOAT_BIG, format)).toEqual('1.234e+90');
+    expect(formatNumber(NUM_FLOAT_SMALL, format)).toEqual('0.000001234');
+    expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('0.2');
+    expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual('0.3333');
+    expect(formatNumber(Math.pow(2, 2.5), format)).toEqual('5.657');
+  });
+  it('matches Number.toString or unrecognized format specified', () => {
+    const format = 'Anything else';
+    expect(formatNumber(NUM_ZERO, format)).toEqual('0');
+    expect(formatNumber(NUM_NAN, format)).toEqual('NaN');
+    expect(formatNumber(NUM_INF_POS, format)).toEqual('Infinity');
+    expect(formatNumber(NUM_INF_NEG, format)).toEqual('-Infinity');
+    expect(formatNumber(NUM_INT_MAX, format)).toEqual('9007199254740991');
+    expect(formatNumber(NUM_INT_MIN, format)).toEqual('-9007199254740991');
+    expect(formatNumber(NUM_MAX, format)).toEqual('1.7976931348623157e+308');
+    expect(formatNumber(NUM_INT_POS, format)).toEqual('1234');
+    expect(formatNumber(NUM_INT_NEG, format)).toEqual('-1234');
+    expect(formatNumber(NUM_INT_BIG, format)).toEqual('100000000000000');
+    expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('1234.56789');
+    expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-1234.56789');
+    expect(formatNumber(NUM_FLOAT_BIG, format)).toEqual('1.234e+90');
+    expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('0.2');
+    expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual('0.3333333333333333');
   });
 
   it('formats Number', () => {

--- a/weave-js/src/core/util/number.test.ts
+++ b/weave-js/src/core/util/number.test.ts
@@ -1,0 +1,204 @@
+import {formatNumber} from './number';
+
+const NUM_ZERO = 0;
+const NUM_NAN = Number.NaN;
+const NUM_INF_POS = Number.POSITIVE_INFINITY;
+const NUM_INF_NEG = Number.NEGATIVE_INFINITY;
+const NUM_INT_MAX = Number.MAX_SAFE_INTEGER;
+const NUM_INT_MIN = Number.MIN_SAFE_INTEGER;
+const NUM_MAX = Number.MAX_VALUE;
+
+const NUM_INT_POS = 1234;
+const NUM_INT_NEG = -1234;
+const NUM_INT_BIG = 100000000000000;
+const NUM_FLOAT_POS = 1234.56789;
+const NUM_FLOAT_NEG = -1234.56789;
+const NUM_FLOAT_SMALL = 1.234e-6;
+const NUM_FLOAT_BIG = 1.234e90;
+const NUM_FRAC_FIFTH = 1 / 5;
+const NUM_FRAC_THIRD = 1 / 3;
+
+describe('formatNumber', () => {
+  it('matches Number.toString on Automatic or unrecognized format specified', () => {
+    for (const format of ['Automatic', 'Anything else']) {
+      expect(formatNumber(NUM_ZERO, format)).toEqual('0');
+      expect(formatNumber(NUM_NAN, format)).toEqual('NaN');
+      expect(formatNumber(NUM_INF_POS, format)).toEqual('Infinity');
+      expect(formatNumber(NUM_INF_NEG, format)).toEqual('-Infinity');
+      expect(formatNumber(NUM_INT_MAX, format)).toEqual('9007199254740991');
+      expect(formatNumber(NUM_INT_MIN, format)).toEqual('-9007199254740991');
+      expect(formatNumber(NUM_MAX, format)).toEqual('1.7976931348623157e+308');
+      expect(formatNumber(NUM_INT_POS, format)).toEqual('1234');
+      expect(formatNumber(NUM_INT_NEG, format)).toEqual('-1234');
+      expect(formatNumber(NUM_INT_BIG, format)).toEqual('100000000000000');
+      expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('1234.56789');
+      expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-1234.56789');
+      expect(formatNumber(NUM_FLOAT_BIG, format)).toEqual('1.234e+90');
+      expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('0.2');
+      expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual(
+        '0.3333333333333333'
+      );
+    }
+  });
+
+  it('formats Number', () => {
+    const format = 'Number';
+    expect(formatNumber(NUM_ZERO, format)).toEqual('0.00');
+    expect(formatNumber(NUM_NAN, format)).toEqual('NaN');
+    expect(formatNumber(NUM_INF_POS, format)).toEqual('∞');
+    expect(formatNumber(NUM_INF_NEG, format)).toEqual('-∞');
+    expect(formatNumber(NUM_INT_MAX, format)).toEqual(
+      '9,007,199,254,740,991.00'
+    );
+    expect(formatNumber(NUM_INT_MIN, format)).toEqual(
+      '-9,007,199,254,740,991.00'
+    );
+    expect(formatNumber(NUM_MAX, format)).toEqual(
+      '179,769,313,486,231,570,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000.00'
+    );
+    expect(formatNumber(NUM_INT_POS, format)).toEqual('1,234.00');
+    expect(formatNumber(NUM_INT_NEG, format)).toEqual('-1,234.00');
+    expect(formatNumber(NUM_INT_BIG, format)).toEqual('100,000,000,000,000.00');
+    expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('1,234.57');
+    expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-1,234.57');
+    expect(formatNumber(NUM_FLOAT_BIG, format)).toEqual(
+      '1,234,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000.00'
+    );
+    expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('0.20');
+    expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual('0.33');
+  });
+
+  it('formats Percent', () => {
+    const format = 'Percent';
+    expect(formatNumber(NUM_ZERO, format)).toEqual('0.00%');
+    expect(formatNumber(NUM_NAN, format)).toEqual('NaN%');
+    expect(formatNumber(NUM_INF_POS, format)).toEqual('∞%');
+    expect(formatNumber(NUM_INF_NEG, format)).toEqual('-∞%');
+    expect(formatNumber(NUM_INT_MAX, format)).toEqual('900719925474099100.00%');
+    expect(formatNumber(NUM_INT_MIN, format)).toEqual(
+      '-900719925474099100.00%'
+    );
+    expect(formatNumber(NUM_MAX, format)).toEqual(
+      '17976931348623157000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.00%'
+    );
+
+    expect(formatNumber(NUM_INT_POS, format)).toEqual('123400.00%');
+    expect(formatNumber(NUM_INT_NEG, format)).toEqual('-123400.00%');
+    expect(formatNumber(NUM_INT_BIG, format)).toEqual('10000000000000000.00%');
+    expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('123456.79%');
+    expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-123456.79%');
+    expect(formatNumber(NUM_FLOAT_BIG, format)).toEqual(
+      '123400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.00%'
+    );
+    expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('20.00%');
+    expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual('33.33%');
+  });
+
+  it('formats Scientific', () => {
+    const format = 'Scientific';
+    expect(formatNumber(NUM_ZERO, format)).toEqual('0.000000e+00');
+    expect(formatNumber(NUM_NAN, format)).toEqual('NaN');
+    expect(formatNumber(NUM_INF_POS, format)).toEqual('∞');
+    expect(formatNumber(NUM_INF_NEG, format)).toEqual('-∞');
+    expect(formatNumber(NUM_INT_POS, format)).toEqual('1.234000e+03');
+    expect(formatNumber(NUM_INT_NEG, format)).toEqual('-1.234000e+03');
+    expect(formatNumber(NUM_INT_BIG, format)).toEqual('1.000000e+14');
+    expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('1.234568e+03');
+    expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-1.234568e+03');
+    expect(formatNumber(NUM_FLOAT_BIG, format)).toEqual('1.234000e+90');
+    expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('2.000000e-01');
+    expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual('3.333333e-01');
+  });
+
+  it('formats Compact', () => {
+    const format = 'Compact';
+    expect(formatNumber(NUM_ZERO, format)).toEqual('0');
+    expect(formatNumber(NUM_NAN, format)).toEqual('NaN');
+    expect(formatNumber(NUM_INF_POS, format)).toEqual('∞');
+    expect(formatNumber(NUM_INF_NEG, format)).toEqual('-∞');
+    expect(formatNumber(NUM_INT_MAX, format)).toEqual('9.01e+15');
+    expect(formatNumber(NUM_INT_MIN, format)).toEqual('-9.01e+15');
+    expect(formatNumber(NUM_MAX, format)).toEqual('1.80e+308');
+    expect(formatNumber(NUM_INT_POS, format)).toEqual('1.2K');
+    expect(formatNumber(NUM_INT_NEG, format)).toEqual('-1.2K');
+    expect(formatNumber(NUM_INT_BIG, format)).toEqual('100T');
+    expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('1.2K');
+    expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-1.2K');
+    expect(formatNumber(NUM_FLOAT_BIG, format)).toEqual('1.23e+90');
+    expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('0.2');
+    expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual('0.33');
+    expect(formatNumber(999_999_999_999_999, format)).toEqual('1000T');
+    expect(formatNumber(1_000_000_000_000_000, format)).toEqual('1.00e+15');
+  });
+
+  it('formats Currency - USD', () => {
+    const format = '$USD';
+    expect(formatNumber(NUM_ZERO, format)).toEqual('$0.00');
+    expect(formatNumber(NUM_NAN, format)).toEqual('$NaN');
+    expect(formatNumber(NUM_INF_POS, format)).toEqual('$∞');
+    expect(formatNumber(NUM_INF_NEG, format)).toEqual('-$∞');
+    expect(formatNumber(NUM_INT_MAX, format)).toEqual(
+      '$9,007,199,254,740,991.00'
+    );
+    expect(formatNumber(NUM_INT_MIN, format)).toEqual(
+      '-$9,007,199,254,740,991.00'
+    );
+    expect(formatNumber(NUM_INT_POS, format)).toEqual('$1,234.00');
+    expect(formatNumber(NUM_INT_NEG, format)).toEqual('-$1,234.00');
+    expect(formatNumber(NUM_INT_BIG, format)).toEqual(
+      '$100,000,000,000,000.00'
+    );
+    expect(formatNumber(NUM_FLOAT_POS, format)).toEqual('$1,234.57');
+    expect(formatNumber(NUM_FLOAT_NEG, format)).toEqual('-$1,234.57');
+    expect(formatNumber(NUM_FRAC_FIFTH, format)).toEqual('$0.20');
+    expect(formatNumber(NUM_FRAC_THIRD, format)).toEqual('$0.33');
+  });
+
+  it('formats Custom', () => {
+    // sign
+    expect(formatNumber(NUM_ZERO, '*+')).toEqual('+0');
+    expect(formatNumber(NUM_INT_POS, '*+')).toEqual('+1234');
+    expect(formatNumber(NUM_INT_POS, '* ')).toEqual(' 1234');
+    expect(formatNumber(NUM_INT_NEG, '* ')).toEqual('-1234');
+
+    // zero
+    expect(formatNumber(NUM_ZERO, '*04')).toEqual('0000');
+    expect(formatNumber(NUM_INT_POS, '*08')).toEqual('00001234');
+    expect(formatNumber(NUM_INT_POS, '*+08')).toEqual('+0001234');
+    expect(formatNumber(NUM_INT_POS, '* 08')).toEqual(' 0001234');
+    expect(formatNumber(NUM_INT_NEG, '*08')).toEqual('-0001234');
+    expect(formatNumber(NUM_INT_NEG, '*+08')).toEqual('-0001234');
+
+    // width
+    expect(formatNumber(NUM_ZERO, '*3')).toEqual('  0');
+    expect(formatNumber(NUM_INT_POS, '*3')).toEqual('1234');
+
+    // grouping
+    expect(formatNumber(NUM_ZERO, '*,')).toEqual('0');
+    expect(formatNumber(NUM_INT_POS, '*,')).toEqual('1,234');
+    expect(formatNumber(NUM_INT_NEG, '*,')).toEqual('-1,234');
+    expect(formatNumber(NUM_FLOAT_POS, '*,')).toEqual('1,234.567890');
+    expect(formatNumber(NUM_FLOAT_NEG, '*,')).toEqual('-1,234.567890');
+
+    // precision
+    expect(formatNumber(NUM_FLOAT_POS, '*.1')).toEqual('1234.6');
+    expect(formatNumber(NUM_FLOAT_POS, '*.2')).toEqual('1234.57');
+    expect(formatNumber(NUM_FLOAT_POS, '*.3')).toEqual('1234.568');
+    expect(formatNumber(NUM_FLOAT_POS, '*.12')).toEqual('1234.567890000000');
+
+    // type
+    expect(formatNumber(NUM_INT_POS, '*')).toEqual('1234');
+    expect(formatNumber(NUM_FLOAT_POS, '*')).toEqual('1234.567890');
+    expect(formatNumber(NUM_INT_POS, '*f')).toEqual('1234.000000');
+    expect(formatNumber(NUM_FLOAT_POS, '*f')).toEqual('1234.567890');
+    expect(formatNumber(NUM_INT_POS, '*d')).toEqual('1234');
+    expect(formatNumber(NUM_FLOAT_POS, '*d')).toEqual('1235'); // Python would error, unknown format code for float
+    expect(formatNumber(NUM_INT_POS, '*e')).toEqual('1.234000e+03');
+    expect(formatNumber(NUM_FLOAT_SMALL, '*e')).toEqual('1.234000e-06');
+    expect(formatNumber(NUM_INT_POS, '*E')).toEqual('1.234000E+03');
+    expect(formatNumber(NUM_FLOAT_SMALL, '*E')).toEqual('1.234000E-06');
+
+    // combination
+    expect(formatNumber(NUM_INT_POS, '*+010,.1f')).toEqual('+001,234.0');
+  });
+});

--- a/weave-js/src/core/util/number.ts
+++ b/weave-js/src/core/util/number.ts
@@ -1,0 +1,167 @@
+/**
+ * Utilities for formatting numbers. These are inspired by Python's format specifier mini-language.
+ */
+
+const FORMAT_NUMBER = new Intl.NumberFormat('en-US', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+  useGrouping: true,
+});
+
+const FORMAT_PERCENT = new Intl.NumberFormat('en-US', {
+  style: 'percent',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+  useGrouping: false,
+});
+
+const FORMAT_COMPACT = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+});
+
+export const NON_CUSTOM_FORMATS = [
+  'Automatic',
+  'Number',
+  'Percent',
+  'Scientific',
+  'Compact',
+];
+
+type CurrencyFormat = {
+  locale: string;
+  currency: string;
+};
+const CURRENCY_FORMATS: Record<string, CurrencyFormat> = {
+  USD: {
+    locale: 'en-US',
+    currency: 'USD',
+  },
+  // TODO: Support other currencies
+};
+
+// See https://docs.python.org/3/library/string.html#format-specification-mini-language
+// format_spec     ::=  [[fill]align][sign]["z"]["#"]["0"][width][grouping_option]["." precision][type]
+// fill            ::=  <any character>
+// align           ::=  "<" | ">" | "=" | "^"
+// sign            ::=  "+" | "-" | " "
+// width           ::=  digit+
+// grouping_option ::=  "_" | ","
+// precision       ::=  digit+
+// type            ::=  "b" | "c" | "d" | "e" | "E" | "f" | "F" | "g" | "G" | "n" | "o" | "s" | "x" | "X" | "%"
+// TODO: Handle fill/align, underscore grouping option, more types
+// TODO: Handle 'z' - coerce negative zero floating-point values to positive zero
+//       after rounding to the format precision.
+// TODO: Handle '#' - use "alternate form" for the conversion
+// TODO: Consider using something like https://keleshev.com/verbose-regular-expressions-in-javascript
+const FORMAT_SPEC_SIGN = '([\\+\\- ]?)';
+const FORMAT_SPEC_WIDTH = '(\\d*)';
+const FORMAT_SPEC_GROUPING_OPTION = '([_,]?)';
+const FORMAT_SPEC_PRECISION = '(?:\\.(\\d+))?';
+const FORMAT_SPEC_TYPE = '([bcdeEfFgGnosxX%]?)';
+
+const RE_FORMAT_SPEC = new RegExp(
+  `${FORMAT_SPEC_SIGN}(0?)${FORMAT_SPEC_WIDTH}${FORMAT_SPEC_GROUPING_OPTION}${FORMAT_SPEC_PRECISION}${FORMAT_SPEC_TYPE}`
+);
+
+const insertAt = (str: string, index: number, insert: string): string => {
+  return str.slice(0, index) + insert + str.slice(index);
+};
+
+export const formatNumber = (n: number, format: string): string => {
+  if (format === 'Number') {
+    return FORMAT_NUMBER.format(n);
+  }
+  if (format === 'Percent') {
+    return FORMAT_PERCENT.format(n);
+  }
+  if (format === 'Scientific') {
+    return formatNumber(n, '*.6e');
+  }
+  if (format === 'Compact') {
+    if (Number.isFinite(n) && Math.abs(n) >= 1e15) {
+      // Output like 1,234,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000T
+      // is not actually very "compact"; just use scientific notation instead.
+      return formatNumber(n, '*.2e');
+    }
+    return FORMAT_COMPACT.format(n);
+  }
+  if (format.startsWith('$')) {
+    const currencyFormat = CURRENCY_FORMATS[format.substring(1)];
+    if (currencyFormat) {
+      const numberFormat = new Intl.NumberFormat(currencyFormat.locale, {
+        style: 'currency',
+        currency: currencyFormat.currency,
+      });
+      return numberFormat.format(n);
+    }
+  }
+  if (format.startsWith('*')) {
+    if (Number.isNaN(n) || !Number.isFinite(n)) {
+      return n.toLocaleString();
+    }
+
+    const match = RE_FORMAT_SPEC.exec(format.substring(1));
+    if (match) {
+      const [sign, zero, width, grouping, precision, type] = match.slice(1);
+
+      const defaultType = Number.isInteger(n) ? 'd' : 'f';
+      const resolvedType = type === '' ? defaultType : type;
+      const notation = ['e', 'E'].includes(resolvedType)
+        ? 'scientific'
+        : 'standard';
+
+      const resolvedWidth = width !== '' ? parseInt(width, 10) : undefined;
+      const useGrouping = grouping === ',';
+
+      const minimumFractionDigits =
+        precision != null
+          ? parseInt(precision, 10)
+          : ['e', 'E', 'f'].includes(resolvedType)
+          ? 6
+          : 0;
+      const maximumFractionDigits = minimumFractionDigits;
+
+      const signDisplay = sign === '+' ? 'always' : 'auto';
+      let prefix = '';
+      if (n > 0 && sign === ' ') {
+        prefix = ' ';
+      }
+
+      const options: Intl.NumberFormatOptions = {
+        notation,
+        useGrouping,
+        minimumFractionDigits,
+        maximumFractionDigits,
+        signDisplay,
+      };
+
+      const numberFormat = new Intl.NumberFormat('en-US', options);
+      let formatted = prefix + numberFormat.format(n);
+
+      if (['e', 'E'].includes(resolvedType)) {
+        const [coefficient, exponent] = formatted.split('E');
+        const resolvedExponent = parseInt(exponent, 10);
+        const esign = resolvedExponent >= 0 ? '+' : ''; // Negative has sign included
+        let exponentStr = exponent;
+        if (Math.abs(resolvedExponent) < 10) {
+          // Insert a zero
+          const index = exponentStr.startsWith('-') ? 1 : 0;
+          exponentStr = insertAt(exponentStr, index, '0');
+        }
+        formatted = `${coefficient}${resolvedType}${esign}${exponentStr}`;
+      }
+
+      if (resolvedWidth != null) {
+        const diff = resolvedWidth - formatted.length;
+        if (diff > 0) {
+          // Padding char gets inserted after the sign
+          const paddingChar = zero !== '' ? '0' : ' ';
+          const index = ['+', '-', ' '].includes(formatted[0]) ? 1 : 0;
+          return insertAt(formatted, index, paddingChar.repeat(diff));
+        }
+      }
+      return formatted;
+    }
+  }
+  return n.toString();
+};

--- a/weave-js/src/core/util/number.ts
+++ b/weave-js/src/core/util/number.ts
@@ -1,6 +1,9 @@
 /**
  * Utilities for formatting numbers. These are inspired by Python's format specifier mini-language.
  */
+import numeral from 'numeral';
+
+import {trimEndChar} from './string';
 
 const FORMAT_NUMBER = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
@@ -68,6 +71,20 @@ const insertAt = (str: string, index: number, insert: string): string => {
 };
 
 export const formatNumber = (n: number, format: string): string => {
+  if (format === 'Automatic') {
+    // Use the same logic as displayValueNoBarChart
+    if (!Number.isFinite(n) || Number.isInteger(n)) {
+      return n.toString();
+    }
+    if (-1 < n && n < 1) {
+      let s = n.toPrecision(4);
+      if (!s.includes('e')) {
+        s = trimEndChar(s, '0');
+      }
+      return s;
+    }
+    return numeral(n).format('0.[000]');
+  }
   if (format === 'Number') {
     return FORMAT_NUMBER.format(n);
   }
@@ -96,7 +113,7 @@ export const formatNumber = (n: number, format: string): string => {
     }
   }
   if (format.startsWith('*')) {
-    if (Number.isNaN(n) || !Number.isFinite(n)) {
+    if (!Number.isFinite(n)) {
       return n.toLocaleString();
     }
 

--- a/weave-js/src/core/util/string.test.ts
+++ b/weave-js/src/core/util/string.test.ts
@@ -1,0 +1,16 @@
+import {trimEndChar} from './string';
+
+describe('trimEndChar', () => {
+  it('handles end char does not exist', () => {
+    expect(trimEndChar('abc', 'd')).toEqual('abc');
+  });
+  it('ignores trim char not at end', () => {
+    expect(trimEndChar('abc', 'b')).toEqual('abc');
+  });
+  it('removes all trim char', () => {
+    expect(trimEndChar('abccccc', 'c')).toEqual('ab');
+  });
+  it('returns empty string if entirely trim char', () => {
+    expect(trimEndChar('ccccc', 'c')).toEqual('');
+  });
+});

--- a/weave-js/src/core/util/string.ts
+++ b/weave-js/src/core/util/string.ts
@@ -59,3 +59,12 @@ export function indent(s: string, level: number) {
 
 export const maybePluralize = (count: number, noun: string, suffix = 's') =>
   `${count} ${noun}${count !== 1 ? suffix : ''}`;
+
+// Return a new string with all occurrences of a character at the end of the input removed.
+export const trimEndChar = (str: string, char: string): string => {
+  let s = str;
+  while (s[s.length - 1] === char) {
+    s = s.slice(0, s.length - 1);
+  }
+  return s;
+};


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-15980

Adds flexible number panel formatting. For ease of use numbers can be formatted with some predefined formats like "Percent"; for flexibility we allow specifying a custom format that supports a subset of  [Python's format specifier mini-language](https://docs.python.org/3/library/string.html#format-specification-mini-language).

This has not been reviewed by design and is not meant to be a final solution (FYI - @joecloughley) but in the short term will allow us to make some of the templates more usable.

Before:
<img width="277" alt="Screenshot 2023-10-10 at 4 16 08 PM" src="https://github.com/wandb/weave/assets/112953339/0c561264-3163-4217-beff-ff6749284138">

After:
<img width="277" alt="Screenshot 2023-10-10 at 4 16 49 PM" src="https://github.com/wandb/weave/assets/112953339/6b6545dd-e30b-49cb-b01e-b4823990565c">

Specifying:
<img width="323" alt="Screenshot 2023-10-10 at 4 14 39 PM" src="https://github.com/wandb/weave/assets/112953339/dd7622c3-3453-4a72-a26d-adc7bf18cec9">
<img width="1401" alt="Screenshot 2023-10-10 at 4 15 37 PM" src="https://github.com/wandb/weave/assets/112953339/38ffc896-ade3-4daf-aa62-60bc9bc42f14">

