### PR TITLE
fix(weave): Fix spacing in data browser

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterBrowser.tsx
@@ -24,6 +24,7 @@ const CenterTable = styled.table`
   border-collapse: collapse;
 
   td {
+    padding: 0px 15px;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -358,14 +359,7 @@ export const CenterBrowser = <RT extends CenterBrowserDataType>(
           <thead>
             <tr>
               {columns.map(c => (
-                <td
-                  style={{
-                    minWidth: '150px',
-                    padding: '0px 10px',
-                  }}
-                  key={c}>
-                  {c}
-                </td>
+                <td key={c}>{c}</td>
               ))}
               {hasOverflowActions && (
                 <td
@@ -382,14 +376,7 @@ export const CenterBrowser = <RT extends CenterBrowserDataType>(
                 onClick={() => primaryAction?.onClick(row, i)}
                 $highlighted={props.selectedRowId === row._id}>
                 {columns.map(c => (
-                  <td
-                    style={{
-                      minWidth: '150px',
-                      padding: '0px 10px',
-                    }}
-                    key={c}>
-                    {(row as any)[c]}
-                  </td>
+                  <td key={c}>{(row as any)[c]}</td>
                 ))}
                 {hasOverflowActions && (
                   <td>

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterBrowser.tsx
@@ -358,7 +358,14 @@ export const CenterBrowser = <RT extends CenterBrowserDataType>(
           <thead>
             <tr>
               {columns.map(c => (
-                <td key={c}>{c}</td>
+                <td
+                  style={{
+                    minWidth: '150px',
+                    padding: '0px 10px',
+                  }}
+                  key={c}>
+                  {c}
+                </td>
               ))}
               {hasOverflowActions && (
                 <td
@@ -375,7 +382,14 @@ export const CenterBrowser = <RT extends CenterBrowserDataType>(
                 onClick={() => primaryAction?.onClick(row, i)}
                 $highlighted={props.selectedRowId === row._id}>
                 {columns.map(c => (
-                  <td key={c}>{(row as any)[c]}</td>
+                  <td
+                    style={{
+                      minWidth: '150px',
+                      padding: '0px 10px',
+                    }}
+                    key={c}>
+                    {(row as any)[c]}
+                  </td>
                 ))}
                 {hasOverflowActions && (
                   <td>


### PR DESCRIPTION
- https://wandb.atlassian.net/browse/WB-15986
- https://www.notion.so/wandbai/Fix-spacing-on-the-data-browser-add965ca327d4b9e8709ec0993f8b2da?pvs=4

### Before
<img width="932" alt="Screen Shot 2023-10-10 at 4 06 16 PM" src="https://github.com/wandb/weave/assets/8609620/1afdeb1a-d6a4-46db-9a58-eb7331406b01">


### After
<img width="876" alt="Screen Shot 2023-10-10 at 4 06 50 PM" src="https://github.com/wandb/weave/assets/8609620/12ed37d0-5206-4153-8623-894fa62712a1">