### PR TITLE
fix: delete key should unsuppress suggestions

### DIFF
--- a/weave-js/src/panel/WeaveExpression/index.tsx
+++ b/weave-js/src/panel/WeaveExpression/index.tsx
@@ -117,7 +117,7 @@ export const WeaveExpression: React.FC<WeaveExpressionProps> = props => {
       // Pressing a non-printable character like shift is not enough to cancel
       // the suggestion panel suppression.
       const isPrintableCharacter = ev.key.length === 1;
-      if (isPrintableCharacter) {
+      if (isPrintableCharacter || ev.key === 'Backspace') {
         setShowSuggestions(true);
       }
 


### PR DESCRIPTION
https://github.com/wandb/weave/pull/616 suppresses suggestions after you run an expression.
If you type a key, it stops suppression of suggestions. However, we have a check for printable characters, so just hitting shift etc won't stop the suppression. However, delete/backspace is a non-printable character that changes the expression, and should make it so you see suggestions again.