### PR TITLE
fix(wir): Check docid when determining if ChildPanel is selected

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -54,6 +54,7 @@ import * as Styles from './PanelExpression/styles';
 import {
   useCloseDrawer,
   usePanelInputExprIsHighlightedByPath,
+  useSelectedDocumentId,
   useSelectedPath,
   useSetInteractingChildPanel,
   useSetPanelInputExprIsHighlighted,
@@ -565,6 +566,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     el => el != null && el !== ''
   );
 
+  const selectedDocumentId = useSelectedDocumentId();
   const pathStr = useMemo(() => ['<root>', ...fullPath].join('.'), [fullPath]);
   const selectedPath = useSelectedPath();
   const selectedPathStr = useMemo(() => {
@@ -575,6 +577,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
   }, [selectedPath]);
 
   const isPanelSelected =
+    selectedDocumentId === documentId &&
     selectedPathStr !== '<root>' &&
     selectedPathStr !== '<root>.main' &&
     pathStr.startsWith(selectedPathStr);


### PR DESCRIPTION
Problem: if a report has multiple weave panels and you try to edit one of them, all panels show the hover controls as though they're the one selected

https://github.com/wandb/weave/assets/17016170/7a0c94a9-c673-455a-9cb4-45a3d701b886

Root cause: currently we only check the ChildPanel's path to determine if it's the selected one. For panels exported to reports, we always add the target panel at path `root.panel`.

Solution: check document ID in addition to path

<img width="1339" alt="Screenshot 2023-10-12 at 10 19 25 AM" src="https://github.com/wandb/weave/assets/17016170/eeea995c-1e08-484b-9e6d-b70b0ded8462">
