### PR TITLE
fix(wir): Update PanelInteractDrawer styles for smaller screens

### DIFF
--- a/weave-js/src/components/Sidebar/PanelInteractDrawer.tsx
+++ b/weave-js/src/components/Sidebar/PanelInteractDrawer.tsx
@@ -24,6 +24,8 @@ export default PanelInteractDrawer;
 const WIDTH_PX = 328;
 
 export const Container = styled.div<{active: boolean; sticky: boolean}>`
+  background: white;
+  z-index: 10;
   flex-shrink: 0;
   font-size: 15px;
   overflow: hidden;


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15856

before:


https://github.com/wandb/weave/assets/17016170/1bdd65ac-add3-453b-99ff-2b7890169a7d

after:


https://github.com/wandb/weave/assets/17016170/547b30cb-ea13-440a-8e1f-80b49002b6dc


made sure it still looks right in boards:


https://github.com/wandb/weave/assets/17016170/29285cd9-9fb7-43a8-bfeb-d1e71f1bc8d4

