### PR TITLE
feat: allow specifying weave_wandb_gql_headers

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -5,7 +5,7 @@
 import configparser
 import enum
 import os
-import pathlib
+import json
 import typing
 from . import util
 from . import errors
@@ -149,6 +149,19 @@ def memdump_sighandler_enabled() -> bool:
 
 def sigterm_sighandler_enabled() -> bool:
     return util.parse_boolean_env_var("WEAVE_ENABLE_SIGTERM_SIGHANDLER")
+
+
+def weave_wandb_gql_headers() -> typing.Dict[str, str]:
+    # expects a json string
+    raw = os.environ.get("WEAVE_WANDB_GQL_HEADERS")
+    if raw:
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            raise errors.WeaveConfigurationError(
+                "WEAVE_WANDB_GQL_HEADERS should be a json string"
+            )
+    return {}
 
 
 def weave_wandb_cookie() -> typing.Optional[str]:

--- a/weave/wandb_api.py
+++ b/weave/wandb_api.py
@@ -70,10 +70,15 @@ def get_wandb_api_context() -> typing.Optional[WandbApiContext]:
 
 def init() -> typing.Optional[contextvars.Token[typing.Optional[WandbApiContext]]]:
     cookie = weave_env.weave_wandb_cookie()
+    headers = weave_env.weave_wandb_gql_headers()
     if cookie:
         # This is a special case for testing. It should never be used in production.
         cookies = {"wandb": cookie}
-        headers = {"use-admin-privileges": "true", "x-origin": "https://app.wandb.test"}
+        headers = {
+            "use-admin-privileges": "true",
+            "x-origin": "https://app.wandb.test",
+            **headers,
+        }
         return set_wandb_api_context("admin", None, headers, cookies)
     api_key = weave_env.weave_wandb_api_key()
     if api_key:


### PR DESCRIPTION
Adds support for specifying custom HTTP headers to be included with GQL requests as environment variables. 