### PR TITLE
chore(weave): Compile `List<AWL>.flatten` to `List<AWL>.AWL-concat`

### DIFF
--- a/weave/compile.py
+++ b/weave/compile.py
@@ -283,6 +283,21 @@ def _simple_optimizations(node: graph.Node) -> typing.Optional[graph.Node]:
                 "ArrowWeaveList-concat",
                 {"arr": arr_node},
             )
+    elif isinstance(node, graph.OutputNode) and node.from_op.name == "concat":
+        from .ops_arrow.arrow import ArrowWeaveListType
+        from .ops_arrow.list_ops import flatten_return_type
+
+        # The operation of flattening a lists of arrow weave lists is exactly equal to the far
+        # more efficient, vectorized concat operation. If this is the case, use it!.
+        arr_node = node.from_op.inputs["arr"]
+        if ArrowWeaveListType().assign_type(arr_node.type) and types.List().assign_type(
+            arr_node.type.object_type
+        ):
+            return graph.OutputNode(
+                flatten_return_type({"arr": arr_node.type}),
+                "ArrowWeaveList-flatten",
+                {"arr": arr_node},
+            )
     return None
 
 

--- a/weave/compile.py
+++ b/weave/compile.py
@@ -287,8 +287,8 @@ def _simple_optimizations(node: graph.Node) -> typing.Optional[graph.Node]:
         from .ops_arrow.arrow import ArrowWeaveListType
         from .ops_arrow.list_ops import flatten_return_type
 
-        # The operation of flattening a lists of arrow weave lists is exactly equal to the far
-        # more efficient, vectorized concat operation. If this is the case, use it!.
+        # The operation of concat on a awl of lists is exactly equal to the far
+        # more efficient, vectorized flatten operation. If this is the case, use it!.
         arr_node = node.from_op.inputs["arr"]
         if ArrowWeaveListType().assign_type(arr_node.type) and types.List().assign_type(
             arr_node.type.object_type

--- a/weave/tests/test_list_arrow_compat.py
+++ b/weave/tests/test_list_arrow_compat.py
@@ -600,8 +600,8 @@ def test_flatten_and_tags(use_arrow):
     item_tag_res = weave.use(item_tag_getter(flattened[0]))
     list_tag_res = weave.use(list_tag_getter(flattened[0]))
 
-    # if use_arrow:
-    #     data_res = data_res
+    if use_arrow:
+        data_res = data_res.to_pylist_notags()
 
     assert data_res == [
         "item_1_1",


### PR DESCRIPTION
There was a query this week consistently hitting our 2min timeout. After this change, the query resolves in < 2 seconds locally (after data is cached)! The key insight is that:
  * a `flatten` op called on a `List<AWL>` is exactly functionally equivalent to calling `AWL-concat` on the same object! 
  * a `concat` op called on a `AWL<list>` is exactly functionally equivalent to calling `AWL-flatten` on the same object! 
 
This PR adds a compile step to do this work.