### PR TITLE
fix: Make arrow.constructors.repeat handle repeat request size of 0

### DIFF
--- a/weave/ops_arrow/constructors.py
+++ b/weave/ops_arrow/constructors.py
@@ -16,6 +16,8 @@ from . import convert
 
 def repeat(value: typing.Any, count: int) -> pa.Array:
     value_single = convert.to_arrow([value])._arrow_data
+    if count == 0:
+        return pa.array([], value_single.type)
     return pa.repeat(value_single[0], count)
 
 
@@ -67,6 +69,7 @@ def vectorized_container_constructor_preprocessor(
 ) -> VectorizedContainerConstructorResults:
     if len(input_dict) == 0:
         return VectorizedContainerConstructorResults([], {}, 0, None)
+
     arrays = []
     prop_types = {}
     awl_artifact = None

--- a/weave/tests/test_arrow.py
+++ b/weave/tests/test_arrow.py
@@ -25,6 +25,9 @@ from ..ops_primitives import list_
 from .. import mappers_arrow
 from ..op_def import map_type
 
+from ..ops_arrow import constructors
+
+
 from ..language_features.tagging import tag_store, tagged_value_type, make_tag_getter_op
 
 
@@ -1789,3 +1792,10 @@ def test_keys_ops():
     all_keys_node = keys_node.flatten().unique()
 
     assert weave.use(all_keys_node).to_pylist_raw() == ["a", "b", "c"]
+
+
+def test_repeat_0():
+    data = {"a": 1}
+    repeated = constructors.repeat(data, 0)
+    assert len(repeated) == 0
+    assert repeated.type == pa.struct({"a": pa.int64()})


### PR DESCRIPTION
Before this would fail with "must pass at least one array." This explicitly handles the length 0 case and fixes the failure. 