### PR TITLE
feat(ui): Apply focus outline only for keyboard interactions

### DIFF
--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -87,6 +87,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
               'night-aware',
               "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
               'disabled:pointer-events-none disabled:opacity-40',
+              'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
               {
                 // small
                 'gap-6 px-6 py-3 text-sm leading-[18px]': isSmall,
@@ -101,10 +102,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
                 // large
                 'gap-8 px-12 py-8 text-base': isLarge,
                 'h-40 w-40 p-0': isLarge && isIconOnly,
-
-                // focus
-                'focus:outline focus:outline-[2px] focus:outline-teal-500':
-                  true,
 
                 // primary
                 'bg-teal-500 text-white hover:bg-teal-450': isPrimary,

--- a/weave-js/src/components/Checkbox/Checkbox.tsx
+++ b/weave-js/src/components/Checkbox/Checkbox.tsx
@@ -34,7 +34,7 @@ export const Checkbox = ({checked, className, ...props}: CheckboxProps) => {
           'inline-flex items-center justify-center',
           'h-18 w-18',
           'rounded border-[1.5px]  dark:border-moon-250',
-          'focus:outline focus:outline-[2px] focus:outline-teal-500',
+          'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
           checked ? 'border-moon-800' : 'border-moon-500',
           {className}
         )}

--- a/weave-js/src/components/Radio/index.tsx
+++ b/weave-js/src/components/Radio/index.tsx
@@ -15,7 +15,8 @@ export const Item = ({
 }: React.ComponentProps<typeof RadioGroup.Item>) => (
   <RadioGroup.Item
     className={twMerge(
-      'flex h-[15px] w-[15px] items-center justify-center rounded-full border-[1px] border-solid border-moon-500 focus:outline focus:outline-[2px] focus:outline-teal-500 data-[state=checked]:border-moon-800',
+      'flex h-[15px] w-[15px] items-center justify-center rounded-full border-[1px] border-solid border-moon-500 data-[state=checked]:border-moon-800',
+      'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
       className
     )}
     {...props}

--- a/weave-js/src/components/Slider/index.tsx
+++ b/weave-js/src/components/Slider/index.tsx
@@ -39,7 +39,8 @@ type SliderThumbProps = React.ComponentProps<typeof RadixSlider.Thumb>;
 export const Thumb = ({className, ...props}: SliderThumbProps) => (
   <RadixSlider.Thumb
     className={twMerge(
-      'block h-[22px] w-[22px] rounded-full border-[1px] border-solid border-moon-350 bg-white focus:outline focus:outline-[2px] focus:outline-teal-500 ',
+      'block h-[22px] w-[22px] rounded-full border-[1px] border-solid border-moon-350 bg-white',
+      'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
       className
     )}
     {...props}
@@ -73,7 +74,8 @@ export const Display = React.forwardRef(
     return (
       <input
         className={twMerge(
-          'ml-8  h-[40px] w-[56px] rounded border-[1px] border-solid border-moon-250 text-center focus:outline focus:outline-[2px] focus:outline-teal-500',
+          'ml-8  h-[40px] w-[56px] rounded border-[1px] border-solid border-moon-250 text-center',
+          'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
           isDirty ? 'text-moon-800' : 'text-moon-250',
           className
         )}

--- a/weave-js/src/components/Switch/index.tsx
+++ b/weave-js/src/components/Switch/index.tsx
@@ -8,7 +8,8 @@ export const Root = ({
 }: React.ComponentProps<typeof Switch.Root>) => (
   <Switch.Root
     className={twMerge(
-      'flex h-[24px] w-[44px] items-center rounded-[12px] p-[1px] transition-colors duration-100 ease-out focus:outline focus:outline-[2px] focus:outline-teal-500',
+      'flex h-[24px] w-[44px] items-center rounded-[12px] p-[1px] transition-colors duration-100 ease-out',
+      'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
       props.checked ? ' bg-teal-500' : 'bg-moon-350',
       className
     )}


### PR DESCRIPTION
A recent change applied focus outlines to common components (e.g. button, checkbox, etc): https://github.com/wandb/weave/pull/764

This means a focus outline will be applied on both keyboard and mouse interactions. We should definitely have focus outlines for keyboard interactions, but I'm not sure about mouse interactions. Is it visually distracting? I'd love some design team input on this. **Update: [synced with design team](https://weightsandbiases.slack.com/archives/C01QMPF38PQ/p1698115091476279?thread_ts=1698092402.588549&cid=C01QMPF38PQ)**

Examples:

https://github.com/wandb/weave/assets/17016170/762d00f8-c753-4ae1-b797-367bb5fe7428

https://github.com/wandb/weave/assets/17016170/7a22d62f-3c94-4933-910f-41c1ec396794

--

We can use the [:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) pseudoclass to apply focus styles only for keyboard interactions, which is what I've done in this PR. However, we should probably consider these [accessibility concerns](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible#accessibility_concerns) before committing to this approach.

Mouse interactions:

https://github.com/wandb/weave/assets/17016170/151ac59a-d66c-4121-9028-42e514d8316b

https://github.com/wandb/weave/assets/17016170/34c740f6-a340-41fd-adda-2d6a8ead8d24

Keyboard interactions:

https://github.com/wandb/weave/assets/17016170/26768a5d-1501-49a5-9fa8-9e6587fe363a

https://github.com/wandb/weave/assets/17016170/59868496-d5cf-4765-a3f0-baf843cd75d3


(Disclaimer: I only tested buttons)