### PR TITLE
fix(wir): Set equalSize so table panel exported to reports have height

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
@@ -45,6 +45,7 @@ export const computeReportSlateNode = (
     {
       disableDeletePanel: true,
       enableAddPanel: true, // actually means "is editable"
+      equalSize: true,
       layoutMode: 'vertical',
     }
   );


### PR DESCRIPTION
JIRA: https://wandb.atlassian.net/browse/WB-15933
Related PR: https://github.com/wandb/core/pull/17777

If group panel config `equalSize` is set to true, `flex: 1` CSS rule is applied to each group item within. This is required when exporting panels to reports because table panels need it to have height and display its contents.

Before:

<img width="1277" alt="Screenshot 2023-10-23 at 6 07 32 PM" src="https://github.com/wandb/weave/assets/17016170/35763763-4c78-4a57-9aab-b59724e4dad8">


After:

<img width="1280" alt="Screenshot 2023-10-23 at 6 07 42 PM" src="https://github.com/wandb/weave/assets/17016170/e827dff7-62e5-460e-8ba0-e3269fe7b33d">
