### PR TITLE
chore: remove animated transition on night mode toggle

### DIFF
--- a/weave-js/src/common/css/Base.less
+++ b/weave-js/src/common/css/Base.less
@@ -1031,20 +1031,16 @@ img.ui.avatar.image {
 }
 
 .night-mode {
-    transition: @nightModeTransition;
     filter: @nightModeFilter;
     img, video, iframe, .inverted.segment, .editable-image, .run-logs, .search-nav, .media-card__fullscreen,
     .night-aware, .night-aware-exclude-children {
-        transition: @nightModeTransition;
         filter: @nightModeFilterRevert;
     }
     .night-aware-exclude-children > :not(.night-aware):not(.night-aware-exclude-children) {
-        transition: @nightModeTransition;
         filter: @nightModeFilter;
     }
     .night-aware-exclude-children > .night-aware,
     .night-aware-exclude-children > .night-aware-exclude-children {
-        transition: @nightModeTransition;
         filter: none;
     }
     .empty-watermark img, .editable-image img, img.image-icon, img.disable-night-mode-filter-revert, .search-nav * {

--- a/weave-js/src/common/css/globals.less
+++ b/weave-js/src/common/css/globals.less
@@ -202,7 +202,6 @@
 @nightModeFilter: invert(100%) hue-rotate(180deg) contrast(80%) brightness(120%);
 // Need to re-apply filter to images to revert them.
 @nightModeFilterRevert: brightness(83.3333%) contrast(125%) hue-rotate(180deg) invert(100%);
-@nightModeTransition: filter 2s;
 
 // Functional Color Rules
 // These should wrap the above colors with semantic names


### PR DESCRIPTION
Currently we have a 2s transition when you go from light mode to dark mode, while going in the other direction happens instantly. Per feedback from design, this makes the transition instant in both directions.

See also https://github.com/wandb/weave/pull/774 which was an option considered to do a 0.4s duration transition in both directions.
