### PR TITLE
feat(ui): Copy useWindowSize from core; add responsive sizes

### DIFF
--- a/weave-js/src/common/css/breakpoints.styles.ts
+++ b/weave-js/src/common/css/breakpoints.styles.ts
@@ -1,0 +1,6 @@
+// https://www.figma.com/file/01KWBdMZg5QM9SRS1pQq0z/Design-System----Robot-Styles?type=design&node-id=96-1210&mode=design&t=e8gsezGHcqe627pt-0
+// Breakpoints are the min value of the range for each size
+
+export const SMALL_BREAKPOINT = 0; // 0px to 767px
+export const MEDIUM_BREAKPOINT = 768; // 768px to 1024px
+export const LARGE_BREAKPOINT = 1025; // 1025px and up

--- a/weave-js/src/common/css/globals.styles.ts
+++ b/weave-js/src/common/css/globals.styles.ts
@@ -1,3 +1,4 @@
+export * from './breakpoints.styles';
 export * from './color.styles';
 export * from './utils';
 

--- a/weave-js/src/common/css/globals_deprecated.styles.ts
+++ b/weave-js/src/common/css/globals_deprecated.styles.ts
@@ -455,11 +455,16 @@ export const RED_LIGHT_2 = RED_LIGHT2;
 export const SPU = '0.5rem'; // standard spacing unit = 8px
 
 /* Responsive styling standards */
+/** @deprecated use MEDIUM_BREAKPOINT instead */
 export const TABLET_BREAKPOINT = '768px'; // 48rem
+/** @deprecated use MEDIUM_BREAKPOINT instead */
 export const TABLET_BREAKPOINT_WIDTH = 768;
 
+/** @deprecated */
 export const TABLET_WIDTH = 1320;
+/** @deprecated */
 export const SMALL_TABLET_WIDTH = 1000;
+/** @deprecated */
 export const MOBILE_WIDTH = 600;
 
 /* Borders */

--- a/weave-js/src/common/hooks/useWindowSize.ts
+++ b/weave-js/src/common/hooks/useWindowSize.ts
@@ -1,0 +1,67 @@
+import _ from 'lodash';
+import {useLayoutEffect, useState} from 'react';
+import {LARGE_BREAKPOINT, MEDIUM_BREAKPOINT} from '../css/breakpoints.styles';
+
+export type ResponsiveSize = 'small' | 'medium' | 'large';
+
+export interface WindowSize {
+  width: number;
+  height: number;
+  responsiveSize: ResponsiveSize;
+}
+
+const getResponsiveSize = (width: number): ResponsiveSize => {
+  if (width < MEDIUM_BREAKPOINT) {
+    return 'small';
+  }
+  if (width < LARGE_BREAKPOINT) {
+    return 'medium';
+  }
+  return 'large';
+};
+
+const windowSize: WindowSize = {
+  width: window.innerWidth,
+  height: window.innerHeight,
+  responsiveSize: getResponsiveSize(window.innerWidth),
+};
+
+function refreshWindowSize() {
+  windowSize.width = window.innerWidth;
+  windowSize.height = window.innerHeight;
+  windowSize.responsiveSize = getResponsiveSize(window.innerWidth);
+}
+
+const componentsWatchingWindowSize: Set<() => void> = new Set();
+
+function renderWatchingComponents() {
+  for (const renderComponent of componentsWatchingWindowSize) {
+    renderComponent();
+  }
+}
+
+const initWindowResizeListener = _.once(() => {
+  window.addEventListener('resize', () => {
+    refreshWindowSize(); // cheap. ok to run on every tick.
+    renderWatchingComponents(); // expensive. ensure all renders are throttled.
+  });
+  refreshWindowSize();
+});
+
+export function useRenderOnWindowResize(throttleMS = 200): void {
+  initWindowResizeListener();
+  const [, forceRender] = useState({});
+  useLayoutEffect(() => {
+    const throttledRender = _.throttle(() => forceRender({}), throttleMS);
+    componentsWatchingWindowSize.add(throttledRender);
+    return () => {
+      componentsWatchingWindowSize.delete(throttledRender);
+    };
+    // eslint-disable-next-line
+  }, []);
+}
+
+export function useWindowSize(throttleMS?: number): WindowSize {
+  useRenderOnWindowResize(throttleMS);
+  return windowSize;
+}


### PR DESCRIPTION
Change summary:

1. Added breakpoint constants from design team ([see figma](https://www.figma.com/file/01KWBdMZg5QM9SRS1pQq0z/Design-System----Robot-Styles?type=design&node-id=96-1210&mode=design&t=e8gsezGHcqe627pt-0))
2. Marked old breakpoint constants as deprecated
3. Copied `useWindowSize` hook from core
4. The primary use case for `useWindowSize` is to check the current viewport width against responsive breakpoints, so I added a `responsiveSize` property to the return value


Testing: call `useWindowSize` in report page and log `responsiveSize` value  (I chose reports just cuz it's what I've been working on lately). On report page, resize window and verify the logged values.

https://github.com/wandb/weave/assets/17016170/cd407f19-e7d8-47d3-ae01-21ae6362f959


Next step: remove `useWindowSize` from core & replace imports (I will update [this PR](https://github.com/wandb/core/pull/17743) for that)