### PR TITLE
ci: Add integration test to ensure that links to board template colabs work

### DIFF
--- a/integration_test/cypress.config.js
+++ b/integration_test/cypress.config.js
@@ -9,6 +9,7 @@ module.exports = defineConfig({
   chromeWebSecurity: false,
   e2e: {
     baseUrl: BASE_URL,
+    experimentalSessionAndOrigin: true,
     setupNodeEvents(on, config) {
       // implement node event listeners here
       // ❗ Must be declared at the top of the function to prevent conflicts

--- a/integration_test/cypress/e2e/interactive/boardTemplateNotebookLinks.cy.ts
+++ b/integration_test/cypress/e2e/interactive/boardTemplateNotebookLinks.cy.ts
@@ -6,7 +6,8 @@ describe('board template notebook links', () => {
     cy.contains('Board templates').click();
 
     cy.get('[data-testid="template-card"]').each(($el, index, $list) => {
-      cy.wrap($el)
+      const currentEl = cy.get('[data-testid="template-card"]').eq(index);
+      currentEl
         .trigger('mouseenter')
         .realHover()
         .trigger('mouseenter')
@@ -17,6 +18,7 @@ describe('board template notebook links', () => {
       cy.get(
         'img[src="https://colab.research.google.com/assets/colab-badge.svg"]'
       )
+
         .parent('a')
         .each(($innerEl, index, $list) => {
           const href = $innerEl.prop('href');
@@ -42,7 +44,18 @@ describe('board template notebook links', () => {
             // check that the status code is 200
             expect(response.status).to.eq(200);
           });
+
+          cy.origin(
+            'https://colab.research.google.com',
+            {args: {href}},
+            ({href}) => {
+              cy.visit(href);
+              cy.contains('pip install').scrollIntoView().should('be.visible');
+            }
+          );
         });
+      goToHomePage();
+      cy.contains('Board templates').click();
     });
   });
 });

--- a/integration_test/cypress/e2e/interactive/boardTemplateNotebookLinks.cy.ts
+++ b/integration_test/cypress/e2e/interactive/boardTemplateNotebookLinks.cy.ts
@@ -27,11 +27,6 @@ describe('board template notebook links', () => {
             /^https:\/\/colab\.research\.google\.com\/github/
           );
 
-          // replace with url of actual notebook. this is a hack
-          // because we can't actually make assertions on the notebook
-          // due to cross-origin restrictions in cypress. this checks
-          // that the notebook is available by making the request
-          // that colab would make to load the notebook.
           const newHref = href
             .replace(
               'https://colab.research.google.com/github',

--- a/integration_test/cypress/e2e/interactive/boardTemplateNotebookLinks.cy.ts
+++ b/integration_test/cypress/e2e/interactive/boardTemplateNotebookLinks.cy.ts
@@ -1,0 +1,53 @@
+import {
+  gotoBlankDashboard,
+  panelTypeInputExpr,
+  addSidebarPanel,
+  scrollToEEAndType,
+  panelChangeId,
+  tableAppendColumn,
+  tableCheckContainsValue,
+  addMainPanel,
+  goToHomePage,
+} from '../testlib';
+
+describe('board template notebook links', () => {
+  it('check that board template notebook links to colab work', () => {
+    goToHomePage();
+    cy.contains('Board templates').click();
+
+    cy.get('[data-testid="template-card"]').each(($el, index, $list) => {
+      cy.wrap($el)
+        .trigger('mouseenter')
+        .realHover()
+        .contains('Try it out')
+        .click();
+
+      cy.get(
+        'img[src="https://colab.research.google.com/assets/colab-badge.svg"]'
+      )
+        .parent('a')
+        .each(($innerEl, index, $list) => {
+          const href = $innerEl.prop('href');
+          // check that the url starts with https://colab.research.google.com/github
+          expect(href).to.match(
+            /^https:\/\/colab\.research\.google\.com\/github/
+          );
+
+          // replace with url of actual notebook
+
+          const newHref = href
+            .replace(
+              'https://colab.research.google.com/github',
+              'https://raw.githubusercontent.com'
+            )
+            .replace('blob/', '');
+
+          // load the notebook
+          cy.request(newHref).then(response => {
+            // check that the status code is 200
+            expect(response.status).to.eq(200);
+          });
+        });
+    });
+  });
+});

--- a/integration_test/cypress/e2e/interactive/boardTemplateNotebookLinks.cy.ts
+++ b/integration_test/cypress/e2e/interactive/boardTemplateNotebookLinks.cy.ts
@@ -1,14 +1,4 @@
-import {
-  gotoBlankDashboard,
-  panelTypeInputExpr,
-  addSidebarPanel,
-  scrollToEEAndType,
-  panelChangeId,
-  tableAppendColumn,
-  tableCheckContainsValue,
-  addMainPanel,
-  goToHomePage,
-} from '../testlib';
+import {goToHomePage} from '../testlib';
 
 describe('board template notebook links', () => {
   it('check that board template notebook links to colab work', () => {
@@ -17,6 +7,8 @@ describe('board template notebook links', () => {
 
     cy.get('[data-testid="template-card"]').each(($el, index, $list) => {
       cy.wrap($el)
+        .trigger('mouseenter')
+        .realHover()
         .trigger('mouseenter')
         .realHover()
         .contains('Try it out')
@@ -33,8 +25,11 @@ describe('board template notebook links', () => {
             /^https:\/\/colab\.research\.google\.com\/github/
           );
 
-          // replace with url of actual notebook
-
+          // replace with url of actual notebook. this is a hack
+          // because we can't actually make assertions on the notebook
+          // due to cross-origin restrictions in cypress. this checks
+          // that the notebook is available by making the request
+          // that colab would make to load the notebook.
           const newHref = href
             .replace(
               'https://colab.research.google.com/github',
@@ -42,7 +37,7 @@ describe('board template notebook links', () => {
             )
             .replace('blob/', '');
 
-          // load the notebook
+          // load the notebook.
           cy.request(newHref).then(response => {
             // check that the status code is 200
             expect(response.status).to.eq(200);

--- a/integration_test/cypress/e2e/testlib.ts
+++ b/integration_test/cypress/e2e/testlib.ts
@@ -110,31 +110,43 @@ export const panelTypeInputExpr = (path: string[], text: string) => {
     .type('{enter}', {force: true});
 };
 
-export const scrollToEEAndType = (path: string[], text: string) => {
+function typeWithRetry(
+  path: string[],
+  text: string,
+  retries: number = 10,
+  delay: number = 1000
+) {
+  // Your check here, for example:
+
   const panel = getPanel(path);
 
-  const ee = panel
+  panel
     .trigger('mouseenter')
     .click()
-    .find('[data-test=expression-editor-container] [contenteditable=true]');
+    .find('[data-test=expression-editor-container] [contenteditable=true]')
+    .realHover()
+    .realClick()
 
-  let currentText: string = '';
-  for (let i = 0; i < 15; i++) {
-    ee.invoke('text').then(t => {
-      currentText = t;
+    .type(text, {force: true})
+    .wait(300)
+    .type('{enter}', {force: true});
+
+  getPanel(path)
+    .find('[data-test=expression-editor-container] [contenteditable=true]')
+    .then($el => {
+      if ($el.text() !== text) {
+        if (retries > 0) {
+          cy.wait(delay);
+          typeWithRetry(path, text, retries - 1, delay);
+        } else {
+          throw new Error('Condition not met');
+        }
+      }
     });
+}
 
-    if (currentText === text) {
-      break;
-    }
-
-    ee.realHover()
-      .realClick()
-
-      .type(text, {force: true})
-      .wait(300)
-      .type('{enter}', {force: true});
-  }
+export const scrollToEEAndType = (path: string[], text: string) => {
+  typeWithRetry(path, text);
 };
 
 export const panelChangeId = (path: string[], text: string) => {

--- a/integration_test/cypress/e2e/testlib.ts
+++ b/integration_test/cypress/e2e/testlib.ts
@@ -77,6 +77,13 @@ export const gotoBlankDashboard = () => {
   cy.get('[data-testid="new-board-button"]').should('be.visible').click();
 };
 
+export const goToHomePage = () => {
+  const url = '/';
+  cy.viewport(1600, 900);
+  cy.visit(url);
+  cy.contains('Board templates').should('be.visible');
+};
+
 export const addSidebarPanel = () => {
   getPanel(['sidebar']).contains('New variable').click();
 };

--- a/integration_test/cypress/e2e/testlib.ts
+++ b/integration_test/cypress/e2e/testlib.ts
@@ -116,8 +116,6 @@ function typeWithRetry(
   retries: number = 10,
   delay: number = 1000
 ) {
-  // Your check here, for example:
-
   const panel = getPanel(path);
 
   panel

--- a/integration_test/cypress/e2e/testlib.ts
+++ b/integration_test/cypress/e2e/testlib.ts
@@ -112,20 +112,29 @@ export const panelTypeInputExpr = (path: string[], text: string) => {
 
 export const scrollToEEAndType = (path: string[], text: string) => {
   const panel = getPanel(path);
-  panel
+
+  const ee = panel
     .trigger('mouseenter')
     .click()
-    .find('[data-test=expression-editor-container] [contenteditable=true]')
+    .find('[data-test=expression-editor-container] [contenteditable=true]');
 
-    .realHover()
-    .realClick()
+  let currentText: string = '';
+  for (let i = 0; i < 15; i++) {
+    ee.invoke('text').then(t => {
+      currentText = t;
+    });
 
-    .realHover()
-    .realClick()
+    if (currentText === text) {
+      break;
+    }
 
-    .type(text, {force: true})
-    .wait(300)
-    .type('{enter}', {force: true});
+    ee.realHover()
+      .realClick()
+
+      .type(text, {force: true})
+      .wait(300)
+      .type('{enter}', {force: true});
+  }
 };
 
 export const panelChangeId = (path: string[], text: string) => {

--- a/integration_test/yarn.lock
+++ b/integration_test/yarn.lock
@@ -27,9 +27,9 @@
     ramda "0.26.1"
 
 "@cypress/request@^2.88.10":
-  version "2.88.11"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.11.tgz#5a4c7399bc2d7e7ed56e92ce5acb620c8b187047"
-  integrity sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==
+  version "2.88.12"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
+  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -46,7 +46,7 @@
     performance-now "^2.1.0"
     qs "~6.10.3"
     safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
+    tough-cookie "^4.1.3"
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
@@ -148,9 +148,9 @@
   integrity sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==
 
 "@types/node@^14.14.31":
-  version "14.18.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.48.tgz#ee5c7ac6e38fd2a9e6885f15c003464cf2da343c"
-  integrity sha512-iL0PIMwejpmuVHgfibHpfDwOdsbmB50wr21X71VnF5d7SsBF7WK+ZvP/SCcFm7Iwb9iiYSap9rlrdhToNAWdxg==
+  version "14.18.63"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
+  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
@@ -1344,7 +1344,7 @@ proxy-from-env@1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
 
-psl@^1.1.28:
+psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
@@ -1368,6 +1368,11 @@ qs@~6.10.3:
   integrity sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==
   dependencies:
     side-channel "^1.0.4"
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 ramda@0.26.1:
   version "0.26.1"
@@ -1440,7 +1445,14 @@ semver@^5.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^7.3.2, semver@^7.3.8:
+semver@^7.3.2:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.8:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
   integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
@@ -1639,13 +1651,15 @@ tmp@^0.2.1, tmp@~0.2.1:
   dependencies:
     rimraf "^3.0.0"
 
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+tough-cookie@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
+  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
   dependencies:
-    psl "^1.1.28"
+    psl "^1.1.33"
     punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
 
 tslib@^2.1.0:
   version "2.5.2"
@@ -1681,6 +1695,11 @@ typescript@^4.8.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -1690,6 +1709,14 @@ untildify@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 utf-8-validate@^5.0.10:
   version "5.0.10"

--- a/integration_test/yarn.lock
+++ b/integration_test/yarn.lock
@@ -27,9 +27,9 @@
     ramda "0.26.1"
 
 "@cypress/request@^2.88.10":
-  version "2.88.12"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
-  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
+  version "2.88.11"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.11.tgz#5a4c7399bc2d7e7ed56e92ce5acb620c8b187047"
+  integrity sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -46,7 +46,7 @@
     performance-now "^2.1.0"
     qs "~6.10.3"
     safe-buffer "^5.1.2"
-    tough-cookie "^4.1.3"
+    tough-cookie "~2.5.0"
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
@@ -148,9 +148,9 @@
   integrity sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==
 
 "@types/node@^14.14.31":
-  version "14.18.63"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
-  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+  version "14.18.48"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.48.tgz#ee5c7ac6e38fd2a9e6885f15c003464cf2da343c"
+  integrity sha512-iL0PIMwejpmuVHgfibHpfDwOdsbmB50wr21X71VnF5d7SsBF7WK+ZvP/SCcFm7Iwb9iiYSap9rlrdhToNAWdxg==
 
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
@@ -1344,7 +1344,7 @@ proxy-from-env@1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
 
-psl@^1.1.33:
+psl@^1.1.28:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
@@ -1368,11 +1368,6 @@ qs@~6.10.3:
   integrity sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==
   dependencies:
     side-channel "^1.0.4"
-
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 ramda@0.26.1:
   version "0.26.1"
@@ -1445,14 +1440,7 @@ semver@^5.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^7.3.2:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
-  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.3.8:
+semver@^7.3.2, semver@^7.3.8:
   version "7.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
   integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
@@ -1651,15 +1639,13 @@ tmp@^0.2.1, tmp@~0.2.1:
   dependencies:
     rimraf "^3.0.0"
 
-tough-cookie@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
-  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
+tough-cookie@~2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
-    psl "^1.1.33"
+    psl "^1.1.28"
     punycode "^2.1.1"
-    universalify "^0.2.0"
-    url-parse "^1.5.3"
 
 tslib@^2.1.0:
   version "2.5.2"
@@ -1695,11 +1681,6 @@ typescript@^4.8.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
-universalify@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
-  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
-
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -1709,14 +1690,6 @@ untildify@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
   integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
-
-url-parse@^1.5.3:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
-  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
 
 utf-8-validate@^5.0.10:
   version "5.0.10"

--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterTemplates.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterTemplates.tsx
@@ -102,6 +102,7 @@ const TemplateCard: React.FC<{
   const [isHover, setIsHover] = React.useState(false);
   return (
     <Template
+      data-testid="template-card"
       onMouseEnter={() => {
         setIsHover(true);
       }}


### PR DESCRIPTION
Adds an integration test that goes through the board template user flow on the weave homepage, ensuring that the links to the tutorial colabs to generate boards work and point to actual colab links. 

https://www.loom.com/share/11959932dc3044f889acee72888b0c8a?sid=7a31d8a2-8fc5-4fd2-8300-4659fdd7e9a7