### PR TITLE
chore(weave): Improve PanelGroup types

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
@@ -46,7 +46,10 @@ export const computeReportSlateNode = (
           // TODO: resolve vars and add items here
           // https://wandb.atlassian.net/browse/WB-14443
         },
-        {childNameBase: 'var'}
+        {
+          childNameBase: 'var',
+          layoutMode: 'vertical',
+        }
       ),
       panel: targetConfig,
     },

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -87,35 +87,55 @@ interface PanelInfo {
   hidden?: boolean;
 }
 export interface PanelGroupConfig {
-  // Determines how to lay out children, and also how to render each child's ControlBar
-  // (ie whether ControlBar is off, or shows the title only, or a fully editable var name, panel
-  // id, and expression).
+  /**
+   * Determines how to lay out children, and also how to render each child's ControlBar
+   * (ie whether ControlBar is off, or shows the title only, or a fully editable var name, panel
+   * id, and expression).
+   */
   layoutMode: (typeof LAYOUT_MODES)[number];
-  // Determines if we use equal sizing for horizontal and vertical layouts.
+  /** Determines if we use equal sizing for horizontal and vertical layouts. */
   equalSize?: boolean;
-
-  // This is totally ignored now!
+  /** @deprecated This is totally ignored now! */
   showExpressions?: boolean | 'titleBar';
-  // Applied to some children, a hack that lets us configure width of the VarBar in a horizontal
-  // layout.
-  // TODO: need to make this parameterized instead.
+  /**
+   * Applied to some children, a hack that lets us configure width of the VarBar in a horizontal
+   * layout.
+   * TODO: need to make this parameterized instead.
+   */
   style?: string;
-  // Children
+  /**
+   * Children
+   */
   items: {[key: string]: ChildPanelConfig};
-  // Should stick panel specific information here.
+  /**
+   * Should stick panel specific information here.
+   */
   panelInfo?: {[key: string]: PanelInfo};
-  // Grid and Flow layout information.
-  gridConfig: PanelBankSectionConfig;
-
-  // Specifies which panels are allowed to be chosen by the panel picker for children of this
-  // group. This is only used to restrict the VarBar to controls.
-  // TODO: remove this! It is really annoying that this is part of the board state. We have to
-  // keep it synchronized for new board creation in panelTree.ts and panel_board.py.
-  // We should probably hardcode the allowed panels just for the varbar instead.
+  /**
+   * Grid and Flow layout information.
+   */
+  gridConfig?: PanelBankSectionConfig;
+  /**
+   * Specifies which panels are allowed to be chosen by the panel picker for children of this
+   * group. This is only used to restrict the VarBar to controls.
+   * TODO: remove this! It is really annoying that this is part of the board state. We have to
+   * keep it synchronized for new board creation in panelTree.ts and panel_board.py.
+   * We should probably hardcode the allowed panels just for the varbar instead.
+   */
   allowedPanels?: string[];
-
-  // This actually means "editable"
+  /**
+   * This actually means "is editable". Controls whether users can
+   * add, delete, or edit the expression of any direct child items.
+   */
   enableAddPanel?: boolean;
+  /**
+   * Controls whether the group itself can be deleted.
+   * Does not affect whether each of its items can be deleted.
+   */
+  disableDeletePanel?: boolean;
+  /**
+   * Used to name newly created child items. Defaults to "panel".
+   */
   childNameBase?: string;
 }
 
@@ -398,11 +418,15 @@ export const addPanelToGroupConfig = (
     draft.items[
       nextPanelName(Object.keys(currentConfig.items), childNameBase)
     ] = childConfig;
-    if (currentConfig.layoutMode === 'flow') {
+    if (
+      currentConfig.layoutMode === 'flow' &&
+      currentConfig.gridConfig?.flowConfig &&
+      draft.gridConfig?.flowConfig
+    ) {
       // If there is only one panel, and one row and column, add a second
       // column. This is a nice behavior in notebooks.
-      const nRows = currentConfig.gridConfig?.flowConfig.rowsPerPage ?? 1;
-      const nCols = currentConfig.gridConfig?.flowConfig.columnsPerPage ?? 1;
+      const nRows = currentConfig.gridConfig.flowConfig.rowsPerPage ?? 1;
+      const nCols = currentConfig.gridConfig.flowConfig.columnsPerPage ?? 1;
       if (
         Object.keys(currentConfig.items).length === 1 &&
         nRows === 1 &&
@@ -665,7 +689,7 @@ export const PanelGroupItem: React.FC<{
 
           // This updates the grid config with the new name, since we use names as ids
           // if we had unique ids, we wouldnt have to do this
-          if (config.gridConfig != null) {
+          if (config.gridConfig != null && draft.gridConfig != null) {
             const gridConfigIndex = config.gridConfig.panels.findIndex(
               p => p.id === name
             );

--- a/weave-js/src/components/Panel2/panelTree.ts
+++ b/weave-js/src/components/Panel2/panelTree.ts
@@ -44,6 +44,7 @@ import {
 } from './PanelGroup';
 import {PanelBankSectionConfig} from '../WeavePanelBank/panelbank';
 import {difference} from '@wandb/weave/common/util/data';
+import {ID} from '@wandb/weave/common/util/id';
 
 export type PanelTreeNode = ChildPanelConfig;
 
@@ -189,8 +190,8 @@ export const makePanel = (
 };
 
 export const makeGroup = (
-  items: {[key: string]: ChildPanelConfig},
-  options?: {[key: string]: any}
+  items: PanelGroupConfig['items'],
+  options?: Omit<PanelGroupConfig, 'items'>
 ) => {
   return makePanel('Group', {items, ...options});
 };
@@ -499,11 +500,12 @@ export const ensureDashboard = (node: PanelTreeNode): ChildPanelFullConfig => {
   }
   let main = node;
   const mainConfig = {
-    layoutMode: 'grid',
+    layoutMode: 'grid' as const,
     showExpressions: true,
     enableAddPanel: true,
     disableDeletePanel: true,
     gridConfig: {
+      id: ID(),
       panels: [
         {
           id: 'panel0',
@@ -569,11 +571,12 @@ export const ensureDashboardFromItems = (
   vars: {[name: string]: NodeOrVoidNode}
 ): ChildPanelFullConfig => {
   const mainConfig = {
-    layoutMode: 'grid',
+    layoutMode: 'grid' as const,
     showExpressions: true,
     enableAddPanel: true,
     disableDeletePanel: true,
     gridConfig: {
+      id: ID(),
       panels: Object.entries(seedItems).map(([name, item], ndx) => ({
         id: name,
         layout: {

--- a/weave-js/src/components/Sidebar/Outline.tsx
+++ b/weave-js/src/components/Sidebar/Outline.tsx
@@ -18,6 +18,7 @@ import {
 } from '../Panel2/PanelInteractContext';
 import {Icon, IconHideHidden, IconLockClosed, IconName} from '../Icon';
 import {Tooltip} from '../Tooltip';
+import {PanelGroupConfig} from '../Panel2/PanelGroup';
 
 const OutlineItem = styled.div``;
 OutlineItem.displayName = 'S.OutlineItem';
@@ -290,7 +291,7 @@ const OutlinePanel: React.FC<OutlinePanelProps> = props => {
 };
 
 export interface OutlineProps {
-  config: ChildPanelFullConfig;
+  config: ChildPanelFullConfig<PanelGroupConfig>;
   updateConfig: (newConfig: ChildPanelFullConfig) => void;
   updateConfig2: (
     change: (oldConfig: ChildPanelConfig) => ChildPanelFullConfig

--- a/weave-js/src/components/WeavePanelBank/PanelBankFlowSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PanelBankFlowSection.tsx
@@ -26,6 +26,7 @@ import {
 import {isFirefox} from './panelbankUtil';
 
 type AllPanelBankFlowSectionProps = PanelBankSectionComponentSharedProps & {
+  panelBankSectionConfigRef: Required<PanelBankSectionConfig>;
   flowConfig: PanelBankFlowSectionConfig;
   currentPage: number;
   setCurrentPage: (newCurrentPage: number) => void;
@@ -378,7 +379,7 @@ export function actionSetFlowConfig(
 ): PanelBankSectionConfig {
   return produce(sectionConfig, draft => {
     draft.flowConfig = {
-      ...sectionConfig.flowConfig,
+      ...sectionConfig.flowConfig!,
       ...newFlowConfig,
     };
   });
@@ -405,7 +406,9 @@ const PanelBankFlowSectionComp = (
     ) => void;
   } & PanelBankSectionComponentSharedProps
 ) => {
-  const {panelBankSectionConfigRef, updateConfig} = props;
+  const {updateConfig} = props;
+  const panelBankSectionConfigRef =
+    props.panelBankSectionConfigRef as Required<PanelBankSectionConfig>;
   const {flowConfig} = panelBankSectionConfigRef;
 
   const updateFlowConfig = useAction(updateConfig, actionSetFlowConfig);
@@ -428,6 +431,7 @@ const PanelBankFlowSectionComp = (
   return (
     <PanelBankFlowSectionInnerComp
       {...props}
+      panelBankSectionConfigRef={panelBankSectionConfigRef}
       currentPage={currentPage}
       setCurrentPage={setCurrentPage}
       flowConfig={flowConfig}

--- a/weave-js/src/components/WeavePanelBank/panelbank.ts
+++ b/weave-js/src/components/WeavePanelBank/panelbank.ts
@@ -45,12 +45,12 @@ export enum SectionPanelSorting {
 
 export interface PanelBankSectionConfig {
   id: string;
-  name: string;
+  name?: string;
   panels: LayedOutPanel[];
-  isOpen: boolean;
-  flowConfig: PanelBankFlowSectionConfig;
-  type: 'grid' | 'flow';
-  sorted: SectionPanelSorting;
+  isOpen?: boolean;
+  flowConfig?: PanelBankFlowSectionConfig;
+  type?: 'grid' | 'flow';
+  sorted?: SectionPanelSorting;
 }
 
 // These are shared by PanelBankFlowSection and PanelBankGridSection


### PR DESCRIPTION
- Convert plain comments to doc comments -- this means when you hover a property you'll get more helpful details

<img width="1268" alt="Screenshot 2023-10-27 at 4 17 48 PM" src="https://github.com/wandb/weave/assets/17016170/92277267-d564-481f-8586-ef67c945bddc">
<img width="1276" alt="Screenshot 2023-10-27 at 4 17 30 PM" src="https://github.com/wandb/weave/assets/17016170/2ca1eb4c-b2ee-45b9-afa2-ce491801f2cf">
<img width="918" alt="Screenshot 2023-10-27 at 4 20 07 PM" src="https://github.com/wandb/weave/assets/17016170/e482cf53-1a04-4615-ace9-06f3fa403b36">

- Better typing for `makeGroup` util so you can't just throw on whatever config values you want

<img width="694" alt="Screenshot 2023-10-27 at 4 22 55 PM" src="https://github.com/wandb/weave/assets/17016170/b5c71a38-190f-4fd7-b2d1-94e152b1dc2e">
<img width="1138" alt="Screenshot 2023-10-27 at 4 23 05 PM" src="https://github.com/wandb/weave/assets/17016170/e5eb77bd-c6e0-4c87-9695-d3cfe49bbefd">

- Better typing for `Outline` component (similar to last bullet)
- Misc changes required to resolve type errors
