### PR TITLE
feat(ui): Move radix dropdown to weave; Use for outline item menu

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -36,6 +36,7 @@
     "@monaco-editor/react": "^4.3.1",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-radio-group": "^1.1.3",
     "@radix-ui/react-slider": "^1.0.4",
     "@radix-ui/react-switch": "^1.0.3",

--- a/weave-js/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/weave-js/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,246 @@
+import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
+import {Icon} from '@wandb/weave/components/Icon';
+import classNames from 'classnames';
+import React from 'react';
+import {twMerge} from 'tailwind-merge';
+
+import {Tailwind} from '../Tailwind';
+
+/**
+ * - {@link RadixDropdownMenu.DropdownMenuProps}
+ * - https://www.radix-ui.com/docs/primitives/components/dropdown-menu#root
+ */
+export type DropdownMenuProps = Omit<
+  RadixDropdownMenu.DropdownMenuProps,
+  'defaultOpen'
+> & {
+  open: boolean;
+};
+
+/**
+ * Our DropdownMenu wraps {@link https://www.radix-ui.com/docs/primitives/components/dropdown-menu
+ * Radix DropdownMenu} but is a strictly controlled component. This means the `defaultOpen` prop
+ * is omitted and the `open` prop is required.
+ */
+export const Root = (props: DropdownMenuProps) => {
+  return <RadixDropdownMenu.Root {...props} />;
+};
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#trigger
+ */
+export const Trigger = (props: RadixDropdownMenu.DropdownMenuTriggerProps) => (
+  <RadixDropdownMenu.Trigger asChild {...props} />
+);
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#portal
+ */
+export const Portal = RadixDropdownMenu.Portal;
+
+/**
+ * Styles for menu contents. Also used for submenu contents.
+ */
+const contentClassName = classNames(
+  'night-aware',
+  'rounded border border-moon-250 bg-white py-6 shadow-md',
+  'dark:border-moon-750 dark:bg-moon-900 dark:text-moon-200'
+);
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#content
+ */
+export const Content = React.forwardRef(
+  (
+    {className, children, ...props}: RadixDropdownMenu.DropdownMenuContentProps,
+    ref
+  ) => (
+    <Tailwind>
+      <RadixDropdownMenu.Content
+        className={twMerge(contentClassName, className)}
+        sideOffset={5}
+        {...props}>
+        {children}
+      </RadixDropdownMenu.Content>
+    </Tailwind>
+  )
+);
+
+/**
+ * https://www.radix-ui.com/primitives/docs/components/dropdown-menu#group
+ */
+export const Group = (props: RadixDropdownMenu.MenuGroupProps) => (
+  <RadixDropdownMenu.Group {...props} />
+);
+/**
+ * Styles for menu items. Also used for submenu triggers.
+ */
+const baseItemClassName = classNames(
+  'flex cursor-pointer items-center gap-10 rounded',
+  'mx-6 px-10 py-6',
+  '[&_svg]:h-18 [&_svg]:w-18',
+  'hover:bg-moon-100 hover:outline-none dark:hover:bg-moon-800',
+  'radix-disabled:pointer-events-none radix-disabled:text-moon-350 dark:radix-disabled:text-moon-650'
+);
+
+/**
+ * https://www.radix-ui.com/primitives/docs/components/dropdown-menu#label
+ */
+export const Label = (props: RadixDropdownMenu.MenuLabelProps) => (
+  <RadixDropdownMenu.Label {...props} />
+);
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#item
+ */
+export const Item = ({
+  className,
+  ...props
+}: RadixDropdownMenu.DropdownMenuItemProps) => (
+  <RadixDropdownMenu.Item
+    className={twMerge(baseItemClassName, className)}
+    {...props}
+  />
+);
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#separator
+ */
+export const Separator = ({
+  className,
+  ...props
+}: RadixDropdownMenu.DropdownMenuSeparatorProps) => (
+  <RadixDropdownMenu.Separator
+    className={twMerge(
+      classNames('my-6 h-px bg-moon-250 dark:bg-moon-750', className)
+    )}
+    {...props}
+  />
+);
+
+/**
+ * - {@link RadixDropdownMenu.DropdownMenuSubProps}
+ * - https://www.radix-ui.com/docs/primitives/components/dropdown-menu#sub
+ */
+export type DropdownMenuSubProps = Omit<
+  RadixDropdownMenu.DropdownMenuSubProps,
+  'defaultOpen'
+> & {
+  open: boolean;
+};
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#sub
+ */
+export const Sub = (props: DropdownMenuSubProps) => (
+  <RadixDropdownMenu.Sub {...props} />
+);
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#subtrigger
+ */
+export const SubTrigger = ({
+  className,
+  ...props
+}: RadixDropdownMenu.MenuSubTriggerProps) => (
+  <RadixDropdownMenu.SubTrigger
+    className={twMerge(
+      baseItemClassName,
+      'radix-state-open:bg-moon-100',
+      'radix-state-open:outline-none',
+      'dark:radix-state-open:bg-moon-800',
+      className
+    )}
+    {...props}
+  />
+);
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#subcontent
+ */
+export const SubContent = React.forwardRef(
+  (
+    {children, className, ...props}: RadixDropdownMenu.MenuSubTriggerProps,
+    ref
+  ) => (
+    <Tailwind>
+      <RadixDropdownMenu.SubContent
+        className={twMerge(contentClassName, className)}
+        sideOffset={13}
+        alignOffset={-7}
+        {...props}>
+        {children}
+      </RadixDropdownMenu.SubContent>
+    </Tailwind>
+  )
+);
+
+/**
+ * - {@link RadixDropdownMenu.DropdownMenuRadioGroupProps}
+ * - https://www.radix-ui.com/docs/primitives/components/dropdown-menu#radiogroup
+ */
+export type DropdownMenuRadioGroupProps =
+  RadixDropdownMenu.DropdownMenuRadioGroupProps & {
+    value: string;
+  };
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#radiogroup
+ */
+export const RadioGroup = (props: DropdownMenuRadioGroupProps) => (
+  <RadixDropdownMenu.RadioGroup {...props} />
+);
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#radioitem
+ */
+export const RadioItem = ({
+  className,
+  children,
+  ...props
+}: RadixDropdownMenu.DropdownMenuRadioItemProps) => (
+  <RadixDropdownMenu.RadioItem
+    className={twMerge(baseItemClassName, className)}
+    {...props}>
+    {children}
+  </RadixDropdownMenu.RadioItem>
+);
+
+/**
+ * https://www.radix-ui.com/primitives/docs/components/dropdown-menu#checkboxitem
+ */
+export const CheckboxItem = ({
+  className,
+  children,
+  ...props
+}: RadixDropdownMenu.DropdownMenuCheckboxItemProps) => (
+  <RadixDropdownMenu.CheckboxItem
+    className={twMerge(baseItemClassName, className)}
+    {...props}>
+    {children}
+  </RadixDropdownMenu.CheckboxItem>
+);
+
+/**
+ * https://www.radix-ui.com/docs/primitives/components/dropdown-menu#itemindicator
+ */
+export const ItemIndicator = RadixDropdownMenu.ItemIndicator;
+
+/**
+ * Custom [ItemIndicator](https://www.radix-ui.com/docs/primitives/components/dropdown-menu#itemindicator)
+ * to indicate the selected item in the style of radio buttons
+ */
+export const ItemIndicatorRadio = () => (
+  <div className="ml-auto flex h-16 w-16 items-center justify-center rounded-full border border-solid border-moon-450">
+    <ItemIndicator className="block h-10 w-10 rounded-full bg-teal-500" />
+  </div>
+);
+
+/**
+ * Custom [ItemIndicator](https://www.radix-ui.com/docs/primitives/components/dropdown-menu#itemindicator)
+ * to indicate the selected item with a checkmark icon
+ */
+export const ItemIndicatorCheckmark = () => (
+  <ItemIndicator>
+    <Icon name="checkmark" />
+  </ItemIndicator>
+);

--- a/weave-js/src/components/DropdownMenu/index.tsx
+++ b/weave-js/src/components/DropdownMenu/index.tsx
@@ -1,0 +1,1 @@
+export * from './DropdownMenu';

--- a/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
@@ -1,5 +1,6 @@
 import {MOON_250} from '@wandb/weave/common/css/color.styles';
 import {useIsViewerWandbEmployee} from '@wandb/weave/common/hooks/useViewerIsWandbEmployee';
+import * as DropdownMenu from '@wandb/weave/components/DropdownMenu';
 import {produce} from 'immer';
 import React, {memo, useCallback, useMemo} from 'react';
 import styled from 'styled-components';
@@ -20,7 +21,6 @@ import {
   IconRetry,
   IconSplit,
 } from '../Panel2/Icons';
-import {PopupMenu} from './PopupMenu';
 import {useSetInteractingPanel} from '../Panel2/PanelInteractContext';
 
 const Divider = styled.div`
@@ -221,14 +221,29 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
   ]);
 
   return (
-    <PopupMenu
-      trigger={trigger}
-      position={`bottom right`}
-      items={menuItems}
-      onClose={onClose}
-      onOpen={onOpen}
+    <DropdownMenu.Root
       open={isOpen}
-    />
+      onOpenChange={open => (open ? onOpen?.() : onClose?.())}>
+      <DropdownMenu.Trigger>
+        {React.cloneElement(trigger, {active: isOpen})}
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          className="z-[100]"
+          onCloseAutoFocus={e => e.preventDefault()}>
+          {menuItems.map(item => (
+            <DropdownMenu.Item
+              key={item.key}
+              onClick={item.onClick}
+              disabled={item.disabled}>
+              {item.icon}
+              {item.content}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
   );
 };
 

--- a/weave-js/src/components/Sidebar/PopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/PopupMenu.tsx
@@ -63,6 +63,7 @@ const PopupMenuComp: React.FC<PopupMenuProps> = ({
   );
 };
 
+/** @deprecated use `@wandb/components/DropdownMenu` instead */
 export const PopupMenu = memo(PopupMenuComp);
 
 const Popup = styled(SemanticPopup)`

--- a/weave-js/vite-plugin-block-cjs.ts
+++ b/weave-js/vite-plugin-block-cjs.ts
@@ -69,6 +69,7 @@ const ALLOWED_CJS_MODULES = [
   '@monaco-editor/loader',
   '@radix-ui/react-checkbox',
   '@radix-ui/react-dialog',
+  '@radix-ui/react-dropdown-menu',
   '@radix-ui/react-radio-group',
   '@radix-ui/react-slider',
   '@radix-ui/react-switch',

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -1861,6 +1861,13 @@
   dependencies:
     "@floating-ui/utils" "^0.1.1"
 
+"@floating-ui/core@^1.4.2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
+  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
+  dependencies:
+    "@floating-ui/utils" "^0.1.3"
+
 "@floating-ui/dom@^1.0.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.1.tgz#88b70defd002fe851f17b4a25efb2d3c04d7a8d7"
@@ -1875,6 +1882,21 @@
   integrity sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==
   dependencies:
     "@floating-ui/core" "^1.3.1"
+
+"@floating-ui/dom@^1.5.1":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
+  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+  dependencies:
+    "@floating-ui/core" "^1.4.2"
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/react-dom@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.2.tgz#fab244d64db08e6bed7be4b5fcce65315ef44d20"
+  integrity sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==
+  dependencies:
+    "@floating-ui/dom" "^1.5.1"
 
 "@floating-ui/react-dom@^2.0.1":
   version "2.0.1"
@@ -1896,6 +1918,11 @@
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.1.tgz#1a5b1959a528e374e8037c4396c3e825d6cf4a83"
   integrity sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==
+
+"@floating-ui/utils@^0.1.3":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
+  integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
 
 "@graphql-codegen/add@^5.0.0":
   version "5.0.0"
@@ -3080,6 +3107,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-arrow@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz#c24f7968996ed934d57fe6cde5d6ec7266e1d25d"
+  integrity sha512-wSP+pHsB/jQRaL6voubsQ/ZlrGBHHrOjmBnr19hxYgtS0WvAFwZhK2WP/YY5yF9uKECCEEDGxuLxq1NBK51wFA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
 "@radix-ui/react-checkbox@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-checkbox/-/react-checkbox-1.0.4.tgz#98f22c38d5010dd6df4c5744cac74087e3275f4b"
@@ -3160,6 +3195,20 @@
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-escape-keydown" "1.0.3"
 
+"@radix-ui/react-dropdown-menu@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.0.6.tgz#cdf13c956c5e263afe4e5f3587b3071a25755b63"
+  integrity sha512-i6TuFOoWmLWq+M/eCLGd/bQ2HfAX1RJgvrBQ6AQLmzfvsLdefxbWu8G9zczcPFfcSPehz9GcpF6K9QYreFV8hA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-menu" "2.0.6"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
 "@radix-ui/react-focus-guards@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz#1ea7e32092216b946397866199d892f71f7f98ad"
@@ -3184,6 +3233,48 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/react-menu@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-menu/-/react-menu-2.0.6.tgz#2c9e093c1a5d5daa87304b2a2f884e32288ae79e"
+  integrity sha512-BVkFLS+bUC8HcImkRKPSiVumA1VPOOEC5WBMiT+QAVsPzW1FJzI9KnqgGxVDPBcql5xXrHkD3JOVoXWEXD8SYA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-popper@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.3.tgz#24c03f527e7ac348fabf18c89795d85d21b00b42"
+  integrity sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-rect" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+    "@radix-ui/rect" "1.0.1"
 
 "@radix-ui/react-portal@1.0.4":
   version "1.0.4"
@@ -3335,6 +3426,14 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
+"@radix-ui/react-use-rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-rect/-/react-use-rect-1.0.1.tgz#fde50b3bb9fd08f4a1cd204572e5943c244fcec2"
+  integrity sha512-Cq5DLuSiuYVKNU8orzJMbl15TXilTnJKUCltMVQg53BQOF1/C5toAaGrowkgksdBQ9H+SRL23g0HDmg9tvmxXw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/rect" "1.0.1"
+
 "@radix-ui/react-use-size@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-size/-/react-use-size-1.0.1.tgz#1c5f5fea940a7d7ade77694bb98116fb49f870b2"
@@ -3342,6 +3441,13 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-use-layout-effect" "1.0.1"
+
+"@radix-ui/rect@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/rect/-/rect-1.0.1.tgz#bf8e7d947671996da2e30f4904ece343bc4a883f"
+  integrity sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"


### PR DESCRIPTION
Something that's been bothering me for a while is the panel overflow menu. It doesn't close on select, and doesn't reposition if the trigger has moved.

https://github.com/wandb/weave/assets/17016170/3aa5c2c6-9a78-4417-9a32-73e937c95290

The component is currently built on semantic-ui's Popup + Menu, which doesn't work that well. I decided to bring over the DropdownMenu from core (built on radix + tailwind), which works much better.

https://github.com/wandb/weave/assets/17016170/9a06439b-f9b0-402a-ac3a-5b4f89ea5466

There will be a follow-up PR in core to remove the copy of `DropdownMenu` there and update import paths.