### PR TITLE
fix(wir): Set entity and project names on create report draft

### DIFF
--- a/weave-js/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/weave-js/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,9 +1,9 @@
 import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
-import {Icon} from '@wandb/weave/components/Icon';
 import classNames from 'classnames';
 import React from 'react';
 import {twMerge} from 'tailwind-merge';
 
+import {Icon} from '../Icon';
 import {Tailwind} from '../Tailwind';
 
 /**

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
@@ -172,8 +172,8 @@ export const ChildPanelExportReport = ({
       });
       await submit(
         newDraftVariables(
-          selectedEntity?.name,
-          selectedProject?.name,
+          selectedEntity.name,
+          selectedProject.name,
           publishedReport,
           slateNode
         )

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
@@ -137,7 +137,14 @@ export const ChildPanelExportReport = ({
       if (draft) {
         return setIsDraftDialogOpen(true);
       } else {
-        return submit(newDraftVariables(report, slateNode));
+        return submit(
+          newDraftVariables(
+            selectedEntity.name,
+            selectedProject.name,
+            report,
+            slateNode
+          )
+        );
       }
     } catch (err) {
       handleError(err);
@@ -156,14 +163,21 @@ export const ChildPanelExportReport = ({
   };
 
   const onDiscardDraft = async () => {
-    if (!hasActiveDraft || !slateNode) {
+    if (!hasActiveDraft || !hasRequiredData) {
       return;
     }
     try {
       await deleteReportDraft({
         variables: {id: activeReportDraft.id},
       });
-      await submit(newDraftVariables(publishedReport, slateNode));
+      await submit(
+        newDraftVariables(
+          selectedEntity?.name,
+          selectedProject?.name,
+          publishedReport,
+          slateNode
+        )
+      );
     } catch (err) {
       handleError(err);
     }

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/utils.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/utils.ts
@@ -182,6 +182,8 @@ export function editDraftVariables(
  * @param slateNode The node to add to the new report draft
  */
 export function newDraftVariables(
+  entityName: string,
+  projectName: string,
   report: PublishedReport,
   slateNode: WeavePanelSlateNode
 ): UpsertReportMutationVariables {
@@ -191,9 +193,11 @@ export function newDraftVariables(
     coverUrl: report.coverUrl,
     description: report.description,
     displayName: report.displayName,
+    entityName,
     name: ID(12),
     parentId: report.id,
     previewUrl: report.previewUrl,
+    projectName,
     spec: JSON.stringify(spec),
     type: 'runs/draft',
   };


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15976

problem: if a new report draft is created when you export a panel, the report draft doesn't show up on the reports table. however, the draft clearly exists because if you click into the report and try to edit, you'll get the "continue draft?" dialog

https://github.com/wandb/weave/assets/17016170/7f9de075-f0ac-4f84-bfc8-511bdd01e11e

solution: I compared the upsert request made by core vs weave and found that core includes `entityName` and `projectName` while weave does not. after adding those properties the reports table correctly detects the drafts created by weave


https://github.com/wandb/weave/assets/17016170/9d944707-b509-474c-93e2-c264c8b1b3bd

