### PR TITLE
feat(ui): Allow tw wrapper style overrides for Button

### DIFF
--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -32,6 +32,7 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   children?: ReactElement | string;
   active?: boolean;
   tooltip?: string;
+  twWrapperStyles?: React.CSSProperties;
 };
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
@@ -46,6 +47,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       children,
       className = '',
       tooltip,
+      twWrapperStyles = {},
       ...htmlAttributes
     },
     ref
@@ -75,6 +77,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const wrapperStyles = {
       display: 'inline-flex',
       width: className.includes('w-full') ? '100%' : undefined,
+      ...twWrapperStyles,
     };
 
     const button = (


### PR DESCRIPTION
Button component currently doesn't expose any way to apply style overrides to the Tailwind wrapper. This can be quite problematic. My current issue is I need to set `display: block` on the wrapper div. I'm sure there's other use cases. Best to allow flexibility.