### PR TITLE
feat(wir): Link to specific report section on panel export

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
@@ -98,12 +98,15 @@ export const ChildPanelExportReport = ({
     }
     const result = await upsertReport({variables});
     const upsertedDraft = result.data?.upsertView?.view!;
-    const reportDraftPath = Urls.reportEdit({
-      entityName: selectedEntity.name,
-      projectName: selectedProject.name,
-      reportID: upsertedDraft.id,
-      reportName: upsertedDraft.displayName ?? '',
-    });
+    const reportDraftPath = Urls.reportEdit(
+      {
+        entityName: selectedEntity.name,
+        projectName: selectedProject.name,
+        reportID: upsertedDraft.id,
+        reportName: upsertedDraft.displayName ?? '',
+      },
+      `#${slateNode.config.panelConfig.config.documentId}`
+    );
     // eslint-disable-next-line wandb/no-unprefixed-urls
     window.open(coreAppUrl(reportDraftPath), '_blank');
     setIsAddingPanel(false);


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15912

Won't really do anything until https://github.com/wandb/core/pull/17913 is merged to core, but it's not blocking. This change can safely be merged either way.

Updates report URL on panel export to point at the specific panel we just added


https://github.com/wandb/weave/assets/17016170/7e3a2cfb-3512-4101-a5a0-e701b96d0514


(note that we link to prod core by default, but the change is still only in localhost so I had to manually update that for the demo above)