### PR TITLE
feat(wir): Highlight selected panel change for report export

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
@@ -4,7 +4,8 @@ import * as Urls from '@wandb/weave/core/_external/util/urls';
 import {opRootViewer} from '@wandb/weave/core';
 import {UpsertReportMutationVariables} from '@wandb/weave/generated/graphql';
 import {useNodeValue} from '@wandb/weave/react';
-import React, {useMemo, useState} from 'react';
+import classNames from 'classnames';
+import React, {useEffect, useMemo, useState} from 'react';
 import _ from 'lodash';
 
 import {Alert} from '../../Alert.styles';
@@ -43,6 +44,25 @@ export const ChildPanelExportReport = ({
   const {result: fullConfig} = useNodeValue(rootConfig.input_node);
   const selectedPath = useSelectedPath();
   const closeDrawer = useCloseDrawer();
+
+  // Export is only allowed for panels *inside* main (excluding main itself)
+  useEffect(() => {
+    if (selectedPath[0] !== 'main' || selectedPath.length < 2) {
+      closeDrawer();
+    }
+  }, [selectedPath, closeDrawer]);
+
+  // If selected path changes while the drawer is open, highlight the
+  // new panel name to alert the user that the target panel changed.
+  const panelName = useMemo(() => _.last(selectedPath), [selectedPath]);
+  const [isPanelNameHighlighted, setIsPanelNameHighlighted] = useState<
+    null | boolean
+  >(null); // initial `null` lets us skip highlight when drawer is first opened
+  useEffect(() => {
+    setIsPanelNameHighlighted(prev => (prev === null ? false : true));
+    const timeout = setTimeout(() => setIsPanelNameHighlighted(false), 1500);
+    return () => clearTimeout(timeout);
+  }, [selectedPath]);
 
   const [selectedEntity, setSelectedEntity] = useState<EntityOption | null>(
     null
@@ -191,7 +211,14 @@ export const ChildPanelExportReport = ({
       <div className="flex h-full flex-col">
         <div className="flex items-center justify-between border-b border-moon-250 px-16 py-12">
           <h2 className="text-lg font-semibold">
-            Add {_.last(selectedPath)} to report
+            Add{' '}
+            <span
+              className={classNames('transition', {
+                'bg-gold-300/[0.5]': isPanelNameHighlighted,
+              })}>
+              {panelName}
+            </span>{' '}
+            to report
           </h2>
           <Button icon="close" variant="ghost" onClick={closeDrawer} />
         </div>


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-16092

before: while "export" drawer is open...
- if user clicks in main area but not on a specific panel, the target panel becomes the whole of main, which should not be allowed
- if user clicks on another panel in main, the target panel changes but it's not obvious to the user

https://github.com/wandb/weave/assets/17016170/fbd11c6c-3d7d-4b70-a94a-0040d05970cb


after:
- drawer closes if target panel is not valid for export (which includes main)
- target panel name is highlighted if changed

https://github.com/wandb/weave/assets/17016170/46ebbd18-a9a6-4ee1-b906-19230e8ddbf9

