### PR TITLE
refactor: Create utils for checking path against main

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -73,7 +73,7 @@ import {getStackIdAndName} from './panellib/libpanel';
 import {replaceChainRoot} from '@wandb/weave/core/mutate';
 
 import {OutlineItemPopupMenu} from '../Sidebar/OutlineItemPopupMenu';
-import {getConfigForPath} from './panelTree';
+import {getConfigForPath, isInsideMain, isMain} from './panelTree';
 import {usePanelPanelContext} from './PanelPanelContextProvider';
 import {Button} from '../Button';
 
@@ -604,7 +604,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     <Styles.Main
       data-weavepath={props.pathEl ?? 'root'}
       onClick={event => {
-        if (fullPath.length <= 2 && fullPath[0] === 'main') {
+        if (isMain(fullPath) || isInsideMain(fullPath, 1)) {
           setSelectedPanel(fullPath);
           event.stopPropagation();
         }

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
@@ -13,6 +13,7 @@ import {Button} from '../../Button';
 import {ChildPanelFullConfig} from '../ChildPanel';
 import {Tailwind} from '../../Tailwind';
 import {useCloseDrawer, useSelectedPath} from '../PanelInteractContext';
+import {isInsideMain} from '../panelTree';
 import {AddPanelErrorAlert} from './AddPanelErrorAlert';
 import {ReportDraftDialog} from './ReportDraftDialog';
 import {ReportSelection} from './ReportSelection';
@@ -47,7 +48,7 @@ export const ChildPanelExportReport = ({
 
   // Export is only allowed for panels *inside* main (excluding main itself)
   useEffect(() => {
-    if (selectedPath[0] !== 'main' || selectedPath.length < 2) {
+    if (!isInsideMain(selectedPath)) {
       closeDrawer();
     }
   }, [selectedPath, closeDrawer]);

--- a/weave-js/src/components/Panel2/panelTree.ts
+++ b/weave-js/src/components/Panel2/panelTree.ts
@@ -494,6 +494,28 @@ const isDashboard = (node: PanelTreeNode): node is Dashboard => {
   );
 };
 
+/**
+ * Returns whether a path points to the "main" group in a {@link Dashboard}
+ */
+export const isMain = (path: string[]): boolean => {
+  return path[0] === 'main' && path.length === 1;
+};
+
+/**
+ * Returns whether a path points to a panel *inside* the "main" group
+ * in a {@link Dashboard}. **This excludes "main" itself!**
+ *
+ * @param path  path to the target panel
+ * @param depth max depth of panels to include. For example, depth 1 will
+ *              only return true for top-level panels in main.
+ */
+export const isInsideMain = (path: string[], depth = Infinity): boolean => {
+  if (depth < 1) {
+    throw new Error('depth must be at least 1');
+  }
+  return path[0] === 'main' && path.length > 1 && path.length <= 1 + depth;
+};
+
 export const ensureDashboard = (node: PanelTreeNode): ChildPanelFullConfig => {
   if (isDashboard(node)) {
     return node;

--- a/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
@@ -10,6 +10,7 @@ import {
   addChild,
   getPath,
   isGroupNode,
+  isInsideMain,
   makePanel,
   setPath,
 } from '../Panel2/panelTree';
@@ -178,7 +179,7 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
       });
     }
 
-    if (path.find(p => p === 'main') != null && path.length > 1) {
+    if (isInsideMain(path)) {
       items.push({
         key: 'split',
         content: 'Split',


### PR DESCRIPTION
Inspired by this comment: https://github.com/wandb/weave/pull/809#discussion_r1379231648

Testing (these are all regression checks):

- Open overflow menu for a panel in main -> split/add to report options are displayed
- Open overflow menu for a panel in varbar -> split/add to report options are **not** displayed
- Open panel editor, then click to main area background (not on a specific panel) -> drawer updates to show outline view
- Open panel editor, then click to another panel in main -> drawer updates to editor for new panel
- Open panel editor, then click to another panel in main, specifically a **group** panel -> drawer updates to editor for whole group (not specific child item that was clicked on)
- Open panel exporter, then click to main area background (not a specific panel) -> drawer closes
- Open panel exporter, then click to another panel in main -> drawer title updates with panel name highlighted