### PR TITLE
feat(wir): Select default project on export to new report

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
@@ -100,7 +100,10 @@ export const ReportSelection = ({
     }),
   });
   const projects = useNodeValue(projectMetaNode, {
-    skip: selectedEntity == null || entities.loading,
+    skip:
+      selectedEntity == null ||
+      entities.loading ||
+      !isNewReportOption(selectedReport),
   });
 
   useEffect(() => {

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
@@ -40,7 +40,8 @@ export const ReportSelection = ({
   setSelectedProject,
   onChange,
 }: ReportSelectionProps) => {
-  const {entityName} = useEntityAndProject(rootConfig);
+  const {entityName: entityNameFromUrl, projectName: projectNameFromUrl} =
+    useEntityAndProject(rootConfig);
 
   // Get all of user's entities
   const entitiesMetaNode = w.opMap({
@@ -54,7 +55,7 @@ export const ReportSelection = ({
   });
   const entities = useNodeValue(entitiesMetaNode);
   const selectedEntityNode = w.opRootEntity({
-    entityName: w.constString(selectedEntity?.name ?? entityName),
+    entityName: w.constString(selectedEntity?.name ?? entityNameFromUrl),
   });
 
   // Get list of reports across all entities and projects
@@ -99,21 +100,18 @@ export const ReportSelection = ({
     }),
   });
   const projects = useNodeValue(projectMetaNode, {
-    skip:
-      selectedEntity == null ||
-      entities.loading ||
-      isNewReportOption(selectedReport),
+    skip: selectedEntity == null || entities.loading,
   });
 
   useEffect(() => {
     // Default initial entity value based on url
     if (!entities.loading && entities.result.length > 0) {
       const foundEntity = entities.result.find(
-        (item: EntityOption) => item.name === entityName
+        (item: EntityOption) => item.name === entityNameFromUrl
       );
       setSelectedEntity(foundEntity ?? entities.result[0]);
     }
-  }, [entityName, entities, setSelectedEntity]);
+  }, [entityNameFromUrl, entities, setSelectedEntity]);
 
   useEffect(() => {
     // Default report value to `New report` option if no reports are found
@@ -125,6 +123,20 @@ export const ReportSelection = ({
       setSelectedReport(DEFAULT_REPORT_OPTION);
     }
   }, [reports, setSelectedReport, selectedReport]);
+
+  useEffect(() => {
+    // If `New report` option is selected, set default project based on url
+    if (
+      isNewReportOption(selectedReport) &&
+      !projects.loading &&
+      projects.result.length > 0
+    ) {
+      const foundProject = projects.result.find(
+        (item: ProjectOption) => item.name === projectNameFromUrl
+      );
+      setSelectedProject(foundProject ?? null);
+    }
+  }, [projectNameFromUrl, projects, selectedReport, setSelectedProject]);
 
   return (
     <div className="mt-8 flex-1">


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-15936

before: when exporting a panel to a report, the entity field auto-populates based on the entity of the board. however, the project field does not. the UX is inconsistent and the extra clicks are slightly tedious.

https://github.com/wandb/weave/assets/17016170/a3ab8f36-33df-4043-90be-9337fd4f9491

after:
- if board is published to a project, project will be auto-selected when user chooses "new report"
- if it's a new board that doesn't belong to any entity/project, user still needs to manually select each of those

https://github.com/wandb/weave/assets/17016170/ea6f9957-25cf-44a7-acdb-edb3bd8f6308
