### PR TITLE
fix: safer preview when artifact version deleted

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomeCenterEntityBrowser.tsx
@@ -37,7 +37,7 @@ import {useNodeValue} from '@wandb/weave/react';
 import {useWeaveContext} from '@wandb/weave/context';
 import {
   HomePreviewSidebarTemplate,
-  HomeExpressionPreviewParts,
+  SafeHomeExpressionPreviewParts,
   SEED_BOARD_OP_NAME,
 } from './HomePreviewSidebar';
 import {useHistory, useParams} from 'react-router-dom';
@@ -423,7 +423,7 @@ const CenterProjectBoardsBrowser: React.FC<
               navigateToExpression(expr);
             },
           }}>
-          <HomeExpressionPreviewParts
+          <SafeHomeExpressionPreviewParts
             expr={expr}
             navigateToExpression={navigateToExpression}
           />
@@ -614,7 +614,7 @@ const CenterProjectLegacyTracesBrowser: React.FC<
             ],
           ]}
           setPreviewNode={setPreviewNode}>
-          <HomeExpressionPreviewParts
+          <SafeHomeExpressionPreviewParts
             expr={convertSimpleLegacyNodeToNewFormat(expr)}
             generatorAllowList={['py_board-trace_monitor']}
             navigateToExpression={navigateToExpression}
@@ -886,7 +886,7 @@ const CenterProjectTablesBrowser: React.FC<
           actions={sidebarActions}
           emptyData={row['number of rows'] === 0}
           emptyDataMessage={<EmptyTableMessage />}>
-          <HomeExpressionPreviewParts
+          <SafeHomeExpressionPreviewParts
             expr={expr}
             navigateToExpression={navigateToExpression}
           />

--- a/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/HomePreviewSidebar.tsx
@@ -39,6 +39,7 @@ import * as S from './styles';
 import {maybePluralize} from '../../../core/util/string';
 import {Unclickable} from './PreviewNode';
 import {trackNewBoardFromTemplateClicked} from '@wandb/weave/util/events';
+import {ErrorBoundary} from '../../ErrorBoundary';
 
 const CenterSpace = styled(LayoutElements.VSpace)`
   border: 1px solid ${MOON_250};
@@ -369,6 +370,20 @@ export const HomeExpressionPreviewParts: React.FC<{
         </Tabs.Content>
       </Tabs.Root>
     </HomeExpressionPreviewPartsWrapper>
+  );
+};
+
+// It's possible for the artifact fetch to fail, and we don't want that to crash the whole page.
+// For example, if the artifact version is deleted in the app UI but the sequence remains.
+export const SafeHomeExpressionPreviewParts: React.FC<{
+  expr: Node;
+  navigateToExpression: NavigateToExpressionType;
+  generatorAllowList?: string[];
+}> = props => {
+  return (
+    <ErrorBoundary>
+      <HomeExpressionPreviewParts {...props} />
+    </ErrorBoundary>
   );
 };
 


### PR DESCRIPTION
If you have a logged table and delete the artifact version but leave the sequence, attempting to preview it in the UI will crash the page. Wrapping the component in an error boundary helps, though a more comprehensive fix is desirable.

Before:
![run-tcctzit5-table_key-–-Weave](https://github.com/wandb/weave/assets/112953339/2be79896-0180-4ac6-9cc9-d7c9fea1e9d6)

After: 
![run-tcctzit5-table_key-–-Weave (1)](https://github.com/wandb/weave/assets/112953339/bb2e44ff-a03b-4bbb-be9c-012ac78fc156)
