### PR TITLE
chore(wir): Remove in-development alert for report export

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ChildPanelExportReport.tsx
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import _ from 'lodash';
 
-import {Alert} from '../../Alert.styles';
 import {Button} from '../../Button';
 import {ChildPanelFullConfig} from '../ChildPanel';
 import {Tailwind} from '../../Tailwind';
@@ -233,12 +232,6 @@ export const ChildPanelExportReport = ({
           <Button icon="close" variant="ghost" onClick={closeDrawer} />
         </div>
         <div className="flex-1 gap-8 p-16">
-          <Alert severity="warning">
-            <p>
-              <b>🚧 Work in progress!</b> This feature is under development
-              behind an internal-only feature flag.
-            </p>
-          </Alert>
           <ReportSelection
             rootConfig={rootConfig}
             selectedEntity={selectedEntity}

--- a/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/ReportSelection.tsx
@@ -150,7 +150,7 @@ export const ReportSelection = ({
   ]);
 
   return (
-    <div className="mt-8 flex-1">
+    <div className="flex-1">
       <label
         htmlFor="entity-selector"
         className="mb-4 block font-semibold text-moon-800">


### PR DESCRIPTION
removes the alert that says WIR is in development

<img width="1270" alt="Screenshot 2023-11-03 at 4 17 58 PM" src="https://github.com/wandb/weave/assets/17016170/7969df4b-3c16-4f86-af78-48b1df94b9cf">
