### PR TITLE
fix: plot config jitter

### DIFF
--- a/weave-js/src/components/Panel2/ConfigPanel/index.tsx
+++ b/weave-js/src/components/Panel2/ConfigPanel/index.tsx
@@ -285,6 +285,7 @@ export const ConfigFieldWrapper = styled.div<{withIcon?: boolean}>`
       color: ${globals.GRAY_800};
     }
   }
+  border: 2px solid transparent;
   &:focus-within {
     border: 2px solid ${globals.TEAL_400};
   }


### PR DESCRIPTION
We add a 2px border to config fields when they have focus. This change in size causes other UI elements to move around in distracting ways. Fixed by having an invisible border when not focused so size stays the same.