### PR TITLE
chore: fix react unique key warning in row height controls

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -794,11 +794,11 @@ const PanelTableInner: React.FC<
               .slice(4)
               .map(rowSize => (
                 <Tooltip
+                  key={rowSize}
                   position="top center"
                   content={rowSizeTooltipContent[RowSize[rowSize]]}
                   trigger={
                     <Button
-                      key={rowSize}
                       startIcon={rowSizeIconName[RowSize[rowSize]]}
                       onClick={() => setRowSize(RowSize[rowSize])}
                       active={config.rowSize === RowSize[rowSize]}


### PR DESCRIPTION
Fix this warning in the developer console:

<img width="835" alt="Screenshot 2023-11-07 at 12 42 10 PM" src="https://github.com/wandb/weave/assets/112953339/bac03f03-7b64-4e29-ac0d-bb0487494626">
