### PR TITLE
fix: advanced properties was toggling when click on input

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -756,21 +756,17 @@ const PanelPlotConfigInner: React.FC<PanelPlotProps> = props => {
     setShowAdvancedProperties(prev => !prev);
   }, []);
   const advancedPropertiesDom = useMemo(() => {
-    return (
+    return showAdvancedProperties ? (
       <>
-        {showAdvancedProperties ? (
-          <div onClick={toggleAdvancedProperties}>
-            {scaleConfigDom}
-            <S.AdvancedPropertiesHeader>
-              Hide advanced properties
-            </S.AdvancedPropertiesHeader>
-          </div>
-        ) : (
-          <S.AdvancedPropertiesHeader onClick={toggleAdvancedProperties}>
-            Advanced properties
-          </S.AdvancedPropertiesHeader>
-        )}
+        {scaleConfigDom}
+        <S.AdvancedPropertiesHeader onClick={toggleAdvancedProperties}>
+          Hide advanced properties
+        </S.AdvancedPropertiesHeader>
       </>
+    ) : (
+      <S.AdvancedPropertiesHeader onClick={toggleAdvancedProperties}>
+        Advanced properties
+      </S.AdvancedPropertiesHeader>
     );
   }, [showAdvancedProperties, toggleAdvancedProperties, scaleConfigDom]);
 


### PR DESCRIPTION
"Advanced properties" in PanelPlot allows you to specify linear vs. log scale for X and Y axes. It is collapsed by default. The onClick handler to hide the section was attached to the wrong div, so it would hide as you were trying to edit.