### PR TITLE
chore: use common component for bottom New Panel button

### DIFF
--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -172,26 +172,8 @@ const ActionBar = styled.div`
 `;
 ActionBar.displayName = 'S.ActionBar';
 
-const AddPanelBar = styled.div`
-  height: 48px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
-  border-radius: 6px;
-  background-color: white;
-  font-weight: 600;
-  color: ${GRAY_500};
-`;
-AddPanelBar.displayName = 'S.AddPanelBar';
-
 const AddPanelBarContainer = styled.div`
   padding: 8px 32px 16px;
-
-  transition: opacity 0.3s;
-  &:not(:hover) {
-    opacity: 0;
-  }
 `;
 AddPanelBarContainer.displayName = 'S.AddPanelBarContainer';
 
@@ -971,10 +953,14 @@ export const PanelGroup: React.FC<PanelGroupProps> = props => {
         />
         {!inJupyter && isAddPanelAllowed && (
           <AddPanelBarContainer ref={addPanelBarRef}>
-            <AddPanelBar onClick={handleAddPanel}>
-              <IconAddNew />
+            <Button
+              variant="secondary"
+              size="large"
+              onClick={handleAddPanel}
+              icon="add-new"
+              className="w-full">
               New panel
-            </AddPanelBar>
+            </Button>
           </AddPanelBarContainer>
         )}
       </div>


### PR DESCRIPTION
The "New panel" button at the bottom of the board fades in and out. Clicking on it before it has faded in still adds a panel, which can be confusing for the user. This PR replaces it with a standard common components Button, so it is always visible and matches the styling of the "New panel" button that is at the top of the board.

Before:
<img width="937" alt="Screenshot 2023-11-07 at 2 32 27 PM" src="https://github.com/wandb/weave/assets/112953339/6fba68e5-cb4e-4227-8d33-bc440f49c773">

After:
<img width="1260" alt="Screenshot 2023-11-07 at 2 34 51 PM" src="https://github.com/wandb/weave/assets/112953339/3b1540f0-d773-4964-982c-0ed8fa9f0d93">
<img width="1274" alt="Screenshot 2023-11-07 at 2 35 31 PM" src="https://github.com/wandb/weave/assets/112953339/e91727f7-c8b9-4bd0-a485-35f35dc0b0f2">
