### PR TITLE
fix: other panel getting resized when you delete a panel

### DIFF
--- a/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
@@ -85,7 +85,9 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
               const index = cursor.config.gridConfig.panels.findIndex(
                 p => p.id === lastStep
               );
-              cursor.config.gridConfig.panels.splice(index, 1);
+              if (index !== -1) {
+                cursor.config.gridConfig.panels.splice(index, 1);
+              }
             }
           } else if (cursor.id === 'LabeledItem') {
             delete cursor.config[lastStep];


### PR DESCRIPTION
When you delete a panel, some times another panel would get resized. An easy way to reproduce this is to create a board from a logged table. The table panel will stretch across the main panel. Add a new panel and immediately delete it. The table will get resized.
