### PR TITLE
fix(wir): Keep panel name on report export

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
+++ b/weave-js/src/components/Panel2/ChildPanelExportReport/computeReportSlateNode.ts
@@ -117,6 +117,7 @@ export const computeReportSlateNode = (
   targetPath: string[]
 ): WeavePanelSlateNode => {
   const targetConfig = getConfigForPath(fullConfig, targetPath);
+  const targetPanelName = targetPath[targetPath.length - 1];
   const varItems = getVarItemsForPath(fullConfig, targetConfig);
   const inputNodeVal = makeGroup(
     {
@@ -124,7 +125,7 @@ export const computeReportSlateNode = (
         childNameBase: 'var',
         layoutMode: 'vertical',
       }),
-      panel: targetConfig,
+      [targetPanelName]: targetConfig,
     },
     {
       disableDeletePanel: true,
@@ -136,7 +137,7 @@ export const computeReportSlateNode = (
         vars: {
           hidden: true,
         },
-        panel: {
+        [targetPanelName]: {
           controlBar: 'editable',
         },
       },


### PR DESCRIPTION
bug bash feedback from Yangyi

https://www.notion.so/wandbai/Panel-name-is-not-carried-over-68b647a972e0408c89e7a3eb8e185fa4?pvs=4