### PR TITLE
fix: make weave1 missing artifact behavior match weave0

### DIFF
--- a/weave/derive_op.py
+++ b/weave/derive_op.py
@@ -260,7 +260,10 @@ class MappedDeriveOpHandler(DeriveOpHandler):
                             return None
                         called = orig_op(x, **new_inputs)
                         # Use the use path to get caching.
-                        res = weave_internal.use(called)
+                        try:
+                            res = weave_internal.use(called)
+                        except errors.WeaveArtifactCollectionNotFound:
+                            return None
                         res = storage.deref(res)
                         return res
 


### PR DESCRIPTION
Internal JIRA ticket: https://wandb.atlassian.net/browse/WB-16272

Fixes an issue where missing artifact collections could trigger full page crashes in the weave1 engine. This matches the weave0 behavior, which fails more gracefully and loads any artifacts that can be found, and returns none for artifacts that cannot be found. 