### PR TITLE
chore: update and add tooltips to plot zoom/select buttons

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/RadioButtons.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/RadioButtons.tsx
@@ -1,112 +1,32 @@
-import {LegacyWBIcon} from '@wandb/weave/common/components/elements/LegacyWBIcon';
-import * as globals from '@wandb/weave/common/css/globals.styles';
+import * as Color from '@wandb/weave/common/css/color.styles';
 import React, {useMemo} from 'react';
 import styled from 'styled-components';
+import {Button} from '../../Button';
+import {IconName} from '../../Icon';
 
 export const BRUSH_MODES = ['zoom' as const, 'select' as const];
 export type BrushMode = (typeof BRUSH_MODES)[number];
 
-interface IconWrapperProps {
-  isDarkMode: boolean;
-  isActive: boolean;
-}
-
-const IconWrapper = styled.div<IconWrapperProps>`
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 4px;
-  background-color: ${props =>
-    props.isActive
-      ? props.isDarkMode
-        ? globals.hexToRGB(globals.TEAL, 0.16)
-        : globals.hexToRGB(globals.TEAL, 0.1)
-      : props.isDarkMode
-      ? globals.GRAY_880
-      : globals.WHITE};
-
-  &:hover {
-    background-color: ${props =>
-      props.isDarkMode ? globals.GRAY_840 : globals.GRAY_50};
-  }
-  cursor: pointer;
-`;
-IconWrapper.displayName = 'S.IconWrapper';
-
-interface IconProps {
-  isDarkMode: boolean;
-  isActive: boolean;
-}
-
-const Icon = styled.div<IconProps>`
-  width: 18px;
-  height: 18px;f
-  background-color: ${props =>
-    props.isActive
-      ? props.isDarkMode
-        ? globals.TEAL_LIGHT2
-        : globals.TEAL_DARK
-      : props.isDarkMode
-      ? globals.GRAY_600
-      : globals.GRAY_500};
-`;
-Icon.displayName = 'S.Icon';
-
-interface IconComponentProps extends IconWrapperProps {
-  onClick: () => void;
-  name: string;
-}
-
-const IconComponent: React.FC<IconComponentProps> = ({
-  isDarkMode,
-  isActive,
-  onClick,
-  name,
-}) => (
-  <IconWrapper isDarkMode={isDarkMode} isActive={isActive} onClick={onClick}>
-    <Icon isDarkMode={isDarkMode} isActive={isActive}>
-      <LegacyWBIcon name={name} className={`wbic-${name}`} />
-    </Icon>
-  </IconWrapper>
-);
-
-interface GroupProps {
-  isDarkMode: boolean;
-}
-
-const Group = styled.div<GroupProps>`
+const Group = styled.div`
   display: flex;
   padding: 4px;
-  background-color: ${props =>
-    props.isDarkMode ? globals.GRAY_880 : globals.WHITE};
-  border: 1px solid
-    ${props => (props.isDarkMode ? globals.GRAY_800 : globals.GRAY_350)};
+  line-height: 0;
+  background-color: ${Color.WHITE};
+  border: 1px solid ${Color.MOON_300};
   border-radius: 4px;
 `;
 Group.displayName = 'S.Group';
-
-interface GroupComponentProps extends GroupProps {
-  children: React.ReactNode;
-}
-
-const GroupComponent: React.FC<GroupComponentProps> = ({
-  children,
-  isDarkMode,
-}) => <Group isDarkMode={isDarkMode}>{children}</Group>;
 
 export const PanelPlotRadioButtons: React.FC<{
   currentValue: BrushMode;
   setMode: (newMode: BrushMode) => void;
 }> = ({currentValue, setMode}) => {
-  // const [isDarkMode, setIsDarkMode] = React.useState(false);
-
   const options = useMemo(
     () => [
       {
         mode: 'zoom' as const,
-        iconName: 'icon-zoom-in-tool',
+        iconName: 'zoom-in-tool' as IconName,
+        tooltip: 'Zoom',
       },
       /*
       {
@@ -116,30 +36,30 @@ export const PanelPlotRadioButtons: React.FC<{
       */
       {
         mode: 'select' as const,
-        iconName: 'icon-select-move-tool',
+        iconName: 'select-move-tool' as IconName,
+        tooltip: 'Select',
       },
     ],
     []
   );
 
   return (
-    <GroupComponent isDarkMode={false}>
-      {options.map(({iconName}, index) => (
-        <IconComponent
-          key={iconName}
-          isActive={currentValue === options[index].mode}
-          isDarkMode={false}
+    <Group>
+      {options.map(({iconName, tooltip}, index) => (
+        <Button
+          icon={iconName}
+          size="small"
+          variant={currentValue === options[index].mode ? 'secondary' : 'ghost'}
+          tooltip={tooltip}
           onClick={() => {
             const brushMode = options[index].mode;
             if (currentValue !== brushMode) {
-              console.log('SETTING BRUSH MODE', currentValue, '=>', brushMode);
               setMode(brushMode);
             }
           }}
-          name={iconName}
         />
       ))}
-    </GroupComponent>
+    </Group>
   );
 };
 


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16296

Use common component buttons for Zoom/Select and add tooltips.

Before:
<img width="67" alt="Screenshot 2023-11-09 at 10 04 33 AM" src="https://github.com/wandb/weave/assets/112953339/638b9d7c-504c-4c2c-8f3a-04ca786be91b">

After: 
<img width="91" alt="Screenshot 2023-11-09 at 10 03 31 AM" src="https://github.com/wandb/weave/assets/112953339/51fa617d-ce41-4036-a061-ca7122af1d73">
