### PR TITLE
fix: bring over app styles for table column selector

### DIFF
--- a/weave-js/src/common/css/TableEditor.less
+++ b/weave-js/src/common/css/TableEditor.less
@@ -1,0 +1,106 @@
+@import '@wandb/weave/common/css/globals.less';
+
+.table-editor {
+  &__search.ui.input {
+    width: 100%;
+    margin-bottom: -16px;
+    & > input {
+      border: none;
+      border-radius: 0;
+      border-bottom: 1px solid @gray400;
+    }
+  }
+}
+
+.column-list-container {
+  background-color: @gray100;
+  padding: 16px;
+  height: 100%;
+  &.hidden-container {
+    margin-right: -8px;
+  }
+  &.visible-container {
+    margin-left: -8px;
+  }
+  &.dragover {
+    background-color: #eee;
+    &.hidden-container .column-field {
+      opacity: 0.8;
+    }
+  }
+  .count-tag {
+    background-color: @gray400;
+    border-radius: 8px;
+    font-size: 12px;
+    padding: 0 4px;
+    margin-left: 8px;
+    font-weight: normal;
+  }
+  .items-scroll-list {
+    margin: 16px 0;
+    height: 350px;
+    overflow: auto;
+  }
+  .ui.button.right {
+    float: right;
+  }
+  .column-limit-msg {
+    font-size: 12px;
+    padding-left: 8px;
+    font-style: italic;
+    color: @gray500;
+  }
+}
+
+.item.column-field-wrapper {
+  padding: 3px 0;
+  transition: padding-top 0.1s;
+  &.disabled > .column-field {
+    opacity: 0.7;
+  }
+  &.drop {
+    padding-top: 40px !important;
+  }
+  .column-field {
+    cursor: pointer;
+    padding: 8px;
+    background-color: @white;
+    border-radius: 4px;
+    user-select: none;
+    display: flex;
+    .column-name {
+      text-overflow: ellipsis;
+      overflow: hidden;
+      flex-grow: 1;
+      word-wrap: break-word;
+    }
+    &:hover {
+      background-color: @gray50;
+    }
+  }
+  i.icon.section-icon {
+    padding-right: 4px;
+    font-size: 18px;
+    color: @gray500;
+  }
+  i.icon.pin {
+    flex-shrink: 0;
+    width: 14px;
+    visibility: hidden;
+    color: @gray400;
+    cursor: pointer;
+    &:hover {
+      color: @gray500;
+    }
+  }
+  i.icon.pin.active {
+    visibility: visible;
+    color: @gray700;
+    &:hover {
+      color: black;
+    }
+  }
+  &:hover i.icon.pin {
+    visibility: visible;
+  }
+}

--- a/weave-js/src/components/Panel2/PanelTable.styles.ts
+++ b/weave-js/src/components/Panel2/PanelTable.styles.ts
@@ -153,18 +153,6 @@ export const TableIcon = styled(WBIcon)<{highlight?: boolean}>`
 `;
 TableIcon.displayName = 'S.TableIcon';
 
-export const TableActionText = styled.span`
-  cursor: pointer;
-  margin-left: 10px;
-  padding: 2px 0px 0px 0px;
-  :hover {
-    color: ${globals.primary};
-    background-color: #eee;
-    border-radius: 2px;
-  }
-`;
-TableActionText.displayName = 'S.TableActionText';
-
 export const ControlIcon = styled(WBIcon)`
   cursor: pointer;
   color: ${globals.primary};

--- a/weave-js/src/components/Panel2/PanelTable/ColumnSelector.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/ColumnSelector.tsx
@@ -1,4 +1,3 @@
-import {LegacyWBIcon} from '@wandb/weave/common/components/elements/LegacyWBIcon';
 import {
   dynamicMatchWithMapping,
   MatchMode,
@@ -6,7 +5,7 @@ import {
 import {Node} from '@wandb/weave/core';
 import {cloneDeep as _cloneDeep} from 'lodash';
 import React, {useCallback, useMemo, useState} from 'react';
-import {Button, Dropdown, Grid, Icon, List} from 'semantic-ui-react';
+import {Dropdown, Grid, Icon, List} from 'semantic-ui-react';
 
 import {useWeaveContext} from '../../../context';
 import * as S from './ColumnSelector.styles';
@@ -14,6 +13,7 @@ import ColumnSelectorField from './ColumnSelectorField';
 import ColumnSelectorListContainer from './ColumnSelectorListContainer';
 import * as Table from './tableState';
 import {ColumnEntry} from './tableState';
+import {Button} from '../../Button';
 
 const MAX_COLUMNS_SHOWN = 100;
 
@@ -291,9 +291,12 @@ const ColumnSelector: React.FC<ColumnSelectorProps> = React.memo(
                 )}
               </div>
               <Button
-                className="right tiny wb-icon-button"
+                variant="secondary"
+                icon="chevron-next"
+                twWrapperStyles={{
+                  float: 'right',
+                }}
                 onClick={() => addAll(searchedColumnsAvailable)}>
-                <LegacyWBIcon name="next" />
                 Add all
               </Button>
             </ColumnSelectorListContainer>
@@ -345,9 +348,9 @@ const ColumnSelector: React.FC<ColumnSelectorProps> = React.memo(
                 )}
               </div>
               <Button
-                className="tiny wb-icon-button"
+                variant="secondary"
+                icon="chevron-back"
                 onClick={() => removeAll(searchedColumnsUsed)}>
-                <LegacyWBIcon name="previous" />
                 Remove all
               </Button>
             </ColumnSelectorListContainer>

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -41,7 +41,6 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import BaseTable, {BaseTableProps} from 'react-base-table';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {
-  Button as SemanticButton,
   Icon as SemanticIcon,
   Menu,
   MenuItemProps,
@@ -901,23 +900,27 @@ const PanelTableInner: React.FC<
         </div>
         {!props.config.simpleTable && (
           <div style={{flex: '0 0 auto'}}>
-            <S.TableActionText
+            <Button
+              variant="ghost"
+              size="small"
               onClick={() => {
                 downloadDataAsCSV();
               }}>
               Export as CSV
-            </S.TableActionText>
+            </Button>
             <Modal
               className="small"
               trigger={
-                <S.TableActionText
+                <Button
                   data-test="select-columns"
+                  variant="ghost"
+                  size="small"
                   onClick={() => {
                     recordEvent('SELECT_COLUMNS');
                     setShowColumnSelect(true);
                   }}>
                   Columns...
-                </S.TableActionText>
+                </Button>
               }
               open={showColumnSelect}
               onClose={() => setShowColumnSelect(false)}>
@@ -929,22 +932,25 @@ const PanelTableInner: React.FC<
                 />
               </Modal.Content>
               <Modal.Actions>
-                <SemanticButton
+                <Button
                   data-test="close-column-select"
-                  primary
+                  variant="primary"
+                  size="large"
                   onClick={() => setShowColumnSelect(false)}>
                   Close
-                </SemanticButton>
+                </Button>
               </Modal.Actions>
             </Modal>
-            <S.TableActionText
+            <Button
               data-test="auto-columns"
+              variant="ghost"
+              size="small"
               onClick={() => {
                 recordEvent('RESET_TABLE');
                 resetTable();
               }}>
-              Reset Table
-            </S.TableActionText>
+              Reset table
+            </Button>
           </div>
         )}
       </div>

--- a/weave-js/src/globalStyleImports.ts
+++ b/weave-js/src/globalStyleImports.ts
@@ -29,3 +29,4 @@ import 'react-table/react-table.css';
 import 'react-toastify/dist/ReactToastify.min.css';
 import '@wandb/semantic/semantic.min.css';
 import '@wandb/weave/common/css/SemanticOverride.less';
+import '@wandb/weave/common/css/TableEditor.less';


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16311

Bring over missing styling from app and update to use new button component.

(A short term improvement while we work on bigger table design updates.)

Before: 
<img width="235" alt="Screenshot 2023-11-09 at 10 09 29 AM" src="https://github.com/wandb/weave/assets/112953339/6227b401-4dbd-4890-b328-cd394cc083ee">
<img width="706" alt="Screenshot 2023-11-09 at 10 09 45 AM" src="https://github.com/wandb/weave/assets/112953339/74da999e-11a0-4d0b-a43c-8597f729f7d3">

After:
<img width="295" alt="Screenshot 2023-11-09 at 10 08 50 AM" src="https://github.com/wandb/weave/assets/112953339/dd596f33-1843-4dc7-aaa2-0fd3e16ed718">

<img width="715" alt="Screenshot 2023-11-09 at 10 08 58 AM" src="https://github.com/wandb/weave/assets/112953339/71947e8e-6055-46c6-b888-d50ee30a8667">
