### PR TITLE
feat: new panels now span entire board width

### DIFF
--- a/integration_test/cypress/e2e/testlib.ts
+++ b/integration_test/cypress/e2e/testlib.ts
@@ -169,7 +169,7 @@ export const tableAppendColumn = (path: string[], expr) => {
 };
 
 export const tableCheckContainsValue = (path: string[], value: string) => {
-  const panel = getPanel(path);
+  const panel = getPanel(path).scrollIntoView();
   panel.find('.BaseTable__row-cell div').contains(value);
 };
 

--- a/weave-js/src/components/WeavePanelBank/panelbankGrid.ts
+++ b/weave-js/src/components/WeavePanelBank/panelbankGrid.ts
@@ -9,7 +9,7 @@ export const GRID_COLUMN_COUNT = 24; // number of grid columns
 export const GRID_ROW_HEIGHT = 32; // height of grid row in px
 export const GRID_CONTAINER_PADDING = [32, 0]; // padding of grid container
 export const GRID_ITEM_MARGIN = [16, 16]; // margin around each grid item
-export const GRID_ITEM_DEFAULT_WIDTH = 12;
+export const GRID_ITEM_DEFAULT_WIDTH = 24;
 export const GRID_ITEM_DEFAULT_HEIGHT = 6;
 
 export type GridLayoutItem = LayoutParameters & {


### PR DESCRIPTION
Make new panels span the entire board width instead of being sized to half of it.

This was a design team request.

The new size requires a small integration test change. Now, adding the two additional panels (with the automatic scrolling on new panel that we have) causes the top table panel to scroll partly out of view, making the test fail. Updated the test to scroll tables into view before checking their contents.