### PR TITLE
feat: Add Duration Type and Vectorize TotalSeconds Function

### DIFF
--- a/weave/mappers_arrow.py
+++ b/weave/mappers_arrow.py
@@ -50,6 +50,16 @@ class ObjectToArrowStruct(mappers_python.ObjectToPyDict):
         return pa.struct(fields)
 
 
+class TimeDeltaToArrowTimeDelta(mappers.Mapper):
+    def result_type(self):
+        return pa.duration("us")
+
+
+class ArrowTimeDeltaToTimeDelta(mappers.Mapper):
+    def apply(self, obj):
+        return obj.as_py()
+
+
 class StringToArrow(mappers_python.StringToPyString):
     def result_type(self):
         if _in_tagging_context.get():
@@ -381,6 +391,8 @@ def map_to_arrow_(
         return NoneToArrowNone(type, mapper, artifact, path)
     elif isinstance(type, types.UnknownType):
         return UnknownToArrowNone(type, mapper, artifact, path)
+    elif isinstance(type, types.TimeDelta):
+        return TimeDeltaToArrowTimeDelta(type, mapper, artifact, path)
     else:
         return DefaultToArrow(type, mapper, artifact, path)
 
@@ -416,6 +428,8 @@ def map_from_arrow_(type, mapper, artifact, path=[], mapper_options=None):
         return mappers_python.NoneToPyNone(type, mapper, artifact, path)
     elif isinstance(type, types.UnknownType):
         return UnknownToArrowNone(type, mapper, artifact, path)
+    elif isinstance(type, types.TimeDelta):
+        return ArrowTimeDeltaToTimeDelta(type, mapper, artifact, path)
     else:
         return DefaultFromArrow(type, mapper, artifact, path)
 

--- a/weave/ops_arrow/arrow.py
+++ b/weave/ops_arrow/arrow.py
@@ -392,7 +392,7 @@ def _object_type_is_basic(object_type):
     if isinstance(object_type, types.Const):
         object_type = object_type.val_type
     return isinstance(object_type, types.BasicType) or (
-        isinstance(object_type, types.Timestamp)
+        isinstance(object_type, (types.Timestamp, types.TimeDelta))
     )
 
 

--- a/weave/ops_arrow/date.py
+++ b/weave/ops_arrow/date.py
@@ -148,10 +148,11 @@ def timestamp_max(self):
     return pc.max(array).as_py()
 
 
-@op(
-    name="timedelta-totalSeconds",
-    input_type={"td": types.TimeDelta()},
-    output_type=types.Number(),
+@arrow_op(
+    name="ArrowWeaveListTimeDelta-totalSeconds",
+    input_type={"td": ArrowWeaveListType(types.TimeDelta())},
+    output_type=ArrowWeaveListType(types.Number()),
 )
 def timedelta_total_seconds(td):
-    return pc.cast(pc.cast(td, pa.duration("s")), pa.float64())
+    new_arrow_data = pc.divide(pc.cast(td._arrow_data, pa.int64()), 1e6)
+    return ArrowWeaveList(new_arrow_data, types.Number(), td._artifact)

--- a/weave/ops_arrow/date.py
+++ b/weave/ops_arrow/date.py
@@ -146,3 +146,12 @@ def timestamp_min(self):
 def timestamp_max(self):
     array = self._arrow_data_asarray_no_tags()
     return pc.max(array).as_py()
+
+
+@op(
+    name="timedelta-totalSeconds",
+    input_type={"td": types.TimeDelta()},
+    output_type=types.Number(),
+)
+def timedelta_total_seconds(td):
+    return pc.cast(pc.cast(td, pa.duration("s")), pa.float64())

--- a/weave/ops_arrow/list_.py
+++ b/weave/ops_arrow/list_.py
@@ -1009,6 +1009,7 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
                     types.ObjectType,
                     types.UnionType,
                     types.Function,
+                    types.TimeDelta,
                 ),
             ):
                 return None

--- a/weave/tests/test_arrow_vectorizer.py
+++ b/weave/tests/test_arrow_vectorizer.py
@@ -7,7 +7,7 @@ from .. import api as weave
 from .. import ops
 from .. import weave_types as types
 from .. import weave_internal
-from ..ops_primitives import dict_, list_
+from ..ops_primitives import dict_, list_, date
 from .. import errors
 
 from ..language_features.tagging import tag_store, tagged_value_type, make_tag_getter_op
@@ -21,6 +21,8 @@ from ..ops_domain import wb_domain_types as wdt
 
 from ..ops_domain import run_ops
 
+
+import datetime
 
 import pyarrow as pa
 
@@ -1390,3 +1392,19 @@ def test_boxed_null_in_array_equal():
     rhs = box.box(None)
     assert util.equal(lhs, rhs).to_pylist() == [False, True, False]
     assert util.not_equal(lhs, rhs).to_pylist() == [True, False, True]
+
+
+def test_duration():
+    dt1 = datetime.timedelta(seconds=1)
+    dt2 = datetime.timedelta(seconds=2)
+    dt3 = datetime.timedelta(seconds=3)
+
+    awl_node = weave.save(arrow.to_arrow([dt1, dt2, dt3]))
+
+    fn = weave_internal.define_fn(
+        {"row": awl_node.type.object_type},
+        lambda row: date.timedelta_total_seconds(row),
+    ).val
+    vec_fn = arrow.vectorize(fn)
+    called = weave_internal.call_fn(vec_fn, {"row": awl_node})
+    assert list(weave.use(called)) == [1, 2, 3]


### PR DESCRIPTION
This PR introduces a new duration type to handle time deltas and adds vectorization to the `totalSeconds` operation for time deltas.

### Changes:
- Two new mapper classes `TimeDeltaToArrowTimeDelta` and `ArrowTimeDeltaToTimeDelta` for converting between Python timedelta objects and Arrow time delta types.
- An operation `timedelta_total_seconds` is added in `weave/ops_arrow/date.py` that calculates the total seconds from a timedelta object, casting it to a float64 for precision.
- The `_object_type_is_basic` function in `weave/ops_arrow/arrow.py` now considers `TimeDelta` as a basic type.
- Unit tests are added to ensure the correct operation of the new duration type conversion and the `totalSeconds` function.
