### PR TITLE
fix: don't show column name changes if canceled

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable.styles.ts
+++ b/weave-js/src/components/Panel2/PanelTable.styles.ts
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 import {OBLIVION} from '../../common/css/color.styles';
 import {hexToRGB} from '../../common/css/utils';
-import {IconButton} from '../IconButton';
 
 export const ColumnHeader = styled.div`
   display: flex;
@@ -226,13 +225,6 @@ export const CellWrapper = styled.div`
   }
 `;
 CellWrapper.displayName = 'S.CellWrapper';
-
-export const CloseIconButton = styled(IconButton)`
-  position: absolute;
-  right: 8px;
-  top: 12px;
-`;
-CloseIconButton.displayName = 'S.CloseIconButton';
 
 export const IndexCellCheckboxWrapper = styled.div<{isSelected: boolean}>`
   ${({isSelected}) => (isSelected ? '' : 'visibility: hidden;')}

--- a/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
@@ -23,9 +23,10 @@ import {Popup} from 'semantic-ui-react';
 import {useWeaveContext} from '../../../context';
 import {focusEditor, WeaveExpression} from '../../../panel/WeaveExpression';
 import {SUGGESTION_OPTION_CLASS} from '../../../panel/WeaveExpression/styles';
+import {Button} from '../../Button';
+import {Tooltip} from '../../Tooltip';
 import {usePanelStacksForType} from '../availablePanels';
 import * as ExpressionView from '../ExpressionView';
-import {IconClose} from '../Icons';
 import {PanelComp2} from '../PanelComp';
 import {PanelContextProvider, usePanelContext} from '../PanelContext';
 import {makeEventRecorder} from '../panellib/libanalytics';
@@ -305,8 +306,8 @@ export const ColumnHeader: React.FC<{
 
   let columnTypeForGroupByChecks = stripTag(workingSelectFunction.type);
   if (!isGroupCol) {
-    /* 
-      Once one column is grouped, the other non-grouped columns are all typed as 
+    /*
+      Once one column is grouped, the other non-grouped columns are all typed as
       lists. So we need to figure out the inner types of the non-grouped columns.
       */
     columnTypeForGroupByChecks = isListLike(columnTypeForGroupByChecks)
@@ -538,12 +539,12 @@ export const ColumnHeader: React.FC<{
                 marginRight: `-${colControlsWidth}px`,
               }}
               onClick={() => setColumnSettingsOpen(!columnSettingsOpen)}>
-              {workingColumnName !== '' ? (
-                <S.ColumnNameText>{workingColumnName}</S.ColumnNameText>
+              {propsColumnName !== '' ? (
+                <S.ColumnNameText>{propsColumnName}</S.ColumnNameText>
               ) : (
                 <ExpressionView.ExpressionView
                   frame={cellFrame}
-                  node={workingSelectFunction}
+                  node={propsSelectFunction}
                 />
               )}
             </S.ColumnName>
@@ -551,9 +552,19 @@ export const ColumnHeader: React.FC<{
           content={
             columnSettingsOpen && (
               <div>
-                <S.CloseIconButton onClick={() => setColumnSettingsOpen(false)}>
-                  <IconClose width={20} />
-                </S.CloseIconButton>
+                <Tooltip
+                  // Button's built-in tooltip attribute won't position properly with custom wrapper style.
+                  trigger={
+                    <Button
+                      variant="ghost"
+                      icon="close"
+                      size="small"
+                      twWrapperStyles={{position: 'absolute', right: 8}}
+                      onClick={() => setColumnSettingsOpen(false)}
+                    />
+                  }
+                  content="Discard changes"
+                />
                 <S.ColumnEditorSection>
                   <S.ColumnEditorSectionLabel>
                     Cell expression


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16406

As a user edited the expression or column name in the table column popup, the changes were immediately reflected in the displayed column header. However, the changes would not be reverted if the popup was canceled.

This change keeps the displayed column header at its starting value, which is consistent with the displayed cell values.

This PR also updates the close button on this panel to use new common components and have a tooltip.

Before:
<img width="390" alt="Screenshot 2023-11-17 at 11 27 54 AM" src="https://github.com/wandb/weave/assets/112953339/0938ddb8-e415-4067-af93-265514084179">

After:
<img width="524" alt="Screenshot 2023-11-17 at 11 23 10 AM" src="https://github.com/wandb/weave/assets/112953339/208bb3b5-0eb7-464e-874f-69266e464c67">
