### PR TITLE
fix: select panel on add and don't deselect if deleting other

### DIFF
--- a/weave-js/src/components/PagePanelContext.tsx
+++ b/weave-js/src/components/PagePanelContext.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 type RequestedActionType = {
-  onClick: () => void;
+  onClick: (event: React.MouseEvent) => void;
   label: string;
   Icon: React.ReactNode;
 };

--- a/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
@@ -1,6 +1,7 @@
 import {MOON_250} from '@wandb/weave/common/css/color.styles';
 import * as DropdownMenu from '@wandb/weave/components/DropdownMenu';
 import {produce} from 'immer';
+import * as _ from 'lodash';
 import React, {memo, useCallback, useMemo} from 'react';
 import styled from 'styled-components';
 
@@ -12,7 +13,10 @@ import {
   // IconRetry,
   IconSplit,
 } from '../Panel2/Icons';
-import {useSetInteractingPanel} from '../Panel2/PanelInteractContext';
+import {
+  useSelectedPath,
+  useSetInteractingPanel,
+} from '../Panel2/PanelInteractContext';
 import {
   addChild,
   getPath,
@@ -54,6 +58,9 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
 }) => {
   const setInteractingPanel = useSetInteractingPanel();
   const {isNumItemsLocked} = config.config;
+
+  const selectedPath = useSelectedPath();
+  const isDeletingSelected = _.isEqual(path, selectedPath);
 
   const handleDelete = useCallback(
     (ev: React.MouseEvent) => {
@@ -97,9 +104,11 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
         })
       );
 
-      goBackToOutline?.();
+      if (isDeletingSelected) {
+        goBackToOutline?.();
+      }
     },
-    [path, config, updateConfig, goBackToOutline]
+    [path, config, updateConfig, goBackToOutline, isDeletingSelected]
   );
 
   // const handleUnnest = useCallback(


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16367

When a panel was deleted through its overflow dropdown, we were navigating back to the outline, even if a different panel was being configured.

This also adds the automatic selection for configuration of a panel added with one of the "New panel" buttons.