### PR TITLE
chore: use common component for back to outline button

### DIFF
--- a/weave-js/src/components/Panel2/PanelPanel.tsx
+++ b/weave-js/src/components/Panel2/PanelPanel.tsx
@@ -437,10 +437,13 @@ export const PanelPanelConfig: React.FC<PanelPanelProps> = props => {
     <SidebarConfig.Container>
       <SidebarConfig.Header>
         <SidebarConfig.HeaderTop lessLeftPad>
-          <SidebarConfig.HeaderTopLeft canGoBack onClick={goBackToOutline}>
-            <Button icon="back" variant="ghost" size="small" />
-            <SidebarConfig.HeaderTopText>Outline</SidebarConfig.HeaderTopText>
-          </SidebarConfig.HeaderTopLeft>
+          <Button
+            variant="ghost"
+            size="small"
+            icon="back"
+            onClick={goBackToOutline}>
+            Outline
+          </Button>
           <SidebarConfig.HeaderTopRight>
             {!selectedIsRoot && !shouldShowOutline && (
               <OutlineItemPopupMenu

--- a/weave-js/src/components/Sidebar/Config.tsx
+++ b/weave-js/src/components/Sidebar/Config.tsx
@@ -1,9 +1,8 @@
 import {
   GRAY_350,
-  GRAY_500,
   SCROLLBAR_STYLES,
 } from '@wandb/weave/common/css/globals.styles';
-import styled, {css} from 'styled-components';
+import styled from 'styled-components';
 
 export const Container = styled.div`
   display: flex;
@@ -27,15 +26,9 @@ export const HeaderTop = styled.div<{lessLeftPad?: boolean}>`
 `;
 HeaderTop.displayName = 'S.HeaderTop';
 
-export const HeaderTopLeft = styled.div<{canGoBack?: boolean}>`
+export const HeaderTopLeft = styled.div`
   display: flex;
   align-items: center;
-  ${p =>
-    p.canGoBack &&
-    css`
-      color: ${GRAY_500};
-      cursor: pointer;
-    `}
 `;
 HeaderTopLeft.displayName = 'S.HeaderTopLeft';
 


### PR DESCRIPTION
The "back to Outline" button is a non-standard component. Because of this, hovering over the back arrow will highlight the background, hovering over the "Outline" text will not, even though clicking either does the same thing.

Before:
<img width="331" alt="Screenshot 2023-11-20 at 2 54 06 PM" src="https://github.com/wandb/weave/assets/112953339/b7bd53e2-ce32-41ad-a2e2-dead4424e2e4">
<img width="317" alt="Screenshot 2023-11-20 at 2 49 46 PM" src="https://github.com/wandb/weave/assets/112953339/06c05fd3-6e06-4d14-84c5-a56b779e1dc9">


After:
<img width="326" alt="Screenshot 2023-11-20 at 2 48 43 PM" src="https://github.com/wandb/weave/assets/112953339/16131de2-b5ca-45c8-96e9-753351327990">
<img width="332" alt="Screenshot 2023-11-20 at 2 48 46 PM" src="https://github.com/wandb/weave/assets/112953339/4f4e6eb8-ee26-432f-a1ca-e37a3ddf63a6">

