### PR TITLE
fix: local integration tests broken by night mode

### DIFF
--- a/weave-js/src/entrypoint.tsx
+++ b/weave-js/src/entrypoint.tsx
@@ -18,7 +18,10 @@ import PagePanel from './components/PagePanel';
 import {PanelRootContextProvider} from './components/Panel2/PanelPanel';
 import {WeaveMessage} from './components/Panel2/WeaveMessage';
 import getConfig from './config';
-import {WeaveViewerContextProvider} from './context/WeaveViewerContext';
+import {
+  useIsAuthenticated,
+  WeaveViewerContextProvider,
+} from './context/WeaveViewerContext';
 import {NotebookComputeGraphContextProvider} from './contextProviders';
 import {
   URL_BROWSE,
@@ -107,23 +110,28 @@ type MainProps = {
   browserType?: string;
 };
 
-const Main = ({browserType}: MainProps) => (
-  <React.Suspense fallback="loading">
-    <ErrorBoundary>
-      <NotebookComputeGraphContextProvider>
-        <StateInspector name="WeaveApp">
-          <PanelRootContextProvider>
-            <WeaveViewerContextProvider>
-              <Themer>
-                <PagePanel browserType={browserType} />
-              </Themer>
-            </WeaveViewerContextProvider>
-          </PanelRootContextProvider>
-        </StateInspector>
-      </NotebookComputeGraphContextProvider>
-    </ErrorBoundary>
-  </React.Suspense>
-);
+const Main = ({browserType}: MainProps) => {
+  // If we aren't authenticated, we don't have the ability to see/set the
+  // user's night mode preference, so we just omit the theme support entirely.
+  const isAuthed = useIsAuthenticated();
+  let page = <PagePanel browserType={browserType} />;
+  if (isAuthed) {
+    page = <Themer>{page}</Themer>;
+  }
+  return (
+    <React.Suspense fallback="loading">
+      <ErrorBoundary>
+        <NotebookComputeGraphContextProvider>
+          <StateInspector name="WeaveApp">
+            <PanelRootContextProvider>
+              <WeaveViewerContextProvider>{page}</WeaveViewerContextProvider>
+            </PanelRootContextProvider>
+          </StateInspector>
+        </NotebookComputeGraphContextProvider>
+      </ErrorBoundary>
+    </React.Suspense>
+  );
+};
 
 const basename = getConfig().PREFIX;
 ReactDOM.render(


### PR DESCRIPTION
Internal slack thread: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1700594468967239

When not authenticated, useViewerUserInfo query was always staying in a "loading" state, which prevented the page from displaying. As a follow up, we should decide if we want to change `useNodeValue`'s behavior with respect to `skip` and `loading`.