### PR TITLE
fix(panelplot): escape dots correctly in panelplot tooltip pick op

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
@@ -11,6 +11,7 @@ import {
   constNodeUnsafe,
   constNumber,
   constString,
+  escapeDots,
   filterNodes,
   isAssignableTo,
   isConstNode,
@@ -714,7 +715,16 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
                   }),
                   index: constNumber(row._rowIndex),
                 }),
-                key: constString(vegaCols[row._seriesIndex].tooltip),
+                key: constString(
+                  escapeDots(
+                    TableState.getTableColumnName(
+                      s.table.columnNames,
+                      s.table.columnSelectFunctions,
+                      s.dims.tooltip,
+                      weave.client.opStore
+                    )
+                  )
+                ),
               });
             } else {
               acc[key] = constNodeUnsafe(

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
@@ -744,6 +744,7 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
       vegaCols,
       vegaReadyTables,
       flatResultNode,
+      weave.client.opStore,
     ]);
 
   const tooltipLineData: {[x: string]: ConstNode} = useMemo(() => {


### PR DESCRIPTION
Fixes an issue where circumventing the panelplot tooltip cache for image files did not work properly for columns that had dots in the names, causing tooltips to appear as `PanelNone`. This reinstates the code from the pre-cache tooltip path, using the proper logic for `escapeDots` to handle those cases and select the right column names.