### PR TITLE
chore: update PanelError to use new Icon component

### DIFF
--- a/weave-js/src/common/components/elements/PanelError.styles.ts
+++ b/weave-js/src/common/components/elements/PanelError.styles.ts
@@ -1,6 +1,0 @@
-import styled from 'styled-components';
-
-export const IconWrapper = styled.div`
-  font-size: 1.5rem;
-  margin-bottom: 4px;
-`;

--- a/weave-js/src/common/components/elements/PanelError.tsx
+++ b/weave-js/src/common/components/elements/PanelError.tsx
@@ -1,8 +1,8 @@
-import {WBIcon} from '@wandb/ui';
 import classNames from 'classnames';
 import React from 'react';
 
-import * as S from './PanelError.styles';
+import {IconInfo} from '../../../components/Icon';
+import {Tailwind} from '../../../components/Tailwind';
 
 type PanelErrorProps = {
   message: React.ReactChild;
@@ -13,12 +13,10 @@ const PanelError: React.FC<PanelErrorProps> = React.memo(
   ({message, className}) => {
     return (
       <div className={classNames('panel-error', className)}>
-        <div>
-          <S.IconWrapper>
-            <WBIcon name="info" />
-          </S.IconWrapper>
+        <Tailwind>
+          <IconInfo width={24} height={24} className="m-auto mb-4" />
           <div>{message}</div>
-        </div>
+        </Tailwind>
       </div>
     );
   }


### PR DESCRIPTION
Before:
<img width="768" alt="before" src="https://github.com/wandb/weave/assets/112953339/277a6e41-1674-4db1-9d04-44eb1b755827">

After:
<img width="824" alt="after" src="https://github.com/wandb/weave/assets/112953339/cd76ff89-9257-46fb-894a-f60c21da7b1d">
