### PR TITLE
fix: don't show const values in default tooltips

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
@@ -669,16 +669,15 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
           const selectFn = table.columnSelectFunctions[colId];
           if (isVoidNode(selectFn)) {
             // use default tooltip
-            const nonNullDims: ExprDimNameType[] = [];
-
             const propertyTypes = PlotState.EXPRESSION_DIM_NAMES.reduce(
               (acc2: {[vegaColName: string]: Type}, dim: ExprDimNameType) => {
                 const colid = s.dims[dim];
 
-                if (!isVoidNode(table.columnSelectFunctions[colid])) {
-                  nonNullDims.push(dim);
+                if (
+                  !isVoidNode(table.columnSelectFunctions[colid]) &&
+                  !isConstNode(table.columnSelectFunctions[colid])
+                ) {
                   const colType = table.columnSelectFunctions[colid].type;
-
                   acc2[vegaCols[row._seriesIndex][dim]] = isTaggedValue(colType)
                     ? taggedValueValueType(colType)
                     : colType;


### PR DESCRIPTION
Update the default tooltip code to ignore const nodes, i.e. mark shape and size are default const values.

Before:
<img width="244" alt="Screenshot 2023-11-27 at 3 53 17 PM" src="https://github.com/wandb/weave/assets/112953339/fb6e555c-04bb-4523-b06e-cbeedb3d8be8">

After:
<img width="250" alt="Screenshot 2023-11-27 at 3 52 57 PM" src="https://github.com/wandb/weave/assets/112953339/5bff91a8-9f3b-41d6-9b24-73d4fa511de6">
