### PR TITLE
chore: Fix RAG example relocatability

### DIFF
--- a/weave/artifact_fs.py
+++ b/weave/artifact_fs.py
@@ -109,6 +109,10 @@ class FilesystemArtifact(artifact_base.Artifact):
     ) -> typing.Generator[typing.IO, None, None]:
         raise NotImplementedError
 
+    @contextlib.contextmanager
+    def writeable_file_path(self, path: str) -> typing.Generator[str, None, None]:
+        raise NotImplementedError
+
     def ref_from_local_str(self, s: str, type: "types.Type") -> "FilesystemArtifactRef":
         path, extra = ref_util.parse_local_ref_str(s)
         return self.RefClass(self, path=path, extra=extra, type=type)

--- a/weave/registry_mem.py
+++ b/weave/registry_mem.py
@@ -80,7 +80,7 @@ class Registry:
     def get_op(self, uri: str) -> op_def.OpDef:
         object_uri = uris.WeaveURI.parse(uri)
         if object_uri.version is not None:
-            object_key = (object_uri.name, object_uri.version)
+            object_key = (object_uri.name, object_uri.version, object_uri.path)
             if object_key in self._op_versions:
                 res = self._op_versions[object_key]
             else:
@@ -164,10 +164,8 @@ class Registry:
         # see comment here: https://github.com/wandb/weave-internal/pull/554#discussion_r1103875156
         if op.location is not None:
             ref = storage.save(op, name=new_name)
-            location = ref.artifact.uri_obj
-            version = ref.version
-            op.version = version
-            op.location = location
+            op.version = ref.version
+            op.location = uris.WeaveURI.parse(ref.uri)
 
         if op.version is not None:
             self._op_versions.pop((name, old_version))

--- a/weave/registry_mem.py
+++ b/weave/registry_mem.py
@@ -25,7 +25,8 @@ class Registry:
     # common_name: name: op_def
     _ops_by_common_name: typing.Dict[str, dict[str, op_def.OpDef]]
 
-    _op_versions: typing.Dict[typing.Tuple[str, str], op_def.OpDef]
+    # Ops stored by their URI (for ops that are non-builtin).
+    _op_versions: typing.Dict[str, op_def.OpDef]
 
     # Maintains a timestamp of when the registry was last updated.
     # This is useful for caching the ops dictionary when serving
@@ -70,8 +71,8 @@ class Registry:
         # if not is_loading:
         self._ops[op.name] = op
         self._ops_by_common_name.setdefault(op.common_name, {})[op.name] = op
-        if version:
-            self._op_versions[(op.name, version)] = op
+        if location:
+            self._op_versions[str(location)] = op
         return op
 
     def have_op(self, op_name: str) -> bool:
@@ -80,7 +81,7 @@ class Registry:
     def get_op(self, uri: str) -> op_def.OpDef:
         object_uri = uris.WeaveURI.parse(uri)
         if object_uri.version is not None:
-            object_key = (object_uri.name, object_uri.version, object_uri.path)
+            object_key = str(object_uri)
             if object_key in self._op_versions:
                 res = self._op_versions[object_key]
             else:
@@ -158,7 +159,7 @@ class Registry:
         self._ops_by_common_name[op.common_name].pop(name)
         self._ops_by_common_name.setdefault(op.common_name, {})[new_name] = op
 
-        old_version = op.version
+        old_location = op.location
 
         # TODO(DG): find a better way to do this than to save the op again
         # see comment here: https://github.com/wandb/weave-internal/pull/554#discussion_r1103875156
@@ -168,8 +169,8 @@ class Registry:
             op.location = uris.WeaveURI.parse(ref.uri)
 
         if op.version is not None:
-            self._op_versions.pop((name, old_version))
-            self._op_versions[(new_name, op.version)] = op
+            self._op_versions.pop(str(old_location))
+            self._op_versions[str(op.location)] = op
 
     # def register_type(self, type: weave_types.Type):
     #    self._types[type.name] = type

--- a/weave/weaveflow/__init__.py
+++ b/weave/weaveflow/__init__.py
@@ -13,3 +13,5 @@ from .model_eval import *
 from .openai import *
 from .anyscale import *
 from .huggingface import *
+
+from .faiss import *

--- a/weave/weaveflow/faiss.py
+++ b/weave/weaveflow/faiss.py
@@ -1,0 +1,13 @@
+import faiss
+import weave
+
+
+class FaissIndexType(weave.types.Type):
+    instance_classes = [faiss.Index]
+
+    def save_instance(self, obj, artifact, name):
+        with artifact.writeable_file_path(f"{name}.faissindex") as write_path:
+            faiss.write_index(obj, write_path)
+
+    def load_instance(self, artifact, name, extra):
+        return faiss.read_index(artifact.path(f"{name}.faissindex"))

--- a/weave/weaveflow/faiss.py
+++ b/weave/weaveflow/faiss.py
@@ -1,13 +1,23 @@
 import faiss
+import typing
 import weave
+
+from weave import artifact_fs
 
 
 class FaissIndexType(weave.types.Type):
     instance_classes = [faiss.Index]
 
-    def save_instance(self, obj, artifact, name):
+    def save_instance(
+        self, obj: faiss.Index, artifact: artifact_fs.FilesystemArtifact, name: str
+    ) -> None:
         with artifact.writeable_file_path(f"{name}.faissindex") as write_path:
             faiss.write_index(obj, write_path)
 
-    def load_instance(self, artifact, name, extra):
+    def load_instance(
+        self,
+        artifact: artifact_fs.FilesystemArtifact,
+        name: str,
+        extra: typing.Optional[list[str]] = None,
+    ) -> faiss.Index:
         return faiss.read_index(artifact.path(f"{name}.faissindex"))


### PR DESCRIPTION
Two bug fixes for handling nested published object/op saving and loading.

Also adds a weave type for FAISS indexes.