### PR TITLE
chore: fix dev warning by prefixing styled component prop

### DIFF
--- a/weave-js/src/components/Panel2/PanelString.styles.ts
+++ b/weave-js/src/components/Panel2/PanelString.styles.ts
@@ -2,9 +2,9 @@ import * as globals from '@wandb/weave/common/css/globals.styles';
 import styled from 'styled-components';
 
 export const StringContainer = styled.div<{
-  spacing?: boolean;
+  $spacing?: boolean;
 }>`
-  padding: ${p => (p.spacing ? '4px 1em' : '0 1em')};
+  padding: ${p => (p.$spacing ? '4px 1em' : '0 1em')};
   width: 100%;
   height: 100%;
   display: flex;
@@ -22,9 +22,9 @@ export const StringContainer = styled.div<{
 StringContainer.displayName = 'S.StringContainer';
 
 export const StringItem = styled.div<{
-  spacing?: boolean;
+  $spacing?: boolean;
 }>`
-  margin: ${p => (p.spacing ? '0' : 'auto')};
+  margin: ${p => (p.$spacing ? '0' : 'auto')};
   width: 100%;
   /* padding: 4px; */
   max-height: 100%;

--- a/weave-js/src/components/Panel2/PanelString.tsx
+++ b/weave-js/src/components/Panel2/PanelString.tsx
@@ -163,8 +163,8 @@ export const PanelString: React.FC<PanelStringProps> = props => {
         />
       );
       return (
-        <S.StringContainer spacing={spacing}>
-          <S.StringItem spacing={spacing}>
+        <S.StringContainer $spacing={spacing}>
+          <S.StringItem $spacing={spacing}>
             <TooltipTrigger
               copyableContent={fullStr}
               content={contentMarkdown}
@@ -204,8 +204,8 @@ export const PanelString: React.FC<PanelStringProps> = props => {
       );
 
       return (
-        <S.StringContainer spacing={spacing}>
-          <S.StringItem spacing={spacing}>
+        <S.StringContainer $spacing={spacing}>
+          <S.StringItem $spacing={spacing}>
             <TooltipTrigger copyableContent={fullStr} content={contentDiff}>
               {contentDiff}
             </TooltipTrigger>
@@ -222,8 +222,8 @@ export const PanelString: React.FC<PanelStringProps> = props => {
 
     // plaintext
     return (
-      <S.StringContainer data-test-weave-id="string" spacing={spacing}>
-        <S.StringItem spacing={spacing}>
+      <S.StringContainer data-test-weave-id="string" $spacing={spacing}>
+        <S.StringItem $spacing={spacing}>
           <TooltipTrigger copyableContent={fullStr} content={contentPlaintext}>
             {contentPlaintext}
           </TooltipTrigger>


### PR DESCRIPTION
Prefix the `spacing` prop in PanelString's styled components with a `$` - this prevents the prop from being passed through to the DOM and fixes the following dev console warning:

<img width="1071" alt="Screenshot 2023-11-28 at 9 03 46 AM" src="https://github.com/wandb/weave/assets/112953339/f11cfe4f-d2a8-48e5-a085-1b9959fe9aa9">
