### PR TITLE
fix: sometimes showing wrong panel config

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -802,10 +802,37 @@ export const ChildPanelConfigComp: React.FC<ChildPanelProps> = props => {
   // Render everything along this path, and its descendants, but only show
   // the controls for this and its descendants.
 
+  // Panels are organized into a tree as seen in the Outline. A board with a
+  // variable and two panels in the main section might look like this:
+  //
+  // <root>
+  //   sidebar
+  //     data
+  //   main
+  //     panel
+  //     panel0
+  //
+  // pathStr is a period-delimited string that identifies a panel.
+  // E.g. <root>.main.panel0
+  // The full delimited path is important for identification as e.g. "panel0" could
+  // have a child that is also named "panel0".
+  // We need to proceed with config display in three cases:
+  // 1. This component is the selected component.
+  // 2. This component is a descendent of the selected component. (E.g. parent is a Group)
+  // 3. This component is an ancestor of the selected component, we need to recurse down.
+  // For other cases display nothing.
+  const isThisPanelSelected = pathStr === selectedPathStr;
+
+  // Handle this panel is <root>.main.panel.child and <root>.main.panel is selected
+  const isThisPanelDescendantOfSelected = isAncestor(pathStr, selectedPathStr);
+
+  // Handle <root>.main.panel is selected and this is <root>.main
+  const isThisPanelAncestorOfSelected = isAncestor(selectedPathStr, pathStr);
+
   const nothingToShow =
-    pathStr !== selectedPathStr &&
-    !isAncestor(pathStr, selectedPathStr) && // E.g. If Group is selected, descendants would show
-    !isAncestor(selectedPathStr, pathStr); // Need to be able to recurse down to selection
+    !isThisPanelSelected &&
+    !isThisPanelDescendantOfSelected &&
+    !isThisPanelAncestorOfSelected;
   if (nothingToShow) {
     return null;
   }

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -758,6 +758,12 @@ const NEW_INSPECTOR_IMPLEMENTED_FOR = new Set([
   `Sections`,
 ]);
 
+// Return true if maybeAncestor is an ancestor of path.
+// Returns false for self and other non-ancestors.
+const isAncestor = (path: string, maybeAncestor: string): boolean => {
+  return path.startsWith(maybeAncestor + '.');
+};
+
 export const ChildPanelConfigComp: React.FC<ChildPanelProps> = props => {
   const {
     newVars,
@@ -796,12 +802,12 @@ export const ChildPanelConfigComp: React.FC<ChildPanelProps> = props => {
   // Render everything along this path, and its descendants, but only show
   // the controls for this and its descendants.
 
-  if (
-    !selectedPathStr.startsWith(pathStr) &&
-    !pathStr.startsWith(selectedPathStr)
-  ) {
-    // Off the path
-    return <></>;
+  const nothingToShow =
+    pathStr !== selectedPathStr &&
+    !isAncestor(pathStr, selectedPathStr) && // E.g. If Group is selected, descendants would show
+    !isAncestor(selectedPathStr, pathStr); // Need to be able to recurse down to selection
+  if (nothingToShow) {
+    return null;
   }
 
   // If we are selected, expose controls for input expression, panel selection,

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -758,10 +758,10 @@ const NEW_INSPECTOR_IMPLEMENTED_FOR = new Set([
   `Sections`,
 ]);
 
-// Return true if maybeAncestor is an ancestor of path.
-// Returns false for self and other non-ancestors.
-const isAncestor = (path: string, maybeAncestor: string): boolean => {
-  return path.startsWith(maybeAncestor + '.');
+// Return true if the panel with path maybeAncestorPath is an ancestor of the
+// given panel's path. Returns false for self and other non-ancestors.
+const isAncestor = (panelPath: string, maybeAncestorPath: string): boolean => {
+  return panelPath.startsWith(maybeAncestorPath + '.');
 };
 
 export const ChildPanelConfigComp: React.FC<ChildPanelProps> = props => {


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16482
Internal slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1701182330468479

The condition for when not to show panel configuration was incorrect e.g. `main.panel` is a prefix of `main.panel0` but `panel` would not be an ancestor of `panel0`.