### PR TITLE
fix: ensure eager mode is disabled in server

### DIFF
--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -388,6 +388,11 @@ def send_local_file(path):
     return send_from_directory("/", path)
 
 
+@blueprint.before_app_first_request
+def _disable_eager_mode():
+    context_state._eager_mode.set(False)
+
+
 def frontend_env():
     """If you add vars here, make sure to define their types in weave-js/src/config.ts"""
     return {

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -388,7 +388,7 @@ def send_local_file(path):
     return send_from_directory("/", path)
 
 
-@blueprint.before_app_first_request
+@blueprint.before_request
 def _disable_eager_mode():
     context_state._eager_mode.set(False)
 


### PR DESCRIPTION
This PR ensures that eager execution mode is disabled whenever we run the server as a flask application. This ensures the standalone server always operates in lazy execution mode. This fixes an exception in the parquet history path that is raised by the server when this function is executed: 

```python
def concat_awls(awls: list[ArrowWeaveList]):
    list = make_list(**{str(i): table for i, table in enumerate(awls)})
    with compile.disable_compile():
        return use(concat(list))
```