### PR TITLE
chore: update color config overflow menu to use new button

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/ConfigDimComponent.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/ConfigDimComponent.tsx
@@ -12,8 +12,8 @@ import {
   useWeaveContext,
   useWeaveRedesignedPlotConfigEnabled,
 } from '../../../context';
+import {Button} from '../../Button';
 import {IconLockedConstrained, IconUnlockedUnconstrained} from '../../Icon';
-import {IconButton} from '../../IconButton';
 import {PopupMenu, Section} from '../../Sidebar/PopupMenu';
 import {Tooltip} from '../../Tooltip';
 import * as ConfigPanel from '../ConfigPanel';
@@ -23,7 +23,6 @@ import {
   IconDelete,
   IconFullScreenModeExpand,
   IconMinimizeMode,
-  IconOverflowHorizontal,
   IconWeave,
 } from '../Icons';
 import * as TableState from '../PanelTable/tableState';
@@ -33,12 +32,6 @@ import * as S from './styles';
 import {DimComponentInputType, DimOption, DimOptionOrSection} from './types';
 import {PLOT_DIMS_UI, SeriesConfig} from './versions';
 import {WeaveExpressionDimConfig} from './WeaveExpressionDimConfig';
-
-const ConfigDimMenuButton = styled(IconButton).attrs({small: true})`
-  margin-left: 4px;
-  padding: 3px;
-`;
-ConfigDimMenuButton.displayName = 'S.ConfigDimMenuButton';
 
 const IconBlank = styled.svg`
   width: 18px;
@@ -307,9 +300,7 @@ export const ConfigDimComponent: React.FC<DimComponentInputType> = props => {
           <PopupMenu
             position="bottom left"
             trigger={
-              <ConfigDimMenuButton>
-                <IconOverflowHorizontal />
-              </ConfigDimMenuButton>
+              <Button variant="ghost" size="small" icon="overflow-horizontal" />
             }
             items={menuItems}
             sections={menuSections}


### PR DESCRIPTION
Use standard button as trigger

Before:
<img width="327" alt="Screenshot 2023-11-29 at 10 47 28 AM" src="https://github.com/wandb/weave/assets/112953339/a3df37f5-24d6-40ea-a73f-6db0ebace5f6">

After:
<img width="312" alt="Screenshot 2023-11-29 at 10 46 29 AM" src="https://github.com/wandb/weave/assets/112953339/c73ab50b-4f59-4a8a-bfb7-55292fe5e991">
