### PR TITLE
perf: make eval faster by only publishing output type once

### DIFF
--- a/weave/weaveflow/evaluate.py
+++ b/weave/weaveflow/evaluate.py
@@ -35,13 +35,11 @@ class EvaluateLLM(Evaluate):
     def compute(self, dataset: Dataset, predictions: list[typing.Any]) -> typing.Any:
         scores = []
         rationales = []
-        result_type = (
-            weave.types.TypedDict(
-                {
-                    "score": weave.types.Float(),
-                    "rationale": weave.types.String(),
-                }
-            ),
+        result_type = weave.types.TypedDict(
+            {
+                "score": weave.types.Float(),
+                "rationale": weave.types.String(),
+            }
         )
 
         for example, prediction in zip(dataset.rows, predictions):

--- a/weave/weaveflow/evaluate.py
+++ b/weave/weaveflow/evaluate.py
@@ -35,18 +35,22 @@ class EvaluateLLM(Evaluate):
     def compute(self, dataset: Dataset, predictions: list[typing.Any]) -> typing.Any:
         scores = []
         rationales = []
+        result_type = (
+            weave.types.TypedDict(
+                {
+                    "score": weave.types.Float(),
+                    "rationale": weave.types.String(),
+                }
+            ),
+        )
+
         for example, prediction in zip(dataset.rows, predictions):
             # example_fields = self.format_example(example)
             messages = self.messages_template(example, prediction)
             try:
                 result = self.chat_llm.complete(
                     messages,
-                    weave.types.TypedDict(
-                        {
-                            "score": weave.types.Float(),
-                            "rationale": weave.types.String(),
-                        }
-                    ),
+                    result_type,
                 )
             except:
                 result = {"score": None, "rationale": None}


### PR DESCRIPTION
Makes LLM evals much faster by eliminating redundant publishing of eval output type. This shaved off ~5 minutes from each of my eval runs. 