### PR TITLE
feat: add quiet variant to button component

### DIFF
--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -63,6 +63,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const isPrimary = variant === 'primary';
     const isSecondary = variant === 'secondary';
     const isGhost = variant === 'ghost';
+    const isQuiet = variant === 'quiet';
     const isDestructive = variant === 'destructive';
 
     const hasBothIcons = startIcon && endIcon;
@@ -89,7 +90,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             classNames(
               'night-aware',
               "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
-              'disabled:pointer-events-none disabled:opacity-40',
+              'disabled:pointer-events-none disabled:opacity-35',
               'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
               {
                 // small
@@ -117,6 +118,14 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
                   isSecondary || isGhost,
                 'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400':
                   (isSecondary || isGhost) && active,
+
+                // quiet
+                'text-moon-500': isQuiet,
+                'bg-oblivion/[0.05] text-moon-800 dark:bg-moonbeam/[0.05] dark:text-moon-200':
+                  isQuiet && active,
+                'hover:text-moon-800 dark:hover:text-moon-200': isQuiet,
+                'hover:bg-oblivion/[0.05] dark:hover:bg-moonbeam/[0.05]':
+                  isQuiet,
 
                 // destructive
                 'bg-red-500 text-white hover:bg-red-450': isDestructive,

--- a/weave-js/src/components/Button/types.ts
+++ b/weave-js/src/components/Button/types.ts
@@ -9,6 +9,7 @@ export const ButtonVariants = {
   Primary: 'primary',
   Secondary: 'secondary',
   Ghost: 'ghost',
+  Quiet: 'quiet',
   Destructive: 'destructive',
 } as const;
 export type ButtonVariant =

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -851,7 +851,9 @@ const PanelTableInner: React.FC<
                       startIcon={rowSizeIconName[RowSize[rowSize]]}
                       onClick={() => setRowSize(RowSize[rowSize])}
                       active={config.rowSize === RowSize[rowSize]}
-                      variant="ghost"
+                      variant={
+                        config.rowSize === RowSize[rowSize] ? 'ghost' : 'quiet'
+                      }
                       size="small"
                     />
                   }
@@ -934,7 +936,7 @@ const PanelTableInner: React.FC<
         {!props.config.simpleTable && (
           <div style={{flex: '0 0 auto'}}>
             <Button
-              variant="ghost"
+              variant="quiet"
               size="small"
               onClick={() => {
                 downloadDataAsCSV();
@@ -946,7 +948,7 @@ const PanelTableInner: React.FC<
               trigger={
                 <Button
                   data-test="select-columns"
-                  variant="ghost"
+                  variant="quiet"
                   size="small"
                   onClick={() => {
                     recordEvent('SELECT_COLUMNS');
@@ -976,7 +978,7 @@ const PanelTableInner: React.FC<
             </Modal>
             <Button
               data-test="auto-columns"
-              variant="ghost"
+              variant="quiet"
               size="small"
               onClick={() => {
                 recordEvent('RESET_TABLE');

--- a/weave-js/tailwind.config.cjs
+++ b/weave-js/tailwind.config.cjs
@@ -186,7 +186,11 @@ module.exports = {
         700: '#193C80',
       },
     },
-    extend: {},
+    extend: {
+      opacity: {
+        35: '.35',
+      },
+    },
   },
   plugins: [require('tailwindcss-radix')],
   corePlugins: {


### PR DESCRIPTION
Adds a new button variant, "quiet" which is kind of like "ghost secondary" - for use where we don't want even as much visual prominence as a ghost button.

<img width="801" alt="Screenshot 2023-11-30 at 3 36 44 PM" src="https://github.com/wandb/weave/assets/112953339/eae706a6-039f-447a-9b17-1119218d8a4a">

Internal Figma: https://www.figma.com/file/01KWBdMZg5QM9SRS1pQq0z/Design-System----Robot-Styles?type=design&node-id=482-6745&mode=design&t=tQ229Vsx1axqFrOR-0
Internal Slack: https://weightsandbiases.slack.com/archives/C01QMPF38PQ/p1701375856855049?thread_ts=1701370967.808779&cid=C01QMPF38PQ
Internal Jira: https://wandb.atlassian.net/browse/WB-16512

This PR includes use of the quiet variant in the table panel as an example. Per @Cecile0112358 this represents the "selected" row height button by switching it to the active ghost variant.

Before: 
<img width="1329" alt="Screenshot 2023-11-30 at 3 31 46 PM" src="https://github.com/wandb/weave/assets/112953339/2599611c-77f8-4d96-b1be-5e394b70ea0e">

After:
![image](https://github.com/wandb/weave/assets/112953339/0179eb57-e7a2-494e-82bc-eb2fba321119)

Per @Cecile0112358 I have also dropped the opacity of disabled buttons from 40% to 35%. Core repo changes to match that tailwind config change and update the storybook will be in a separate PR.