### PR TITLE
fix: case-insensitive suggestion reordering

### DIFF
--- a/weave-js/src/core/suggest.ts
+++ b/weave-js/src/core/suggest.ts
@@ -68,6 +68,7 @@ import type {OpStore} from './opStore/types';
 import {findConsumingOp, isBinaryOp, opDisplayName} from './opStore/util';
 import {getStackAtNodeOrOp} from './refineHelpers';
 import {notEmpty} from './util/obj';
+import {trimStartChar} from './util/string';
 
 export interface AutosuggestResult<
   Replacement extends EditingNode | EditingOp
@@ -813,14 +814,15 @@ export async function autosuggest(
       );
     } else {
       // result = result.filter(item => item.suggestionString.includes(query));
+      const lowerQuery = trimStartChar(query, '.').toLocaleLowerCase();
       result = result.sort((a, b) => {
         return (
-          (b.suggestionString.includes(query!) ||
-          b.suggestionString.startsWith('"')
+          (b.suggestionString.startsWith('"') ||
+          b.suggestionString.toLocaleLowerCase().includes(lowerQuery)
             ? 1
             : -1) -
-          (a.suggestionString.includes(query!) ||
-          a.suggestionString.startsWith('"')
+          (a.suggestionString.startsWith('"') ||
+          a.suggestionString.toLocaleLowerCase().includes(lowerQuery)
             ? 1
             : -1)
         );

--- a/weave-js/src/core/util/string.test.ts
+++ b/weave-js/src/core/util/string.test.ts
@@ -1,4 +1,19 @@
-import {trimEndChar} from './string';
+import {trimEndChar, trimStartChar} from './string';
+
+describe('trimStartChar', () => {
+  it('handles start char does not exist', () => {
+    expect(trimStartChar('abc', 'd')).toEqual('abc');
+  });
+  it('ignores trim char not at start', () => {
+    expect(trimStartChar('abc', 'b')).toEqual('abc');
+  });
+  it('removes all trim char', () => {
+    expect(trimStartChar('aaaaabc', 'a')).toEqual('bc');
+  });
+  it('returns empty string if entirely trim char', () => {
+    expect(trimStartChar('aaaaa', 'a')).toEqual('');
+  });
+});
 
 describe('trimEndChar', () => {
   it('handles end char does not exist', () => {

--- a/weave-js/src/core/util/string.ts
+++ b/weave-js/src/core/util/string.ts
@@ -60,6 +60,15 @@ export function indent(s: string, level: number) {
 export const maybePluralize = (count: number, noun: string, suffix = 's') =>
   `${count} ${noun}${count !== 1 ? suffix : ''}`;
 
+// Return a new string with all occurrences of a character at the start of the input removed.
+export const trimStartChar = (str: string, char: string): string => {
+  let s = str;
+  while (s.startsWith(char)) {
+    s = s.slice(1);
+  }
+  return s;
+};
+
 // Return a new string with all occurrences of a character at the end of the input removed.
 export const trimEndChar = (str: string, char: string): string => {
   let s = str;


### PR DESCRIPTION
In expression editor, when user has entered a partial string, we sort matching results to the top. This was case-sensitive and the leading period in the query meant only matches at the start of the string would get sorted to the top, which did not seem to be the intent of the code.

Before:
No reordering
<img width="274" alt="Screenshot 2023-12-04 at 9 48 24 AM" src="https://github.com/wandb/weave/assets/112953339/4343ffa9-c79a-4bbd-a054-0ba87d91dc56">

After:
Case-insensitive matches have been sorted to top
<img width="314" alt="Screenshot 2023-12-04 at 9 47 39 AM" src="https://github.com/wandb/weave/assets/112953339/651e28ac-9e82-4e5d-9a0f-9a6b15a6d0a9">
