### PR TITLE
feat: Empty expression panels tell user to configure

### DIFF
--- a/weave-js/src/components/Panel2/PanelExpr.tsx
+++ b/weave-js/src/components/Panel2/PanelExpr.tsx
@@ -37,8 +37,8 @@ Secondary.displayName = 'S.Secondary';
 export const PanelExpression: React.FC<PanelExpressionProps> = props => {
   return (
     <Container>
-      <Primary>Panel requires configuration</Primary>
-      <Secondary>Please configure in the inspector.</Secondary>
+      <Primary>Empty panel</Primary>
+      <Secondary>Open the panel editor to configure.</Secondary>
     </Container>
   );
 };

--- a/weave-js/src/components/Panel2/PanelExpr.tsx
+++ b/weave-js/src/components/Panel2/PanelExpr.tsx
@@ -1,13 +1,46 @@
 import React from 'react';
+import styled from 'styled-components';
 
+import * as Colors from '../../common/css/color.styles';
 import * as Panel2 from './panel';
 
 const inputType = 'any';
 
 type PanelExpressionProps = Panel2.PanelProps<typeof inputType>;
 
+const Container = styled.div`
+  height: 100%;
+  color: ${Colors.MOON_450};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-style: normal;
+  font-family: Source Sans Pro;
+  line-height: 24px;
+  gap: 12px;
+`;
+Container.displayName = 'S.Container';
+
+const Primary = styled.div`
+  font-size: 20px;
+  font-weight: 600;
+`;
+Primary.displayName = 'S.Primary';
+
+const Secondary = styled.div`
+  font-size: 16px;
+  font-weight: 400;
+`;
+Secondary.displayName = 'S.Secondary';
+
 export const PanelExpression: React.FC<PanelExpressionProps> = props => {
-  return <></>;
+  return (
+    <Container>
+      <Primary>Panel requires configuration</Primary>
+      <Secondary>Please configure in the inspector.</Secondary>
+    </Container>
+  );
 };
 
 export const Spec: Panel2.PanelSpec = {


### PR DESCRIPTION
Internal Figma: https://www.figma.com/file/7FDRLfBXsEDyGWhH2IJ8Kn/Weave-plot-UX-improvements?type=design&node-id=2%3A3391&mode=dev
Internal Notion: https://www.notion.so/wandbai/RFC-Plot-UX-improvements-61b5f5c537ac444992b2736ae9a138cf?pvs=4#5f53e29a17d94c209e78b3eceae215d4
Internal Jira: https://wandb.atlassian.net/browse/WB-16488

<img width="588" alt="Screenshot 2023-12-04 at 10 15 48 AM" src="https://github.com/wandb/weave/assets/112953339/6a264cfa-29db-4937-b7b3-f46f85bdebe2">

(I have a slight concern about the term "inspector" since we don't use that elsewhere but matching what's in Figma for now.)