### PR TITLE
fix: incorrectly showing EE when other panel selected

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -584,7 +584,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     selectedDocumentId === documentId &&
     selectedPathStr !== '<root>' &&
     selectedPathStr !== '<root>.main' &&
-    pathStr.startsWith(selectedPathStr);
+    (pathStr === selectedPathStr || isAncestor(pathStr, selectedPathStr));
 
   const {ref: editorBarRef, width: editorBarWidth} =
     useElementWidth<HTMLDivElement>();


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16505

This is the same kind of bug that was fixed in https://github.com/wandb/weave/pull/892

In this example, the mouse is not over panel0, but we are rendering the expression editor as if it was, because the selection check for ancestry was using the incorrect "startsWith" and the top panel (named "panel") is a prefix of "panel0".
<img width="1358" alt="Screenshot 2023-12-04 at 10 33 46 AM" src="https://github.com/wandb/weave/assets/112953339/6fb79650-9bdb-4fd2-af6d-5202a8d8c91e">

After:
<img width="1346" alt="Screenshot 2023-12-04 at 10 40 23 AM" src="https://github.com/wandb/weave/assets/112953339/01bdd81a-9531-44ea-aa68-1ab2f377b4d2">
