### PR TITLE
fix: Fix unnest output type for tagged lists

### DIFF
--- a/weave-js/src/core/ops/primitives/list.ts
+++ b/weave-js/src/core/ops/primitives/list.ts
@@ -1345,8 +1345,8 @@ export const opUnnest = makeOp({
       if (propertyType == null) {
         throw new Error('opUnnest: expected all property types to be non-null');
       }
-      newPropertyTypes[key] = isList(propertyType)
-        ? propertyType.objectType
+      newPropertyTypes[key] = isListLike(propertyType)
+        ? listObjectType(propertyType)
         : propertyType;
     }
     return maybe({

--- a/weave-js/src/core/ops/primitives/list.ts
+++ b/weave-js/src/core/ops/primitives/list.ts
@@ -25,7 +25,6 @@ import {
   isAssignableTo,
   isConcreteTaggedValue,
   isFunction,
-  isList,
   isListLike,
   isTaggedValue,
   isTypedDict,


### PR DESCRIPTION
Fixes an issue where unnest output types were not properly unnested when columns were tagged lists. This led to panelplot crashes for certain grouping configurations. 