### PR TITLE
fix: Short circuit list ops

### DIFF
--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -719,6 +719,12 @@ def _ensure_variadic_fn(
 def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
     debug_str = graph_debug.node_expr_str_full(fn)
     logging.info("Vectorizing: %s", debug_str)
+
+    if len(awl) == 0:
+        # Short circuit empty list for performance reasons and to avoid calling 
+        # aggregations on empty lists.
+        return convert.to_arrow([], types.List(fn.type), artifact=awl._artifact)
+
     from .. import execute_fast
 
     fn = execute_fast._resolve_static_branches(fn)

--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -723,6 +723,9 @@ def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
     if len(awl) == 0:
         # Short circuit empty list for performance reasons and to avoid calling
         # aggregations on empty lists.
+        logging.info(
+            "Short circuiting vectorization on %s because it is empty.", debug_str
+        )
         return convert.to_arrow([], types.List(fn.type), artifact=awl._artifact)
 
     from .. import execute_fast

--- a/weave/ops_arrow/vectorize.py
+++ b/weave/ops_arrow/vectorize.py
@@ -721,7 +721,7 @@ def _apply_fn_node(awl: ArrowWeaveList, fn: graph.OutputNode) -> ArrowWeaveList:
     logging.info("Vectorizing: %s", debug_str)
 
     if len(awl) == 0:
-        # Short circuit empty list for performance reasons and to avoid calling 
+        # Short circuit empty list for performance reasons and to avoid calling
         # aggregations on empty lists.
         return convert.to_arrow([], types.List(fn.type), artifact=awl._artifact)
 


### PR DESCRIPTION
Short circuits vectorized function application to length-0 AWLs. This prevents errors from being thrown when trying to do aggregations on empty AWLs, and improves performance.