### PR TITLE
chore: update table pagination controls to use new button and icons

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -863,17 +863,23 @@ const PanelTableInner: React.FC<
         )}
         <div
           style={{flex: '1 0 auto', display: 'flex', justifyContent: 'center'}}>
-          <div style={{flex: '0 0 auto'}}>
-            <S.TableIcon
-              style={{padding: '4px 5px 0px'}}
-              name="left-arrow"
+          <div
+            style={{flex: '0 0 auto', display: 'flex', alignItems: 'center'}}>
+            <Button
+              variant="quiet"
+              size="small"
+              icon="back"
+              tooltip="First page"
               onClick={() => {
                 updateIndexOffset(0);
               }}
             />
-            <S.TableIcon
-              style={{padding: '4px 5px 0px'}}
-              name="chevron-left"
+            <Button
+              variant="quiet"
+              size="small"
+              icon="chevron-back"
+              tooltip="Previous page"
+              className="mr-4"
               onClick={() => {
                 updateIndexOffset(adjustedIndexOffset - nonPinnedVisibleRows);
               }}
@@ -904,7 +910,7 @@ const PanelTableInner: React.FC<
                 }
               }}
             />
-            <span style={{lineHeight: '20px'}}>
+            <span style={{lineHeight: '24px'}}>
               &nbsp;-{' '}
               {adjustedIndexOffset +
                 nonPinnedVisibleRows -
@@ -915,16 +921,21 @@ const PanelTableInner: React.FC<
                 ? 'many'
                 : totalRowCountUse.result - (useOneBasedIndex ? 0 : 1)}
             </span>
-            <S.TableIcon
-              style={{padding: '4px 5px 0px'}}
-              name="chevron-right"
+            <Button
+              variant="quiet"
+              size="small"
+              icon="chevron-next"
+              tooltip="Next page"
+              className="ml-4"
               onClick={() => {
                 updateIndexOffset(adjustedIndexOffset + nonPinnedVisibleRows);
               }}
             />
-            <S.TableIcon
-              style={{padding: '4px 5px 0px'}}
-              name="right-arrow"
+            <Button
+              variant="quiet"
+              size="small"
+              icon="forward-next"
+              tooltip="Last page"
               onClick={() => {
                 updateIndexOffset(
                   totalRowCountUse.result - nonPinnedVisibleRows


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16407

Update table pagination buttons to use new common button/icon components. This improves consistency, makes it easy to give them tooltips, etc.

Before:
<img width="218" alt="Screenshot 2023-12-05 at 12 47 44 PM" src="https://github.com/wandb/weave/assets/112953339/ee355917-7b3c-4559-9b7c-c49fae58928c">

After:
<img width="225" alt="Screenshot 2023-12-05 at 12 47 01 PM" src="https://github.com/wandb/weave/assets/112953339/d47b1be3-d929-462d-8e26-696b5d5cdf31">
