### PR TITLE
feat: Enhanced Color Functionality in PanelPlot and Observability Panel

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/util.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/util.ts
@@ -2,6 +2,7 @@ import {
   Frame,
   isAssignableTo,
   isTypedDict,
+  isVoidNode,
   list,
   listObjectType,
   maybe,
@@ -113,6 +114,7 @@ export const useVegaReadyTables = (series: SeriesConfig[], frame: Frame) => {
     return tables.map((table, i) => {
       const dims = allDims[i];
       const labelSelectFn = table.columnSelectFunctions[dims.label];
+      const colorSelectFn = table.columnSelectFunctions[dims.color];
       if (labelSelectFn.nodeType !== 'void') {
         const labelType = TableState.getTableColType(table, dims.label);
         if (frame.runColors != null) {
@@ -158,7 +160,8 @@ export const useVegaReadyTables = (series: SeriesConfig[], frame: Frame) => {
           isAssignableTo(
             labelType,
             oneOrMany(maybe(union(['number', 'string', 'boolean'])))
-          )
+          ) &&
+          isVoidNode(colorSelectFn)
         ) {
           return TableState.updateColumnSelect(
             table,

--- a/weave/panels_py/panel_observability.py
+++ b/weave/panels_py/panel_observability.py
@@ -192,7 +192,7 @@ def observability(
             }
         ),
         color_title="state",
-        color=state_color_func,
+        color=state_color_func.val,
         groupby_dims=["x", "label"],
         mark="bar",
         domain_x=bin_range,


### PR DESCRIPTION
Allows configuration of panelplot color dimension independently of label dimension in code (JS API, python API, but not in EE). Not doing this messes up custom colors in the launch observability dashboard. 