### PR TITLE
chore: update config to use common select component

### DIFF
--- a/weave-js/src/components/Form/Select.tsx
+++ b/weave-js/src/components/Form/Select.tsx
@@ -199,6 +199,14 @@ const getStyles = <
         },
       };
     },
+    menu: baseStyles => ({
+      ...baseStyles,
+      // TODO: Semantic-UI based dropdowns have their z-index set to 3,
+      //       which causes their selected value to appear in front of the
+      //       react-select popup. We should remove this hack once we've
+      //       eliminated Semantic-UI based dropdowns.
+      zIndex: 4,
+    }),
     menuList: baseStyles => {
       return {
         ...baseStyles,

--- a/weave-js/src/components/Panel2/PanelPlot/ConfigDimComponent.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/ConfigDimComponent.tsx
@@ -16,7 +16,6 @@ import {Button} from '../../Button';
 import {IconLockedConstrained, IconUnlockedUnconstrained} from '../../Icon';
 import {PopupMenu, Section} from '../../Sidebar/PopupMenu';
 import {Tooltip} from '../../Tooltip';
-import * as ConfigPanel from '../ConfigPanel';
 import {
   IconAddNew,
   IconCheckmark,
@@ -27,6 +26,7 @@ import {
 } from '../Icons';
 import * as TableState from '../PanelTable/tableState';
 import {ConfigDimLabel} from './ConfigDimLabel';
+import {ConfigSelect} from './ConfigSelect';
 import * as PlotState from './plotState';
 import * as S from './styles';
 import {DimComponentInputType, DimOption, DimOptionOrSection} from './types';
@@ -435,13 +435,12 @@ export const ConfigDimComponent: React.FC<DimComponentInputType> = props => {
         postfixComponent={postFixComponent}
         multiline={redesignedPlotConfigEnabled && multiline}
         redesignedPlotConfigEnabled={redesignedPlotConfigEnabled}>
-        <ConfigPanel.ModifiedDropdownConfigField
-          selection
-          data-testid={`dropdown-${dimName}`}
+        <ConfigSelect
+          testId={`dropdown-${dimName}`}
           placeholder={dimension.defaultState().compareValue}
           value={dimension.state().value}
           options={dimension.options}
-          onChange={(e, {value}) => {
+          onChange={({value}) => {
             const newSeries = produce(config.series, draft => {
               draft.forEach(s => {
                 if (isShared || _.isEqual(s, dimension.series)) {

--- a/weave-js/src/components/Panel2/PanelPlot/ConfigSelect.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/ConfigSelect.tsx
@@ -1,0 +1,72 @@
+/**
+ * A select component for use in panel plot config based
+ * on our commmon select component.
+ */
+import {Select} from '@wandb/weave/components/Form/Select';
+import React from 'react';
+import styled from 'styled-components';
+
+import {Icon} from '../../Icon';
+import {DropdownOption} from './plotState';
+
+const SelectOptionLabel = styled.div`
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+SelectOptionLabel.displayName = 'S.SelectOptionLabel';
+
+const SelectOptionLabelText = styled.span`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+SelectOptionLabelText.displayName = 'S.SelectOptionLabelText';
+
+type ConfigSelectProps = {
+  testId: string;
+  placeholder: string;
+  options: DropdownOption[];
+  value: any;
+  onChange?: (option: DropdownOption) => void;
+};
+
+const OptionLabel = (props: DropdownOption) => {
+  return (
+    <SelectOptionLabel>
+      {props.icon && <Icon name={props.icon} />}
+      <SelectOptionLabelText>{props.text}</SelectOptionLabelText>
+    </SelectOptionLabel>
+  );
+};
+
+export const ConfigSelect = ({
+  testId,
+  placeholder,
+  options,
+  value,
+  onChange,
+}: ConfigSelectProps) => {
+  const optionValue = options.find(x => x.value === value);
+
+  const onReactSelectChange = onChange
+    ? (option: DropdownOption | null) => {
+        if (option) {
+          onChange(option);
+        }
+      }
+    : undefined;
+  return (
+    <div data-testid={testId}>
+      <Select<DropdownOption>
+        data-testid={testId}
+        options={options}
+        value={optionValue}
+        placeholder={placeholder}
+        onChange={onReactSelectChange}
+        formatOptionLabel={OptionLabel}
+        isSearchable={false}
+      />
+    </div>
+  );
+};

--- a/weave-js/src/components/Panel2/PanelPlot/plotState.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/plotState.ts
@@ -33,6 +33,7 @@ import {
 import {immerable, produce} from 'immer';
 import _ from 'lodash';
 
+import {IconName} from '../../Icon';
 import * as TableState from '../PanelTable/tableState';
 import {
   AnyPlotConfig,
@@ -314,11 +315,12 @@ class YDimensionWithConditionalY2 extends MultiFieldDimension {
   }
 }
 
-type DropdownOption = {
+export type DropdownOption = {
   key: string;
   value: any;
   text: string;
   representableAsExpression?: boolean;
+  icon?: IconName;
 };
 
 class DropDownDimension extends DimensionLike {
@@ -375,20 +377,47 @@ const lineStyleOptions = LINE_SHAPES.map(o => ({
   representableAsExpression: o !== 'series',
 }));
 
+const markShapeIcons: Record<string, IconName> = {
+  auto: 'magic-wand-stick',
+  point: 'chart-scatterplot',
+  bar: 'chart-vertical-bars',
+  boxplot: 'box-plot',
+  line: 'linear-scale',
+  area: 'area',
+};
+
 const markOptions = [
-  {key: 'auto' as const, value: null, text: 'auto' as const},
+  {
+    key: 'auto' as const,
+    value: null,
+    text: 'auto' as const,
+    icon: markShapeIcons.auto,
+  },
   ...MARK_OPTIONS.map(o => ({
     key: o,
     value: o,
     text: o,
+    icon: markShapeIcons[o],
   })),
 ];
+
+const pointShapeIcons: Record<string, IconName> = {
+  circle: 'circle',
+  square: 'square',
+  cross: 'cross',
+  diamond: 'diamond',
+  'triangle-up': 'triangle-up',
+  'triangle-down': 'triangle-down',
+  'triangle-right': 'triangle-right',
+  'triangle-left': 'triangle-left',
+};
 
 const pointShapeOptions = POINT_SHAPES.map(o => ({
   key: o,
   value: o,
   text: o === 'series' ? 'Encode from series' : o,
   representableAsExpression: o !== 'series',
+  icon: pointShapeIcons[o],
 }));
 
 export const dimensionTypeOptions = [


### PR DESCRIPTION
Update mark and point shape to use react-select component.

(Waiting on design for some more icons for the mark selector - it will get them soon.)
Before: 
<img width="295" alt="Screenshot 2023-12-08 at 2 04 34 PM" src="https://github.com/wandb/weave/assets/112953339/54a8ea8c-66dc-4da7-897a-90ef5f0cd686">

After:

<img width="314" alt="Screenshot 2023-12-08 at 1 26 22 PM" src="https://github.com/wandb/weave/assets/112953339/5c488ada-ccc0-45d2-b9ef-3dfcbb34d89c">
