### PR TITLE
feat: new panel type selector

### DIFF
--- a/weave-js/src/components/Form/Select.tsx
+++ b/weave-js/src/components/Form/Select.tsx
@@ -199,6 +199,14 @@ const getStyles = <
         },
       };
     },
+    menu: baseStyles => ({
+      ...baseStyles,
+      // TODO: Semantic-UI based dropdowns have their z-index set to 3,
+      //       which causes their selected value to appear in front of the
+      //       react-select popup. We should remove this hack once we've
+      //       eliminated Semantic-UI based dropdowns.
+      zIndex: 4,
+    }),
     menuList: baseStyles => {
       return {
         ...baseStyles,

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -75,6 +75,7 @@ import PanelNameEditor from './PanelNameEditor';
 import {usePanelPanelContext} from './PanelPanelContextProvider';
 import {TableState} from './PanelTable/tableState';
 import {getConfigForPath, isInsideMain, isMain} from './panelTree';
+import {SelectPanelType} from './SelectPanelType';
 
 // This could be rendered as a code block with assignments, like
 // so.
@@ -245,6 +246,8 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
         key: si.id,
         active: isActive,
         selected: isActive,
+        icon: si.icon,
+        category: si.category,
       };
     });
   }, [handler, stackIds]);
@@ -859,12 +862,11 @@ export const ChildPanelConfigComp: React.FC<ChildPanelProps> = props => {
           </PanelContextProvider>
         </ConfigPanel.ConfigOption>
       )}
-
       <ConfigPanel.ConfigOption label="Panel type">
-        <ConfigPanel.ModifiedDropdownConfigField
+        <SelectPanelType
           value={curPanelId}
           options={panelOptions}
-          onChange={(e, {value}) => {
+          onChange={({value}) => {
             if (typeof value === `string` && value) {
               handlePanelChange(value);
             }

--- a/weave-js/src/components/Panel2/PanelBarChart/index.ts
+++ b/weave-js/src/components/Panel2/PanelBarChart/index.ts
@@ -5,6 +5,8 @@ import Component from './Component';
 export const Spec: Panel2.PanelSpec = {
   id: 'barchart',
   displayName: 'Bar Chart',
+  icon: 'chart-horizontal-bars',
+  category: 'Data',
   Component,
   inputType,
   canFullscreen: true,

--- a/weave-js/src/components/Panel2/PanelBoolean/index.ts
+++ b/weave-js/src/components/Panel2/PanelBoolean/index.ts
@@ -5,6 +5,8 @@ import {inputType} from './common';
 
 export const Spec: Panel2.PanelSpec = {
   id: 'boolean',
+  icon: 'boolean',
+  category: 'Primitive',
   Component: React.lazy(() => import('./Component')),
   inputType,
 };

--- a/weave-js/src/components/Panel2/PanelColor.tsx
+++ b/weave-js/src/components/Panel2/PanelColor.tsx
@@ -42,6 +42,7 @@ export const PanelColor: React.FC<PanelColorProps> = props => {
 
 export const Spec: Panel2.PanelSpec = {
   id: 'Color',
+  icon: 'color',
   Component: PanelColor,
   inputType,
 };

--- a/weave-js/src/components/Panel2/PanelDate/index.ts
+++ b/weave-js/src/components/Panel2/PanelDate/index.ts
@@ -5,6 +5,8 @@ import {inputType} from './common';
 
 export const Spec: Panel2.PanelSpec = {
   id: 'date',
+  icon: 'date',
+  category: 'Primitive',
   Component: React.lazy(() => import('./Component')),
   inputType,
 };

--- a/weave-js/src/components/Panel2/PanelDateRange.tsx
+++ b/weave-js/src/components/Panel2/PanelDateRange.tsx
@@ -316,6 +316,7 @@ export const PanelDateRange: React.FC<PanelDateRangeProps> = props => {
 export const Spec: Panel.PanelSpec = {
   hidden: true,
   id: 'DateRange',
+  icon: 'date',
   initialize: initializedPanelDateRange,
   ConfigComponent: PanelDateRangeConfigComponent,
   Component: PanelDateRange,

--- a/weave-js/src/components/Panel2/PanelExpr.tsx
+++ b/weave-js/src/components/Panel2/PanelExpr.tsx
@@ -45,6 +45,7 @@ export const PanelExpression: React.FC<PanelExpressionProps> = props => {
 
 export const Spec: Panel2.PanelSpec = {
   id: 'Expression',
+  icon: 'code-alt',
   Component: PanelExpression,
   inputType,
   hidden: true,

--- a/weave-js/src/components/Panel2/PanelFilterEditor.tsx
+++ b/weave-js/src/components/Panel2/PanelFilterEditor.tsx
@@ -792,6 +792,7 @@ export const PanelFilterEditor: React.FC<PanelFilterEditorProps> = props => {
 export const Spec: Panel2.PanelSpec = {
   hidden: true,
   id: 'FilterEditor',
+  icon: 'filter-alt',
   Component: PanelFilterEditor,
   inputType,
 };

--- a/weave-js/src/components/Panel2/PanelGroup.tsx
+++ b/weave-js/src/components/Panel2/PanelGroup.tsx
@@ -1062,6 +1062,8 @@ export const PANEL_GROUP2_ID = 'Group';
 export const Spec: Panel2.PanelSpec = {
   hidden: true,
   id: PANEL_GROUP2_ID,
+  icon: 'group',
+  category: 'Organize',
   initialize: (weave, inputNode) => PANEL_GROUP_DEFAULT_CONFIG(),
   Component: PanelGroup,
   ConfigComponent: PanelGroupConfigComponent,

--- a/weave-js/src/components/Panel2/PanelHexColor.tsx
+++ b/weave-js/src/components/Panel2/PanelHexColor.tsx
@@ -51,6 +51,7 @@ export const PanelHexColor: React.FC<PanelHexColorProps> = props => {
 
 export const Spec: Panel2.PanelSpec = {
   id: 'HexColor',
+  icon: 'color',
   Component: PanelHexColor,
   inputType,
 };

--- a/weave-js/src/components/Panel2/PanelHistogram/index.ts
+++ b/weave-js/src/components/Panel2/PanelHistogram/index.ts
@@ -5,6 +5,8 @@ import ConfigComponent from './ConfigComponent';
 
 export const Spec: Panel2.PanelSpec = {
   id: 'histogram',
+  icon: 'chart-vertical-bars',
+  category: 'Data',
   ConfigComponent,
   Component,
   inputType,

--- a/weave-js/src/components/Panel2/PanelNumber.tsx
+++ b/weave-js/src/components/Panel2/PanelNumber.tsx
@@ -172,6 +172,8 @@ export const PanelNumber: React.FC<
 
 export const Spec: Panel2.PanelSpec = {
   id: 'number',
+  icon: 'number',
+  category: 'Primitive',
   Component: PanelNumber,
   ConfigComponent: PanelNumberConfig,
   inputType,

--- a/weave-js/src/components/Panel2/PanelObject.tsx
+++ b/weave-js/src/components/Panel2/PanelObject.tsx
@@ -390,6 +390,7 @@ const PanelObjectChild: React.FC<
 
 export const Spec: Panel2.PanelSpec = {
   id: 'object',
+  icon: 'list-bullets',
   Component: PanelObject,
   ConfigComponent: PanelObjectConfig,
   inputType,

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -643,6 +643,8 @@ const PanelPlot2: React.FC<PanelPlotProps> = props => {
 
 export const Spec: Panel2.PanelSpec = {
   id: 'plot',
+  icon: 'chart-horizontal-bars',
+  category: 'Data',
   initialize: async (weave, inputNode, stack) => {
     // Can't happen, id was selected based on Node type
     if (inputNode.nodeType === 'void') {

--- a/weave-js/src/components/Panel2/PanelRegistry.tsx
+++ b/weave-js/src/components/Panel2/PanelRegistry.tsx
@@ -1,3 +1,4 @@
+import {IconName} from '../Icon';
 import * as Panel from './panel';
 import {Spec as PanelArtifactVersionAliasesSpec} from './PanelArtifactVersionAliases';
 import {Spec as AudioSpec} from './PanelAudio';
@@ -21,6 +22,7 @@ import {Spec as IdCompareCountSpec} from './PanelIdCompareCount';
 import {Spec as IdCountSpec} from './PanelIdCount';
 import {Spec as ImageSpec} from './PanelImage';
 import {Spec as ImageCompareSpec} from './PanelImageCompare';
+import {PanelCategory} from './panellib/types';
 import {Spec as LinkSpec} from './PanelLink';
 import {Spec as MaybeSpec} from './PanelMaybe';
 import {Spec as MoleculeSpec} from './PanelMolecule';
@@ -81,6 +83,9 @@ export type ConverterSpecArray = Panel.PanelConvertSpec[];
 // this up as part of encapsulating panel registry.
 
 let panelSpecs: Panel.PanelSpec[] = [];
+
+const panelIdToIcon: Record<string, IconName> = {};
+const panelIdToCategory: Record<string, PanelCategory> = {};
 
 const initSpecs = () => {
   if (panelSpecs.length === 0) {
@@ -171,6 +176,16 @@ const initSpecs = () => {
       ExpressionGraph,
     ].concat(weavePythonPanelSpecs());
   }
+
+  // Initialize panel id to icon and category mapping
+  for (const spec of panelSpecs) {
+    if (spec.icon) {
+      panelIdToIcon[spec.id] = spec.icon;
+    }
+    if (spec.category) {
+      panelIdToCategory[spec.id] = spec.category;
+    }
+  }
 };
 
 export const PanelSpecs: PanelSpecFunc = () => {
@@ -187,6 +202,25 @@ export const registerPanel = (spec: Panel.PanelSpec) => {
   } else {
     panelSpecs[index] = spec;
   }
+
+  // Update panel id mappings
+  if (spec.icon) {
+    panelIdToIcon[spec.id] = spec.icon;
+  } else {
+    delete panelIdToIcon[spec.id];
+  }
+  if (spec.category) {
+    panelIdToCategory[spec.id] = spec.category;
+  } else {
+    delete panelIdToCategory[spec.id];
+  }
+};
+
+export const getPanelIcon = (panelId: string): IconName => {
+  return panelIdToIcon[panelId] ?? 'panel';
+};
+export const getPanelCategory = (panelId: string): PanelCategory => {
+  return panelIdToCategory[panelId] ?? 'Other';
 };
 
 let converterSpecs: ConverterSpecArray = [];

--- a/weave-js/src/components/Panel2/PanelString.tsx
+++ b/weave-js/src/components/Panel2/PanelString.tsx
@@ -258,6 +258,8 @@ export const PanelString: React.FC<PanelStringProps> = props => {
 
 export const Spec: Panel2.PanelSpec = {
   id: 'string',
+  icon: 'text-language-alt',
+  category: 'Primitive',
   canFullscreen: true,
   Component: PanelString,
   ConfigComponent: PanelStringConfig,

--- a/weave-js/src/components/Panel2/PanelStringEditor.tsx
+++ b/weave-js/src/components/Panel2/PanelStringEditor.tsx
@@ -42,6 +42,7 @@ export const PanelStringEditor: React.FC<PanelStringEditorProps> = props => {
 export const Spec: Panel2.PanelSpec = {
   hidden: false,
   id: 'StringEditor',
+  icon: 'pencil-edit',
   Component: PanelStringEditor,
   inputType,
 };

--- a/weave-js/src/components/Panel2/PanelStringHistogram.tsx
+++ b/weave-js/src/components/Panel2/PanelStringHistogram.tsx
@@ -208,6 +208,8 @@ const PanelStringHistogramInner: React.FC<
 
 export const Spec: Panel2.PanelSpec = {
   id: 'string-histogram',
+  icon: 'chart-horizontal-bars',
+  category: 'Data',
   Component: PanelStringHistogram,
   inputType,
   canFullscreen: true,

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1468,6 +1468,8 @@ const applyTableStateToRowsNode = (
 
 export const TableSpec: Panel2.PanelSpec = {
   id: 'table',
+  icon: 'table',
+  category: 'Data',
   initialize: async (weave, inputNode, stack) => {
     if (inputNode.nodeType === 'void') {
       // Can't happen, id was selected based on Node type

--- a/weave-js/src/components/Panel2/SelectPanelType.tsx
+++ b/weave-js/src/components/Panel2/SelectPanelType.tsx
@@ -1,0 +1,82 @@
+/**
+ * A select component for panel type.
+ */
+import {Select} from '@wandb/weave/components/Form/Select';
+import * as _ from 'lodash';
+import React from 'react';
+import styled from 'styled-components';
+
+import {Icon, IconName} from '../Icon';
+
+type TypeOption = {
+  readonly value: string;
+  readonly text: string;
+  readonly icon: IconName;
+  readonly category: string;
+};
+
+type GroupedOption = {
+  readonly label: string;
+  readonly options: TypeOption[];
+};
+
+const SelectOptionLabel = styled.div`
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+SelectOptionLabel.displayName = 'S.SelectOptionLabel';
+
+const SelectOptionLabelText = styled.span`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+SelectOptionLabelText.displayName = 'S.SelectOptionLabelText';
+
+type ConfigSelectProps = {
+  options: TypeOption[];
+  value: string | undefined;
+  onChange?: (option: TypeOption) => void;
+};
+
+const OptionLabel = (props: TypeOption) => {
+  return (
+    <SelectOptionLabel>
+      <Icon name={props.icon} />
+      <SelectOptionLabelText>{props.text}</SelectOptionLabelText>
+    </SelectOptionLabel>
+  );
+};
+
+export const SelectPanelType = ({
+  options,
+  value,
+  onChange,
+}: ConfigSelectProps) => {
+  const optionValue = options.find(x => x.value === value);
+
+  const onReactSelectChange = onChange
+    ? (option: TypeOption | null) => {
+        if (option) {
+          onChange(option);
+        }
+      }
+    : undefined;
+
+  const groupedOptions: GroupedOption[] = [];
+  const grouped = _.groupBy(options, 'category');
+  Object.keys(grouped).forEach(key => {
+    groupedOptions.push({label: key, options: grouped[key]});
+  });
+
+  return (
+    <Select<TypeOption, false, GroupedOption>
+      options={groupedOptions}
+      value={optionValue}
+      onChange={onReactSelectChange}
+      formatOptionLabel={OptionLabel}
+      isSearchable={false}
+    />
+  );
+};

--- a/weave-js/src/components/Panel2/availablePanels.tsx
+++ b/weave-js/src/components/Panel2/availablePanels.tsx
@@ -16,6 +16,7 @@ import {useDeepMemo} from '../../hookUtils';
 import * as Panel from './panel';
 import * as PanelLib from './panellib/libpanel';
 import * as LibTypes from './panellib/libtypes';
+import {getStackInfo, StackInfo} from './panellib/stackinfo';
 import * as PanelRegistry from './PanelRegistry';
 import {Spec as PanelTableMergeSpec} from './PanelTableMerge';
 
@@ -212,7 +213,7 @@ export function getPanelStacksForType(
   opts: GetPanelStacksForTypeOpts = {}
 ): {
   curPanelId: string | undefined;
-  stackIds: Array<{id: string; displayName: string}>;
+  stackIds: StackInfo[];
   handler: PanelStack | undefined;
 } {
   let handlerStacks = getTypeHandlerStacks(type);
@@ -296,7 +297,7 @@ export function getPanelStacksForType(
     );
   }
 
-  const stackIds = handlerStacks.map(PanelLib.getStackIdAndName);
+  const stackIds = handlerStacks.map(getStackInfo);
   const configuredStackIndex = stackIds.findIndex(si => si.id === panelId);
   let backupConfiguredStackIndex = -1;
   // If there is not an exact match...

--- a/weave-js/src/components/Panel2/panellib/libpanel.ts
+++ b/weave-js/src/components/Panel2/panellib/libpanel.ts
@@ -6,7 +6,9 @@ import {
   Weave,
 } from '@wandb/weave/core';
 
+import {IconName} from '../../Icon';
 import {ConfiguredTransform} from '../panel';
+import {PanelCategory} from './types';
 
 // Generic parameters:
 // Globals
@@ -57,6 +59,13 @@ export interface PanelSpec<X, C, T extends Type> {
   id: string;
   hidden?: boolean;
   displayName?: string;
+
+  // An icon that will be associated with this panel type.
+  // Used in panel type selector, outline, etc.
+  icon?: IconName;
+
+  category?: PanelCategory;
+
   // Provide initial config for panel. This is called once when the panel
   // is first created.
   initialize?: (

--- a/weave-js/src/components/Panel2/panellib/stackinfo.ts
+++ b/weave-js/src/components/Panel2/panellib/stackinfo.ts
@@ -1,0 +1,26 @@
+import {Type} from '../../../core/model';
+import {IconName} from '../../Icon';
+import {getPanelCategory, getPanelIcon} from '../PanelRegistry';
+import {getStackIdAndName, PanelSpecNode} from './libpanel';
+import {PanelCategory} from './types';
+
+export type StackInfo = {
+  readonly id: string;
+  readonly displayName: string;
+  readonly icon: IconName;
+  readonly category: PanelCategory;
+};
+
+export function getStackInfo<X, C, T extends Type>(
+  panel: PanelSpecNode<X, C, T>
+): StackInfo {
+  const {id, displayName} = getStackIdAndName(panel);
+  const icon = getPanelIcon(id);
+  const category = getPanelCategory(id);
+  return {
+    id,
+    displayName,
+    icon,
+    category,
+  };
+}

--- a/weave-js/src/components/Panel2/panellib/types.ts
+++ b/weave-js/src/components/Panel2/panellib/types.ts
@@ -1,0 +1,5 @@
+// These types are shared beween panellib and the panel registry.
+
+// Category for grouping types in the Panel Type selector.
+// We expect this set to change based on feedback.
+export type PanelCategory = 'Primitive' | 'Data' | 'Organize' | 'Other';

--- a/weave-js/src/components/Sidebar/Outline.tsx
+++ b/weave-js/src/components/Sidebar/Outline.tsx
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import React, {useCallback, useState} from 'react';
 import styled, {css} from 'styled-components';
 
-import {Icon, IconHideHidden, IconLockClosed, IconName} from '../Icon';
+import {Icon, IconHideHidden, IconLockClosed} from '../Icon';
 import {IconButton} from '../IconButton';
 import {getPanelStacksForType} from '../Panel2/availablePanels';
 import {ChildPanelConfig, ChildPanelFullConfig} from '../Panel2/ChildPanel';
@@ -16,6 +16,7 @@ import {
   usePanelIsHoveredByPath,
   useSetPanelIsHoveredInOutline,
 } from '../Panel2/PanelInteractContext';
+import {getPanelIcon} from '../Panel2/PanelRegistry';
 import {panelChildren} from '../Panel2/panelTree';
 import {Tooltip} from '../Tooltip';
 import {OutlineItemPopupMenu} from './OutlineItemPopupMenu';
@@ -128,20 +129,6 @@ export const shouldDisablePanelDelete = (
   path.length === 0 ||
   (path.length === 1 && ['main', 'sidebar'].includes(path[0]));
 
-const PANEL_TYPE_TO_ICON: Record<string, IconName> = {
-  Group: 'group',
-  boolean: 'boolean',
-  number: 'number',
-  string: 'text-language-alt',
-  date: 'date',
-  DateRange: 'date',
-  FilterEditor: 'filter-alt',
-  table: 'table',
-  plot: 'chart-horizontal-bars',
-  Histogram: 'chart-vertical-bars',
-  object: 'list-bullets',
-  Expression: 'code-alt',
-};
 const getPanelTypeIcon = (panelId: string | undefined) => {
   if (!panelId) {
     return 'panel';
@@ -152,7 +139,7 @@ const getPanelTypeIcon = (panelId: string | undefined) => {
   if (panelId.startsWith('maybe.')) {
     panelId = panelId.slice(6);
   }
-  return PANEL_TYPE_TO_ICON[panelId] ?? 'panel';
+  return getPanelIcon(panelId);
 };
 
 const OutlinePanel: React.FC<OutlinePanelProps> = props => {


### PR DESCRIPTION
Create a new select widget for panel type that supports icons and grouping. Icon association is now part of the panel spec; the outline is updated to pull the information from there.

Internal Jira: https://wandb.atlassian.net/browse/WB-16556
Internal design RFC: https://www.notion.so/wandbai/RFC-Plot-UX-improvements-61b5f5c537ac444992b2736ae9a138cf?pvs=4#97503190d2c34c7a8e59abe135334601

Before:
<img width="314" alt="Screenshot 2023-12-06 at 2 20 18 PM" src="https://github.com/wandb/weave/assets/112953339/e8fd36ce-6c41-4e2c-97cc-06f4a6b024a8">

After:
<img width="321" alt="Screenshot 2023-12-06 at 2 02 09 PM" src="https://github.com/wandb/weave/assets/112953339/4edff529-16c4-4d4e-bbd9-8ca178bcf085">
