### PR TITLE
feat: duplicating a panel preserves its size

### DIFF
--- a/weave-js/src/components/Panel2/panelTree.ts
+++ b/weave-js/src/components/Panel2/panelTree.ts
@@ -32,7 +32,10 @@ import {
 import {produce} from 'immer';
 import * as _ from 'lodash';
 
-import {PanelBankSectionConfig} from '../WeavePanelBank/panelbank';
+import {
+  LayoutParameters,
+  PanelBankSectionConfig,
+} from '../WeavePanelBank/panelbank';
 import {
   ChildPanelConfig,
   childPanelFromTableState,
@@ -305,22 +308,43 @@ export const movePath = (
 export const addChild = (
   node: PanelTreeNode,
   path: string[],
-  value: PanelTreeNode
+  value: PanelTreeNode,
+  layout?: LayoutParameters
 ) => {
   const group = getPath(node, path);
   if (!isGroupNode(group)) {
     throw new Error('Cannot add child to non-group panel');
   }
-  return setPath(node, path, {
+  const nextName = nextPanelName(Object.keys(group.config.items));
+  const groupValue = {
     ...group,
     config: {
       ...group.config,
       items: {
         ...group.config.items,
-        [nextPanelName(Object.keys(group.config.items))]: value,
+        [nextName]: value,
       },
     },
-  });
+  };
+
+  // Set the location for the new child
+  if (layout && groupValue.config.gridConfig) {
+    groupValue.config = {
+      ...groupValue.config,
+      gridConfig: {
+        ...groupValue.config.gridConfig,
+        panels: [
+          ...groupValue.config.gridConfig.panels,
+          {
+            id: nextName,
+            layout,
+          },
+        ],
+      },
+    };
+  }
+
+  return setPath(node, path, groupValue);
 };
 
 type DefinitionWithDirtyHandler = Definition & {

--- a/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
@@ -161,7 +161,18 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
       updateConfig2(oldConfig => {
         oldConfig = getFullChildPanel(oldConfig);
         const targetPanel = getPath(oldConfig, panelPath);
-        return addChild(oldConfig, panelPath.slice(0, -1), targetPanel);
+        // We need to find the layout parameters for the panel being
+        // duplicated inside its parent's grid config so we can insert
+        // the clone next to the original and with the same width and height.
+        const targetId = panelPath[panelPath.length - 1];
+        const parentPath = panelPath.slice(0, -1);
+        const parentPanel = getPath(oldConfig, parentPath);
+        const parentLayouts = parentPanel.config.gridConfig.panels;
+        const targetLayoutObject = _.find(parentLayouts, {
+          id: targetId,
+        });
+        const duplicateLayout = targetLayoutObject?.layout;
+        return addChild(oldConfig, parentPath, targetPanel, duplicateLayout);
       });
 
       goBackToOutline?.();


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16493

When we duplicate a panel, make the new one the same size, and position it near the original instead of at the end.

Before:  Duplicating top left "latency over time" panel adds big panel to the bottom. This is below the fold and we don't autoscroll, so it's not obvious the operation even succeeded.
![jamie-rasmussen-langchaintest-Boards-–-Weave](https://github.com/wandb/weave/assets/112953339/3f50443c-2e80-40d7-a9c9-f931b1199d13)

After: Duplicating the same panel keeps its size and positions it near the original. There's still room for improvement on layout, but this seems better.
![jamie-rasmussen-langchaintest-Boards-–-Weave (1)](https://github.com/wandb/weave/assets/112953339/6685bfce-e09e-4df2-9e8f-2e108d3d708e)

