### PR TITLE
chore: less verbose prettier output

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -19,7 +19,7 @@
     "generate": "graphql-codegen",
     "generate:watch": "graphql-codegen -w",
     "prettier": "prettier --config .prettierrc --check \"src/**/*.ts\" \"src/**/*.tsx\"",
-    "prettier-fix": "prettier --config .prettierrc --write \"src/**/*.ts\" \"src/**/*.tsx\"",
+    "prettier-fix": "prettier --loglevel warn --config .prettierrc --write \"src/**/*.ts\" \"src/**/*.tsx\"",
     "lint": "yarn eslint & yarn tslint & yarn prettier & wait",
     "lint-fix": "yarn eslint-fix & yarn tslint-fix & yarn prettier-fix & wait"
   },


### PR DESCRIPTION
Reduce verbosity of prettier so lint warnings are easier to notice. This is keeping consistency with a change I made to core.
See internal PR https://github.com/wandb/core/pull/18445 for more info.