### PR TITLE
feat: duplicated panel automatically selected for config

### DIFF
--- a/weave-js/src/components/Panel2/panelTree.ts
+++ b/weave-js/src/components/Panel2/panelTree.ts
@@ -309,20 +309,20 @@ export const addChild = (
   node: PanelTreeNode,
   path: string[],
   value: PanelTreeNode,
+  panelName: string,
   layout?: LayoutParameters
 ) => {
   const group = getPath(node, path);
   if (!isGroupNode(group)) {
     throw new Error('Cannot add child to non-group panel');
   }
-  const nextName = nextPanelName(Object.keys(group.config.items));
   const groupValue = {
     ...group,
     config: {
       ...group.config,
       items: {
         ...group.config.items,
-        [nextName]: value,
+        [panelName]: value,
       },
     },
   };
@@ -336,7 +336,7 @@ export const addChild = (
         panels: [
           ...groupValue.config.gridConfig.panels,
           {
-            id: nextName,
+            id: panelName,
             layout,
           },
         ],

--- a/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
@@ -23,6 +23,7 @@ import {
   isGroupNode,
   isInsideMain,
   makePanel,
+  nextPanelName,
   setPath,
 } from '../Panel2/panelTree';
 import {OutlinePanelProps} from './Outline';
@@ -156,6 +157,7 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
     },
     [updateConfig2, goBackToOutline]
   );
+
   const handleDuplicate = useCallback(
     (panelPath: string[]) => {
       updateConfig2(oldConfig => {
@@ -172,12 +174,22 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
           id: targetId,
         });
         const duplicateLayout = targetLayoutObject?.layout;
-        return addChild(oldConfig, parentPath, targetPanel, duplicateLayout);
+        const newPanelName = nextPanelName(
+          Object.keys(parentPanel.config.items)
+        );
+        const newPanelPath = [...parentPath, newPanelName];
+        const updatedConfig = addChild(
+          oldConfig,
+          parentPath,
+          targetPanel,
+          newPanelName,
+          duplicateLayout
+        );
+        setInteractingPanel('config', newPanelPath, 'input');
+        return updatedConfig;
       });
-
-      goBackToOutline?.();
     },
-    [updateConfig2, goBackToOutline]
+    [updateConfig2, setInteractingPanel]
   );
   const menuItems = useMemo(() => {
     const items = [];
@@ -196,7 +208,10 @@ const OutlineItemPopupMenuComp: React.FC<OutlineItemPopupMenuProps> = ({
         key: 'duplicate',
         content: 'Duplicate',
         icon: <IconCopy />,
-        onClick: () => handleDuplicate(path),
+        onClick: (ev: React.MouseEvent) => {
+          ev.stopPropagation();
+          handleDuplicate(path);
+        },
       });
     }
 


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16492

Today, when you duplicate a panel, that source panel is selected. The config panel will not be automatically opened if it is closed.

This change makes it so the newly created panel is selected and its configuration is opened. This reduces the steps a user needs to take for common cases like creating a plot from the same data as a table.