### PR TITLE
feat(ui): Update slider display styles

### DIFF
--- a/weave-js/src/components/Slider/index.tsx
+++ b/weave-js/src/components/Slider/index.tsx
@@ -75,8 +75,9 @@ export const Display = React.forwardRef(
     return (
       <input
         className={twMerge(
-          'ml-8  h-[40px] w-[56px] rounded border-[1px] border-solid border-moon-250 text-center',
-          'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
+          'ml-8 h-[32px] w-[56px] rounded text-center outline outline-1 outline-moon-250',
+          'hover:outline-2 hover:outline-teal-500/[0.4]',
+          'focus:outline-2 focus:outline-teal-500/[0.64]',
           isDirty ? 'text-moon-800' : 'text-moon-250',
           className
         )}


### PR DESCRIPTION
Updates styling of `Slider.Display` so it's more consistent with other input interfaces (e.g. Select, TextField)

Before: a bit too tall, no hover styles, incorrect focus color

https://github.com/wandb/weave/assets/17016170/91927530-8b0f-4d1b-adfb-2339c76894b4

After: height, hover, and focus styles match other inputs (second example shows it side-by-side with a select menu)


https://github.com/wandb/weave/assets/17016170/04f976e6-abf2-49d8-8619-6795c944e231


https://github.com/wandb/weave/assets/17016170/19fe814a-189c-4696-b750-11e6c4dd7a4b

