### PR TITLE
feat: enable finding consuming calls for any table row

### DIFF
--- a/weave/artifact_base.py
+++ b/weave/artifact_base.py
@@ -32,5 +32,16 @@ class ArtifactRef(ref_base.Ref):
         self.path = path
         super().__init__(obj=obj, type=type, extra=extra)
 
+    def with_extra(
+        self, new_type: types.Type, obj: typing.Any, extra: list[str]
+    ) -> "ArtifactRef":
+        return self.__class__(
+            artifact=self.artifact,
+            path=self.path,
+            type=new_type,
+            obj=obj,
+            extra=extra,
+        )
+
     def local_ref_str(self) -> str:
         raise NotImplementedError

--- a/weave/artifact_fs.py
+++ b/weave/artifact_fs.py
@@ -256,7 +256,7 @@ class FilesystemArtifactRef(artifact_base.ArtifactRef):
             # TODO: fix
             from . import types_numpy
 
-            if isinstance(ot, types.List):
+            if types.is_list_like(ot):
                 self._type = ot.object_type
             elif isinstance(ot, types_numpy.NumpyArrayType):
                 # The Numpy type implementation is not consistent with how list extra refs

--- a/weave/artifact_fs.py
+++ b/weave/artifact_fs.py
@@ -257,7 +257,7 @@ class FilesystemArtifactRef(artifact_base.ArtifactRef):
             from . import types_numpy
 
             if types.is_list_like(ot):
-                self._type = ot.object_type
+                self._type = ot.object_type  # type: ignore
             elif isinstance(ot, types_numpy.NumpyArrayType):
                 # The Numpy type implementation is not consistent with how list extra refs
                 # work!

--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -832,6 +832,10 @@ class WandbArtifactRef(artifact_fs.FilesystemArtifactRef):
         client = graph_client_context.require_graph_client()
         return client.ref_input_to(self)
 
+    def value_input_to(self) -> eager.WeaveIter["run.Run"]:
+        client = graph_client_context.require_graph_client()
+        return client.ref_value_input_to(self)
+
     def output_of(self) -> typing.Optional["run.Run"]:
         client = graph_client_context.require_graph_client()
         return client.ref_output_of(self)

--- a/weave/context_state.py
+++ b/weave/context_state.py
@@ -145,10 +145,6 @@ _frontend_url: contextvars.ContextVar[typing.Optional[str]] = contextvars.Contex
 )
 
 
-def monitor_is_disabled() -> bool:
-    return _monitor_disabled.get()
-
-
 @contextlib.contextmanager
 def monitor_disabled():
     token = _monitor_disabled.set(True)

--- a/weave/context_state.py
+++ b/weave/context_state.py
@@ -66,6 +66,13 @@ _loading_built_ins: contextvars.ContextVar[
 
 
 @contextlib.contextmanager
+def loading_builtins(builtins):
+    token = _loading_built_ins.set(builtins)
+    yield _loading_built_ins.get()
+    _loading_built_ins.reset(token)
+
+
+@contextlib.contextmanager
 def loading_op_location(location):
     token = _loading_op_location.set(location)
     yield _loading_op_location.get()

--- a/weave/decorator_op.py
+++ b/weave/decorator_op.py
@@ -6,6 +6,7 @@ from . import registry_mem
 from . import op_def
 from . import op_args
 from . import derive_op
+from . import context_state
 from . import weave_types as types
 from . import pyfunc_type_util
 
@@ -38,12 +39,16 @@ def op(
     input_type, output_type as arguments to op (Python types preferred).
     """
 
+    # For builtins, enforce that parameter and return types must be declared.
+    # For user ops, allow missing types.
+    allow_unknowns = not context_state._loading_built_ins.get()
+
     def wrap(f):
         weave_input_type = pyfunc_type_util.determine_input_type(
-            f, input_type, allow_unknowns=True
+            f, input_type, allow_unknowns=allow_unknowns
         )
         weave_output_type = pyfunc_type_util.determine_output_type(
-            f, output_type, allow_unknowns=True
+            f, output_type, allow_unknowns=allow_unknowns
         )
 
         fq_op_name = name

--- a/weave/decorator_op.py
+++ b/weave/decorator_op.py
@@ -39,8 +39,12 @@ def op(
     """
 
     def wrap(f):
-        weave_input_type = pyfunc_type_util.determine_input_type(f, input_type)
-        weave_output_type = pyfunc_type_util.determine_output_type(f, output_type)
+        weave_input_type = pyfunc_type_util.determine_input_type(
+            f, input_type, allow_unknowns=True
+        )
+        weave_output_type = pyfunc_type_util.determine_output_type(
+            f, output_type, allow_unknowns=True
+        )
 
         fq_op_name = name
         if fq_op_name is None:

--- a/weave/execute.py
+++ b/weave/execute.py
@@ -436,8 +436,26 @@ def execute_async_op(
     job.start()
 
 
+def publish_enabled():
+    # only auto publish if we have inited monitoring (with weave.init or init_monitor)
+    # and eager mode is on, as in weaveflow
+
+    # We're checking mon.streamtable, which is available if weave.init is called.
+    # But if the user instead called init_monitor, this check would pass but the
+    # later publish calls would fill since weave.init is required for those.
+    # Our intention is to replace init_monitor with weave.init, but that is not
+    # yet complete.
+    # TODO: Fix
+    return monitor.default_monitor().streamtable and context_state.eager_mode()
+
+
 def _auto_publish(obj: typing.Any, output_refs: typing.List[ref_base.Ref]):
     import numpy as np
+
+    ref = storage.get_ref(obj)
+    if ref:
+        output_refs.append(ref)
+        return ref
 
     if isinstance(obj, dict):
         return {k: _auto_publish(v, output_refs) for k, v in obj.items()}
@@ -454,7 +472,6 @@ def _auto_publish(obj: typing.Any, output_refs: typing.List[ref_base.Ref]):
         return obj
     from .api import publish
 
-    ref = storage.get_ref(obj)
     if not ref:
         ref = publish(
             obj,
@@ -491,14 +508,7 @@ def publish_graph(
         elif isinstance(node, graph.ConstNode):
             auto_publish(node.val)
 
-    mon = monitor.default_monitor()
-    # We're checking mon.streamtable, which is available if weave.init is called.
-    # But if the user instead called init_monitor, this check would pass but the
-    # later publish calls would fill since weave.init is required for those.
-    # Our intention is to replace init_monitor with weave.init, but that is not
-    # yet complete.
-    # TODO: Fix
-    if mon.streamtable and not context_state.monitor_is_disabled():
+    if publish_enabled():
         graph.map_nodes_full(nodes, _publish_node)
 
 
@@ -531,8 +541,7 @@ def hash_inputs(
 def execute_sync_op(op_def: op_def.OpDef, inputs: Mapping[str, typing.Any]):
     mon = monitor.default_monitor()
     mon_span_inputs = {**inputs}
-    st = mon.streamtable
-    if op_def.location and st:
+    if publish_enabled() and op_def.location:
         op_def_ref = storage._get_ref(op_def)
         if not isinstance(op_def_ref, artifact_wandb.WandbArtifactRef):
             # This should have already been published by publish_graph if monitoring
@@ -548,18 +557,17 @@ def execute_sync_op(op_def: op_def.OpDef, inputs: Mapping[str, typing.Any]):
         )
 
         with context_state.lazy_execution():
-            with context_state.monitor_disabled():
-                maybe_span_node = mon.rows()
-                if maybe_span_node is None:
-                    return None
+            maybe_span_node = mon.rows()
+            if maybe_span_node is None:
+                return None
 
-                span_node = maybe_span_node.filter(  # type: ignore
-                    lambda x: x["attributes"]["input_hash"] == input_hash
-                )
-                iter: eager.WeaveIter[
-                    stream_data_interfaces.TraceSpanDict
-                ] = eager.WeaveIter(span_node)
-                span_dict = iter[0]
+            span_node = maybe_span_node.filter(  # type: ignore
+                lambda x: x["attributes"]["input_hash"] == input_hash
+            )
+            iter: eager.WeaveIter[
+                stream_data_interfaces.TraceSpanDict
+            ] = eager.WeaveIter(span_node)
+            span_dict = iter[0]
 
             if (
                 span_dict != None and span_dict is not None
@@ -575,6 +583,7 @@ def execute_sync_op(op_def: op_def.OpDef, inputs: Mapping[str, typing.Any]):
 
             for i, ref in enumerate(refs[:3]):
                 span.inputs["_ref%s" % i] = ref
+                span.inputs["_ref_digest%s" % i] = ref.digest
             try:
                 res = op_def.resolve_fn(**inputs)
             except Exception as e:

--- a/weave/graph_client.py
+++ b/weave/graph_client.py
@@ -74,6 +74,14 @@ class GraphClient:
             filter_node = rows_node.filter(lambda row: row["inputs._ref0"] == ref)  # type: ignore
             return WeaveIter(filter_node, cls=Run)
 
+    def ref_value_input_to(
+        self, ref: artifact_wandb.WandbArtifactRef
+    ) -> WeaveIter[Run]:
+        with context_state.lazy_execution():
+            rows_node = self.runs_st.rows()
+            filter_node = rows_node.filter(lambda row: row["inputs._ref_digest0"] == ref.digest)  # type: ignore
+            return WeaveIter(filter_node, cls=Run)
+
     def ref_output_of(
         self, ref: artifact_wandb.WandbArtifactRef
     ) -> typing.Optional[Run]:

--- a/weave/op_def.py
+++ b/weave/op_def.py
@@ -350,7 +350,6 @@ class OpDef:
                 graph.expr_vars(arg_node) for arg_node in refine_params.values()
             )
         ):
-
             called_refine_output_type = _self.refine_output_type(**refine_params)
             tracer = engine_trace.tracer()  # type: ignore
             with tracer.trace("refine.%s" % _self.uri):

--- a/weave/ops_arrow/arrow.py
+++ b/weave/ops_arrow/arrow.py
@@ -256,6 +256,10 @@ class ArrowWeaveListType(types.Type):
             )
 
         res.validate()
+
+        if extra is not None:
+            return res[int(extra[0])]
+
         return res
 
 

--- a/weave/ops_arrow/list_.py
+++ b/weave/ops_arrow/list_.py
@@ -1291,7 +1291,7 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
             # in this list
             if isinstance(ref, artifact_base.ArtifactRef):
                 result = box.box(result)
-                new_ref = ref.with_extra(self.object_type, result, str(index))
+                new_ref = ref.with_extra(self.object_type, result, [str(index)])
                 ref_base._put_ref(result, new_ref)
             return result
         return awl

--- a/weave/ops_arrow/list_.py
+++ b/weave/ops_arrow/list_.py
@@ -1282,7 +1282,18 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
             result_rows, self.object_type, self._artifact
         )
         if isinstance(index, int):
-            return awl.to_pylist_tagged()[0]
+            result = awl.to_pylist_tagged()[0]
+            ref = ref_base.get_ref(self)
+            from .. import artifact_base
+
+            # Ensure we associate a ref for the row we're returning,
+            # so if the user calls an op on the row, the op refers to a sub-row
+            # in this list
+            if isinstance(ref, artifact_base.ArtifactRef):
+                result = box.box(result)
+                new_ref = ref.with_extra(self.object_type, result, str(index))
+                ref_base._put_ref(result, new_ref)
+            return result
         return awl
 
     def __getitem__(

--- a/weave/ref_base.py
+++ b/weave/ref_base.py
@@ -1,8 +1,11 @@
 import typing
 import weakref
+import hashlib
+import json
 import contextlib
 import contextvars
 import collections
+import functools
 
 from . import uris
 from . import box
@@ -46,6 +49,9 @@ class Ref:
         if self._obj is not None:
             return self._obj
 
+        if self.extra is not None:
+            raise ValueError("Cannot get object from Ref with extra for now")
+
         if not self.is_saved:
             # PR TODO: this path needs to happen in FSArtifact, as you can
             # always get the value of a MemArtifact
@@ -70,6 +76,18 @@ class Ref:
     @property
     def type(self) -> "types.Type":
         raise NotImplementedError
+
+    @functools.cached_property
+    def digest(self) -> str:
+        hash = hashlib.md5()
+        # This can encounter non-serialized objects, even though Ref
+        # must be a pointer to an object that can only contain serializable
+        # stuff and refs. But we recursively deserialize all sub-refs when
+        # fetching a ref. So we need to walk obj, converting objs back to
+        # refs where we can, before this json.dumps call.
+        # TODO: fix
+        hash.update(json.dumps(self.obj).encode())
+        return hash.hexdigest()
 
     @classmethod
     def from_str(cls, s: str) -> "Ref":

--- a/weave/ref_base.py
+++ b/weave/ref_base.py
@@ -49,9 +49,6 @@ class Ref:
         if self._obj is not None:
             return self._obj
 
-        if self.extra is not None:
-            raise ValueError("Cannot get object from Ref with extra for now")
-
         if not self.is_saved:
             # PR TODO: this path needs to happen in FSArtifact, as you can
             # always get the value of a MemArtifact

--- a/weave/tests/test_op.py
+++ b/weave/tests/test_op.py
@@ -5,6 +5,7 @@ from .. import graph
 from .. import types
 from .. import weave_internal
 from .. import storage
+from .. import context_state
 from . import test_helpers
 from .. import uris
 
@@ -124,10 +125,11 @@ def test_op_callable_output_type_and_return_type_declared():
 
 def test_op_no_arg_type():
     with pytest.raises(weave.errors.WeaveDefinitionError):
+        with context_state.loading_builtins(True):
 
-        @weave.op()
-        def op_callable_output_type_and_return_type_declared(a: int):
-            return str(a)
+            @weave.op()
+            def op_callable_output_type_and_return_type_declared(a: int):
+                return str(a)
 
 
 class SomeUnknownObj:
@@ -144,10 +146,11 @@ def test_op_unknown_arg_type():
 
 def test_op_no_return_type():
     with pytest.raises(weave.errors.WeaveDefinitionError):
+        with context_state.loading_builtins(True):
 
-        @weave.op(input_type={"a": types.Int()})
-        def op_callable_output_type_and_return_type_declared(a: int):
-            return str(a)
+            @weave.op(input_type={"a": types.Int()})
+            def op_callable_output_type_and_return_type_declared(a: int):
+                return str(a)
 
 
 def test_op_inferred_list_return():

--- a/weave/tests/test_weaveflow.py
+++ b/weave/tests/test_weaveflow.py
@@ -1,0 +1,55 @@
+import pytest
+import weave
+import typing
+
+
+@pytest.mark.skip("weaveflow tests disabled since they require W&B for now")
+def test_digestrefs():
+    from weave import weaveflow
+
+    graph_client = weave.init("digestrefs3")
+
+    ds = weave.WeaveList(
+        [
+            {
+                "id": "0",
+                "val": 100,
+            },
+            {
+                "id": "0",
+                "val": 101,
+            },
+        ]
+    )
+
+    ds0_ref = weave.publish(ds, "digestrefs")
+
+    ds0 = weave.ref(str(ds0_ref)).get()
+
+    @weave.op()
+    def add5_to_row(row) -> int:
+        return row["val"] + 5
+
+    ds0_row0 = ds0[0]
+
+    from .. import ref_base
+
+    ds0_row0_ref = ref_base.get_ref(ds0_row0)
+    assert ds0_row0_ref != None
+
+    x = add5_to_row(ds0_row0)
+
+    calls = ds0_row0_ref.input_to()
+    assert len(calls) == 1
+
+    ds = ds + [{"id": 2, "val": -10}]
+    ds1_ref = weave.publish(ds, "digestrefs")
+
+    ds1 = weave.ref(str(ds1_ref)).get()
+    ds1_row0 = ds1[0]
+    ds1_row0_ref = ref_base.get_ref(ds1_row0)
+
+    assert ds0_row0_ref.digest == ds1_row0_ref.digest
+
+    assert len(ds1_row0_ref.input_to()) == 0
+    assert len(ds1_row0_ref.value_input_to()) == 1


### PR DESCRIPTION
This makes it so we can look up calls that consumed the value of a given object. In particular this is useful so we can show all the calls that consumed a specific row of a dataset in the UI. So if for example I'm looking at the 5th question in my QA dataset, I can see any calls that have been made with that question.

```
dataset_ref = weave.publish(weave.Dataset([...]), ...)
dataset = dataset_ref.get()

@weave.op()
def my_op(v):
  return v['val'] + 5

my_op(dataset.rows[0])
dataset.rows[0].input_to() # -> returns the call that we just did

# publish new version of dataset
dataset_ref = weave.publish(weave.Dataset([...]), ...)
dataset = dataset_ref.get()

dataset.rows[0].input_to() # -> returns nothing because the dataset[0] ref is a row in the new version
dataset.rows[0].value_input_to() # -> returns the same call as above
```

This is achieved by a few changes:
- attach a ref to any rows grabbed out of an arrow weave list with `__getitem__`. This ref will have "#<row_index>" on the end.
- ensure if an object that is an input to a call has a ref available, we log the ref instead of the value in the call
- all Ref have a new .digest property that computes the digest of the pointed to object
- store computed digest for any refs in the call table, to make call table searchable by digest
- add appropriate read api to GraphClient and WandbArtifactRef 

TODOs:
- [x] can't fetch sub-list ref by constructing ref than doing .obj
- [x] (leaving as TODO in code with comment block) .digest will fail when there are sub-refs
- [x] (moved to tracking doc) define ref extra structure for other object types, and ID lookups in list, and commit to a structure
- [x] (moved to tracking doc) use digest in input_hash, and md5 instead of sha256
- [x] change to enforce type requirement for built-in ops, but not custom ops

BONUS:
- no longer need typing.Any in weave argument lists