### PR TITLE
fix: default range for x

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
@@ -980,12 +980,10 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
     return brushTypesResult;
   }, [listOfTableNodes, config.series, weave]);
 
+  const signalDomainX = concreteConfig.signals.domain.x;
   const xScaleAndDomain = useMemo(
-    () =>
-      concreteConfig.signals.domain.x
-        ? {scale: {domain: concreteConfig.signals.domain.x}}
-        : {},
-    [concreteConfig.signals.domain.x]
+    () => (signalDomainX ? {scale: {domain: signalDomainX}} : {}),
+    [signalDomainX]
   );
   const yScaleAndDomain = useMemo(
     () =>
@@ -1076,10 +1074,23 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
             };
           }
         } else {
+          // If we haven't zoomed in, and we have quantitative data, use the extent of the x values
+          let xScaleAndDomainFromData = {};
+          if (xAxisType === 'quantitative' && _.isEmpty(xScaleAndDomain)) {
+            xScaleAndDomainFromData = {
+              scale: {
+                domain: {
+                  data: newSpec.data.name,
+                  field: fixedXKey,
+                },
+              },
+            };
+          }
           newSpec.encoding.x = {
             field: fixedXKey,
             type: xAxisType,
             ...xScaleAndDomain,
+            ...xScaleAndDomainFromData,
           };
         }
         if (xAxisType === 'temporal' && xTimeUnit && isDashboard) {


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16641

`xScaleAndDomain` is defined like this:
```
      concreteConfig.signals.domain.x
        ? {scale: {domain: concreteConfig.signals.domain.x}}
        : {},
```
That empty object when there is no zoom seems to cause Vega to use the domain [0, max] and not [min, max]. In the screenshots below, the x values are timestamps that are close together, but far from zero, causing all of the points to overlap in a misleading way, and the user to have to zoom in a lot to see a more useful visualization. The change here is to reference the data field, which makes Vega use its min/max.

Before:
<img width="993" alt="Screenshot 2023-12-13 at 10 06 13 PM" src="https://github.com/wandb/weave/assets/112953339/c92bbf1f-a754-4112-8328-5db40f45eb08">

After:
<img width="994" alt="Screenshot 2023-12-13 at 10 07 29 PM" src="https://github.com/wandb/weave/assets/112953339/013aa4b1-fcee-442e-8aaa-edf88149ad76">
