### PR TITLE
launch schema

### DIFF
--- a/weave-js/src/common/components/Monaco/bootstrap.ts
+++ b/weave-js/src/common/components/Monaco/bootstrap.ts
@@ -59,37 +59,37 @@ const jsonSchemas = [
   {
     uri: 'http://dev.wandb.com/schema/sagemaker.json',
     schema: sagemakerSchema,
-    fileMatch: ['sagemaker'],
+    fileMatch: ['launch/sagemaker'],
   },
   {
     uri: 'http://dev.wandb.com/schema/vertex.json',
     schema: vertexSchema,
-    fileMatch: ['vertex', 'gcp-vertex'],
+    fileMatch: ['launch/vertex', 'launch/gcp-vertex'],
   },
   {
     uri: 'http://dev.wandb.com/schema/pytorchjob.json',
     schema: pytorchJobSchema,
-    fileMatch: ['pytorchjob'],
+    fileMatch: ['launch/pytorchjob'],
   },
   {
     uri: 'http://dev.wandb.com/schema/job.json',
     schema: kubernetesJobSchema,
-    fileMatch: ['kubernetes'],
+    fileMatch: ['launch/kubernetes'],
   },
   {
     uri: 'http://dev.wandb.com/schema/volcanojob.json',
     schema: volcanoJobSchema,
-    fileMatch: ['volcano'],
+    fileMatch: ['launch/volcano'],
   },
   {
     uri: 'http://dev.wandb.com/schema/jobset.json',
     schema: jobsetSchema,
-    fileMatch: ['jobset'],
+    fileMatch: ['launch/jobset'],
   },
   {
     uri: 'http://dev.wandb.com/schema/dockerrun.json',
     schema: dockerRunSchema,
-    fileMatch: ['local-container'],
+    fileMatch: ['launch/local-container'],
   },
 ];
 
@@ -97,27 +97,27 @@ const yamlSchemas = [
   {
     uri: 'http://dev.wandb.com/schema/pytorchjob.json',
     schema: pytorchJobSchema,
-    fileMatch: ['pytorchjob'],
+    fileMatch: ['launch/pytorchjob'],
   },
   {
     uri: 'http://dev.wandb.com/schema/job.json',
     schema: kubernetesJobSchema,
-    fileMatch: ['kubernetes'],
+    fileMatch: ['launch/kubernetes'],
   },
   {
     uri: 'http://dev.wandb.com/schema/volcanojob.json',
     schema: volcanoJobSchema,
-    fileMatch: ['volcano'],
+    fileMatch: ['launch/volcano'],
   },
   {
     uri: 'http://dev.wandb.com/schema/jobset.json',
     schema: jobsetSchema,
-    fileMatch: ['jobset'],
+    fileMatch: ['launch/jobset'],
   },
   {
     uri: 'http://dev.wandb.com/schema/dockerrun.json',
     schema: dockerRunSchema,
-    fileMatch: ['local-container'],
+    fileMatch: ['launch/local-container'],
   },
   {
     uri: 'http://dev.wandb.com/schema/sweep-config-schema.json',
@@ -127,12 +127,12 @@ const yamlSchemas = [
   {
     uri: 'http://dev.wandb.com/schema/sagemaker.json',
     schema: sagemakerSchema,
-    fileMatch: ['sagemaker'],
+    fileMatch: ['launch/sagemaker'],
   },
   {
     uri: 'http://dev.wandb.com/schema/vertex.json',
     schema: vertexSchema,
-    fileMatch: ['vertex', 'gcp-vertex'],
+    fileMatch: ['launch/vertex', 'launch/gcp-vertex'],
   },
 ];
 

--- a/weave-js/src/common/components/Monaco/bootstrap.ts
+++ b/weave-js/src/common/components/Monaco/bootstrap.ts
@@ -90,7 +90,7 @@ const jsonSchemas = [
     uri: 'http://dev.wandb.com/schema/dockerrun.json',
     schema: dockerRunSchema,
     fileMatch: ['local-container'],
-  } 
+  },
 ];
 
 const yamlSchemas = [
@@ -133,7 +133,7 @@ const yamlSchemas = [
     uri: 'http://dev.wandb.com/schema/vertex.json',
     schema: vertexSchema,
     fileMatch: ['vertex', 'gcp-vertex'],
-  }
+  },
 ];
 
 (window as any).MonacoEnvironment = {

--- a/weave-js/src/common/components/Monaco/bootstrap.ts
+++ b/weave-js/src/common/components/Monaco/bootstrap.ts
@@ -21,9 +21,9 @@
  * (seemingly) ~150K. I'm suspicious I may not have measured it right.
  */
 
-import './set-window-monaco';
-import 'monaco-yaml/lib/esm/monaco.contribution';
 import 'monaco-editor/esm/vs/language/json/monaco.contribution';
+import 'monaco-yaml/lib/esm/monaco.contribution';
+import './set-window-monaco';
 
 import stringify from 'json-stringify-pretty-compact';
 import type monaco from 'monaco-editor';
@@ -59,33 +59,33 @@ const yamlSchemas = [
   {
     uri: 'http://dev.wandb.com/schema/pytorchjob.json',
     schema: pytorchJobSchema,
-    fileMatch: ['pytorchjob.yaml'],
+    fileMatch: ['pytorchjob'],
   },
   {
     uri: 'http://dev.wandb.com/schema/job.json',
-    schema:  kubernetesJobSchema,
-    fileMatch: ['job.yaml'],
+    schema: kubernetesJobSchema,
+    fileMatch: ['kubernetes'],
   },
   {
     uri: 'http://dev.wandb.com/schema/volcanojob.json',
     schema: volcanoJobSchema,
-    fileMatch: ['volcanojob.yaml'],
+    fileMatch: ['volcano'],
   },
   {
     uri: 'http://dev.wandb.com/schema/jobset.json',
     schema: jobsetSchema,
-    fileMatch: ['jobset.yaml'],
+    fileMatch: ['jobset'],
   },
   {
     uri: 'http://dev.wandb.com/schema/dockerrun.json',
     schema: dockerRunSchema,
-    fileMatch: ['dockerrun.yaml'],
+    fileMatch: ['docker'],
   },
   {
     uri: 'http://dev.wandb.com/schema/sweep-config-schema.json',
     schema: sweepConfigSchema,
     fileMatch: ['sweep-config.yaml'],
-  }
+  },
 ];
 
 (window as any).MonacoEnvironment = {

--- a/weave-js/src/common/components/Monaco/bootstrap.ts
+++ b/weave-js/src/common/components/Monaco/bootstrap.ts
@@ -56,6 +56,41 @@ const jsonSchemas = [
     schema: {...vegaLiteSchema},
     uri: 'https://vega.github.io/schema/vega-lite/v4.json',
   },
+  {
+    uri: 'http://dev.wandb.com/schema/sagemaker.json',
+    schema: sagemakerSchema,
+    fileMatch: ['sagemaker'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/vertex.json',
+    schema: vertexSchema,
+    fileMatch: ['vertex', 'gcp-vertex'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/pytorchjob.json',
+    schema: pytorchJobSchema,
+    fileMatch: ['pytorchjob'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/job.json',
+    schema: kubernetesJobSchema,
+    fileMatch: ['kubernetes'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/volcanojob.json',
+    schema: volcanoJobSchema,
+    fileMatch: ['volcano'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/jobset.json',
+    schema: jobsetSchema,
+    fileMatch: ['jobset'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/dockerrun.json',
+    schema: dockerRunSchema,
+    fileMatch: ['local-container'],
+  } 
 ];
 
 const yamlSchemas = [
@@ -139,7 +174,7 @@ monacoEditor.languages.registerDocumentFormattingEditProvider('json', {
 });
 
 (monacoEditor.languages as any).yaml.yamlDefaults.setDiagnosticsOptions({
-  // validate: true,
+  validate: true,
   inlineSuggest: true,
   schemas: yamlSchemas,
   enableSchemaRequest: true,

--- a/weave-js/src/common/components/Monaco/bootstrap.ts
+++ b/weave-js/src/common/components/Monaco/bootstrap.ts
@@ -34,7 +34,12 @@ import yamlWorker from 'monaco-yaml/lib/esm/yaml.worker.js?worker&inline';
 import * as vegaSchema from 'vega/build/vega-schema.json';
 import * as vegaLiteSchema from 'vega-lite/build/vega-lite-schema.json';
 
+import dockerRunSchema from './schemas/dockerrun.json';
+import kubernetesJobSchema from './schemas/job.json';
+import jobsetSchema from './schemas/jobset.json';
+import pytorchJobSchema from './schemas/pytorchjob.json';
 import sweepConfigSchema from './schemas/sweep-config-schema.json';
+import volcanoJobSchema from './schemas/volcanojob.json';
 
 const jsonSchemas = [
   {
@@ -52,10 +57,35 @@ const jsonSchemas = [
 
 const yamlSchemas = [
   {
-    uri: 'http://dev.wandb.com/schema/config.json',
-    schema: {...sweepConfigSchema},
-    fileMatch: ['*'],
+    uri: 'http://dev.wandb.com/schema/pytorchjob.json',
+    schema: pytorchJobSchema,
+    fileMatch: ['pytorchjob.yaml'],
   },
+  {
+    uri: 'http://dev.wandb.com/schema/job.json',
+    schema:  kubernetesJobSchema,
+    fileMatch: ['job.yaml'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/volcanojob.json',
+    schema: volcanoJobSchema,
+    fileMatch: ['volcanojob.yaml'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/jobset.json',
+    schema: jobsetSchema,
+    fileMatch: ['jobset.yaml'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/dockerrun.json',
+    schema: dockerRunSchema,
+    fileMatch: ['dockerrun.yaml'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/sweep-config-schema.json',
+    schema: sweepConfigSchema,
+    fileMatch: ['sweep-config.yaml'],
+  }
 ];
 
 (window as any).MonacoEnvironment = {
@@ -96,7 +126,8 @@ monacoEditor.languages.registerDocumentFormattingEditProvider('json', {
 });
 
 (monacoEditor.languages as any).yaml.yamlDefaults.setDiagnosticsOptions({
-  validate: true,
+  // validate: true,
+  inlineSuggest: true,
   schemas: yamlSchemas,
   enableSchemaRequest: true,
   format: true,

--- a/weave-js/src/common/components/Monaco/bootstrap.ts
+++ b/weave-js/src/common/components/Monaco/bootstrap.ts
@@ -21,9 +21,10 @@
  * (seemingly) ~150K. I'm suspicious I may not have measured it right.
  */
 
-import 'monaco-editor/esm/vs/language/json/monaco.contribution';
-import 'monaco-yaml/lib/esm/monaco.contribution';
+
 import './set-window-monaco';
+import 'monaco-yaml/lib/esm/monaco.contribution';
+import 'monaco-editor/esm/vs/language/json/monaco.contribution';
 
 import stringify from 'json-stringify-pretty-compact';
 import type monaco from 'monaco-editor';

--- a/weave-js/src/common/components/Monaco/bootstrap.ts
+++ b/weave-js/src/common/components/Monaco/bootstrap.ts
@@ -39,6 +39,7 @@ import dockerRunSchema from './schemas/dockerrun.json';
 import kubernetesJobSchema from './schemas/job.json';
 import jobsetSchema from './schemas/jobset.json';
 import pytorchJobSchema from './schemas/pytorchjob.json';
+import sagemakerSchema from './schemas/sagemaker.json';
 import sweepConfigSchema from './schemas/sweep-config-schema.json';
 import volcanoJobSchema from './schemas/volcanojob.json';
 
@@ -80,13 +81,18 @@ const yamlSchemas = [
   {
     uri: 'http://dev.wandb.com/schema/dockerrun.json',
     schema: dockerRunSchema,
-    fileMatch: ['docker'],
+    fileMatch: ['local-container'],
   },
   {
     uri: 'http://dev.wandb.com/schema/sweep-config-schema.json',
     schema: sweepConfigSchema,
     fileMatch: ['sweep-config.yaml'],
   },
+  {
+    uri: 'http://dev.wandb.com/schema/sagemaker.json',
+    schema: sagemakerSchema,
+    fileMatch: ['sagemaker'],
+  }
 ];
 
 (window as any).MonacoEnvironment = {

--- a/weave-js/src/common/components/Monaco/bootstrap.ts
+++ b/weave-js/src/common/components/Monaco/bootstrap.ts
@@ -41,6 +41,7 @@ import jobsetSchema from './schemas/jobset.json';
 import pytorchJobSchema from './schemas/pytorchjob.json';
 import sagemakerSchema from './schemas/sagemaker.json';
 import sweepConfigSchema from './schemas/sweep-config-schema.json';
+import vertexSchema from './schemas/vertex.json';
 import volcanoJobSchema from './schemas/volcanojob.json';
 
 const jsonSchemas = [
@@ -92,6 +93,11 @@ const yamlSchemas = [
     uri: 'http://dev.wandb.com/schema/sagemaker.json',
     schema: sagemakerSchema,
     fileMatch: ['sagemaker'],
+  },
+  {
+    uri: 'http://dev.wandb.com/schema/vertex.json',
+    schema: vertexSchema,
+    fileMatch: ['vertex', 'gcp-vertex'],
   }
 ];
 

--- a/weave-js/src/common/components/Monaco/schemas/dockerrun.json
+++ b/weave-js/src/common/components/Monaco/schemas/dockerrun.json
@@ -1,0 +1,442 @@
+{
+  "type": "object",
+  "properties": {
+    "blkio-weight": {
+      "type": "integer",
+      "description": "Block IO (relative"
+    },
+    "blkio-weight-device": {
+      "type": "array",
+      "description": "Block IO weight"
+    },
+    "cap-add": {
+      "type": "array",
+      "description": "Add Linux capabilities"
+    },
+    "cap-drop": {
+      "type": "array",
+      "description": "Drop Linux capabilities"
+    },
+    "cgroup-parent": {
+      "type": "string",
+      "description": "Optional parent cgroup"
+    },
+    "cgroupns": {
+      "type": "string",
+      "description": "Cgroup namespace to"
+    },
+    "cidfile": {
+      "type": "string",
+      "description": "Write the container ID"
+    },
+    "cpu-period": {
+      "type": "integer",
+      "description": "Limit CPU CFS"
+    },
+    "cpu-quota": {
+      "type": "integer",
+      "description": "Limit CPU CFS"
+    },
+    "cpu-rt-period": {
+      "type": "integer",
+      "description": "Limit CPU real-time"
+    },
+    "cpu-rt-runtime": {
+      "type": "integer",
+      "description": "Limit CPU real-time"
+    },
+    "cpu-shares": {
+      "type": "integer",
+      "description": "CPU shares (relative"
+    },
+    "c": {
+      "type": "integer",
+      "description": "CPU shares (relative"
+    },
+    "cpus": {
+      "type": "string",
+      "description": "Number of CPUs"
+    },
+    "cpuset-cpus": {
+      "type": "string",
+      "description": "CPUs in which to allow"
+    },
+    "cpuset-mems": {
+      "type": "string",
+      "description": "MEMs in which to allow"
+    },
+    "detach": {
+      "type": "string",
+      "description": ""
+    },
+    "d": {
+      "type": "string",
+      "description": ""
+    },
+    "detach-keys": {
+      "type": "string",
+      "description": "Override the key"
+    },
+    "device": {
+      "type": "array",
+      "description": "Add a host device to"
+    },
+    "device-cgroup-rule": {
+      "type": "array",
+      "description": "Add a rule to the"
+    },
+    "device-read-bps": {
+      "type": "array",
+      "description": "Limit read rate (bytes"
+    },
+    "device-read-iops": {
+      "type": "array",
+      "description": "Limit read rate (IO"
+    },
+    "device-write-bps": {
+      "type": "array",
+      "description": "Limit write rate"
+    },
+    "device-write-iops": {
+      "type": "array",
+      "description": "Limit write rate (IO"
+    },
+    "disable-content-trust": {
+      "type": "string",
+      "description": ""
+    },
+    "dns": {
+      "type": "array",
+      "description": "Set custom DNS servers"
+    },
+    "dns-option": {
+      "type": "array",
+      "description": "Set DNS options"
+    },
+    "dns-search": {
+      "type": "array",
+      "description": "Set custom DNS search"
+    },
+    "domainname": {
+      "type": "string",
+      "description": "Container NIS domain name"
+    },
+    "entrypoint": {
+      "type": "string",
+      "description": "Overwrite the default"
+    },
+    "env": {
+      "type": "array",
+      "description": "Set environment variables"
+    },
+    "e": {
+      "type": "array",
+      "description": "Set environment variables"
+    },
+    "env-file": {
+      "type": "array",
+      "description": "Read in a file of"
+    },
+    "expose": {
+      "type": "array",
+      "description": "Expose a port or a"
+    },
+    "gpus": {
+      "type": "string",
+      "description": ""
+    },
+    "group-add": {
+      "type": "array",
+      "description": "Add additional groups"
+    },
+    "health-cmd": {
+      "type": "string",
+      "description": "Command to run to"
+    },
+    "health-interval": {
+      "type": "string",
+      "description": "Time between running"
+    },
+    "health-retries": {
+      "type": "integer",
+      "description": "Consecutive failures"
+    },
+    "health-start-period": {
+      "type": "string",
+      "description": "Start period for the"
+    },
+    "health-timeout": {
+      "type": "string",
+      "description": "Maximum time to allow"
+    },
+    "help": {
+      "type": "string",
+      "description": ""
+    },
+    "hostname": {
+      "type": "string",
+      "description": "Container host name"
+    },
+    "h": {
+      "type": "string",
+      "description": "Container host name"
+    },
+    "init": {
+      "type": "string",
+      "description": ""
+    },
+    "interactive": {
+      "type": "string",
+      "description": ""
+    },
+    "i": {
+      "type": "string",
+      "description": ""
+    },
+    "ip": {
+      "type": "string",
+      "description": "IPv4 address (e.g.,"
+    },
+    "ip6": {
+      "type": "string",
+      "description": "IPv6 address (e.g.,"
+    },
+    "ipc": {
+      "type": "string",
+      "description": "IPC mode to use"
+    },
+    "isolation": {
+      "type": "string",
+      "description": "Container isolation"
+    },
+    "kernel-memory": {
+      "type": "string",
+      "description": "Kernel memory limit"
+    },
+    "label": {
+      "type": "array",
+      "description": "Set meta data on a"
+    },
+    "l": {
+      "type": "array",
+      "description": "Set meta data on a"
+    },
+    "label-file": {
+      "type": "array",
+      "description": "Read in a line"
+    },
+    "link": {
+      "type": "array",
+      "description": "Add link to another"
+    },
+    "link-local-ip": {
+      "type": "array",
+      "description": "Container IPv4/IPv6"
+    },
+    "log-driver": {
+      "type": "string",
+      "description": "Logging driver for the"
+    },
+    "log-opt": {
+      "type": "array",
+      "description": "Log driver options"
+    },
+    "mac-address": {
+      "type": "string",
+      "description": "Container MAC address"
+    },
+    "memory": {
+      "type": "string",
+      "description": "Memory limit"
+    },
+    "m": {
+      "type": "string",
+      "description": "Memory limit"
+    },
+    "memory-reservation": {
+      "type": "string",
+      "description": "Memory soft limit"
+    },
+    "memory-swap": {
+      "type": "string",
+      "description": "Swap limit equal to"
+    },
+    "memory-swappiness": {
+      "type": "integer",
+      "description": "Tune container memory"
+    },
+    "mount": {
+      "type": "string",
+      "description": "Attach a filesystem"
+    },
+    "name": {
+      "type": "string",
+      "description": "Assign a name to the"
+    },
+    "network": {
+      "type": "string",
+      "description": "Connect a container to"
+    },
+    "network-alias": {
+      "type": "array",
+      "description": "Add network-scoped"
+    },
+    "no-healthcheck": {
+      "type": "string",
+      "description": ""
+    },
+    "oom-kill-disable": {
+      "type": "string",
+      "description": ""
+    },
+    "oom-score-adj": {
+      "type": "integer",
+      "description": "Tune host's OOM"
+    },
+    "pid": {
+      "type": "string",
+      "description": "PID namespace to use"
+    },
+    "pids-limit": {
+      "type": "integer",
+      "description": "Tune container pids"
+    },
+    "platform": {
+      "type": "string",
+      "description": "Set platform if server"
+    },
+    "privileged": {
+      "type": "string",
+      "description": ""
+    },
+    "publish": {
+      "type": "array",
+      "description": "Publish a container's"
+    },
+    "p": {
+      "type": "array",
+      "description": "Publish a container's"
+    },
+    "publish-all": {
+      "type": "string",
+      "description": ""
+    },
+    "P": {
+      "type": "string",
+      "description": ""
+    },
+    "pull": {
+      "type": "string",
+      "description": "Pull image before"
+    },
+    "quiet": {
+      "type": "string",
+      "description": ""
+    },
+    "q": {
+      "type": "string",
+      "description": ""
+    },
+    "read-only": {
+      "type": "string",
+      "description": ""
+    },
+    "restart": {
+      "type": "string",
+      "description": "Restart policy to"
+    },
+    "rm": {
+      "type": "string",
+      "description": ""
+    },
+    "runtime": {
+      "type": "string",
+      "description": "Runtime to use for"
+    },
+    "security-opt": {
+      "type": "array",
+      "description": "Security Options"
+    },
+    "shm-size": {
+      "type": "string",
+      "description": "Size of /dev/shm"
+    },
+    "sig-proxy": {
+      "type": "string",
+      "description": ""
+    },
+    "stop-signal": {
+      "type": "string",
+      "description": "Signal to stop the"
+    },
+    "stop-timeout": {
+      "type": "integer",
+      "description": "Timeout (in seconds)"
+    },
+    "storage-opt": {
+      "type": "array",
+      "description": "Storage driver options"
+    },
+    "sysctl": {
+      "type": "object",
+      "description": "Sysctl options"
+    },
+    "tmpfs": {
+      "type": "array",
+      "description": "Mount a tmpfs directory"
+    },
+    "tty": {
+      "type": "string",
+      "description": ""
+    },
+    "t": {
+      "type": "string",
+      "description": ""
+    },
+    "ulimit": {
+      "type": "string",
+      "description": "Ulimit options (default [])"
+    },
+    "user": {
+      "type": "string",
+      "description": "Username or UID"
+    },
+    "u": {
+      "type": "string",
+      "description": "Username or UID"
+    },
+    "userns": {
+      "type": "string",
+      "description": "User namespace to use"
+    },
+    "uts": {
+      "type": "string",
+      "description": "UTS namespace to use"
+    },
+    "volume": {
+      "type": "array",
+      "description": "Bind mount a volume"
+    },
+    "v": {
+      "type": "array",
+      "description": "Bind mount a volume"
+    },
+    "volume-driver": {
+      "type": "string",
+      "description": "Optional volume driver"
+    },
+    "volumes-from": {
+      "type": "array",
+      "description": "Mount volumes from the"
+    },
+    "workdir": {
+      "type": "string",
+      "description": "Working directory"
+    },
+    "w": {
+      "type": "string",
+      "description": "Working directory"
+    }
+  },
+  "additionalProperties": false
+}

--- a/weave-js/src/common/components/Monaco/schemas/job.json
+++ b/weave-js/src/common/components/Monaco/schemas/job.json
@@ -1,0 +1,6252 @@
+{
+  "description": "Job represents the configuration of a single job.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "creationTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "deletionTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "type": "string"
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "type": "array",
+          "items": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "type": "object",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                "type": "string"
+              },
+              "fieldsType": {
+                "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                "type": "string"
+              },
+              "fieldsV1": {
+                "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                "type": "object"
+              },
+              "manager": {
+                "description": "Manager is an identifier of the workflow managing these fields.",
+                "type": "string"
+              },
+              "operation": {
+                "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                "type": "string"
+              },
+              "subresource": {
+                "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                "type": "string"
+              },
+              "time": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+          "type": "string"
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "type": "array",
+          "items": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": "object",
+            "required": ["apiVersion", "kind", "name", "uid"],
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "blockOwnerDeletion": {
+                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                "type": "boolean"
+              },
+              "controller": {
+                "description": "If true, this reference points to the managing controller.",
+                "type": "boolean"
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                "type": "string"
+              }
+            },
+            "x-kubernetes-map-type": "atomic"
+          },
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+          "type": "string"
+        }
+      }
+    },
+    "spec": {
+      "description": "JobSpec describes how the job execution will look like.",
+      "type": "object",
+      "required": ["template"],
+      "properties": {
+        "activeDeadlineSeconds": {
+          "description": "Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "backoffLimit": {
+          "description": "Specifies the number of retries before marking this job failed. Defaults to 6",
+          "type": "integer",
+          "format": "int32"
+        },
+        "backoffLimitPerIndex": {
+          "description": "Specifies the limit for the number of retries within an index before marking this index as failed. When enabled the number of failures per index is kept in the pod's batch.kubernetes.io/job-index-failure-count annotation. It can only be set when Job's completionMode=Indexed, and the Pod's restart policy is Never. The field is immutable. This field is alpha-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (disabled by default).",
+          "type": "integer",
+          "format": "int32"
+        },
+        "completionMode": {
+          "description": "completionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`.\n\n`NonIndexed` means that the Job is considered complete when there have been .spec.completions successfully completed Pods. Each Pod completion is homologous to each other.\n\n`Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`.\n\nMore completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.\n\nPossible enum values:\n - `\"Indexed\"` is a Job completion mode. In this mode, the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1). The Job is considered complete when a Pod completes for each completion index.\n - `\"NonIndexed\"` is a Job completion mode. In this mode, the Job is considered complete when there have been .spec.completions successfully completed Pods. Pod completions are homologous to each other.",
+          "type": "string",
+          "enum": ["Indexed", "NonIndexed"]
+        },
+        "completions": {
+          "description": "Specifies the desired number of successfully finished pods the job should be run with.  Setting to null means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+          "type": "integer",
+          "format": "int32"
+        },
+        "manualSelector": {
+          "description": "manualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector",
+          "type": "boolean"
+        },
+        "maxFailedIndexes": {
+          "description": "Specifies the maximal number of failed indexes before marking the Job as failed, when backoffLimitPerIndex is set. Once the number of failed indexes exceeds this number the entire Job is marked as Failed and its execution is terminated. When left as null the job continues execution of all of its indexes and is marked with the `Complete` Job condition. It can only be specified when backoffLimitPerIndex is set. It can be null or up to completions. It is required and must be less than or equal to 10^4 when is completions greater than 10^5. This field is alpha-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (disabled by default).",
+          "type": "integer",
+          "format": "int32"
+        },
+        "parallelism": {
+          "description": "Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+          "type": "integer",
+          "format": "int32"
+        },
+        "podFailurePolicy": {
+          "description": "PodFailurePolicy describes how failed pods influence the backoffLimit.",
+          "type": "object",
+          "required": ["rules"],
+          "properties": {
+            "rules": {
+              "description": "A list of pod failure policy rules. The rules are evaluated in order. Once a rule matches a Pod failure, the remaining of the rules are ignored. When no rule matches the Pod failure, the default handling applies - the counter of pod failures is incremented and it is checked against the backoffLimit. At most 20 elements are allowed.",
+              "type": "array",
+              "items": {
+                "description": "PodFailurePolicyRule describes how a pod failure is handled when the requirements are met. One of onExitCodes and onPodConditions, but not both, can be used in each rule.",
+                "type": "object",
+                "required": ["action"],
+                "properties": {
+                  "action": {
+                    "description": "Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are:\n\n- FailJob: indicates that the pod's job is marked as Failed and all\n  running pods are terminated.\n- FailIndex: indicates that the pod's index is marked as Failed and will\n  not be restarted.\n  This value is alpha-level. It can be used when the\n  `JobBackoffLimitPerIndex` feature gate is enabled (disabled by default).\n- Ignore: indicates that the counter towards the .backoffLimit is not\n  incremented and a replacement pod is created.\n- Count: indicates that the pod is handled in the default way - the\n  counter towards the .backoffLimit is incremented.\nAdditional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.\n\nPossible enum values:\n - `\"Count\"` This is an action which might be taken on a pod failure - the pod failure is handled in the default way - the counter towards .backoffLimit, represented by the job's .status.failed field, is incremented.\n - `\"FailIndex\"` This is an action which might be taken on a pod failure - mark the Job's index as failed to avoid restarts within this index. This action can only be used when backoffLimitPerIndex is set.\n - `\"FailJob\"` This is an action which might be taken on a pod failure - mark the pod's job as Failed and terminate all running pods.\n - `\"Ignore\"` This is an action which might be taken on a pod failure - the counter towards .backoffLimit, represented by the job's .status.failed field, is not incremented and a replacement pod is created.",
+                    "type": "string",
+                    "enum": ["Count", "FailIndex", "FailJob", "Ignore"]
+                  },
+                  "onExitCodes": {
+                    "description": "PodFailurePolicyOnExitCodesRequirement describes the requirement for handling a failed pod based on its container exit codes. In particular, it lookups the .state.terminated.exitCode for each app container and init container status, represented by the .status.containerStatuses and .status.initContainerStatuses fields in the Pod status, respectively. Containers completed with success (exit code 0) are excluded from the requirement check.",
+                    "type": "object",
+                    "required": ["operator", "values"],
+                    "properties": {
+                      "containerName": {
+                        "description": "Restricts the check for exit codes to the container with the specified name. When null, the rule applies to all containers. When specified, it should match one the container or initContainer names in the pod template.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are:\n\n- In: the requirement is satisfied if at least one container exit code\n  (might be multiple if there are multiple containers not restricted\n  by the 'containerName' field) is in the set of specified values.\n- NotIn: the requirement is satisfied if at least one container exit code\n  (might be multiple if there are multiple containers not restricted\n  by the 'containerName' field) is not in the set of specified values.\nAdditional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.\n\nPossible enum values:\n - `\"In\"`\n - `\"NotIn\"`",
+                        "type": "string",
+                        "enum": ["In", "NotIn"]
+                      },
+                      "values": {
+                        "description": "Specifies the set of values. Each returned container exit code (might be multiple in case of multiple containers) is checked against this set of values with respect to the operator. The list of values must be ordered and must not contain duplicates. Value '0' cannot be used for the In operator. At least one element is required. At most 255 elements are allowed.",
+                        "type": "array",
+                        "items": {
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "x-kubernetes-list-type": "set"
+                      }
+                    }
+                  },
+                  "onPodConditions": {
+                    "description": "Represents the requirement on the pod conditions. The requirement is represented as a list of pod condition patterns. The requirement is satisfied if at least one pattern matches an actual pod condition. At most 20 elements are allowed.",
+                    "type": "array",
+                    "items": {
+                      "description": "PodFailurePolicyOnPodConditionsPattern describes a pattern for matching an actual pod condition type.",
+                      "type": "object",
+                      "required": ["type", "status"],
+                      "properties": {
+                        "status": {
+                          "description": "Specifies the required Pod condition status. To match a pod condition it is required that the specified status equals the pod condition status. Defaults to True.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Specifies the required Pod condition type. To match a pod condition it is required that specified type equals the pod condition type.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-list-type": "atomic"
+                  }
+                }
+              },
+              "x-kubernetes-list-type": "atomic"
+            }
+          }
+        },
+        "podReplacementPolicy": {
+          "description": "podReplacementPolicy specifies when to create replacement Pods. Possible values are: - TerminatingOrFailed means that we recreate pods\n  when they are terminating (has a metadata.deletionTimestamp) or failed.\n- Failed means to wait until a previously created Pod is fully terminated (has phase\n  Failed or Succeeded) before creating a replacement Pod.\n\nWhen using podFailurePolicy, Failed is the the only allowed value. TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use. This is an alpha field. Enable JobPodReplacementPolicy to be able to use this field.\n\nPossible enum values:\n - `\"Failed\"` means to wait until a previously created Pod is fully terminated (has phase Failed or Succeeded) before creating a replacement Pod.\n - `\"TerminatingOrFailed\"` means that we recreate pods when they are terminating (has a metadata.deletionTimestamp) or failed.",
+          "type": "string",
+          "enum": ["Failed", "TerminatingOrFailed"]
+        },
+        "selector": {
+          "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+          "type": "object",
+          "properties": {
+            "matchExpressions": {
+              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+              "type": "array",
+              "items": {
+                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                "type": "object",
+                "required": ["key", "operator"],
+                "properties": {
+                  "key": {
+                    "description": "key is the label key that the selector applies to.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "matchLabels": {
+              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "suspend": {
+          "description": "suspend specifies whether the Job controller should create Pods or not. If a Job is created with suspend set to true, no Pods are created by the Job controller. If a Job is suspended after creation (i.e. the flag goes from false to true), the Job controller will delete all active Pods associated with this Job. Users must design their workload to gracefully handle this. Suspending a Job will reset the StartTime field of the Job, effectively resetting the ActiveDeadlineSeconds timer too. Defaults to false.",
+          "type": "boolean"
+        },
+        "template": {
+          "description": "PodTemplateSpec describes the data a pod should have when created from a template",
+          "type": "object",
+          "properties": {
+            "metadata": {
+              "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+              "type": "object",
+              "properties": {
+                "annotations": {
+                  "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "creationTimestamp": {
+                  "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "deletionGracePeriodSeconds": {
+                  "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "deletionTimestamp": {
+                  "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "finalizers": {
+                  "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "generateName": {
+                  "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                  "type": "string"
+                },
+                "generation": {
+                  "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "labels": {
+                  "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "managedFields": {
+                  "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+                  "type": "array",
+                  "items": {
+                    "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+                    "type": "object",
+                    "properties": {
+                      "apiVersion": {
+                        "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                        "type": "object"
+                      },
+                      "manager": {
+                        "description": "Manager is an identifier of the workflow managing these fields.",
+                        "type": "string"
+                      },
+                      "operation": {
+                        "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                        "type": "string"
+                      },
+                      "time": {
+                        "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                        "type": "string",
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                },
+                "name": {
+                  "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                  "type": "string"
+                },
+                "namespace": {
+                  "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                  "type": "array",
+                  "items": {
+                    "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                    "type": "object",
+                    "required": ["apiVersion", "kind", "name", "uid"],
+                    "properties": {
+                      "apiVersion": {
+                        "description": "API version of the referent.",
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "description": "If true, this reference points to the managing controller.",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                        "type": "string"
+                      },
+                      "uid": {
+                        "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                        "type": "string"
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "x-kubernetes-patch-merge-key": "uid",
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "resourceVersion": {
+                  "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                  "type": "string"
+                },
+                "selfLink": {
+                  "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                  "type": "string"
+                },
+                "uid": {
+                  "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                  "type": "string"
+                }
+              }
+            },
+            "spec": {
+              "description": "PodSpec is a description of a pod.",
+              "type": "object",
+              "required": ["containers"],
+              "properties": {
+                "activeDeadlineSeconds": {
+                  "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "affinity": {
+                  "description": "Affinity is a group of affinity scheduling rules.",
+                  "type": "object",
+                  "properties": {
+                    "nodeAffinity": {
+                      "description": "Node affinity is a group of node affinity scheduling rules.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                            "type": "object",
+                            "required": ["weight", "preference"],
+                            "properties": {
+                              "preference": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": ["key", "operator"],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\n\nPossible enum values:\n - `\"DoesNotExist\"`\n - `\"Exists\"`\n - `\"Gt\"`\n - `\"In\"`\n - `\"Lt\"`\n - `\"NotIn\"`",
+                                          "type": "string",
+                                          "enum": [
+                                            "DoesNotExist",
+                                            "Exists",
+                                            "Gt",
+                                            "In",
+                                            "Lt",
+                                            "NotIn"
+                                          ]
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": ["key", "operator"],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\n\nPossible enum values:\n - `\"DoesNotExist\"`\n - `\"Exists\"`\n - `\"Gt\"`\n - `\"In\"`\n - `\"Lt\"`\n - `\"NotIn\"`",
+                                          "type": "string",
+                                          "enum": [
+                                            "DoesNotExist",
+                                            "Exists",
+                                            "Gt",
+                                            "In",
+                                            "Lt",
+                                            "NotIn"
+                                          ]
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+                          "type": "object",
+                          "required": ["nodeSelectorTerms"],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                              "type": "array",
+                              "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": ["key", "operator"],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\n\nPossible enum values:\n - `\"DoesNotExist\"`\n - `\"Exists\"`\n - `\"Gt\"`\n - `\"In\"`\n - `\"Lt\"`\n - `\"NotIn\"`",
+                                          "type": "string",
+                                          "enum": [
+                                            "DoesNotExist",
+                                            "Exists",
+                                            "Gt",
+                                            "In",
+                                            "Lt",
+                                            "NotIn"
+                                          ]
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": ["key", "operator"],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.\n\nPossible enum values:\n - `\"DoesNotExist\"`\n - `\"Exists\"`\n - `\"Gt\"`\n - `\"In\"`\n - `\"Lt\"`\n - `\"NotIn\"`",
+                                          "type": "string",
+                                          "enum": [
+                                            "DoesNotExist",
+                                            "Exists",
+                                            "Gt",
+                                            "In",
+                                            "Lt",
+                                            "NotIn"
+                                          ]
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      }
+                    },
+                    "podAffinity": {
+                      "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": ["weight", "podAffinityTerm"],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                "type": "object",
+                                "required": ["topologyKey"],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": ["key", "operator"],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": ["key", "operator"],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                            "type": "object",
+                            "required": ["topologyKey"],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": ["key", "operator"],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": ["key", "operator"],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "podAntiAffinity": {
+                      "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": ["weight", "podAffinityTerm"],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                "type": "object",
+                                "required": ["topologyKey"],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": ["key", "operator"],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": ["key", "operator"],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          }
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                            "type": "object",
+                            "required": ["topologyKey"],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": ["key", "operator"],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                      "type": "object",
+                                      "required": ["key", "operator"],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "automountServiceAccountToken": {
+                  "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                  "type": "boolean"
+                },
+                "containers": {
+                  "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+                  "type": "array",
+                  "items": {
+                    "description": "A single application container that you want to run within a pod.",
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "args": {
+                        "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "command": {
+                        "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "env": {
+                        "description": "List of environment variables to set in the container. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                              "type": "object",
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "description": "Selects a key from a ConfigMap.",
+                                  "type": "object",
+                                  "required": ["key"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "fieldRef": {
+                                  "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                  "type": "object",
+                                  "required": ["fieldPath"],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                  "type": "object",
+                                  "required": ["resource"],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                      "type": "string"
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "secretKeyRef": {
+                                  "description": "SecretKeySelector selects a key of a Secret.",
+                                  "type": "object",
+                                  "required": ["key"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "name",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "envFrom": {
+                        "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                          "type": "object",
+                          "properties": {
+                            "configMapRef": {
+                              "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret must be defined",
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+                        "type": "string",
+                        "enum": ["Always", "IfNotPresent", "Never"]
+                      },
+                      "lifecycle": {
+                        "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                        "type": "object",
+                        "properties": {
+                          "postStart": {
+                            "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                            "type": "object",
+                            "properties": {
+                              "exec": {
+                                "description": "ExecAction describes a \"run in container\" action.",
+                                "type": "object",
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": "object",
+                                      "required": ["name", "value"],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                    "type": "string",
+                                    "enum": ["HTTP", "HTTPS"]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "preStop": {
+                            "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                            "type": "object",
+                            "properties": {
+                              "exec": {
+                                "description": "ExecAction describes a \"run in container\" action.",
+                                "type": "object",
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": "object",
+                                      "required": ["name", "value"],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                    "type": "string",
+                                    "enum": ["HTTP", "HTTPS"]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "livenessProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                        "type": "string"
+                      },
+                      "ports": {
+                        "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
+                          "type": "object",
+                          "required": ["containerPort"],
+                          "properties": {
+                            "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "hostIP": {
+                              "description": "What host IP to bind the external port to.",
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".\n\nPossible enum values:\n - `\"SCTP\"` is the SCTP protocol.\n - `\"TCP\"` is the TCP protocol.\n - `\"UDP\"` is the UDP protocol.",
+                              "type": "string",
+                              "enum": ["SCTP", "TCP", "UDP"]
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map",
+                        "x-kubernetes-patch-merge-key": "containerPort",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "readinessProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "resizePolicy": {
+                        "description": "Resources resize policy for the container.",
+                        "type": "array",
+                        "items": {
+                          "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                          "type": "object",
+                          "required": ["resourceName", "restartPolicy"],
+                          "properties": {
+                            "resourceName": {
+                              "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "resources": {
+                        "description": "ResourceRequirements describes the compute resource requirements.",
+                        "type": "object",
+                        "properties": {
+                          "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "type": "array",
+                            "items": {
+                              "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                              "type": "object",
+                              "required": ["name"],
+                              "properties": {
+                                "name": {
+                                  "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-map-keys": ["name"],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                              "type": "string"
+                            }
+                          },
+                          "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "restartPolicy": {
+                        "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                        "type": "object",
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "description": "Adds and removes POSIX capabilities from running containers.",
+                            "type": "object",
+                            "properties": {
+                              "add": {
+                                "description": "Added capabilities",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "drop": {
+                                "description": "Removed capabilities",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.\n\nPossible enum values:\n - `\"Default\"` uses the container runtime defaults for readonly and masked paths for /proc. Most container runtimes mask certain paths in /proc to avoid accidental security exposure of special devices or information.\n - `\"Unmasked\"` bypasses the default masking behavior of the container runtime and ensures the newly created /proc the container stays in tact with no modifications.",
+                            "type": "string",
+                            "enum": ["Default", "Unmasked"]
+                          },
+                          "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "seLinuxOptions": {
+                            "description": "SELinuxOptions are the labels to be applied to the container",
+                            "type": "object",
+                            "properties": {
+                              "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
+                                "type": "string"
+                              },
+                              "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
+                                "type": "string"
+                              },
+                              "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "seccompProfile": {
+                            "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                            "type": "object",
+                            "required": ["type"],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.\n\nPossible enum values:\n - `\"Localhost\"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.\n - `\"RuntimeDefault\"` represents the default container runtime seccomp profile.\n - `\"Unconfined\"` indicates no seccomp profile is applied (A.K.A. unconfined).",
+                                "type": "string",
+                                "enum": [
+                                  "Localhost",
+                                  "RuntimeDefault",
+                                  "Unconfined"
+                                ]
+                              }
+                            },
+                            "x-kubernetes-unions": [
+                              {
+                                "discriminator": "type",
+                                "fields-to-discriminateBy": {
+                                  "localhostProfile": "LocalhostProfile"
+                                }
+                              }
+                            ]
+                          },
+                          "windowsOptions": {
+                            "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                            "type": "object",
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "startupProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.\n\nPossible enum values:\n - `\"FallbackToLogsOnError\"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.\n - `\"File\"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.",
+                        "type": "string",
+                        "enum": ["FallbackToLogsOnError", "File"]
+                      },
+                      "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
+                        "type": "array",
+                        "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                          "type": "object",
+                          "required": ["name", "devicePath"],
+                          "properties": {
+                            "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "devicePath",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
+                          "type": "object",
+                          "required": ["name", "mountPath"],
+                          "properties": {
+                            "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.\n\nPossible enum values:\n - `\"Bidirectional\"` means that the volume in a container will receive new mounts from the host or other containers, and its own mounts will be propagated from the container to the host or other containers. Note that this mode is recursively applied to all mounts in the volume (\"rshared\" in Linux terminology).\n - `\"HostToContainer\"` means that the volume in a container will receive new mounts from the host or other containers, but filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode is recursively applied to all mounts in the volume (\"rslave\" in Linux terminology).\n - `\"None\"` means that the volume in a container will not receive new mounts from the host or other containers, and filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode corresponds to \"private\" in Linux terminology.",
+                              "type": "string",
+                              "enum": [
+                                "Bidirectional",
+                                "HostToContainer",
+                                "None"
+                              ]
+                            },
+                            "name": {
+                              "description": "This must match the Name of a Volume.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "mountPath",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "workingDir": {
+                        "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-patch-merge-key": "name",
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "dnsConfig": {
+                  "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+                  "type": "object",
+                  "properties": {
+                    "nameservers": {
+                      "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "options": {
+                      "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+                      "type": "array",
+                      "items": {
+                        "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Required.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "searches": {
+                      "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "dnsPolicy": {
+                  "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.\n\nPossible enum values:\n - `\"ClusterFirst\"` indicates that the pod should use cluster DNS first unless hostNetwork is true, if it is available, then fall back on the default (as determined by kubelet) DNS settings.\n - `\"ClusterFirstWithHostNet\"` indicates that the pod should use cluster DNS first, if it is available, then fall back on the default (as determined by kubelet) DNS settings.\n - `\"Default\"` indicates that the pod should use the default (as determined by kubelet) DNS settings.\n - `\"None\"` indicates that the pod should use empty DNS settings. DNS parameters such as nameservers and search paths should be defined via DNSConfig.",
+                  "type": "string",
+                  "enum": [
+                    "ClusterFirst",
+                    "ClusterFirstWithHostNet",
+                    "Default",
+                    "None"
+                  ]
+                },
+                "enableServiceLinks": {
+                  "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+                  "type": "boolean"
+                },
+                "ephemeralContainers": {
+                  "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
+                  "type": "array",
+                  "items": {
+                    "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.\n\nTo add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "args": {
+                        "description": "Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "command": {
+                        "description": "Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "env": {
+                        "description": "List of environment variables to set in the container. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                              "type": "object",
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "description": "Selects a key from a ConfigMap.",
+                                  "type": "object",
+                                  "required": ["key"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "fieldRef": {
+                                  "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                  "type": "object",
+                                  "required": ["fieldPath"],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                  "type": "object",
+                                  "required": ["resource"],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                      "type": "string"
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "secretKeyRef": {
+                                  "description": "SecretKeySelector selects a key of a Secret.",
+                                  "type": "object",
+                                  "required": ["key"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "name",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "envFrom": {
+                        "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                          "type": "object",
+                          "properties": {
+                            "configMapRef": {
+                              "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret must be defined",
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+                        "type": "string",
+                        "enum": ["Always", "IfNotPresent", "Never"]
+                      },
+                      "lifecycle": {
+                        "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                        "type": "object",
+                        "properties": {
+                          "postStart": {
+                            "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                            "type": "object",
+                            "properties": {
+                              "exec": {
+                                "description": "ExecAction describes a \"run in container\" action.",
+                                "type": "object",
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": "object",
+                                      "required": ["name", "value"],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                    "type": "string",
+                                    "enum": ["HTTP", "HTTPS"]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "preStop": {
+                            "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                            "type": "object",
+                            "properties": {
+                              "exec": {
+                                "description": "ExecAction describes a \"run in container\" action.",
+                                "type": "object",
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": "object",
+                                      "required": ["name", "value"],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                    "type": "string",
+                                    "enum": ["HTTP", "HTTPS"]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "livenessProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+                        "type": "string"
+                      },
+                      "ports": {
+                        "description": "Ports are not allowed for ephemeral containers.",
+                        "type": "array",
+                        "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
+                          "type": "object",
+                          "required": ["containerPort"],
+                          "properties": {
+                            "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "hostIP": {
+                              "description": "What host IP to bind the external port to.",
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".\n\nPossible enum values:\n - `\"SCTP\"` is the SCTP protocol.\n - `\"TCP\"` is the TCP protocol.\n - `\"UDP\"` is the UDP protocol.",
+                              "type": "string",
+                              "enum": ["SCTP", "TCP", "UDP"]
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map",
+                        "x-kubernetes-patch-merge-key": "containerPort",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "readinessProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "resizePolicy": {
+                        "description": "Resources resize policy for the container.",
+                        "type": "array",
+                        "items": {
+                          "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                          "type": "object",
+                          "required": ["resourceName", "restartPolicy"],
+                          "properties": {
+                            "resourceName": {
+                              "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "resources": {
+                        "description": "ResourceRequirements describes the compute resource requirements.",
+                        "type": "object",
+                        "properties": {
+                          "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "type": "array",
+                            "items": {
+                              "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                              "type": "object",
+                              "required": ["name"],
+                              "properties": {
+                                "name": {
+                                  "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-map-keys": ["name"],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                              "type": "string"
+                            }
+                          },
+                          "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "restartPolicy": {
+                        "description": "Restart policy for the container to manage the restart behavior of each container within a pod. This may only be set for init containers. You cannot set this field on ephemeral containers.",
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                        "type": "object",
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "description": "Adds and removes POSIX capabilities from running containers.",
+                            "type": "object",
+                            "properties": {
+                              "add": {
+                                "description": "Added capabilities",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "drop": {
+                                "description": "Removed capabilities",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.\n\nPossible enum values:\n - `\"Default\"` uses the container runtime defaults for readonly and masked paths for /proc. Most container runtimes mask certain paths in /proc to avoid accidental security exposure of special devices or information.\n - `\"Unmasked\"` bypasses the default masking behavior of the container runtime and ensures the newly created /proc the container stays in tact with no modifications.",
+                            "type": "string",
+                            "enum": ["Default", "Unmasked"]
+                          },
+                          "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "seLinuxOptions": {
+                            "description": "SELinuxOptions are the labels to be applied to the container",
+                            "type": "object",
+                            "properties": {
+                              "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
+                                "type": "string"
+                              },
+                              "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
+                                "type": "string"
+                              },
+                              "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "seccompProfile": {
+                            "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                            "type": "object",
+                            "required": ["type"],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.\n\nPossible enum values:\n - `\"Localhost\"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.\n - `\"RuntimeDefault\"` represents the default container runtime seccomp profile.\n - `\"Unconfined\"` indicates no seccomp profile is applied (A.K.A. unconfined).",
+                                "type": "string",
+                                "enum": [
+                                  "Localhost",
+                                  "RuntimeDefault",
+                                  "Unconfined"
+                                ]
+                              }
+                            },
+                            "x-kubernetes-unions": [
+                              {
+                                "discriminator": "type",
+                                "fields-to-discriminateBy": {
+                                  "localhostProfile": "LocalhostProfile"
+                                }
+                              }
+                            ]
+                          },
+                          "windowsOptions": {
+                            "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                            "type": "object",
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "startupProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                        "type": "boolean"
+                      },
+                      "targetContainerName": {
+                        "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.",
+                        "type": "string"
+                      },
+                      "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.\n\nPossible enum values:\n - `\"FallbackToLogsOnError\"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.\n - `\"File\"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.",
+                        "type": "string",
+                        "enum": ["FallbackToLogsOnError", "File"]
+                      },
+                      "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
+                        "type": "array",
+                        "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                          "type": "object",
+                          "required": ["name", "devicePath"],
+                          "properties": {
+                            "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "devicePath",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
+                          "type": "object",
+                          "required": ["name", "mountPath"],
+                          "properties": {
+                            "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.\n\nPossible enum values:\n - `\"Bidirectional\"` means that the volume in a container will receive new mounts from the host or other containers, and its own mounts will be propagated from the container to the host or other containers. Note that this mode is recursively applied to all mounts in the volume (\"rshared\" in Linux terminology).\n - `\"HostToContainer\"` means that the volume in a container will receive new mounts from the host or other containers, but filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode is recursively applied to all mounts in the volume (\"rslave\" in Linux terminology).\n - `\"None\"` means that the volume in a container will not receive new mounts from the host or other containers, and filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode corresponds to \"private\" in Linux terminology.",
+                              "type": "string",
+                              "enum": [
+                                "Bidirectional",
+                                "HostToContainer",
+                                "None"
+                              ]
+                            },
+                            "name": {
+                              "description": "This must match the Name of a Volume.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "mountPath",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "workingDir": {
+                        "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-patch-merge-key": "name",
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "hostAliases": {
+                  "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
+                  "type": "array",
+                  "items": {
+                    "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+                    "type": "object",
+                    "properties": {
+                      "hostnames": {
+                        "description": "Hostnames for the above IP address.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "ip": {
+                        "description": "IP address of the host file entry.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-patch-merge-key": "ip",
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "hostIPC": {
+                  "description": "Use the host's ipc namespace. Optional: Default to false.",
+                  "type": "boolean"
+                },
+                "hostNetwork": {
+                  "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+                  "type": "boolean"
+                },
+                "hostPID": {
+                  "description": "Use the host's pid namespace. Optional: Default to false.",
+                  "type": "boolean"
+                },
+                "hostUsers": {
+                  "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+                  "type": "boolean"
+                },
+                "hostname": {
+                  "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+                  "type": "string"
+                },
+                "imagePullSecrets": {
+                  "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                  "type": "array",
+                  "items": {
+                    "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "x-kubernetes-patch-merge-key": "name",
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "initContainers": {
+                  "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+                  "type": "array",
+                  "items": {
+                    "description": "A single application container that you want to run within a pod.",
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "args": {
+                        "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "command": {
+                        "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "env": {
+                        "description": "List of environment variables to set in the container. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvVar represents an environment variable present in a Container.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "description": "EnvVarSource represents a source for the value of an EnvVar.",
+                              "type": "object",
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "description": "Selects a key from a ConfigMap.",
+                                  "type": "object",
+                                  "required": ["key"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key to select.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the ConfigMap or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "fieldRef": {
+                                  "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                  "type": "object",
+                                  "required": ["fieldPath"],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                  "type": "object",
+                                  "required": ["resource"],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                      "type": "string"
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "secretKeyRef": {
+                                  "description": "SecretKeySelector selects a key of a Secret.",
+                                  "type": "object",
+                                  "required": ["key"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "Specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "name",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "envFrom": {
+                        "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                          "type": "object",
+                          "properties": {
+                            "configMapRef": {
+                              "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the ConfigMap must be defined",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "prefix": {
+                              "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "Specify whether the Secret must be defined",
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+                        "type": "string",
+                        "enum": ["Always", "IfNotPresent", "Never"]
+                      },
+                      "lifecycle": {
+                        "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+                        "type": "object",
+                        "properties": {
+                          "postStart": {
+                            "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                            "type": "object",
+                            "properties": {
+                              "exec": {
+                                "description": "ExecAction describes a \"run in container\" action.",
+                                "type": "object",
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": "object",
+                                      "required": ["name", "value"],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                    "type": "string",
+                                    "enum": ["HTTP", "HTTPS"]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "preStop": {
+                            "description": "LifecycleHandler defines a specific action that should be taken in a lifecycle hook. One and only one of the fields, except TCPSocket must be specified.",
+                            "type": "object",
+                            "properties": {
+                              "exec": {
+                                "description": "ExecAction describes a \"run in container\" action.",
+                                "type": "object",
+                                "properties": {
+                                  "command": {
+                                    "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "httpGet": {
+                                "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                      "type": "object",
+                                      "required": ["name", "value"],
+                                      "properties": {
+                                        "name": {
+                                          "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "The header field value",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "Path to access on the HTTP server.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  },
+                                  "scheme": {
+                                    "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                    "type": "string",
+                                    "enum": ["HTTP", "HTTPS"]
+                                  }
+                                }
+                              },
+                              "tcpSocket": {
+                                "description": "TCPSocketAction describes an action based on opening a socket",
+                                "type": "object",
+                                "required": ["port"],
+                                "properties": {
+                                  "host": {
+                                    "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                    "type": "string",
+                                    "format": "int-or-string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "livenessProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                        "type": "string"
+                      },
+                      "ports": {
+                        "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "ContainerPort represents a network port in a single container.",
+                          "type": "object",
+                          "required": ["containerPort"],
+                          "properties": {
+                            "containerPort": {
+                              "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "hostIP": {
+                              "description": "What host IP to bind the external port to.",
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "name": {
+                              "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".\n\nPossible enum values:\n - `\"SCTP\"` is the SCTP protocol.\n - `\"TCP\"` is the TCP protocol.\n - `\"UDP\"` is the UDP protocol.",
+                              "type": "string",
+                              "enum": ["SCTP", "TCP", "UDP"]
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "containerPort",
+                          "protocol"
+                        ],
+                        "x-kubernetes-list-type": "map",
+                        "x-kubernetes-patch-merge-key": "containerPort",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "readinessProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "resizePolicy": {
+                        "description": "Resources resize policy for the container.",
+                        "type": "array",
+                        "items": {
+                          "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                          "type": "object",
+                          "required": ["resourceName", "restartPolicy"],
+                          "properties": {
+                            "resourceName": {
+                              "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "resources": {
+                        "description": "ResourceRequirements describes the compute resource requirements.",
+                        "type": "object",
+                        "properties": {
+                          "claims": {
+                            "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                            "type": "array",
+                            "items": {
+                              "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                              "type": "object",
+                              "required": ["name"],
+                              "properties": {
+                                "name": {
+                                  "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-map-keys": ["name"],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "limits": {
+                            "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                              "type": "string"
+                            }
+                          },
+                          "requests": {
+                            "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                            "type": "object",
+                            "additionalProperties": {
+                              "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "restartPolicy": {
+                        "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+                        "type": "object",
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "capabilities": {
+                            "description": "Adds and removes POSIX capabilities from running containers.",
+                            "type": "object",
+                            "properties": {
+                              "add": {
+                                "description": "Added capabilities",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "drop": {
+                                "description": "Removed capabilities",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "privileged": {
+                            "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.\n\nPossible enum values:\n - `\"Default\"` uses the container runtime defaults for readonly and masked paths for /proc. Most container runtimes mask certain paths in /proc to avoid accidental security exposure of special devices or information.\n - `\"Unmasked\"` bypasses the default masking behavior of the container runtime and ensures the newly created /proc the container stays in tact with no modifications.",
+                            "type": "string",
+                            "enum": ["Default", "Unmasked"]
+                          },
+                          "readOnlyRootFilesystem": {
+                            "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "seLinuxOptions": {
+                            "description": "SELinuxOptions are the labels to be applied to the container",
+                            "type": "object",
+                            "properties": {
+                              "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
+                                "type": "string"
+                              },
+                              "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
+                                "type": "string"
+                              },
+                              "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "seccompProfile": {
+                            "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                            "type": "object",
+                            "required": ["type"],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.\n\nPossible enum values:\n - `\"Localhost\"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.\n - `\"RuntimeDefault\"` represents the default container runtime seccomp profile.\n - `\"Unconfined\"` indicates no seccomp profile is applied (A.K.A. unconfined).",
+                                "type": "string",
+                                "enum": [
+                                  "Localhost",
+                                  "RuntimeDefault",
+                                  "Unconfined"
+                                ]
+                              }
+                            },
+                            "x-kubernetes-unions": [
+                              {
+                                "discriminator": "type",
+                                "fields-to-discriminateBy": {
+                                  "localhostProfile": "LocalhostProfile"
+                                }
+                              }
+                            ]
+                          },
+                          "windowsOptions": {
+                            "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                            "type": "object",
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "startupProbe": {
+                        "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+                        "type": "object",
+                        "properties": {
+                          "exec": {
+                            "description": "ExecAction describes a \"run in container\" action.",
+                            "type": "object",
+                            "properties": {
+                              "command": {
+                                "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "grpc": {
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "port": {
+                                "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "httpGet": {
+                            "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                  "type": "object",
+                                  "required": ["name", "value"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "The header field value",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "Path to access on the HTTP server.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              },
+                              "scheme": {
+                                "description": "Scheme to use for connecting to the host. Defaults to HTTP.\n\nPossible enum values:\n - `\"HTTP\"` means that the scheme used will be http://\n - `\"HTTPS\"` means that the scheme used will be https://",
+                                "type": "string",
+                                "enum": ["HTTP", "HTTPS"]
+                              }
+                            }
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "successThreshold": {
+                            "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "tcpSocket": {
+                            "description": "TCPSocketAction describes an action based on opening a socket",
+                            "type": "object",
+                            "required": ["port"],
+                            "properties": {
+                              "host": {
+                                "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "IntOrString is a type that can hold an int32 or a string.  When used in JSON or YAML marshalling and unmarshalling, it produces or consumes the inner type.  This allows you to have, for example, a JSON field that can accept a name or number.",
+                                "type": "string",
+                                "format": "int-or-string"
+                              }
+                            }
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "stdin": {
+                        "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.\n\nPossible enum values:\n - `\"FallbackToLogsOnError\"` will read the most recent contents of the container logs for the container status message when the container exits with an error and the terminationMessagePath has no contents.\n - `\"File\"` is the default behavior and will set the container status message to the contents of the container's terminationMessagePath when the container exits.",
+                        "type": "string",
+                        "enum": ["FallbackToLogsOnError", "File"]
+                      },
+                      "tty": {
+                        "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "description": "volumeDevices is the list of block devices to be used by the container.",
+                        "type": "array",
+                        "items": {
+                          "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                          "type": "object",
+                          "required": ["name", "devicePath"],
+                          "properties": {
+                            "devicePath": {
+                              "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                              "type": "string"
+                            },
+                            "name": {
+                              "description": "name must match the name of a persistentVolumeClaim in the pod",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "devicePath",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "volumeMounts": {
+                        "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "VolumeMount describes a mounting of a Volume within a container.",
+                          "type": "object",
+                          "required": ["name", "mountPath"],
+                          "properties": {
+                            "mountPath": {
+                              "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.\n\nPossible enum values:\n - `\"Bidirectional\"` means that the volume in a container will receive new mounts from the host or other containers, and its own mounts will be propagated from the container to the host or other containers. Note that this mode is recursively applied to all mounts in the volume (\"rshared\" in Linux terminology).\n - `\"HostToContainer\"` means that the volume in a container will receive new mounts from the host or other containers, but filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode is recursively applied to all mounts in the volume (\"rslave\" in Linux terminology).\n - `\"None\"` means that the volume in a container will not receive new mounts from the host or other containers, and filesystems mounted inside the container won't be propagated to the host or other containers. Note that this mode corresponds to \"private\" in Linux terminology.",
+                              "type": "string",
+                              "enum": [
+                                "Bidirectional",
+                                "HostToContainer",
+                                "None"
+                              ]
+                            },
+                            "name": {
+                              "description": "This must match the Name of a Volume.",
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                              "type": "boolean"
+                            },
+                            "subPath": {
+                              "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-patch-merge-key": "mountPath",
+                        "x-kubernetes-patch-strategy": "merge"
+                      },
+                      "workingDir": {
+                        "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-patch-merge-key": "name",
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "nodeName": {
+                  "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+                  "type": "string"
+                },
+                "nodeSelector": {
+                  "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "os": {
+                  "description": "PodOS defines the OS parameters of a pod.",
+                  "type": "object",
+                  "required": ["name"],
+                  "properties": {
+                    "name": {
+                      "description": "Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null",
+                      "type": "string"
+                    }
+                  }
+                },
+                "overhead": {
+                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md",
+                  "type": "object",
+                  "additionalProperties": {
+                    "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                    "type": "string"
+                  }
+                },
+                "preemptionPolicy": {
+                  "description": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.\n\nPossible enum values:\n - `\"Never\"` means that pod never preempts other pods with lower priority.\n - `\"PreemptLowerPriority\"` means that pod can preempt other pods with lower priority.",
+                  "type": "string",
+                  "enum": ["Never", "PreemptLowerPriority"]
+                },
+                "priority": {
+                  "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "priorityClassName": {
+                  "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+                  "type": "string"
+                },
+                "readinessGates": {
+                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
+                  "type": "array",
+                  "items": {
+                    "description": "PodReadinessGate contains the reference to a pod condition",
+                    "type": "object",
+                    "required": ["conditionType"],
+                    "properties": {
+                      "conditionType": {
+                        "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "resourceClaims": {
+                  "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable.",
+                  "type": "array",
+                  "items": {
+                    "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource. It adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
+                        "type": "string"
+                      },
+                      "source": {
+                        "description": "ClaimSource describes a reference to a ResourceClaim.\n\nExactly one of these fields should be set.  Consumers of this type must treat an empty object as if it has an unknown value.",
+                        "type": "object",
+                        "properties": {
+                          "resourceClaimName": {
+                            "description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.",
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": ["name"],
+                  "x-kubernetes-list-type": "map",
+                  "x-kubernetes-patch-merge-key": "name",
+                  "x-kubernetes-patch-strategy": "merge,retainKeys"
+                },
+                "restartPolicy": {
+                  "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy\n\nPossible enum values:\n - `\"Always\"`\n - `\"Never\"`\n - `\"OnFailure\"`",
+                  "type": "string",
+                  "enum": ["Always", "Never", "OnFailure"]
+                },
+                "runtimeClassName": {
+                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class",
+                  "type": "string"
+                },
+                "schedulerName": {
+                  "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+                  "type": "string"
+                },
+                "schedulingGates": {
+                  "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.\n\nThis is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                  "type": "array",
+                  "items": {
+                    "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the scheduling gate. Each scheduling gate must have a unique name field.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": ["name"],
+                  "x-kubernetes-list-type": "map",
+                  "x-kubernetes-patch-merge-key": "name",
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "securityContext": {
+                  "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+                  "type": "object",
+                  "properties": {
+                    "fsGroup": {
+                      "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "fsGroupChangePolicy": {
+                      "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.\n\nPossible enum values:\n - `\"Always\"` indicates that volume's ownership and permissions should always be changed whenever volume is mounted inside a Pod. This the default behavior.\n - `\"OnRootMismatch\"` indicates that volume's ownership and permissions will be changed only when permission and ownership of root directory does not match with expected permissions on the volume. This can help shorten the time it takes to change ownership and permissions of a volume.",
+                      "type": "string",
+                      "enum": ["Always", "OnRootMismatch"]
+                    },
+                    "runAsGroup": {
+                      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "runAsNonRoot": {
+                      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "seLinuxOptions": {
+                      "description": "SELinuxOptions are the labels to be applied to the container",
+                      "type": "object",
+                      "properties": {
+                        "level": {
+                          "description": "Level is SELinux level label that applies to the container.",
+                          "type": "string"
+                        },
+                        "role": {
+                          "description": "Role is a SELinux role label that applies to the container.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "Type is a SELinux type label that applies to the container.",
+                          "type": "string"
+                        },
+                        "user": {
+                          "description": "User is a SELinux user label that applies to the container.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "seccompProfile": {
+                      "description": "SeccompProfile defines a pod/container's seccomp profile settings. Only one profile source may be set.",
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": {
+                        "localhostProfile": {
+                          "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                          "type": "string"
+                        },
+                        "type": {
+                          "description": "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.\n\nPossible enum values:\n - `\"Localhost\"` indicates a profile defined in a file on the node should be used. The file's location relative to <kubelet-root-dir>/seccomp.\n - `\"RuntimeDefault\"` represents the default container runtime seccomp profile.\n - `\"Unconfined\"` indicates no seccomp profile is applied (A.K.A. unconfined).",
+                          "type": "string",
+                          "enum": ["Localhost", "RuntimeDefault", "Unconfined"]
+                        }
+                      },
+                      "x-kubernetes-unions": [
+                        {
+                          "discriminator": "type",
+                          "fields-to-discriminateBy": {
+                            "localhostProfile": "LocalhostProfile"
+                          }
+                        }
+                      ]
+                    },
+                    "supplementalGroups": {
+                      "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container. Note that group memberships defined in the container image for the uid of the container process are still effective, even if they are not included in this list. Note that this field cannot be set when spec.os.name is windows.",
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "format": "int64"
+                      }
+                    },
+                    "sysctls": {
+                      "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                      "type": "array",
+                      "items": {
+                        "description": "Sysctl defines a kernel parameter to be set",
+                        "type": "object",
+                        "required": ["name", "value"],
+                        "properties": {
+                          "name": {
+                            "description": "Name of a property to set",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Value of a property to set",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "windowsOptions": {
+                      "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+                      "type": "object",
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "serviceAccount": {
+                  "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+                  "type": "string"
+                },
+                "serviceAccountName": {
+                  "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                  "type": "string"
+                },
+                "setHostnameAsFQDN": {
+                  "description": "If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.",
+                  "type": "boolean"
+                },
+                "shareProcessNamespace": {
+                  "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.",
+                  "type": "boolean"
+                },
+                "subdomain": {
+                  "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
+                  "type": "string"
+                },
+                "terminationGracePeriodSeconds": {
+                  "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "tolerations": {
+                  "description": "If specified, the pod's tolerations.",
+                  "type": "array",
+                  "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                    "type": "object",
+                    "properties": {
+                      "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.\n\nPossible enum values:\n - `\"NoExecute\"` Evict any already-running pods that do not tolerate the taint. Currently enforced by NodeController.\n - `\"NoSchedule\"` Do not allow new pods to schedule onto the node unless they tolerate the taint, but allow all pods submitted to Kubelet without going through the scheduler to start, and allow all already-running pods to continue running. Enforced by the scheduler.\n - `\"PreferNoSchedule\"` Like TaintEffectNoSchedule, but the scheduler tries not to schedule new pods onto the node, rather than prohibiting new pods from scheduling onto the node entirely. Enforced by the scheduler.",
+                        "type": "string",
+                        "enum": ["NoExecute", "NoSchedule", "PreferNoSchedule"]
+                      },
+                      "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.\n\nPossible enum values:\n - `\"Equal\"`\n - `\"Exists\"`",
+                        "type": "string",
+                        "enum": ["Equal", "Exists"]
+                      },
+                      "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "value": {
+                        "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "topologySpreadConstraints": {
+                  "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.",
+                  "type": "array",
+                  "items": {
+                    "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                    "type": "object",
+                    "required": ["maxSkew", "topologyKey", "whenUnsatisfiable"],
+                    "properties": {
+                      "labelSelector": {
+                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "type": "object",
+                              "required": ["key", "operator"],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "maxSkew": {
+                        "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "minDomains": {
+                        "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew.\n\nThis is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "nodeAffinityPolicy": {
+                        "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.\n\nPossible enum values:\n - `\"Honor\"` means use this scheduling directive when calculating pod topology spread skew.\n - `\"Ignore\"` means ignore this scheduling directive when calculating pod topology spread skew.",
+                        "type": "string",
+                        "enum": ["Honor", "Ignore"]
+                      },
+                      "nodeTaintsPolicy": {
+                        "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.\n\nPossible enum values:\n - `\"Honor\"` means use this scheduling directive when calculating pod topology spread skew.\n - `\"Ignore\"` means ignore this scheduling directive when calculating pod topology spread skew.",
+                        "type": "string",
+                        "enum": ["Honor", "Ignore"]
+                      },
+                      "topologyKey": {
+                        "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.\n\nPossible enum values:\n - `\"DoNotSchedule\"` instructs the scheduler not to schedule the pod when constraints are not satisfied.\n - `\"ScheduleAnyway\"` instructs the scheduler to schedule the pod even if constraints are not satisfied.",
+                        "type": "string",
+                        "enum": ["DoNotSchedule", "ScheduleAnyway"]
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "topologyKey",
+                    "whenUnsatisfiable"
+                  ],
+                  "x-kubernetes-list-type": "map",
+                  "x-kubernetes-patch-merge-key": "topologyKey",
+                  "x-kubernetes-patch-strategy": "merge"
+                },
+                "volumes": {
+                  "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                  "type": "array",
+                  "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "required": ["volumeID"],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "azureDisk": {
+                        "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                        "type": "object",
+                        "required": ["diskName", "diskURI"],
+                        "properties": {
+                          "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.\n\nPossible enum values:\n - `\"None\"`\n - `\"ReadOnly\"`\n - `\"ReadWrite\"`",
+                            "type": "string",
+                            "enum": ["None", "ReadOnly", "ReadWrite"]
+                          },
+                          "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared\n\nPossible enum values:\n - `\"Dedicated\"`\n - `\"Managed\"`\n - `\"Shared\"`",
+                            "type": "string",
+                            "enum": ["Dedicated", "Managed", "Shared"]
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "azureFile": {
+                        "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                        "type": "object",
+                        "required": ["secretName", "shareName"],
+                        "properties": {
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "description": "shareName is the azure share Name",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cephfs": {
+                        "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+                        "type": "object",
+                        "required": ["monitors"],
+                        "properties": {
+                          "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cinder": {
+                        "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "required": ["volumeID"],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "configMap": {
+                        "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": ["key", "path"],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "name": {
+                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "csi": {
+                        "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+                        "type": "object",
+                        "required": ["driver"],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "downwardAPI": {
+                        "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "Items is a list of downward API volume file",
+                            "type": "array",
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "type": "object",
+                              "required": ["path"],
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                  "type": "object",
+                                  "required": ["fieldPath"],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                  "type": "object",
+                                  "required": ["resource"],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                      "type": "string"
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "emptyDir": {
+                        "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "properties": {
+                          "medium": {
+                            "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "ephemeral": {
+                        "description": "Represents an ephemeral volume that is handled by a normal storage driver.",
+                        "type": "object",
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "description": "PersistentVolumeClaimTemplate is used to produce PersistentVolumeClaim objects as part of an EphemeralVolumeSource.",
+                            "type": "object",
+                            "required": ["spec"],
+                            "properties": {
+                              "metadata": {
+                                "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+                                "type": "object",
+                                "properties": {
+                                  "annotations": {
+                                    "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "creationTimestamp": {
+                                    "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "deletionGracePeriodSeconds": {
+                                    "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  "deletionTimestamp": {
+                                    "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  "finalizers": {
+                                    "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-patch-strategy": "merge"
+                                  },
+                                  "generateName": {
+                                    "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+                                    "type": "string"
+                                  },
+                                  "generation": {
+                                    "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  "labels": {
+                                    "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "managedFields": {
+                                    "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+                                      "type": "object",
+                                      "properties": {
+                                        "apiVersion": {
+                                          "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                                          "type": "string"
+                                        },
+                                        "fieldsType": {
+                                          "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                                          "type": "string"
+                                        },
+                                        "fieldsV1": {
+                                          "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                                          "type": "object"
+                                        },
+                                        "manager": {
+                                          "description": "Manager is an identifier of the workflow managing these fields.",
+                                          "type": "string"
+                                        },
+                                        "operation": {
+                                          "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                                          "type": "string"
+                                        },
+                                        "subresource": {
+                                          "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                                          "type": "string"
+                                        },
+                                        "time": {
+                                          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                                          "type": "string",
+                                          "format": "date-time"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "name": {
+                                    "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+                                    "type": "string"
+                                  },
+                                  "ownerReferences": {
+                                    "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+                                      "type": "object",
+                                      "required": [
+                                        "apiVersion",
+                                        "kind",
+                                        "name",
+                                        "uid"
+                                      ],
+                                      "properties": {
+                                        "apiVersion": {
+                                          "description": "API version of the referent.",
+                                          "type": "string"
+                                        },
+                                        "blockOwnerDeletion": {
+                                          "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                                          "type": "boolean"
+                                        },
+                                        "controller": {
+                                          "description": "If true, this reference points to the managing controller.",
+                                          "type": "boolean"
+                                        },
+                                        "kind": {
+                                          "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                                          "type": "string"
+                                        },
+                                        "uid": {
+                                          "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "x-kubernetes-patch-merge-key": "uid",
+                                    "x-kubernetes-patch-strategy": "merge"
+                                  },
+                                  "resourceVersion": {
+                                    "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                                    "type": "string"
+                                  },
+                                  "selfLink": {
+                                    "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+                                    "type": "string"
+                                  },
+                                  "uid": {
+                                    "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "spec": {
+                                "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+                                "type": "object",
+                                "properties": {
+                                  "accessModes": {
+                                    "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "dataSource": {
+                                    "description": "TypedLocalObjectReference contains enough information to let you locate the typed referenced object inside the same namespace.",
+                                    "type": "object",
+                                    "required": ["kind", "name"],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "dataSourceRef": {
+                                    "type": "object",
+                                    "required": ["kind", "name"],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "description": "ResourceRequirements describes the compute resource requirements.",
+                                    "type": "object",
+                                    "properties": {
+                                      "claims": {
+                                        "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                          "type": "object",
+                                          "required": ["name"],
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-map-keys": ["name"],
+                                        "x-kubernetes-list-type": "map"
+                                      },
+                                      "limits": {
+                                        "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "requests": {
+                                        "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "selector": {
+                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                          "type": "object",
+                                          "required": ["key", "operator"],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "storageClassName": {
+                                    "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.\n\nPossible enum values:\n - `\"Block\"` means the volume will not be formatted with a filesystem and will remain a raw block device.\n - `\"Filesystem\"` means the volume will be or is formatted with a filesystem.",
+                                    "type": "string",
+                                    "enum": ["Block", "Filesystem"]
+                                  },
+                                  "volumeName": {
+                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "fc": {
+                        "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun is Optional: FC target lun number",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "flexVolume": {
+                        "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                        "type": "object",
+                        "required": ["driver"],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                            "type": "string"
+                          },
+                          "options": {
+                            "description": "options is Optional: this field holds extra command options if any.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "flocker": {
+                        "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+                        "type": "object",
+                        "properties": {
+                          "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "gcePersistentDisk": {
+                        "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "required": ["pdName"],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "gitRepo": {
+                        "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                        "type": "object",
+                        "required": ["repository"],
+                        "properties": {
+                          "directory": {
+                            "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                            "type": "string"
+                          },
+                          "repository": {
+                            "description": "repository is the URL",
+                            "type": "string"
+                          },
+                          "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "glusterfs": {
+                        "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+                        "type": "object",
+                        "required": ["endpoints", "path"],
+                        "properties": {
+                          "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "hostPath": {
+                        "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+                        "type": "object",
+                        "required": ["path"],
+                        "properties": {
+                          "path": {
+                            "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n\nPossible enum values:\n - `\"\"` For backwards compatible, leave it empty if unset\n - `\"BlockDevice\"` A block device must exist at the given path\n - `\"CharDevice\"` A character device must exist at the given path\n - `\"Directory\"` A directory must exist at the given path\n - `\"DirectoryOrCreate\"` If nothing exists at the given path, an empty directory will be created there as needed with file mode 0755, having the same group and ownership with Kubelet.\n - `\"File\"` A file must exist at the given path\n - `\"FileOrCreate\"` If nothing exists at the given path, an empty file will be created there as needed with file mode 0644, having the same group and ownership with Kubelet.\n - `\"Socket\"` A UNIX socket must exist at the given path",
+                            "type": "string",
+                            "enum": [
+                              "",
+                              "BlockDevice",
+                              "CharDevice",
+                              "Directory",
+                              "DirectoryOrCreate",
+                              "File",
+                              "FileOrCreate",
+                              "Socket"
+                            ]
+                          }
+                        }
+                      },
+                      "iscsi": {
+                        "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "required": ["targetPortal", "iqn", "lun"],
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "portals": {
+                            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+                        "type": "object",
+                        "required": ["server", "path"],
+                        "properties": {
+                          "path": {
+                            "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+                        "type": "object",
+                        "required": ["claimName"],
+                        "properties": {
+                          "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "photonPersistentDisk": {
+                        "description": "Represents a Photon Controller persistent disk resource.",
+                        "type": "object",
+                        "required": ["pdID"],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "portworxVolume": {
+                        "description": "PortworxVolumeSource represents a Portworx volume resource.",
+                        "type": "object",
+                        "required": ["volumeID"],
+                        "properties": {
+                          "fsType": {
+                            "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "projected": {
+                        "description": "Represents a projected volume source",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "sources": {
+                            "description": "sources is the list of volume projections",
+                            "type": "array",
+                            "items": {
+                              "description": "Projection that may be projected along with other supported volume types",
+                              "type": "object",
+                              "properties": {
+                                "configMap": {
+                                  "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": ["key", "path"],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                      "type": "boolean"
+                                    }
+                                  }
+                                },
+                                "downwardAPI": {
+                                  "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                        "type": "object",
+                                        "required": ["path"],
+                                        "properties": {
+                                          "fieldRef": {
+                                            "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+                                            "type": "object",
+                                            "required": ["fieldPath"],
+                                            "properties": {
+                                              "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+                                            "type": "object",
+                                            "required": ["resource"],
+                                            "properties": {
+                                              "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "description": "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation.",
+                                                "type": "string"
+                                              },
+                                              "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "secret": {
+                                  "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": ["key", "path"],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  }
+                                },
+                                "serviceAccountToken": {
+                                  "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+                                  "type": "object",
+                                  "required": ["path"],
+                                  "properties": {
+                                    "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                      "type": "integer",
+                                      "format": "int64"
+                                    },
+                                    "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the token into.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "quobyte": {
+                        "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+                        "type": "object",
+                        "required": ["registry", "volume"],
+                        "properties": {
+                          "group": {
+                            "description": "group to map volume access to Default is no group",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                            "type": "string"
+                          },
+                          "user": {
+                            "description": "user to map volume access to Defaults to serivceaccount user",
+                            "type": "string"
+                          },
+                          "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "rbd": {
+                        "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "required": ["monitors", "image"],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                            "type": "string"
+                          },
+                          "image": {
+                            "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "pool": {
+                            "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "scaleIO": {
+                        "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+                        "type": "object",
+                        "required": ["gateway", "system", "secretRef"],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                            "type": "string"
+                          },
+                          "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "secret": {
+                        "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": ["key", "path"],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "storageos": {
+                        "description": "Represents a StorageOS persistent volume resource.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "vsphereVolume": {
+                        "description": "Represents a vSphere volume resource.",
+                        "type": "object",
+                        "required": ["volumePath"],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "x-kubernetes-patch-merge-key": "name",
+                  "x-kubernetes-patch-strategy": "merge,retainKeys"
+                }
+              }
+            }
+          }
+        },
+        "ttlSecondsAfterFinished": {
+          "description": "ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "status": {
+      "description": "JobStatus represents the current state of a Job.",
+      "type": "object",
+      "properties": {
+        "active": {
+          "description": "The number of pending and running pods.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "completedIndexes": {
+          "description": "completedIndexes holds the completed indexes when .spec.completionMode = \"Indexed\" in a text format. The indexes are represented as decimal integers separated by commas. The numbers are listed in increasing order. Three or more consecutive numbers are compressed and represented by the first and last element of the series, separated by a hyphen. For example, if the completed indexes are 1, 3, 4, 5 and 7, they are represented as \"1,3-5,7\".",
+          "type": "string"
+        },
+        "completionTime": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "conditions": {
+          "description": "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+          "type": "array",
+          "items": {
+            "description": "JobCondition describes current state of a job.",
+            "type": "object",
+            "required": ["type", "status"],
+            "properties": {
+              "lastProbeTime": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastTransitionTime": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "Human readable message indicating details about last transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "(brief) reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of job condition, Complete or Failed.",
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-type": "atomic",
+          "x-kubernetes-patch-merge-key": "type",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "failed": {
+          "description": "The number of pods which reached phase Failed.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "failedIndexes": {
+          "description": "FailedIndexes holds the failed indexes when backoffLimitPerIndex=true. The indexes are represented in the text format analogous as for the `completedIndexes` field, ie. they are kept as decimal integers separated by commas. The numbers are listed in increasing order. Three or more consecutive numbers are compressed and represented by the first and last element of the series, separated by a hyphen. For example, if the failed indexes are 1, 3, 4, 5 and 7, they are represented as \"1,3-5,7\". This field is alpha-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (disabled by default).",
+          "type": "string"
+        },
+        "ready": {
+          "description": "The number of pods which have a Ready condition.\n\nThis field is beta-level. The job controller populates the field when the feature gate JobReadyPods is enabled (enabled by default).",
+          "type": "integer",
+          "format": "int32"
+        },
+        "startTime": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "succeeded": {
+          "description": "The number of pods which reached phase Succeeded.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "terminating": {
+          "description": "The number of pods which are terminating (in phase Pending or Running and have a deletionTimestamp).\n\nThis field is alpha-level. The job controller populates the field when the feature gate JobPodReplacementPolicy is enabled (disabled by default).",
+          "type": "integer",
+          "format": "int32"
+        },
+        "uncountedTerminatedPods": {
+          "description": "UncountedTerminatedPods holds UIDs of Pods that have terminated but haven't been accounted in Job status counters.",
+          "type": "object",
+          "properties": {
+            "failed": {
+              "description": "failed holds UIDs of failed Pods.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "x-kubernetes-list-type": "set"
+            },
+            "succeeded": {
+              "description": "succeeded holds UIDs of succeeded Pods.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "x-kubernetes-list-type": "set"
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "batch",
+      "kind": "Job",
+      "version": "v1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/weave-js/src/common/components/Monaco/schemas/jobset.json
+++ b/weave-js/src/common/components/Monaco/schemas/jobset.json
@@ -1,0 +1,6031 @@
+{
+  "description": "JobSet is the Schema for the jobsets API",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "creationTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "deletionTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "type": "string"
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "type": "array",
+          "items": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "type": "object",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                "type": "string"
+              },
+              "fieldsType": {
+                "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                "type": "string"
+              },
+              "fieldsV1": {
+                "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                "type": "object"
+              },
+              "manager": {
+                "description": "Manager is an identifier of the workflow managing these fields.",
+                "type": "string"
+              },
+              "operation": {
+                "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                "type": "string"
+              },
+              "subresource": {
+                "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                "type": "string"
+              },
+              "time": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+          "type": "string"
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "type": "array",
+          "items": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": "object",
+            "required": ["apiVersion", "kind", "name", "uid"],
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "blockOwnerDeletion": {
+                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                "type": "boolean"
+              },
+              "controller": {
+                "description": "If true, this reference points to the managing controller.",
+                "type": "boolean"
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                "type": "string"
+              }
+            },
+            "x-kubernetes-map-type": "atomic"
+          },
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+          "type": "string"
+        }
+      }
+    },
+    "spec": {
+      "description": "JobSetSpec defines the desired state of JobSet",
+      "type": "object",
+      "properties": {
+        "failurePolicy": {
+          "description": "FailurePolicy, if set, configures when to declare the JobSet as failed. The JobSet is always declared failed if any job in the set finished with status failed.",
+          "type": "object",
+          "properties": {
+            "maxRestarts": {
+              "description": "MaxRestarts defines the limit on the number of JobSet restarts. A restart is achieved by recreating all active child jobs.",
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "network": {
+          "description": "Network defines the networking options for the jobset.",
+          "type": "object",
+          "properties": {
+            "enableDNSHostnames": {
+              "description": "EnableDNSHostnames allows pods to be reached via their hostnames. Pods will be reachable using the fully qualified pod hostname: <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<subdomain>",
+              "type": "boolean"
+            },
+            "subdomain": {
+              "description": "Subdomain is an explicit choice for a network subdomain name When set, any replicated job in the set is added to this network. Defaults to <jobSet.name> if not set.",
+              "type": "string"
+            }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "replicatedJobs": {
+          "description": "ReplicatedJobs is the group of jobs that will form the set.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "template"],
+            "properties": {
+              "name": {
+                "description": "Name is the name of the entry and will be used as a suffix for the Job name.",
+                "type": "string"
+              },
+              "replicas": {
+                "description": "Replicas is the number of jobs that will be created from this ReplicatedJob's template. Jobs names will be in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>",
+                "type": "integer",
+                "format": "int32"
+              },
+              "template": {
+                "description": "Template defines the template of the Job that will be created.",
+                "type": "object",
+                "properties": {
+                  "metadata": {
+                    "description": "Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "type": "object",
+                    "properties": {
+                      "annotations": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "finalizers": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "spec": {
+                    "description": "Specification of the desired behavior of the job. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                    "type": "object",
+                    "required": ["template"],
+                    "properties": {
+                      "activeDeadlineSeconds": {
+                        "description": "Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "backoffLimit": {
+                        "description": "Specifies the number of retries before marking this job failed. Defaults to 6",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "backoffLimitPerIndex": {
+                        "description": "Specifies the limit for the number of retries within an index before marking this index as failed. When enabled the number of failures per index is kept in the pod's batch.kubernetes.io/job-index-failure-count annotation. It can only be set when Job's completionMode=Indexed, and the Pod's restart policy is Never. The field is immutable. This field is alpha-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (disabled by default).",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "completionMode": {
+                        "description": "completionMode specifies how Pod completions are tracked. It can be `NonIndexed` (default) or `Indexed`. \n `NonIndexed` means that the Job is considered complete when there have been .spec.completions successfully completed Pods. Each Pod completion is homologous to each other. \n `Indexed` means that the Pods of a Job get an associated completion index from 0 to (.spec.completions - 1), available in the annotation batch.kubernetes.io/job-completion-index. The Job is considered complete when there is one successfully completed Pod for each index. When value is `Indexed`, .spec.completions must be specified and `.spec.parallelism` must be less than or equal to 10^5. In addition, The Pod name takes the form `$(job-name)-$(index)-$(random-string)`, the Pod hostname takes the form `$(job-name)-$(index)`. \n More completion modes can be added in the future. If the Job controller observes a mode that it doesn't recognize, which is possible during upgrades due to version skew, the controller skips updates for the Job.",
+                        "type": "string"
+                      },
+                      "completions": {
+                        "description": "Specifies the desired number of successfully finished pods the job should be run with.  Setting to null means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "manualSelector": {
+                        "description": "manualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector",
+                        "type": "boolean"
+                      },
+                      "maxFailedIndexes": {
+                        "description": "Specifies the maximal number of failed indexes before marking the Job as failed, when backoffLimitPerIndex is set. Once the number of failed indexes exceeds this number the entire Job is marked as Failed and its execution is terminated. When left as null the job continues execution of all of its indexes and is marked with the `Complete` Job condition. It can only be specified when backoffLimitPerIndex is set. It can be null or up to completions. It is required and must be less than or equal to 10^4 when is completions greater than 10^5. This field is alpha-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (disabled by default).",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "parallelism": {
+                        "description": "Specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "podFailurePolicy": {
+                        "description": "Specifies the policy of handling failed pods. In particular, it allows to specify the set of actions and conditions which need to be satisfied to take the associated action. If empty, the default behaviour applies - the counter of failed pods, represented by the jobs's .status.failed field, is incremented and it is checked against the backoffLimit. This field cannot be used in combination with restartPolicy=OnFailure. \n This field is beta-level. It can be used when the `JobPodFailurePolicy` feature gate is enabled (enabled by default).",
+                        "type": "object",
+                        "required": ["rules"],
+                        "properties": {
+                          "rules": {
+                            "description": "A list of pod failure policy rules. The rules are evaluated in order. Once a rule matches a Pod failure, the remaining of the rules are ignored. When no rule matches the Pod failure, the default handling applies - the counter of pod failures is incremented and it is checked against the backoffLimit. At most 20 elements are allowed.",
+                            "type": "array",
+                            "items": {
+                              "description": "PodFailurePolicyRule describes how a pod failure is handled when the requirements are met. One of onExitCodes and onPodConditions, but not both, can be used in each rule.",
+                              "type": "object",
+                              "required": ["action"],
+                              "properties": {
+                                "action": {
+                                  "description": "Specifies the action taken on a pod failure when the requirements are satisfied. Possible values are: \n - FailJob: indicates that the pod's job is marked as Failed and all running pods are terminated. - FailIndex: indicates that the pod's index is marked as Failed and will not be restarted. This value is alpha-level. It can be used when the `JobBackoffLimitPerIndex` feature gate is enabled (disabled by default). - Ignore: indicates that the counter towards the .backoffLimit is not incremented and a replacement pod is created. - Count: indicates that the pod is handled in the default way - the counter towards the .backoffLimit is incremented. Additional values are considered to be added in the future. Clients should react to an unknown action by skipping the rule.",
+                                  "type": "string"
+                                },
+                                "onExitCodes": {
+                                  "description": "Represents the requirement on the container exit codes.",
+                                  "type": "object",
+                                  "required": ["operator", "values"],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Restricts the check for exit codes to the container with the specified name. When null, the rule applies to all containers. When specified, it should match one the container or initContainer names in the pod template.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents the relationship between the container exit code(s) and the specified values. Containers completed with success (exit code 0) are excluded from the requirement check. Possible values are: \n - In: the requirement is satisfied if at least one container exit code (might be multiple if there are multiple containers not restricted by the 'containerName' field) is in the set of specified values. - NotIn: the requirement is satisfied if at least one container exit code (might be multiple if there are multiple containers not restricted by the 'containerName' field) is not in the set of specified values. Additional values are considered to be added in the future. Clients should react to an unknown operator by assuming the requirement is not satisfied.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "Specifies the set of values. Each returned container exit code (might be multiple in case of multiple containers) is checked against this set of values with respect to the operator. The list of values must be ordered and must not contain duplicates. Value '0' cannot be used for the In operator. At least one element is required. At most 255 elements are allowed.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "x-kubernetes-list-type": "set"
+                                    }
+                                  }
+                                },
+                                "onPodConditions": {
+                                  "description": "Represents the requirement on the pod conditions. The requirement is represented as a list of pod condition patterns. The requirement is satisfied if at least one pattern matches an actual pod condition. At most 20 elements are allowed.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "PodFailurePolicyOnPodConditionsPattern describes a pattern for matching an actual pod condition type.",
+                                    "type": "object",
+                                    "required": ["status", "type"],
+                                    "properties": {
+                                      "status": {
+                                        "description": "Specifies the required Pod condition status. To match a pod condition it is required that the specified status equals the pod condition status. Defaults to True.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "Specifies the required Pod condition type. To match a pod condition it is required that specified type equals the pod condition type.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "podReplacementPolicy": {
+                        "description": "podReplacementPolicy specifies when to create replacement Pods. Possible values are: - TerminatingOrFailed means that we recreate pods when they are terminating (has a metadata.deletionTimestamp) or failed. - Failed means to wait until a previously created Pod is fully terminated (has phase Failed or Succeeded) before creating a replacement Pod. \n When using podFailurePolicy, Failed is the the only allowed value. TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use. This is an alpha field. Enable JobPodReplacementPolicy to be able to use this field.",
+                        "type": "string"
+                      },
+                      "selector": {
+                        "description": "A label query over pods that should match the pod count. Normally, the system sets this field for you. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                              "type": "object",
+                              "required": ["key", "operator"],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "suspend": {
+                        "description": "suspend specifies whether the Job controller should create Pods or not. If a Job is created with suspend set to true, no Pods are created by the Job controller. If a Job is suspended after creation (i.e. the flag goes from false to true), the Job controller will delete all active Pods associated with this Job. Users must design their workload to gracefully handle this. Suspending a Job will reset the StartTime field of the Job, effectively resetting the ActiveDeadlineSeconds timer too. Defaults to false.",
+                        "type": "boolean"
+                      },
+                      "template": {
+                        "description": "Describes the pod that will be created when executing a job. The only allowed template.spec.restartPolicy values are \"Never\" or \"OnFailure\". More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/",
+                        "type": "object",
+                        "properties": {
+                          "metadata": {
+                            "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                            "type": "object",
+                            "properties": {
+                              "annotations": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "finalizers": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "labels": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "spec": {
+                            "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                            "type": "object",
+                            "required": ["containers"],
+                            "properties": {
+                              "activeDeadlineSeconds": {
+                                "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+                                "type": "integer",
+                                "format": "int64"
+                              },
+                              "affinity": {
+                                "description": "If specified, the pod's scheduling constraints",
+                                "type": "object",
+                                "properties": {
+                                  "nodeAffinity": {
+                                    "description": "Describes node affinity scheduling rules for the pod.",
+                                    "type": "object",
+                                    "properties": {
+                                      "preferredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                          "type": "object",
+                                          "required": ["preference", "weight"],
+                                          "properties": {
+                                            "preference": {
+                                              "description": "A node selector term, associated with the corresponding weight.",
+                                              "type": "object",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "A list of node selector requirements by node's labels.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "The label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "matchFields": {
+                                                  "description": "A list of node selector requirements by node's fields.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "The label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "weight": {
+                                              "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "requiredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                        "type": "object",
+                                        "required": ["nodeSelectorTerms"],
+                                        "properties": {
+                                          "nodeSelectorTerms": {
+                                            "description": "Required. A list of node selector terms. The terms are ORed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                              "type": "object",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "A list of node selector requirements by node's labels.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "The label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "matchFields": {
+                                                  "description": "A list of node selector requirements by node's fields.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "The label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-map-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    }
+                                  },
+                                  "podAffinity": {
+                                    "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                                    "type": "object",
+                                    "properties": {
+                                      "preferredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                          "type": "object",
+                                          "required": [
+                                            "podAffinityTerm",
+                                            "weight"
+                                          ],
+                                          "properties": {
+                                            "podAffinityTerm": {
+                                              "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                              "type": "object",
+                                              "required": ["topologyKey"],
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "description": "A label query over a set of resources, in this case pods.",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
+                                                },
+                                                "namespaceSelector": {
+                                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
+                                                },
+                                                "namespaces": {
+                                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "topologyKey": {
+                                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "weight": {
+                                              "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "requiredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                          "type": "object",
+                                          "required": ["topologyKey"],
+                                          "properties": {
+                                            "labelSelector": {
+                                              "description": "A label query over a set of resources, in this case pods.",
+                                              "type": "object",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "key is the label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "matchLabels": {
+                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "namespaceSelector": {
+                                              "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                              "type": "object",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "key is the label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "matchLabels": {
+                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "namespaces": {
+                                              "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "topologyKey": {
+                                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "podAntiAffinity": {
+                                    "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                                    "type": "object",
+                                    "properties": {
+                                      "preferredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                          "type": "object",
+                                          "required": [
+                                            "podAffinityTerm",
+                                            "weight"
+                                          ],
+                                          "properties": {
+                                            "podAffinityTerm": {
+                                              "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                              "type": "object",
+                                              "required": ["topologyKey"],
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "description": "A label query over a set of resources, in this case pods.",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
+                                                },
+                                                "namespaceSelector": {
+                                                  "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
+                                                },
+                                                "namespaces": {
+                                                  "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "topologyKey": {
+                                                  "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "weight": {
+                                              "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "requiredDuringSchedulingIgnoredDuringExecution": {
+                                        "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                          "type": "object",
+                                          "required": ["topologyKey"],
+                                          "properties": {
+                                            "labelSelector": {
+                                              "description": "A label query over a set of resources, in this case pods.",
+                                              "type": "object",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "key is the label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "matchLabels": {
+                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "namespaceSelector": {
+                                              "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                              "type": "object",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "description": "key is the label key that the selector applies to.",
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "matchLabels": {
+                                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "namespaces": {
+                                              "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "topologyKey": {
+                                              "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "automountServiceAccountToken": {
+                                "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                                "type": "boolean"
+                              },
+                              "containers": {
+                                "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A single application container that you want to run within a pod.",
+                                  "type": "object",
+                                  "required": ["name"],
+                                  "properties": {
+                                    "args": {
+                                      "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "command": {
+                                      "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "env": {
+                                      "description": "List of environment variables to set in the container. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "type": "object",
+                                        "required": ["name"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "type": "string"
+                                          },
+                                          "valueFrom": {
+                                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                            "type": "object",
+                                            "properties": {
+                                              "configMapKeyRef": {
+                                                "description": "Selects a key of a ConfigMap.",
+                                                "type": "object",
+                                                "required": ["key"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key to select.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the ConfigMap or its key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "fieldRef": {
+                                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                "type": "object",
+                                                "required": ["fieldPath"],
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "description": "Path of the field to select in the specified API version.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "resourceFieldRef": {
+                                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                "type": "object",
+                                                "required": ["resource"],
+                                                "properties": {
+                                                  "containerName": {
+                                                    "description": "Container name: required for volumes, optional for env vars",
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "description": "Required: resource to select",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "secretKeyRef": {
+                                                "description": "Selects a key of a secret in the pod's namespace",
+                                                "type": "object",
+                                                "required": ["key"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the Secret or its key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "envFrom": {
+                                      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                        "type": "object",
+                                        "properties": {
+                                          "configMapRef": {
+                                            "description": "The ConfigMap to select from",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the ConfigMap must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "prefix": {
+                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "The Secret to select from",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the Secret must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "image": {
+                                      "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                      "type": "string"
+                                    },
+                                    "imagePullPolicy": {
+                                      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                      "type": "string"
+                                    },
+                                    "lifecycle": {
+                                      "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                                      "type": "object",
+                                      "properties": {
+                                        "postStart": {
+                                          "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                          "type": "object",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "Exec specifies the action to take.",
+                                              "type": "object",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGet specifies the http request to perform.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "tcpSocket": {
+                                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "preStop": {
+                                          "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                          "type": "object",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "Exec specifies the action to take.",
+                                              "type": "object",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGet specifies the http request to perform.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "tcpSocket": {
+                                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "livenessProbe": {
+                                      "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "ports": {
+                                      "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "ContainerPort represents a network port in a single container.",
+                                        "type": "object",
+                                        "required": ["containerPort"],
+                                        "properties": {
+                                          "containerPort": {
+                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "hostIP": {
+                                            "description": "What host IP to bind the external port to.",
+                                            "type": "string"
+                                          },
+                                          "hostPort": {
+                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "name": {
+                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                            "type": "string"
+                                          },
+                                          "protocol": {
+                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-map-keys": [
+                                        "containerPort",
+                                        "protocol"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    },
+                                    "readinessProbe": {
+                                      "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "resizePolicy": {
+                                      "description": "Resources resize policy for the container.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                        "type": "object",
+                                        "required": [
+                                          "resourceName",
+                                          "restartPolicy"
+                                        ],
+                                        "properties": {
+                                          "resourceName": {
+                                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                            "type": "string"
+                                          },
+                                          "restartPolicy": {
+                                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "resources": {
+                                      "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                      "type": "object",
+                                      "properties": {
+                                        "claims": {
+                                          "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                            "type": "object",
+                                            "required": ["name"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
+                                        },
+                                        "limits": {
+                                          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "requests": {
+                                          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "restartPolicy": {
+                                      "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+                                      "type": "string"
+                                    },
+                                    "securityContext": {
+                                      "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                                      "type": "object",
+                                      "properties": {
+                                        "allowPrivilegeEscalation": {
+                                          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "capabilities": {
+                                          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "properties": {
+                                            "add": {
+                                              "description": "Added capabilities",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "Capability represent POSIX capabilities type",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "drop": {
+                                              "description": "Removed capabilities",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "Capability represent POSIX capabilities type",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "privileged": {
+                                          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "procMount": {
+                                          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "string"
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsGroup": {
+                                          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "runAsNonRoot": {
+                                          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsUser": {
+                                          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "seLinuxOptions": {
+                                          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "properties": {
+                                            "level": {
+                                              "description": "Level is SELinux level label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "role": {
+                                              "description": "Role is a SELinux role label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "Type is a SELinux type label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "user": {
+                                              "description": "User is a SELinux user label that applies to the container.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "seccompProfile": {
+                                          "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "required": ["type"],
+                                          "properties": {
+                                            "localhostProfile": {
+                                              "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "windowsOptions": {
+                                          "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                          "type": "object",
+                                          "properties": {
+                                            "gmsaCredentialSpec": {
+                                              "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                              "type": "string"
+                                            },
+                                            "gmsaCredentialSpecName": {
+                                              "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                              "type": "string"
+                                            },
+                                            "hostProcess": {
+                                              "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                              "type": "boolean"
+                                            },
+                                            "runAsUserName": {
+                                              "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "startupProbe": {
+                                      "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "stdin": {
+                                      "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "stdinOnce": {
+                                      "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                      "type": "boolean"
+                                    },
+                                    "terminationMessagePath": {
+                                      "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "terminationMessagePolicy": {
+                                      "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "tty": {
+                                      "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "volumeDevices": {
+                                      "description": "volumeDevices is the list of block devices to be used by the container.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                        "type": "object",
+                                        "required": ["devicePath", "name"],
+                                        "properties": {
+                                          "devicePath": {
+                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "volumeMounts": {
+                                      "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                        "type": "object",
+                                        "required": ["mountPath", "name"],
+                                        "properties": {
+                                          "mountPath": {
+                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "type": "string"
+                                          },
+                                          "mountPropagation": {
+                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "This must match the Name of a Volume.",
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                            "type": "boolean"
+                                          },
+                                          "subPath": {
+                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                            "type": "string"
+                                          },
+                                          "subPathExpr": {
+                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "workingDir": {
+                                      "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "dnsConfig": {
+                                "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
+                                "type": "object",
+                                "properties": {
+                                  "nameservers": {
+                                    "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "options": {
+                                    "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Required.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "searches": {
+                                    "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "dnsPolicy": {
+                                "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+                                "type": "string"
+                              },
+                              "enableServiceLinks": {
+                                "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+                                "type": "boolean"
+                              },
+                              "ephemeralContainers": {
+                                "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
+                                "type": "array",
+                                "items": {
+                                  "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted.",
+                                  "type": "object",
+                                  "required": ["name"],
+                                  "properties": {
+                                    "args": {
+                                      "description": "Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "command": {
+                                      "description": "Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "env": {
+                                      "description": "List of environment variables to set in the container. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "type": "object",
+                                        "required": ["name"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "type": "string"
+                                          },
+                                          "valueFrom": {
+                                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                            "type": "object",
+                                            "properties": {
+                                              "configMapKeyRef": {
+                                                "description": "Selects a key of a ConfigMap.",
+                                                "type": "object",
+                                                "required": ["key"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key to select.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the ConfigMap or its key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "fieldRef": {
+                                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                "type": "object",
+                                                "required": ["fieldPath"],
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "description": "Path of the field to select in the specified API version.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "resourceFieldRef": {
+                                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                "type": "object",
+                                                "required": ["resource"],
+                                                "properties": {
+                                                  "containerName": {
+                                                    "description": "Container name: required for volumes, optional for env vars",
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "description": "Required: resource to select",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "secretKeyRef": {
+                                                "description": "Selects a key of a secret in the pod's namespace",
+                                                "type": "object",
+                                                "required": ["key"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the Secret or its key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "envFrom": {
+                                      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                        "type": "object",
+                                        "properties": {
+                                          "configMapRef": {
+                                            "description": "The ConfigMap to select from",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the ConfigMap must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "prefix": {
+                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "The Secret to select from",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the Secret must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "image": {
+                                      "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+                                      "type": "string"
+                                    },
+                                    "imagePullPolicy": {
+                                      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                      "type": "string"
+                                    },
+                                    "lifecycle": {
+                                      "description": "Lifecycle is not allowed for ephemeral containers.",
+                                      "type": "object",
+                                      "properties": {
+                                        "postStart": {
+                                          "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                          "type": "object",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "Exec specifies the action to take.",
+                                              "type": "object",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGet specifies the http request to perform.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "tcpSocket": {
+                                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "preStop": {
+                                          "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                          "type": "object",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "Exec specifies the action to take.",
+                                              "type": "object",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGet specifies the http request to perform.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "tcpSocket": {
+                                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "livenessProbe": {
+                                      "description": "Probes are not allowed for ephemeral containers.",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+                                      "type": "string"
+                                    },
+                                    "ports": {
+                                      "description": "Ports are not allowed for ephemeral containers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "ContainerPort represents a network port in a single container.",
+                                        "type": "object",
+                                        "required": ["containerPort"],
+                                        "properties": {
+                                          "containerPort": {
+                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "hostIP": {
+                                            "description": "What host IP to bind the external port to.",
+                                            "type": "string"
+                                          },
+                                          "hostPort": {
+                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "name": {
+                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                            "type": "string"
+                                          },
+                                          "protocol": {
+                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-map-keys": [
+                                        "containerPort",
+                                        "protocol"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    },
+                                    "readinessProbe": {
+                                      "description": "Probes are not allowed for ephemeral containers.",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "resizePolicy": {
+                                      "description": "Resources resize policy for the container.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                        "type": "object",
+                                        "required": [
+                                          "resourceName",
+                                          "restartPolicy"
+                                        ],
+                                        "properties": {
+                                          "resourceName": {
+                                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                            "type": "string"
+                                          },
+                                          "restartPolicy": {
+                                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "resources": {
+                                      "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
+                                      "type": "object",
+                                      "properties": {
+                                        "claims": {
+                                          "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                            "type": "object",
+                                            "required": ["name"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
+                                        },
+                                        "limits": {
+                                          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "requests": {
+                                          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "restartPolicy": {
+                                      "description": "Restart policy for the container to manage the restart behavior of each container within a pod. This may only be set for init containers. You cannot set this field on ephemeral containers.",
+                                      "type": "string"
+                                    },
+                                    "securityContext": {
+                                      "description": "Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.",
+                                      "type": "object",
+                                      "properties": {
+                                        "allowPrivilegeEscalation": {
+                                          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "capabilities": {
+                                          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "properties": {
+                                            "add": {
+                                              "description": "Added capabilities",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "Capability represent POSIX capabilities type",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "drop": {
+                                              "description": "Removed capabilities",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "Capability represent POSIX capabilities type",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "privileged": {
+                                          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "procMount": {
+                                          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "string"
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsGroup": {
+                                          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "runAsNonRoot": {
+                                          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsUser": {
+                                          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "seLinuxOptions": {
+                                          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "properties": {
+                                            "level": {
+                                              "description": "Level is SELinux level label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "role": {
+                                              "description": "Role is a SELinux role label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "Type is a SELinux type label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "user": {
+                                              "description": "User is a SELinux user label that applies to the container.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "seccompProfile": {
+                                          "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "required": ["type"],
+                                          "properties": {
+                                            "localhostProfile": {
+                                              "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "windowsOptions": {
+                                          "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                          "type": "object",
+                                          "properties": {
+                                            "gmsaCredentialSpec": {
+                                              "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                              "type": "string"
+                                            },
+                                            "gmsaCredentialSpecName": {
+                                              "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                              "type": "string"
+                                            },
+                                            "hostProcess": {
+                                              "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                              "type": "boolean"
+                                            },
+                                            "runAsUserName": {
+                                              "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "startupProbe": {
+                                      "description": "Probes are not allowed for ephemeral containers.",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "stdin": {
+                                      "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "stdinOnce": {
+                                      "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                      "type": "boolean"
+                                    },
+                                    "targetContainerName": {
+                                      "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec. \n The container runtime must implement support for this feature. If the runtime does not support namespace targeting then the result of setting this field is undefined.",
+                                      "type": "string"
+                                    },
+                                    "terminationMessagePath": {
+                                      "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "terminationMessagePolicy": {
+                                      "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "tty": {
+                                      "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "volumeDevices": {
+                                      "description": "volumeDevices is the list of block devices to be used by the container.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                        "type": "object",
+                                        "required": ["devicePath", "name"],
+                                        "properties": {
+                                          "devicePath": {
+                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "volumeMounts": {
+                                      "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                        "type": "object",
+                                        "required": ["mountPath", "name"],
+                                        "properties": {
+                                          "mountPath": {
+                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "type": "string"
+                                          },
+                                          "mountPropagation": {
+                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "This must match the Name of a Volume.",
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                            "type": "boolean"
+                                          },
+                                          "subPath": {
+                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                            "type": "string"
+                                          },
+                                          "subPathExpr": {
+                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "workingDir": {
+                                      "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "hostAliases": {
+                                "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
+                                "type": "array",
+                                "items": {
+                                  "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+                                  "type": "object",
+                                  "properties": {
+                                    "hostnames": {
+                                      "description": "Hostnames for the above IP address.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "ip": {
+                                      "description": "IP address of the host file entry.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "hostIPC": {
+                                "description": "Use the host's ipc namespace. Optional: Default to false.",
+                                "type": "boolean"
+                              },
+                              "hostNetwork": {
+                                "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+                                "type": "boolean"
+                              },
+                              "hostPID": {
+                                "description": "Use the host's pid namespace. Optional: Default to false.",
+                                "type": "boolean"
+                              },
+                              "hostUsers": {
+                                "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod. Setting false is useful for mitigating container breakout vulnerabilities even allowing users to run their containers as root without actually having root privileges on the host. This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.",
+                                "type": "boolean"
+                              },
+                              "hostname": {
+                                "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+                                "type": "string"
+                              },
+                              "imagePullSecrets": {
+                                "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                                "type": "array",
+                                "items": {
+                                  "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "initContainers": {
+                                "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/",
+                                "type": "array",
+                                "items": {
+                                  "description": "A single application container that you want to run within a pod.",
+                                  "type": "object",
+                                  "required": ["name"],
+                                  "properties": {
+                                    "args": {
+                                      "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "command": {
+                                      "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "env": {
+                                      "description": "List of environment variables to set in the container. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "EnvVar represents an environment variable present in a Container.",
+                                        "type": "object",
+                                        "required": ["name"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to \"\".",
+                                            "type": "string"
+                                          },
+                                          "valueFrom": {
+                                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                            "type": "object",
+                                            "properties": {
+                                              "configMapKeyRef": {
+                                                "description": "Selects a key of a ConfigMap.",
+                                                "type": "object",
+                                                "required": ["key"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key to select.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the ConfigMap or its key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "fieldRef": {
+                                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                                "type": "object",
+                                                "required": ["fieldPath"],
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "description": "Path of the field to select in the specified API version.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "resourceFieldRef": {
+                                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                                "type": "object",
+                                                "required": ["resource"],
+                                                "properties": {
+                                                  "containerName": {
+                                                    "description": "Container name: required for volumes, optional for env vars",
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "description": "Required: resource to select",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "secretKeyRef": {
+                                                "description": "Selects a key of a secret in the pod's namespace",
+                                                "type": "object",
+                                                "required": ["key"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "Specify whether the Secret or its key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "envFrom": {
+                                      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                        "type": "object",
+                                        "properties": {
+                                          "configMapRef": {
+                                            "description": "The ConfigMap to select from",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the ConfigMap must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "prefix": {
+                                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "description": "The Secret to select from",
+                                            "type": "object",
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "description": "Specify whether the Secret must be defined",
+                                                "type": "boolean"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "image": {
+                                      "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                                      "type": "string"
+                                    },
+                                    "imagePullPolicy": {
+                                      "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                                      "type": "string"
+                                    },
+                                    "lifecycle": {
+                                      "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                                      "type": "object",
+                                      "properties": {
+                                        "postStart": {
+                                          "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                          "type": "object",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "Exec specifies the action to take.",
+                                              "type": "object",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGet specifies the http request to perform.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "tcpSocket": {
+                                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "preStop": {
+                                          "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod's termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                          "type": "object",
+                                          "properties": {
+                                            "exec": {
+                                              "description": "Exec specifies the action to take.",
+                                              "type": "object",
+                                              "properties": {
+                                                "command": {
+                                                  "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "httpGet": {
+                                              "description": "HTTPGet specifies the http request to perform.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                                  "type": "string"
+                                                },
+                                                "httpHeaders": {
+                                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                    "type": "object",
+                                                    "required": [
+                                                      "name",
+                                                      "value"
+                                                    ],
+                                                    "properties": {
+                                                      "name": {
+                                                        "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "description": "The header field value",
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "path": {
+                                                  "description": "Path to access on the HTTP server.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "scheme": {
+                                                  "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "tcpSocket": {
+                                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                              "type": "object",
+                                              "required": ["port"],
+                                              "properties": {
+                                                "host": {
+                                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                                  "type": "string"
+                                                },
+                                                "port": {
+                                                  "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                                  "x-kubernetes-int-or-string": true
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "livenessProbe": {
+                                      "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "ports": {
+                                      "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "ContainerPort represents a network port in a single container.",
+                                        "type": "object",
+                                        "required": ["containerPort"],
+                                        "properties": {
+                                          "containerPort": {
+                                            "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "hostIP": {
+                                            "description": "What host IP to bind the external port to.",
+                                            "type": "string"
+                                          },
+                                          "hostPort": {
+                                            "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "name": {
+                                            "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                            "type": "string"
+                                          },
+                                          "protocol": {
+                                            "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-map-keys": [
+                                        "containerPort",
+                                        "protocol"
+                                      ],
+                                      "x-kubernetes-list-type": "map"
+                                    },
+                                    "readinessProbe": {
+                                      "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "resizePolicy": {
+                                      "description": "Resources resize policy for the container.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                        "type": "object",
+                                        "required": [
+                                          "resourceName",
+                                          "restartPolicy"
+                                        ],
+                                        "properties": {
+                                          "resourceName": {
+                                            "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                            "type": "string"
+                                          },
+                                          "restartPolicy": {
+                                            "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "resources": {
+                                      "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                      "type": "object",
+                                      "properties": {
+                                        "claims": {
+                                          "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                            "type": "object",
+                                            "required": ["name"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-list-map-keys": [
+                                            "name"
+                                          ],
+                                          "x-kubernetes-list-type": "map"
+                                        },
+                                        "limits": {
+                                          "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "requests": {
+                                          "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "restartPolicy": {
+                                      "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type. Setting the RestartPolicy as \"Always\" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy \"Always\" will be shut down. This lifecycle differs from normal init containers and is often referred to as a \"sidecar\" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.",
+                                      "type": "string"
+                                    },
+                                    "securityContext": {
+                                      "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                                      "type": "object",
+                                      "properties": {
+                                        "allowPrivilegeEscalation": {
+                                          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "capabilities": {
+                                          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "properties": {
+                                            "add": {
+                                              "description": "Added capabilities",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "Capability represent POSIX capabilities type",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "drop": {
+                                              "description": "Removed capabilities",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "Capability represent POSIX capabilities type",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "privileged": {
+                                          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "procMount": {
+                                          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "string"
+                                        },
+                                        "readOnlyRootFilesystem": {
+                                          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsGroup": {
+                                          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "runAsNonRoot": {
+                                          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                          "type": "boolean"
+                                        },
+                                        "runAsUser": {
+                                          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "seLinuxOptions": {
+                                          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "properties": {
+                                            "level": {
+                                              "description": "Level is SELinux level label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "role": {
+                                              "description": "Role is a SELinux role label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "Type is a SELinux type label that applies to the container.",
+                                              "type": "string"
+                                            },
+                                            "user": {
+                                              "description": "User is a SELinux user label that applies to the container.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "seccompProfile": {
+                                          "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                          "type": "object",
+                                          "required": ["type"],
+                                          "properties": {
+                                            "localhostProfile": {
+                                              "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "windowsOptions": {
+                                          "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                          "type": "object",
+                                          "properties": {
+                                            "gmsaCredentialSpec": {
+                                              "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                              "type": "string"
+                                            },
+                                            "gmsaCredentialSpecName": {
+                                              "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                              "type": "string"
+                                            },
+                                            "hostProcess": {
+                                              "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                              "type": "boolean"
+                                            },
+                                            "runAsUserName": {
+                                              "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "startupProbe": {
+                                      "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod's lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                      "type": "object",
+                                      "properties": {
+                                        "exec": {
+                                          "description": "Exec specifies the action to take.",
+                                          "type": "object",
+                                          "properties": {
+                                            "command": {
+                                              "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "failureThreshold": {
+                                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "grpc": {
+                                          "description": "GRPC specifies an action involving a GRPC port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "port": {
+                                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                              "type": "integer",
+                                              "format": "int32"
+                                            },
+                                            "service": {
+                                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "httpGet": {
+                                          "description": "HTTPGet specifies the http request to perform.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                              "type": "string"
+                                            },
+                                            "httpHeaders": {
+                                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                                "type": "object",
+                                                "required": ["name", "value"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                    "type": "string"
+                                                  },
+                                                  "value": {
+                                                    "description": "The header field value",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "path": {
+                                              "description": "Path to access on the HTTP server.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "scheme": {
+                                              "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "initialDelaySeconds": {
+                                          "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "periodSeconds": {
+                                          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "successThreshold": {
+                                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "tcpSocket": {
+                                          "description": "TCPSocket specifies an action involving a TCP port.",
+                                          "type": "object",
+                                          "required": ["port"],
+                                          "properties": {
+                                            "host": {
+                                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                              "type": "string"
+                                            },
+                                            "port": {
+                                              "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                              "x-kubernetes-int-or-string": true
+                                            }
+                                          }
+                                        },
+                                        "terminationGracePeriodSeconds": {
+                                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                                          "type": "integer",
+                                          "format": "int64"
+                                        },
+                                        "timeoutSeconds": {
+                                          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        }
+                                      }
+                                    },
+                                    "stdin": {
+                                      "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "stdinOnce": {
+                                      "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false",
+                                      "type": "boolean"
+                                    },
+                                    "terminationMessagePath": {
+                                      "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "terminationMessagePolicy": {
+                                      "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.",
+                                      "type": "string"
+                                    },
+                                    "tty": {
+                                      "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                                      "type": "boolean"
+                                    },
+                                    "volumeDevices": {
+                                      "description": "volumeDevices is the list of block devices to be used by the container.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                        "type": "object",
+                                        "required": ["devicePath", "name"],
+                                        "properties": {
+                                          "devicePath": {
+                                            "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "volumeMounts": {
+                                      "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                        "type": "object",
+                                        "required": ["mountPath", "name"],
+                                        "properties": {
+                                          "mountPath": {
+                                            "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                            "type": "string"
+                                          },
+                                          "mountPropagation": {
+                                            "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "This must match the Name of a Volume.",
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                            "type": "boolean"
+                                          },
+                                          "subPath": {
+                                            "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                            "type": "string"
+                                          },
+                                          "subPathExpr": {
+                                            "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "workingDir": {
+                                      "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "nodeName": {
+                                "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+                                "type": "string"
+                              },
+                              "nodeSelector": {
+                                "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "os": {
+                                "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup",
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "overhead": {
+                                "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "preemptionPolicy": {
+                                "description": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+                                "type": "string"
+                              },
+                              "priority": {
+                                "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "priorityClassName": {
+                                "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+                                "type": "string"
+                              },
+                              "readinessGates": {
+                                "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
+                                "type": "array",
+                                "items": {
+                                  "description": "PodReadinessGate contains the reference to a pod condition",
+                                  "type": "object",
+                                  "required": ["conditionType"],
+                                  "properties": {
+                                    "conditionType": {
+                                      "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "resourceClaims": {
+                                "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable.",
+                                "type": "array",
+                                "items": {
+                                  "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource. It adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+                                  "type": "object",
+                                  "required": ["name"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
+                                      "type": "string"
+                                    },
+                                    "source": {
+                                      "description": "Source describes where to find the ResourceClaim.",
+                                      "type": "object",
+                                      "properties": {
+                                        "resourceClaimName": {
+                                          "description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.",
+                                          "type": "string"
+                                        },
+                                        "resourceClaimTemplateName": {
+                                          "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod. \n The template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted. The pod name and resource name, along with a generated component, will be used to form a unique name for the ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses. \n This field is immutable and no changes will be made to the corresponding ResourceClaim by the control plane after creating the ResourceClaim.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-map-keys": ["name"],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "restartPolicy": {
+                                "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+                                "type": "string"
+                              },
+                              "runtimeClassName": {
+                                "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class",
+                                "type": "string"
+                              },
+                              "schedulerName": {
+                                "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+                                "type": "string"
+                              },
+                              "schedulingGates": {
+                                "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod. \n SchedulingGates can only be set at pod creation time, and be removed only afterwards. \n This is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                                "type": "array",
+                                "items": {
+                                  "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+                                  "type": "object",
+                                  "required": ["name"],
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the scheduling gate. Each scheduling gate must have a unique name field.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-map-keys": ["name"],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "securityContext": {
+                                "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
+                                "type": "object",
+                                "properties": {
+                                  "fsGroup": {
+                                    "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume. Note that this field cannot be set when spec.os.name is windows.",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  "fsGroupChangePolicy": {
+                                    "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used. Note that this field cannot be set when spec.os.name is windows.",
+                                    "type": "string"
+                                  },
+                                  "runAsGroup": {
+                                    "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  "runAsNonRoot": {
+                                    "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  "seLinuxOptions": {
+                                    "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                                    "type": "object",
+                                    "properties": {
+                                      "level": {
+                                        "description": "Level is SELinux level label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "description": "Role is a SELinux role label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "Type is a SELinux type label that applies to the container.",
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "description": "User is a SELinux user label that applies to the container.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "seccompProfile": {
+                                    "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                                    "type": "object",
+                                    "required": ["type"],
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "supplementalGroups": {
+                                    "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container. Note that group memberships defined in the container image for the uid of the container process are still effective, even if they are not included in this list. Note that this field cannot be set when spec.os.name is windows.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "integer",
+                                      "format": "int64"
+                                    }
+                                  },
+                                  "sysctls": {
+                                    "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Sysctl defines a kernel parameter to be set",
+                                      "type": "object",
+                                      "required": ["name", "value"],
+                                      "properties": {
+                                        "name": {
+                                          "description": "Name of a property to set",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "Value of a property to set",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "windowsOptions": {
+                                    "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                    "type": "object",
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "serviceAccount": {
+                                "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+                                "type": "string"
+                              },
+                              "serviceAccountName": {
+                                "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                                "type": "string"
+                              },
+                              "setHostnameAsFQDN": {
+                                "description": "If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname). In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\\\SYSTEM\\\\CurrentControlSet\\\\Services\\\\Tcpip\\\\Parameters to FQDN. If a pod does not have FQDN, this has no effect. Default to false.",
+                                "type": "boolean"
+                              },
+                              "shareProcessNamespace": {
+                                "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.",
+                                "type": "boolean"
+                              },
+                              "subdomain": {
+                                "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
+                                "type": "string"
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.",
+                                "type": "integer",
+                                "format": "int64"
+                              },
+                              "tolerations": {
+                                "description": "If specified, the pod's tolerations.",
+                                "type": "array",
+                                "items": {
+                                  "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                                  "type": "object",
+                                  "properties": {
+                                    "effect": {
+                                      "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                                      "type": "string"
+                                    },
+                                    "key": {
+                                      "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                                      "type": "string"
+                                    },
+                                    "tolerationSeconds": {
+                                      "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                                      "type": "integer",
+                                      "format": "int64"
+                                    },
+                                    "value": {
+                                      "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "topologySpreadConstraints": {
+                                "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                                  "type": "object",
+                                  "required": [
+                                    "maxSkew",
+                                    "topologyKey",
+                                    "whenUnsatisfiable"
+                                  ],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "matchLabelKeys": {
+                                      "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot be set when LabelSelector isn't set. Keys that don't exist in the incoming pod labels will be ignored. A null or empty list means only match against labelSelector. \n This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "maxSkew": {
+                                      "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "minDomains": {
+                                      "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "nodeAffinityPolicy": {
+                                      "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                                      "type": "string"
+                                    },
+                                    "nodeTaintsPolicy": {
+                                      "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy. This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                                      "type": "string"
+                                    },
+                                    "topologyKey": {
+                                      "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes meet the requirements of nodeAffinityPolicy and nodeTaintsPolicy. e.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology. And, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology. It's a required field.",
+                                      "type": "string"
+                                    },
+                                    "whenUnsatisfiable": {
+                                      "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assignment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "topologyKey",
+                                  "whenUnsatisfiable"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "volumes": {
+                                "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                                "type": "array",
+                                "items": {
+                                  "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                                  "type": "object",
+                                  "required": ["name"],
+                                  "properties": {
+                                    "awsElasticBlockStore": {
+                                      "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                      "type": "object",
+                                      "required": ["volumeID"],
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                          "type": "string"
+                                        },
+                                        "partition": {
+                                          "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                          "type": "boolean"
+                                        },
+                                        "volumeID": {
+                                          "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "azureDisk": {
+                                      "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                                      "type": "object",
+                                      "required": ["diskName", "diskURI"],
+                                      "properties": {
+                                        "cachingMode": {
+                                          "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                                          "type": "string"
+                                        },
+                                        "diskName": {
+                                          "description": "diskName is the Name of the data disk in the blob storage",
+                                          "type": "string"
+                                        },
+                                        "diskURI": {
+                                          "description": "diskURI is the URI of data disk in the blob storage",
+                                          "type": "string"
+                                        },
+                                        "fsType": {
+                                          "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "kind": {
+                                          "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        }
+                                      }
+                                    },
+                                    "azureFile": {
+                                      "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                                      "type": "object",
+                                      "required": ["secretName", "shareName"],
+                                      "properties": {
+                                        "readOnly": {
+                                          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "secretName": {
+                                          "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                                          "type": "string"
+                                        },
+                                        "shareName": {
+                                          "description": "shareName is the azure share Name",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "cephfs": {
+                                      "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                                      "type": "object",
+                                      "required": ["monitors"],
+                                      "properties": {
+                                        "monitors": {
+                                          "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "path": {
+                                          "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                          "type": "boolean"
+                                        },
+                                        "secretFile": {
+                                          "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "user": {
+                                          "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "cinder": {
+                                      "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                      "type": "object",
+                                      "required": ["volumeID"],
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "volumeID": {
+                                          "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "configMap": {
+                                      "description": "configMap represents a configMap that should populate this volume",
+                                      "type": "object",
+                                      "properties": {
+                                        "defaultMode": {
+                                          "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "items": {
+                                          "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "Maps a string key to a path within a volume.",
+                                            "type": "object",
+                                            "required": ["key", "path"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the key to project.",
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                "type": "integer",
+                                                "format": "int32"
+                                              },
+                                              "path": {
+                                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "name": {
+                                          "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "csi": {
+                                      "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                                      "type": "object",
+                                      "required": ["driver"],
+                                      "properties": {
+                                        "driver": {
+                                          "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                          "type": "string"
+                                        },
+                                        "fsType": {
+                                          "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                          "type": "string"
+                                        },
+                                        "nodePublishSecretRef": {
+                                          "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                          "type": "boolean"
+                                        },
+                                        "volumeAttributes": {
+                                          "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "downwardAPI": {
+                                      "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                                      "type": "object",
+                                      "properties": {
+                                        "defaultMode": {
+                                          "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "items": {
+                                          "description": "Items is a list of downward API volume file",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                            "type": "object",
+                                            "required": ["path"],
+                                            "properties": {
+                                              "fieldRef": {
+                                                "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                "type": "object",
+                                                "required": ["fieldPath"],
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "description": "Path of the field to select in the specified API version.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "mode": {
+                                                "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                "type": "integer",
+                                                "format": "int32"
+                                              },
+                                              "path": {
+                                                "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                "type": "object",
+                                                "required": ["resource"],
+                                                "properties": {
+                                                  "containerName": {
+                                                    "description": "Container name: required for volumes, optional for env vars",
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "description": "Required: resource to select",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "emptyDir": {
+                                      "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                      "type": "object",
+                                      "properties": {
+                                        "medium": {
+                                          "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                          "type": "string"
+                                        },
+                                        "sizeLimit": {
+                                          "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    },
+                                    "ephemeral": {
+                                      "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time.",
+                                      "type": "object",
+                                      "properties": {
+                                        "volumeClaimTemplate": {
+                                          "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil.",
+                                          "type": "object",
+                                          "required": ["spec"],
+                                          "properties": {
+                                            "metadata": {
+                                              "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                                              "type": "object",
+                                              "properties": {
+                                                "annotations": {
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "finalizers": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "labels": {
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "namespace": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "spec": {
+                                              "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                                              "type": "object",
+                                              "properties": {
+                                                "accessModes": {
+                                                  "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "dataSource": {
+                                                  "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                                  "type": "object",
+                                                  "required": ["kind", "name"],
+                                                  "properties": {
+                                                    "apiGroup": {
+                                                      "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                                      "type": "string"
+                                                    },
+                                                    "kind": {
+                                                      "description": "Kind is the type of resource being referenced",
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "description": "Name is the name of resource being referenced",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
+                                                },
+                                                "dataSourceRef": {
+                                                  "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While dataSource ignores disallowed values (dropping them), dataSourceRef preserves all values, and generates an error if a disallowed value is specified. * While dataSource only allows local objects, dataSourceRef allows objects in any namespaces. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                  "type": "object",
+                                                  "required": ["kind", "name"],
+                                                  "properties": {
+                                                    "apiGroup": {
+                                                      "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                                      "type": "string"
+                                                    },
+                                                    "kind": {
+                                                      "description": "Kind is the type of resource being referenced",
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "description": "Name is the name of resource being referenced",
+                                                      "type": "string"
+                                                    },
+                                                    "namespace": {
+                                                      "description": "Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "resources": {
+                                                  "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "claims": {
+                                                      "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                                        "type": "object",
+                                                        "required": ["name"],
+                                                        "properties": {
+                                                          "name": {
+                                                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                            "type": "string"
+                                                          }
+                                                        }
+                                                      },
+                                                      "x-kubernetes-list-map-keys": [
+                                                        "name"
+                                                      ],
+                                                      "x-kubernetes-list-type": "map"
+                                                    },
+                                                    "limits": {
+                                                      "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                        "x-kubernetes-int-or-string": true
+                                                      }
+                                                    },
+                                                    "requests": {
+                                                      "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                        "x-kubernetes-int-or-string": true
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "selector": {
+                                                  "description": "selector is a label query over volumes to consider for binding.",
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                                      "type": "array",
+                                                      "items": {
+                                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                        "type": "object",
+                                                        "required": [
+                                                          "key",
+                                                          "operator"
+                                                        ],
+                                                        "properties": {
+                                                          "key": {
+                                                            "description": "key is the label key that the selector applies to.",
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                            "type": "array",
+                                                            "items": {
+                                                              "type": "string"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "matchLabels": {
+                                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                                      "type": "object",
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
+                                                },
+                                                "storageClassName": {
+                                                  "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                                  "type": "string"
+                                                },
+                                                "volumeMode": {
+                                                  "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                                  "type": "string"
+                                                },
+                                                "volumeName": {
+                                                  "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "fc": {
+                                      "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                                      "type": "object",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                          "type": "string"
+                                        },
+                                        "lun": {
+                                          "description": "lun is Optional: FC target lun number",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "targetWWNs": {
+                                          "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "wwids": {
+                                          "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "flexVolume": {
+                                      "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                                      "type": "object",
+                                      "required": ["driver"],
+                                      "properties": {
+                                        "driver": {
+                                          "description": "driver is the name of the driver to use for this volume.",
+                                          "type": "string"
+                                        },
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                          "type": "string"
+                                        },
+                                        "options": {
+                                          "description": "options is Optional: this field holds extra command options if any.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "flocker": {
+                                      "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                                      "type": "object",
+                                      "properties": {
+                                        "datasetName": {
+                                          "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                                          "type": "string"
+                                        },
+                                        "datasetUUID": {
+                                          "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "gcePersistentDisk": {
+                                      "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                      "type": "object",
+                                      "required": ["pdName"],
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                          "type": "string"
+                                        },
+                                        "partition": {
+                                          "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "pdName": {
+                                          "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                          "type": "boolean"
+                                        }
+                                      }
+                                    },
+                                    "gitRepo": {
+                                      "description": "gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                                      "type": "object",
+                                      "required": ["repository"],
+                                      "properties": {
+                                        "directory": {
+                                          "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                                          "type": "string"
+                                        },
+                                        "repository": {
+                                          "description": "repository is the URL",
+                                          "type": "string"
+                                        },
+                                        "revision": {
+                                          "description": "revision is the commit hash for the specified revision.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "glusterfs": {
+                                      "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                                      "type": "object",
+                                      "required": ["endpoints", "path"],
+                                      "properties": {
+                                        "endpoints": {
+                                          "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                          "type": "boolean"
+                                        }
+                                      }
+                                    },
+                                    "hostPath": {
+                                      "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.",
+                                      "type": "object",
+                                      "required": ["path"],
+                                      "properties": {
+                                        "path": {
+                                          "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "iscsi": {
+                                      "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                                      "type": "object",
+                                      "required": [
+                                        "iqn",
+                                        "lun",
+                                        "targetPortal"
+                                      ],
+                                      "properties": {
+                                        "chapAuthDiscovery": {
+                                          "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                                          "type": "boolean"
+                                        },
+                                        "chapAuthSession": {
+                                          "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                                          "type": "boolean"
+                                        },
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                          "type": "string"
+                                        },
+                                        "initiatorName": {
+                                          "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                                          "type": "string"
+                                        },
+                                        "iqn": {
+                                          "description": "iqn is the target iSCSI Qualified Name.",
+                                          "type": "string"
+                                        },
+                                        "iscsiInterface": {
+                                          "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                                          "type": "string"
+                                        },
+                                        "lun": {
+                                          "description": "lun represents iSCSI Target Lun number.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "portals": {
+                                          "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "targetPortal": {
+                                          "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "name": {
+                                      "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "nfs": {
+                                      "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                      "type": "object",
+                                      "required": ["path", "server"],
+                                      "properties": {
+                                        "path": {
+                                          "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                          "type": "boolean"
+                                        },
+                                        "server": {
+                                          "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "persistentVolumeClaim": {
+                                      "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                      "type": "object",
+                                      "required": ["claimName"],
+                                      "properties": {
+                                        "claimName": {
+                                          "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+                                          "type": "boolean"
+                                        }
+                                      }
+                                    },
+                                    "photonPersistentDisk": {
+                                      "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                                      "type": "object",
+                                      "required": ["pdID"],
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "pdID": {
+                                          "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "portworxVolume": {
+                                      "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                                      "type": "object",
+                                      "required": ["volumeID"],
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "volumeID": {
+                                          "description": "volumeID uniquely identifies a Portworx volume",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "projected": {
+                                      "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                                      "type": "object",
+                                      "properties": {
+                                        "defaultMode": {
+                                          "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "sources": {
+                                          "description": "sources is the list of volume projections",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "Projection that may be projected along with other supported volume types",
+                                            "type": "object",
+                                            "properties": {
+                                              "configMap": {
+                                                "description": "configMap information about the configMap data to project",
+                                                "type": "object",
+                                                "properties": {
+                                                  "items": {
+                                                    "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "description": "Maps a string key to a path within a volume.",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "key",
+                                                        "path"
+                                                      ],
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the key to project.",
+                                                          "type": "string"
+                                                        },
+                                                        "mode": {
+                                                          "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                          "type": "integer",
+                                                          "format": "int32"
+                                                        },
+                                                        "path": {
+                                                          "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "downwardAPI": {
+                                                "description": "downwardAPI information about the downwardAPI data to project",
+                                                "type": "object",
+                                                "properties": {
+                                                  "items": {
+                                                    "description": "Items is a list of DownwardAPIVolume file",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                                      "type": "object",
+                                                      "required": ["path"],
+                                                      "properties": {
+                                                        "fieldRef": {
+                                                          "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "fieldPath"
+                                                          ],
+                                                          "properties": {
+                                                            "apiVersion": {
+                                                              "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                              "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                              "description": "Path of the field to select in the specified API version.",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        },
+                                                        "mode": {
+                                                          "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                          "type": "integer",
+                                                          "format": "int32"
+                                                        },
+                                                        "path": {
+                                                          "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                          "type": "string"
+                                                        },
+                                                        "resourceFieldRef": {
+                                                          "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                          "type": "object",
+                                                          "required": [
+                                                            "resource"
+                                                          ],
+                                                          "properties": {
+                                                            "containerName": {
+                                                              "description": "Container name: required for volumes, optional for env vars",
+                                                              "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                              "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                              "x-kubernetes-int-or-string": true
+                                                            },
+                                                            "resource": {
+                                                              "description": "Required: resource to select",
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "x-kubernetes-map-type": "atomic"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "secret": {
+                                                "description": "secret information about the secret data to project",
+                                                "type": "object",
+                                                "properties": {
+                                                  "items": {
+                                                    "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "description": "Maps a string key to a path within a volume.",
+                                                      "type": "object",
+                                                      "required": [
+                                                        "key",
+                                                        "path"
+                                                      ],
+                                                      "properties": {
+                                                        "key": {
+                                                          "description": "key is the key to project.",
+                                                          "type": "string"
+                                                        },
+                                                        "mode": {
+                                                          "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                          "type": "integer",
+                                                          "format": "int32"
+                                                        },
+                                                        "path": {
+                                                          "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                          "type": "string"
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "name": {
+                                                    "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                                    "type": "string"
+                                                  },
+                                                  "optional": {
+                                                    "description": "optional field specify whether the Secret or its key must be defined",
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "serviceAccountToken": {
+                                                "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                                "type": "object",
+                                                "required": ["path"],
+                                                "properties": {
+                                                  "audience": {
+                                                    "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                                    "type": "string"
+                                                  },
+                                                  "expirationSeconds": {
+                                                    "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                                    "type": "integer",
+                                                    "format": "int64"
+                                                  },
+                                                  "path": {
+                                                    "description": "path is the path relative to the mount point of the file to project the token into.",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "quobyte": {
+                                      "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                                      "type": "object",
+                                      "required": ["registry", "volume"],
+                                      "properties": {
+                                        "group": {
+                                          "description": "group to map volume access to Default is no group",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                                          "type": "boolean"
+                                        },
+                                        "registry": {
+                                          "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                                          "type": "string"
+                                        },
+                                        "tenant": {
+                                          "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                          "type": "string"
+                                        },
+                                        "user": {
+                                          "description": "user to map volume access to Defaults to serivceaccount user",
+                                          "type": "string"
+                                        },
+                                        "volume": {
+                                          "description": "volume is a string that references an already created Quobyte volume by name.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "rbd": {
+                                      "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                                      "type": "object",
+                                      "required": ["image", "monitors"],
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                          "type": "string"
+                                        },
+                                        "image": {
+                                          "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "string"
+                                        },
+                                        "keyring": {
+                                          "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "string"
+                                        },
+                                        "monitors": {
+                                          "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "pool": {
+                                          "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "user": {
+                                          "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "scaleIO": {
+                                      "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                                      "type": "object",
+                                      "required": [
+                                        "gateway",
+                                        "secretRef",
+                                        "system"
+                                      ],
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                                          "type": "string"
+                                        },
+                                        "gateway": {
+                                          "description": "gateway is the host address of the ScaleIO API Gateway.",
+                                          "type": "string"
+                                        },
+                                        "protectionDomain": {
+                                          "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "sslEnabled": {
+                                          "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                                          "type": "boolean"
+                                        },
+                                        "storageMode": {
+                                          "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                                          "type": "string"
+                                        },
+                                        "storagePool": {
+                                          "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                                          "type": "string"
+                                        },
+                                        "system": {
+                                          "description": "system is the name of the storage system as configured in ScaleIO.",
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "secret": {
+                                      "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                      "type": "object",
+                                      "properties": {
+                                        "defaultMode": {
+                                          "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                          "type": "integer",
+                                          "format": "int32"
+                                        },
+                                        "items": {
+                                          "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "Maps a string key to a path within a volume.",
+                                            "type": "object",
+                                            "required": ["key", "path"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the key to project.",
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                                                "type": "integer",
+                                                "format": "int32"
+                                              },
+                                              "path": {
+                                                "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "optional": {
+                                          "description": "optional field specify whether the Secret or its keys must be defined",
+                                          "type": "boolean"
+                                        },
+                                        "secretName": {
+                                          "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "storageos": {
+                                      "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                                      "type": "object",
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                          "type": "boolean"
+                                        },
+                                        "secretRef": {
+                                          "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                                          "type": "object",
+                                          "properties": {
+                                            "name": {
+                                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "volumeName": {
+                                          "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                                          "type": "string"
+                                        },
+                                        "volumeNamespace": {
+                                          "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "vsphereVolume": {
+                                      "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                                      "type": "object",
+                                      "required": ["volumePath"],
+                                      "properties": {
+                                        "fsType": {
+                                          "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                          "type": "string"
+                                        },
+                                        "storagePolicyID": {
+                                          "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                          "type": "string"
+                                        },
+                                        "storagePolicyName": {
+                                          "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                                          "type": "string"
+                                        },
+                                        "volumePath": {
+                                          "description": "volumePath is the path that identifies vSphere volume vmdk",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "ttlSecondsAfterFinished": {
+                        "description": "ttlSecondsAfterFinished limits the lifetime of a Job that has finished execution (either Complete or Failed). If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. When the Job is being deleted, its lifecycle guarantees (e.g. finalizers) will be honored. If this field is unset, the Job won't be automatically deleted. If this field is set to zero, the Job becomes eligible to be deleted immediately after it finishes.",
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": ["name"],
+          "x-kubernetes-list-type": "map"
+        },
+        "successPolicy": {
+          "description": "SuccessPolicy configures when to declare the JobSet as succeeded. The JobSet is always declared succeeded if all jobs in the set finished with status complete.",
+          "type": "object",
+          "required": ["operator"],
+          "properties": {
+            "operator": {
+              "description": "Operator determines either All or Any of the selected jobs should succeed to consider the JobSet successful",
+              "type": "string",
+              "enum": ["All", "Any"]
+            },
+            "targetReplicatedJobs": {
+              "description": "TargetReplicatedJobs are the names of the replicated jobs the operator will apply to. A null or empty list will apply to all replicatedJobs.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "x-kubernetes-list-type": "atomic"
+            }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "suspend": {
+          "description": "Suspend suspends all running child Jobs when set to true.",
+          "type": "boolean"
+        }
+      }
+    },
+    "status": {
+      "description": "JobSetStatus defines the observed state of JobSet",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "type": "array",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "type": "object",
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "type": "string",
+                "maxLength": 32768
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "type": "string",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": ["True", "False", "Unknown"]
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": ["type"],
+          "x-kubernetes-list-type": "map"
+        },
+        "replicatedJobsStatus": {
+          "description": "ReplicatedJobsStatus track the number of JobsReady for each replicatedJob.",
+          "type": "array",
+          "items": {
+            "description": "ReplicatedJobStatus defines the observed ReplicatedJobs Readiness.",
+            "type": "object",
+            "required": ["active", "failed", "name", "ready", "succeeded"],
+            "properties": {
+              "active": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "failed": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "name": {
+                "type": "string"
+              },
+              "ready": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "succeeded": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": ["name"],
+          "x-kubernetes-list-type": "map"
+        },
+        "restarts": {
+          "description": "Restarts tracks the number of times the JobSet has restarted (i.e. recreated in case of RecreateAll policy).",
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "jobset.x-k8s.io",
+      "kind": "JobSet",
+      "version": "v1alpha2"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/weave-js/src/common/components/Monaco/schemas/pytorchjob.json
+++ b/weave-js/src/common/components/Monaco/schemas/pytorchjob.json
@@ -1,0 +1,6178 @@
+{
+  "description": "PyTorchJob Represents a PyTorchJob resource.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "creationTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "deletionTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "type": "string"
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "type": "array",
+          "items": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "type": "object",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                "type": "string"
+              },
+              "fieldsType": {
+                "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                "type": "string"
+              },
+              "fieldsV1": {
+                "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                "type": "object"
+              },
+              "manager": {
+                "description": "Manager is an identifier of the workflow managing these fields.",
+                "type": "string"
+              },
+              "operation": {
+                "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                "type": "string"
+              },
+              "subresource": {
+                "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                "type": "string"
+              },
+              "time": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+          "type": "string"
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "type": "array",
+          "items": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": "object",
+            "required": ["apiVersion", "kind", "name", "uid"],
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "blockOwnerDeletion": {
+                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                "type": "boolean"
+              },
+              "controller": {
+                "description": "If true, this reference points to the managing controller.",
+                "type": "boolean"
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                "type": "string"
+              }
+            },
+            "x-kubernetes-map-type": "atomic"
+          },
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+          "type": "string"
+        }
+      }
+    },
+    "spec": {
+      "description": "Specification of the desired state of the PyTorchJob.",
+      "type": "object",
+      "required": ["pytorchReplicaSpecs"],
+      "properties": {
+        "elasticPolicy": {
+          "type": "object",
+          "properties": {
+            "maxReplicas": {
+              "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas, defaults to null.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "maxRestarts": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "metrics": {
+              "description": "Metrics contains the specifications which are used to calculate the desired replica count (the maximum replica count across all metrics will be used).  The desired replica count is calculated with multiplying the ratio between the target value and the current value by the current number of pods. Ergo, metrics used must decrease as the pod count is increased, and vice-versa.",
+              "type": "array",
+              "items": {
+                "description": "MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).",
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "containerResource": {
+                    "description": "containerResource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing a single container in each pod of the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+                    "type": "object",
+                    "required": ["container", "name", "target"],
+                    "properties": {
+                      "container": {
+                        "description": "container is the name of the container in the pods of the scaling target",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "name is the name of the resource in question.",
+                        "type": "string"
+                      },
+                      "target": {
+                        "description": "target specifies the target value for the given metric",
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                          "averageUtilization": {
+                            "description": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "averageValue": {
+                            "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "value is the target value of the metric (as a quantity).",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "external": {
+                    "description": "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
+                    "type": "object",
+                    "required": ["metric", "target"],
+                    "properties": {
+                      "metric": {
+                        "description": "metric identifies the target metric by name and selector",
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                          "name": {
+                            "description": "name is the name of the given metric",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "type": "object",
+                                  "required": ["key", "operator"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "target": {
+                        "description": "target specifies the target value for the given metric",
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                          "averageUtilization": {
+                            "description": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "averageValue": {
+                            "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "value is the target value of the metric (as a quantity).",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "object": {
+                    "description": "object refers to a metric describing a single kubernetes object (for example, hits-per-second on an Ingress object).",
+                    "type": "object",
+                    "required": ["describedObject", "metric", "target"],
+                    "properties": {
+                      "describedObject": {
+                        "description": "describedObject specifies the descriptions of a object,such as kind,name apiVersion",
+                        "type": "object",
+                        "required": ["kind", "name"],
+                        "properties": {
+                          "apiVersion": {
+                            "description": "apiVersion is the API version of the referent",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "metric": {
+                        "description": "metric identifies the target metric by name and selector",
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                          "name": {
+                            "description": "name is the name of the given metric",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "type": "object",
+                                  "required": ["key", "operator"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "target": {
+                        "description": "target specifies the target value for the given metric",
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                          "averageUtilization": {
+                            "description": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "averageValue": {
+                            "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "value is the target value of the metric (as a quantity).",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "pods": {
+                    "description": "pods refers to a metric describing each pod in the current scale target (for example, transactions-processed-per-second).  The values will be averaged together before being compared to the target value.",
+                    "type": "object",
+                    "required": ["metric", "target"],
+                    "properties": {
+                      "metric": {
+                        "description": "metric identifies the target metric by name and selector",
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                          "name": {
+                            "description": "name is the name of the given metric",
+                            "type": "string"
+                          },
+                          "selector": {
+                            "description": "selector is the string-encoded form of a standard kubernetes label selector for the given metric When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping. When unset, just the metricName will be used to gather metrics.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                  "type": "object",
+                                  "required": ["key", "operator"],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "target": {
+                        "description": "target specifies the target value for the given metric",
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                          "averageUtilization": {
+                            "description": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "averageValue": {
+                            "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "value is the target value of the metric (as a quantity).",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "resource": {
+                    "description": "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+                    "type": "object",
+                    "required": ["name", "target"],
+                    "properties": {
+                      "name": {
+                        "description": "name is the name of the resource in question.",
+                        "type": "string"
+                      },
+                      "target": {
+                        "description": "target specifies the target value for the given metric",
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                          "averageUtilization": {
+                            "description": "averageUtilization is the target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods. Currently only valid for Resource metric source type",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "averageValue": {
+                            "description": "averageValue is the target value of the average of the metric across all relevant pods (as a quantity)",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "description": "type represents whether the metric type is Utilization, Value, or AverageValue",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "value is the target value of the metric (as a quantity).",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "type": {
+                    "description": "type is the type of metric source.  It should be one of \"ContainerResource\", \"External\", \"Object\", \"Pods\" or \"Resource\", each mapping to a matching field in the object. Note: \"ContainerResource\" type is available on when the feature-gate HPAContainerMetrics is enabled",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "minReplicas": {
+              "description": "minReplicas is the lower limit for the number of replicas to which the training job can scale down.  It defaults to null.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "nProcPerNode": {
+              "description": "Number of workers per node; supported values: [auto, cpu, gpu, int]. Deprecated: This API is deprecated in v1.7+ Use .spec.nprocPerNode instead.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "rdzvBackend": {
+              "type": "string"
+            },
+            "rdzvConf": {
+              "description": "RDZVConf contains additional rendezvous configuration (<key1>=<value1>,<key2>=<value2>,...).",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "rdzvHost": {
+              "type": "string"
+            },
+            "rdzvId": {
+              "type": "string"
+            },
+            "rdzvPort": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "standalone": {
+              "description": "Start a local standalone rendezvous backend that is represented by a C10d TCP store on port 29400. Useful when launching single-node, multi-worker job. If specified --rdzv_backend, --rdzv_endpoint, --rdzv_id are auto-assigned; any explicitly set values are ignored.",
+              "type": "boolean"
+            }
+          }
+        },
+        "nprocPerNode": {
+          "description": "Number of workers per node; supported values: [auto, cpu, gpu, int]. For more, https://github.com/pytorch/pytorch/blob/26f7f470df64d90e092081e39507e4ac751f55d6/torch/distributed/run.py#L629-L658. Defaults to auto.",
+          "type": "string"
+        },
+        "pytorchReplicaSpecs": {
+          "description": "A map of PyTorchReplicaType (type) to ReplicaSpec (value). Specifies the PyTorch cluster configuration. For example, { \"Master\": PyTorchReplicaSpec, \"Worker\": PyTorchReplicaSpec, }",
+          "type": "object",
+          "additionalProperties": {
+            "description": "ReplicaSpec is a description of the replica",
+            "type": "object",
+            "properties": {
+              "replicas": {
+                "description": "Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.",
+                "type": "integer",
+                "format": "int32"
+              },
+              "restartPolicy": {
+                "description": "Restart policy for all replicas within the job. One of Always, OnFailure, Never and ExitCode. Default to Never.",
+                "type": "string"
+              },
+              "template": {
+                "description": "Template is the object that describes the pod that will be created for this replica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in ReplicaSpec",
+                "type": "object",
+                "properties": {
+                  "metadata": {
+                    "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+                    "type": "object",
+                    "properties": {
+                      "annotations": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "finalizers": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "spec": {
+                    "description": "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+                    "type": "object",
+                    "required": ["containers"],
+                    "properties": {
+                      "activeDeadlineSeconds": {
+                        "description": "Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "affinity": {
+                        "description": "If specified, the pod's scheduling constraints",
+                        "type": "object",
+                        "properties": {
+                          "nodeAffinity": {
+                            "description": "Describes node affinity scheduling rules for the pod.",
+                            "type": "object",
+                            "properties": {
+                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.",
+                                "type": "array",
+                                "items": {
+                                  "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                  "type": "object",
+                                  "required": ["preference", "weight"],
+                                  "properties": {
+                                    "preference": {
+                                      "description": "A node selector term, associated with the corresponding weight.",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "A list of node selector requirements by node's labels.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "The label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchFields": {
+                                          "description": "A list of node selector requirements by node's fields.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "The label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "weight": {
+                                      "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    }
+                                  }
+                                }
+                              },
+                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.",
+                                "type": "object",
+                                "required": ["nodeSelectorTerms"],
+                                "properties": {
+                                  "nodeSelectorTerms": {
+                                    "description": "Required. A list of node selector terms. The terms are ORed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "A list of node selector requirements by node's labels.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "The label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchFields": {
+                                          "description": "A list of node selector requirements by node's fields.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "The label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          },
+                          "podAffinity": {
+                            "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                            "type": "object",
+                            "properties": {
+                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.",
+                                "type": "array",
+                                "items": {
+                                  "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                  "type": "object",
+                                  "required": ["podAffinityTerm", "weight"],
+                                  "properties": {
+                                    "podAffinityTerm": {
+                                      "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                      "type": "object",
+                                      "required": ["topologyKey"],
+                                      "properties": {
+                                        "labelSelector": {
+                                          "description": "A label query over a set of resources, in this case pods.",
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "namespaceSelector": {
+                                          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "namespaces": {
+                                          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "topologyKey": {
+                                          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "weight": {
+                                      "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    }
+                                  }
+                                }
+                              },
+                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "description": "If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node.",
+                                "type": "array",
+                                "items": {
+                                  "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                  "type": "object",
+                                  "required": ["topologyKey"],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "A label query over a set of resources, in this case pods.",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "namespaceSelector": {
+                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "namespaces": {
+                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "topologyKey": {
+                                      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "podAntiAffinity": {
+                            "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                            "type": "object",
+                            "properties": {
+                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e.",
+                                "type": "array",
+                                "items": {
+                                  "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                  "type": "object",
+                                  "required": ["podAffinityTerm", "weight"],
+                                  "properties": {
+                                    "podAffinityTerm": {
+                                      "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                      "type": "object",
+                                      "required": ["topologyKey"],
+                                      "properties": {
+                                        "labelSelector": {
+                                          "description": "A label query over a set of resources, in this case pods.",
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "namespaceSelector": {
+                                          "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "namespaces": {
+                                          "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "topologyKey": {
+                                          "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "weight": {
+                                      "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    }
+                                  }
+                                }
+                              },
+                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "description": "If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node.",
+                                "type": "array",
+                                "items": {
+                                  "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running",
+                                  "type": "object",
+                                  "required": ["topologyKey"],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "A label query over a set of resources, in this case pods.",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "namespaceSelector": {
+                                      "description": "A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means \"this pod's namespace\". An empty selector ({}) matches all namespaces.",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "namespaces": {
+                                      "description": "namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "topologyKey": {
+                                      "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "automountServiceAccountToken": {
+                        "description": "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
+                        "type": "boolean"
+                      },
+                      "containers": {
+                        "description": "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.",
+                        "type": "array",
+                        "items": {
+                          "description": "A single application container that you want to run within a pod.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "args": {
+                              "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "command": {
+                              "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "env": {
+                              "description": "List of environment variables to set in the container. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "EnvVar represents an environment variable present in a Container.",
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".",
+                                    "type": "string"
+                                  },
+                                  "valueFrom": {
+                                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                    "type": "object",
+                                    "properties": {
+                                      "configMapKeyRef": {
+                                        "description": "Selects a key of a ConfigMap.",
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key to select.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "fieldRef": {
+                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                        "type": "object",
+                                        "required": ["fieldPath"],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                        "type": "object",
+                                        "required": ["resource"],
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "secretKeyRef": {
+                                        "description": "Selects a key of a secret in the pod's namespace",
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "Specify whether the Secret or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "envFrom": {
+                              "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                "type": "object",
+                                "properties": {
+                                  "configMapRef": {
+                                    "description": "The ConfigMap to select from",
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "prefix": {
+                                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "The Secret to select from",
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                              "type": "string"
+                            },
+                            "imagePullPolicy": {
+                              "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                              "type": "object",
+                              "properties": {
+                                "postStart": {
+                                  "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "description": "Exec specifies the action to take.",
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "description": "HTTPGet specifies the http request to perform.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "description": "Path to access on the HTTP server.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preStop": {
+                                  "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed.",
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "description": "Exec specifies the action to take.",
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "description": "HTTPGet specifies the http request to perform.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "description": "Path to access on the HTTP server.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "livenessProbe": {
+                              "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "name": {
+                              "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                              "type": "string"
+                            },
+                            "ports": {
+                              "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.",
+                              "type": "array",
+                              "items": {
+                                "description": "ContainerPort represents a network port in a single container.",
+                                "type": "object",
+                                "required": ["containerPort"],
+                                "properties": {
+                                  "containerPort": {
+                                    "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "hostIP": {
+                                    "description": "What host IP to bind the external port to.",
+                                    "type": "string"
+                                  },
+                                  "hostPort": {
+                                    "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "name": {
+                                    "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "containerPort",
+                                "protocol"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "readinessProbe": {
+                              "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "resizePolicy": {
+                              "description": "Resources resize policy for the container.",
+                              "type": "array",
+                              "items": {
+                                "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                "type": "object",
+                                "required": ["resourceName", "restartPolicy"],
+                                "properties": {
+                                  "resourceName": {
+                                    "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                    "type": "string"
+                                  },
+                                  "restartPolicy": {
+                                    "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "resources": {
+                              "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object",
+                              "properties": {
+                                "claims": {
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-map-keys": ["name"],
+                                  "x-kubernetes-list-type": "map"
+                                },
+                                "limits": {
+                                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "requests": {
+                                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            },
+                            "restartPolicy": {
+                              "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type.",
+                              "type": "string"
+                            },
+                            "securityContext": {
+                              "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                              "type": "object",
+                              "properties": {
+                                "allowPrivilegeEscalation": {
+                                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "capabilities": {
+                                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "properties": {
+                                    "add": {
+                                      "description": "Added capabilities",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Capability represent POSIX capabilities type",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "drop": {
+                                      "description": "Removed capabilities",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Capability represent POSIX capabilities type",
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "privileged": {
+                                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "procMount": {
+                                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "string"
+                                },
+                                "readOnlyRootFilesystem": {
+                                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "runAsGroup": {
+                                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "runAsNonRoot": {
+                                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.",
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "seLinuxOptions": {
+                                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "properties": {
+                                    "level": {
+                                      "description": "Level is SELinux level label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "description": "Role is a SELinux role label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "Type is a SELinux type label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "description": "User is a SELinux user label that applies to the container.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "seccompProfile": {
+                                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": ["type"],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "windowsOptions": {
+                                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                  "type": "object",
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "startupProbe": {
+                              "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "stdin": {
+                              "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                              "type": "boolean"
+                            },
+                            "stdinOnce": {
+                              "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions.",
+                              "type": "boolean"
+                            },
+                            "terminationMessagePath": {
+                              "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log.",
+                              "type": "string"
+                            },
+                            "terminationMessagePolicy": {
+                              "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error.",
+                              "type": "string"
+                            },
+                            "tty": {
+                              "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                              "type": "boolean"
+                            },
+                            "volumeDevices": {
+                              "description": "volumeDevices is the list of block devices to be used by the container.",
+                              "type": "array",
+                              "items": {
+                                "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                "type": "object",
+                                "required": ["devicePath", "name"],
+                                "properties": {
+                                  "devicePath": {
+                                    "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "volumeMounts": {
+                              "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                "type": "object",
+                                "required": ["mountPath", "name"],
+                                "properties": {
+                                  "mountPath": {
+                                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                    "type": "string"
+                                  },
+                                  "mountPropagation": {
+                                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "This must match the Name of a Volume.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                    "type": "boolean"
+                                  },
+                                  "subPath": {
+                                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                    "type": "string"
+                                  },
+                                  "subPathExpr": {
+                                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "workingDir": {
+                              "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "dnsConfig": {
+                        "description": "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.",
+                        "type": "object",
+                        "properties": {
+                          "nameservers": {
+                            "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "options": {
+                            "description": "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.",
+                            "type": "array",
+                            "items": {
+                              "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Required.",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "searches": {
+                            "description": "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "dnsPolicy": {
+                        "description": "Set DNS policy for the pod. Defaults to \"ClusterFirst\". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
+                        "type": "string"
+                      },
+                      "enableServiceLinks": {
+                        "description": "EnableServiceLinks indicates whether information about services should be injected into pod's environment variables, matching the syntax of Docker links. Optional: Defaults to true.",
+                        "type": "boolean"
+                      },
+                      "ephemeralContainers": {
+                        "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
+                        "type": "array",
+                        "items": {
+                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "args": {
+                              "description": "Arguments to the entrypoint. The image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "command": {
+                              "description": "Entrypoint array. Not executed within a shell. The image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "env": {
+                              "description": "List of environment variables to set in the container. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "EnvVar represents an environment variable present in a Container.",
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".",
+                                    "type": "string"
+                                  },
+                                  "valueFrom": {
+                                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                    "type": "object",
+                                    "properties": {
+                                      "configMapKeyRef": {
+                                        "description": "Selects a key of a ConfigMap.",
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key to select.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "fieldRef": {
+                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                        "type": "object",
+                                        "required": ["fieldPath"],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                        "type": "object",
+                                        "required": ["resource"],
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "secretKeyRef": {
+                                        "description": "Selects a key of a secret in the pod's namespace",
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "Specify whether the Secret or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "envFrom": {
+                              "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                "type": "object",
+                                "properties": {
+                                  "configMapRef": {
+                                    "description": "The ConfigMap to select from",
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "prefix": {
+                                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "The Secret to select from",
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images",
+                              "type": "string"
+                            },
+                            "imagePullPolicy": {
+                              "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "description": "Lifecycle is not allowed for ephemeral containers.",
+                              "type": "object",
+                              "properties": {
+                                "postStart": {
+                                  "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "description": "Exec specifies the action to take.",
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "description": "HTTPGet specifies the http request to perform.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "description": "Path to access on the HTTP server.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preStop": {
+                                  "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed.",
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "description": "Exec specifies the action to take.",
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "description": "HTTPGet specifies the http request to perform.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "description": "Path to access on the HTTP server.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "livenessProbe": {
+                              "description": "Probes are not allowed for ephemeral containers.",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "name": {
+                              "description": "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+                              "type": "string"
+                            },
+                            "ports": {
+                              "description": "Ports are not allowed for ephemeral containers.",
+                              "type": "array",
+                              "items": {
+                                "description": "ContainerPort represents a network port in a single container.",
+                                "type": "object",
+                                "required": ["containerPort"],
+                                "properties": {
+                                  "containerPort": {
+                                    "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "hostIP": {
+                                    "description": "What host IP to bind the external port to.",
+                                    "type": "string"
+                                  },
+                                  "hostPort": {
+                                    "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "name": {
+                                    "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "containerPort",
+                                "protocol"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "readinessProbe": {
+                              "description": "Probes are not allowed for ephemeral containers.",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "resizePolicy": {
+                              "description": "Resources resize policy for the container.",
+                              "type": "array",
+                              "items": {
+                                "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                "type": "object",
+                                "required": ["resourceName", "restartPolicy"],
+                                "properties": {
+                                  "resourceName": {
+                                    "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                    "type": "string"
+                                  },
+                                  "restartPolicy": {
+                                    "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "resources": {
+                              "description": "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
+                              "type": "object",
+                              "properties": {
+                                "claims": {
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-map-keys": ["name"],
+                                  "x-kubernetes-list-type": "map"
+                                },
+                                "limits": {
+                                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "requests": {
+                                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            },
+                            "restartPolicy": {
+                              "description": "Restart policy for the container to manage the restart behavior of each container within a pod. This may only be set for init containers. You cannot set this field on ephemeral containers.",
+                              "type": "string"
+                            },
+                            "securityContext": {
+                              "description": "Optional: SecurityContext defines the security options the ephemeral container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.",
+                              "type": "object",
+                              "properties": {
+                                "allowPrivilegeEscalation": {
+                                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "capabilities": {
+                                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "properties": {
+                                    "add": {
+                                      "description": "Added capabilities",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Capability represent POSIX capabilities type",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "drop": {
+                                      "description": "Removed capabilities",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Capability represent POSIX capabilities type",
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "privileged": {
+                                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "procMount": {
+                                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "string"
+                                },
+                                "readOnlyRootFilesystem": {
+                                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "runAsGroup": {
+                                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "runAsNonRoot": {
+                                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.",
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "seLinuxOptions": {
+                                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "properties": {
+                                    "level": {
+                                      "description": "Level is SELinux level label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "description": "Role is a SELinux role label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "Type is a SELinux type label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "description": "User is a SELinux user label that applies to the container.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "seccompProfile": {
+                                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": ["type"],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "windowsOptions": {
+                                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                  "type": "object",
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "startupProbe": {
+                              "description": "Probes are not allowed for ephemeral containers.",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "stdin": {
+                              "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                              "type": "boolean"
+                            },
+                            "stdinOnce": {
+                              "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions.",
+                              "type": "boolean"
+                            },
+                            "targetContainerName": {
+                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container uses the namespaces configured in the Pod spec. \n The container runtime must implement support for this feature.",
+                              "type": "string"
+                            },
+                            "terminationMessagePath": {
+                              "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log.",
+                              "type": "string"
+                            },
+                            "terminationMessagePolicy": {
+                              "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error.",
+                              "type": "string"
+                            },
+                            "tty": {
+                              "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                              "type": "boolean"
+                            },
+                            "volumeDevices": {
+                              "description": "volumeDevices is the list of block devices to be used by the container.",
+                              "type": "array",
+                              "items": {
+                                "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                "type": "object",
+                                "required": ["devicePath", "name"],
+                                "properties": {
+                                  "devicePath": {
+                                    "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "volumeMounts": {
+                              "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                "type": "object",
+                                "required": ["mountPath", "name"],
+                                "properties": {
+                                  "mountPath": {
+                                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                    "type": "string"
+                                  },
+                                  "mountPropagation": {
+                                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "This must match the Name of a Volume.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                    "type": "boolean"
+                                  },
+                                  "subPath": {
+                                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                    "type": "string"
+                                  },
+                                  "subPathExpr": {
+                                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "workingDir": {
+                              "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "hostAliases": {
+                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.",
+                        "type": "array",
+                        "items": {
+                          "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+                          "type": "object",
+                          "properties": {
+                            "hostnames": {
+                              "description": "Hostnames for the above IP address.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "ip": {
+                              "description": "IP address of the host file entry.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "hostIPC": {
+                        "description": "Use the host's ipc namespace. Optional: Default to false.",
+                        "type": "boolean"
+                      },
+                      "hostNetwork": {
+                        "description": "Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.",
+                        "type": "boolean"
+                      },
+                      "hostPID": {
+                        "description": "Use the host's pid namespace. Optional: Default to false.",
+                        "type": "boolean"
+                      },
+                      "hostUsers": {
+                        "description": "Use the host's user namespace. Optional: Default to true. If set to true or not present, the pod will be run in the host user namespace, useful for when the pod needs a feature only available to the host user namespace, such as loading a kernel module with CAP_SYS_MODULE. When set to false, a new userns is created for the pod.",
+                        "type": "boolean"
+                      },
+                      "hostname": {
+                        "description": "Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.",
+                        "type": "string"
+                      },
+                      "imagePullSecrets": {
+                        "description": "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod",
+                        "type": "array",
+                        "items": {
+                          "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      },
+                      "initContainers": {
+                        "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers.",
+                        "type": "array",
+                        "items": {
+                          "description": "A single application container that you want to run within a pod.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "args": {
+                              "description": "Arguments to the entrypoint. The container image's CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "command": {
+                              "description": "Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container's environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "env": {
+                              "description": "List of environment variables to set in the container. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "EnvVar represents an environment variable present in a Container.",
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. \"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".",
+                                    "type": "string"
+                                  },
+                                  "valueFrom": {
+                                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                    "type": "object",
+                                    "properties": {
+                                      "configMapKeyRef": {
+                                        "description": "Selects a key of a ConfigMap.",
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key to select.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "fieldRef": {
+                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                                        "type": "object",
+                                        "required": ["fieldPath"],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                                        "type": "object",
+                                        "required": ["resource"],
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "secretKeyRef": {
+                                        "description": "Selects a key of a secret in the pod's namespace",
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "Specify whether the Secret or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "envFrom": {
+                              "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                "type": "object",
+                                "properties": {
+                                  "configMapRef": {
+                                    "description": "The ConfigMap to select from",
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "prefix": {
+                                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "The Secret to select from",
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.",
+                              "type": "string"
+                            },
+                            "imagePullPolicy": {
+                              "description": "Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "description": "Actions that the management system should take in response to container lifecycle events. Cannot be updated.",
+                              "type": "object",
+                              "properties": {
+                                "postStart": {
+                                  "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "description": "Exec specifies the action to take.",
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "description": "HTTPGet specifies the http request to perform.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "description": "Path to access on the HTTP server.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preStop": {
+                                  "description": "PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod's termination grace period countdown begins before the PreStop hook is executed.",
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "description": "Exec specifies the action to take.",
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "description": "HTTPGet specifies the http request to perform.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "description": "The header field value",
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "description": "Path to access on the HTTP server.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for the backward compatibility. There are no validation of this field and lifecycle hooks will fail in runtime when tcp handler is specified.",
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "livenessProbe": {
+                              "description": "Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "name": {
+                              "description": "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+                              "type": "string"
+                            },
+                            "ports": {
+                              "description": "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.",
+                              "type": "array",
+                              "items": {
+                                "description": "ContainerPort represents a network port in a single container.",
+                                "type": "object",
+                                "required": ["containerPort"],
+                                "properties": {
+                                  "containerPort": {
+                                    "description": "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "hostIP": {
+                                    "description": "What host IP to bind the external port to.",
+                                    "type": "string"
+                                  },
+                                  "hostPort": {
+                                    "description": "Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "name": {
+                                    "description": "If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "containerPort",
+                                "protocol"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "readinessProbe": {
+                              "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "resizePolicy": {
+                              "description": "Resources resize policy for the container.",
+                              "type": "array",
+                              "items": {
+                                "description": "ContainerResizePolicy represents resource resize policy for the container.",
+                                "type": "object",
+                                "required": ["resourceName", "restartPolicy"],
+                                "properties": {
+                                  "resourceName": {
+                                    "description": "Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.",
+                                    "type": "string"
+                                  },
+                                  "restartPolicy": {
+                                    "description": "Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "resources": {
+                              "description": "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                              "type": "object",
+                              "properties": {
+                                "claims": {
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-map-keys": ["name"],
+                                  "x-kubernetes-list-type": "map"
+                                },
+                                "limits": {
+                                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "requests": {
+                                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            },
+                            "restartPolicy": {
+                              "description": "RestartPolicy defines the restart behavior of individual containers in a pod. This field may only be set for init containers, and the only allowed value is \"Always\". For non-init containers or when this field is not specified, the restart behavior is defined by the Pod's restart policy and the container type.",
+                              "type": "string"
+                            },
+                            "securityContext": {
+                              "description": "SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                              "type": "object",
+                              "properties": {
+                                "allowPrivilegeEscalation": {
+                                  "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "capabilities": {
+                                  "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "properties": {
+                                    "add": {
+                                      "description": "Added capabilities",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Capability represent POSIX capabilities type",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "drop": {
+                                      "description": "Removed capabilities",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Capability represent POSIX capabilities type",
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "privileged": {
+                                  "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "procMount": {
+                                  "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "string"
+                                },
+                                "readOnlyRootFilesystem": {
+                                  "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "boolean"
+                                },
+                                "runAsGroup": {
+                                  "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "runAsNonRoot": {
+                                  "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.",
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "seLinuxOptions": {
+                                  "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "properties": {
+                                    "level": {
+                                      "description": "Level is SELinux level label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "description": "Role is a SELinux role label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "Type is a SELinux type label that applies to the container.",
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "description": "User is a SELinux user label that applies to the container.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "seccompProfile": {
+                                  "description": "The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": ["type"],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "windowsOptions": {
+                                  "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                                  "type": "object",
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "startupProbe": {
+                              "description": "StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.",
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "description": "Exec specifies the action to take.",
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "description": "GRPC specifies an action involving a GRPC port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). \n If this is not specified, the default behavior is defined by gRPC.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "description": "HTTPGet specifies the http request to perform.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead.",
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "description": "The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "description": "The header field value",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "description": "Path to access on the HTTP server.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "description": "Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "description": "TCPSocket specifies an action involving a TCP port.",
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "stdin": {
+                              "description": "Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.",
+                              "type": "boolean"
+                            },
+                            "stdinOnce": {
+                              "description": "Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions.",
+                              "type": "boolean"
+                            },
+                            "terminationMessagePath": {
+                              "description": "Optional: Path at which the file to which the container's termination message will be written is mounted into the container's filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log.",
+                              "type": "string"
+                            },
+                            "terminationMessagePolicy": {
+                              "description": "Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error.",
+                              "type": "string"
+                            },
+                            "tty": {
+                              "description": "Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.",
+                              "type": "boolean"
+                            },
+                            "volumeDevices": {
+                              "description": "volumeDevices is the list of block devices to be used by the container.",
+                              "type": "array",
+                              "items": {
+                                "description": "volumeDevice describes a mapping of a raw block device within a container.",
+                                "type": "object",
+                                "required": ["devicePath", "name"],
+                                "properties": {
+                                  "devicePath": {
+                                    "description": "devicePath is the path inside of the container that the device will be mapped to.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "name must match the name of a persistentVolumeClaim in the pod",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "volumeMounts": {
+                              "description": "Pod volumes to mount into the container's filesystem. Cannot be updated.",
+                              "type": "array",
+                              "items": {
+                                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                "type": "object",
+                                "required": ["mountPath", "name"],
+                                "properties": {
+                                  "mountPath": {
+                                    "description": "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+                                    "type": "string"
+                                  },
+                                  "mountPropagation": {
+                                    "description": "mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "This must match the Name of a Volume.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.",
+                                    "type": "boolean"
+                                  },
+                                  "subPath": {
+                                    "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root).",
+                                    "type": "string"
+                                  },
+                                  "subPathExpr": {
+                                    "description": "Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to \"\" (volume's root). SubPathExpr and SubPath are mutually exclusive.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "workingDir": {
+                              "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "nodeName": {
+                        "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
+                        "type": "string"
+                      },
+                      "nodeSelector": {
+                        "description": "NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node's labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "os": {
+                        "description": "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.hostUsers - spec.securityContext.seLinuxOptions - spec.securityContext.",
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                          "name": {
+                            "description": "Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "overhead": {
+                        "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "preemptionPolicy": {
+                        "description": "PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.",
+                        "type": "string"
+                      },
+                      "priority": {
+                        "description": "The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "priorityClassName": {
+                        "description": "If specified, indicates the pod's priority. \"system-node-critical\" and \"system-cluster-critical\" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.",
+                        "type": "string"
+                      },
+                      "readinessGates": {
+                        "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates",
+                        "type": "array",
+                        "items": {
+                          "description": "PodReadinessGate contains the reference to a pod condition",
+                          "type": "object",
+                          "required": ["conditionType"],
+                          "properties": {
+                            "conditionType": {
+                              "description": "ConditionType refers to a condition in the pod's condition list with matching type.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "resourceClaims": {
+                        "description": "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable.",
+                        "type": "array",
+                        "items": {
+                          "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource. It adds a name to it that uniquely identifies the ResourceClaim inside the Pod. Containers that need access to the ResourceClaim reference it with this name.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "description": "Name uniquely identifies this resource claim inside the pod. This must be a DNS_LABEL.",
+                              "type": "string"
+                            },
+                            "source": {
+                              "description": "Source describes where to find the ResourceClaim.",
+                              "type": "object",
+                              "properties": {
+                                "resourceClaimName": {
+                                  "description": "ResourceClaimName is the name of a ResourceClaim object in the same namespace as this pod.",
+                                  "type": "string"
+                                },
+                                "resourceClaimTemplateName": {
+                                  "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate object in the same namespace as this pod. \n The template will be used to create a new ResourceClaim, which will be bound to this pod. When this pod is deleted, the ResourceClaim will also be deleted.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "restartPolicy": {
+                        "description": "Restart policy for all containers within the pod. One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy",
+                        "type": "string"
+                      },
+                      "runtimeClassName": {
+                        "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.",
+                        "type": "string"
+                      },
+                      "schedulerName": {
+                        "description": "If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.",
+                        "type": "string"
+                      },
+                      "schedulingGates": {
+                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the scheduler will not attempt to schedule the pod. \n SchedulingGates can only be set at pod creation time, and be removed only afterwards. \n This is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                        "type": "array",
+                        "items": {
+                          "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the scheduling gate. Each scheduling gate must have a unique name field.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "securityContext": {
+                        "description": "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.",
+                        "type": "object",
+                        "properties": {
+                          "fsGroup": {
+                            "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "fsGroupChangePolicy": {
+                            "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified, \"Always\" is used.",
+                            "type": "string"
+                          },
+                          "runAsGroup": {
+                            "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.",
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "seLinuxOptions": {
+                            "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "properties": {
+                              "level": {
+                                "description": "Level is SELinux level label that applies to the container.",
+                                "type": "string"
+                              },
+                              "role": {
+                                "description": "Role is a SELinux role label that applies to the container.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "Type is a SELinux type label that applies to the container.",
+                                "type": "string"
+                              },
+                              "user": {
+                                "description": "User is a SELinux user label that applies to the container.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "seccompProfile": {
+                            "description": "The seccomp options to use by the containers in this pod. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "required": ["type"],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is \"Localhost\". Must NOT be set for any other type.",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "supplementalGroups": {
+                            "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID, the fsGroup (if specified), and group memberships defined in the container image for the uid of the container process. If unspecified, no additional groups are added to any container.",
+                            "type": "array",
+                            "items": {
+                              "type": "integer",
+                              "format": "int64"
+                            }
+                          },
+                          "sysctls": {
+                            "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.",
+                            "type": "array",
+                            "items": {
+                              "description": "Sysctl defines a kernel parameter to be set",
+                              "type": "object",
+                              "required": ["name", "value"],
+                              "properties": {
+                                "name": {
+                                  "description": "Name of a property to set",
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "description": "Value of a property to set",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "windowsOptions": {
+                            "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.",
+                            "type": "object",
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "description": "HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.",
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "serviceAccount": {
+                        "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
+                        "type": "string"
+                      },
+                      "serviceAccountName": {
+                        "description": "ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/",
+                        "type": "string"
+                      },
+                      "setHostnameAsFQDN": {
+                        "description": "If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default). In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).",
+                        "type": "boolean"
+                      },
+                      "shareProcessNamespace": {
+                        "description": "Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.",
+                        "type": "boolean"
+                      },
+                      "subdomain": {
+                        "description": "If specified, the fully qualified Pod hostname will be \"<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>\". If not specified, the pod will not have a domainname at all.",
+                        "type": "string"
+                      },
+                      "terminationGracePeriodSeconds": {
+                        "description": "Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "tolerations": {
+                        "description": "If specified, the pod's tolerations.",
+                        "type": "array",
+                        "items": {
+                          "description": "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
+                          "type": "object",
+                          "properties": {
+                            "effect": {
+                              "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                              "type": "string"
+                            },
+                            "key": {
+                              "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
+                              "type": "string"
+                            },
+                            "tolerationSeconds": {
+                              "description": "TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.",
+                              "type": "integer",
+                              "format": "int64"
+                            },
+                            "value": {
+                              "description": "Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "topologySpreadConstraints": {
+                        "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.",
+                        "type": "array",
+                        "items": {
+                          "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                          "type": "object",
+                          "required": [
+                            "maxSkew",
+                            "topologyKey",
+                            "whenUnsatisfiable"
+                          ],
+                          "properties": {
+                            "labelSelector": {
+                              "description": "LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.",
+                              "type": "object",
+                              "properties": {
+                                "matchExpressions": {
+                                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                    "type": "object",
+                                    "required": ["key", "operator"],
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the label key that the selector applies to.",
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "matchLabels": {
+                                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "matchLabelKeys": {
+                              "description": "MatchLabelKeys is a set of pod label keys to select the pods over which spreading will be calculated. The keys are used to lookup values from the incoming pod labels, those key-value labels are ANDed with labelSelector to select the group of existing pods over which spreading will be calculated for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "maxSkew": {
+                              "description": "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "minDomains": {
+                              "description": "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "nodeAffinityPolicy": {
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector when calculating pod topology spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations. - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations. \n If this value is nil, the behavior is equivalent to the Honor policy.",
+                              "type": "string"
+                            },
+                            "nodeTaintsPolicy": {
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating pod topology spread skew. Options are: - Honor: nodes without taints, along with tainted nodes for which the incoming pod has a toleration, are included. - Ignore: node taints are ignored. All nodes are included. \n If this value is nil, the behavior is equivalent to the Ignore policy.",
+                              "type": "string"
+                            },
+                            "topologyKey": {
+                              "description": "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology.",
+                              "type": "string"
+                            },
+                            "whenUnsatisfiable": {
+                              "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "topologyKey",
+                          "whenUnsatisfiable"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "volumes": {
+                        "description": "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+                        "type": "array",
+                        "items": {
+                          "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "awsElasticBlockStore": {
+                              "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                              "type": "object",
+                              "required": ["volumeID"],
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "type": "string"
+                                },
+                                "partition": {
+                                  "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                  "type": "boolean"
+                                },
+                                "volumeID": {
+                                  "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "azureDisk": {
+                              "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                              "type": "object",
+                              "required": ["diskName", "diskURI"],
+                              "properties": {
+                                "cachingMode": {
+                                  "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                                  "type": "string"
+                                },
+                                "diskName": {
+                                  "description": "diskName is the Name of the data disk in the blob storage",
+                                  "type": "string"
+                                },
+                                "diskURI": {
+                                  "description": "diskURI is the URI of data disk in the blob storage",
+                                  "type": "string"
+                                },
+                                "fsType": {
+                                  "description": "fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "azureFile": {
+                              "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                              "type": "object",
+                              "required": ["secretName", "shareName"],
+                              "properties": {
+                                "readOnly": {
+                                  "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                  "type": "boolean"
+                                },
+                                "secretName": {
+                                  "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                                  "type": "string"
+                                },
+                                "shareName": {
+                                  "description": "shareName is the azure share Name",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "cephfs": {
+                              "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                              "type": "object",
+                              "required": ["monitors"],
+                              "properties": {
+                                "monitors": {
+                                  "description": "monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "path": {
+                                  "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                  "type": "boolean"
+                                },
+                                "secretFile": {
+                                  "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "user": {
+                                  "description": "user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "cinder": {
+                              "description": "cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                              "type": "object",
+                              "required": ["volumeID"],
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "description": "secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "volumeID": {
+                                  "description": "volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "configMap": {
+                              "description": "configMap represents a configMap that should populate this volume",
+                              "type": "object",
+                              "properties": {
+                                "defaultMode": {
+                                  "description": "defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "items": {
+                                  "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "type": "object",
+                                    "required": ["key", "path"],
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "csi": {
+                              "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).",
+                              "type": "object",
+                              "required": ["driver"],
+                              "properties": {
+                                "driver": {
+                                  "description": "driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+                                  "type": "string"
+                                },
+                                "fsType": {
+                                  "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.",
+                                  "type": "string"
+                                },
+                                "nodePublishSecretRef": {
+                                  "description": "nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).",
+                                  "type": "boolean"
+                                },
+                                "volumeAttributes": {
+                                  "description": "volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "downwardAPI": {
+                              "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                              "type": "object",
+                              "properties": {
+                                "defaultMode": {
+                                  "description": "Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "items": {
+                                  "description": "Items is a list of downward API volume file",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "type": "object",
+                                    "required": ["path"],
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "type": "object",
+                                        "required": ["fieldPath"],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "type": "object",
+                                        "required": ["resource"],
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "emptyDir": {
+                              "description": "emptyDir represents a temporary directory that shares a pod's lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                              "type": "object",
+                              "properties": {
+                                "medium": {
+                                  "description": "medium represents what type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                                  "type": "string"
+                                },
+                                "sizeLimit": {
+                                  "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            },
+                            "ephemeral": {
+                              "description": "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.",
+                              "type": "object",
+                              "properties": {
+                                "volumeClaimTemplate": {
+                                  "description": "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry.",
+                                  "type": "object",
+                                  "required": ["spec"],
+                                  "properties": {
+                                    "metadata": {
+                                      "description": "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+                                      "type": "object",
+                                      "properties": {
+                                        "annotations": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "finalizers": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "labels": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "spec": {
+                                      "description": "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+                                      "type": "object",
+                                      "properties": {
+                                        "accessModes": {
+                                          "description": "accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "dataSource": {
+                                          "description": "dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source.",
+                                          "type": "object",
+                                          "required": ["kind", "name"],
+                                          "properties": {
+                                            "apiGroup": {
+                                              "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "Kind is the type of resource being referenced",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name is the name of resource being referenced",
+                                              "type": "string"
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "dataSourceRef": {
+                                          "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner.",
+                                          "type": "object",
+                                          "required": ["kind", "name"],
+                                          "properties": {
+                                            "apiGroup": {
+                                              "description": "APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.",
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "description": "Kind is the type of resource being referenced",
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "description": "Name is the name of resource being referenced",
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "description": "Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "resources": {
+                                          "description": "resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                          "type": "object",
+                                          "properties": {
+                                            "claims": {
+                                              "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                                "type": "object",
+                                                "required": ["name"],
+                                                "properties": {
+                                                  "name": {
+                                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-list-map-keys": [
+                                                "name"
+                                              ],
+                                              "x-kubernetes-list-type": "map"
+                                            },
+                                            "limits": {
+                                              "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "requests": {
+                                              "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "selector": {
+                                          "description": "selector is a label query over volumes to consider for binding.",
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                              "type": "array",
+                                              "items": {
+                                                "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "description": "key is the label key that the selector applies to.",
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "storageClassName": {
+                                          "description": "storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                          "type": "string"
+                                        },
+                                        "volumeMode": {
+                                          "description": "volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.",
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "fc": {
+                              "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                              "type": "object",
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "type": "string"
+                                },
+                                "lun": {
+                                  "description": "lun is Optional: FC target lun number",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                  "type": "boolean"
+                                },
+                                "targetWWNs": {
+                                  "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "wwids": {
+                                  "description": "wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "flexVolume": {
+                              "description": "flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+                              "type": "object",
+                              "required": ["driver"],
+                              "properties": {
+                                "driver": {
+                                  "description": "driver is the name of the driver to use for this volume.",
+                                  "type": "string"
+                                },
+                                "fsType": {
+                                  "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                                  "type": "string"
+                                },
+                                "options": {
+                                  "description": "options is Optional: this field holds extra command options if any.",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                },
+                                "readOnly": {
+                                  "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "description": "secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            },
+                            "flocker": {
+                              "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running",
+                              "type": "object",
+                              "properties": {
+                                "datasetName": {
+                                  "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated",
+                                  "type": "string"
+                                },
+                                "datasetUUID": {
+                                  "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "gcePersistentDisk": {
+                              "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                              "type": "object",
+                              "required": ["pdName"],
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "type": "string"
+                                },
+                                "partition": {
+                                  "description": "partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as \"1\". Similarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "pdName": {
+                                  "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "gitRepo": {
+                              "description": "gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+                              "type": "object",
+                              "required": ["repository"],
+                              "properties": {
+                                "directory": {
+                                  "description": "directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.",
+                                  "type": "string"
+                                },
+                                "repository": {
+                                  "description": "repository is the URL",
+                                  "type": "string"
+                                },
+                                "revision": {
+                                  "description": "revision is the commit hash for the specified revision.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "glusterfs": {
+                              "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                              "type": "object",
+                              "required": ["endpoints", "path"],
+                              "properties": {
+                                "endpoints": {
+                                  "description": "endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "description": "path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "hostPath": {
+                              "description": "hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.",
+                              "type": "object",
+                              "required": ["path"],
+                              "properties": {
+                                "path": {
+                                  "description": "path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "type for HostPath Volume Defaults to \"\" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "iscsi": {
+                              "description": "iscsi represents an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md",
+                              "type": "object",
+                              "required": ["iqn", "lun", "targetPortal"],
+                              "properties": {
+                                "chapAuthDiscovery": {
+                                  "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                                  "type": "boolean"
+                                },
+                                "chapAuthSession": {
+                                  "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                                  "type": "boolean"
+                                },
+                                "fsType": {
+                                  "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "type": "string"
+                                },
+                                "initiatorName": {
+                                  "description": "initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.",
+                                  "type": "string"
+                                },
+                                "iqn": {
+                                  "description": "iqn is the target iSCSI Qualified Name.",
+                                  "type": "string"
+                                },
+                                "iscsiInterface": {
+                                  "description": "iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).",
+                                  "type": "string"
+                                },
+                                "lun": {
+                                  "description": "lun represents iSCSI Target Lun number.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "portals": {
+                                  "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "readOnly": {
+                                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.",
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "targetPortal": {
+                                  "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "name": {
+                              "description": "name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                              "type": "string"
+                            },
+                            "nfs": {
+                              "description": "nfs represents an NFS mount on the host that shares a pod's lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                              "type": "object",
+                              "required": ["path", "server"],
+                              "properties": {
+                                "path": {
+                                  "description": "path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                  "type": "boolean"
+                                },
+                                "server": {
+                                  "description": "server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "persistentVolumeClaim": {
+                              "description": "persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                              "type": "object",
+                              "required": ["claimName"],
+                              "properties": {
+                                "claimName": {
+                                  "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "photonPersistentDisk": {
+                              "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                              "type": "object",
+                              "required": ["pdID"],
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                  "type": "string"
+                                },
+                                "pdID": {
+                                  "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "portworxVolume": {
+                              "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                              "type": "object",
+                              "required": ["volumeID"],
+                              "properties": {
+                                "fsType": {
+                                  "description": "fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                  "type": "boolean"
+                                },
+                                "volumeID": {
+                                  "description": "volumeID uniquely identifies a Portworx volume",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "projected": {
+                              "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                              "type": "object",
+                              "properties": {
+                                "defaultMode": {
+                                  "description": "defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "sources": {
+                                  "description": "sources is the list of volume projections",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Projection that may be projected along with other supported volume types",
+                                    "type": "object",
+                                    "properties": {
+                                      "configMap": {
+                                        "description": "configMap information about the configMap data to project",
+                                        "type": "object",
+                                        "properties": {
+                                          "items": {
+                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "Maps a string key to a path within a volume.",
+                                              "type": "object",
+                                              "required": ["key", "path"],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the key to project.",
+                                                  "type": "string"
+                                                },
+                                                "mode": {
+                                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used.",
+                                                  "type": "integer",
+                                                  "format": "int32"
+                                                },
+                                                "path": {
+                                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "downwardAPI": {
+                                        "description": "downwardAPI information about the downwardAPI data to project",
+                                        "type": "object",
+                                        "properties": {
+                                          "items": {
+                                            "description": "Items is a list of DownwardAPIVolume file",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                              "type": "object",
+                                              "required": ["path"],
+                                              "properties": {
+                                                "fieldRef": {
+                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                  "type": "object",
+                                                  "required": ["fieldPath"],
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                      "type": "string"
+                                                    },
+                                                    "fieldPath": {
+                                                      "description": "Path of the field to select in the specified API version.",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
+                                                },
+                                                "mode": {
+                                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used.",
+                                                  "type": "integer",
+                                                  "format": "int32"
+                                                },
+                                                "path": {
+                                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                                  "type": "string"
+                                                },
+                                                "resourceFieldRef": {
+                                                  "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                                  "type": "object",
+                                                  "required": ["resource"],
+                                                  "properties": {
+                                                    "containerName": {
+                                                      "description": "Container name: required for volumes, optional for env vars",
+                                                      "type": "string"
+                                                    },
+                                                    "divisor": {
+                                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "resource": {
+                                                      "description": "Required: resource to select",
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "x-kubernetes-map-type": "atomic"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "secret": {
+                                        "description": "secret information about the secret data to project",
+                                        "type": "object",
+                                        "properties": {
+                                          "items": {
+                                            "description": "items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "Maps a string key to a path within a volume.",
+                                              "type": "object",
+                                              "required": ["key", "path"],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the key to project.",
+                                                  "type": "string"
+                                                },
+                                                "mode": {
+                                                  "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used.",
+                                                  "type": "integer",
+                                                  "format": "int32"
+                                                },
+                                                "path": {
+                                                  "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "optional field specify whether the Secret or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "serviceAccountToken": {
+                                        "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                        "type": "object",
+                                        "required": ["path"],
+                                        "properties": {
+                                          "audience": {
+                                            "description": "audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.",
+                                            "type": "string"
+                                          },
+                                          "expirationSeconds": {
+                                            "description": "expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.",
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          "path": {
+                                            "description": "path is the path relative to the mount point of the file to project the token into.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "quobyte": {
+                              "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                              "type": "object",
+                              "required": ["registry", "volume"],
+                              "properties": {
+                                "group": {
+                                  "description": "group to map volume access to Default is no group",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.",
+                                  "type": "boolean"
+                                },
+                                "registry": {
+                                  "description": "registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+                                  "type": "string"
+                                },
+                                "tenant": {
+                                  "description": "tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "description": "user to map volume access to Defaults to serivceaccount user",
+                                  "type": "string"
+                                },
+                                "volume": {
+                                  "description": "volume is a string that references an already created Quobyte volume by name.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "rbd": {
+                              "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md",
+                              "type": "object",
+                              "required": ["image", "monitors"],
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "type": "string"
+                                },
+                                "image": {
+                                  "description": "image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                  "type": "string"
+                                },
+                                "keyring": {
+                                  "description": "keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                  "type": "string"
+                                },
+                                "monitors": {
+                                  "description": "monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "pool": {
+                                  "description": "pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "description": "secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "user": {
+                                  "description": "user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "scaleIO": {
+                              "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                              "type": "object",
+                              "required": ["gateway", "secretRef", "system"],
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Default is \"xfs\".",
+                                  "type": "string"
+                                },
+                                "gateway": {
+                                  "description": "gateway is the host address of the ScaleIO API Gateway.",
+                                  "type": "string"
+                                },
+                                "protectionDomain": {
+                                  "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "description": "secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "sslEnabled": {
+                                  "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                                  "type": "boolean"
+                                },
+                                "storageMode": {
+                                  "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.",
+                                  "type": "string"
+                                },
+                                "storagePool": {
+                                  "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                                  "type": "string"
+                                },
+                                "system": {
+                                  "description": "system is the name of the storage system as configured in ScaleIO.",
+                                  "type": "string"
+                                },
+                                "volumeName": {
+                                  "description": "volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "secret": {
+                              "description": "secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                              "type": "object",
+                              "properties": {
+                                "defaultMode": {
+                                  "description": "defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "items": {
+                                  "description": "items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "type": "object",
+                                    "required": ["key", "path"],
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "optional": {
+                                  "description": "optional field specify whether the Secret or its keys must be defined",
+                                  "type": "boolean"
+                                },
+                                "secretName": {
+                                  "description": "secretName is the name of the secret in the pod's namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "storageos": {
+                              "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                              "type": "object",
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "description": "readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.",
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "description": "secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "volumeName": {
+                                  "description": "volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.",
+                                  "type": "string"
+                                },
+                                "volumeNamespace": {
+                                  "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to \"default\" if you are not using namespaces within StorageOS.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "vsphereVolume": {
+                              "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                              "type": "object",
+                              "required": ["volumePath"],
+                              "properties": {
+                                "fsType": {
+                                  "description": "fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                                  "type": "string"
+                                },
+                                "storagePolicyID": {
+                                  "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                                  "type": "string"
+                                },
+                                "storagePolicyName": {
+                                  "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                                  "type": "string"
+                                },
+                                "volumePath": {
+                                  "description": "volumePath is the path that identifies vSphere volume vmdk",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "runPolicy": {
+          "description": "RunPolicy encapsulates various runtime policies of the distributed training job, for example how to clean up resources and how long the job can stay active.",
+          "type": "object",
+          "properties": {
+            "activeDeadlineSeconds": {
+              "description": "Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "backoffLimit": {
+              "description": "Optional number of retries before marking this job failed.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "cleanPodPolicy": {
+              "description": "CleanPodPolicy defines the policy to kill pods after the job completes. Default to None.",
+              "type": "string"
+            },
+            "schedulingPolicy": {
+              "description": "SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling",
+              "type": "object",
+              "properties": {
+                "minAvailable": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "minResources": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "priorityClass": {
+                  "type": "string"
+                },
+                "queue": {
+                  "type": "string"
+                },
+                "scheduleTimeoutSeconds": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "suspend": {
+              "description": "suspend specifies whether the Job controller should create Pods or not. If a Job is created with suspend set to true, no Pods are created by the Job controller. If a Job is suspended after creation (i.e. the flag goes from false to true), the Job controller will delete all active Pods and PodGroups associated with this Job. Users must design their workload to gracefully handle this.",
+              "type": "boolean"
+            },
+            "ttlSecondsAfterFinished": {
+              "description": "TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "Most recently observed status of the PyTorchJob. Read-only (modified by the system).",
+      "type": "object",
+      "properties": {
+        "completionTime": {
+          "description": "Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "conditions": {
+          "description": "Conditions is an array of current observed job conditions.",
+          "type": "array",
+          "items": {
+            "description": "JobCondition describes the state of the job at a certain point.",
+            "type": "object",
+            "required": ["status", "type"],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastUpdateTime": {
+                "description": "The last time this condition was updated.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of job condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "lastReconcileTime": {
+          "description": "Represents last time when the job was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "replicaStatuses": {
+          "description": "ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "ReplicaStatus represents the current observed state of the replica.",
+            "type": "object",
+            "properties": {
+              "active": {
+                "description": "The number of actively running pods.",
+                "type": "integer",
+                "format": "int32"
+              },
+              "failed": {
+                "description": "The number of pods which reached phase Failed.",
+                "type": "integer",
+                "format": "int32"
+              },
+              "labelSelector": {
+                "description": "Deprecated: Use Selector instead",
+                "type": "object",
+                "properties": {
+                  "matchExpressions": {
+                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                    "type": "array",
+                    "items": {
+                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                      "type": "object",
+                      "required": ["key", "operator"],
+                      "properties": {
+                        "key": {
+                          "description": "key is the label key that the selector applies to.",
+                          "type": "string"
+                        },
+                        "operator": {
+                          "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                          "type": "string"
+                        },
+                        "values": {
+                          "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "matchLabels": {
+                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "x-kubernetes-map-type": "atomic"
+              },
+              "selector": {
+                "description": "A Selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty Selector matches all objects. A null Selector matches no objects.",
+                "type": "string"
+              },
+              "succeeded": {
+                "description": "The number of pods which reached phase Succeeded.",
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        },
+        "startTime": {
+          "description": "Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "kubeflow.org",
+      "kind": "PyTorchJob",
+      "version": "v1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/weave-js/src/common/components/Monaco/schemas/sagemaker.json
+++ b/weave-js/src/common/components/Monaco/schemas/sagemaker.json
@@ -68,7 +68,11 @@
           "properties": {
             "TrainingRepositoryAccessMode": {
               "type": "string",
-              "description": "The method that your training job will use to gain access to the images in your private Docker registry. For access to an image in a private Docker registry, set to Vpc. Valid Values: Platform | Vpc"
+              "description": "The method that your training job will use to gain access to the images in your private Docker registry. For access to an image in a private Docker registry, set to Vpc.",
+              "enum": [
+                "Platform",
+                "Vpc"
+              ]
             },
             "TrainingRepositoryAuthConfig": {
               "type": "object",
@@ -92,7 +96,12 @@
         },
         "TrainingInputMode": {
           "type": "string",
-          "description": "The training input mode that the algorithm supports. For more information about input modes, see Algorithms. Pipe mode If an algorithm supports Pipe mode, Amazon SageMaker streams data directly from Amazon S3 to the container. File mode If an algorithm supports File mode, SageMaker downloads the training data from S3 to the provisioned ML storage volume, and mounts the directory to the Docker volume for the training container. You must provision the ML storage volume with sufficient capacity to accommodate the data downloaded from S3. In addition to the training data, the ML storage volume also stores the output model. The algorithm container uses the ML storage volume to also store intermediate information, if any. For distributed algorithms, training data is distributed uniformly. Your training duration is predictable if the input data objects sizes are approximately the same. SageMaker does not split the files any further for model training. If the object sizes are skewed, training won't be optimal as the data distribution is also skewed when one host in a training cluster is overloaded, thus becoming a bottleneck in training. FastFile mode If an algorithm supports FastFile mode, SageMaker streams data directly from S3 to the container with no code changes, and provides file system access to the data. Users can author their training script to interact with these files as if they were stored on disk. FastFile mode works best when the data is read sequentially. Augmented manifest files aren't supported. The startup time is lower when there are fewer files in the S3 bucket provided. Valid Values: Pipe | File | FastFile"
+          "description": "The training input mode that the algorithm supports. For more information about input modes, see Algorithms. Pipe mode If an algorithm supports Pipe mode, Amazon SageMaker streams data directly from Amazon S3 to the container. File mode If an algorithm supports File mode, SageMaker downloads the training data from S3 to the provisioned ML storage volume, and mounts the directory to the Docker volume for the training container. You must provision the ML storage volume with sufficient capacity to accommodate the data downloaded from S3. In addition to the training data, the ML storage volume also stores the output model. The algorithm container uses the ML storage volume to also store intermediate information, if any. For distributed algorithms, training data is distributed uniformly. Your training duration is predictable if the input data objects sizes are approximately the same. SageMaker does not split the files any further for model training. If the object sizes are skewed, training won't be optimal as the data distribution is also skewed when one host in a training cluster is overloaded, thus becoming a bottleneck in training. FastFile mode If an algorithm supports FastFile mode, SageMaker streams data directly from S3 to the container with no code changes, and provides file system access to the data. Users can author their training script to interact with these files as if they were stored on disk. FastFile mode works best when the data is read sequentially. Augmented manifest files aren't supported. The startup time is lower when there are fewer files in the S3 bucket provided.",
+          "enum": [
+            "Pipe",
+            "File",
+            "FastFile"
+          ]
         }
       },
       "required": [
@@ -105,12 +114,12 @@
       "properties": {
         "LocalPath": {
           "type": "string",
-          "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+          "description": "(Optional) The local directory where checkpoints are written. The default directory is /opt/ml/checkpoints/. Length Constraints: Maximum length of 4096.",
           "pattern": ".*"
         },
         "S3Uri": {
           "type": "string",
-          "description": "Depending on the value specified for the S3DataType, identifies either a key name prefix or a manifest. For example: A key name prefix might look like this: s3://bucketname/exampleprefix A manifest might look like this: s3://bucketname/example.manifest A manifest is an S3 object which is a JSON file consisting of an array of elements. The first element is a prefix which is followed by one or more suffixes. SageMaker appends the suffix elements to the prefix to get a full set of S3Uri. Note that the prefix must be a valid non-empty S3Uri that precludes users from specifying a manifest whose individual S3Uri is sourced from different S3 buckets. The following code example shows a valid manifest format: [ {\"prefix\": \"s3://customer_bucket/some/prefix/\"}, \"relative/path/to/custdata-1\", \"relative/path/custdata-2\", ... \"relative/path/custdata-N\" ] This JSON is equivalent to the following S3Uri list: s3://customer_bucket/some/prefix/relative/path/to/custdata-1 s3://customer_bucket/some/prefix/relative/path/custdata-2 ... s3://customer_bucket/some/prefix/relative/path/custdata-N The complete set of S3Uri in this manifest is the input data for the channel for this data source. The object that each S3Uri points to must be readable by the IAM role that SageMaker uses to perform tasks on your behalf. Your input bucket must be located in same AWS region as your training job. Length Constraints: Maximum length of 1024.",
+          "description": "Identifies the S3 path where you want SageMaker to store checkpoints. For example, s3://bucket-name/key-name-prefix. Length Constraints: Maximum length of 1024.",
           "pattern": "^(https|s3)://([^/]+)/?(.*)$"
         }
       },
@@ -161,7 +170,7 @@
         },
         "LocalPath": {
           "type": "string",
-          "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+          "description": "(Optional) The local directory where checkpoints are written. The default directory is /opt/ml/checkpoints/. Length Constraints: Maximum length of 4096.",
           "pattern": ".*"
         },
         "S3OutputPath": {
@@ -181,11 +190,64 @@
           "properties": {
             "InstanceType": {
               "type": "string",
-              "description": "The instance type to deploy a custom rule for profiling a training job. Valid Values: ml.t3.medium | ml.t3.large | ml.t3.xlarge | ml.t3.2xlarge | ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.r5.large | ml.r5.xlarge | ml.r5.2xlarge | ml.r5.4xlarge | ml.r5.8xlarge | ml.r5.12xlarge | ml.r5.16xlarge | ml.r5.24xlarge | ml.g4dn.xlarge | ml.g4dn.2xlarge | ml.g4dn.4xlarge | ml.g4dn.8xlarge | ml.g4dn.12xlarge | ml.g4dn.16xlarge"
+              "description": "The ML compute instance type. NoteSageMaker Training on Amazon Elastic Compute Cloud (EC2) P4de instances is in preview release starting December 9th, 2022. Amazon EC2 P4de instances (currently in preview) are powered by 8 NVIDIA A100 GPUs with 80GB high-performance HBM2e GPU memory, which accelerate the speed of training ML models that need to be trained on large datasets of high-resolution data. In this preview release, Amazon SageMaker supports ML training jobs on P4de instances (ml.p4de.24xlarge) to reduce model training time. The ml.p4de.24xlarge instances are available in the following AWS Regions. US East (N. Virginia) (us-east-1) US West (Oregon) (us-west-2) To request quota limit increase and start using P4de instances, contact the SageMaker Training service team through your account team.",
+              "enum": [
+                "ml.m4.xlarge",
+                "ml.m4.2xlarge",
+                "ml.m4.4xlarge",
+                "ml.m4.10xlarge",
+                "ml.m4.16xlarge",
+                "ml.g4dn.xlarge",
+                "ml.g4dn.2xlarge",
+                "ml.g4dn.4xlarge",
+                "ml.g4dn.8xlarge",
+                "ml.g4dn.12xlarge",
+                "ml.g4dn.16xlarge",
+                "ml.m5.large",
+                "ml.m5.xlarge",
+                "ml.m5.2xlarge",
+                "ml.m5.4xlarge",
+                "ml.m5.12xlarge",
+                "ml.m5.24xlarge",
+                "ml.c4.xlarge",
+                "ml.c4.2xlarge",
+                "ml.c4.4xlarge",
+                "ml.c4.8xlarge",
+                "ml.p2.xlarge",
+                "ml.p2.8xlarge",
+                "ml.p2.16xlarge",
+                "ml.p3.2xlarge",
+                "ml.p3.8xlarge",
+                "ml.p3.16xlarge",
+                "ml.p3dn.24xlarge",
+                "ml.p4d.24xlarge",
+                "ml.c5.xlarge",
+                "ml.c5.2xlarge",
+                "ml.c5.4xlarge",
+                "ml.c5.9xlarge",
+                "ml.c5.18xlarge",
+                "ml.c5n.xlarge",
+                "ml.c5n.2xlarge",
+                "ml.c5n.4xlarge",
+                "ml.c5n.9xlarge",
+                "ml.c5n.18xlarge",
+                "ml.g5.xlarge",
+                "ml.g5.2xlarge",
+                "ml.g5.4xlarge",
+                "ml.g5.8xlarge",
+                "ml.g5.16xlarge",
+                "ml.g5.12xlarge",
+                "ml.g5.24xlarge",
+                "ml.g5.48xlarge",
+                "ml.trn1.2xlarge",
+                "ml.trn1.32xlarge",
+                "ml.trn1n.32xlarge",
+                "ml.p5.48xlarge"
+              ]
             },
             "LocalPath": {
               "type": "string",
-              "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+              "description": "(Optional) The local directory where checkpoints are written. The default directory is /opt/ml/checkpoints/. Length Constraints: Maximum length of 4096.",
               "pattern": ".*"
             },
             "RuleConfigurationName": {
@@ -195,7 +257,7 @@
             },
             "RuleEvaluatorImage": {
               "type": "string",
-              "description": "The Amazon Elastic Container Registry Image for the managed rule evaluation. Length Constraints: Maximum length of 255.",
+              "description": "The Amazon Elastic Container (ECR) Image for the managed rule evaluation. Length Constraints: Maximum length of 255.",
               "pattern": ".*"
             },
             "RuleParameters": {
@@ -215,12 +277,13 @@
             },
             "VolumeSizeInGB": {
               "type": "number",
-              "description": "The size, in GB, of the ML storage volume attached to the processing instance. Valid Range: Minimum value of 0."
+              "description": "The size of the ML storage volume that you want to provision. ML storage volumes store model artifacts and incremental states. Training algorithms might also use the ML storage volume for scratch space. If you want to store the training data in the ML storage volume, choose File as the TrainingInputMode in the algorithm specification. When using an ML instance with NVMe SSD volumes, SageMaker doesn't provision Amazon EBS General Purpose SSD (gp2) storage. Available storage is fixed to the NVMe-type instance's storage capacity. SageMaker configures storage paths for training datasets, checkpoints, model artifacts, and outputs to use the entire capacity of the instance storage. For example, ML instance families with the NVMe-type instance storage include ml.p4d, ml.g4dn, and ml.g5. When using an ML instance with the EBS-only storage option and without instance storage, you must define the size of EBS volume through VolumeSizeInGB in the ResourceConfig API. For example, ML instance families that use EBS volumes include ml.c5 and ml.p2. To look up instance types and their instance storage types and volumes, see Amazon EC2 Instance Types. To find the default local paths defined by the SageMaker training platform, see Amazon SageMaker Training Storage Folders for Training Datasets, Checkpoints, Model Artifacts, and Outputs. Valid Range: Minimum value of 1."
             }
           },
           "required": [
             "RuleConfigurationName",
-            "RuleEvaluatorImage"
+            "RuleEvaluatorImage",
+            "VolumeSizeInGB"
           ]
         }
       ],
@@ -309,7 +372,11 @@
             },
             "CompressionType": {
               "type": "string",
-              "description": "The model output compression type. Select None to output an uncompressed model, recommended for large model outputs. Defaults to gzip. Valid Values: GZIP | NONE"
+              "description": "The model output compression type. Select None to output an uncompressed model, recommended for large model outputs. Defaults to gzip.",
+              "enum": [
+                "GZIP",
+                "NONE"
+              ]
             },
             "ContentType": {
               "type": "string",
@@ -329,7 +396,11 @@
                     },
                     "FileSystemAccessMode": {
                       "type": "string",
-                      "description": "The access mode of the mount of the directory associated with the channel. A directory can be mounted either in ro (read-only) or rw (read-write) mode. Valid Values: rw | ro"
+                      "description": "The access mode of the mount of the directory associated with the channel. A directory can be mounted either in ro (read-only) or rw (read-write) mode.",
+                      "enum": [
+                        "rw",
+                        "ro"
+                      ]
                     },
                     "FileSystemId": {
                       "type": "string",
@@ -338,7 +409,11 @@
                     },
                     "FileSystemType": {
                       "type": "string",
-                      "description": "The file system type. Valid Values: EFS | FSxLustre"
+                      "description": "The file system type.",
+                      "enum": [
+                        "EFS",
+                        "FSxLustre"
+                      ]
                     }
                   },
                   "required": [
@@ -374,15 +449,24 @@
                     },
                     "S3DataDistributionType": {
                       "type": "string",
-                      "description": "If you want SageMaker to replicate the entire dataset on each ML compute instance that is launched for model training, specify FullyReplicated. If you want SageMaker to replicate a subset of data on each ML compute instance that is launched for model training, specify ShardedByS3Key. If there are n ML compute instances launched for a training job, each instance gets approximately 1/n of the number of S3 objects. In this case, model training on each machine uses only the subset of training data. Don't choose more ML compute instances for training than available S3 objects. If you do, some nodes won't get any data and you will pay for nodes that aren't getting any training data. This applies in both File and Pipe modes. Keep this in mind when developing algorithms. In distributed training, where you use multiple ML compute EC2 instances, you might choose ShardedByS3Key. If the algorithm requires copying training data to the ML storage volume (when TrainingInputMode is set to File), this copies 1/n of the number of objects. Valid Values: FullyReplicated | ShardedByS3Key"
+                      "description": "If you want SageMaker to replicate the entire dataset on each ML compute instance that is launched for model training, specify FullyReplicated. If you want SageMaker to replicate a subset of data on each ML compute instance that is launched for model training, specify ShardedByS3Key. If there are n ML compute instances launched for a training job, each instance gets approximately 1/n of the number of S3 objects. In this case, model training on each machine uses only the subset of training data. Don't choose more ML compute instances for training than available S3 objects. If you do, some nodes won't get any data and you will pay for nodes that aren't getting any training data. This applies in both File and Pipe modes. Keep this in mind when developing algorithms. In distributed training, where you use multiple ML compute EC2 instances, you might choose ShardedByS3Key. If the algorithm requires copying training data to the ML storage volume (when TrainingInputMode is set to File), this copies 1/n of the number of objects.",
+                      "enum": [
+                        "FullyReplicated",
+                        "ShardedByS3Key"
+                      ]
                     },
                     "S3DataType": {
                       "type": "string",
-                      "description": "If you choose S3Prefix, S3Uri identifies a key name prefix. SageMaker uses all objects that match the specified key name prefix for model training. If you choose ManifestFile, S3Uri identifies an object that is a manifest file containing a list of object keys that you want SageMaker to use for model training. If you choose AugmentedManifestFile, S3Uri identifies an object that is an augmented manifest file in JSON lines format. This file contains the data you want to use for model training. AugmentedManifestFile can only be used if the Channel's input mode is Pipe. Valid Values: ManifestFile | S3Prefix | AugmentedManifestFile"
+                      "description": "If you choose S3Prefix, S3Uri identifies a key name prefix. SageMaker uses all objects that match the specified key name prefix for model training. If you choose ManifestFile, S3Uri identifies an object that is a manifest file containing a list of object keys that you want SageMaker to use for model training. If you choose AugmentedManifestFile, S3Uri identifies an object that is an augmented manifest file in JSON lines format. This file contains the data you want to use for model training. AugmentedManifestFile can only be used if the Channel's input mode is Pipe.",
+                      "enum": [
+                        "ManifestFile",
+                        "S3Prefix",
+                        "AugmentedManifestFile"
+                      ]
                     },
                     "S3Uri": {
                       "type": "string",
-                      "description": "Depending on the value specified for the S3DataType, identifies either a key name prefix or a manifest. For example: A key name prefix might look like this: s3://bucketname/exampleprefix A manifest might look like this: s3://bucketname/example.manifest A manifest is an S3 object which is a JSON file consisting of an array of elements. The first element is a prefix which is followed by one or more suffixes. SageMaker appends the suffix elements to the prefix to get a full set of S3Uri. Note that the prefix must be a valid non-empty S3Uri that precludes users from specifying a manifest whose individual S3Uri is sourced from different S3 buckets. The following code example shows a valid manifest format: [ {\"prefix\": \"s3://customer_bucket/some/prefix/\"}, \"relative/path/to/custdata-1\", \"relative/path/custdata-2\", ... \"relative/path/custdata-N\" ] This JSON is equivalent to the following S3Uri list: s3://customer_bucket/some/prefix/relative/path/to/custdata-1 s3://customer_bucket/some/prefix/relative/path/custdata-2 ... s3://customer_bucket/some/prefix/relative/path/custdata-N The complete set of S3Uri in this manifest is the input data for the channel for this data source. The object that each S3Uri points to must be readable by the IAM role that SageMaker uses to perform tasks on your behalf. Your input bucket must be located in same AWS region as your training job. Length Constraints: Maximum length of 1024.",
+                      "description": "Identifies the S3 path where you want SageMaker to store checkpoints. For example, s3://bucket-name/key-name-prefix. Length Constraints: Maximum length of 1024.",
                       "pattern": "^(https|s3)://([^/]+)/?(.*)$"
                     }
                   },
@@ -397,11 +481,20 @@
             },
             "InputMode": {
               "type": "string",
-              "description": "(Optional) The input mode to use for the data channel in a training job. If you don't set a value for InputMode, SageMaker uses the value set for TrainingInputMode. Use this parameter to override the TrainingInputMode setting in a AlgorithmSpecification request when you have a channel that needs a different input mode from the training job's general setting. To download the data from Amazon Simple Storage Service (Amazon S3) to the provisioned ML storage volume, and mount the directory to a Docker volume, use File input mode. To stream data directly from Amazon S3 to the container, choose Pipe input mode. To use a model for incremental training, choose File input model. Valid Values: Pipe | File | FastFile"
+              "description": "(Optional) The input mode to use for the data channel in a training job. If you don't set a value for InputMode, SageMaker uses the value set for TrainingInputMode. Use this parameter to override the TrainingInputMode setting in a AlgorithmSpecification request when you have a channel that needs a different input mode from the training job's general setting. To download the data from Amazon Simple Storage Service (Amazon S3) to the provisioned ML storage volume, and mount the directory to a Docker volume, use File input mode. To stream data directly from Amazon S3 to the container, choose Pipe input mode. To use a model for incremental training, choose File input model.",
+              "enum": [
+                "Pipe",
+                "File",
+                "FastFile"
+              ]
             },
             "RecordWrapperType": {
               "type": "string",
-              "description": "Specify RecordIO as the value when input data is in raw format but the training algorithm requires the RecordIO format. In this case, SageMaker wraps each individual S3 object in a RecordIO record. If the input data is already in RecordIO format, you don't need to set this attribute. For more information, see Create a Dataset Using RecordIO. In File mode, leave this field unset or set it to None. Valid Values: None | RecordIO"
+              "description": "Specify RecordIO as the value when input data is in raw format but the training algorithm requires the RecordIO format. In this case, SageMaker wraps each individual S3 object in a RecordIO record. If the input data is already in RecordIO format, you don't need to set this attribute. For more information, see Create a Dataset Using RecordIO. In File mode, leave this field unset or set it to None.",
+              "enum": [
+                "None",
+                "RecordIO"
+              ]
             },
             "ShuffleConfig": {
               "type": "object",
@@ -430,7 +523,11 @@
       "properties": {
         "CompressionType": {
           "type": "string",
-          "description": "The model output compression type. Select None to output an uncompressed model, recommended for large model outputs. Defaults to gzip. Valid Values: GZIP | NONE"
+          "description": "The model output compression type. Select None to output an uncompressed model, recommended for large model outputs. Defaults to gzip.",
+          "enum": [
+            "GZIP",
+            "NONE"
+          ]
         },
         "KmsKeyId": {
           "type": "string",
@@ -484,11 +581,64 @@
           "properties": {
             "InstanceType": {
               "type": "string",
-              "description": "The instance type to deploy a custom rule for profiling a training job. Valid Values: ml.t3.medium | ml.t3.large | ml.t3.xlarge | ml.t3.2xlarge | ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.r5.large | ml.r5.xlarge | ml.r5.2xlarge | ml.r5.4xlarge | ml.r5.8xlarge | ml.r5.12xlarge | ml.r5.16xlarge | ml.r5.24xlarge | ml.g4dn.xlarge | ml.g4dn.2xlarge | ml.g4dn.4xlarge | ml.g4dn.8xlarge | ml.g4dn.12xlarge | ml.g4dn.16xlarge"
+              "description": "The ML compute instance type. NoteSageMaker Training on Amazon Elastic Compute Cloud (EC2) P4de instances is in preview release starting December 9th, 2022. Amazon EC2 P4de instances (currently in preview) are powered by 8 NVIDIA A100 GPUs with 80GB high-performance HBM2e GPU memory, which accelerate the speed of training ML models that need to be trained on large datasets of high-resolution data. In this preview release, Amazon SageMaker supports ML training jobs on P4de instances (ml.p4de.24xlarge) to reduce model training time. The ml.p4de.24xlarge instances are available in the following AWS Regions. US East (N. Virginia) (us-east-1) US West (Oregon) (us-west-2) To request quota limit increase and start using P4de instances, contact the SageMaker Training service team through your account team.",
+              "enum": [
+                "ml.m4.xlarge",
+                "ml.m4.2xlarge",
+                "ml.m4.4xlarge",
+                "ml.m4.10xlarge",
+                "ml.m4.16xlarge",
+                "ml.g4dn.xlarge",
+                "ml.g4dn.2xlarge",
+                "ml.g4dn.4xlarge",
+                "ml.g4dn.8xlarge",
+                "ml.g4dn.12xlarge",
+                "ml.g4dn.16xlarge",
+                "ml.m5.large",
+                "ml.m5.xlarge",
+                "ml.m5.2xlarge",
+                "ml.m5.4xlarge",
+                "ml.m5.12xlarge",
+                "ml.m5.24xlarge",
+                "ml.c4.xlarge",
+                "ml.c4.2xlarge",
+                "ml.c4.4xlarge",
+                "ml.c4.8xlarge",
+                "ml.p2.xlarge",
+                "ml.p2.8xlarge",
+                "ml.p2.16xlarge",
+                "ml.p3.2xlarge",
+                "ml.p3.8xlarge",
+                "ml.p3.16xlarge",
+                "ml.p3dn.24xlarge",
+                "ml.p4d.24xlarge",
+                "ml.c5.xlarge",
+                "ml.c5.2xlarge",
+                "ml.c5.4xlarge",
+                "ml.c5.9xlarge",
+                "ml.c5.18xlarge",
+                "ml.c5n.xlarge",
+                "ml.c5n.2xlarge",
+                "ml.c5n.4xlarge",
+                "ml.c5n.9xlarge",
+                "ml.c5n.18xlarge",
+                "ml.g5.xlarge",
+                "ml.g5.2xlarge",
+                "ml.g5.4xlarge",
+                "ml.g5.8xlarge",
+                "ml.g5.16xlarge",
+                "ml.g5.12xlarge",
+                "ml.g5.24xlarge",
+                "ml.g5.48xlarge",
+                "ml.trn1.2xlarge",
+                "ml.trn1.32xlarge",
+                "ml.trn1n.32xlarge",
+                "ml.p5.48xlarge"
+              ]
             },
             "LocalPath": {
               "type": "string",
-              "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+              "description": "(Optional) The local directory where checkpoints are written. The default directory is /opt/ml/checkpoints/. Length Constraints: Maximum length of 4096.",
               "pattern": ".*"
             },
             "RuleConfigurationName": {
@@ -498,7 +648,7 @@
             },
             "RuleEvaluatorImage": {
               "type": "string",
-              "description": "The Amazon Elastic Container Registry Image for the managed rule evaluation. Length Constraints: Maximum length of 255.",
+              "description": "The Amazon Elastic Container (ECR) Image for the managed rule evaluation. Length Constraints: Maximum length of 255.",
               "pattern": ".*"
             },
             "RuleParameters": {
@@ -518,7 +668,7 @@
             },
             "VolumeSizeInGB": {
               "type": "number",
-              "description": "The size, in GB, of the ML storage volume attached to the processing instance. Valid Range: Minimum value of 0."
+              "description": "The size of the ML storage volume that you want to provision. ML storage volumes store model artifacts and incremental states. Training algorithms might also use the ML storage volume for scratch space. If you want to store the training data in the ML storage volume, choose File as the TrainingInputMode in the algorithm specification. When using an ML instance with NVMe SSD volumes, SageMaker doesn't provision Amazon EBS General Purpose SSD (gp2) storage. Available storage is fixed to the NVMe-type instance's storage capacity. SageMaker configures storage paths for training datasets, checkpoints, model artifacts, and outputs to use the entire capacity of the instance storage. For example, ML instance families with the NVMe-type instance storage include ml.p4d, ml.g4dn, and ml.g5. When using an ML instance with the EBS-only storage option and without instance storage, you must define the size of EBS volume through VolumeSizeInGB in the ResourceConfig API. For example, ML instance families that use EBS volumes include ml.c5 and ml.p2. To look up instance types and their instance storage types and volumes, see Amazon EC2 Instance Types. To find the default local paths defined by the SageMaker training platform, see Amazon SageMaker Training Storage Folders for Training Datasets, Checkpoints, Model Artifacts, and Outputs. Valid Range: Minimum value of 1."
             }
           },
           "required": []
@@ -550,7 +700,60 @@
                 },
                 "InstanceType": {
                   "type": "string",
-                  "description": "The instance type to deploy a custom rule for profiling a training job. Valid Values: ml.t3.medium | ml.t3.large | ml.t3.xlarge | ml.t3.2xlarge | ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.r5.large | ml.r5.xlarge | ml.r5.2xlarge | ml.r5.4xlarge | ml.r5.8xlarge | ml.r5.12xlarge | ml.r5.16xlarge | ml.r5.24xlarge | ml.g4dn.xlarge | ml.g4dn.2xlarge | ml.g4dn.4xlarge | ml.g4dn.8xlarge | ml.g4dn.12xlarge | ml.g4dn.16xlarge"
+                  "description": "The ML compute instance type. NoteSageMaker Training on Amazon Elastic Compute Cloud (EC2) P4de instances is in preview release starting December 9th, 2022. Amazon EC2 P4de instances (currently in preview) are powered by 8 NVIDIA A100 GPUs with 80GB high-performance HBM2e GPU memory, which accelerate the speed of training ML models that need to be trained on large datasets of high-resolution data. In this preview release, Amazon SageMaker supports ML training jobs on P4de instances (ml.p4de.24xlarge) to reduce model training time. The ml.p4de.24xlarge instances are available in the following AWS Regions. US East (N. Virginia) (us-east-1) US West (Oregon) (us-west-2) To request quota limit increase and start using P4de instances, contact the SageMaker Training service team through your account team.",
+                  "enum": [
+                    "ml.m4.xlarge",
+                    "ml.m4.2xlarge",
+                    "ml.m4.4xlarge",
+                    "ml.m4.10xlarge",
+                    "ml.m4.16xlarge",
+                    "ml.g4dn.xlarge",
+                    "ml.g4dn.2xlarge",
+                    "ml.g4dn.4xlarge",
+                    "ml.g4dn.8xlarge",
+                    "ml.g4dn.12xlarge",
+                    "ml.g4dn.16xlarge",
+                    "ml.m5.large",
+                    "ml.m5.xlarge",
+                    "ml.m5.2xlarge",
+                    "ml.m5.4xlarge",
+                    "ml.m5.12xlarge",
+                    "ml.m5.24xlarge",
+                    "ml.c4.xlarge",
+                    "ml.c4.2xlarge",
+                    "ml.c4.4xlarge",
+                    "ml.c4.8xlarge",
+                    "ml.p2.xlarge",
+                    "ml.p2.8xlarge",
+                    "ml.p2.16xlarge",
+                    "ml.p3.2xlarge",
+                    "ml.p3.8xlarge",
+                    "ml.p3.16xlarge",
+                    "ml.p3dn.24xlarge",
+                    "ml.p4d.24xlarge",
+                    "ml.c5.xlarge",
+                    "ml.c5.2xlarge",
+                    "ml.c5.4xlarge",
+                    "ml.c5.9xlarge",
+                    "ml.c5.18xlarge",
+                    "ml.c5n.xlarge",
+                    "ml.c5n.2xlarge",
+                    "ml.c5n.4xlarge",
+                    "ml.c5n.9xlarge",
+                    "ml.c5n.18xlarge",
+                    "ml.g5.xlarge",
+                    "ml.g5.2xlarge",
+                    "ml.g5.4xlarge",
+                    "ml.g5.8xlarge",
+                    "ml.g5.16xlarge",
+                    "ml.g5.12xlarge",
+                    "ml.g5.24xlarge",
+                    "ml.g5.48xlarge",
+                    "ml.trn1.2xlarge",
+                    "ml.trn1.32xlarge",
+                    "ml.trn1n.32xlarge",
+                    "ml.p5.48xlarge"
+                  ]
                 }
               },
               "required": [
@@ -562,7 +765,60 @@
         },
         "InstanceType": {
           "type": "string",
-          "description": "The instance type to deploy a custom rule for profiling a training job. Valid Values: ml.t3.medium | ml.t3.large | ml.t3.xlarge | ml.t3.2xlarge | ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.r5.large | ml.r5.xlarge | ml.r5.2xlarge | ml.r5.4xlarge | ml.r5.8xlarge | ml.r5.12xlarge | ml.r5.16xlarge | ml.r5.24xlarge | ml.g4dn.xlarge | ml.g4dn.2xlarge | ml.g4dn.4xlarge | ml.g4dn.8xlarge | ml.g4dn.12xlarge | ml.g4dn.16xlarge"
+          "description": "The ML compute instance type. NoteSageMaker Training on Amazon Elastic Compute Cloud (EC2) P4de instances is in preview release starting December 9th, 2022. Amazon EC2 P4de instances (currently in preview) are powered by 8 NVIDIA A100 GPUs with 80GB high-performance HBM2e GPU memory, which accelerate the speed of training ML models that need to be trained on large datasets of high-resolution data. In this preview release, Amazon SageMaker supports ML training jobs on P4de instances (ml.p4de.24xlarge) to reduce model training time. The ml.p4de.24xlarge instances are available in the following AWS Regions. US East (N. Virginia) (us-east-1) US West (Oregon) (us-west-2) To request quota limit increase and start using P4de instances, contact the SageMaker Training service team through your account team.",
+          "enum": [
+            "ml.m4.xlarge",
+            "ml.m4.2xlarge",
+            "ml.m4.4xlarge",
+            "ml.m4.10xlarge",
+            "ml.m4.16xlarge",
+            "ml.g4dn.xlarge",
+            "ml.g4dn.2xlarge",
+            "ml.g4dn.4xlarge",
+            "ml.g4dn.8xlarge",
+            "ml.g4dn.12xlarge",
+            "ml.g4dn.16xlarge",
+            "ml.m5.large",
+            "ml.m5.xlarge",
+            "ml.m5.2xlarge",
+            "ml.m5.4xlarge",
+            "ml.m5.12xlarge",
+            "ml.m5.24xlarge",
+            "ml.c4.xlarge",
+            "ml.c4.2xlarge",
+            "ml.c4.4xlarge",
+            "ml.c4.8xlarge",
+            "ml.p2.xlarge",
+            "ml.p2.8xlarge",
+            "ml.p2.16xlarge",
+            "ml.p3.2xlarge",
+            "ml.p3.8xlarge",
+            "ml.p3.16xlarge",
+            "ml.p3dn.24xlarge",
+            "ml.p4d.24xlarge",
+            "ml.c5.xlarge",
+            "ml.c5.2xlarge",
+            "ml.c5.4xlarge",
+            "ml.c5.9xlarge",
+            "ml.c5.18xlarge",
+            "ml.c5n.xlarge",
+            "ml.c5n.2xlarge",
+            "ml.c5n.4xlarge",
+            "ml.c5n.9xlarge",
+            "ml.c5n.18xlarge",
+            "ml.g5.xlarge",
+            "ml.g5.2xlarge",
+            "ml.g5.4xlarge",
+            "ml.g5.8xlarge",
+            "ml.g5.16xlarge",
+            "ml.g5.12xlarge",
+            "ml.g5.24xlarge",
+            "ml.g5.48xlarge",
+            "ml.trn1.2xlarge",
+            "ml.trn1.32xlarge",
+            "ml.trn1n.32xlarge",
+            "ml.p5.48xlarge"
+          ]
         },
         "KeepAlivePeriodInSeconds": {
           "type": "number",
@@ -575,7 +831,7 @@
         },
         "VolumeSizeInGB": {
           "type": "number",
-          "description": "The size, in GB, of the ML storage volume attached to the processing instance. Valid Range: Minimum value of 0."
+          "description": "The size of the ML storage volume that you want to provision. ML storage volumes store model artifacts and incremental states. Training algorithms might also use the ML storage volume for scratch space. If you want to store the training data in the ML storage volume, choose File as the TrainingInputMode in the algorithm specification. When using an ML instance with NVMe SSD volumes, SageMaker doesn't provision Amazon EBS General Purpose SSD (gp2) storage. Available storage is fixed to the NVMe-type instance's storage capacity. SageMaker configures storage paths for training datasets, checkpoints, model artifacts, and outputs to use the entire capacity of the instance storage. For example, ML instance families with the NVMe-type instance storage include ml.p4d, ml.g4dn, and ml.g5. When using an ML instance with the EBS-only storage option and without instance storage, you must define the size of EBS volume through VolumeSizeInGB in the ResourceConfig API. For example, ML instance families that use EBS volumes include ml.c5 and ml.p2. To look up instance types and their instance storage types and volumes, see Amazon EC2 Instance Types. To find the default local paths defined by the SageMaker training platform, see Amazon SageMaker Training Storage Folders for Training Datasets, Checkpoints, Model Artifacts, and Outputs. Valid Range: Minimum value of 1."
         }
       },
       "required": [],
@@ -648,7 +904,7 @@
       "properties": {
         "LocalPath": {
           "type": "string",
-          "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+          "description": "(Optional) The local directory where checkpoints are written. The default directory is /opt/ml/checkpoints/. Length Constraints: Maximum length of 4096.",
           "pattern": ".*"
         },
         "S3OutputPath": {

--- a/weave-js/src/common/components/Monaco/schemas/sagemaker.json
+++ b/weave-js/src/common/components/Monaco/schemas/sagemaker.json
@@ -1,0 +1,713 @@
+{
+  "type": "object",
+  "properties": {
+    "AlgorithmSpecification": {
+      "type": "object",
+      "properties": {
+        "AlgorithmName": {
+          "type": "string",
+          "description": "The name of the algorithm resource to use for the training job. This must be an algorithm resource that you created or subscribe to on AWS Marketplace. NoteYou must specify either the algorithm name to the AlgorithmName parameter or the image URI of the algorithm container to the TrainingImage parameter.Note that the AlgorithmName parameter is mutually exclusive with the TrainingImage parameter. If you specify a value for the AlgorithmName parameter, you can't specify a value for TrainingImage, and vice versa.If you specify values for both parameters, the training job might break; if you don't specify any value for both parameters, the training job might raise a null error. Length Constraints: Minimum length of 1. Maximum length of 170.",
+          "pattern": "(arn:aws[a-z\\-]*:sagemaker:[a-z0-9\\-]*:[0-9]{12}:[a-z\\-]*\\/)?([a-zA-Z0-9]([a-zA-Z0-9-]){0,62})(?<!-)$"
+        },
+        "ContainerArguments": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            }
+          ],
+          "description": "The arguments for a container used to run a training job. See How Amazon SageMaker Runs Your Training Image for additional information. Array Members: Minimum number of 1 item. Maximum number of 100 items. Length Constraints: Maximum length of 256.",
+          "pattern": ".*"
+        },
+        "ContainerEntrypoint": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            }
+          ],
+          "description": "The entrypoint script for a Docker container used to run a training job. This script takes precedence over the default train processing instructions. See How Amazon SageMaker Runs Your Training Image for more information. Array Members: Minimum number of 1 item. Maximum number of 100 items. Length Constraints: Maximum length of 256.",
+          "pattern": ".*"
+        },
+        "EnableSageMakerMetricsTimeSeries": {
+          "type": "boolean",
+          "description": "To generate and save time-series metrics during training, set to true. The default is false and time-series metrics aren't generated except in the following cases: You use one of the SageMaker built-in algorithms You use one of the following Prebuilt SageMaker Docker Images: Tensorflow (version >= 1.15) MXNet (version >= 1.6) PyTorch (version >= 1.3) You specify at least one MetricDefinition"
+        },
+        "MetricDefinitions": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "Name": {
+                  "type": "string",
+                  "description": "The name of the metric. Length Constraints: Minimum length of 1. Maximum length of 255.",
+                  "pattern": ".+"
+                },
+                "Regex": {
+                  "type": "string",
+                  "description": "A regular expression that searches the output of a training job and gets the value of the metric. For more information about using regular expressions to define metrics, see Defining metrics and environment variables. Length Constraints: Minimum length of 1. Maximum length of 500.",
+                  "pattern": ".+"
+                }
+              },
+              "required": [
+                "Name",
+                "Regex"
+              ]
+            }
+          ],
+          "description": "A list of metric definition objects. Each object specifies the metric name and regular expressions used to parse algorithm logs. SageMaker publishes each metric to Amazon CloudWatch. Array Members: Minimum number of 0 items. Maximum number of 40 items."
+        },
+        "TrainingImage": {
+          "type": "string",
+          "description": "The registry path of the Docker image that contains the training algorithm. For information about docker registry paths for SageMaker built-in algorithms, see Docker Registry Paths and Example Code in the Amazon SageMaker developer guide. SageMaker supports both registry/repository[:tag] and registry/repository[@digest] image path formats. For more information about using your custom training container, see Using Your Own Algorithms with Amazon SageMaker. NoteYou must specify either the algorithm name to the AlgorithmName parameter or the image URI of the algorithm container to the TrainingImage parameter.For more information, see the note in the AlgorithmName parameter description. Length Constraints: Maximum length of 255.",
+          "pattern": ".*"
+        },
+        "TrainingImageConfig": {
+          "type": "object",
+          "properties": {
+            "TrainingRepositoryAccessMode": {
+              "type": "string",
+              "description": "The method that your training job will use to gain access to the images in your private Docker registry. For access to an image in a private Docker registry, set to Vpc. Valid Values: Platform | Vpc"
+            },
+            "TrainingRepositoryAuthConfig": {
+              "type": "object",
+              "properties": {
+                "TrainingRepositoryCredentialsProviderArn": {
+                  "type": "string",
+                  "description": "The Amazon Resource Name (ARN) of an AWS Lambda function used to give SageMaker access credentials to your private Docker registry. Length Constraints: Minimum length of 1. Maximum length of 2048.",
+                  "pattern": "arn:[\\p{Alnum}\\-]+:lambda:[\\p{Alnum}\\-]+:[0-9]{12}:function:.*"
+                }
+              },
+              "required": [
+                "TrainingRepositoryCredentialsProviderArn"
+              ],
+              "description": "An object containing authentication information for a private Docker registry containing your training images."
+            }
+          },
+          "required": [
+            "TrainingRepositoryAccessMode"
+          ],
+          "description": "The configuration to use an image from a private Docker registry for a training job."
+        },
+        "TrainingInputMode": {
+          "type": "string",
+          "description": "The training input mode that the algorithm supports. For more information about input modes, see Algorithms. Pipe mode If an algorithm supports Pipe mode, Amazon SageMaker streams data directly from Amazon S3 to the container. File mode If an algorithm supports File mode, SageMaker downloads the training data from S3 to the provisioned ML storage volume, and mounts the directory to the Docker volume for the training container. You must provision the ML storage volume with sufficient capacity to accommodate the data downloaded from S3. In addition to the training data, the ML storage volume also stores the output model. The algorithm container uses the ML storage volume to also store intermediate information, if any. For distributed algorithms, training data is distributed uniformly. Your training duration is predictable if the input data objects sizes are approximately the same. SageMaker does not split the files any further for model training. If the object sizes are skewed, training won't be optimal as the data distribution is also skewed when one host in a training cluster is overloaded, thus becoming a bottleneck in training. FastFile mode If an algorithm supports FastFile mode, SageMaker streams data directly from S3 to the container with no code changes, and provides file system access to the data. Users can author their training script to interact with these files as if they were stored on disk. FastFile mode works best when the data is read sequentially. Augmented manifest files aren't supported. The startup time is lower when there are fewer files in the S3 bucket provided. Valid Values: Pipe | File | FastFile"
+        }
+      },
+      "required": [
+        "TrainingInputMode"
+      ],
+      "description": "The registry path of the Docker image that contains the training algorithm and algorithm-specific metadata, including the input mode. For more information about algorithms provided by SageMaker, see Algorithms. For information about providing your own algorithms, see Using Your Own Algorithms with Amazon SageMaker."
+    },
+    "CheckpointConfig": {
+      "type": "object",
+      "properties": {
+        "LocalPath": {
+          "type": "string",
+          "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+          "pattern": ".*"
+        },
+        "S3Uri": {
+          "type": "string",
+          "description": "Depending on the value specified for the S3DataType, identifies either a key name prefix or a manifest. For example: A key name prefix might look like this: s3://bucketname/exampleprefix A manifest might look like this: s3://bucketname/example.manifest A manifest is an S3 object which is a JSON file consisting of an array of elements. The first element is a prefix which is followed by one or more suffixes. SageMaker appends the suffix elements to the prefix to get a full set of S3Uri. Note that the prefix must be a valid non-empty S3Uri that precludes users from specifying a manifest whose individual S3Uri is sourced from different S3 buckets. The following code example shows a valid manifest format: [ {\"prefix\": \"s3://customer_bucket/some/prefix/\"}, \"relative/path/to/custdata-1\", \"relative/path/custdata-2\", ... \"relative/path/custdata-N\" ] This JSON is equivalent to the following S3Uri list: s3://customer_bucket/some/prefix/relative/path/to/custdata-1 s3://customer_bucket/some/prefix/relative/path/custdata-2 ... s3://customer_bucket/some/prefix/relative/path/custdata-N The complete set of S3Uri in this manifest is the input data for the channel for this data source. The object that each S3Uri points to must be readable by the IAM role that SageMaker uses to perform tasks on your behalf. Your input bucket must be located in same AWS region as your training job. Length Constraints: Maximum length of 1024.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+        }
+      },
+      "required": [
+        "S3Uri"
+      ],
+      "description": "Contains information about the output location for managed spot training checkpoint data."
+    },
+    "DebugHookConfig": {
+      "type": "object",
+      "properties": {
+        "CollectionConfigurations": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "CollectionName": {
+                  "type": "string",
+                  "description": "The name of the tensor collection. The name must be unique relative to other rule configuration names. Length Constraints: Minimum length of 1. Maximum length of 256.",
+                  "pattern": ".*"
+                },
+                "CollectionParameters": {
+                  "type": "object",
+                  "properties": {
+                    "string": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [],
+                  "description": "Parameter values for the tensor collection. The allowed parameters are \"name\", \"include_regex\", \"reduction_config\", \"save_config\", \"tensor_names\", and \"save_histogram\". Map Entries: Minimum number of 0 items. Maximum number of 20 items. Key Length Constraints: Minimum length of 1. Maximum length of 256. Key Pattern: .* Value Length Constraints: Maximum length of 256. Value Pattern: .*"
+                }
+              },
+              "required": []
+            }
+          ],
+          "description": "Configuration information for Amazon SageMaker Debugger tensor collections. To learn more about how to configure the CollectionConfiguration parameter, see Use the SageMaker and Debugger Configuration API Operations to Create, Update, and Debug Your Training Job. Array Members: Minimum number of 0 items. Maximum number of 20 items."
+        },
+        "HookParameters": {
+          "type": "object",
+          "properties": {
+            "string": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "description": "Configuration information for the Amazon SageMaker Debugger hook parameters. Map Entries: Minimum number of 0 items. Maximum number of 20 items. Key Length Constraints: Minimum length of 1. Maximum length of 256. Key Pattern: .* Value Length Constraints: Maximum length of 256. Value Pattern: .*"
+        },
+        "LocalPath": {
+          "type": "string",
+          "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+          "pattern": ".*"
+        },
+        "S3OutputPath": {
+          "type": "string",
+          "description": "Path to Amazon S3 storage location for rules. Length Constraints: Maximum length of 1024.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+        }
+      },
+      "required": [],
+      "description": "Configuration information for the Amazon SageMaker Debugger hook parameters, metric and tensor collections, and storage paths. To learn more about how to configure the DebugHookConfig parameter, see Use the SageMaker and Debugger Configuration API Operations to Create, Update, and Debug Your Training Job."
+    },
+    "DebugRuleConfigurations": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "InstanceType": {
+              "type": "string",
+              "description": "The instance type to deploy a custom rule for profiling a training job. Valid Values: ml.t3.medium | ml.t3.large | ml.t3.xlarge | ml.t3.2xlarge | ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.r5.large | ml.r5.xlarge | ml.r5.2xlarge | ml.r5.4xlarge | ml.r5.8xlarge | ml.r5.12xlarge | ml.r5.16xlarge | ml.r5.24xlarge | ml.g4dn.xlarge | ml.g4dn.2xlarge | ml.g4dn.4xlarge | ml.g4dn.8xlarge | ml.g4dn.12xlarge | ml.g4dn.16xlarge"
+            },
+            "LocalPath": {
+              "type": "string",
+              "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+              "pattern": ".*"
+            },
+            "RuleConfigurationName": {
+              "type": "string",
+              "description": "The name of the rule configuration. It must be unique relative to other rule configuration names. Length Constraints: Minimum length of 1. Maximum length of 256.",
+              "pattern": ".*"
+            },
+            "RuleEvaluatorImage": {
+              "type": "string",
+              "description": "The Amazon Elastic Container Registry Image for the managed rule evaluation. Length Constraints: Maximum length of 255.",
+              "pattern": ".*"
+            },
+            "RuleParameters": {
+              "type": "object",
+              "properties": {
+                "string": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "description": "Runtime configuration for rule container. Map Entries: Minimum number of 0 items. Maximum number of 100 items. Key Length Constraints: Minimum length of 1. Maximum length of 256. Key Pattern: .* Value Length Constraints: Maximum length of 256. Value Pattern: .*"
+            },
+            "S3OutputPath": {
+              "type": "string",
+              "description": "Path to Amazon S3 storage location for rules. Length Constraints: Maximum length of 1024.",
+              "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+            },
+            "VolumeSizeInGB": {
+              "type": "number",
+              "description": "The size, in GB, of the ML storage volume attached to the processing instance. Valid Range: Minimum value of 0."
+            }
+          },
+          "required": [
+            "RuleConfigurationName",
+            "RuleEvaluatorImage"
+          ]
+        }
+      ],
+      "description": "Configuration information for Amazon SageMaker Debugger rules for debugging output tensors. Array Members: Minimum number of 0 items. Maximum number of 20 items."
+    },
+    "EnableInterContainerTrafficEncryption": {
+      "type": "boolean",
+      "description": "To encrypt all communications between ML compute instances in distributed training, choose True. Encryption provides greater security for distributed training, but training might take longer. How long it takes depends on the amount of communication between compute instances, especially if you use a deep learning algorithm in distributed training. For more information, see Protect Communications Between ML Compute Instances in a Distributed Training Job."
+    },
+    "EnableManagedSpotTraining": {
+      "type": "boolean",
+      "description": "To train models using managed spot training, choose True. Managed spot training provides a fully managed and scalable infrastructure for training machine learning models. this option is useful when training jobs can be interrupted and when there is flexibility when the training job is run. The complete and intermediate results of jobs are stored in an Amazon S3 bucket, and can be used as a starting point to train models incrementally. Amazon SageMaker provides metrics and logs in CloudWatch. They can be used to see when managed spot training jobs are running, interrupted, resumed, or completed."
+    },
+    "EnableNetworkIsolation": {
+      "type": "boolean",
+      "description": "Isolates the training container. No inbound or outbound network calls can be made, except for calls between peers within a training cluster for distributed training. If you enable network isolation for training jobs that are configured to use a VPC, SageMaker downloads and uploads customer data and model artifacts through the specified VPC, but the training container does not have network access."
+    },
+    "Environment": {
+      "type": "object",
+      "properties": {
+        "string": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "description": "The environment variables to set in the Docker container. Map Entries: Maximum number of 100 items. Key Length Constraints: Maximum length of 512. Key Pattern: [a-zA-Z_][a-zA-Z0-9_]* Value Length Constraints: Maximum length of 512. Value Pattern: [\\S\\s]*"
+    },
+    "ExperimentConfig": {
+      "type": "object",
+      "properties": {
+        "ExperimentName": {
+          "type": "string",
+          "description": "The name of an existing experiment to associate with the trial component. Length Constraints: Minimum length of 1. Maximum length of 120.",
+          "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,119}"
+        },
+        "RunName": {
+          "type": "string",
+          "description": "The name of the experiment run to associate with the trial component. Length Constraints: Minimum length of 1. Maximum length of 120.",
+          "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,119}"
+        },
+        "TrialComponentDisplayName": {
+          "type": "string",
+          "description": "The display name for the trial component. If this key isn't specified, the display name is the trial component name. Length Constraints: Minimum length of 1. Maximum length of 120.",
+          "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,119}"
+        },
+        "TrialName": {
+          "type": "string",
+          "description": "The name of an existing trial to associate the trial component with. If not specified, a new trial is created. Length Constraints: Minimum length of 1. Maximum length of 120.",
+          "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,119}"
+        }
+      },
+      "required": [],
+      "description": "Associates a SageMaker job as a trial component with an experiment and trial. Specified when you call the following APIs: CreateProcessingJob CreateTrainingJob CreateTransformJob"
+    },
+    "HyperParameters": {
+      "type": "object",
+      "properties": {
+        "string": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "description": "Algorithm-specific parameters that influence the quality of the model. You set hyperparameters before you start the learning process. For a list of hyperparameters for each training algorithm provided by SageMaker, see Algorithms. You can specify a maximum of 100 hyperparameters. Each hyperparameter is a key-value pair. Each key and value is limited to 256 characters, as specified by the Length Constraint. ImportantDo not include any security-sensitive information including account access IDs, secrets or tokens in any hyperparameter field. If the use of security-sensitive credentials are detected, SageMaker will reject your training job request and return an exception error. Map Entries: Minimum number of 0 items. Maximum number of 100 items. Key Length Constraints: Maximum length of 256. Key Pattern: .* Value Length Constraints: Maximum length of 2500. Value Pattern: .*"
+    },
+    "InfraCheckConfig": {
+      "type": "object",
+      "properties": {
+        "EnableInfraCheck": {
+          "type": "boolean",
+          "description": "Enables an infrastructure health check."
+        }
+      },
+      "required": [],
+      "description": "Contains information about the infrastructure health check configuration for the training job."
+    },
+    "InputDataConfig": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "ChannelName": {
+              "type": "string",
+              "description": "The name of the channel. Length Constraints: Minimum length of 1. Maximum length of 64.",
+              "pattern": "[A-Za-z0-9\\.\\-_]+"
+            },
+            "CompressionType": {
+              "type": "string",
+              "description": "The model output compression type. Select None to output an uncompressed model, recommended for large model outputs. Defaults to gzip. Valid Values: GZIP | NONE"
+            },
+            "ContentType": {
+              "type": "string",
+              "description": "The MIME type of the data. Length Constraints: Maximum length of 256.",
+              "pattern": ".*"
+            },
+            "DataSource": {
+              "type": "object",
+              "properties": {
+                "FileSystemDataSource": {
+                  "type": "object",
+                  "properties": {
+                    "DirectoryPath": {
+                      "type": "string",
+                      "description": "The full path to the directory to associate with the channel. Length Constraints: Maximum length of 4096.",
+                      "pattern": ".*"
+                    },
+                    "FileSystemAccessMode": {
+                      "type": "string",
+                      "description": "The access mode of the mount of the directory associated with the channel. A directory can be mounted either in ro (read-only) or rw (read-write) mode. Valid Values: rw | ro"
+                    },
+                    "FileSystemId": {
+                      "type": "string",
+                      "description": "The file system id. Length Constraints: Minimum length of 11.",
+                      "pattern": "^(fs-[0-9a-f]{8,})$"
+                    },
+                    "FileSystemType": {
+                      "type": "string",
+                      "description": "The file system type. Valid Values: EFS | FSxLustre"
+                    }
+                  },
+                  "required": [
+                    "DirectoryPath",
+                    "FileSystemAccessMode",
+                    "FileSystemId",
+                    "FileSystemType"
+                  ],
+                  "description": "The file system that is associated with a channel."
+                },
+                "S3DataSource": {
+                  "type": "object",
+                  "properties": {
+                    "AttributeNames": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "A list of one or more attribute names to use that are found in a specified augmented manifest file. Array Members: Maximum number of 16 items. Length Constraints: Minimum length of 1. Maximum length of 256.",
+                      "pattern": ".+"
+                    },
+                    "InstanceGroupNames": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "description": "A list of names of instance groups that get data from the S3 data source. Array Members: Maximum number of 5 items. Length Constraints: Minimum length of 1. Maximum length of 64.",
+                      "pattern": ".+"
+                    },
+                    "S3DataDistributionType": {
+                      "type": "string",
+                      "description": "If you want SageMaker to replicate the entire dataset on each ML compute instance that is launched for model training, specify FullyReplicated. If you want SageMaker to replicate a subset of data on each ML compute instance that is launched for model training, specify ShardedByS3Key. If there are n ML compute instances launched for a training job, each instance gets approximately 1/n of the number of S3 objects. In this case, model training on each machine uses only the subset of training data. Don't choose more ML compute instances for training than available S3 objects. If you do, some nodes won't get any data and you will pay for nodes that aren't getting any training data. This applies in both File and Pipe modes. Keep this in mind when developing algorithms. In distributed training, where you use multiple ML compute EC2 instances, you might choose ShardedByS3Key. If the algorithm requires copying training data to the ML storage volume (when TrainingInputMode is set to File), this copies 1/n of the number of objects. Valid Values: FullyReplicated | ShardedByS3Key"
+                    },
+                    "S3DataType": {
+                      "type": "string",
+                      "description": "If you choose S3Prefix, S3Uri identifies a key name prefix. SageMaker uses all objects that match the specified key name prefix for model training. If you choose ManifestFile, S3Uri identifies an object that is a manifest file containing a list of object keys that you want SageMaker to use for model training. If you choose AugmentedManifestFile, S3Uri identifies an object that is an augmented manifest file in JSON lines format. This file contains the data you want to use for model training. AugmentedManifestFile can only be used if the Channel's input mode is Pipe. Valid Values: ManifestFile | S3Prefix | AugmentedManifestFile"
+                    },
+                    "S3Uri": {
+                      "type": "string",
+                      "description": "Depending on the value specified for the S3DataType, identifies either a key name prefix or a manifest. For example: A key name prefix might look like this: s3://bucketname/exampleprefix A manifest might look like this: s3://bucketname/example.manifest A manifest is an S3 object which is a JSON file consisting of an array of elements. The first element is a prefix which is followed by one or more suffixes. SageMaker appends the suffix elements to the prefix to get a full set of S3Uri. Note that the prefix must be a valid non-empty S3Uri that precludes users from specifying a manifest whose individual S3Uri is sourced from different S3 buckets. The following code example shows a valid manifest format: [ {\"prefix\": \"s3://customer_bucket/some/prefix/\"}, \"relative/path/to/custdata-1\", \"relative/path/custdata-2\", ... \"relative/path/custdata-N\" ] This JSON is equivalent to the following S3Uri list: s3://customer_bucket/some/prefix/relative/path/to/custdata-1 s3://customer_bucket/some/prefix/relative/path/custdata-2 ... s3://customer_bucket/some/prefix/relative/path/custdata-N The complete set of S3Uri in this manifest is the input data for the channel for this data source. The object that each S3Uri points to must be readable by the IAM role that SageMaker uses to perform tasks on your behalf. Your input bucket must be located in same AWS region as your training job. Length Constraints: Maximum length of 1024.",
+                      "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+                    }
+                  },
+                  "required": [
+                    "S3DataType"
+                  ],
+                  "description": "The S3 location of the data source that is associated with a channel."
+                }
+              },
+              "required": [],
+              "description": "The location of the channel data."
+            },
+            "InputMode": {
+              "type": "string",
+              "description": "(Optional) The input mode to use for the data channel in a training job. If you don't set a value for InputMode, SageMaker uses the value set for TrainingInputMode. Use this parameter to override the TrainingInputMode setting in a AlgorithmSpecification request when you have a channel that needs a different input mode from the training job's general setting. To download the data from Amazon Simple Storage Service (Amazon S3) to the provisioned ML storage volume, and mount the directory to a Docker volume, use File input mode. To stream data directly from Amazon S3 to the container, choose Pipe input mode. To use a model for incremental training, choose File input model. Valid Values: Pipe | File | FastFile"
+            },
+            "RecordWrapperType": {
+              "type": "string",
+              "description": "Specify RecordIO as the value when input data is in raw format but the training algorithm requires the RecordIO format. In this case, SageMaker wraps each individual S3 object in a RecordIO record. If the input data is already in RecordIO format, you don't need to set this attribute. For more information, see Create a Dataset Using RecordIO. In File mode, leave this field unset or set it to None. Valid Values: None | RecordIO"
+            },
+            "ShuffleConfig": {
+              "type": "object",
+              "properties": {
+                "Seed": {
+                  "type": "number",
+                  "description": "Determines the shuffling order in ShuffleConfig value."
+                }
+              },
+              "required": [
+                "Seed"
+              ],
+              "description": "A configuration for a shuffle option for input data in a channel. If you use S3Prefix for S3DataType, this shuffles the results of the S3 key prefix matches. If you use ManifestFile, the order of the S3 object references in the ManifestFile is shuffled. If you use AugmentedManifestFile, the order of the JSON lines in the AugmentedManifestFile is shuffled. The shuffling order is determined using the Seed value. For Pipe input mode, shuffling is done at the start of every epoch. With large datasets this ensures that the order of the training data is different for each epoch, it helps reduce bias and possible overfitting. In a multi-node training job when ShuffleConfig is combined with S3DataDistributionType of ShardedByS3Key, the data is shuffled across nodes so that the content sent to a particular node on the first epoch might be sent to a different node on the second epoch."
+            }
+          },
+          "required": [
+            "ChannelName",
+            "DataSource"
+          ]
+        }
+      ],
+      "description": "An array of Channel objects. Each channel is a named input source. InputDataConfig describes the input data and its location. Algorithms can accept input data from one or more channels. For example, an algorithm might have two channels of input data, training_data and validation_data. The configuration for each channel provides the S3, EFS, or FSx location where the input data is stored. It also provides information about the stored data: the MIME type, compression method, and whether the data is wrapped in RecordIO format. Depending on the input mode that the algorithm supports, SageMaker either copies input data files from an S3 bucket to a local directory in the Docker container, or makes it available as input streams. For example, if you specify an EFS location, input data files are available as input streams. They do not need to be downloaded. Your input must be in the same AWS region as your training job. Array Members: Minimum number of 1 item. Maximum number of 20 items."
+    },
+    "OutputDataConfig": {
+      "type": "object",
+      "properties": {
+        "CompressionType": {
+          "type": "string",
+          "description": "The model output compression type. Select None to output an uncompressed model, recommended for large model outputs. Defaults to gzip. Valid Values: GZIP | NONE"
+        },
+        "KmsKeyId": {
+          "type": "string",
+          "description": "The AWS Key Management Service (AWS KMS) key that SageMaker uses to encrypt the model artifacts at rest using Amazon S3 server-side encryption. The KmsKeyId can be any of the following formats: // KMS Key ID \"1234abcd-12ab-34cd-56ef-1234567890ab\" // Amazon Resource Name (ARN) of a KMS Key \"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\" // KMS Key Alias \"alias/ExampleAlias\" // Amazon Resource Name (ARN) of a KMS Key Alias \"arn:aws:kms:us-west-2:111122223333:alias/ExampleAlias\" If you use a KMS key ID or an alias of your KMS key, the SageMaker execution role must include permissions to call kms:Encrypt. If you don't provide a KMS key ID, SageMaker uses the default KMS key for Amazon S3 for your role's account. For more information, see KMS-Managed Encryption Keys in the Amazon Simple Storage Service Developer Guide. If the output data is stored in Amazon S3 Express One Zone, it is encrypted with server-side encryption with Amazon S3 managed keys (SSE-S3). KMS key is not supported for Amazon S3 Express One Zone The KMS key policy must grant permission to the IAM role that you specify in your CreateTrainingJob, CreateTransformJob, or CreateHyperParameterTuningJob requests. For more information, see Using Key Policies in AWS KMS in the AWS Key Management Service Developer Guide. Length Constraints: Maximum length of 2048.",
+          "pattern": ".*"
+        },
+        "S3OutputPath": {
+          "type": "string",
+          "description": "Path to Amazon S3 storage location for rules. Length Constraints: Maximum length of 1024.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+        }
+      },
+      "required": [],
+      "description": "Specifies the path to the S3 location where you want to store model artifacts. SageMaker creates subfolders for the artifacts."
+    },
+    "ProfilerConfig": {
+      "type": "object",
+      "properties": {
+        "DisableProfiler": {
+          "type": "boolean",
+          "description": "Configuration to turn off Amazon SageMaker Debugger's system monitoring and profiling functionality. To turn it off, set to True."
+        },
+        "ProfilingIntervalInMilliseconds": {
+          "type": "number",
+          "description": "A time interval for capturing system metrics in milliseconds. Available values are 100, 200, 500, 1000 (1 second), 5000 (5 seconds), and 60000 (1 minute) milliseconds. The default value is 500 milliseconds."
+        },
+        "ProfilingParameters": {
+          "type": "object",
+          "properties": {
+            "string": {
+              "type": "string"
+            }
+          },
+          "required": [],
+          "description": "Configuration information for capturing framework metrics. Available key strings for different profiling options are DetailedProfilingConfig, PythonProfilingConfig, and DataLoaderProfilingConfig. The following codes are configuration structures for the ProfilingParameters parameter. To learn more about how to configure the ProfilingParameters parameter, see Use the SageMaker and Debugger Configuration API Operations to Create, Update, and Debug Your Training Job. Map Entries: Minimum number of 0 items. Maximum number of 20 items. Key Length Constraints: Minimum length of 1. Maximum length of 256. Key Pattern: .* Value Length Constraints: Maximum length of 256. Value Pattern: .*"
+        },
+        "S3OutputPath": {
+          "type": "string",
+          "description": "Path to Amazon S3 storage location for rules. Length Constraints: Maximum length of 1024.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+        }
+      },
+      "required": [],
+      "description": "Configuration information for Amazon SageMaker Debugger system monitoring, framework profiling, and storage paths."
+    },
+    "ProfilerRuleConfigurations": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "InstanceType": {
+              "type": "string",
+              "description": "The instance type to deploy a custom rule for profiling a training job. Valid Values: ml.t3.medium | ml.t3.large | ml.t3.xlarge | ml.t3.2xlarge | ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.r5.large | ml.r5.xlarge | ml.r5.2xlarge | ml.r5.4xlarge | ml.r5.8xlarge | ml.r5.12xlarge | ml.r5.16xlarge | ml.r5.24xlarge | ml.g4dn.xlarge | ml.g4dn.2xlarge | ml.g4dn.4xlarge | ml.g4dn.8xlarge | ml.g4dn.12xlarge | ml.g4dn.16xlarge"
+            },
+            "LocalPath": {
+              "type": "string",
+              "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+              "pattern": ".*"
+            },
+            "RuleConfigurationName": {
+              "type": "string",
+              "description": "The name of the rule configuration. It must be unique relative to other rule configuration names. Length Constraints: Minimum length of 1. Maximum length of 256.",
+              "pattern": ".*"
+            },
+            "RuleEvaluatorImage": {
+              "type": "string",
+              "description": "The Amazon Elastic Container Registry Image for the managed rule evaluation. Length Constraints: Maximum length of 255.",
+              "pattern": ".*"
+            },
+            "RuleParameters": {
+              "type": "object",
+              "properties": {
+                "string": {
+                  "type": "string"
+                }
+              },
+              "required": [],
+              "description": "Runtime configuration for rule container. Map Entries: Minimum number of 0 items. Maximum number of 100 items. Key Length Constraints: Minimum length of 1. Maximum length of 256. Key Pattern: .* Value Length Constraints: Maximum length of 256. Value Pattern: .*"
+            },
+            "S3OutputPath": {
+              "type": "string",
+              "description": "Path to Amazon S3 storage location for rules. Length Constraints: Maximum length of 1024.",
+              "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+            },
+            "VolumeSizeInGB": {
+              "type": "number",
+              "description": "The size, in GB, of the ML storage volume attached to the processing instance. Valid Range: Minimum value of 0."
+            }
+          },
+          "required": []
+        }
+      ],
+      "description": "Configuration information for Amazon SageMaker Debugger rules for profiling system and framework metrics. Array Members: Minimum number of 0 items. Maximum number of 20 items."
+    },
+    "ResourceConfig": {
+      "type": "object",
+      "properties": {
+        "InstanceCount": {
+          "type": "number",
+          "description": "The number of ML compute instances to use. For distributed training, provide a value greater than 1. Valid Range: Minimum value of 0."
+        },
+        "InstanceGroups": {
+          "type": "array",
+          "items": [
+            {
+              "type": "object",
+              "properties": {
+                "InstanceCount": {
+                  "type": "number",
+                  "description": "The number of ML compute instances to use. For distributed training, provide a value greater than 1. Valid Range: Minimum value of 0."
+                },
+                "InstanceGroupName": {
+                  "type": "string",
+                  "description": "Specifies the name of the instance group. Length Constraints: Minimum length of 1. Maximum length of 64.",
+                  "pattern": ".+"
+                },
+                "InstanceType": {
+                  "type": "string",
+                  "description": "The instance type to deploy a custom rule for profiling a training job. Valid Values: ml.t3.medium | ml.t3.large | ml.t3.xlarge | ml.t3.2xlarge | ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.r5.large | ml.r5.xlarge | ml.r5.2xlarge | ml.r5.4xlarge | ml.r5.8xlarge | ml.r5.12xlarge | ml.r5.16xlarge | ml.r5.24xlarge | ml.g4dn.xlarge | ml.g4dn.2xlarge | ml.g4dn.4xlarge | ml.g4dn.8xlarge | ml.g4dn.12xlarge | ml.g4dn.16xlarge"
+                }
+              },
+              "required": [
+                "InstanceGroupName"
+              ]
+            }
+          ],
+          "description": "The configuration of a heterogeneous cluster in JSON format. Array Members: Maximum number of 5 items."
+        },
+        "InstanceType": {
+          "type": "string",
+          "description": "The instance type to deploy a custom rule for profiling a training job. Valid Values: ml.t3.medium | ml.t3.large | ml.t3.xlarge | ml.t3.2xlarge | ml.m4.xlarge | ml.m4.2xlarge | ml.m4.4xlarge | ml.m4.10xlarge | ml.m4.16xlarge | ml.c4.xlarge | ml.c4.2xlarge | ml.c4.4xlarge | ml.c4.8xlarge | ml.p2.xlarge | ml.p2.8xlarge | ml.p2.16xlarge | ml.p3.2xlarge | ml.p3.8xlarge | ml.p3.16xlarge | ml.c5.xlarge | ml.c5.2xlarge | ml.c5.4xlarge | ml.c5.9xlarge | ml.c5.18xlarge | ml.m5.large | ml.m5.xlarge | ml.m5.2xlarge | ml.m5.4xlarge | ml.m5.12xlarge | ml.m5.24xlarge | ml.r5.large | ml.r5.xlarge | ml.r5.2xlarge | ml.r5.4xlarge | ml.r5.8xlarge | ml.r5.12xlarge | ml.r5.16xlarge | ml.r5.24xlarge | ml.g4dn.xlarge | ml.g4dn.2xlarge | ml.g4dn.4xlarge | ml.g4dn.8xlarge | ml.g4dn.12xlarge | ml.g4dn.16xlarge"
+        },
+        "KeepAlivePeriodInSeconds": {
+          "type": "number",
+          "description": "The duration of time in seconds to retain configured resources in a warm pool for subsequent training jobs. Valid Range: Minimum value of 0. Maximum value of 3600."
+        },
+        "VolumeKmsKeyId": {
+          "type": "string",
+          "description": "The AWS KMS key that SageMaker uses to encrypt data on the storage volume attached to the ML compute instance(s) that run the training job. NoteCertain Nitro-based instances include local storage, dependent on the instance type. Local storage volumes are encrypted using a hardware module on the instance. You can't request a VolumeKmsKeyId when using an instance type with local storage.For a list of instance types that support local instance storage, see Instance Store Volumes.For more information about local instance storage encryption, see SSD Instance Store Volumes. The VolumeKmsKeyId can be in any of the following formats: // KMS Key ID \"1234abcd-12ab-34cd-56ef-1234567890ab\" // Amazon Resource Name (ARN) of a KMS Key \"arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab\" Length Constraints: Maximum length of 2048.",
+          "pattern": ".*"
+        },
+        "VolumeSizeInGB": {
+          "type": "number",
+          "description": "The size, in GB, of the ML storage volume attached to the processing instance. Valid Range: Minimum value of 0."
+        }
+      },
+      "required": [],
+      "description": "The resources, including the ML compute instances and ML storage volumes, to use for model training. ML storage volumes store model artifacts and incremental states. Training algorithms might also use ML storage volumes for scratch space. If you want SageMaker to use the ML storage volume to store the training data, choose File as the TrainingInputMode in the algorithm specification. For distributed training algorithms, specify an instance count greater than 1."
+    },
+    "RetryStrategy": {
+      "type": "object",
+      "properties": {
+        "MaximumRetryAttempts": {
+          "type": "number",
+          "description": "The number of times to retry the job. When the job is retried, it's SecondaryStatus is changed to STARTING. Valid Range: Minimum value of 1. Maximum value of 30."
+        }
+      },
+      "required": [
+        "MaximumRetryAttempts"
+      ],
+      "description": "The number of times to retry the job when the job fails due to an InternalServerError."
+    },
+    "RoleArn": {
+      "type": "string",
+      "description": "The Amazon Resource Name (ARN) of an IAM role that SageMaker can assume to perform tasks on your behalf. During model training, SageMaker needs your permission to read input data from an S3 bucket, download a Docker image that contains training code, write model artifacts to an S3 bucket, write logs to Amazon CloudWatch Logs, and publish metrics to Amazon CloudWatch. You grant permissions for all of these tasks to an IAM role. For more information, see SageMaker Roles. NoteTo be able to pass this role to SageMaker, the caller of this API must have the iam:PassRole permission. Length Constraints: Minimum length of 20. Maximum length of 2048.",
+      "pattern": "^arn:aws[a-z\\-]*:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+$"
+    },
+    "StoppingCondition": {
+      "type": "object",
+      "properties": {
+        "MaxPendingTimeInSeconds": {
+          "type": "number",
+          "description": "The maximum length of time, in seconds, that a training or compilation job can be pending before it is stopped. Valid Range: Minimum value of 7200. Maximum value of 2419200."
+        },
+        "MaxRuntimeInSeconds": {
+          "type": "number",
+          "description": "The maximum length of time, in seconds, that a training or compilation job can run before it is stopped. For compilation jobs, if the job does not complete during this time, a TimeOut error is generated. We recommend starting with 900 seconds and increasing as necessary based on your model. For all other jobs, if the job does not complete during this time, SageMaker ends the job. When RetryStrategy is specified in the job request, MaxRuntimeInSeconds specifies the maximum time for all of the attempts in total, not each individual attempt. The default value is 1 day. The maximum value is 28 days. The maximum time that a TrainingJob can run in total, including any time spent publishing metrics or archiving and uploading models after it has been stopped, is 30 days. Valid Range: Minimum value of 1."
+        },
+        "MaxWaitTimeInSeconds": {
+          "type": "number",
+          "description": "The maximum length of time, in seconds, that a managed Spot training job has to complete. It is the amount of time spent waiting for Spot capacity plus the amount of time the job can run. It must be equal to or greater than MaxRuntimeInSeconds. If the job does not complete during this time, SageMaker ends the job. When RetryStrategy is specified in the job request, MaxWaitTimeInSeconds specifies the maximum time for all of the attempts in total, not each individual attempt. Valid Range: Minimum value of 1."
+        }
+      },
+      "required": [],
+      "description": "Specifies a limit to how long a model training job can run. It also specifies how long a managed Spot training job has to complete. When the job reaches the time limit, SageMaker ends the training job. Use this API to cap model training costs. To stop a job, SageMaker sends the algorithm the SIGTERM signal, which delays job termination for 120 seconds. Algorithms can use this 120-second window to save the model artifacts, so the results of training are not lost."
+    },
+    "Tags": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "Key": {
+              "type": "string",
+              "description": "The tag key. Tag keys must be unique per resource. Length Constraints: Minimum length of 1. Maximum length of 128.",
+              "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+            },
+            "Value": {
+              "type": "string",
+              "description": "The tag value. Length Constraints: Minimum length of 0. Maximum length of 256.",
+              "pattern": "^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$"
+            }
+          },
+          "required": [
+            "Key",
+            "Value"
+          ]
+        }
+      ],
+      "description": "An array of key-value pairs. You can use tags to categorize your AWS resources in different ways, for example, by purpose, owner, or environment. For more information, see Tagging AWS Resources. Array Members: Minimum number of 0 items. Maximum number of 50 items."
+    },
+    "TensorBoardOutputConfig": {
+      "type": "object",
+      "properties": {
+        "LocalPath": {
+          "type": "string",
+          "description": "Path to local storage location for output of rules. Defaults to /opt/ml/processing/output/rule/. Length Constraints: Maximum length of 4096.",
+          "pattern": ".*"
+        },
+        "S3OutputPath": {
+          "type": "string",
+          "description": "Path to Amazon S3 storage location for rules. Length Constraints: Maximum length of 1024.",
+          "pattern": "^(https|s3)://([^/]+)/?(.*)$"
+        }
+      },
+      "required": [],
+      "description": "Configuration of storage locations for the Amazon SageMaker Debugger TensorBoard output data."
+    },
+    "TrainingJobName": {
+      "type": "string",
+      "description": "The name of the training job. The name must be unique within an AWS Region in an AWS account. Length Constraints: Minimum length of 1. Maximum length of 63.",
+      "pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9]){0,62}"
+    },
+    "VpcConfig": {
+      "type": "object",
+      "properties": {
+        "SecurityGroupIds": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            }
+          ],
+          "description": "The VPC security group IDs, in the form sg-xxxxxxxx. Specify the security groups for the VPC that is specified in the Subnets field. Array Members: Minimum number of 1 item. Maximum number of 5 items. Length Constraints: Maximum length of 32.",
+          "pattern": "[-0-9a-zA-Z]+"
+        },
+        "Subnets": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            }
+          ],
+          "description": "The ID of the subnets in the VPC to which you want to connect your training job or model. For information about the availability of specific instance types, see Supported Instance Types and Availability Zones. Array Members: Minimum number of 1 item. Maximum number of 16 items. Length Constraints: Maximum length of 32.",
+          "pattern": "[-0-9a-zA-Z]+"
+        }
+      },
+      "required": [
+        "SecurityGroupIds",
+        "Subnets"
+      ],
+      "description": "A VpcConfig object that specifies the VPC that you want your training job to connect to. Control access to and from your training container by configuring the VPC. For more information, see Protect Training Jobs by Using an Amazon Virtual Private Cloud."
+    },
+    "type": {
+      "type": "object"
+    },
+    "schema": {
+      "type": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  "required": [
+    "AlgorithmSpecification",
+    "OutputDataConfig",
+    "ResourceConfig",
+    "RoleArn",
+    "StoppingCondition",
+    "TrainingJobName"
+  ]
+}

--- a/weave-js/src/common/components/Monaco/schemas/vertex.json
+++ b/weave-js/src/common/components/Monaco/schemas/vertex.json
@@ -1,0 +1,305 @@
+{
+  "type": "object",
+  "schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "spec": {
+      "properties": {
+        "base_output_directory": {
+          "description": "The Google Cloud Storage location where the output is to be written to.",
+          "type": "object",
+          "id": "google_cloud_aiplatform_v1_gcs_destination",
+          "properties": {
+            "output_uri_prefix": {
+              "description": "Required. Google Cloud Storage URI to output directory. If the uri doesn't end with '/', a '/' will be automatically appended. The directory is created if it doesn't exist.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "output_uri_prefix"
+          ]
+        },
+        "worker_pool_specs": {
+          "type": "array",
+          "description": "Required. The spec of the worker pools including machine type and Docker image. All worker pools except the first one are optional and can be skipped by providing an empty value.",
+          "items": {
+            "id": "google_cloud_aiplatform_v1_worker_pool_spec",
+            "description": "Represents the spec of a worker pool in a job.",
+            "properties": {
+              "nfs_mounts": {
+                "type": "array",
+                "description": "Optional. List of NFS mount spec.",
+                "items": {
+                  "description": "Represents a mount configuration for Network File System (NFS) to mount.",
+                  "type": "object",
+                  "id": "google_cloud_aiplatform_v1_nfs_mount",
+                  "properties": {
+                    "server": {
+                      "description": "Required. IP address of the NFS server.",
+                      "type": "string"
+                    },
+                    "path": {
+                      "type": "string",
+                      "description": "Required. Source path exported from NFS server. Has to start with '/', and combined with the ip address, it indicates the source mount path in the form of `server:path`"
+                    },
+                    "mount_point": {
+                      "description": "Required. Destination mount path. The NFS will be mounted for the user under /mnt/nfs/",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "server",
+                    "path",
+                    "mount_point"
+                  ]
+                }
+              },
+              "python_package_spec": {
+                "description": "The spec of a Python packaged code.",
+                "type": "object",
+                "properties": {
+                  "args": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "description": "Command line arguments to be passed to the Python task."
+                  },
+                  "executor_image_uri": {
+                    "description": "Required. The URI of a container image in Artifact Registry that will run the provided Python package. Vertex AI provides a wide range of executor images with pre-installed packages to meet users' various use cases. See the list of [pre-built containers for training](https://cloud.google.com/vertex-ai/docs/training/pre-built-containers). You must use an image from this list.",
+                    "type": "string"
+                  },
+                  "env": {
+                    "type": "array",
+                    "description": "Environment variables to be passed to the python module. Maximum limit is 100.",
+                    "items": {
+                      "description": "Represents an environment variable present in a Container or Python Module.",
+                      "id": "google_cloud_aiplatform_v1_env_var",
+                      "properties": {
+                        "value": {
+                          "description": "Required. Variables that reference a $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Required. Name of the environment variable. Must be a valid C identifier.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "required": [
+                        "value",
+                        "name"
+                      ]
+                    }
+                  },
+                  "package_uris": {
+                    "type": "array",
+                    "description": "Required. The Google Cloud Storage location of the Python package files which are the training program and its dependent packages. The maximum number of package URIs is 100.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "python_module": {
+                    "description": "Required. The Python module name to run after installing the packages.",
+                    "type": "string"
+                  }
+                },
+                "id": "google_cloud_aiplatform_v1_python_package_spec",
+                "required": [
+                  "executor_image_uri",
+                  "package_uris",
+                  "python_module"
+                ]
+              },
+              "container_spec": {
+                "description": "The spec of a Container.",
+                "type": "object",
+                "id": "google_cloud_aiplatform_v1_container_spec",
+                "properties": {
+                  "command": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "The command to be invoked when the container is started. It overrides the entrypoint instruction in Dockerfile when provided.",
+                    "type": "array"
+                  },
+                  "image_uri": {
+                    "type": "string",
+                    "description": "Required. The URI of a container image in the Container Registry that is to be run on each worker replica."
+                  },
+                  "args": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array",
+                    "description": "The arguments to be passed when starting the container."
+                  },
+                  "env": {
+                    "description": "Environment variables to be passed to the container. Maximum limit is 100.",
+                    "items": {
+                      "description": "Represents an environment variable present in a Container or Python Module.",
+                      "id": "google_cloud_aiplatform_v1_env_var",
+                      "properties": {
+                        "value": {
+                          "description": "Required. Variables that reference a $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Required. Name of the environment variable. Must be a valid C identifier.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "required": [
+                        "value",
+                        "name"
+                      ]
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "image_uri"
+                ]
+              },
+              "replica_count": {
+                "description": "Optional. The number of worker replicas to use for this worker pool.",
+                "format": "int64",
+                "type": "string"
+              },
+              "disk_spec": {
+                "description": "Represents the spec of disk options.",
+                "id": "google_cloud_aiplatform_v1_disk_spec",
+                "type": "object",
+                "properties": {
+                  "boot_disk_type": {
+                    "type": "string",
+                    "description": "Type of the boot disk (default is \"pd-ssd\"). Valid values: \"pd-ssd\" (Persistent Disk Solid State Drive) or \"pd-standard\" (Persistent Disk Hard Disk Drive)."
+                  },
+                  "boot_disk_size_gb": {
+                    "type": "integer",
+                    "description": "Size in GB of the boot disk (default is 100GB).",
+                    "format": "int32"
+                  }
+                }
+              },
+              "machine_spec": {
+                "description": "Specification of a single machine.",
+                "id": "google_cloud_aiplatform_v1_machine_spec",
+                "properties": {
+                  "accelerator_type": {
+                    "type": "string",
+                    "enumDescriptions": [
+                      "Unspecified accelerator type, which means no accelerator.",
+                      "Nvidia Tesla K80 GPU.",
+                      "Nvidia Tesla P100 GPU.",
+                      "Nvidia Tesla V100 GPU.",
+                      "Nvidia Tesla P4 GPU.",
+                      "Nvidia Tesla T4 GPU.",
+                      "Nvidia Tesla A100 GPU.",
+                      "Nvidia A100 80GB GPU.",
+                      "Nvidia L4 GPU.",
+                      "TPU v2.",
+                      "TPU v3.",
+                      "TPU v4."
+                    ],
+                    "enum": [
+                      "ACCELERATOR_TYPE_UNSPECIFIED",
+                      "NVIDIA_TESLA_K80",
+                      "NVIDIA_TESLA_P100",
+                      "NVIDIA_TESLA_V100",
+                      "NVIDIA_TESLA_P4",
+                      "NVIDIA_TESLA_T4",
+                      "NVIDIA_TESLA_A100",
+                      "NVIDIA_A100_80GB",
+                      "NVIDIA_L4",
+                      "TPU_V2",
+                      "TPU_V3",
+                      "TPU_V4_POD"
+                    ],
+                    "description": "Immutable. The type of accelerator(s) that may be attached to the machine as per accelerator_count."
+                  },
+                  "machine_type": {
+                    "description": "Immutable. The type of the machine. See the [list of machine types supported for prediction](https://cloud.google.com/vertex-ai/docs/predictions/configure-compute#machine-types) See the [list of machine types supported for custom training](https://cloud.google.com/vertex-ai/docs/training/configure-compute#machine-types). For DeployedModel this field is optional, and the default value is `n1-standard-2`. For BatchPredictionJob or as part of WorkerPoolSpec this field is required.",
+                    "type": "string"
+                  },
+                  "accelerator_count": {
+                    "description": "The number of accelerators to attach to the machine.",
+                    "format": "int32",
+                    "type": "integer"
+                  },
+                  "tpu_topology": {
+                    "description": "Immutable. The topology of the TPUs. Corresponds to the TPU topologies available from GKE. (Example: tpu_topology: \"2x2x1\").",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "required": [
+            "container_spec"
+          ]
+        },
+        "staging_bucket": {
+          "type": "string",
+          "description": "The staging bucket for the custom job.",
+          "pattern": "^gs://[a-z0-9-]+/.*$"
+        },
+        "encryption_key_spec_name": {
+          "type": "string",
+          "description": [
+            "Customer-managed encryption key name for a CustomJob. If this is set, then all resources created by the CustomJob will be encrypted with the provided encryption key."
+          ]
+        },
+        "labels": {
+          "type": "object",
+          "description": "The labels with user-defined metadata to organize CustomJobs. Label keys and values can be no longer than 64 characters (Unicode codepoints), can only contain lowercase letters, numeric characters, underscores and dashes. International characters are allowed. See https://goo.gl/xmQnxf for more information and examples of labels.."
+        }
+      },
+      "required": [
+        "worker_pool_specs",
+        "staging_bucket"
+      ],
+      "description": "Arguments to the CustomJob constructor in the Vertex AI Python SDK. See https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform.CustomJob for more information."
+    },
+    "run": {
+      "type": "object",
+      "properties": {
+        "network": {
+          "description": "Optional. The full name of the Compute Engine [network](/compute/docs/networks-and-firewalls#networks) to which the Job should be peered. For example, `projects/12345/global/networks/myVPC`. [Format](/compute/docs/reference/rest/v1/networks/insert) is of the form `projects/{project}/global/networks/{network}`. Where {project} is a project number, as in `12345`, and {network} is a network name. To specify this field, you must have already [configured VPC Network Peering for Vertex AI](https://cloud.google.com/vertex-ai/docs/general/vpc-peering). If this field is left unspecified, the job is not peered with any network.",
+          "type": "string"
+        },
+        "enable_web_access": {
+          "type": "boolean",
+          "description": "Optional. Whether you want Vertex AI to enable [interactive shell access](https://cloud.google.com/vertex-ai/docs/training/monitor-debug-interactive-shell) to training containers. If set to `true`, you can access interactive shells at the URIs given by CustomJob.web_access_uris or Trial.web_access_uris (within HyperparameterTuningJob.trials)."
+        },
+        "experiment_run": {
+          "description": "Optional. The Experiment Run associated with this job. Format: `projects/{project}/locations/{location}/metadataStores/{metadataStores}/contexts/{experiment-name}-{experiment-run-name}`",
+          "type": "string"
+        },
+        "experiment": {
+          "description": "Optional. The Experiment associated with this job. Format: `projects/{project}/locations/{location}/metadataStores/{metadataStores}/contexts/{experiment-name}`",
+          "type": "string"
+        },
+        "tensorboard": {
+          "description": "Optional. The name of a Vertex AI Tensorboard resource to which this CustomJob will upload Tensorboard logs. Format: `projects/{project}/locations/{location}/tensorboards/{tensorboard}`",
+          "type": "string"
+        },
+        "service_account": {
+          "description": "Specifies the service account for workload run-as account. Users submitting jobs must have act-as permission on this run-as account. If unspecified, the [Vertex AI Custom Code Service Agent](https://cloud.google.com/vertex-ai/docs/general/access-control#service-agents) for the CustomJob's project is used.",
+          "type": "string"
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "The maximum job running time in seconds. The default is 7 days (604800 seconds). "
+        },
+        "restart_job_on_worker_restart": {
+          "type": "boolean",
+          "description": "Restarts the entire CustomJob if a worker gets restarted. This feature can be used by distributed training jobs that are not resilient to workers leaving and joining a job."
+        }
+      },
+      "description": "Arguments to the CustomJob.run (or submit, if async) method in the Vertex AI Python SDK. See https://cloud.google.com/python/docs/reference/aiplatform/latest/google.cloud.aiplatform.CustomJob#google_cloud_aiplatform_CustomJob_run for more information."
+    }
+  }
+}

--- a/weave-js/src/common/components/Monaco/schemas/volcanojob.json
+++ b/weave-js/src/common/components/Monaco/schemas/volcanojob.json
@@ -1,0 +1,4804 @@
+{
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "creationTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "deletionGracePeriodSeconds": {
+          "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "deletionTimestamp": {
+          "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "finalizers": {
+          "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "generateName": {
+          "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will return a 409.\n\nApplied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency",
+          "type": "string"
+        },
+        "generation": {
+          "description": "A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "labels": {
+          "description": "Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "managedFields": {
+          "description": "ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like \"ci-cd\". The set of fields is always in the version that the workflow used when modifying the object.",
+          "type": "array",
+          "items": {
+            "description": "ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.",
+            "type": "object",
+            "properties": {
+              "apiVersion": {
+                "description": "APIVersion defines the version of this resource that this field set applies to. The format is \"group/version\" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.",
+                "type": "string"
+              },
+              "fieldsType": {
+                "description": "FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: \"FieldsV1\"",
+                "type": "string"
+              },
+              "fieldsV1": {
+                "description": "FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.\n\nEach key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.\n\nThe exact format is defined in sigs.k8s.io/structured-merge-diff",
+                "type": "object"
+              },
+              "manager": {
+                "description": "Manager is an identifier of the workflow managing these fields.",
+                "type": "string"
+              },
+              "operation": {
+                "description": "Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.",
+                "type": "string"
+              },
+              "subresource": {
+                "description": "Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.",
+                "type": "string"
+              },
+              "time": {
+                "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "name": {
+          "description": "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.\n\nMust be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces",
+          "type": "string"
+        },
+        "ownerReferences": {
+          "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
+          "type": "array",
+          "items": {
+            "description": "OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.",
+            "type": "object",
+            "required": ["apiVersion", "kind", "name", "uid"],
+            "properties": {
+              "apiVersion": {
+                "description": "API version of the referent.",
+                "type": "string"
+              },
+              "blockOwnerDeletion": {
+                "description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs \"delete\" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.",
+                "type": "boolean"
+              },
+              "controller": {
+                "description": "If true, this reference points to the managing controller.",
+                "type": "boolean"
+              },
+              "kind": {
+                "description": "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                "type": "string"
+              },
+              "name": {
+                "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names",
+                "type": "string"
+              },
+              "uid": {
+                "description": "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+                "type": "string"
+              }
+            },
+            "x-kubernetes-map-type": "atomic"
+          },
+          "x-kubernetes-patch-merge-key": "uid",
+          "x-kubernetes-patch-strategy": "merge"
+        },
+        "resourceVersion": {
+          "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+          "type": "string"
+        },
+        "selfLink": {
+          "description": "Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.",
+          "type": "string"
+        },
+        "uid": {
+          "description": "UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.\n\nPopulated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids",
+          "type": "string"
+        }
+      }
+    },
+    "spec": {
+      "type": "object",
+      "properties": {
+        "maxRetry": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "minAvailable": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "minSuccess": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1
+        },
+        "plugins": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "policies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string"
+              },
+              "event": {
+                "type": "string"
+              },
+              "events": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "exitCode": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "timeout": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "queue": {
+          "type": "string"
+        },
+        "runningEstimate": {
+          "type": "string"
+        },
+        "schedulerName": {
+          "type": "string"
+        },
+        "tasks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dependsOn": {
+                "type": "object",
+                "properties": {
+                  "iteration": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "maxRetry": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "minAvailable": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "name": {
+                "type": "string"
+              },
+              "policies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "action": {
+                      "type": "string"
+                    },
+                    "event": {
+                      "type": "string"
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "exitCode": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "timeout": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "replicas": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "template": {
+                "type": "object",
+                "properties": {
+                  "metadata": {
+                    "type": "object",
+                    "properties": {
+                      "annotations": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "finalizers": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "spec": {
+                    "type": "object",
+                    "required": ["containers"],
+                    "properties": {
+                      "activeDeadlineSeconds": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "affinity": {
+                        "type": "object",
+                        "properties": {
+                          "nodeAffinity": {
+                            "type": "object",
+                            "properties": {
+                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": ["preference", "weight"],
+                                  "properties": {
+                                    "preference": {
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    }
+                                  }
+                                }
+                              },
+                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "type": "object",
+                                "required": ["nodeSelectorTerms"],
+                                "properties": {
+                                  "nodeSelectorTerms": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchFields": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "podAffinity": {
+                            "type": "object",
+                            "properties": {
+                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": ["podAffinityTerm", "weight"],
+                                  "properties": {
+                                    "podAffinityTerm": {
+                                      "type": "object",
+                                      "required": ["topologyKey"],
+                                      "properties": {
+                                        "labelSelector": {
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "namespaceSelector": {
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "namespaces": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "topologyKey": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    }
+                                  }
+                                }
+                              },
+                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": ["topologyKey"],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "namespaceSelector": {
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "namespaces": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "topologyKey": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "podAntiAffinity": {
+                            "type": "object",
+                            "properties": {
+                              "preferredDuringSchedulingIgnoredDuringExecution": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": ["podAffinityTerm", "weight"],
+                                  "properties": {
+                                    "podAffinityTerm": {
+                                      "type": "object",
+                                      "required": ["topologyKey"],
+                                      "properties": {
+                                        "labelSelector": {
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "namespaceSelector": {
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "namespaces": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "topologyKey": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "weight": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    }
+                                  }
+                                }
+                              },
+                              "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": ["topologyKey"],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "namespaceSelector": {
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["key", "operator"],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "matchLabels": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "namespaces": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "topologyKey": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "automountServiceAccountToken": {
+                        "type": "boolean"
+                      },
+                      "containers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "args": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "command": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "env": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  },
+                                  "valueFrom": {
+                                    "type": "object",
+                                    "properties": {
+                                      "configMapKeyRef": {
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      },
+                                      "fieldRef": {
+                                        "type": "object",
+                                        "required": ["fieldPath"],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "resourceFieldRef": {
+                                        "type": "object",
+                                        "required": ["resource"],
+                                        "properties": {
+                                          "containerName": {
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "secretKeyRef": {
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "envFrom": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "configMapRef": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  },
+                                  "prefix": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imagePullPolicy": {
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "type": "object",
+                              "properties": {
+                                "postStart": {
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preStop": {
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "livenessProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ports": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["containerPort"],
+                                "properties": {
+                                  "containerPort": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "hostIP": {
+                                    "type": "string"
+                                  },
+                                  "hostPort": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "containerPort",
+                                "protocol"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "readinessProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "resizePolicy": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["resourceName", "restartPolicy"],
+                                "properties": {
+                                  "resourceName": {
+                                    "type": "string"
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "resources": {
+                              "type": "object",
+                              "properties": {
+                                "claims": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-map-keys": ["name"],
+                                  "x-kubernetes-list-type": "map"
+                                },
+                                "limits": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "requests": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            },
+                            "securityContext": {
+                              "type": "object",
+                              "properties": {
+                                "allowPrivilegeEscalation": {
+                                  "type": "boolean"
+                                },
+                                "capabilities": {
+                                  "type": "object",
+                                  "properties": {
+                                    "add": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "drop": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "privileged": {
+                                  "type": "boolean"
+                                },
+                                "procMount": {
+                                  "type": "string"
+                                },
+                                "readOnlyRootFilesystem": {
+                                  "type": "boolean"
+                                },
+                                "runAsGroup": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "runAsNonRoot": {
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "seLinuxOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "level": {
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "seccompProfile": {
+                                  "type": "object",
+                                  "required": ["type"],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "windowsOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "startupProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "stdin": {
+                              "type": "boolean"
+                            },
+                            "stdinOnce": {
+                              "type": "boolean"
+                            },
+                            "terminationMessagePath": {
+                              "type": "string"
+                            },
+                            "terminationMessagePolicy": {
+                              "type": "string"
+                            },
+                            "tty": {
+                              "type": "boolean"
+                            },
+                            "volumeDevices": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["devicePath", "name"],
+                                "properties": {
+                                  "devicePath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "volumeMounts": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["mountPath", "name"],
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "mountPropagation": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "subPath": {
+                                    "type": "string"
+                                  },
+                                  "subPathExpr": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "workingDir": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "dnsConfig": {
+                        "type": "object",
+                        "properties": {
+                          "nameservers": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "options": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "searches": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "dnsPolicy": {
+                        "type": "string"
+                      },
+                      "enableServiceLinks": {
+                        "type": "boolean"
+                      },
+                      "ephemeralContainers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "args": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "command": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "env": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  },
+                                  "valueFrom": {
+                                    "type": "object",
+                                    "properties": {
+                                      "configMapKeyRef": {
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      },
+                                      "fieldRef": {
+                                        "type": "object",
+                                        "required": ["fieldPath"],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "resourceFieldRef": {
+                                        "type": "object",
+                                        "required": ["resource"],
+                                        "properties": {
+                                          "containerName": {
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "secretKeyRef": {
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "envFrom": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "configMapRef": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  },
+                                  "prefix": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imagePullPolicy": {
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "type": "object",
+                              "properties": {
+                                "postStart": {
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preStop": {
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "livenessProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ports": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["containerPort"],
+                                "properties": {
+                                  "containerPort": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "hostIP": {
+                                    "type": "string"
+                                  },
+                                  "hostPort": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "containerPort",
+                                "protocol"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "readinessProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "resizePolicy": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["resourceName", "restartPolicy"],
+                                "properties": {
+                                  "resourceName": {
+                                    "type": "string"
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "resources": {
+                              "type": "object",
+                              "properties": {
+                                "claims": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-map-keys": ["name"],
+                                  "x-kubernetes-list-type": "map"
+                                },
+                                "limits": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "requests": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            },
+                            "securityContext": {
+                              "type": "object",
+                              "properties": {
+                                "allowPrivilegeEscalation": {
+                                  "type": "boolean"
+                                },
+                                "capabilities": {
+                                  "type": "object",
+                                  "properties": {
+                                    "add": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "drop": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "privileged": {
+                                  "type": "boolean"
+                                },
+                                "procMount": {
+                                  "type": "string"
+                                },
+                                "readOnlyRootFilesystem": {
+                                  "type": "boolean"
+                                },
+                                "runAsGroup": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "runAsNonRoot": {
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "seLinuxOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "level": {
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "seccompProfile": {
+                                  "type": "object",
+                                  "required": ["type"],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "windowsOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "startupProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "stdin": {
+                              "type": "boolean"
+                            },
+                            "stdinOnce": {
+                              "type": "boolean"
+                            },
+                            "targetContainerName": {
+                              "type": "string"
+                            },
+                            "terminationMessagePath": {
+                              "type": "string"
+                            },
+                            "terminationMessagePolicy": {
+                              "type": "string"
+                            },
+                            "tty": {
+                              "type": "boolean"
+                            },
+                            "volumeDevices": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["devicePath", "name"],
+                                "properties": {
+                                  "devicePath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "volumeMounts": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["mountPath", "name"],
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "mountPropagation": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "subPath": {
+                                    "type": "string"
+                                  },
+                                  "subPathExpr": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "workingDir": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "hostAliases": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "hostnames": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "ip": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "hostIPC": {
+                        "type": "boolean"
+                      },
+                      "hostNetwork": {
+                        "type": "boolean"
+                      },
+                      "hostPID": {
+                        "type": "boolean"
+                      },
+                      "hostUsers": {
+                        "type": "boolean"
+                      },
+                      "hostname": {
+                        "type": "string"
+                      },
+                      "imagePullSecrets": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "initContainers": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "args": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "command": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "env": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  },
+                                  "valueFrom": {
+                                    "type": "object",
+                                    "properties": {
+                                      "configMapKeyRef": {
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      },
+                                      "fieldRef": {
+                                        "type": "object",
+                                        "required": ["fieldPath"],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "resourceFieldRef": {
+                                        "type": "object",
+                                        "required": ["resource"],
+                                        "properties": {
+                                          "containerName": {
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "secretKeyRef": {
+                                        "type": "object",
+                                        "required": ["key"],
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "envFrom": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "configMapRef": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  },
+                                  "prefix": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imagePullPolicy": {
+                              "type": "string"
+                            },
+                            "lifecycle": {
+                              "type": "object",
+                              "properties": {
+                                "postStart": {
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preStop": {
+                                  "type": "object",
+                                  "properties": {
+                                    "exec": {
+                                      "type": "object",
+                                      "properties": {
+                                        "command": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "httpGet": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "httpHeaders": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": ["name", "value"],
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "scheme": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "tcpSocket": {
+                                      "type": "object",
+                                      "required": ["port"],
+                                      "properties": {
+                                        "host": {
+                                          "type": "string"
+                                        },
+                                        "port": {
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "livenessProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ports": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["containerPort"],
+                                "properties": {
+                                  "containerPort": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "hostIP": {
+                                    "type": "string"
+                                  },
+                                  "hostPort": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "containerPort",
+                                "protocol"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "readinessProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "resizePolicy": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["resourceName", "restartPolicy"],
+                                "properties": {
+                                  "resourceName": {
+                                    "type": "string"
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "resources": {
+                              "type": "object",
+                              "properties": {
+                                "claims": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": ["name"],
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-map-keys": ["name"],
+                                  "x-kubernetes-list-type": "map"
+                                },
+                                "limits": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "requests": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            },
+                            "securityContext": {
+                              "type": "object",
+                              "properties": {
+                                "allowPrivilegeEscalation": {
+                                  "type": "boolean"
+                                },
+                                "capabilities": {
+                                  "type": "object",
+                                  "properties": {
+                                    "add": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "drop": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "privileged": {
+                                  "type": "boolean"
+                                },
+                                "procMount": {
+                                  "type": "string"
+                                },
+                                "readOnlyRootFilesystem": {
+                                  "type": "boolean"
+                                },
+                                "runAsGroup": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "runAsNonRoot": {
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "seLinuxOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "level": {
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "seccompProfile": {
+                                  "type": "object",
+                                  "required": ["type"],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "windowsOptions": {
+                                  "type": "object",
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "startupProbe": {
+                              "type": "object",
+                              "properties": {
+                                "exec": {
+                                  "type": "object",
+                                  "properties": {
+                                    "command": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "failureThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "grpc": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "port": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "service": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "httpGet": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "httpHeaders": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "required": ["name", "value"],
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "scheme": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "initialDelaySeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "periodSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "successThreshold": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "tcpSocket": {
+                                  "type": "object",
+                                  "required": ["port"],
+                                  "properties": {
+                                    "host": {
+                                      "type": "string"
+                                    },
+                                    "port": {
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                },
+                                "terminationGracePeriodSeconds": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "timeoutSeconds": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            },
+                            "stdin": {
+                              "type": "boolean"
+                            },
+                            "stdinOnce": {
+                              "type": "boolean"
+                            },
+                            "terminationMessagePath": {
+                              "type": "string"
+                            },
+                            "terminationMessagePolicy": {
+                              "type": "string"
+                            },
+                            "tty": {
+                              "type": "boolean"
+                            },
+                            "volumeDevices": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["devicePath", "name"],
+                                "properties": {
+                                  "devicePath": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "volumeMounts": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": ["mountPath", "name"],
+                                "properties": {
+                                  "mountPath": {
+                                    "type": "string"
+                                  },
+                                  "mountPropagation": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "subPath": {
+                                    "type": "string"
+                                  },
+                                  "subPathExpr": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "workingDir": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "nodeName": {
+                        "type": "string"
+                      },
+                      "nodeSelector": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "os": {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "overhead": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "preemptionPolicy": {
+                        "type": "string"
+                      },
+                      "priority": {
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "priorityClassName": {
+                        "type": "string"
+                      },
+                      "readinessGates": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["conditionType"],
+                          "properties": {
+                            "conditionType": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "resourceClaims": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "type": "object",
+                              "properties": {
+                                "resourceClaimName": {
+                                  "type": "string"
+                                },
+                                "resourceClaimTemplateName": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      },
+                      "runtimeClassName": {
+                        "type": "string"
+                      },
+                      "schedulerName": {
+                        "type": "string"
+                      },
+                      "schedulingGates": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "securityContext": {
+                        "type": "object",
+                        "properties": {
+                          "fsGroup": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "fsGroupChangePolicy": {
+                            "type": "string"
+                          },
+                          "runAsGroup": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "seLinuxOptions": {
+                            "type": "object",
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "seccompProfile": {
+                            "type": "object",
+                            "required": ["type"],
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "supplementalGroups": {
+                            "type": "array",
+                            "items": {
+                              "type": "integer",
+                              "format": "int64"
+                            }
+                          },
+                          "sysctls": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": ["name", "value"],
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "windowsOptions": {
+                            "type": "object",
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "serviceAccount": {
+                        "type": "string"
+                      },
+                      "serviceAccountName": {
+                        "type": "string"
+                      },
+                      "setHostnameAsFQDN": {
+                        "type": "boolean"
+                      },
+                      "shareProcessNamespace": {
+                        "type": "boolean"
+                      },
+                      "subdomain": {
+                        "type": "string"
+                      },
+                      "terminationGracePeriodSeconds": {
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "tolerations": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "effect": {
+                              "type": "string"
+                            },
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "tolerationSeconds": {
+                              "type": "integer",
+                              "format": "int64"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "topologySpreadConstraints": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "maxSkew",
+                            "topologyKey",
+                            "whenUnsatisfiable"
+                          ],
+                          "properties": {
+                            "labelSelector": {
+                              "type": "object",
+                              "properties": {
+                                "matchExpressions": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": ["key", "operator"],
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "matchLabels": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "matchLabelKeys": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "maxSkew": {
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "minDomains": {
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "nodeAffinityPolicy": {
+                              "type": "string"
+                            },
+                            "nodeTaintsPolicy": {
+                              "type": "string"
+                            },
+                            "topologyKey": {
+                              "type": "string"
+                            },
+                            "whenUnsatisfiable": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "topologyKey",
+                          "whenUnsatisfiable"
+                        ],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "volumes": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "awsElasticBlockStore": {
+                              "type": "object",
+                              "required": ["volumeID"],
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "partition": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "volumeID": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "azureDisk": {
+                              "type": "object",
+                              "required": ["diskName", "diskURI"],
+                              "properties": {
+                                "cachingMode": {
+                                  "type": "string"
+                                },
+                                "diskName": {
+                                  "type": "string"
+                                },
+                                "diskURI": {
+                                  "type": "string"
+                                },
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "kind": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "azureFile": {
+                              "type": "object",
+                              "required": ["secretName", "shareName"],
+                              "properties": {
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "secretName": {
+                                  "type": "string"
+                                },
+                                "shareName": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "cephfs": {
+                              "type": "object",
+                              "required": ["monitors"],
+                              "properties": {
+                                "monitors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "secretFile": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "cinder": {
+                              "type": "object",
+                              "required": ["volumeID"],
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "volumeID": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "configMap": {
+                              "type": "object",
+                              "properties": {
+                                "defaultMode": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": ["key", "path"],
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "csi": {
+                              "type": "object",
+                              "required": ["driver"],
+                              "properties": {
+                                "driver": {
+                                  "type": "string"
+                                },
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "nodePublishSecretRef": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "volumeAttributes": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "downwardAPI": {
+                              "type": "object",
+                              "properties": {
+                                "defaultMode": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": ["path"],
+                                    "properties": {
+                                      "fieldRef": {
+                                        "type": "object",
+                                        "required": ["fieldPath"],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "mode": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "type": "object",
+                                        "required": ["resource"],
+                                        "properties": {
+                                          "containerName": {
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "emptyDir": {
+                              "type": "object",
+                              "properties": {
+                                "medium": {
+                                  "type": "string"
+                                },
+                                "sizeLimit": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            },
+                            "ephemeral": {
+                              "type": "object",
+                              "properties": {
+                                "volumeClaimTemplate": {
+                                  "type": "object",
+                                  "required": ["spec"],
+                                  "properties": {
+                                    "metadata": {
+                                      "type": "object",
+                                      "properties": {
+                                        "annotations": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "finalizers": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "labels": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "namespace": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "spec": {
+                                      "type": "object",
+                                      "properties": {
+                                        "accessModes": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "dataSource": {
+                                          "type": "object",
+                                          "required": ["kind", "name"],
+                                          "properties": {
+                                            "apiGroup": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "dataSourceRef": {
+                                          "type": "object",
+                                          "required": ["kind", "name"],
+                                          "properties": {
+                                            "apiGroup": {
+                                              "type": "string"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "namespace": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "resources": {
+                                          "type": "object",
+                                          "properties": {
+                                            "claims": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "required": ["name"],
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-list-map-keys": [
+                                                "name"
+                                              ],
+                                              "x-kubernetes-list-type": "map"
+                                            },
+                                            "limits": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "requests": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "selector": {
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "required": ["key", "operator"],
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "matchLabels": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "storageClassName": {
+                                          "type": "string"
+                                        },
+                                        "volumeMode": {
+                                          "type": "string"
+                                        },
+                                        "volumeName": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "fc": {
+                              "type": "object",
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "lun": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "targetWWNs": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "wwids": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "flexVolume": {
+                              "type": "object",
+                              "required": ["driver"],
+                              "properties": {
+                                "driver": {
+                                  "type": "string"
+                                },
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "options": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "flocker": {
+                              "type": "object",
+                              "properties": {
+                                "datasetName": {
+                                  "type": "string"
+                                },
+                                "datasetUUID": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "gcePersistentDisk": {
+                              "type": "object",
+                              "required": ["pdName"],
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "partition": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "pdName": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "gitRepo": {
+                              "type": "object",
+                              "required": ["repository"],
+                              "properties": {
+                                "directory": {
+                                  "type": "string"
+                                },
+                                "repository": {
+                                  "type": "string"
+                                },
+                                "revision": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "glusterfs": {
+                              "type": "object",
+                              "required": ["endpoints", "path"],
+                              "properties": {
+                                "endpoints": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "hostPath": {
+                              "type": "object",
+                              "required": ["path"],
+                              "properties": {
+                                "path": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "iscsi": {
+                              "type": "object",
+                              "required": ["iqn", "lun", "targetPortal"],
+                              "properties": {
+                                "chapAuthDiscovery": {
+                                  "type": "boolean"
+                                },
+                                "chapAuthSession": {
+                                  "type": "boolean"
+                                },
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "initiatorName": {
+                                  "type": "string"
+                                },
+                                "iqn": {
+                                  "type": "string"
+                                },
+                                "iscsiInterface": {
+                                  "type": "string"
+                                },
+                                "lun": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "portals": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "targetPortal": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "nfs": {
+                              "type": "object",
+                              "required": ["path", "server"],
+                              "properties": {
+                                "path": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "server": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "persistentVolumeClaim": {
+                              "type": "object",
+                              "required": ["claimName"],
+                              "properties": {
+                                "claimName": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "photonPersistentDisk": {
+                              "type": "object",
+                              "required": ["pdID"],
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "pdID": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "portworxVolume": {
+                              "type": "object",
+                              "required": ["volumeID"],
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "volumeID": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "projected": {
+                              "type": "object",
+                              "properties": {
+                                "defaultMode": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "sources": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "configMap": {
+                                        "type": "object",
+                                        "properties": {
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "required": ["key", "path"],
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "mode": {
+                                                  "type": "integer",
+                                                  "format": "int32"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      },
+                                      "downwardAPI": {
+                                        "type": "object",
+                                        "properties": {
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "required": ["path"],
+                                              "properties": {
+                                                "fieldRef": {
+                                                  "type": "object",
+                                                  "required": ["fieldPath"],
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldPath": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "mode": {
+                                                  "type": "integer",
+                                                  "format": "int32"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                },
+                                                "resourceFieldRef": {
+                                                  "type": "object",
+                                                  "required": ["resource"],
+                                                  "properties": {
+                                                    "containerName": {
+                                                      "type": "string"
+                                                    },
+                                                    "divisor": {
+                                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "resource": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "secret": {
+                                        "type": "object",
+                                        "properties": {
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "required": ["key", "path"],
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "mode": {
+                                                  "type": "integer",
+                                                  "format": "int32"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          }
+                                        }
+                                      },
+                                      "serviceAccountToken": {
+                                        "type": "object",
+                                        "required": ["path"],
+                                        "properties": {
+                                          "audience": {
+                                            "type": "string"
+                                          },
+                                          "expirationSeconds": {
+                                            "type": "integer",
+                                            "format": "int64"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "quobyte": {
+                              "type": "object",
+                              "required": ["registry", "volume"],
+                              "properties": {
+                                "group": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "registry": {
+                                  "type": "string"
+                                },
+                                "tenant": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                },
+                                "volume": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "rbd": {
+                              "type": "object",
+                              "required": ["image", "monitors"],
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "image": {
+                                  "type": "string"
+                                },
+                                "keyring": {
+                                  "type": "string"
+                                },
+                                "monitors": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "pool": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "scaleIO": {
+                              "type": "object",
+                              "required": ["gateway", "secretRef", "system"],
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "gateway": {
+                                  "type": "string"
+                                },
+                                "protectionDomain": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "sslEnabled": {
+                                  "type": "boolean"
+                                },
+                                "storageMode": {
+                                  "type": "string"
+                                },
+                                "storagePool": {
+                                  "type": "string"
+                                },
+                                "system": {
+                                  "type": "string"
+                                },
+                                "volumeName": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "secret": {
+                              "type": "object",
+                              "properties": {
+                                "defaultMode": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": ["key", "path"],
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                },
+                                "secretName": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "storageos": {
+                              "type": "object",
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "secretRef": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "volumeName": {
+                                  "type": "string"
+                                },
+                                "volumeNamespace": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "vsphereVolume": {
+                              "type": "object",
+                              "required": ["volumePath"],
+                              "properties": {
+                                "fsType": {
+                                  "type": "string"
+                                },
+                                "storagePolicyID": {
+                                  "type": "string"
+                                },
+                                "storagePolicyName": {
+                                  "type": "string"
+                                },
+                                "volumePath": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "topologyPolicy": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "ttlSecondsAfterFinished": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["mountPath"],
+            "properties": {
+              "mountPath": {
+                "type": "string"
+              },
+              "volumeClaim": {
+                "type": "object",
+                "properties": {
+                  "accessModes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "dataSource": {
+                    "type": "object",
+                    "required": ["kind", "name"],
+                    "properties": {
+                      "apiGroup": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "dataSourceRef": {
+                    "type": "object",
+                    "required": ["kind", "name"],
+                    "properties": {
+                      "apiGroup": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "resources": {
+                    "type": "object",
+                    "properties": {
+                      "claims": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["name"],
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-map-keys": ["name"],
+                        "x-kubernetes-list-type": "map"
+                      },
+                      "limits": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      },
+                      "requests": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
+                    }
+                  },
+                  "selector": {
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": ["key", "operator"],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "values": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "matchLabels": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "storageClassName": {
+                    "type": "string"
+                  },
+                  "volumeMode": {
+                    "type": "string"
+                  },
+                  "volumeName": {
+                    "type": "string"
+                  }
+                }
+              },
+              "volumeClaimName": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["status"],
+            "properties": {
+              "lastTransitionTime": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "status": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "controlledResources": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "failed": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "minAvailable": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "pending": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "retryCount": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "running": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "runningDuration": {
+          "type": "string"
+        },
+        "state": {
+          "type": "object",
+          "properties": {
+            "lastTransitionTime": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "message": {
+              "type": "string"
+            },
+            "phase": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        "succeeded": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "taskStatusCount": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "phase": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        },
+        "terminating": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "unknown": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "batch.volcano.sh",
+      "kind": "Job",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}


### PR DESCRIPTION
This PR adds new schema for the weave-bootstrapped monaco editor to use on launch resource arguments. There is a new schema for each type of queue (there are a few for k8s queues because we support a variety of CRD)

The PR introduces a filematch for validation schema selection, meaning we can control the schema used on an editor by setting the `path` field of the editor to target a specific schema.