### PR TITLE
feat: button to quickly create plot from table

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -67,6 +67,7 @@ import {
   useSelectedDocumentId,
   useSelectedPath,
   useSetInteractingChildPanel,
+  useSetInteractingPanel,
   useSetPanelInputExprIsHighlighted,
   useSetSelectedPanel,
 } from './PanelInteractContext';
@@ -74,7 +75,14 @@ import {getStackIdAndName} from './panellib/libpanel';
 import PanelNameEditor from './PanelNameEditor';
 import {usePanelPanelContext} from './PanelPanelContextProvider';
 import {TableState} from './PanelTable/tableState';
-import {getConfigForPath, isInsideMain, isMain} from './panelTree';
+import {
+  addChild,
+  getConfigForPath,
+  getPath,
+  isInsideMain,
+  isMain,
+  nextPanelName,
+} from './panelTree';
 import {SelectPanelType} from './SelectPanelType';
 
 // This could be rendered as a code block with assignments, like
@@ -214,6 +222,46 @@ export interface ChildPanelProps {
   updateInput?: (partialInput: PanelInput) => void;
   updateName?: (newName: string) => void;
 }
+
+// Create a plot panel from a table panel.
+const insertPlotPanel = (
+  panelPathTable: string[],
+  updateConfig2: any,
+  setInteractingPanel: any
+) => {
+  updateConfig2((oldConfig: any) => {
+    oldConfig = getFullChildPanel(oldConfig);
+    const tablePanel = getPath(oldConfig, panelPathTable);
+    // We need to find the layout parameters for the panel being
+    // duplicated inside its parent's grid config so we can insert
+    // the clone next to the original and with the same width and height.
+    const tableId = panelPathTable[panelPathTable.length - 1];
+    const parentPath = panelPathTable.slice(0, -1);
+    const parentPanel = getPath(oldConfig, parentPath);
+    const parentLayouts = parentPanel.config.gridConfig.panels;
+    const targetLayoutObject = _.find(parentLayouts, {
+      id: tableId,
+    });
+    const duplicateLayout = targetLayoutObject?.layout;
+    const plotPanelName = nextPanelName(Object.keys(parentPanel.config.items));
+    const plotPanelPath = [...parentPath, plotPanelName];
+    const plotPanel = {
+      id: 'plot',
+      input_node: tablePanel.input_node,
+      config: undefined,
+      vars: {},
+    };
+    const updatedConfig = addChild(
+      oldConfig,
+      parentPath,
+      plotPanel,
+      plotPanelName,
+      duplicateLayout
+    );
+    setInteractingPanel('config', plotPanelPath, 'input');
+    return updatedConfig;
+  });
+};
 
 const useChildPanelCommon = (props: ChildPanelProps) => {
   const {updateConfig} = props;
@@ -471,7 +519,8 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
     [panelInputExpr.type]
   );
 
-  const setInteractingPanel = useSetInteractingChildPanel();
+  const setInteractingPanel = useSetInteractingPanel();
+  const setInteractingChildPanel = useSetInteractingChildPanel();
 
   return useMemo(
     () => ({
@@ -492,6 +541,7 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
       updatePanelConfig2,
       updatePanelInput,
       setInteractingPanel,
+      setInteractingChildPanel,
     }),
     [
       curPanelId,
@@ -511,6 +561,7 @@ const useChildPanelCommon = (props: ChildPanelProps) => {
       updatePanelConfig2,
       updatePanelInput,
       setInteractingPanel,
+      setInteractingChildPanel,
     ]
   );
 };
@@ -539,6 +590,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     updatePanelConfig2,
     updatePanelInput,
     setInteractingPanel,
+    setInteractingChildPanel,
   } = useChildPanelCommon(props);
 
   const {frame} = usePanelContext();
@@ -668,6 +720,22 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
             {props.editable && (
               <EditorIcons visible={showEditControls || isMenuOpen}>
                 {props.prefixButtons}
+                {curPanelId === 'table' && (
+                  <Button
+                    variant="ghost"
+                    size="small"
+                    icon="chart-scatterplot"
+                    tooltip="Create a plot from this table"
+                    onClick={(ev: React.MouseEvent) => {
+                      ev.stopPropagation();
+                      insertPlotPanel(
+                        fullPath,
+                        updateConfig2,
+                        setInteractingPanel
+                      );
+                    }}
+                  />
+                )}
                 <Tooltip
                   position="top center"
                   trigger={
@@ -677,7 +745,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
                       icon="pencil-edit"
                       data-testid="open-panel-editor"
                       onClick={() =>
-                        setInteractingPanel(
+                        setInteractingChildPanel(
                           'config',
                           props.pathEl ?? '',
                           documentId

--- a/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
+++ b/weave-js/src/components/Sidebar/OutlineItemPopupMenu.tsx
@@ -33,6 +33,7 @@ const Divider = styled.div`
   border: 0.5px solid ${MOON_250};
   width: 200%;
 `;
+Divider.displayName = 'S.Divider';
 
 export type OutlineItemPopupMenuProps = Pick<
   OutlinePanelProps,


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-16368

Reduces number of clicks to create a plot panel with the same input as a table from four to one.

Before: 
1. Click overflow menu
2. Click "Duplicate" option
3. In panel config, click "Panel type" dropdown
4. Select "Plot" option

After:
1. Click plot icon button in table header

It uses the same logic as panel duplication in terms of inserting the new panel.

<img width="338" alt="Screenshot 2023-12-14 at 4 29 14 PM" src="https://github.com/wandb/weave/assets/112953339/993bbfb6-9020-496e-a8e7-637b3695642f">
