### PR TITLE
chore: add react-sortable-hoc dependency

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -106,6 +106,7 @@
     "react-resizable": "^3.0.5",
     "react-router-dom": "^5.1.2",
     "react-select": "^5.4.0",
+    "react-sortable-hoc": "^2.0.0",
     "react-syntax-highlighter": "^15.5.0",
     "react-table": "^6.8.6",
     "react-textarea-autosize": "8.3.4",

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -13359,6 +13359,15 @@ react-select@^5.4.0:
     react-transition-group "^4.3.0"
     use-isomorphic-layout-effect "^1.1.2"
 
+react-sortable-hoc@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz#f6780d8aa4b922a21f3e754af542f032677078b7"
+  integrity sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    invariant "^2.2.4"
+    prop-types "^15.5.7"
+
 react-style-singleton@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"


### PR DESCRIPTION
See https://react-select.com/advanced#sortable-multiselect - an upcoming PR will use this library in conjunction with our react-select based component, e.g. to allow changing the order of fields selected for the plot tooltip.