### PR TITLE
chore(weave): Don't crash when NullArray is sent to dim down resolver

### DIFF
--- a/weave/ops_arrow/arraylist_ops.py
+++ b/weave/ops_arrow/arraylist_ops.py
@@ -86,6 +86,17 @@ def list_dim_downresolver(
 ):
     without_tags = self.without_tags()
     a = arrow_as_array(without_tags._arrow_data)
+    
+    if output_object_type == None:
+        output_object_type = without_tags.object_type.object_type  # type: ignore
+
+    if isinstance(a, pa.NullArray):
+        return ArrowWeaveList(
+            pa.nulls(len(a)),
+            output_object_type,
+            self._artifact,
+        )
+    
     values = a.flatten()
 
     start_indexes = a.offsets[:-1]
@@ -100,8 +111,7 @@ def list_dim_downresolver(
     result = pa.compute.replace_with_mask(
         nulls, non_0len, non_0len_agged.combine_chunks()
     )
-    if output_object_type == None:
-        output_object_type = without_tags.object_type.object_type  # type: ignore
+
     return ArrowWeaveList(
         result,
         output_object_type,

--- a/weave/ops_arrow/arraylist_ops.py
+++ b/weave/ops_arrow/arraylist_ops.py
@@ -86,7 +86,7 @@ def list_dim_downresolver(
 ):
     without_tags = self.without_tags()
     a = arrow_as_array(without_tags._arrow_data)
-    
+
     if output_object_type == None:
         output_object_type = without_tags.object_type.object_type  # type: ignore
 
@@ -96,7 +96,7 @@ def list_dim_downresolver(
             output_object_type,
             self._artifact,
         )
-    
+
     values = a.flatten()
 
     start_indexes = a.offsets[:-1]

--- a/weave/ops_arrow/arraylist_ops.py
+++ b/weave/ops_arrow/arraylist_ops.py
@@ -92,7 +92,7 @@ def list_dim_downresolver(
 
     if isinstance(a, pa.NullArray):
         return ArrowWeaveList(
-            pa.nulls(len(a)),
+            a,
             output_object_type,
             self._artifact,
         )


### PR DESCRIPTION
When a NullArray is used in dimdown resolver (totally valid) we were crashing. This fixes that.