### PR TITLE
chore: switch to GHA runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,8 +44,8 @@ jobs:
     timeout-minutes: 7
     needs:
       - build-container
-    runs-on: [self-hosted, gke-runner]
-    # runs-on: ubuntu-latest
+    # runs-on: [self-hosted, gke-runner]
+    runs-on: ubuntu-latest
     container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test:${{ github.sha }}
     steps:
       - uses: actions/checkout@v2
@@ -145,8 +145,8 @@ jobs:
       # - lint
       # - test
     if: always()
-    runs-on: [self-hosted, gke-runner]
-    # runs-on: ubuntu-latest
+    3 runs-on: [self-hosted, gke-runner]
+    runs-on: ubuntu-latest
 
     container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-integration-test:${{ github.sha }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,8 @@ jobs:
     timeout-minutes: 15 # do not raise! running longer than this indicates an issue with the tests. fix there.
     needs:
       - build-container
-    runs-on: [self-hosted, gke-runner]
+    # runs-on: [self-hosted, gke-runner]
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -145,7 +145,7 @@ jobs:
       # - lint
       # - test
     if: always()
-    3 runs-on: [self-hosted, gke-runner]
+    # runs-on: [self-hosted, gke-runner]
     runs-on: ubuntu-latest
 
     container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-integration-test:${{ github.sha }}


### PR DESCRIPTION
Our k8s CI cluster is having a networking issue. Switching CI back over to GHA runners. 