### PR TITLE
chore: Graph interface

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,3 +91,18 @@ You can tell everything is working if the weave UI renders and you see your serv
 ## Environment variables
 
 Some ops require environment variables to be set, like OPENAI_API_KEY. You need to set these for the server environment and your Jupyter notebook.
+
+
+## Unit tests
+
+Some of the unit tests try to run a wandb server container, and will produce 403s if that container is out of date. The container is only accessible to wandb developers currently.
+
+For wandb developers, if you encounter 403s in unit tests do:
+
+```
+docker pull --platform linux/amd64 us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
+```
+
+You may need to "gcloud auth login" first.
+
+And you may need to kill the running container by `docker ps` and then `docker kill`

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -11,7 +11,13 @@ import {
   Node,
   Type,
 } from '@wandb/weave/core';
-import {ArtifactRef, parseRef, refUri, useNodeValue} from '@wandb/weave/react';
+import {
+  ArtifactRef,
+  isWandbArtifactRef,
+  parseRef,
+  refUri,
+  useNodeValue,
+} from '@wandb/weave/react';
 import React, {FC, useMemo} from 'react';
 
 import {useWeaveflowRouteContext} from '../Browse3/context';
@@ -70,6 +76,9 @@ export const SmallRef: FC<{objRef: ArtifactRef; wfTable?: WFDBTableType}> = ({
   );
   if (refTypeQuery.loading) {
     return Item;
+  }
+  if (!isWandbArtifactRef(objRef)) {
+    return <div>[Error: non wandb ref]</div>;
   }
   return <Link to={refUIUrl(rootTypeName, objRef, wfTable)}>{Item}</Link>;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -59,7 +59,7 @@ const browse2Context = {
     wfTable?: WFDBTableType
   ) => {
     if (!isWandbArtifactRef(objRef)) {
-      throw new Error('Not a wandb artifact ref');
+      throw new Error('Not a wandb artifact ref: ' + JSON.stringify(objRef));
     }
     return `/${objRef.entityName}/${objRef.projectName}/${rootTypeName}/${objRef.artifactName}/${objRef.artifactVersion}`;
   },
@@ -172,7 +172,7 @@ const browse3ContextGen = (
       wfTable?: WFDBTableType
     ) => {
       if (!isWandbArtifactRef(objRef)) {
-        throw new Error('Not a wandb artifact ref');
+        throw new Error('Not a wandb artifact ref: ' + JSON.stringify(objRef));
       }
       if (wfTable === 'OpVersion' || rootTypeName === 'OpDef') {
         return browse3Context.opVersionUIUrl(

--- a/weave/artifact_wandb.py
+++ b/weave/artifact_wandb.py
@@ -35,7 +35,7 @@ from urllib import parse
 
 if typing.TYPE_CHECKING:
     from weave.wandb_interface.wandb_lite_run import InMemoryLazyLiteRun
-    from . import run
+    from .run_streamtable_span import RunStreamTableSpan
 
 
 quote_slashes = functools.partial(parse.quote, safe="")
@@ -828,15 +828,15 @@ class WandbArtifactRef(artifact_fs.FilesystemArtifactRef):
             path=uri.path,
         )
 
-    def input_to(self) -> eager.WeaveIter["run.Run"]:
+    def input_to(self) -> eager.WeaveIter["RunStreamTableSpan"]:
         client = graph_client_context.require_graph_client()
         return client.ref_input_to(self)
 
-    def value_input_to(self) -> eager.WeaveIter["run.Run"]:
+    def value_input_to(self) -> eager.WeaveIter["RunStreamTableSpan"]:
         client = graph_client_context.require_graph_client()
         return client.ref_value_input_to(self)
 
-    def output_of(self) -> typing.Optional["run.Run"]:
+    def output_of(self) -> typing.Optional["RunStreamTableSpan"]:
         client = graph_client_context.require_graph_client()
         return client.ref_output_of(self)
 

--- a/weave/execute.py
+++ b/weave/execute.py
@@ -477,8 +477,9 @@ def publish_graph(
     nodes: typing.List[graph.Node],
 ):
     """Publish all ops and ConstNodes found in graph"""
-    client = graph_client_context.get_graph_client()
-    if client is not None and context_state.eager_mode():
+    maybe_client = graph_client_context.get_graph_client()
+    if maybe_client is not None and context_state.eager_mode():
+        client = typing.cast(graph_client_context.GraphClient, maybe_client)
 
         def _publish_node(node: graph.Node):
             if isinstance(node, graph.OutputNode):

--- a/weave/execute.py
+++ b/weave/execute.py
@@ -55,6 +55,9 @@ from . import language_nullability
 
 from . import parallelism
 
+if typing.TYPE_CHECKING:
+    from .graph_client import GraphClient
+
 TRACE_LOCAL = trace_local.TraceLocal()
 
 # Set this to true when debugging for costly, but detailed storyline of execution
@@ -479,7 +482,7 @@ def publish_graph(
     """Publish all ops and ConstNodes found in graph"""
     maybe_client = graph_client_context.get_graph_client()
     if maybe_client is not None and context_state.eager_mode():
-        client = typing.cast(graph_client_context.GraphClient, maybe_client)
+        client = typing.cast("GraphClient", maybe_client)
 
         def _publish_node(node: graph.Node):
             if isinstance(node, graph.OutputNode):
@@ -503,7 +506,7 @@ def execute_sync_op(op_def: op_def.OpDef, inputs: Mapping[str, typing.Any]):
     client = graph_client_context.get_graph_client()
     if client is not None and context_state.eager_mode() and op_def.location:
         op_def_ref = storage._get_ref(op_def)
-        if not isinstance(op_def_ref, artifact_wandb.WandbArtifactRef):
+        if not client.ref_is_own(op_def_ref):
             # This should have already been published by publish_graph if monitoring
             # is turned on.
             raise errors.WeaveInternalError(

--- a/weave/execute_fast.py
+++ b/weave/execute_fast.py
@@ -112,6 +112,7 @@ def _can_fast_map(map_fn):
         lambda n: isinstance(n, graph.OutputNode)
         and (
             op_can_be_async(n.from_op.name)
+            or "://" in n.from_op.name
             or op_policy.should_cache(n.from_op.name)
             or op_policy.should_run_in_parallel(n.from_op.name)
         ),

--- a/weave/graph_client.py
+++ b/weave/graph_client.py
@@ -86,7 +86,7 @@ class GraphClient:
         with context_state.lazy_execution():
             with compile.enable_compile():
                 rows_node = self.runs_st.rows()
-                filter_node = rows_node.filter(
+                filter_node = rows_node.filter(  # type: ignore
                     lambda row: ops_primitives.Boolean.bool_and(
                         row["name"] == op_name,
                         row["attributes"]["_inputs_digest"] == inputs_digest,
@@ -162,7 +162,7 @@ class GraphClient:
                 return None
             return feedback_attrs
 
-    def ref_is_own(self, ref: ref_base.Ref) -> bool:
+    def ref_is_own(self, ref: typing.Optional[ref_base.Ref]) -> bool:
         return isinstance(ref, artifact_wandb.WandbArtifactRef)
 
     ##### Write API
@@ -201,15 +201,20 @@ class GraphClient:
         else:
             trace_id = str(uuid.uuid4())
             parent_id = None
+        cur_time = time.time()
         span = stream_data_interfaces.TraceSpanDict(
             span_id=str(uuid.uuid4()),
             trace_id=trace_id,
             parent_id=parent_id,
             name=op_name,
             status_code="UNSET",
-            start_time_s=time.time(),
+            start_time_s=cur_time,
+            end_time_s=cur_time,  # currently required, so set to start time for now?
             inputs=inputs,
             attributes=attrs,
+            output=None,
+            summary=None,
+            exception=None,
         )
         # Don't log create for now
         # self.runs_st.log(span)

--- a/weave/monitoring/monitor.py
+++ b/weave/monitoring/monitor.py
@@ -17,14 +17,12 @@ from .. import errors
 from .. import graph
 from .. import stream_data_interfaces
 from .. import graph_client_context
+from .. import run_context
+from .. import run_streamtable_span
 
 logger = logging.getLogger(__name__)
 
 _global_monitor: typing.Optional["Monitor"] = None
-
-_current_span: contextvars.ContextVar[typing.Optional["Span"]] = contextvars.ContextVar(
-    "_current_span", default=None
-)
 
 _attributes: contextvars.ContextVar[
     typing.Dict[str, typing.Any]
@@ -168,6 +166,31 @@ class Span:
             "summary": self.summary,
         }
 
+    def asdict_unsafe(self) -> stream_data_interfaces.TraceSpanDict:
+        start_time_s = self.start_time.timestamp()
+        end_time_s = None
+        if self.end_time is not None:
+            end_time_s = self.end_time.timestamp()
+            self.summary["latency_s"] = end_time_s - start_time_s
+        return {
+            "parent_id": self.parent_id,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "name": self.name,
+            "status_code": self.status_code,
+            "start_time_s": start_time_s,
+            "end_time_s": end_time_s,  # type: ignore
+            "inputs": self.inputs,
+            "output": self.output,
+            "exception": (
+                f"{type(self.exception).__name__}: {str(self.exception)}"
+                if self.exception is not None
+                else None
+            ),
+            "attributes": self.attributes,
+            "summary": self.summary,
+        }
+
 
 # A type used to indicate that inputs is guaranteed to be set, for pre and post process callbacks.
 class SpanWithInputs(Span):
@@ -205,20 +228,23 @@ class Monitor:
                 "WARNING: Not logging spans.  Call weave.monitor.init_monitor() to enable logging."
             )
 
-        parent_span = _current_span.get()
+        # A song and dance to switch between span/run semantics. Will be cleaned
+        # up as we switch entirely to the run interface.
+
+        parent_run = run_context.get_current_run()
         trace_id = None
-        if parent_span is not None:
-            parent_id = parent_span.span_id
-            trace_id = parent_span.trace_id
+        if parent_run is not None:
+            parent_id = parent_run.id
+            trace_id = parent_run.trace_id
         else:
             parent_id = None
         span = Span(name, self.streamtable, parent_id, trace_id, _attributes.get())
-        token = _current_span.set(span)
-        try:
-            yield span
-        finally:
-            span.autoclose()
-            _current_span.reset(token)
+        run = run_streamtable_span.RunStreamTableSpan(span.asdict_unsafe())
+        with run_context.current_run(run):
+            try:
+                yield span
+            finally:
+                span.autoclose()
 
     @contextlib.contextmanager
     def attributes(self, attributes: typing.Dict[str, typing.Any]) -> typing.Iterator:

--- a/weave/op_def.py
+++ b/weave/op_def.py
@@ -30,6 +30,9 @@ from .language_features.tagging import (
 )
 from . import language_autocall
 
+if typing.TYPE_CHECKING:
+    from .run_streamtable_span import RunStreamTableSpan
+
 
 _no_refine: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "_no_refine", default=False
@@ -603,7 +606,8 @@ class OpDef:
     def op_def_is_auto_tag_handling_arrow_op(self) -> bool:
         return isinstance(self, AutoTagHandlingArrowOpDef)
 
-    def runs(self) -> eager.WeaveIter[run.Run]:
+    # TODO: Should be generic Run protocol, but need to update graph_client type first.
+    def runs(self) -> eager.WeaveIter["RunStreamTableSpan"]:
         client = graph_client_context.require_graph_client()
         return client.op_runs(self)
 

--- a/weave/ops_arrow/concat.py
+++ b/weave/ops_arrow/concat.py
@@ -593,3 +593,21 @@ def concatenate(
         result = _concatenate(self, other, depth)
     result.validate()
     return result
+
+
+def _merge_concat_split(
+    arr: list[ArrowWeaveList],
+) -> tuple[list[ArrowWeaveList], list[ArrowWeaveList]]:
+    if len(arr) < 2:
+        raise ValueError("arr must have length of at least 2")
+    middle_index = len(arr) // 2
+    return arr[:middle_index], arr[middle_index:]
+
+
+def concatenate_all(arr: list[ArrowWeaveList]) -> ArrowWeaveList:
+    if len(arr) == 0:
+        raise ValueError("arr must not be empty")
+    if len(arr) == 1:
+        return arr[0]
+    left, right = _merge_concat_split(arr)
+    return concatenate_all(left).concat(concatenate_all(right))

--- a/weave/ops_arrow/list_ops.py
+++ b/weave/ops_arrow/list_ops.py
@@ -28,6 +28,7 @@ from . import arrow_tags
 from .vectorize import _apply_fn_node_with_tag_pushdown
 from . import convert
 from .convert import to_compare_safe
+from .concat import concatenate_all
 from .constructors import (
     vectorized_container_constructor_preprocessor,
     vectorized_input_types,
@@ -712,25 +713,7 @@ def concat(arr):
 
     # We merge the lists mergesort-style, which is `O(n*log(n))`
     # DO NOT merge the lists reduce-style, which is `O(n^2)`
-    return merge_concat(tagged)
-
-
-def merge_concat(arr: list[ArrowWeaveList]) -> ArrowWeaveList:
-    if len(arr) == 0:
-        raise ValueError("arr must not be empty")
-    if len(arr) == 1:
-        return arr[0]
-    left, right = merge_concat_split(arr)
-    return merge_concat(left).concat(merge_concat(right))
-
-
-def merge_concat_split(
-    arr: list[ArrowWeaveList],
-) -> tuple[list[ArrowWeaveList], list[ArrowWeaveList]]:
-    if len(arr) < 2:
-        raise ValueError("arr must have length of at least 2")
-    middle_index = len(arr) // 2
-    return arr[:middle_index], arr[middle_index:]
+    return concatenate_all(tagged)
 
 
 # # Putting this here instead of in number b/c it is just a map function

--- a/weave/ops_domain/run_history/history_op_common.py
+++ b/weave/ops_domain/run_history/history_op_common.py
@@ -395,9 +395,9 @@ def process_history_awl_tables(tables: list[ArrowWeaveList]):
 
 
 def concat_awls(awls: list[ArrowWeaveList]):
-    list = make_list(**{str(i): table for i, table in enumerate(awls)})
-    with compile.disable_compile():
-        return use(concat(list))
+    from ...ops_arrow.concat import concatenate_all
+
+    return concatenate_all(awls)
 
 
 def awl_to_pa_table(awl: ArrowWeaveList):

--- a/weave/parallelism.py
+++ b/weave/parallelism.py
@@ -6,6 +6,7 @@ from typing import Optional, Callable, TypeVar, Iterator, Generator
 from . import context
 from . import context_state
 from . import graph_client_context
+from . import run_context
 from . import execute
 from . import forward_graph
 from . import memo
@@ -56,6 +57,7 @@ def do_in_parallel(
     top_level_stats = execute.get_top_level_stats()
     eager_mode = context_state.eager_mode()
     graph_client = graph_client_context.get_graph_client()
+    current_run = run_context.get_current_run()
 
     def do_one_with_memo_and_parallel_budget(x: ItemType) -> ResultType:
         memo_token = memo._memo_storage.set(memo_ctx)
@@ -64,14 +66,15 @@ def do_in_parallel(
         try:
             with parallel_budget_ctx(remaining_budget_per_thread):
                 with graph_client_context.set_graph_client(graph_client):
-                    with context_state.set_eager_mode(eager_mode):
-                        with wandb_api.wandb_api_context(wandb_api_ctx):
-                            with context.execution_client():
-                                with forward_graph.node_result_store(
-                                    result_store
-                                ) as thread_result_store:
-                                    with execute.top_level_stats() as thread_top_level_stats:
-                                        return do_one(x)
+                    with run_context.set_current_run(current_run):
+                        with context_state.set_eager_mode(eager_mode):
+                            with wandb_api.wandb_api_context(wandb_api_ctx):
+                                with context.execution_client():
+                                    with forward_graph.node_result_store(
+                                        result_store
+                                    ) as thread_result_store:
+                                        with execute.top_level_stats() as thread_top_level_stats:
+                                            return do_one(x)
         finally:
             memo._memo_storage.reset(memo_token)
             if thread_result_store is not None:

--- a/weave/parallelism.py
+++ b/weave/parallelism.py
@@ -57,7 +57,7 @@ def do_in_parallel(
     top_level_stats = execute.get_top_level_stats()
     eager_mode = context_state.eager_mode()
     graph_client = graph_client_context.get_graph_client()
-    current_run = run_context.get_current_run()
+    run_stack = run_context.get_run_stack()
 
     def do_one_with_memo_and_parallel_budget(x: ItemType) -> ResultType:
         memo_token = memo._memo_storage.set(memo_ctx)
@@ -66,7 +66,7 @@ def do_in_parallel(
         try:
             with parallel_budget_ctx(remaining_budget_per_thread):
                 with graph_client_context.set_graph_client(graph_client):
-                    with run_context.set_current_run(current_run):
+                    with run_context.set_run_stack(run_stack):
                         with context_state.set_eager_mode(eager_mode):
                             with wandb_api.wandb_api_context(wandb_api_ctx):
                                 with context.execution_client():

--- a/weave/run.py
+++ b/weave/run.py
@@ -30,7 +30,7 @@ class Run:
         return self._attrs["name"]
 
     @property
-    def ui_url(self):
+    def ui_url(self) -> str:
         gc = graph_client_context.require_graph_client()
         return f"http://localhost:3000/{BROWSE3_PATH}/{gc.entity_name}/{gc.project_name}/calls/{self.id}"
 

--- a/weave/run.py
+++ b/weave/run.py
@@ -1,101 +1,21 @@
 import typing
 
-from .urls import BROWSE3_PATH
-from . import uris
-from . import artifact_wandb
-from . import stream_data_interfaces
-from . import graph_client_context
-from .eager import WeaveIter
 
-
-class Run:
-    _attrs: stream_data_interfaces.TraceSpanDict
-
-    def __init__(self, attrs: stream_data_interfaces.TraceSpanDict) -> None:
-        self._attrs = attrs
-
-    def __repr__(self) -> str:
-        return f"<Run {self.uri} {self.id}>"
-
+class RunKey(typing.Protocol):
     @property
     def id(self) -> str:
-        return self._attrs["span_id"]
+        ...
 
     @property
     def trace_id(self) -> str:
-        return self._attrs["trace_id"]
+        ...
+
+
+class Run(typing.Protocol):
+    @property
+    def id(self) -> str:
+        ...
 
     @property
-    def uri(self) -> str:
-        return self._attrs["name"]
-
-    @property
-    def ui_url(self) -> str:
-        gc = graph_client_context.require_graph_client()
-        return f"http://localhost:3000/{BROWSE3_PATH}/{gc.entity_name}/{gc.project_name}/calls/{self.id}"
-
-    @property
-    def op_ref(self) -> typing.Optional[artifact_wandb.WandbArtifactRef]:
-        if self.uri.startswith("wandb-artifact"):
-            parsed = uris.WeaveURI.parse(self.uri).to_ref()
-            if not isinstance(parsed, artifact_wandb.WandbArtifactRef):
-                raise ValueError("expected wandb artifact ref")
-            return parsed
-        return None
-
-    @property
-    def status_code(self) -> str:
-        return self._attrs["status_code"]
-
-    @property
-    def attributes(self) -> dict[str, typing.Any]:
-        attrs_dict = self._attrs.get("attributes", {})
-        if not isinstance(attrs_dict, dict):
-            return {}
-        return {k: v for k, v in attrs_dict.items() if v != None}
-
-    @property
-    def inputs(self) -> dict[str, typing.Any]:
-        input_dict = self._attrs.get("input", {})
-        if not isinstance(input_dict, dict):
-            return {}
-        keys = input_dict.get("_keys")
-        if keys is None:
-            keys = [k for k in input_dict.keys() if input_dict[k] != None]
-        return {k: input_dict[k] for k in keys}
-
-    @property
-    def output(self) -> typing.Any:
-        if self.status_code != "SUCCESS":
-            return None
-        output_dict = self._attrs.get("output")
-        if isinstance(output_dict, dict):
-            keys = output_dict.get("_keys")
-            if keys is None:
-                keys = [k for k in output_dict.keys() if output_dict[k] != None]
-            output = {k: output_dict.get(k) for k in keys}
-            if "_result" in output:
-                return output["_result"]
-        return output
-
-    @property
-    def parent_id(self) -> typing.Optional[str]:
-        return self._attrs["parent_id"]
-
-    def add_feedback(self, feedback: dict[str, typing.Any]) -> None:
-        client = graph_client_context.require_graph_client()
-        client.add_feedback(self.id, feedback)
-
-    def feedback(self) -> WeaveIter[dict[str, typing.Any]]:
-        client = graph_client_context.require_graph_client()
-        return client.run_feedback(self.id)
-
-    def parent(self) -> typing.Optional["Run"]:
-        client = graph_client_context.require_graph_client()
-        if self.parent_id is None:
-            return None
-        return client.run(self.parent_id)
-
-    def children(self) -> WeaveIter["Run"]:
-        client = graph_client_context.require_graph_client()
-        return client.run_children(self.id)
+    def trace_id(self) -> str:
+        ...

--- a/weave/run.py
+++ b/weave/run.py
@@ -1,5 +1,6 @@
 import typing
 
+from .urls import BROWSE3_PATH
 from . import uris
 from . import artifact_wandb
 from . import stream_data_interfaces
@@ -21,8 +22,17 @@ class Run:
         return self._attrs["span_id"]
 
     @property
+    def trace_id(self) -> str:
+        return self._attrs["trace_id"]
+
+    @property
     def uri(self) -> str:
         return self._attrs["name"]
+
+    @property
+    def ui_url(self):
+        gc = graph_client_context.require_graph_client()
+        return f"http://localhost:3000/{BROWSE3_PATH}/{gc.entity_name}/{gc.project_name}/calls/{self.id}"
 
     @property
     def op_ref(self) -> typing.Optional[artifact_wandb.WandbArtifactRef]:

--- a/weave/run_context.py
+++ b/weave/run_context.py
@@ -1,0 +1,25 @@
+import contextlib
+import contextvars
+import typing
+
+if typing.TYPE_CHECKING:
+    from .run import Run
+
+_current_run: contextvars.ContextVar[typing.Optional["Run"]] = contextvars.ContextVar(
+    "run", default=None
+)
+
+
+@contextlib.contextmanager
+def set_current_run(
+    client: typing.Optional["Run"],
+) -> typing.Iterator[typing.Optional["Run"]]:
+    client_token = _current_run.set(client)
+    try:
+        yield client
+    finally:
+        _current_run.reset(client_token)
+
+
+def get_current_run() -> typing.Optional["Run"]:
+    return _current_run.get()

--- a/weave/run_context.py
+++ b/weave/run_context.py
@@ -14,7 +14,7 @@ _run_stack: contextvars.ContextVar[list["Run"]] = contextvars.ContextVar(
 @contextlib.contextmanager
 def current_run(
     run: "Run",
-) -> typing.Iterator[typing.Optional["Run"]]:
+) -> typing.Iterator[list["Run"]]:
     new_stack = copy.copy(_run_stack.get())
     new_stack.append(run)
 
@@ -36,7 +36,7 @@ def get_run_stack() -> list["Run"]:
 @contextlib.contextmanager
 def set_run_stack(
     stack: list["Run"],
-) -> typing.Iterator[typing.Optional["Run"]]:
+) -> typing.Iterator[list["Run"]]:
     token = _run_stack.set(stack)
     try:
         yield stack

--- a/weave/run_streamtable_span.py
+++ b/weave/run_streamtable_span.py
@@ -1,0 +1,97 @@
+import typing
+
+from .urls import BROWSE3_PATH
+from . import uris
+from . import artifact_wandb
+from . import stream_data_interfaces
+from . import graph_client_context
+from .eager import WeaveIter
+
+
+class RunStreamTableSpan:
+    _attrs: stream_data_interfaces.TraceSpanDict
+
+    def __init__(self, attrs: stream_data_interfaces.TraceSpanDict) -> None:
+        self._attrs = attrs
+
+    def __repr__(self) -> str:
+        return f"<Run {self.uri} {self.id}>"
+
+    @property
+    def id(self) -> str:
+        return self._attrs["span_id"]
+
+    @property
+    def trace_id(self) -> str:
+        return self._attrs["trace_id"]
+
+    @property
+    def uri(self) -> str:
+        return self._attrs["name"]
+
+    @property
+    def ui_url(self) -> str:
+        gc = graph_client_context.require_graph_client()
+        return f"http://localhost:3000/{BROWSE3_PATH}/{gc.entity_name}/{gc.project_name}/calls/{self.id}"
+
+    @property
+    def op_ref(self) -> typing.Optional[artifact_wandb.WandbArtifactRef]:
+        if self.uri.startswith("wandb-artifact"):
+            parsed = uris.WeaveURI.parse(self.uri).to_ref()
+            if not isinstance(parsed, artifact_wandb.WandbArtifactRef):
+                raise ValueError("expected wandb artifact ref")
+            return parsed
+        return None
+
+    @property
+    def status_code(self) -> str:
+        return self._attrs["status_code"]
+
+    @property
+    def attributes(self) -> dict[str, typing.Any]:
+        attrs_dict = self._attrs.get("attributes", {})
+        if not isinstance(attrs_dict, dict):
+            return {}
+        return {k: v for k, v in attrs_dict.items() if v != None}
+
+    @property
+    def inputs(self) -> dict[str, typing.Any]:
+        input_dict = self._attrs.get("input", {})
+        if not isinstance(input_dict, dict):
+            return {}
+        keys = input_dict.get("_keys")
+        if keys is None:
+            keys = [k for k in input_dict.keys() if input_dict[k] != None]
+        return {k: input_dict[k] for k in keys}
+
+    @property
+    def output(self) -> typing.Any:
+        if self.status_code != "SUCCESS":
+            return None
+        output_dict = self._attrs.get("output")
+        if isinstance(output_dict, dict):
+            keys = output_dict.get("_keys")
+            if keys is None:
+                keys = [k for k in output_dict.keys() if output_dict[k] != None]
+            output = {k: output_dict.get(k) for k in keys}
+            if "_result" in output:
+                return output["_result"]
+        return output
+
+    @property
+    def parent_id(self) -> typing.Optional[str]:
+        return self._attrs["parent_id"]
+
+    def add_feedback(self, feedback: dict[str, typing.Any]) -> None:
+        client = graph_client_context.require_graph_client()
+        client.add_feedback(self.id, feedback)
+
+    def feedback(self) -> WeaveIter[dict[str, typing.Any]]:
+        client = graph_client_context.require_graph_client()
+        return client.run_feedback(self.id)
+
+    def parent(self) -> typing.Optional["RunStreamTableSpan"]:
+        client = graph_client_context.require_graph_client()
+        if self.parent_id is None:
+            return None
+        return client.run(self.parent_id)

--- a/weave/storage.py
+++ b/weave/storage.py
@@ -157,9 +157,12 @@ def _direct_publish(
     _merge: typing.Optional[bool] = False,
 ) -> artifact_wandb.WandbArtifactRef:
     _orig_ref = _get_ref(obj)
+    if isinstance(_orig_ref, artifact_wandb.WandbArtifactRef):
+        return _orig_ref
     if isinstance(_orig_ref, artifact_local.LocalArtifactRef):
         res = PUBLISH_CACHE_BY_LOCAL_ART.get(_orig_ref)
         if res is not None:
+            ref_base._put_ref(obj, res)
             return res
 
     weave_type = assume_weave_type or _get_weave_type(obj)
@@ -206,6 +209,8 @@ def _direct_publish(
 
     if isinstance(_orig_ref, artifact_local.LocalArtifactRef):
         PUBLISH_CACHE_BY_LOCAL_ART[_orig_ref] = ref
+
+    ref_base._put_ref(obj, ref)
 
     return ref
 

--- a/weave/tests/test_weaveflow.py
+++ b/weave/tests/test_weaveflow.py
@@ -7,7 +7,7 @@ import typing
 def test_digestrefs():
     from weave import weaveflow
 
-    graph_client = weave.init("digestrefs3")
+    graph_client = weave.init("digestrefs4")
 
     ds = weave.WeaveList(
         [

--- a/weave/weaveflow/__init__.py
+++ b/weave/weaveflow/__init__.py
@@ -1,6 +1,11 @@
 from .. import context_state as _context_state
 
 _context_state._eager_mode.set(True)
+from .. import logs
+
+# If there is no WEAVE_LOG_LEVEL, this will set to ERROR
+# from python's default which is WARNING
+logs.configure_logger()
 
 from .dataset import *
 from .model import *


### PR DESCRIPTION
This PR moves the write APIs that Weave uses into GraphClient, which prior to this was just the read API (except for add_feedback)

Think of graph_client as the "weave server interface", it should contain all the API surface that the Weave engine and user APIs make use of.

This paves the way for creating other GraphClient implementations (after a little more refactoring), so that we can:
- unit test Weaveflow
- remove the old trace_local interface
- speed up all the Weave unit tests by a lot (by making them use a Memory implementation instead of the local artifacts implementation which is slow)
- enable logging to local artifacts, and later selectively synchronizing to wandb ("offline mode")
- experimenting with other implementations, like using a table for non-custom objects, or using a new high-scale DB

Additional quality of life changes:
- Don't print everything that is published during op executing, just print the top-level run location
- Disable weave warning logging (like vectorization warnings)
- Fix a UI crash when using evaluation, due to a local-artifact reference (I didn't fix the local-artifact reference yet, I just made the UI not crash if it encounters them)
- Fix "use not allowed in eager mode" UI crash that occurs in history_op_common, by just calling the concatenate_all function directly instead of executing it in the weave engine with use

TODO:
- [x] ensure non-op logging gets captured (monitor logging, like openai traces)
- [x] fix typing.cast in execute.py, a lint change broke the PR