### PR TITLE
fix: keep panel selection on panel resize

### DIFF
--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -625,6 +625,9 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
     el => el != null && el !== ''
   );
 
+  // Store the last mouse down coordinates so we can distinguish click from drag.
+  const [lastMouseDownCoords, setLastMouseDownCoords] = useState({x: 0, y: 0});
+
   const selectedDocumentId = useSelectedDocumentId();
   const pathStr = useMemo(() => ['<root>', ...fullPath].join('.'), [fullPath]);
   const selectedPath = useSelectedPath();
@@ -657,8 +660,22 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
   ) : (
     <Styles.Main
       data-weavepath={props.pathEl ?? 'root'}
+      onMouseDown={event => {
+        event.stopPropagation();
+        setLastMouseDownCoords({x: event.clientX, y: event.clientY});
+      }}
       onClick={event => {
-        if (isMain(fullPath) || isInsideMain(fullPath, 1)) {
+        if (isInsideMain(fullPath, 1)) {
+          setSelectedPanel(fullPath);
+          event.stopPropagation();
+        } else if (
+          isMain(fullPath) &&
+          event.clientX === lastMouseDownCoords.x &&
+          event.clientY === lastMouseDownCoords.y
+        ) {
+          // User has clicked on the background of the main panel
+          // and did not drag to a different position.
+          // i.e. We don't change the selected panel if the user is dragging to resize a panel.
           setSelectedPanel(fullPath);
           event.stopPropagation();
         }

--- a/weave-js/src/components/Panel2/ChildPanel.tsx
+++ b/weave-js/src/components/Panel2/ChildPanel.tsx
@@ -626,7 +626,7 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
   );
 
   // Store the last mouse down coordinates so we can distinguish click from drag.
-  const [lastMouseDownCoords, setLastMouseDownCoords] = useState({x: 0, y: 0});
+  const lastMouseDownCoordsRef = useRef({x: 0, y: 0});
 
   const selectedDocumentId = useSelectedDocumentId();
   const pathStr = useMemo(() => ['<root>', ...fullPath].join('.'), [fullPath]);
@@ -662,22 +662,24 @@ export const ChildPanel: React.FC<ChildPanelProps> = props => {
       data-weavepath={props.pathEl ?? 'root'}
       onMouseDown={event => {
         event.stopPropagation();
-        setLastMouseDownCoords({x: event.clientX, y: event.clientY});
+        lastMouseDownCoordsRef.current = {
+          x: event.clientX,
+          y: event.clientY,
+        };
       }}
       onClick={event => {
+        event.stopPropagation();
         if (isInsideMain(fullPath, 1)) {
           setSelectedPanel(fullPath);
-          event.stopPropagation();
         } else if (
           isMain(fullPath) &&
-          event.clientX === lastMouseDownCoords.x &&
-          event.clientY === lastMouseDownCoords.y
+          event.clientX === lastMouseDownCoordsRef.current.x &&
+          event.clientY === lastMouseDownCoordsRef.current.y
         ) {
           // User has clicked on the background of the main panel
           // and did not drag to a different position.
           // i.e. We don't change the selected panel if the user is dragging to resize a panel.
           setSelectedPanel(fullPath);
-          event.stopPropagation();
         }
       }}
       onMouseEnter={() => setIsHoverPanel(true)}


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-15746

Clicking on the main panel group (board background) sets that as the selected panel. To the user this looks like clearing the selection and displaying the outline. This PR keeps track of where the mouse down event occurred, so we can distinguish between clicking on the background and the user dragging the corner of a panel to resize it, which will also generate an onClick event. i.e. This PR makes it so we preserve the panel selection when resizing.