### PR TITLE
chore(weave): Quick and dirty Condensed Navbar

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -460,6 +460,7 @@ export const RunsTable: FC<{
   }, [apiRef, loading]);
   return (
     <DataGridPro
+      sx={{border: 0}}
       apiRef={apiRef}
       loading={loading}
       rows={tableData}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/Browse3SideNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/Browse3SideNav.tsx
@@ -8,7 +8,6 @@ import {
   ModelTraining,
   NavigateBefore,
   NavigateNext,
-  Restore,
   Rule,
   Scoreboard,
   Segment,
@@ -19,12 +18,10 @@ import {
 } from '@mui/icons-material';
 import {
   Autocomplete,
-  BottomNavigationAction,
   Box,
   FormControl,
   IconButton,
   ListSubheader,
-  Stack,
   TextField,
 } from '@mui/material';
 import Divider from '@mui/material/Divider';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/Browse3SideNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/Browse3SideNav.tsx
@@ -7,19 +7,24 @@ import {
   ManageHistory,
   ModelTraining,
   NavigateBefore,
+  NavigateNext,
+  Restore,
   Rule,
   Scoreboard,
   Segment,
   TableChart,
   Tune,
   TypeSpecimen,
+  Undo,
 } from '@mui/icons-material';
 import {
   Autocomplete,
+  BottomNavigationAction,
   Box,
   FormControl,
   IconButton,
   ListSubheader,
+  Stack,
   TextField,
 } from '@mui/material';
 import Divider from '@mui/material/Divider';
@@ -181,6 +186,10 @@ const Browse3ProjectSideNav: FC<Browse3ProjectSideNavProps> = props => {
   const wbSidebarWidth = 56;
   const wbSideBarSpeed = 0.2;
   const initialWidth = drawerWidth - wbSidebarWidth;
+  const [open, setOpen] = useState(true);
+  const adjustedDrawerWidth = useMemo(() => {
+    return open ? drawerWidth : wbSidebarWidth;
+  }, [open]);
   const [width, setWidth] = useState(initialWidth);
   const onNavigateAwayFromProject = useCallback(() => {
     if (!props.navigateAwayFromProject) {
@@ -193,10 +202,10 @@ const Browse3ProjectSideNav: FC<Browse3ProjectSideNavProps> = props => {
   }, [props.navigateAwayFromProject]);
   useEffect(() => {
     const t = setTimeout(() => {
-      setWidth(drawerWidth);
+      setWidth(adjustedDrawerWidth);
     }, 0);
     return () => clearTimeout(t);
-  }, []);
+  }, [adjustedDrawerWidth]);
 
   return (
     <Drawer
@@ -226,34 +235,66 @@ const Browse3ProjectSideNav: FC<Browse3ProjectSideNavProps> = props => {
           borderBottom: '1px solid #e0e0e0',
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'space-between',
+          justifyContent: 'space-evenly',
           flexDirection: 'row',
           gap: 1,
         }}>
-        {props.navigateAwayFromProject && (
-          <IconButton
-            size="small"
+        <IconButton size="small" onClick={() => setOpen(o => !o)}>
+          {open ? <NavigateBefore /> : <NavigateNext />}
+        </IconButton>
+        {open && (
+          <FormControl fullWidth>
+            <Autocomplete
+              size={'small'}
+              disablePortal
+              disableClearable
+              options={projects}
+              value={props.project}
+              onChange={(event, newValue) => {
+                props.navigateToProject(newValue);
+              }}
+              renderInput={params => <TextField {...params} label="Project" />}
+            />
+          </FormControl>
+        )}
+      </Box>
+
+      <SideNav sections={sections} open={open} />
+
+      {props.navigateAwayFromProject && (
+        <Box
+          sx={{
+            height: 52,
+            borderTop: '1px solid #e0e0e0',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexDirection: 'row',
+            // gap: 1,
+            flex: '0 0 auto',
+            overflow: 'hidden',
+          }}>
+          <ListItemButton
+            sx={{height: '100%', width: '100%'}}
             onClick={() => {
               onNavigateAwayFromProject();
             }}>
-            <NavigateBefore />
-          </IconButton>
-        )}
-        <FormControl fullWidth>
-          <Autocomplete
-            size={'small'}
-            disablePortal
-            disableClearable
-            options={projects}
-            value={props.project}
-            onChange={(event, newValue) => {
-              props.navigateToProject(newValue);
-            }}
-            renderInput={params => <TextField {...params} label="Project" />}
-          />
-        </FormControl>
-      </Box>
-      <SideNav sections={sections} />;
+            <ListItemIcon>
+              <Undo />
+            </ListItemIcon>
+            <ListItemText
+              sx={{
+                '&>span.MuiTypography-root': {
+                  textOverflow: 'ellipsis',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                },
+              }}
+              primary="Back to Experiments"
+            />
+          </ListItemButton>
+        </Box>
+      )}
     </Drawer>
   );
 };
@@ -269,22 +310,41 @@ type ItemType = {
   onClick: () => void;
   children?: ItemType[];
 };
-const SideBarNavItem: FC<{item: ItemType; depth?: number}> = props => {
+const SideBarNavItem: FC<{
+  item: ItemType;
+  depth?: number;
+  open: boolean;
+}> = props => {
   const depth = props.depth ?? 0;
+  const show = props.open || depth === 0;
   return (
     <Fragment>
       <ListItemButton
-        sx={{pl: 2 + depth}}
+        sx={{
+          pl: 2 + depth,
+          height: !show ? 0 : 48,
+          opacity: !show ? 0 : undefined,
+          pt: !show ? 0 : undefined,
+          pb: !show ? 0 : undefined,
+          overflow: 'hidden',
+          transition: 'all 0.3s ease-in-out',
+        }}
         onClick={props.item.onClick}
         selected={props.item.selected}>
         <ListItemIcon>{props.item.icon}</ListItemIcon>
         <ListItemText primary={props.item.title} />
       </ListItemButton>
+      {/* <BottomNavigationAction label="Recents" icon={<Restore />} /> */}
       {props.item.children && (
         <List disablePadding>
           {props.item.children.map((item, itemIndex) => {
             return (
-              <SideBarNavItem item={item} depth={depth + 2} key={itemIndex} />
+              <SideBarNavItem
+                item={item}
+                depth={depth + 2}
+                key={itemIndex}
+                open={props.open}
+              />
             );
           })}
         </List>
@@ -293,25 +353,40 @@ const SideBarNavItem: FC<{item: ItemType; depth?: number}> = props => {
   );
 };
 const SideNav: FC<{
+  open: boolean;
   sections: SectionType[];
 }> = props => {
   return (
-    <Box sx={{overflow: 'auto'}}>
+    <Box sx={{overflow: 'auto', flex: '1 1 auto'}}>
       {props.sections.map((section, sectionIndex) => {
         return (
           <Fragment key={sectionIndex}>
             <ListSubheader
               id="nested-list-subheader"
               sx={{
-                pt: 1,
+                pt: !props.open ? 0 : 1,
+                height: !props.open ? 0 : 48,
+                opacity: !props.open ? 0 : undefined,
+                overflow: 'hidden',
+                transition: 'all 0.3s ease-in-out',
               }}>
               {/* {sectionIndex !== 0 && <Divider />} */}
               {section.title}
               <Divider />
             </ListSubheader>
-            <List>
+            <List
+              sx={{
+                p: !props.open ? 0 : undefined,
+                transition: 'all 0.3s ease-in-out',
+              }}>
               {section.items.map((item, itemIndex) => {
-                return <SideBarNavItem item={item} key={itemIndex} />;
+                return (
+                  <SideBarNavItem
+                    item={item}
+                    key={itemIndex}
+                    open={props.open}
+                  />
+                );
               })}
             </List>
           </Fragment>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -487,6 +487,7 @@ const ObjectVersionsTable: React.FC<{
           sortModel: [{field: 'createdAt', sort: 'desc'}],
         },
       }}
+      sx={{border: 0}}
       rowHeight={38}
       columns={columns}
       experimentalFeatures={{columnGrouping: true}}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimpleFilterableDataTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimpleFilterableDataTable.tsx
@@ -168,6 +168,7 @@ export const FilterableTable = <
       showPopoutButton={Object.keys(props.frozenFilter ?? {}).length > 0}
       filterListItems={filterListItems}>
       <DataGridPro
+        sx={{border: 0}}
         rows={dataGridRowData}
         rowHeight={38}
         columns={dataGridColumns}
@@ -206,6 +207,7 @@ export const FilterLayoutTemplate: React.FC<{
           flexDirection: 'column',
           overflowY: 'auto',
           overflowX: 'hidden',
+          borderLeft: '1px solid #e0e0e0',
         }}>
         {isOpen ? (
           <>
@@ -213,7 +215,7 @@ export const FilterLayoutTemplate: React.FC<{
               sx={{
                 pl: 1,
                 pr: 1,
-                height: 57,
+                height: 56,
                 flex: '0 0 auto',
                 borderBottom: '1px solid #e0e0e0',
                 position: 'sticky',
@@ -254,7 +256,7 @@ export const FilterLayoutTemplate: React.FC<{
         ) : (
           <Box
             sx={{
-              height: 57,
+              height: 56,
               flex: '0 0 auto',
               borderBottom: '1px solid #e0e0e0',
               display: 'flex',


### PR DESCRIPTION
Implements a quick and dirty collapsing navbar. This will certainly change with design, but it helps give more real-estate to the primary area in prep for a peek view.

<img width="2056" alt="Screenshot 2023-12-19 at 14 33 11" src="https://github.com/wandb/weave/assets/2142768/8421e97a-b75b-4053-9790-0ce03daad391">
<img width="2056" alt="Screenshot 2023-12-19 at 14 33 03" src="https://github.com/wandb/weave/assets/2142768/55de3ffd-3f1f-47f9-8ef7-631c0880b52f">
