### PR TITLE
refactor: move DimensionLike into its own file

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/ConfigDimLabel.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/ConfigDimLabel.tsx
@@ -2,8 +2,8 @@ import * as globals from '@wandb/weave/common/css/globals.styles';
 import React from 'react';
 
 import * as ConfigPanel from '../ConfigPanel';
-import {DASHBOARD_DIM_NAME_MAP, DIM_NAME_MAP} from './plotState';
-import {DimComponentInputType} from './types';
+import {DASHBOARD_DIM_NAME_MAP} from './plotState';
+import {DIM_NAME_MAP, DimComponentInputType} from './types';
 
 export const ConfigDimLabel: React.FC<
   Omit<DimComponentInputType, 'extraOptions'> & {

--- a/weave-js/src/components/Panel2/PanelPlot/DimensionLike.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/DimensionLike.ts
@@ -1,0 +1,70 @@
+import {WeaveInterface} from '@wandb/weave/core';
+import {immerable, produce} from 'immer';
+import _ from 'lodash';
+
+import {DimName, DimState, DimType} from './types';
+import {SeriesConfig} from './versions';
+
+/* A DimensionLike object is as a container for the state of a single config panel UI component
+ or group of related components for a single series. DimensionLike objects can be compared
+ to other DimensionLike objects, and can perform immutable state updates on SeriesConfig
+ objects.
+ */
+export abstract class DimensionLike {
+  readonly type: DimType;
+  readonly name: DimName;
+  readonly series: SeriesConfig;
+
+  // lets us use produce() to create new instances of these classes via mutation
+  public [immerable] = true;
+
+  protected readonly weave: WeaveInterface;
+
+  protected constructor(
+    type: DimType,
+    name: DimName,
+    series: SeriesConfig,
+    weave: WeaveInterface
+  ) {
+    this.type = type;
+    this.name = name;
+    this.series = series;
+    this.weave = weave;
+  }
+
+  withSeries(series: SeriesConfig): DimensionLike {
+    return produce(this, draft => {
+      draft.series = series;
+    });
+  }
+
+  // abstract method to impute a series with the default value for this dimension, returning a new series
+  abstract imputeThisSeriesWithDefaultState(): SeriesConfig;
+
+  // given another series, return
+  abstract imputeOtherSeriesWithThisState(s: SeriesConfig): SeriesConfig;
+
+  isVoid(): boolean {
+    return _.isEqual(
+      this.state().compareValue,
+      this.defaultState().compareValue
+    );
+  }
+
+  // return true if two dimensions are the same type, have the same state, have the same name, and
+  // have equal children. optionally return true if at least one of the dimensions is in the void state
+  equals(other: DimensionLike, tolerateVoid: boolean = false): boolean {
+    return (
+      this.type === other.type &&
+      this.name === other.name &&
+      (_.isEqual(this.state().compareValue, other.state().compareValue) ||
+        (tolerateVoid && (this.isVoid() || other.isVoid())))
+    );
+  }
+
+  // default state of the dimension, e.g., mark setting = undefined for mark, null expression for weave
+  abstract defaultState(): DimState;
+
+  // current state of the dimension e.g., mark setting for mark, or table Select function for expression dim
+  abstract state(): DimState;
+}

--- a/weave-js/src/components/Panel2/PanelPlot/types.ts
+++ b/weave-js/src/components/Panel2/PanelPlot/types.ts
@@ -1,7 +1,7 @@
 import * as Panel2 from '../panel';
 import * as TableType from '../PanelTable/tableType';
-import {DimensionLike} from './plotState';
-import {AnyPlotConfig, PlotConfig} from './versions';
+import {DimensionLike} from './DimensionLike';
+import {AnyPlotConfig, PlotConfig, SeriesConfig} from './versions';
 
 export type AxisName = 'x' | 'y';
 
@@ -31,3 +31,32 @@ export type DimComponentInputType = {
   extraOptions?: DimOptionOrSection[];
   multiline?: boolean;
 };
+
+export const DIM_NAME_MAP: {
+  [K in keyof SeriesConfig['dims'] | 'mark' | 'lineStyle']: string;
+} = {
+  pointSize: 'Size',
+  pointShape: 'Shape',
+  x: 'X Dim',
+  y: 'Y Dim',
+  label: 'Color',
+  color: 'Color',
+  mark: 'Mark',
+  tooltip: 'Tooltip',
+  y2: 'Y2 Dim',
+  lineStyle: 'Style',
+};
+
+export type DimName = keyof typeof DIM_NAME_MAP;
+
+export type DimState = {
+  value: any;
+  compareValue: string;
+};
+
+// Controls the ways a dimension can be interacted with in the UI
+export type DimType =
+  | 'optionSelect'
+  | 'weaveExpression'
+  | 'group'
+  | 'dropdownWithExpression';


### PR DESCRIPTION
Just a refactoring, moving DimensionLike out of plotState.ts - would like to do more to bring the size of that down further.