### PR TITLE
fix: short circuit pa.not_equal when null

### DIFF
--- a/weave/ops_arrow/util.py
+++ b/weave/ops_arrow/util.py
@@ -50,6 +50,9 @@ def not_equal(lhs: pa.Array, rhs: typing.Union[pa.Array, pa.Scalar]) -> pa.Array
     if rhs == None:
         rhs = None
 
+    if isinstance(lhs, pa.NullArray) and (isinstance(rhs, pa.NullArray) or not rhs):
+        return pc.fill_null(pc.cast(lhs, pa.bool_()), False)
+
     one_null, both_null = _eq_null_consumer_helper(lhs, rhs)
     result = pc.not_equal(lhs, rhs)
     result = pc.replace_with_mask(result, both_null, False)


### PR DESCRIPTION
pa.not_equal errors when comparing `null` and `null` types, handle this case explicitly

https://wandb.atlassian.net/browse/WB-16723