### PR TITLE
fix: allow selection of grouped temporal bin data

### DIFF
--- a/weave/panels/panel_plot.py
+++ b/weave/panels/panel_plot.py
@@ -812,6 +812,14 @@ def filter_node_to_selection(
             selection_max = selection[1]  # type: ignore
 
             if (
+                weave.types.TypedDict({"start": weave.types.Timestamp()}).assign_type(
+                    target.type
+                )
+                and isinstance(selection_min, (int, float))
+                and isinstance(selection_max, (int, float))
+            ):
+                target = target["start"].toNumber()
+            elif (
                 weave.types.Timestamp().assign_type(target.type)
                 and isinstance(selection_min, (int, float))
                 and isinstance(selection_max, (int, float))

--- a/weave/panels/panel_plot.py
+++ b/weave/panels/panel_plot.py
@@ -811,6 +811,9 @@ def filter_node_to_selection(
             selection_min = selection[0]  # type: ignore
             selection_max = selection[1]  # type: ignore
 
+            # This is a hack to handle selection of data from plots that have a temporal
+            # range defined with bins ("start", "stop") instead of a single timestamp.
+            # Should naievly handle selection of data from plots using op timestamps-binsnice
             if (
                 weave.types.TypedDict({"start": weave.types.Timestamp()}).assign_type(
                     target.type


### PR DESCRIPTION
when the data being selected has been operated on by binning function, we can't naively assume `target` is temporal. Lets hack-ily handle the case where our temporal data is defined by bin `start`