### PR TITLE
fix(plot): use type after unnest for tooltip nodes

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
@@ -726,8 +726,19 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
                 ),
               });
             } else {
+              const unnestedRowType = listObjectType(
+                listOfTableNodes[row._seriesIndex].type
+              ) as TypedDictType;
+
+              const unnestedType =
+                unnestedRowType.propertyTypes[
+                  vegaCols[row._seriesIndex].tooltip
+                ]!;
+
               acc[key] = constNodeUnsafe(
-                isTaggedValue(type) ? taggedValueValueType(type) : type,
+                isTaggedValue(unnestedType)
+                  ? taggedValueValueType(unnestedType)
+                  : unnestedType,
                 row[vegaCols[row._seriesIndex].tooltip]
               );
             }
@@ -740,10 +751,11 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
     }, [
       concattedNonLineTable,
       concreteConfig.series,
-      vegaCols,
       vegaReadyTables,
+      vegaCols,
       flatResultNode,
       weave.client.opStore,
+      listOfTableNodes,
     ]);
 
   const tooltipLineData: {[x: string]: ConstNode} = useMemo(() => {

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot2Inner.tsx
@@ -669,6 +669,11 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
           const selectFn = table.columnSelectFunctions[colId];
           if (isVoidNode(selectFn)) {
             // use default tooltip
+
+            const unnestedRowType = listObjectType(
+              listOfTableNodes[row._seriesIndex].type
+            ) as TypedDictType;
+
             const propertyTypes = PlotState.EXPRESSION_DIM_NAMES.reduce(
               (acc2: {[vegaColName: string]: Type}, dim: ExprDimNameType) => {
                 const colid = s.dims[dim];
@@ -677,8 +682,9 @@ export const PanelPlot2Inner: React.FC<PanelPlotProps> = props => {
                   !isVoidNode(table.columnSelectFunctions[colid]) &&
                   !isConstNode(table.columnSelectFunctions[colid])
                 ) {
-                  const colType = table.columnSelectFunctions[colid].type;
-                  acc2[vegaCols[row._seriesIndex][dim]] = isTaggedValue(colType)
+                  const colName = vegaCols[row._seriesIndex][dim];
+                  const colType = unnestedRowType.propertyTypes[colName]!;
+                  acc2[colName] = isTaggedValue(colType)
                     ? taggedValueValueType(colType)
                     : colType;
                 }


### PR DESCRIPTION
We were using the type before unnesting as the tooltip node type in cached-value, non-line tooltips. This updates the tooltip cache to use the correct (unnested) type. 