### PR TITLE
chore: use less generic icon for image/audio panels

### DIFF
--- a/weave-js/src/components/Panel2/PanelAudio/index.ts
+++ b/weave-js/src/components/Panel2/PanelAudio/index.ts
@@ -5,6 +5,7 @@ import {inputType} from './common';
 
 export const Spec: Panel2.PanelSpec = {
   id: 'audio-file',
+  icon: 'music-audio',
   Component: React.lazy(() => import('./Component')),
   inputType,
   displayName: 'Audio',

--- a/weave-js/src/components/Panel2/PanelImage.tsx
+++ b/weave-js/src/components/Panel2/PanelImage.tsx
@@ -234,6 +234,7 @@ const PanelImage: FC<PanelImageProps> = ({config, input}) => {
 
 export const Spec: Panel2.PanelSpec<PanelImageConfigType> = {
   id: 'image-file',
+  icon: 'photo',
   displayName: 'Image',
   ConfigComponent: PanelImageConfig,
   Component: PanelImage,


### PR DESCRIPTION
In outline view, use less generic icons for image and audio panels.

Before:
<img width="287" alt="Screenshot 2024-01-02 at 3 52 52 PM" src="https://github.com/wandb/weave/assets/112953339/f32ff03f-6a76-46c2-a4b3-b87809102edf">

After:
<img width="260" alt="Screenshot 2024-01-02 at 3 51 49 PM" src="https://github.com/wandb/weave/assets/112953339/984ebe99-9ccd-4db1-b73b-b5c0c4ace28b">
