### PR TITLE
chore: Ensure runs are logged after ctrl-c

### DIFF
--- a/weave/execute.py
+++ b/weave/execute.py
@@ -526,7 +526,7 @@ def execute_sync_op(op_def: op_def.OpDef, inputs: Mapping[str, typing.Any]):
         try:
             with run_context.current_run(run):
                 res = op_def.resolve_fn(**inputs)
-        except Exception as e:
+        except BaseException as e:
             client.fail_run(run, e)
             print("Error running ", op_def.name)
             raise

--- a/weave/graph_client.py
+++ b/weave/graph_client.py
@@ -83,7 +83,7 @@ class GraphClient(Protocol, Generic[R]):
         ...
 
     @abstractmethod
-    def fail_run(self, run: R, exception: Exception) -> None:
+    def fail_run(self, run: R, exception: BaseException) -> None:
         ...
 
     @abstractmethod

--- a/weave/graph_client_local.py
+++ b/weave/graph_client_local.py
@@ -131,7 +131,7 @@ class GraphClientLocal(GraphClient[WeaveRunObj]):
         with_digest_inputs["_digests"] = [ref.digest for ref in input_refs]
         return WeaveRunObj(run_id, op_name, inputs=with_digest_inputs)
 
-    def fail_run(self, run: Run, exception: Exception) -> None:
+    def fail_run(self, run: Run, exception: BaseException) -> None:
         raise NotImplementedError
 
     def finish_run(

--- a/weave/graph_client_wandb_art_st.py
+++ b/weave/graph_client_wandb_art_st.py
@@ -232,7 +232,7 @@ class GraphClientWandbArtStreamTable(GraphClient[RunStreamTableSpan]):
         # self.runs_st.log(span)
         return RunStreamTableSpan(span)
 
-    def fail_run(self, run: RunStreamTableSpan, exception: Exception) -> None:
+    def fail_run(self, run: RunStreamTableSpan, exception: BaseException) -> None:
         span = copy.copy(run._attrs)
         span["end_time_s"] = time.time()
         span["status_code"] = "ERROR"


### PR DESCRIPTION
BaseException is broader than Exception, it includes KeyboardInterrupt. This PR ensures we log run spans for all BaseException. This is especially important right now given runs are only created when they are finished as opposed to when they are started. This ensures that for infinitely running agents that can only be stopped by ctrl-c, we still log the top level run span.