### PR TITLE
chore: update plot group by to new component

### DIFF
--- a/weave-js/src/components/Form/Select.tsx
+++ b/weave-js/src/components/Form/Select.tsx
@@ -88,7 +88,7 @@ const CLEAR_INDICATOR_PADDING: Record<SelectSize, number> = {
   variable: 2,
 } as const;
 
-type AdditionalProps = {
+export type AdditionalProps = {
   size?: SelectSize;
   errorState?: boolean;
   groupDivider?: boolean;

--- a/weave-js/src/components/Form/SelectMultiple.tsx
+++ b/weave-js/src/components/Form/SelectMultiple.tsx
@@ -1,5 +1,6 @@
 /**
  * Customized version of react-select for selecting multiple options.
+ * See https://react-select.com/advanced#sortable-multiselect
  */
 
 import React, {MouseEventHandler} from 'react';
@@ -11,7 +12,6 @@ import {
 } from 'react-select';
 import {
   SortableContainer,
-  SortableContainerProps,
   SortableElement,
   SortableHandle,
   SortEndHandler,
@@ -19,6 +19,7 @@ import {
 
 import {AdditionalProps, Select} from './Select';
 
+// Create a copy of the specified array, moving an item from one index to another.
 function arrayMove<T>(array: readonly T[], from: number, to: number) {
   const slicedArray = array.slice();
   slicedArray.splice(
@@ -35,32 +36,29 @@ const SortableMultiValueLabel = SortableHandle(
 
 type Props<Option> = ReactSelectProps<Option, true> & AdditionalProps;
 
-export const SelectMultipleSortable = <Option,>(props: Props<Option>) => {
-  const SortableMultiValue = SortableElement(
-    (smvprops: MultiValueProps<Option>) => {
-      // this prevents the menu from being opened/closed when the user clicks
-      // on a value to begin dragging it. ideally, detecting a click (instead of
-      // a drag) would still focus the control and toggle the menu, but that
-      // requires some magic with refs that are out of scope for this example
-      const onMouseDown: MouseEventHandler<HTMLDivElement> = e => {
-        e.preventDefault();
-        e.stopPropagation();
-      };
-      const innerProps = {...smvprops.innerProps, onMouseDown};
-      return (
-        <components.MultiValue
-          {...smvprops}
-          innerProps={innerProps}
-          isDisabled={true}
-        />
-      );
-    }
+const MultiValue = (smvprops: MultiValueProps) => {
+  // this prevents the menu from being opened/closed when the user clicks
+  // on a value to begin dragging it. ideally, detecting a click (instead of
+  // a drag) would still focus the control and toggle the menu, but that
+  // requires some magic with refs that are out of scope for this example
+  const onMouseDown: MouseEventHandler<HTMLDivElement> = e => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+  const innerProps = {...smvprops.innerProps, onMouseDown};
+  return (
+    <components.MultiValue
+      {...smvprops}
+      innerProps={innerProps}
+      isDisabled={true}
+    />
   );
+};
 
-  const SortableSelect = SortableContainer(Select) as React.ComponentClass<
-    Props<Option> & SortableContainerProps
-  >;
+const SortableMultiValue = SortableElement(MultiValue);
+const SortableSelect = SortableContainer(Select) as any;
 
+export const SelectMultipleSortable = <Option,>(props: Props<Option>) => {
   const [selected, setSelected] = React.useState<readonly Option[]>([]);
   const onSortEnd: SortEndHandler = ({oldIndex, newIndex}) => {
     const newValue = arrayMove(selected, oldIndex, newIndex);
@@ -76,7 +74,7 @@ export const SelectMultipleSortable = <Option,>(props: Props<Option>) => {
       onSortEnd={onSortEnd}
       distance={4}
       // small fix for https://github.com/clauderic/react-sortable-hoc/pull/352:
-      getHelperDimensions={({node}) => node.getBoundingClientRect()}
+      getHelperDimensions={({node}: any) => node.getBoundingClientRect()}
       size="variable"
       isMulti
       components={{

--- a/weave-js/src/components/Form/SelectMultiple.tsx
+++ b/weave-js/src/components/Form/SelectMultiple.tsx
@@ -1,0 +1,101 @@
+/**
+ * Customized version of react-select for selecting multiple options.
+ */
+
+import React, {MouseEventHandler} from 'react';
+import {
+  components,
+  MultiValueGenericProps,
+  MultiValueProps,
+  Props as ReactSelectProps,
+} from 'react-select';
+import {
+  SortableContainer,
+  SortableContainerProps,
+  SortableElement,
+  SortableHandle,
+  SortEndHandler,
+} from 'react-sortable-hoc';
+
+import {AdditionalProps, Select} from './Select';
+
+function arrayMove<T>(array: readonly T[], from: number, to: number) {
+  const slicedArray = array.slice();
+  slicedArray.splice(
+    to < 0 ? array.length + to : to,
+    0,
+    slicedArray.splice(from, 1)[0]
+  );
+  return slicedArray;
+}
+
+const SortableMultiValueLabel = SortableHandle(
+  (props: MultiValueGenericProps) => <components.MultiValueLabel {...props} />
+);
+
+type Props<Option> = ReactSelectProps<Option, true> & AdditionalProps;
+
+export const SelectMultipleSortable = <Option,>(props: Props<Option>) => {
+  const SortableMultiValue = SortableElement(
+    (smvprops: MultiValueProps<Option>) => {
+      // this prevents the menu from being opened/closed when the user clicks
+      // on a value to begin dragging it. ideally, detecting a click (instead of
+      // a drag) would still focus the control and toggle the menu, but that
+      // requires some magic with refs that are out of scope for this example
+      const onMouseDown: MouseEventHandler<HTMLDivElement> = e => {
+        e.preventDefault();
+        e.stopPropagation();
+      };
+      const innerProps = {...smvprops.innerProps, onMouseDown};
+      return (
+        <components.MultiValue
+          {...smvprops}
+          innerProps={innerProps}
+          isDisabled={true}
+        />
+      );
+    }
+  );
+
+  const SortableSelect = SortableContainer(Select) as React.ComponentClass<
+    Props<Option> & SortableContainerProps
+  >;
+
+  const [selected, setSelected] = React.useState<readonly Option[]>([]);
+  const onSortEnd: SortEndHandler = ({oldIndex, newIndex}) => {
+    const newValue = arrayMove(selected, oldIndex, newIndex);
+    setSelected(newValue);
+  };
+
+  return (
+    <SortableSelect
+      {...props}
+      useDragHandle
+      // react-sortable-hoc props:
+      axis="xy"
+      onSortEnd={onSortEnd}
+      distance={4}
+      // small fix for https://github.com/clauderic/react-sortable-hoc/pull/352:
+      getHelperDimensions={({node}) => node.getBoundingClientRect()}
+      size="variable"
+      isMulti
+      components={{
+        // @ts-ignore We're failing to provide a required index prop to SortableElement
+        MultiValue: SortableMultiValue,
+        MultiValueLabel: SortableMultiValueLabel,
+      }}
+    />
+  );
+};
+
+type SelectMultipleProps<Opt> = Props<Opt> & {
+  sortable?: boolean;
+};
+
+export const SelectMultiple = <Option,>(props: SelectMultipleProps<Option>) => {
+  return props.sortable ? (
+    <SelectMultipleSortable {...props} />
+  ) : (
+    <Select {...props} size="variable" isMulti />
+  );
+};

--- a/weave-js/src/components/Panel2/PanelPlot/SelectGroupBy.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/SelectGroupBy.tsx
@@ -1,0 +1,61 @@
+/**
+ * A select component for panel plot group by.
+ */
+import React from 'react';
+import {OnChangeValue} from 'react-select';
+
+import {SelectMultiple} from '../../Form/SelectMultiple';
+import {SeriesConfig} from './versions';
+
+export type GroupByOption = {
+  readonly value: string;
+  readonly label: string;
+};
+
+type SelectGroupByProps = {
+  options: GroupByOption[];
+  series: SeriesConfig;
+
+  onAdd: (dimName: keyof SeriesConfig['dims'], value: string) => void;
+  onRemove: (dimName: keyof SeriesConfig['dims'], value: string) => void;
+};
+
+export const SelectGroupBy = ({
+  options,
+  series,
+  onAdd,
+  onRemove,
+}: SelectGroupByProps) => {
+  const value = options.filter(o => series.table.groupBy.includes(o.value));
+
+  const onChange = (newValue: OnChangeValue<GroupByOption, true>) => {
+    if (newValue == null) {
+      return;
+    }
+    const values = newValue.map(x => x.value);
+    const valueToAdd = values.filter(x => !series.table.groupBy.includes(x));
+    const valueToRemove = series.table.groupBy.filter(x => !values.includes(x));
+
+    if (valueToAdd.length > 0) {
+      const v = valueToAdd[0];
+      const dimName = options.find(o => o.value === v)
+        ?.label as keyof SeriesConfig['dims'];
+      onAdd(dimName, v);
+    } else if (valueToRemove.length > 0) {
+      const v = valueToRemove[0];
+      const dimName = options.find(o => o.value === v)
+        ?.label as keyof SeriesConfig['dims'];
+      onRemove(dimName, v);
+    }
+  };
+
+  return (
+    <SelectMultiple<GroupByOption>
+      options={options}
+      value={value}
+      onChange={onChange}
+      isSearchable={false}
+      placeholder="Select dimensions..."
+    />
+  );
+};

--- a/weave-js/src/components/Panel2/PanelPlot/SelectGroupBy.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/SelectGroupBy.tsx
@@ -55,6 +55,7 @@ export const SelectGroupBy = ({
       value={value}
       onChange={onChange}
       isSearchable={false}
+      isClearable={false}
       placeholder="Select dimensions..."
     />
   );


### PR DESCRIPTION
Adds a generic select component that optionally allows dragging the selected options to rearrange them. This code is based on a react-select example: https://react-select.com/advanced#sortable-multiselect

The second part of this PR replaces the current panel plot "Group by" selector with the new component. This does not take advantage of the sorting, but a later PR for specifying the tooltip dimension will.

The main advantage is more consistent styling. We also add placeholder text.

Before:
<img width="317" alt="Screenshot 2024-01-03 at 11 00 36 AM" src="https://github.com/wandb/weave/assets/112953339/cfc6c185-2c31-443c-aa9b-676a179ffeee">
<img width="304" alt="Screenshot 2024-01-03 at 11 00 31 AM" src="https://github.com/wandb/weave/assets/112953339/7371a58d-678a-4c85-8693-5cad6a5b93cd">

After:
<img width="314" alt="Screenshot 2024-01-03 at 11 01 46 AM" src="https://github.com/wandb/weave/assets/112953339/70ad1ed6-7214-4566-82cf-3552abe9d61e">
<img width="310" alt="Screenshot 2024-01-03 at 2 30 49 PM" src="https://github.com/wandb/weave/assets/112953339/eb461ceb-5ed7-4ba9-9549-eb73bad78dda">
