### PR TITLE
chore: Fix weaveflow ref loading issue

### DIFF
--- a/weave/api.py
+++ b/weave/api.py
@@ -178,7 +178,7 @@ def ref(uri: str) -> _ref_base.Ref:
             version = "latest"
         else:
             name, version = uri.split(":")
-        uri = str(client.ref_uri(name, version))
+        uri = str(client.ref_uri(name, version, "obj"))
 
     return _ref_base.Ref.from_str(uri)
 

--- a/weave/graph_client.py
+++ b/weave/graph_client.py
@@ -59,7 +59,7 @@ class GraphClient(Protocol, Generic[R]):
         ...
 
     @abstractmethod
-    def ref_uri(self, name: str, version: str) -> WeaveURI:
+    def ref_uri(self, name: str, version: str, path: str) -> WeaveURI:
         ...
 
     @abstractmethod

--- a/weave/graph_client_local.py
+++ b/weave/graph_client_local.py
@@ -105,8 +105,10 @@ class GraphClientLocal(GraphClient[WeaveRunObj]):
     def ref_is_own(self, ref: typing.Optional[ref_base.Ref]) -> bool:
         return isinstance(ref, artifact_local.LocalArtifactRef)
 
-    def ref_uri(self, name: str, version: str) -> artifact_local.WeaveLocalArtifactURI:
-        return artifact_local.WeaveLocalArtifactURI(name, version)
+    def ref_uri(
+        self, name: str, version: str, path: str
+    ) -> artifact_local.WeaveLocalArtifactURI:
+        return artifact_local.WeaveLocalArtifactURI(name, version, path=path)
 
     def run_ui_url(self, run: Run) -> str:
         raise NotImplementedError

--- a/weave/graph_client_wandb_art_st.py
+++ b/weave/graph_client_wandb_art_st.py
@@ -165,9 +165,11 @@ class GraphClientWandbArtStreamTable(GraphClient[RunStreamTableSpan]):
     def ref_is_own(self, ref: typing.Optional[Ref]) -> bool:
         return isinstance(ref, artifact_wandb.WandbArtifactRef)
 
-    def ref_uri(self, name: str, version: str) -> artifact_wandb.WeaveWBArtifactURI:
+    def ref_uri(
+        self, name: str, version: str, path: str
+    ) -> artifact_wandb.WeaveWBArtifactURI:
         return artifact_wandb.WeaveWBArtifactURI(
-            name, version, self.entity_name, self.project_name
+            name, version, self.entity_name, self.project_name, path=path
         )
 
     def run_ui_url(self, run: Run) -> str:


### PR DESCRIPTION
`weave.ref('dataset').get()` was failing, because we were not using the 'obj' path.