### PR TITLE
fix: Async ops, fix openai patching, gnarly shutdown bugfix, perf

### DIFF
--- a/weave/context_state.py
+++ b/weave/context_state.py
@@ -293,3 +293,12 @@ def ref_tracking(enabled: bool):
     token = _ref_tracking_enabled.set(enabled)
     yield _ref_tracking_enabled.get()
     _ref_tracking_enabled.reset(token)
+
+
+_serverless_io_service: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_serverless_io_service", default=False
+)
+
+
+def serverless_io_service() -> bool:
+    return _serverless_io_service.get()

--- a/weave/graph_client_local.py
+++ b/weave/graph_client_local.py
@@ -65,7 +65,13 @@ class GraphClientLocal(GraphClient[WeaveRunObj]):
         raise NotImplementedError
 
     def op_runs(self, op_def: OpDef) -> Sequence[Run]:
-        raise NotImplementedError
+        runs = storage.objects(types.RunType())
+        result: list[WeaveRunObj] = []
+        for run_ref in runs:
+            run = typing.cast(WeaveRunObj, run_ref.get())
+            if run.op_name == str(op_def.location):
+                result.append(run)
+        return result
 
     def ref_input_to(self, ref: Ref) -> Sequence[Run]:
         runs = storage.objects(types.RunType())

--- a/weave/graph_client_wandb_art_st.py
+++ b/weave/graph_client_wandb_art_st.py
@@ -51,7 +51,6 @@ class GraphClientWandbArtStreamTable(GraphClient[RunStreamTableSpan]):
     def __init__(self, entity_name: str, project_name: str):
         self.entity_name = entity_name
         self.project_name = project_name
-        self.saved_objs = {}
 
     @functools.cached_property
     def runs_st(self) -> monitoring.StreamTable:
@@ -185,10 +184,6 @@ class GraphClientWandbArtStreamTable(GraphClient[RunStreamTableSpan]):
     def save_object(
         self, obj: typing.Any, name: str, branch_name: str
     ) -> artifact_wandb.WandbArtifactRef:
-        saved = self.saved_objs.get(id(obj))
-        if saved:
-            return saved
-
         from . import storage
 
         res = storage._direct_publish(
@@ -198,7 +193,6 @@ class GraphClientWandbArtStreamTable(GraphClient[RunStreamTableSpan]):
             wb_project_name=self.project_name,
             branch_name=branch_name,
         )
-        self.saved_objs[id(obj)] = res
         return res
 
     def create_run(

--- a/weave/graph_client_wandb_art_st.py
+++ b/weave/graph_client_wandb_art_st.py
@@ -51,6 +51,7 @@ class GraphClientWandbArtStreamTable(GraphClient[RunStreamTableSpan]):
     def __init__(self, entity_name: str, project_name: str):
         self.entity_name = entity_name
         self.project_name = project_name
+        self.saved_objs = {}
 
     @functools.cached_property
     def runs_st(self) -> monitoring.StreamTable:
@@ -184,15 +185,21 @@ class GraphClientWandbArtStreamTable(GraphClient[RunStreamTableSpan]):
     def save_object(
         self, obj: typing.Any, name: str, branch_name: str
     ) -> artifact_wandb.WandbArtifactRef:
+        saved = self.saved_objs.get(id(obj))
+        if saved:
+            return saved
+
         from . import storage
 
-        return storage._direct_publish(
+        res = storage._direct_publish(
             obj,
             name=name,
             wb_entity_name=self.entity_name,
             wb_project_name=self.project_name,
             branch_name=branch_name,
         )
+        self.saved_objs[id(obj)] = res
+        return res
 
     def create_run(
         self,

--- a/weave/monitoring/monitor.py
+++ b/weave/monitoring/monitor.py
@@ -366,6 +366,15 @@ def default_monitor() -> Monitor:
 
 
 def _get_global_monitor() -> typing.Optional[Monitor]:
+    client = graph_client_context.get_graph_client()
+    if client is not None:
+        if not isinstance(
+            client, graph_client_wandb_art_st.GraphClientWandbArtStreamTable
+        ):
+            raise ValueError(
+                "monitor logging (via openai patch for example) is only supported with wandb client currently"
+            )
+        return Monitor(client.runs_st)
     return _global_monitor
 
 

--- a/weave/op_def.py
+++ b/weave/op_def.py
@@ -3,7 +3,7 @@ import copy
 import contextvars
 import contextlib
 import typing
-from typing import Iterable
+from typing import Sequence
 import inspect
 
 from weave.weavejs_fixes import fixup_node
@@ -607,7 +607,7 @@ class OpDef:
     def op_def_is_auto_tag_handling_arrow_op(self) -> bool:
         return isinstance(self, AutoTagHandlingArrowOpDef)
 
-    def runs(self) -> Iterable[Run]:
+    def runs(self) -> Sequence[Run]:
         client = graph_client_context.require_graph_client()
         return client.op_runs(self)
 

--- a/weave/storage.py
+++ b/weave/storage.py
@@ -149,6 +149,7 @@ def _direct_publish(
     _lite_run: typing.Optional["InMemoryLazyLiteRun"] = None,
     _merge: typing.Optional[bool] = False,
 ) -> artifact_wandb.WandbArtifactRef:
+    _orig_obj = obj
     _orig_ref = _get_ref(obj)
     if isinstance(_orig_ref, artifact_wandb.WandbArtifactRef):
         return _orig_ref
@@ -204,6 +205,7 @@ def _direct_publish(
         PUBLISH_CACHE_BY_LOCAL_ART[_orig_ref] = ref
 
     ref_base._put_ref(obj, ref)
+    ref_base._put_ref(_orig_obj, ref)
 
     return ref
 

--- a/weave/tests/test_weaveflow.py
+++ b/weave/tests/test_weaveflow.py
@@ -161,3 +161,26 @@ def test_weaveflow_nested_op(user_by_api_key_in_env):
 
         res = double_adder(1, 2)
         assert res == 6
+
+
+def test_async_ops(cache_mode_minimal):
+    with weave.local_client():
+
+        @weave.op()
+        async def async_op_add1(v: int) -> int:
+            return v + 1
+
+        @weave.op()
+        async def async_op_add5(v: int) -> int:
+            for i in range(5):
+                v = await async_op_add1(v)
+            return v
+
+        called = async_op_add5(10)
+        import asyncio
+
+        result = asyncio.run(called)
+        assert result == 15
+
+        assert len(async_op_add5.runs()) == 1
+        assert len(async_op_add1.runs()) == 5

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -253,7 +253,6 @@ class StreamTable(_StreamTableSync):
         )
 
         self.queue: queue.Queue = queue.Queue()
-        atexit.register(self._at_exit)
         self._lock = threading.Lock()
         self._join_event = threading.Event()
         self._thread = threading.Thread(target=self._thread_body)

--- a/weave/weave_init.py
+++ b/weave/weave_init.py
@@ -12,11 +12,15 @@ class InitializedClient:
         self.graph_client_token = context_state._graph_client.set(client)
         self.ref_tracking_token = context_state._ref_tracking_enabled.set(True)
         self.eager_mode_token = context_state._eager_mode.set(True)
+        self.serverless_io_service_token = context_state._serverless_io_service.set(
+            True
+        )
 
     def reset(self) -> None:
         context_state._graph_client.reset(self.graph_client_token)
         context_state._ref_tracking_enabled.reset(self.ref_tracking_token)
         context_state._eager_mode.reset(self.eager_mode_token)
+        context_state._serverless_io_service.reset(self.serverless_io_service_token)
 
 
 def init_wandb(project_name: str) -> InitializedClient:


### PR DESCRIPTION
This PR cleans up everything I needed to get fast weaveflow evaluation working:
- adds async op support (just decorate an async function with weave.op and use it as usual)
- adds a perf improvement to the wandb graph client to avoid repeatedly trying to publish the same objets
- fixes a super gnarly shutdown hang due to not being able to use the IO service in atexit handlers
- fixes openai patching to work with weaveflow init