### PR TITLE
fix: Pin wandb to <= 0.16.1 due to two breaking changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-wandb>=0.15.5
+wandb>=0.15.5,<=0.16.1
 sentry-sdk<1.29.0 # 1.29.0 adds monkey-patched GQL error handling which breaks our unit tests communicating with the server
 python-json-logger>=2.0.4
 numpy>=1.21


### PR DESCRIPTION
Here are the two breaking changes:

- AttributeError: module 'wandb.apis.public' has no attribute 'gql' : Wandb commit here: https://github.com/wandb/wandb/commit/bee62176d45c7bbae6c1c0a2b5f8c647efc76692
- Breaking change to ArtifactSaver interface (Jason's commit!): https://github.com/wandb/wandb/commit/cb57e43018daff0909147f09f76f675dc59968b2#diff-06a6146aec248dca32eaf76c52b4959a978ce8de96b20c103e8f2e26ebe33775