### PR TITLE
feat: Hugely improved op saving/loading support

### DIFF
--- a/weave/cli.py
+++ b/weave/cli.py
@@ -49,7 +49,6 @@ def serve(
     env: str,
     port: int,
 ) -> None:
-    print(f"Serving {model_ref}")
     parsed_ref = uris.WeaveURI.parse(model_ref).to_ref()
     if not isinstance(parsed_ref, artifact_wandb.WandbArtifactRef):
         raise ValueError(f"Expected a wandb artifact ref, got {parsed_ref}")

--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -290,3 +290,9 @@ def consistent_table_col_ids():
 def ref_tracking():
     with context_state.ref_tracking(True):
         yield
+
+
+@pytest.fixture()
+def strict_op_saving():
+    with context_state.strict_op_saving(True):
+        yield

--- a/weave/context_state.py
+++ b/weave/context_state.py
@@ -302,3 +302,21 @@ _serverless_io_service: contextvars.ContextVar[bool] = contextvars.ContextVar(
 
 def serverless_io_service() -> bool:
     return _serverless_io_service.get()
+
+
+# Throw an error if op saving encounters an unknonwn condition.
+# The default behavior is to warn.
+_strict_op_saving: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "_strict_op_saving", default=False
+)
+
+
+def get_strict_op_saving() -> bool:
+    return _strict_op_saving.get()
+
+
+@contextlib.contextmanager
+def strict_op_saving(enabled: bool):
+    token = _strict_op_saving.set(enabled)
+    yield _strict_op_saving.get()
+    _strict_op_saving.reset(token)

--- a/weave/decorator_op.py
+++ b/weave/decorator_op.py
@@ -80,7 +80,6 @@ def op(
             pure=pure,
             plugins=plugins,
             mutation=mutation,
-            _decl_locals=inspect.currentframe().f_back.f_locals,
         )
         if weavify:
             from .weavify import op_to_weave_fn

--- a/weave/derive_op.py
+++ b/weave/derive_op.py
@@ -1,3 +1,7 @@
+# This contains logic for making "mapped" ops for all regularly declared ops.
+# These derived ops are not yet fully Weave serializable due to some non-json stuff
+#     in their closure. So we disable strict_op_saving when deriving them.
+
 import copy
 import inspect
 import typing
@@ -19,6 +23,7 @@ from . import weave_internal
 from . import execute_fast
 from . import op_policy
 from . import parallelism
+from . import context_state
 
 from .language_features.tagging import tag_store
 
@@ -373,26 +378,27 @@ class MappedDeriveOpHandler(DeriveOpHandler):
         base_weave_type: type[types.Type],
         orig_op_new_name: str,
     ):
-        named_args = derived_op.input_type.named_args()
-        if len(named_args) == 0 or not isinstance(
-            derived_op.input_type, op_args.OpNamedArgs
-        ):
-            raise errors.WeaveDefinitionError(
-                f"Expected mapped op {derived_op.name} to have named first argument."
+        with context_state.strict_op_saving(False):
+            named_args = derived_op.input_type.named_args()
+            if len(named_args) == 0 or not isinstance(
+                derived_op.input_type, op_args.OpNamedArgs
+            ):
+                raise errors.WeaveDefinitionError(
+                    f"Expected mapped op {derived_op.name} to have named first argument."
+                )
+            first_arg = named_args[0]
+            # Check to see if the first argument is a list of UnknownType. This is how
+            # we know that the type is expected to be the class type
+            first_arg_is_cls = first_arg.type == types.List(
+                types.optional(types.UnknownType())
             )
-        first_arg = named_args[0]
-        # Check to see if the first argument is a list of UnknownType. This is how
-        # we know that the type is expected to be the class type
-        first_arg_is_cls = first_arg.type == types.List(
-            types.optional(types.UnknownType())
-        )
-        if first_arg_is_cls:
-            derived_op.input_type.arg_types[first_arg.name] = types.List(
-                types.optional(base_weave_type())
+            if first_arg_is_cls:
+                derived_op.input_type.arg_types[first_arg.name] = types.List(
+                    types.optional(base_weave_type())
+                )
+            registry_mem.memory_registry.rename_op(
+                derived_op.name, MappedDeriveOpHandler.derived_name(orig_op_new_name)
             )
-        registry_mem.memory_registry.rename_op(
-            derived_op.name, MappedDeriveOpHandler.derived_name(orig_op_new_name)
-        )
 
 
 def _mapped_refine_output_type(orig_op):
@@ -443,8 +449,12 @@ def handler_for_id(handler_id: str) -> type[DeriveOpHandler]:
 
 
 def derive_ops(op: op_def.OpDef):
-    for handler in DeriveOpHandler.__subclasses__():
-        if handler.should_derive_op(op) and handler.handler_id not in op.derived_ops:
-            new_op = handler.make_derived_op(op)
-            op.derived_ops[handler.handler_id] = new_op
-            new_op.derived_from = op
+    with context_state.strict_op_saving(False):
+        for handler in DeriveOpHandler.__subclasses__():
+            if (
+                handler.should_derive_op(op)
+                and handler.handler_id not in op.derived_ops
+            ):
+                new_op = handler.make_derived_op(op)
+                op.derived_ops[handler.handler_id] = new_op
+                new_op.derived_from = op

--- a/weave/errors.py
+++ b/weave/errors.py
@@ -165,3 +165,7 @@ class WeaveMissingOpDefError(WeaveBaseError):
 
 class WeaveMergeArtifactSpecError(WeaveBaseError):
     pass
+
+
+class WeaveOpSerializeError(WeaveBaseError):
+    pass

--- a/weave/op_def.py
+++ b/weave/op_def.py
@@ -209,7 +209,6 @@ class OpDef:
     location: typing.Optional[uris.WeaveURI]
     is_builtin: bool = False
     weave_fn: typing.Optional[graph.Node]
-    _decl_locals: typing.Dict[str, typing.Any]
     instance: typing.Union[None, graph.Node]
     hidden: bool
     pure: bool
@@ -254,7 +253,6 @@ class OpDef:
         weave_fn: typing.Optional[graph.Node] = None,
         *,
         plugins=None,
-        _decl_locals=None,  # These are python locals() from the enclosing scope.
     ):
         self.name = name
         self.input_type = input_type
@@ -271,7 +269,6 @@ class OpDef:
             if is_builtin is not None
             else context_state.get_loading_built_ins()
         )
-        self._decl_locals = _decl_locals
         self.version = None
         self.location = None
         self.instance = None

--- a/weave/op_def_type.py
+++ b/weave/op_def_type.py
@@ -371,7 +371,7 @@ class OpDefType(types.Type):
                 # Weaveflow Merge: fromlist correctly imports submodules
                 mod = __import__(import_name, fromlist=[module_dir])
             except Exception as e:
-                print("Op loading exception. This might be fine!")
+                print("Op loading exception. This might be fine!", e)
                 import traceback
 
                 traceback.print_exc()

--- a/weave/op_def_type.py
+++ b/weave/op_def_type.py
@@ -157,15 +157,6 @@ class ExternalVariableFinder(ast.NodeVisitor):
         ):
             self.external_vars[node.id] = True
 
-    def generic_visit(self, node):
-        """Visit a node and add a new scope if it's a new block."""
-        # print("GEN VISIT", node)
-        # if isinstance(node, (ast.For, ast.While, ast.If, ast.With, ast.Try)):
-        #     self.scope_stack.append(set())
-        super().generic_visit(node)
-        # if isinstance(node, (ast.For, ast.While, ast.If, ast.With, ast.Try)):
-        #     self.scope_stack.pop()
-
 
 def resolve_var(fn: typing.Callable, var_name: str):
     """Given a python function, resolve a non-local variable name."""

--- a/weave/serve_fastapi.py
+++ b/weave/serve_fastapi.py
@@ -1,5 +1,6 @@
 import typing
 import datetime
+import inspect
 from fastapi import FastAPI, Header, HTTPException, Depends
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from typing import Optional
@@ -128,7 +129,10 @@ def object_method_app(
 
     @app.post(f"/{method_name}", summary=method_name)
     async def method_route(item: Item) -> dict:  # type: ignore
-        result = bound_method_op(**item.dict())  # type: ignore
+        if inspect.iscoroutinefunction(bound_method_op.raw_resolve_fn):
+            result = await bound_method_op(**item.dict())  # type: ignore
+        else:
+            result = bound_method_op(**item.dict())  # type: ignore
         return {"result": result}
 
     return app

--- a/weave/tests/op_versioning_importfrom.py
+++ b/weave/tests/op_versioning_importfrom.py
@@ -1,0 +1,7 @@
+import weave
+from numpy import array
+
+
+@weave.op()
+def versioned_op_importfrom(a: int) -> float:
+    return array([x + 1 for x in range(a)]).mean()

--- a/weave/tests/op_versioning_inlineimport.py
+++ b/weave/tests/op_versioning_inlineimport.py
@@ -1,0 +1,22 @@
+import weave
+
+
+@weave.op()
+def versioned_op_inline_import(a: int) -> float:
+    import numpy
+
+    return numpy.array([a, a]).mean()
+
+
+@weave.op()
+def versioned_op_inline_import_alias(a: int) -> float:
+    import numpy as np
+
+    return np.array([a, a]).mean()
+
+
+@weave.op()
+def versioned_op_inline_importfrom(a: int) -> float:
+    from numpy import array
+
+    return array([a, a]).mean()

--- a/weave/tests/op_versioning_obj.py
+++ b/weave/tests/op_versioning_obj.py
@@ -1,0 +1,14 @@
+import weave
+from weave import artifact_fs
+
+import numpy as np
+
+
+@weave.type()
+class MyTestObjWithOp:
+    val: int
+
+    @weave.op()
+    def versioned_op(self, a: int) -> float:
+        # Rely on the "import numpy as np" import
+        return np.array([a, self.val]).mean()

--- a/weave/tests/op_versioning_solo.py
+++ b/weave/tests/op_versioning_solo.py
@@ -1,0 +1,9 @@
+import weave
+from weave import artifact_fs
+import numpy as np
+
+
+@weave.op()
+def solo_versioned_op(a: int) -> float:
+    # Rely on the "import numpy as np" import
+    return np.array([a, a]).mean()

--- a/weave/tests/test_op_versioning.py
+++ b/weave/tests/test_op_versioning.py
@@ -173,3 +173,15 @@ def test_op_versioning_closure_contant(strict_op_saving):
         saved_code = f.read()
 
     assert saved_code == EXPECTED_CLOSURE_CONTANT_OP_CODE
+
+
+def test_op_versioning_exception(strict_op_saving):
+    # Just ensure this doesn't raise by running it.
+    @weave.op()
+    def versioned_op_exception(a: int) -> float:
+        try:
+            x = 1 / 0
+        except Exception as e:
+            print("E", e)
+            return 9999
+        return x

--- a/weave/weaveflow/util.py
+++ b/weave/weaveflow/util.py
@@ -1,0 +1,24 @@
+from typing import AsyncIterator, Callable, Iterable, Tuple, TypeVar, Awaitable
+import asyncio
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+async def async_foreach(
+    sequence: Iterable[T],
+    func: Callable[[T], Awaitable[U]],
+    max_concurrent_tasks: int,
+) -> AsyncIterator[Tuple[T, U]]:
+    semaphore = asyncio.Semaphore(max_concurrent_tasks)
+
+    async def process_item(item: T) -> Tuple[T, U]:
+        async with semaphore:
+            result = await func(item)
+            return item, result
+
+    tasks = [asyncio.create_task(process_item(item)) for item in sequence]
+
+    for task in asyncio.as_completed(tasks):
+        item, result = await task
+        yield item, result


### PR DESCRIPTION
- Fix cases where ops that were methods on classes didn't capture dependencies
- Much better error messages/warnings: walk the AST of op function bodies, ensuring that we can capture any variables that are external references to the function
- Improve module import generation, handles more cases
- Capture closure variables that are json-able correctly.
- Add unit tests for all these cases

Bonus:
- fix "weave serve" for async ops
- add async_foreach util