### PR TITLE
chore(weave): Dramatic simplification of Weaveflow UI pre internal release

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CallViewSmall.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CallViewSmall.tsx
@@ -54,7 +54,7 @@ export const CallViewSmall: FC<{
             />
           </Box>
           <Typography variant="body2" component="span">
-            {monthRoundedTime(call.summary.latency_s, true)}
+            {monthRoundedTime(call.summary.latency_s)}
           </Typography>
         </CallEl>
       </Typography>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -100,6 +100,7 @@ export const RunsTable: FC<{
       return {
         id: call.span_id,
         ormCall,
+        loading,
         opVersion: ormCall?.opVersion()?.op()?.name(),
         isRoot: ormCall?.parentCall() == null,
         opCategory: ormCall?.opVersion()?.opCategory(),
@@ -144,7 +145,7 @@ export const RunsTable: FC<{
         ),
       };
     });
-  }, [orm?.projectConnection, spans]);
+  }, [orm?.projectConnection, spans, loading]);
 
   const columns = useMemo(() => {
     const cols: GridColDef[] = [
@@ -457,9 +458,9 @@ export const RunsTable: FC<{
       expand: true,
     });
   }, [apiRef, loading]);
-  if (loading) {
-    return null;
-  }
+  // if (loading) {
+  //   return null;
+  // }
   return (
     <DataGridPro
       sx={{border: 0}}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -457,6 +457,9 @@ export const RunsTable: FC<{
       expand: true,
     });
   }, [apiRef, loading]);
+  if (loading) {
+    return null;
+  }
   return (
     <DataGridPro
       sx={{border: 0}}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -298,27 +298,29 @@ export const RunsTable: FC<{
       const attributesGrouping = buildTree(attributesOrder, 'attributes');
       colGroupingModel.push(attributesGrouping);
       for (const key of attributesOrder) {
-        cols.push({
-          flex: 1,
-          minWidth: 150,
-          field: 'attributes.' + key,
-          headerName: key.split('.').slice(-1)[0],
-          renderCell: cellParams => {
-            if (
-              typeof cellParams.row['attributes.' + key] === 'string' &&
-              cellParams.row['attributes.' + key].startsWith(
-                'wandb-artifact:///'
-              )
-            ) {
-              return (
-                <SmallRef
-                  objRef={parseRef(cellParams.row['attributes.' + key])}
-                />
-              );
-            }
-            return cellParams.row['attributes.' + key];
-          },
-        });
+        if (!key.startsWith('_')) {
+          cols.push({
+            flex: 1,
+            minWidth: 150,
+            field: 'attributes.' + key,
+            headerName: key.split('.').slice(-1)[0],
+            renderCell: cellParams => {
+              if (
+                typeof cellParams.row['attributes.' + key] === 'string' &&
+                cellParams.row['attributes.' + key].startsWith(
+                  'wandb-artifact:///'
+                )
+              ) {
+                return (
+                  <SmallRef
+                    objRef={parseRef(cellParams.row['attributes.' + key])}
+                  />
+                );
+              }
+              return cellParams.row['attributes.' + key];
+            },
+          });
+        }
       }
 
       const inputOrder =

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -3,7 +3,7 @@ import {SmartToy as SmartToyIcon} from '@mui/icons-material';
 import {TableRows as TableRowsIcon} from '@mui/icons-material';
 import {DataObject as DataObjectIcon} from '@mui/icons-material';
 import {Spoke as SpokeIcon} from '@mui/icons-material';
-import {Box, Typography} from '@mui/material';
+import {Box} from '@mui/material';
 import {
   callOpVeryUnsafe,
   constString,
@@ -58,20 +58,22 @@ export const SmallRef: FC<{objRef: ArtifactRef; wfTable?: WFDBTableType}> = ({
   const rootType = getRootType(refType);
   const label = objRef.artifactName + ':' + objRef.artifactVersion.slice(0, 6);
   const rootTypeName = getTypeName(rootType);
-  let icon = <SpokeIcon />;
+  let icon = <SpokeIcon sx={{height: '100%'}} />;
   if (rootTypeName === 'Dataset') {
-    icon = <DatasetIcon />;
+    icon = <DatasetIcon sx={{height: '100%'}} />;
   } else if (rootTypeName === 'Model') {
-    icon = <SmartToyIcon />;
+    icon = <SmartToyIcon sx={{height: '100%'}} />;
   } else if (rootTypeName === 'list') {
-    icon = <TableRowsIcon />;
+    icon = <TableRowsIcon sx={{height: '100%'}} />;
   } else if (rootTypeName === 'OpDef') {
-    icon = <DataObjectIcon />;
+    icon = <DataObjectIcon sx={{height: '100%'}} />;
   }
   const Item = (
     <Box display="flex" alignItems="center">
-      <Box mr={1}>{icon}</Box>
-      <Typography variant="body1">{label}</Typography>
+      <Box mr={1} sx={{height: '1rem'}}>
+        {icon}
+      </Box>
+      {label}
     </Box>
   );
   if (refTypeQuery.loading) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/callTree.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/callTree.ts
@@ -57,7 +57,7 @@ export interface Call {
   span_id: string;
   trace_id: string;
   parent_id: string;
-  timestamp: string;
+  timestamp: number;
   start_time_ms: number;
   end_time_ms: number;
 }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -131,14 +131,14 @@ export const Browse3: FC<{
   navigateAwayFromProject?: () => void;
   projectRoot(entityName: string, projectName: string): string;
 }> = props => {
-  const weaveContext = useWeaveContext();
-  useEffect(() => {
-    const previousPolling = weaveContext.client.isPolling();
-    weaveContext.client.setPolling(true);
-    return () => {
-      weaveContext.client.setPolling(previousPolling);
-    };
-  }, [props.projectRoot, weaveContext]);
+  // const weaveContext = useWeaveContext();
+  // useEffect(() => {
+  //   const previousPolling = weaveContext.client.isPolling();
+  //   weaveContext.client.setPolling(true);
+  //   return () => {
+  //     weaveContext.client.setPolling(previousPolling);
+  //   };
+  // }, [props.projectRoot, weaveContext]);
   return (
     <Browse3WeaveflowRouteContextProvider projectRoot={props.projectRoot}>
       <Switch>
@@ -402,7 +402,10 @@ const useNaiveProjectDataConnection = (entity: string, project: string) => {
     if (
       objectsValue.result == null &&
       runsValue.result == null &&
-      feedbackValue.result == null
+      feedbackValue.result == null &&
+      objectsValue.loading &&
+      runsValue.loading &&
+      feedbackValue.loading
     ) {
       return null;
     }
@@ -414,9 +417,12 @@ const useNaiveProjectDataConnection = (entity: string, project: string) => {
     return connection;
   }, [
     entity,
+    feedbackValue.loading,
     feedbackValue.result,
+    objectsValue.loading,
     objectsValue.result,
     project,
+    runsValue.loading,
     runsValue.result,
   ]);
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -18,7 +18,6 @@ import {
   useParams,
 } from 'react-router-dom';
 
-import {useWeaveContext} from '../../../context';
 import {useNodeValue} from '../../../react';
 import {URL_BROWSE3} from '../../../urls';
 import {ErrorBoundary} from '../../ErrorBoundary';
@@ -451,9 +450,12 @@ const ProjectRedirect: FC = () => {
   useEffect(() => {
     if (params.tab == null) {
       history.replace(
-        baseRouter.callsUIUrl(params.entity ?? '', params.project ?? '', {
-          traceRootsOnly: true,
+        baseRouter.opVersionsUIUrl(params.entity, params.project, {
+          isLatest: true,
         })
+        // baseRouter.callsUIUrl(params.entity ?? '', params.project ?? '', {
+        //   traceRootsOnly: true,
+        // })
       );
     }
   }, [baseRouter, history, params.entity, params.project, params.tab]);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/Browse3SideNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/Browse3SideNav.tsx
@@ -418,6 +418,21 @@ const useSectionsForProject = (props: Browse3ProjectSideNavProps) => {
   const sections: SectionType[] = useMemo(() => {
     return [
       {
+        title: 'Structure',
+        items: [
+          {
+            title: 'Operations', // 'Methods (OpDefVersions)',
+            selected: props.selectedCategory === 'ops',
+            icon: <ManageHistory />,
+            onClick: () => {
+              props.navigateToOpVersions({
+                isLatest: true,
+              });
+            },
+          },
+        ],
+      },
+      {
         title: 'Records',
         items: [
           {
@@ -435,30 +450,30 @@ const useSectionsForProject = (props: Browse3ProjectSideNavProps) => {
               });
             },
             // TODO: Get Feedback from team on this
-            children: [
-              {
-                title: 'Models',
-                icon: <Layers />,
-                selected: props.filterCategory === 'model',
-                onClick: () => {
-                  props.navigateToObjectVersions({
-                    typeCategory: 'model',
-                    latest: true,
-                  });
-                },
-              },
-              {
-                title: 'Datasets',
-                icon: <Dataset />,
-                selected: props.filterCategory === 'dataset',
-                onClick: () => {
-                  props.navigateToObjectVersions({
-                    typeCategory: 'dataset',
-                    latest: true,
-                  });
-                },
-              },
-            ],
+            // children: [
+            //   {
+            //     title: 'Models',
+            //     icon: <Layers />,
+            //     selected: props.filterCategory === 'model',
+            //     onClick: () => {
+            //       props.navigateToObjectVersions({
+            //         typeCategory: 'model',
+            //         latest: true,
+            //       });
+            //     },
+            //   },
+            //   {
+            //     title: 'Datasets',
+            //     icon: <Dataset />,
+            //     selected: props.filterCategory === 'dataset',
+            //     onClick: () => {
+            //       props.navigateToObjectVersions({
+            //         typeCategory: 'dataset',
+            //         latest: true,
+            //       });
+            //     },
+            //   },
+            // ],
           },
           {
             title: 'Calls', // 'Traces (Calls)',
@@ -478,95 +493,95 @@ const useSectionsForProject = (props: Browse3ProjectSideNavProps) => {
               });
             },
             // TODO: Get Feedback from team on this
-            children: [
-              {
-                title: 'Train',
-                selected: props.filterCategory === 'train',
-                icon: <ModelTraining />,
-                onClick: () => {
-                  props.navigateToCalls({opCategory: 'train'});
-                },
-              },
-              {
-                title: 'Predict',
-                selected: props.filterCategory === 'predict',
-                icon: <AutoFixHigh />,
-                onClick: () => {
-                  props.navigateToCalls({opCategory: 'predict'});
-                },
-              },
-              {
-                title: 'Score',
-                selected: props.filterCategory === 'score',
-                icon: <Scoreboard />,
-                onClick: () => {
-                  props.navigateToCalls({opCategory: 'score'});
-                },
-              },
-              {
-                title: 'Evaluate',
-                selected: props.filterCategory === 'evaluate',
-                icon: <Rule />,
-                onClick: () => {
-                  props.navigateToCalls({opCategory: 'evaluate'});
-                },
-              },
-              {
-                title: 'Tune',
-                selected: props.filterCategory === 'tune',
-                icon: <Tune />,
-                onClick: () => {
-                  props.navigateToCalls({opCategory: 'tune'});
-                },
-              },
-            ],
+            // children: [
+            //   {
+            //     title: 'Train',
+            //     selected: props.filterCategory === 'train',
+            //     icon: <ModelTraining />,
+            //     onClick: () => {
+            //       props.navigateToCalls({opCategory: 'train'});
+            //     },
+            //   },
+            //   {
+            //     title: 'Predict',
+            //     selected: props.filterCategory === 'predict',
+            //     icon: <AutoFixHigh />,
+            //     onClick: () => {
+            //       props.navigateToCalls({opCategory: 'predict'});
+            //     },
+            //   },
+            //   {
+            //     title: 'Score',
+            //     selected: props.filterCategory === 'score',
+            //     icon: <Scoreboard />,
+            //     onClick: () => {
+            //       props.navigateToCalls({opCategory: 'score'});
+            //     },
+            //   },
+            //   {
+            //     title: 'Evaluate',
+            //     selected: props.filterCategory === 'evaluate',
+            //     icon: <Rule />,
+            //     onClick: () => {
+            //       props.navigateToCalls({opCategory: 'evaluate'});
+            //     },
+            //   },
+            //   {
+            //     title: 'Tune',
+            //     selected: props.filterCategory === 'tune',
+            //     icon: <Tune />,
+            //     onClick: () => {
+            //       props.navigateToCalls({opCategory: 'tune'});
+            //     },
+            //   },
+            // ],
           },
         ],
       },
-      {
-        title: 'Structure',
-        items: [
-          {
-            title: 'Types', // 'Classes (TypeVersions)',
-            selected: props.selectedCategory === 'types',
-            icon: <TypeSpecimen />,
-            onClick: () => {
-              props.navigateToTypeVersions();
-            },
-          },
-          {
-            title: 'Operations', // 'Methods (OpDefVersions)',
-            selected: props.selectedCategory === 'ops',
-            icon: <ManageHistory />,
-            onClick: () => {
-              props.navigateToOpVersions({
-                isLatest: true,
-              });
-            },
-          },
-        ],
-      },
-      {
-        title: 'Analytics',
-        items: [
-          {
-            title: 'Boards',
-            selected: props.selectedCategory === 'boards',
-            icon: <DashboardCustomize />,
-            onClick: () => {
-              props.navigateToBoards();
-            },
-          },
-          {
-            title: 'Tables',
-            selected: props.selectedCategory === 'tables',
-            icon: <TableChart />,
-            onClick: () => {
-              props.navigateToTables();
-            },
-          },
-        ],
-      },
+      // {
+      //   title: 'Structure',
+      //   items: [
+      //     {
+      //       title: 'Types', // 'Classes (TypeVersions)',
+      //       selected: props.selectedCategory === 'types',
+      //       icon: <TypeSpecimen />,
+      //       onClick: () => {
+      //         props.navigateToTypeVersions();
+      //       },
+      //     },
+      //     {
+      //       title: 'Operations', // 'Methods (OpDefVersions)',
+      //       selected: props.selectedCategory === 'ops',
+      //       icon: <ManageHistory />,
+      //       onClick: () => {
+      //         props.navigateToOpVersions({
+      //           isLatest: true,
+      //         });
+      //       },
+      //     },
+      //   ],
+      // },
+      // {
+      //   title: 'Analytics',
+      //   items: [
+      //     {
+      //       title: 'Boards',
+      //       selected: props.selectedCategory === 'boards',
+      //       icon: <DashboardCustomize />,
+      //       onClick: () => {
+      //         props.navigateToBoards();
+      //       },
+      //     },
+      //     {
+      //       title: 'Tables',
+      //       selected: props.selectedCategory === 'tables',
+      //       icon: <TableChart />,
+      //       onClick: () => {
+      //         props.navigateToTables();
+      //       },
+      //     },
+      //   ],
+      // },
     ];
   }, [props]);
   return sections;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/Browse3SideNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/Browse3SideNav.tsx
@@ -1,19 +1,9 @@
 import {
-  AutoFixHigh,
   Category,
-  DashboardCustomize,
-  Dataset,
-  Layers,
   ManageHistory,
-  ModelTraining,
   NavigateBefore,
   NavigateNext,
-  Rule,
-  Scoreboard,
   Segment,
-  TableChart,
-  Tune,
-  TypeSpecimen,
   Undo,
 } from '@mui/icons-material';
 import {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage.tsx
@@ -138,20 +138,20 @@ const useCallTabs = (call: WFCall) => {
   ];
 };
 
-const callMenuItems = [
-  {
-    label: '(Under Construction) Open in Board',
-    onClick: () => {
-      console.log('TODO: Open in Board');
-    },
-  },
-  {
-    label: '(Under Construction) Compare',
-    onClick: () => {
-      console.log('TODO: Compare');
-    },
-  },
-];
+// const callMenuItems = [
+//   {
+//     label: '(Under Construction) Open in Board',
+//     onClick: () => {
+//       console.log('TODO: Open in Board');
+//     },
+//   },
+//   {
+//     label: '(Under Construction) Compare',
+//     onClick: () => {
+//       console.log('TODO: Compare');
+//     },
+//   },
+// ];
 
 const CallPageInnerHorizontal: React.FC<{
   call: WFCall;
@@ -210,7 +210,7 @@ const CallPageInnerHorizontal: React.FC<{
                 <SimplePageLayoutContext.Provider value={{}}>
                   <SimplePageLayout
                     title={title}
-                    menuItems={callMenuItems}
+                    // menuItems={callMenuItems}
                     tabs={callTabs}
                   />
                 </SimplePageLayoutContext.Provider>
@@ -241,7 +241,7 @@ const CallPageInnerVertical: React.FC<{
             setVerticalLayout(false);
           },
         },
-        ...callMenuItems,
+        // ...callMenuItems,
       ]}
       leftSidebar={<CallTraceView call={call} treeOnly />}
       tabs={callTabs}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -87,7 +87,15 @@ const ObjectVersionPageInner: React.FC<{
       // ]}
       tabs={[
         {
-          label: 'Overview',
+          label: 'Values',
+          content: (
+            <ScrollableTabContent>
+              <WeaveEditor objType={objectName} node={itemNode} />
+            </ScrollableTabContent>
+          ),
+        },
+        {
+          label: 'Metadata',
           content: (
             <ScrollableTabContent>
               <SimpleKeyValueTable
@@ -121,14 +129,6 @@ const ObjectVersionPageInner: React.FC<{
                   ),
                 }}
               />
-            </ScrollableTabContent>
-          ),
-        },
-        {
-          label: 'Values',
-          content: (
-            <ScrollableTabContent>
-              <WeaveEditor objType={objectName} node={itemNode} />
             </ScrollableTabContent>
           ),
         },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -4,7 +4,6 @@ import {constString, opGet} from '../../../../../core';
 import {nodeFromExtra} from '../../Browse2/Browse2ObjectVersionItemPage';
 import {WeaveEditor} from '../../Browse2/WeaveEditors';
 import {CallsTable} from './CallsPage';
-import {useMakeNewBoard} from './common/hooks';
 import {CallLink, ObjectLink, TypeVersionLink} from './common/Links';
 import {CenteredAnimatedLoader} from './common/Loader';
 import {
@@ -55,37 +54,37 @@ const ObjectVersionPageInner: React.FC<{
     const extraFields = refExtra.split('/');
     return nodeFromExtra(objNode, extraFields);
   }, [baseUri, refExtra]);
-  const {onMakeBoard} = useMakeNewBoard(itemNode);
+  // const {onMakeBoard} = useMakeNewBoard(itemNode);
 
   return (
     <SimplePageLayout
       title={objectName + ' : ' + objectVersionHash}
-      menuItems={[
-        {
-          label: 'Open in Board',
-          onClick: () => {
-            onMakeBoard();
-          },
-        },
-        {
-          label: '(Under Construction) Compare',
-          onClick: () => {
-            console.log('(Under Construction) Compare');
-          },
-        },
-        {
-          label: '(Under Construction) Process with Function',
-          onClick: () => {
-            console.log('(Under Construction) Process with Function');
-          },
-        },
-        {
-          label: '(Coming Soon) Add to Hub',
-          onClick: () => {
-            console.log('(Under Construction) Add to Hub');
-          },
-        },
-      ]}
+      // menuItems={[
+      //   {
+      //     label: 'Open in Board',
+      //     onClick: () => {
+      //       onMakeBoard();
+      //     },
+      //   },
+      //   {
+      //     label: '(Under Construction) Compare',
+      //     onClick: () => {
+      //       console.log('(Under Construction) Compare');
+      //     },
+      //   },
+      //   {
+      //     label: '(Under Construction) Process with Function',
+      //     onClick: () => {
+      //       console.log('(Under Construction) Process with Function');
+      //     },
+      //   },
+      //   {
+      //     label: '(Coming Soon) Add to Hub',
+      //     onClick: () => {
+      //       console.log('(Under Construction) Add to Hub');
+      //     },
+      //   },
+      // ]}
       tabs={[
         {
           label: 'Overview',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -193,6 +193,11 @@ const ObjectVersionProducingCallsItem: React.FC<{
         entityName={producingCalls[0].entity()}
         projectName={producingCalls[0].project()}
         callId={producingCalls[0].callID()}
+        opName={
+          producingCalls[0].opVersion()?.op().name() ??
+          producingCalls[0].spanName() ??
+          ''
+        }
       />
     );
   }
@@ -205,6 +210,7 @@ const ObjectVersionProducingCallsItem: React.FC<{
               entityName={call.entity()}
               projectName={call.project()}
               callId={call.callID()}
+              opName={call.opVersion()?.op().name() ?? call.spanName() ?? ''}
             />
           </li>
         );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -1,8 +1,6 @@
 import {
   Autocomplete,
-  Box,
   Checkbox,
-  Chip,
   FormControl,
   ListItem,
   ListItemButton,
@@ -20,14 +18,7 @@ import React, {useEffect, useMemo, useState} from 'react';
 
 import {useWeaveflowRouteContext} from '../context';
 import {basicField} from './common/DataTable';
-import {
-  CallsLink,
-  ObjectLink,
-  ObjectVersionLink,
-  ObjectVersionsLink,
-  OpVersionLink,
-  TypeVersionLink,
-} from './common/Links';
+import {ObjectVersionLink, ObjectVersionsLink} from './common/Links';
 import {FilterLayoutTemplate} from './common/SimpleFilterableDataTable';
 import {SimplePageLayout} from './common/SimplePageLayout';
 import {TypeVersionCategoryChip} from './common/TypeVersionCategoryChip';
@@ -343,14 +334,7 @@ const ObjectVersionsTable: React.FC<{
     });
   }, [props.objectVersions]);
   const columns: GridColDef[] = [
-    basicField('createdAt', 'Created At', {
-      width: 150,
-      renderCell: params => {
-        return moment(params.value as number).format('YYYY-MM-DD HH:mm:ss');
-      },
-    }),
-
-    basicField('version', 'Version', {
+    basicField('version', 'Object', {
       renderCell: params => {
         // Icon to indicate navigation to the object version
         return (
@@ -359,7 +343,7 @@ const ObjectVersionsTable: React.FC<{
             projectName={params.row.obj.project()}
             objectName={params.row.obj.object().name()}
             version={params.row.obj.version()}
-            hideName
+            versionIndex={params.row.obj.versionIndex()}
           />
         );
       },
@@ -372,76 +356,83 @@ const ObjectVersionsTable: React.FC<{
         );
       },
     }),
-    basicField('object', 'Object', {
-      renderCell: params => (
-        <ObjectLink
-          entityName={params.row.obj.entity()}
-          projectName={params.row.obj.project()}
-          objectName={params.value as string}
-        />
-      ),
-    }),
-
-    basicField('typeVersion', 'Type Version', {
-      renderCell: params => (
-        <TypeVersionLink
-          entityName={params.row.obj.entity()}
-          projectName={params.row.obj.project()}
-          typeName={params.row.obj.typeVersion().type().name()}
-          version={params.row.obj.typeVersion().version()}
-        />
-      ),
-    }),
-    basicField('inputTo', 'Input To', {
+    basicField('createdAt', 'Created', {
       width: 100,
       renderCell: params => {
-        if (params.value === 0) {
-          return '';
-        }
-
-        return (
-          <CallsLink
-            entity={params.row.obj.entity()}
-            project={params.row.obj.project()}
-            callCount={params.value}
-            filter={{
-              inputObjectVersions: [
-                params.row.obj.object().name() + ':' + params.row.obj.version(),
-              ],
-            }}
-          />
-        );
+        // return moment(params.value as number).format('YYYY-MM-DD HH:mm:ss');
+        return moment(params.value as number).fromNow();
       },
     }),
-    basicField('outputFrom', 'Output From', {
-      width: 100,
-      renderCell: params => {
-        if (!params.value) {
-          return '';
-        }
-        const outputFrom = params.row.obj.outputFrom();
-        if (outputFrom.length === 0) {
-          return '';
-        }
-        // if (outputFrom.length === 1) {
-        return (
-          <OpVersionLink
-            entityName={outputFrom[0].entity()}
-            projectName={outputFrom[0].project()}
-            opName={outputFrom[0].opVersion().op().name()}
-            version={outputFrom[0].opVersion().version()}
-            versionIndex={outputFrom[0].opVersion().versionIndex()}
-          />
-        );
-      },
-    }),
-    basicField('versionIndex', 'Version', {
-      width: 100,
-    }),
+    // basicField('object', 'Object', {
+    //   renderCell: params => (
+    //     <ObjectLink
+    //       entityName={params.row.obj.entity()}
+    //       projectName={params.row.obj.project()}
+    //       objectName={params.value as string}
+    //     />
+    //   ),
+    // }),
 
-    ...[
-      props.usingLatestFilter
-        ? basicField('peerVersions', 'Peer Versions', {
+    // basicField('typeVersion', 'Type Version', {
+    //   renderCell: params => (
+    //     <TypeVersionLink
+    //       entityName={params.row.obj.entity()}
+    //       projectName={params.row.obj.project()}
+    //       typeName={params.row.obj.typeVersion().type().name()}
+    //       version={params.row.obj.typeVersion().version()}
+    //     />
+    //   ),
+    // }),
+    // basicField('inputTo', 'Input To', {
+    //   width: 100,
+    //   renderCell: params => {
+    //     if (params.value === 0) {
+    //       return '';
+    //     }
+
+    //     return (
+    //       <CallsLink
+    //         entity={params.row.obj.entity()}
+    //         project={params.row.obj.project()}
+    //         callCount={params.value}
+    //         filter={{
+    //           inputObjectVersions: [
+    //             params.row.obj.object().name() + ':' + params.row.obj.version(),
+    //           ],
+    //         }}
+    //       />
+    //     );
+    //   },
+    // }),
+    // basicField('outputFrom', 'Output From', {
+    //   width: 100,
+    //   renderCell: params => {
+    //     if (!params.value) {
+    //       return '';
+    //     }
+    //     const outputFrom = params.row.obj.outputFrom();
+    //     if (outputFrom.length === 0) {
+    //       return '';
+    //     }
+    //     // if (outputFrom.length === 1) {
+    //     return (
+    //       <OpVersionLink
+    //         entityName={outputFrom[0].entity()}
+    //         projectName={outputFrom[0].project()}
+    //         opName={outputFrom[0].opVersion().op().name()}
+    //         version={outputFrom[0].opVersion().version()}
+    //         versionIndex={outputFrom[0].opVersion().versionIndex()}
+    //       />
+    //     );
+    //   },
+    // }),
+    // basicField('versionIndex', 'Version', {
+    //   width: 100,
+    // }),
+
+    ...(props.usingLatestFilter
+      ? [
+          basicField('peerVersions', 'Versions', {
             width: 100,
             renderCell: params => {
               return (
@@ -457,28 +448,29 @@ const ObjectVersionsTable: React.FC<{
                 />
               );
             },
-          })
-        : basicField('isLatest', 'Latest', {
-            width: 100,
-            renderCell: params => {
-              if (params.value) {
-                return (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      height: '100%',
-                      width: '100%',
-                    }}>
-                    <Chip label="Yes" size="small" />
-                  </Box>
-                );
-              }
-              return '';
-            },
           }),
-    ],
+        ]
+      : []),
+    // : [basicField('isLatest', 'Latest', {
+    //     width: 100,
+    //     renderCell: params => {
+    //       if (params.value) {
+    //         return (
+    //           <Box
+    //             sx={{
+    //               display: 'flex',
+    //               alignItems: 'center',
+    //               justifyContent: 'center',
+    //               height: '100%',
+    //               width: '100%',
+    //             }}>
+    //             <Chip label="Yes" size="small" />
+    //           </Box>
+    //         );
+    //       }
+    //       return '';
+    //     },
+    //   }),]
   ];
   const columnGroupingModel: GridColumnGroupingModel = [];
   return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -429,6 +429,7 @@ const ObjectVersionsTable: React.FC<{
             projectName={outputFrom[0].project()}
             opName={outputFrom[0].opVersion().op().name()}
             version={outputFrom[0].opVersion().version()}
+            versionIndex={outputFrom[0].opVersion().versionIndex()}
           />
         );
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -47,7 +47,8 @@ export const ObjectVersionsPage: React.FC<{
 }> = props => {
   return (
     <SimplePageLayout
-      title="Object Versions"
+      // title="Object Versions"
+      title="Objects"
       tabs={[
         {
           label: 'All',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
@@ -61,7 +61,20 @@ const OpVersionPageInner: React.FC<{
       title={opName + ' : ' + opVersionHash}
       tabs={[
         {
-          label: 'Overview',
+          label: 'Calls',
+          content: (
+            <CallsTable
+              entity={entity}
+              project={project}
+              frozenFilter={{
+                opVersions: [opName + ':' + opVersionHash],
+                traceRootsOnly: false,
+              }}
+            />
+          ),
+        },
+        {
+          label: 'Metadata',
           content: (
             <ScrollableTabContent>
               <SimpleKeyValueTable
@@ -114,19 +127,6 @@ const OpVersionPageInner: React.FC<{
           ),
         },
         {
-          label: 'Calls',
-          content: (
-            <CallsTable
-              entity={entity}
-              project={project}
-              frozenFilter={{
-                opVersions: [opName + ':' + opVersionHash],
-                traceRootsOnly: false,
-              }}
-            />
-          ),
-        },
-        {
           label: 'Invokes',
           content: (
             <FilterableOpVersionsTable
@@ -158,7 +158,16 @@ const OpVersionPageInner: React.FC<{
           label: 'Execute',
           content: (
             <ScrollableTabContent>
-              <OpVersionExecute streamId={streamId} uri={uri} />
+              <UnderConstruction
+                title="Execute"
+                message={
+                  <>
+                    This page will allow you to call this op version with
+                    specific inputs.
+                  </>
+                }
+              />
+              {/* <OpVersionExecute streamId={streamId} uri={uri} /> */}
             </ScrollableTabContent>
           ),
         },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
@@ -1,12 +1,6 @@
-import {Box, TextField, Typography} from '@material-ui/core';
-import * as globals from '@wandb/weave/common/css/globals.styles';
-import React, {useMemo} from 'react';
-import {Button} from 'semantic-ui-react';
+import React from 'react';
 
 import {Browse2OpDefCode} from '../../Browse2/Browse2OpDefCode';
-import {StreamId} from '../../Browse2/callTree';
-import {useFirstCall, useOpSignature} from '../../Browse2/callTreeHooks';
-import {Paper} from '../../Browse2/CommonLib';
 import {CallsTable} from './CallsPage';
 import {OpLink, OpVersionLink, TypeVersionLink} from './common/Links';
 import {CenteredAnimatedLoader} from './common/Loader';
@@ -47,14 +41,14 @@ const OpVersionPageInner: React.FC<{
   const opName = opVersion.op().name();
   const opVersionHash = opVersion.version();
 
-  const streamId = useMemo(
-    () => ({
-      entityName: entity,
-      projectName: project,
-      streamName: 'stream',
-    }),
-    [entity, project]
-  );
+  // const streamId = useMemo(
+  //   () => ({
+  //     entityName: entity,
+  //     projectName: project,
+  //     streamName: 'stream',
+  //   }),
+  //   [entity, project]
+  // );
 
   return (
     <SimplePageLayout
@@ -210,6 +204,7 @@ const OpVersionOpTree: React.FC<{opVersion: WFOpVersion}> = ({opVersion}) => {
               projectName={v.project()}
               opName={v.op().name()}
               version={v.version()}
+              versionIndex={v.versionIndex()}
             />
             <OpVersionOpTree opVersion={v} />
           </li>
@@ -219,38 +214,38 @@ const OpVersionOpTree: React.FC<{opVersion: WFOpVersion}> = ({opVersion}) => {
   );
 };
 
-const OpVersionExecute: React.FC<{
-  streamId: StreamId;
-  uri: string;
-}> = ({streamId, uri}) => {
-  const firstCall = useFirstCall(streamId, uri);
-  const opSignature = useOpSignature(streamId, uri);
-  return (
-    <Paper>
-      <Typography variant="h6" gutterBottom>
-        Call Op
-      </Typography>
-      <Box sx={{width: 400}}>
-        {opSignature.result != null &&
-          Object.keys(opSignature.result.inputTypes).map(k => (
-            <Box key={k} mb={2}>
-              <TextField
-                label={k}
-                fullWidth
-                value={
-                  firstCall.result != null
-                    ? firstCall.result.inputs[k]
-                    : undefined
-                }
-              />
-            </Box>
-          ))}
-      </Box>
-      <Box pt={1}>
-        <Button variant="outlined" sx={{backgroundColor: globals.lightYellow}}>
-          Execute
-        </Button>
-      </Box>
-    </Paper>
-  );
-};
+// const OpVersionExecute: React.FC<{
+//   streamId: StreamId;
+//   uri: string;
+// }> = ({streamId, uri}) => {
+//   const firstCall = useFirstCall(streamId, uri);
+//   const opSignature = useOpSignature(streamId, uri);
+//   return (
+//     <Paper>
+//       <Typography variant="h6" gutterBottom>
+//         Call Op
+//       </Typography>
+//       <Box sx={{width: 400}}>
+//         {opSignature.result != null &&
+//           Object.keys(opSignature.result.inputTypes).map(k => (
+//             <Box key={k} mb={2}>
+//               <TextField
+//                 label={k}
+//                 fullWidth
+//                 value={
+//                   firstCall.result != null
+//                     ? firstCall.result.inputs[k]
+//                     : undefined
+//                 }
+//               />
+//             </Box>
+//           ))}
+//       </Box>
+//       <Box pt={1}>
+//         <Button variant="outlined" sx={{backgroundColor: globals.lightYellow}}>
+//           Execute
+//         </Button>
+//       </Box>
+//     </Paper>
+//   );
+// };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -41,7 +41,8 @@ export const OpVersionsPage: React.FC<{
 }> = props => {
   return (
     <SimplePageLayout
-      title="Op Versions"
+      // title="Op Versions"
+      title="Operations"
       tabs={[
         {
           label: 'All',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -11,7 +11,7 @@ import moment from 'moment';
 import React, {useCallback, useMemo} from 'react';
 
 import {useWeaveflowRouteContext} from '../context';
-import {OpVersionLink} from './common/Links';
+import {OpVersionLink, OpVersionsLink} from './common/Links';
 import {OpVersionCategoryChip} from './common/OpVersionCategoryChip';
 import {
   FilterableTable,
@@ -177,6 +177,29 @@ export const FilterableOpVersionsTable: React.FC<{
 
       opName: {
         columnId: 'opName',
+        // This grid display does not match the data for the column
+        // ... a bit of a hack
+        gridDisplay: {
+          columnLabel: 'Versions',
+          columnValue: obj => obj.obj.op().name(),
+          gridColDefOptions: {
+            renderCell: params => {
+              return (
+                <OpVersionsLink
+                  entity={params.row.obj.entity()}
+                  project={params.row.obj.project()}
+                  versionCount={params.row.obj.op().opVersions().length}
+                  filter={{
+                    opName: params.row.obj.op().name(),
+                  }}
+                />
+              );
+            },
+            width: 100,
+            minWidth: 100,
+            maxWidth: 100,
+          },
+        },
         // gridDisplay: {
         //   columnLabel: 'Op',
         //   columnValue: obj => obj.obj.op().name(),
@@ -242,6 +265,9 @@ export const FilterableOpVersionsTable: React.FC<{
         //         />
         //       );
         //     },
+        //     width: 100,
+        //     minWidth: 100,
+        //     maxWidth: 100,
         //   },
         // },
       } as WFHighLevelDataColumn<

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -88,30 +88,10 @@ export const FilterableOpVersionsTable: React.FC<{
 
   const columns = useMemo(() => {
     return {
-      createdAt: {
-        columnId: 'createdAt',
-        gridDisplay: {
-          columnLabel: 'Created At',
-          columnValue: obj => obj.obj.createdAtMs(),
-          gridColDefOptions: {
-            renderCell: params => {
-              return moment(params.value as number).format(
-                'YYYY-MM-DD HH:mm:ss'
-              );
-            },
-          },
-        },
-      } as WFHighLevelDataColumn<
-        {obj: WFOpVersion},
-        any,
-        number,
-        'createdAt',
-        WFHighLevelOpVersionFilter
-      >,
       version: {
         columnId: 'version',
         gridDisplay: {
-          columnLabel: 'Version',
+          columnLabel: 'Op',
           columnValue: obj => obj.obj.version(),
           gridColDefOptions: {
             renderCell: params => {
@@ -121,7 +101,6 @@ export const FilterableOpVersionsTable: React.FC<{
                   projectName={params.row.obj.project()}
                   opName={params.row.obj.op().name()}
                   version={params.row.obj.version()}
-                  hideName
                 />
               );
             },
@@ -134,10 +113,32 @@ export const FilterableOpVersionsTable: React.FC<{
         'version',
         WFHighLevelOpVersionFilter
       >,
+      createdAt: {
+        columnId: 'createdAt',
+        gridDisplay: {
+          columnLabel: 'Created',
+          columnValue: obj => obj.obj.createdAtMs(),
+          gridColDefOptions: {
+            renderCell: params => {
+              // return moment(params.value as number).format(
+              //   'YYYY-MM-DD HH:mm:ss'
+              // );
+              return moment(params.value as number).fromNow();
+            },
+          },
+        },
+      } as WFHighLevelDataColumn<
+        {obj: WFOpVersion},
+        any,
+        number,
+        'createdAt',
+        WFHighLevelOpVersionFilter
+      >,
+
       opCategory: {
         columnId: 'opCategory',
         gridDisplay: {
-          columnLabel: 'Op Category',
+          columnLabel: 'Category',
           columnValue: obj => obj.obj.opCategory(),
           gridColDefOptions: {
             renderCell: params => {
@@ -172,21 +173,21 @@ export const FilterableOpVersionsTable: React.FC<{
       >,
       opName: {
         columnId: 'opName',
-        gridDisplay: {
-          columnLabel: 'Op',
-          columnValue: obj => obj.obj.op().name(),
-          gridColDefOptions: {
-            renderCell: params => {
-              return (
-                <OpLink
-                  entityName={params.row.obj.entity()}
-                  projectName={params.row.obj.project()}
-                  opName={params.value as any}
-                />
-              );
-            },
-          },
-        },
+        // gridDisplay: {
+        //   columnLabel: 'Op',
+        //   columnValue: obj => obj.obj.op().name(),
+        //   gridColDefOptions: {
+        //     renderCell: params => {
+        //       return (
+        //         <OpLink
+        //           entityName={params.row.obj.entity()}
+        //           projectName={params.row.obj.project()}
+        //           opName={params.value as any}
+        //         />
+        //       );
+        //     },
+        //   },
+        // },
         filterControls: {
           filterPredicate: ({obj}, filter) => {
             if (filter.opName == null) {
@@ -214,31 +215,31 @@ export const FilterableOpVersionsTable: React.FC<{
       >,
       calls: {
         columnId: 'calls',
-        gridDisplay: {
-          columnLabel: 'Calls',
-          columnValue: obj => obj.obj.calls().length,
-          gridColDefOptions: {
-            renderCell: params => {
-              if (params.value === 0) {
-                return '';
-              }
-              return (
-                <CallsLink
-                  entity={params.row.obj.entity()}
-                  project={params.row.obj.project()}
-                  callCount={params.value as number}
-                  filter={{
-                    opVersions: [
-                      params.row.obj.op().name() +
-                        ':' +
-                        params.row.obj.version(),
-                    ],
-                  }}
-                />
-              );
-            },
-          },
-        },
+        // gridDisplay: {
+        //   columnLabel: 'Calls',
+        //   columnValue: obj => obj.obj.calls().length,
+        //   gridColDefOptions: {
+        //     renderCell: params => {
+        //       if (params.value === 0) {
+        //         return '';
+        //       }
+        //       return (
+        //         <CallsLink
+        //           entity={params.row.obj.entity()}
+        //           project={params.row.obj.project()}
+        //           callCount={params.value as number}
+        //           filter={{
+        //             opVersions: [
+        //               params.row.obj.op().name() +
+        //                 ':' +
+        //                 params.row.obj.version(),
+        //             ],
+        //           }}
+        //         />
+        //       );
+        //     },
+        //   },
+        // },
       } as WFHighLevelDataColumn<
         {obj: WFOpVersion},
         string[],
@@ -248,31 +249,31 @@ export const FilterableOpVersionsTable: React.FC<{
       >,
       invokedByOpVersions: {
         columnId: 'invokedByOpVersions',
-        gridDisplay: {
-          columnLabel: 'Invoked By',
-          columnValue: obj => obj.obj.invokedBy().length,
-          gridColDefOptions: {
-            renderCell: params => {
-              if (params.value === 0) {
-                return '';
-              }
-              return (
-                <OpVersionsLink
-                  entity={params.row.obj.entity()}
-                  project={params.row.obj.project()}
-                  versionCount={params.value as number}
-                  filter={{
-                    invokesOpVersions: [
-                      params.row.obj.op().name() +
-                        ':' +
-                        params.row.obj.version(),
-                    ],
-                  }}
-                />
-              );
-            },
-          },
-        },
+        // gridDisplay: {
+        //   columnLabel: 'Invoked By',
+        //   columnValue: obj => obj.obj.invokedBy().length,
+        //   gridColDefOptions: {
+        //     renderCell: params => {
+        //       if (params.value === 0) {
+        //         return '';
+        //       }
+        //       return (
+        //         <OpVersionsLink
+        //           entity={params.row.obj.entity()}
+        //           project={params.row.obj.project()}
+        //           versionCount={params.value as number}
+        //           filter={{
+        //             invokesOpVersions: [
+        //               params.row.obj.op().name() +
+        //                 ':' +
+        //                 params.row.obj.version(),
+        //             ],
+        //           }}
+        //         />
+        //       );
+        //     },
+        //   },
+        // },
         filterControls: {
           filterPredicate: ({obj}, filter) => {
             if (
@@ -307,31 +308,31 @@ export const FilterableOpVersionsTable: React.FC<{
       >,
       invokesOpVersions: {
         columnId: 'invokesOpVersions',
-        gridDisplay: {
-          columnLabel: 'Invokes',
-          columnValue: obj => obj.obj.invokes().length,
-          gridColDefOptions: {
-            renderCell: params => {
-              if (params.value === 0) {
-                return '';
-              }
-              return (
-                <OpVersionsLink
-                  entity={params.row.obj.entity()}
-                  project={params.row.obj.project()}
-                  versionCount={params.value as number}
-                  filter={{
-                    invokedByOpVersions: [
-                      params.row.obj.op().name() +
-                        ':' +
-                        params.row.obj.version(),
-                    ],
-                  }}
-                />
-              );
-            },
-          },
-        },
+        // gridDisplay: {
+        //   columnLabel: 'Invokes',
+        //   columnValue: obj => obj.obj.invokes().length,
+        //   gridColDefOptions: {
+        //     renderCell: params => {
+        //       if (params.value === 0) {
+        //         return '';
+        //       }
+        //       return (
+        //         <OpVersionsLink
+        //           entity={params.row.obj.entity()}
+        //           project={params.row.obj.project()}
+        //           versionCount={params.value as number}
+        //           filter={{
+        //             invokedByOpVersions: [
+        //               params.row.obj.op().name() +
+        //                 ':' +
+        //                 params.row.obj.version(),
+        //             ],
+        //           }}
+        //         />
+        //       );
+        //     },
+        //   },
+        // },
         filterControls: {
           filterPredicate: ({obj}, filter) => {
             if (
@@ -366,31 +367,31 @@ export const FilterableOpVersionsTable: React.FC<{
       >,
       consumesTypeVersions: {
         columnId: 'consumesTypeVersions',
-        gridDisplay: {
-          columnLabel: 'Consumes Types',
-          columnValue: obj => obj.obj.inputTypesVersions().length,
-          gridColDefOptions: {
-            renderCell: params => {
-              if (params.value === 0) {
-                return '';
-              }
-              return (
-                <TypeVersionsLink
-                  entity={params.row.obj.entity()}
-                  project={params.row.obj.project()}
-                  versionCount={params.value as number}
-                  filter={{
-                    inputTo: [
-                      params.row.obj.op().name() +
-                        ':' +
-                        params.row.obj.version(),
-                    ],
-                  }}
-                />
-              );
-            },
-          },
-        },
+        // gridDisplay: {
+        //   columnLabel: 'Consumes Types',
+        //   columnValue: obj => obj.obj.inputTypesVersions().length,
+        //   gridColDefOptions: {
+        //     renderCell: params => {
+        //       if (params.value === 0) {
+        //         return '';
+        //       }
+        //       return (
+        //         <TypeVersionsLink
+        //           entity={params.row.obj.entity()}
+        //           project={params.row.obj.project()}
+        //           versionCount={params.value as number}
+        //           filter={{
+        //             inputTo: [
+        //               params.row.obj.op().name() +
+        //                 ':' +
+        //                 params.row.obj.version(),
+        //             ],
+        //           }}
+        //         />
+        //       );
+        //     },
+        //   },
+        // },
         filterControls: {
           filterPredicate: ({obj}, filter) => {
             if (
@@ -425,31 +426,31 @@ export const FilterableOpVersionsTable: React.FC<{
       >,
       producesTypeVersions: {
         columnId: 'producesTypeVersions',
-        gridDisplay: {
-          columnLabel: 'Produces Types',
-          columnValue: obj => obj.obj.outputTypeVersions().length,
-          gridColDefOptions: {
-            renderCell: params => {
-              if (params.value === 0) {
-                return '';
-              }
-              return (
-                <TypeVersionsLink
-                  entity={params.row.obj.entity()}
-                  project={params.row.obj.project()}
-                  versionCount={params.value as number}
-                  filter={{
-                    outputFrom: [
-                      params.row.obj.op().name() +
-                        ':' +
-                        params.row.obj.version(),
-                    ],
-                  }}
-                />
-              );
-            },
-          },
-        },
+        // gridDisplay: {
+        //   columnLabel: 'Produces Types',
+        //   columnValue: obj => obj.obj.outputTypeVersions().length,
+        //   gridColDefOptions: {
+        //     renderCell: params => {
+        //       if (params.value === 0) {
+        //         return '';
+        //       }
+        //       return (
+        //         <TypeVersionsLink
+        //           entity={params.row.obj.entity()}
+        //           project={params.row.obj.project()}
+        //           versionCount={params.value as number}
+        //           filter={{
+        //             outputFrom: [
+        //               params.row.obj.op().name() +
+        //                 ':' +
+        //                 params.row.obj.version(),
+        //             ],
+        //           }}
+        //         />
+        //       );
+        //     },
+        //   },
+        // },
         filterControls: {
           filterPredicate: ({obj}, filter) => {
             if (
@@ -499,11 +500,11 @@ export const FilterableOpVersionsTable: React.FC<{
       // >,
       versionIndex: {
         columnId: 'versionIndex',
-        gridDisplay: {
-          columnLabel: 'Version Index',
-          columnValue: obj => obj.obj.versionIndex(),
-          gridColDefOptions: {},
-        },
+        // gridDisplay: {
+        //   columnLabel: 'Version Index',
+        //   columnValue: obj => obj.obj.versionIndex(),
+        //   gridColDefOptions: {},
+        // },
       } as WFHighLevelDataColumn<
         {obj: WFOpVersion},
         any,
@@ -513,29 +514,29 @@ export const FilterableOpVersionsTable: React.FC<{
       >,
       isLatest: {
         columnId: 'isLatest',
-        gridDisplay: {
-          columnLabel: 'Latest',
-          columnValue: obj => obj.obj.aliases().includes('latest'),
-          gridColDefOptions: {
-            renderCell: params => {
-              if (params.value) {
-                return (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      height: '100%',
-                      width: '100%',
-                    }}>
-                    <Chip label="Yes" size="small" />
-                  </Box>
-                );
-              }
-              return '';
-            },
-          },
-        },
+        // gridDisplay: {
+        //   columnLabel: 'Latest',
+        //   columnValue: obj => obj.obj.aliases().includes('latest'),
+        //   gridColDefOptions: {
+        //     renderCell: params => {
+        //       if (params.value) {
+        //         return (
+        //           <Box
+        //             sx={{
+        //               display: 'flex',
+        //               alignItems: 'center',
+        //               justifyContent: 'center',
+        //               height: '100%',
+        //               width: '100%',
+        //             }}>
+        //             <Chip label="Yes" size="small" />
+        //           </Box>
+        //         );
+        //       }
+        //       return '';
+        //     },
+        //   },
+        // },
         filterControls: {
           filterPredicate: ({obj}, {isLatest}) => {
             return !isLatest || obj.aliases().includes('latest') === isLatest;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -1,4 +1,4 @@
-import {Box, Chip, ListItemText} from '@material-ui/core';
+import {ListItemText} from '@material-ui/core';
 import {
   Autocomplete,
   Checkbox,
@@ -11,13 +11,7 @@ import moment from 'moment';
 import React, {useCallback, useMemo} from 'react';
 
 import {useWeaveflowRouteContext} from '../context';
-import {
-  CallsLink,
-  OpLink,
-  OpVersionLink,
-  OpVersionsLink,
-  TypeVersionsLink,
-} from './common/Links';
+import {OpVersionLink} from './common/Links';
 import {OpVersionCategoryChip} from './common/OpVersionCategoryChip';
 import {
   FilterableTable,
@@ -101,6 +95,7 @@ export const FilterableOpVersionsTable: React.FC<{
                   projectName={params.row.obj.project()}
                   opName={params.row.obj.op().name()}
                   version={params.row.obj.version()}
+                  versionIndex={params.row.obj.versionIndex()}
                 />
               );
             },
@@ -113,27 +108,6 @@ export const FilterableOpVersionsTable: React.FC<{
         'version',
         WFHighLevelOpVersionFilter
       >,
-      createdAt: {
-        columnId: 'createdAt',
-        gridDisplay: {
-          columnLabel: 'Created',
-          columnValue: obj => obj.obj.createdAtMs(),
-          gridColDefOptions: {
-            renderCell: params => {
-              // return moment(params.value as number).format(
-              //   'YYYY-MM-DD HH:mm:ss'
-              // );
-              return moment(params.value as number).fromNow();
-            },
-          },
-        },
-      } as WFHighLevelDataColumn<
-        {obj: WFOpVersion},
-        any,
-        number,
-        'createdAt',
-        WFHighLevelOpVersionFilter
-      >,
 
       opCategory: {
         columnId: 'opCategory',
@@ -144,6 +118,9 @@ export const FilterableOpVersionsTable: React.FC<{
             renderCell: params => {
               return <OpVersionCategoryChip opCategory={params.value as any} />;
             },
+            width: 100,
+            minWidth: 100,
+            maxWidth: 100,
           },
         },
         filterControls: {
@@ -171,6 +148,32 @@ export const FilterableOpVersionsTable: React.FC<{
         'opCategory',
         WFHighLevelOpVersionFilter
       >,
+
+      createdAt: {
+        columnId: 'createdAt',
+        gridDisplay: {
+          columnLabel: 'Created',
+          columnValue: obj => obj.obj.createdAtMs(),
+          gridColDefOptions: {
+            renderCell: params => {
+              // return moment(params.value as number).format(
+              //   'YYYY-MM-DD HH:mm:ss'
+              // );
+              return moment(params.value as number).fromNow();
+            },
+            width: 100,
+            minWidth: 100,
+            maxWidth: 100,
+          },
+        },
+      } as WFHighLevelDataColumn<
+        {obj: WFOpVersion},
+        any,
+        number,
+        'createdAt',
+        WFHighLevelOpVersionFilter
+      >,
+
       opName: {
         columnId: 'opName',
         // gridDisplay: {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -115,6 +115,7 @@ export const OpVersionLink: React.FC<{
   projectName: string;
   opName: string;
   version: string;
+  versionIndex: number;
 }> = props => {
   const {peekingRouter} = useWeaveflowRouteContext();
   // const text = props.hideName
@@ -124,7 +125,7 @@ export const OpVersionLink: React.FC<{
   if (text.startsWith('op-')) {
     text = text.slice(3);
   }
-  text = text.replace(/-/g, ':');
+  text += ':v' + props.versionIndex;
   return (
     <Link
       to={peekingRouter.opVersionUIUrl(
@@ -141,10 +142,11 @@ export const OpVersionLink: React.FC<{
 export const CallLink: React.FC<{
   entityName: string;
   projectName: string;
+  opName: string;
   callId: string;
 }> = props => {
   const {peekingRouter} = useWeaveflowRouteContext();
-
+  const text = props.opName + ':' + truncateID(props.callId);
   return (
     <Link
       to={peekingRouter.callUIUrl(
@@ -153,7 +155,7 @@ export const CallLink: React.FC<{
         '',
         props.callId
       )}>
-      {truncateID(props.callId)}
+      {text}
     </Link>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -115,12 +115,16 @@ export const OpVersionLink: React.FC<{
   projectName: string;
   opName: string;
   version: string;
-  hideName?: boolean;
 }> = props => {
   const {peekingRouter} = useWeaveflowRouteContext();
-  const text = props.hideName
-    ? props.version
-    : props.opName + ': ' + truncateID(props.version);
+  // const text = props.hideName
+  //   ? props.version
+  //   : props.opName + ': ' + truncateID(props.version);
+  let text = props.opName;
+  if (text.startsWith('op-')) {
+    text = text.slice(3);
+  }
+  text = text.replace(/-/g, ':');
   return (
     <Link
       to={peekingRouter.opVersionUIUrl(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -73,12 +73,13 @@ export const ObjectVersionLink: React.FC<{
   projectName: string;
   objectName: string;
   version: string;
-  hideName?: boolean;
+  versionIndex: number;
 }> = props => {
   const {peekingRouter} = useWeaveflowRouteContext();
-  const text = props.hideName
-    ? props.version
-    : props.objectName + ': ' + truncateID(props.version);
+  // const text = props.hideName
+  //   ? props.version
+  //   : props.objectName + ': ' + truncateID(props.version);
+  const text = props.objectName + ':v' + props.versionIndex;
   return (
     <Link
       to={peekingRouter.objectVersionUIUrl(
@@ -208,7 +209,7 @@ export const OpVersionsLink: React.FC<{
         props.project,
         props.filter
       )}>
-      {props.versionCount} versions
+      {props.versionCount} version{props.versionCount !== 1 ? 's' : ''}
     </Link>
   );
 };
@@ -227,7 +228,7 @@ export const TypeVersionsLink: React.FC<{
         props.project,
         props.filter
       )}>
-      {props.versionCount} versions
+      {props.versionCount} version{props.versionCount !== 1 ? 's' : ''}
     </Link>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimpleFilterableDataTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimpleFilterableDataTable.tsx
@@ -174,6 +174,9 @@ export const FilterableTable = <
         columns={dataGridColumns}
         experimentalFeatures={{columnGrouping: true}}
         disableRowSelectionOnClick
+        initialState={{
+          sorting: {sortModel: [{field: 'createdAt', sort: 'desc'}]},
+        }}
       />
     </FilterLayoutTemplate>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfInterface/naive.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfInterface/naive.ts
@@ -804,7 +804,8 @@ class WFNaiveOpVersion implements WFOpVersion {
     this.opVersionDict = opVersionDict;
   }
   opCategory(): HackyOpCategory | null {
-    const opName = this.opVersionDict.name;
+    const opNames = this.opVersionDict.name.split('-');
+    const opName = opNames[opNames.length - 1];
     const categories = ['train', 'predict', 'score', 'evaluate', 'tune'];
     for (const category of categories) {
       if (opName.toLocaleLowerCase().includes(category)) {

--- a/weave-js/src/time.ts
+++ b/weave-js/src/time.ts
@@ -106,13 +106,12 @@ export function monthRoundedTime(ns: number) {
   const m = Math.floor((ns % hour) / minute);
   const s = Math.floor(ns % minute);
   const ms = Math.floor((ns * 1000) % 1000);
-
   const moDisplay = mo > 0 ? mo + 'mo ' : '';
   const dDisplay = d > 0 ? d + 'd ' : '';
   const hDisplay = h > 0 ? h + 'h ' : '';
   const mDisplay = m > 0 ? m + 'm ' : '';
-  const sDisplay = s > 0 ? s + 's' : '';
-  const msDisplay = ns < 0 ? ms + 'ms' : '';
+  const sDisplay = s >= 1 ? s + 's' : '';
+  const msDisplay = ns < 1 ? ms + 'ms' : '';
   return [moDisplay, dDisplay, hDisplay, mDisplay, sDisplay, msDisplay]
     .filter(item => item !== '')
     .join(' ');

--- a/weave-js/src/time.ts
+++ b/weave-js/src/time.ts
@@ -93,7 +93,7 @@ export class TimeDelta {
 // units from largest to smallest, down to seconds
 // largest unit in this timestamp will be months
 // e.g. 2mo 17d 2h 18m 6s
-export function monthRoundedTime(ns: number, includeMs?: boolean) {
+export function monthRoundedTime(ns: number) {
   // convenient units in seconds
   const minute = 60;
   const hour = minute * 60;
@@ -111,12 +111,8 @@ export function monthRoundedTime(ns: number, includeMs?: boolean) {
   const dDisplay = d > 0 ? d + 'd ' : '';
   const hDisplay = h > 0 ? h + 'h ' : '';
   const mDisplay = m > 0 ? m + 'm ' : '';
-  let sDisplay = s >= 0 ? s + 's' : '';
-  let msDisplay = '';
-  if (includeMs) {
-    sDisplay = s > 0 ? s + 's' : '';
-    msDisplay = ms >= 0 ? ms + 'ms' : '';
-  }
+  const sDisplay = s > 0 ? s + 's' : '';
+  const msDisplay = ns < 0 ? ms + 'ms' : '';
   return [moDisplay, dDisplay, hDisplay, mDisplay, sDisplay, msDisplay]
     .filter(item => item !== '')
     .join(' ');


### PR DESCRIPTION
In response to our design discussion today, this PR removes a bunch of features that are viewed as distractions for MVP. I kept everything in code, just commented out for now. Changes:

* Sidebar simplified to just Operations, Objects, and Calls
* Default page is now "Operations"
* OpVersions:
     * Op Versions page renamed to "Operations"
     * Columns are minimal: Op, Category, Created, Versions
     * Note: "Op" is now the name of the op + version
     * Clicking Op brings you to the Op Version page
     * Clicking on "Versions" lists all the versions for the op which it belongs to.
* OpVersion Page
     * Defaults to "Calls Tab" - metadata tab moved to the right
     * Removed useless action menu
     * Made "Execute" an under-construction tab.
* ObjectVersions Page:
     * Renamed to "Objects"
     * Columns are just Object, Category, Created, Versions
     * "Object" is now object name + version
     * Clicking the Object brings you to object version page
     * Clicking Versions lists all versions for that object
* ObjectVersion Page
     * Defaults to "Values" tab - metadata moved to the right
     * Removed useless action menu
* CallsPage:
     * Simplified columns: Visual status indicator, Call, Category, Called, Latency (then show I/O if possible)
     * Col is now CallName + version
   
* Created is default sort everywhere
* Couple little style details
