### PR TITLE
feat: common component timestamp

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -9,10 +9,10 @@ import {
 import {parseRef} from '@wandb/weave/react';
 import {monthRoundedTime} from '@wandb/weave/time';
 import * as _ from 'lodash';
-import moment from 'moment';
 import React, {FC, useEffect, useMemo, useRef} from 'react';
 import {useParams} from 'react-router-dom';
 
+import {Timestamp} from '../../../Timestamp';
 import {CallLink, opVersionText} from '../Browse3/pages/common/Links';
 import {useMaybeWeaveflowORMContext} from '../Browse3/pages/wfInterface/context';
 import {flattenObject} from './browse2Util';
@@ -248,10 +248,12 @@ export const RunsTable: FC<{
         minWidth: 100,
         maxWidth: 100,
         renderCell: cellParams => {
-          // return moment(cellParams.row.timestampMs).format(
-          //   'YYYY-MM-DD HH:mm:ss'
-          // );
-          return moment(cellParams.row.timestampMs).fromNow();
+          return (
+            <Timestamp
+              value={cellParams.row.timestampMs / 1000}
+              format="relative"
+            />
+          );
         },
       },
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -13,9 +13,9 @@ import {
   GridColumnGroupingModel,
   GridRowsProp,
 } from '@mui/x-data-grid-pro';
-import moment from 'moment';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import {Timestamp} from '../../../../Timestamp';
 import {useWeaveflowRouteContext} from '../context';
 import {basicField} from './common/DataTable';
 import {ObjectVersionLink, ObjectVersionsLink} from './common/Links';
@@ -359,8 +359,12 @@ const ObjectVersionsTable: React.FC<{
     basicField('createdAt', 'Created', {
       width: 100,
       renderCell: params => {
-        // return moment(params.value as number).format('YYYY-MM-DD HH:mm:ss');
-        return moment(params.value as number).fromNow();
+        return (
+          <Timestamp
+            value={(params.value as number) / 1000}
+            format="relative"
+          />
+        );
       },
     }),
     // basicField('object', 'Object', {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -7,9 +7,9 @@ import {
   ListItemButton,
   TextField,
 } from '@mui/material';
-import moment from 'moment';
 import React, {useCallback, useMemo} from 'react';
 
+import {Timestamp} from '../../../../Timestamp';
 import {useWeaveflowRouteContext} from '../context';
 import {CallsLink, OpVersionLink, OpVersionsLink} from './common/Links';
 import {OpVersionCategoryChip} from './common/OpVersionCategoryChip';
@@ -196,10 +196,12 @@ export const FilterableOpVersionsTable: React.FC<{
           columnValue: obj => obj.obj.createdAtMs(),
           gridColDefOptions: {
             renderCell: params => {
-              // return moment(params.value as number).format(
-              //   'YYYY-MM-DD HH:mm:ss'
-              // );
-              return moment(params.value as number).fromNow();
+              return (
+                <Timestamp
+                  value={(params.value as number) / 1000}
+                  format="relative"
+                />
+              );
             },
             width: 100,
             minWidth: 100,

--- a/weave-js/src/components/Timestamp.tsx
+++ b/weave-js/src/components/Timestamp.tsx
@@ -1,0 +1,96 @@
+/**
+ * Render UTC timestamp from server.
+ */
+import moment from 'moment';
+import React from 'react';
+import TimeAgo, {Formatter} from 'react-timeago';
+
+import {Tooltip} from './Tooltip';
+
+type Value = string | number;
+
+type TimestampProps = {
+  // Acceptable format: "2022-10-04T14:24:44"
+  // Acceptable format: 1704824493 (seconds since epoch)
+  value: Value;
+
+  // Force a specific format. Special case:
+  // "relative" - e.g. "2 hours ago"
+  // See: https://momentjs.com/docs/#/displaying/format/
+  format?: string;
+
+  // By default, a "relative" timestamp will update automatically.
+  // If you don't want this behavior you can set this prop to false.
+  live?: boolean;
+};
+
+// Return short and long formatted versions of the provided timestamp.
+export const formatTimestamp = (value: string, overrideFormat?: string) => {
+  const then = moment.utc(value, 'YYYY-MM-DDTHH:mm:ss').local();
+  return formatTimestampInternal(then, overrideFormat);
+};
+
+const formatTimestampInternal = (
+  then: moment.Moment,
+  overrideFormat?: string
+) => {
+  let format = overrideFormat;
+  if (!format) {
+    const now = moment();
+    format = 'MMM Do YYYY [at] h:mma';
+    if (now.year() === then.year()) {
+      format = 'MMM Do [at] h:mma';
+    }
+  }
+  return {
+    // TODO: It would be nice if we could display a timezone string here to
+    //       make it clear to the user this is local time. However, we don't have
+    //       a reliable way to get it. We'd have to add a dependency on moment-timezone
+    //       and then ask it to guess.
+    //       REF: https://github.com/moment/moment/issues/162
+    long: then.format('dddd, MMMM Do YYYY [at] h:mm:ss a'),
+    short: then.format(format),
+  };
+};
+
+const valueToMoment = (value: Value): moment.Moment => {
+  if (typeof value === 'number') {
+    return moment.unix(value);
+  }
+  return moment.utc(value, 'YYYY-MM-DDTHH:mm:ss').local();
+};
+
+// See: https://www.npmjs.com/package/react-timeago#formatter-optional
+const TIMEAGO_FORMATTER: Formatter = (
+  value,
+  unit,
+  suffix,
+  epochSeconds,
+  nextFormatter
+) =>
+  unit === 'second'
+    ? 'just now'
+    : nextFormatter!(value, unit, suffix, epochSeconds);
+
+export const Timestamp = ({value, format, live = true}: TimestampProps) => {
+  const then = valueToMoment(value);
+  if (format === 'relative') {
+    const content = then.format('dddd, MMMM Do YYYY [at] h:mm:ss a');
+    const timeago = (
+      <TimeAgo
+        title="" // Suppress the default tooltip
+        minPeriod={10}
+        formatter={TIMEAGO_FORMATTER}
+        date={then.format('YYYY-MM-DDTHH:mm:ssZ')}
+        live={live}
+      />
+    );
+    return (
+      <Tooltip position="top center" content={content} trigger={timeago} />
+    );
+  }
+
+  const {long, short} = formatTimestampInternal(then, format);
+  const text = <span>{short}</span>;
+  return <Tooltip position="top center" content={long} trigger={text} />;
+};


### PR DESCRIPTION
Bringing over the common Timestamp component from core, updating it to add relative time display features. Updated weaveflow UI to use it. The main advantages over using moment.fromNow are that it will do live updating and also shows the absolute time in a tooltip.

<img width="341" alt="Screenshot 2024-01-11 at 10 37 53 AM" src="https://github.com/wandb/weave/assets/112953339/773baf6a-c79e-4639-8d90-ad4eee68afcf">
