### PR TITLE
feat: Full Weave serialization of op closures including other op calls

### DIFF
--- a/weave/artifact_base.py
+++ b/weave/artifact_base.py
@@ -27,9 +27,13 @@ class ArtifactRef(ref_base.Ref):
         type: typing.Optional[types.Type] = None,
         obj: typing.Optional[typing.Any] = None,
         extra: typing.Optional[list[str]] = None,
+        # Denotes that the ref should be saved as a path ref (just the path and extra)
+        # without the full uri, because its a reference within an artifact
+        serialize_as_path_ref: bool = False,
     ):
         self.artifact = artifact
         self.path = path
+        self.serialize_as_path_ref = serialize_as_path_ref
         super().__init__(obj=obj, type=type, extra=extra)
 
     def with_extra(

--- a/weave/artifact_fs.py
+++ b/weave/artifact_fs.py
@@ -210,7 +210,9 @@ _loading_artifact: contextvars.ContextVar[
 
 
 @contextlib.contextmanager
-def loading_artifact(artifact: FilesystemArtifact):
+def loading_artifact(
+    artifact: FilesystemArtifact,
+) -> typing.Generator[typing.Optional[FilesystemArtifact], None, None]:
     token = _loading_artifact.set(artifact)
     try:
         yield _loading_artifact.get()

--- a/weave/ecosystem/all.py
+++ b/weave/ecosystem/all.py
@@ -26,7 +26,9 @@ ALL_MODULES = (
     "shawn",
     "replicate",
     "openai",
-    "py",
+    # By declares a weave type for the python type "type" and causes problems
+    # with op serialization
+    # "py",
     "langchain",
     "umap",
     "hdbscan",

--- a/weave/errors.py
+++ b/weave/errors.py
@@ -169,3 +169,7 @@ class WeaveMergeArtifactSpecError(WeaveBaseError):
 
 class WeaveOpSerializeError(WeaveBaseError):
     pass
+
+
+class WeaveInitError(WeaveBaseError):
+    pass

--- a/weave/execute.py
+++ b/weave/execute.py
@@ -493,8 +493,8 @@ def execute_sync_op(op_def: op_def.OpDef, inputs: Mapping[str, typing.Any]):
             with run_context.current_run(run):
                 res = op_def.resolve_fn(**inputs)
         except BaseException as e:
-            client.fail_run(run, e)
             print("Error running ", op_def.name)
+            client.fail_run(run, e)
             raise
         if isinstance(res, box.BoxedNone):
             res = None

--- a/weave/graph_client_context.py
+++ b/weave/graph_client_context.py
@@ -2,6 +2,7 @@ import contextlib
 import typing
 
 from . import context_state
+from . import errors
 
 if typing.TYPE_CHECKING:
     from .graph_client import GraphClient
@@ -25,5 +26,5 @@ def get_graph_client() -> typing.Optional["GraphClient"]:
 def require_graph_client() -> "GraphClient":
     client = get_graph_client()
     if not client:
-        raise ValueError("You must call `weave.init(<project_name>)` first")
+        raise errors.WeaveInitError("You must call `weave.init(<project_name>)` first")
     return client

--- a/weave/graph_client_local.py
+++ b/weave/graph_client_local.py
@@ -145,7 +145,8 @@ class GraphClientLocal(GraphClient[WeaveRunObj]):
         return WeaveRunObj(run_id, op_name, inputs=with_digest_inputs)
 
     def fail_run(self, run: Run, exception: BaseException) -> None:
-        raise NotImplementedError
+        # TODO: Need to implement for local, for now just do nothing.
+        pass
 
     def finish_run(
         self,

--- a/weave/op_def_type.py
+++ b/weave/op_def_type.py
@@ -256,7 +256,7 @@ def get_code_deps(
                 # we just import it. This is ok for libraries, but not
                 # if the user has functions declared within their
                 # package but outside of the op module.
-                fn_code_deps, fn_warnings = get_code_deps(var_value)
+                fn_code_deps, fn_warnings = get_code_deps(var_value, artifact)
                 warnings += fn_warnings
                 import_code += fn_code_deps
                 import_code += inspect.getsource(var_value)

--- a/weave/storage.py
+++ b/weave/storage.py
@@ -6,6 +6,7 @@ import pathlib
 import functools
 import contextvars
 import contextlib
+import json
 
 from . import errors
 from . import ref_base
@@ -19,6 +20,7 @@ from . import mappers_python
 from . import box
 from . import errors
 from . import graph
+from . import graph_client_context
 from . import timestamp
 
 Ref = ref_base.Ref
@@ -431,6 +433,56 @@ def from_python(obj: dict, wb_type: typing.Optional[types.Type] = None) -> typin
     return res
 
 
+def to_json_with_refs(
+    obj: typing.Any,
+    artifact: artifact_base.Artifact,
+    path: typing.Optional[list[str]] = None,
+    wb_type: typing.Optional[types.Type] = None,
+):
+    """Convert an object to a JSON-serializable object, with refs to any custom objects.
+
+    Contains business logic:
+      - OpDef are always saved as top-level artifacts.
+      - All other custom objects are saved as refs within the provided artifact
+        if there is not are a ref available for them.
+    """
+
+    # This is newer than to_python, save and publish above, and doesn't use the "mapper"
+    # pattern, which is overkill. Much better to just write a simple function like this.
+    from . import op_def
+
+    if wb_type is None:
+        wb_type = types.TypeRegistry.type_of(obj)
+    if path is None:
+        path = []
+    if isinstance(wb_type, (types.Number, types.String, types.NoneType, types.Boolean)):
+        return obj
+    elif isinstance(wb_type, types.TypedDict):
+        if not isinstance(obj, dict):
+            raise ValueError("Expected dict for TypedDict, got %s" % type(obj).__name__)
+        return {
+            k: to_json_with_refs(
+                v, artifact, path + [k], wb_type=wb_type.property_types[k]
+            )
+            for (k, v) in obj.items()
+        }
+    elif isinstance(wb_type, types.List):
+        if not isinstance(obj, list):
+            raise ValueError("Expected list for List, got %s" % type(obj).__name__)
+        return [
+            to_json_with_refs(v, artifact, path + [str(i)], wb_type=wb_type.object_type)
+            for i, v in enumerate(obj)
+        ]
+    elif isinstance(obj, op_def.OpDef):
+        gc = graph_client_context.require_graph_client()
+        return gc.save_object(obj, obj.name, "latest")
+    else:
+        res = artifact.set("/".join(path), wb_type, obj)
+        if res.artifact == artifact:
+            res.serialize_as_path_ref = True
+        return res
+
+
 def make_js_serializer():
     artifact = artifact_mem.MemArtifact()
     return functools.partial(to_weavejs, artifact=artifact)
@@ -468,3 +520,18 @@ def to_weavejs(obj, artifact: typing.Optional[artifact_base.Artifact] = None):
         wb_type, artifact, mapper_options={"use_stable_refs": False}
     )
     return mapper.apply(obj)
+
+
+def artifact_path_ref(artifact_path: str) -> artifact_base.ArtifactRef:
+    """Return a reference to an object in the current artifact based on its path.
+
+    This is only callable during artifact loading, and should not generally be
+    called by user code.
+    """
+    loading_artifact = artifact_fs.get_loading_artifact()
+    if loading_artifact is None:
+        raise errors.WeaveSerializeError(
+            "artifact_path_ref can only be used while loading an artifact."
+        )
+
+    return loading_artifact.ref_from_local_str(artifact_path)

--- a/weave/storage.py
+++ b/weave/storage.py
@@ -474,7 +474,12 @@ def to_json_with_refs(
             for i, v in enumerate(obj)
         ]
     elif isinstance(obj, op_def.OpDef):
-        gc = graph_client_context.require_graph_client()
+        try:
+            gc = graph_client_context.require_graph_client()
+        except errors.WeaveInitError:
+            raise errors.WeaveSerializeError(
+                "Can't serialize OpDef with a client initialization"
+            )
         return gc.save_object(obj, obj.name, "latest")
     else:
         res = artifact.set("/".join(path), wb_type, obj)


### PR DESCRIPTION
Example

```
@weave.op()
def cat(v: int):
    print("hello from cat()")
    return v + 1

@weave.op()
def dog(v: int):
    print("hello from dog()")
    return v - 1

x = {"a": cat, "b": np.array([1, 2, 3])}

@weave.op()
def pony(v: int):
    v = dog(v)
    v = x["a"](v) + x["b"].mean()
    v = np.array([v, v, v]).mean()

    print("hello from pony()")
    return v + 99

pony(...)
```

serializes to

```
import typing
import weave


dog = weave.ref('local-artifact:///op-dog:5b1dba2d0802ab99a3c9/obj').get()
x = {
    "a": weave.ref('local-artifact:///op-cat:7dfb9a69dc75d47fa618/obj').get(),
    "b": weave.storage.artifact_path_ref('x/b#0').get()
}
import numpy as np
import weave.api as weave
@weave.op()
def pony(v: int):
    v = dog(v)
    v = x["a"](v) + x["b"].mean()
    v = np.array([v, v, v]).mean()

    print("hello from pony()")
    return v + 99
```