### PR TITLE
fix: Fix cases where objects that don't have a Weave type are passed to ops.

### DIFF
--- a/weave/execute.py
+++ b/weave/execute.py
@@ -453,6 +453,8 @@ def _auto_publish(obj: typing.Any, output_refs: typing.List[ref_base.Ref]):
     elif isinstance(obj, list):
         return [_auto_publish(v, output_refs) for v in obj]
     weave_type = types.TypeRegistry.type_of(obj)
+    if weave_type == types.UnknownType():
+        return "<UnknownType>"
     if not (
         types.is_custom_type(weave_type) or isinstance(weave_type, types.ObjectType)
     ):

--- a/weave/op_def_type.py
+++ b/weave/op_def_type.py
@@ -304,7 +304,7 @@ def get_code_deps(
                     )
                 except (errors.WeaveTypeError, errors.WeaveSerializeError) as e:
                     warnings.append(
-                        f"Didn't serialize value of {var_name} needed by {fn}. Encountered: {e}"
+                        f"Serialization error for value of {var_name} needed by {fn}. Encountered:\n    {e}"
                     )
                 else:
                     code_paragraph = (
@@ -398,10 +398,9 @@ class OpDefType(types.Type):
             code = result["code"]
             warnings = result["warnings"]
             if warnings:
-                message = (
-                    f"Did not fully serialize op {obj}. This op may not be reloadable, but calls to it will be versioned.\n"
-                    + "\n  ".join(warnings)
-                )
+                message = f"Partial serialization failure for op {obj}. This op may not be reloadable"
+                for warning in warnings:
+                    message += "\n  " + warning
                 if context_state.get_strict_op_saving():
                     raise errors.WeaveOpSerializeError(message)
                 else:

--- a/weave/pyfunc_type_util.py
+++ b/weave/pyfunc_type_util.py
@@ -66,7 +66,7 @@ def determine_input_type(
             existing_weave_type = weave_input_type.arg_types.get(input_name)
             if python_type is not None:
                 inferred_type = infer_types.python_type_to_type(python_type)
-                if inferred_type == types.UnknownType():
+                if not allow_unknowns and inferred_type == types.UnknownType():
                     raise errors.WeaveDefinitionError(
                         "Weave Type could not be determined from Python type (%s) for arg: %s."
                         % (python_type, input_name)

--- a/weave/storage.py
+++ b/weave/storage.py
@@ -457,6 +457,8 @@ def to_json_with_refs(
         path = []
     if isinstance(wb_type, (types.Number, types.String, types.NoneType, types.Boolean)):
         return obj
+    elif isinstance(wb_type, types.UnknownType):
+        raise errors.WeaveTypeError(f"Can't serialize {obj}. Type is UnknownType.")
     elif isinstance(wb_type, types.TypedDict):
         if not isinstance(obj, dict):
             raise ValueError("Expected dict for TypedDict, got %s" % type(obj).__name__)

--- a/weave/tests/test_op.py
+++ b/weave/tests/test_op.py
@@ -136,6 +136,7 @@ class SomeUnknownObj:
     pass
 
 
+@pytest.mark.skip("We allow Unknown types now")
 def test_op_unknown_arg_type():
     with pytest.raises(weave.errors.WeaveDefinitionError):
 

--- a/weave/tests/test_weaveflow.py
+++ b/weave/tests/test_weaveflow.py
@@ -191,3 +191,47 @@ def test_weaveflow_publish_numpy(user_by_api_key_in_env):
     with weave.wandb_client("weaveflow_example"):
         v = {"a": np.array([[1, 2, 3], [4, 5, 6]])}
         ref = weave.publish(v, "dict-with-numpy")
+
+
+def test_weaveflow_unknown_type_op_param_undeclared(eager_mode):
+    class SomeUnknownObject:
+        x: int
+
+        def __init__(self, x: int):
+            self.x = x
+
+    @weave.op()
+    def op_with_unknown_param(v) -> int:
+        return v.x + 2
+
+    assert op_with_unknown_param(SomeUnknownObject(x=10)) == 12
+
+
+def test_weaveflow_unknown_type_op_param_declared(eager_mode):
+    class SomeUnknownObject:
+        x: int
+
+        def __init__(self, x: int):
+            self.x = x
+
+    @weave.op()
+    def op_with_unknown_param(v: SomeUnknownObject) -> int:
+        return v.x + 2
+
+    assert op_with_unknown_param(SomeUnknownObject(x=10)) == 12
+
+
+def test_weaveflow_unknown_type_op_param_closure(eager_mode):
+    class SomeUnknownObject:
+        x: int
+
+        def __init__(self, x: int):
+            self.x = x
+
+    v = SomeUnknownObject(x=10)
+
+    @weave.op()
+    def op_with_unknown_param() -> int:
+        return v.x + 2
+
+    assert op_with_unknown_param() == 12

--- a/weave/weave_types.py
+++ b/weave/weave_types.py
@@ -158,8 +158,8 @@ class TypeRegistry:
             obj_type = type_.type_of(obj)
             if obj_type is not None:
                 return obj_type
-        # return UnknownType()
-        raise errors.WeaveTypeError("no Type for obj: (%s) %s" % (type(obj), obj))
+        # No TypeError here, return UnknownType
+        return UnknownType()
 
     @staticmethod
     def type_from_dict(d: typing.Union[str, dict]) -> "Type":


### PR DESCRIPTION
The prime example of an object which doesn't have a Weave type is openai.Client

We will still print warnings in these cases for now.

- Fixed case where object with unknown type is passed as argument to op with undeclared type
- Fixed case where object with unknown type is passed as argument to op with declared type
- Fixed where object with unknown type is captured by op closure.
