### PR TITLE
feat: update navigation sidebar to better match app

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -23,7 +23,7 @@ import {URL_BROWSE3} from '../../../urls';
 import {ErrorBoundary} from '../../ErrorBoundary';
 import {Browse2EntityPage} from './Browse2/Browse2EntityPage';
 import {Browse2HomePage} from './Browse2/Browse2HomePage';
-import {RouteAwareBrowse3ProjectSideNav} from './Browse3/Browse3SideNav';
+// import {RouteAwareBrowse3ProjectSideNav} from './Browse3/Browse3SideNav';
 import {
   baseContext,
   browse2Context,
@@ -63,6 +63,7 @@ import {
   fnNaiveBootstrapRuns,
   WFNaiveProject,
 } from './Browse3/pages/wfInterface/naive';
+import {SideNav} from './Browse3/SideNav';
 
 LicenseInfo.setLicenseKey(
   '7684ecd9a2d817a3af28ae2a8682895aTz03NjEwMSxFPTE3MjgxNjc2MzEwMDAsUz1wcm8sTE09c3Vic2NyaXB0aW9uLEtWPTI='
@@ -244,9 +245,10 @@ const Browse3Mounted: FC<{
               display: 'flex',
               flexDirection: 'row',
             }}>
-            <RouteAwareBrowse3ProjectSideNav
+            <SideNav />
+            {/* <RouteAwareBrowse3ProjectSideNav
               navigateAwayFromProject={props.navigateAwayFromProject}
-            />
+            /> */}
             <Box
               component="main"
               sx={{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/SideNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/SideNav.tsx
@@ -1,0 +1,123 @@
+import {IconNames} from '@wandb/weave/components/Icon';
+import React, {useMemo} from 'react';
+import {useParams} from 'react-router-dom';
+
+import {useWeaveflowRouteContext} from './context';
+import {useURLSearchParamsDict} from './pages/util';
+import {Sidebar, SidebarItem} from './Sidebar';
+
+export const SideNav = () => {
+  const params = useParams<{
+    entity: string;
+    project: string;
+    tab:
+      | 'types'
+      | 'type-versions'
+      | 'objects'
+      | 'object-versions'
+      | 'ops'
+      | 'op-versions'
+      | 'calls'
+      | 'boards'
+      | 'tables';
+  }>();
+  const {entity, project} = params;
+  const currentProject = project;
+  const currentEntity = entity;
+  const query = useURLSearchParamsDict();
+  const filters = useMemo(() => {
+    if (query.filter === undefined) {
+      return {};
+    }
+    try {
+      return JSON.parse(query.filter);
+    } catch (e) {
+      console.log(e);
+      return {};
+    }
+  }, [query.filter]);
+  const filterCategory = useMemo(() => {
+    const category = Object.keys(filters).find(key =>
+      key.toLowerCase().includes('category')
+    );
+    if (category === undefined) {
+      return undefined;
+    }
+    return filters[category];
+  }, [filters]);
+
+  const selectedItemId = useMemo(() => {
+    if (params.tab === 'types' || params.tab === 'type-versions') {
+      return 'types';
+    } else if (params.tab === 'objects' || params.tab === 'object-versions') {
+      if (filterCategory === 'model') {
+        return 'models';
+      } else if (filterCategory === 'dataset') {
+        return 'datasets';
+      }
+      return 'objects';
+    } else if (params.tab === 'ops' || params.tab === 'op-versions') {
+      return 'ops';
+    } else if (params.tab === 'calls') {
+      return 'calls';
+    }
+    return null;
+  }, [params.tab, filterCategory]);
+
+  const {baseRouter} = useWeaveflowRouteContext();
+  if (!currentProject || !currentEntity) {
+    return null;
+  }
+
+  const items: SidebarItem[] = [
+    {
+      // section: 'Structure',
+      id: 'ops',
+      name: 'Operations',
+      iconName: IconNames.JobProgramCode,
+      path: baseRouter.opVersionsUIUrl(entity, project, {
+        isLatest: true,
+      }),
+    },
+    {
+      // section: 'Records',
+      id: 'calls',
+      name: 'Calls',
+      iconName: IconNames.RunningRepeat,
+      path: baseRouter.callsUIUrl(entity, project, {
+        traceRootsOnly: true,
+      }),
+    },
+    {
+      // section: 'Records',
+      id: 'objects',
+      name: 'Objects',
+      iconName: IconNames.CubeContainer,
+      path: baseRouter.objectVersionsUIUrl(entity, project, {
+        latest: true,
+      }),
+    },
+    // {
+    //   // section: 'Records',
+    //   id: 'models',
+    //   name: 'Models',
+    //   iconName: IconNames.Model,
+    //   path: baseRouter.objectVersionsUIUrl(entity, project, {
+    //     typeCategory: 'model',
+    //     latest: true,
+    //   }),
+    // },
+    // {
+    //   // section: 'Records',
+    //   id: 'datasets',
+    //   name: 'Datasets',
+    //   iconName: IconNames.Table,
+    //   path: baseRouter.objectVersionsUIUrl(entity, project, {
+    //     typeCategory: 'dataset',
+    //     latest: true,
+    //   }),
+    // },
+  ];
+
+  return <Sidebar items={items} selectedItem={selectedItemId} />;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/Sidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/Sidebar.tsx
@@ -1,0 +1,109 @@
+import {
+  MEDIUM_BREAKPOINT,
+  MOON_150,
+  MOON_250,
+  WHITE,
+} from '@wandb/weave/common/css/globals.styles';
+import {IconName} from '@wandb/weave/components/Icon';
+import React from 'react';
+import styled from 'styled-components';
+
+import SidebarSection from './SidebarSection';
+
+const StyledSidebar = styled.div`
+  background-color: ${WHITE};
+  box-sizing: content-box;
+  border-right: 1px solid ${MOON_250};
+  width: 56px;
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    width: 100%;
+    height: 56px;
+    border-right: none;
+    border-bottom: 1px solid ${MOON_250};
+  }
+`;
+StyledSidebar.displayName = 'S.StyledSidebar';
+
+const SidebarSections = styled.div`
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: sticky;
+  top: 0;
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    gap: 14px;
+    height: 100%;
+    overflow-x: auto;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    margin: 0;
+    padding: 0 12px;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: stretch;
+  }
+`;
+SidebarSections.displayName = 'S.SidebarSections';
+
+const SidebarSectionHeader = styled.div`
+  font-family: 'Source Sans Pro';
+  font-weight: 800;
+  height: 14px;
+  font-size: 10px;
+  line-height: 14px;
+  text-align: center;
+  background-color: ${MOON_150};
+  padding: 4px 0;
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    display: none;
+  }
+`;
+StyledSidebar.displayName = 'S.StyledSidebar';
+
+export type SidebarItem = {
+  id: string;
+  iconName: IconName;
+  name: string;
+  nameTooltip?: string;
+  path: string;
+  // Enables multiple sections with headers
+  section?: string;
+};
+
+type SidebarProps = {
+  selectedItem: string | null;
+  items: SidebarItem[];
+};
+
+export const Sidebar = (props: SidebarProps) => {
+  if (props.items.length < 2) {
+    return null;
+  }
+
+  const sections = new Set<string>();
+  props.items.forEach(item => {
+    sections.add(item.section ?? '');
+  });
+
+  return (
+    <StyledSidebar className="fancy-page__sidebar">
+      <SidebarSections>
+        {Array.from(sections).map((section, i) => (
+          <React.Fragment key={'section__' + i}>
+            {section !== '' && (
+              <SidebarSectionHeader>{section}</SidebarSectionHeader>
+            )}
+            <SidebarSection
+              selectedItem={props.selectedItem}
+              items={props.items.filter(
+                item => section === (item.section ?? '')
+              )}
+            />
+          </React.Fragment>
+        ))}
+      </SidebarSections>
+    </StyledSidebar>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/SidebarSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/SidebarSection.tsx
@@ -1,0 +1,152 @@
+import {
+  hexToRGB,
+  MEDIUM_BREAKPOINT,
+  MOON_250,
+  MOON_800,
+  MOONBEAM,
+  OBLIVION,
+  TEAL_450,
+  TEAL_550,
+  TRANSPARENT,
+} from '@wandb/weave/common/css/globals.styles';
+import {Icon} from '@wandb/weave/components/Icon';
+import React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {isInNightMode} from '../../../nightMode';
+import {Tooltip} from '../../../Tooltip';
+import {SidebarItem} from './Sidebar';
+
+const SidebarWrapper = styled.div`
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    display: flex;
+    align-items: center;
+  }
+`;
+SidebarWrapper.displayName = 'S.SidebarWrapper';
+
+const SidebarButton = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+SidebarButton.displayName = 'S.SidebarButton';
+
+type ItemIconProps = {
+  color: string;
+};
+const ItemIcon = styled.div<ItemIconProps>`
+  height: 32px;
+  box-sizing: border-box;
+  border-radius: 8px;
+  padding: 6px 12px;
+  background-color: ${props => props.color};
+  display: flex;
+  align-items: center;
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    padding: 0 12px;
+  }
+`;
+ItemIcon.displayName = 'S.ItemIcon';
+
+type ItemLabelProps = {
+  color: string;
+};
+const ItemLabel = styled.div<ItemLabelProps>`
+  color: ${props => props.color};
+  font-family: 'Source Sans Pro';
+  font-weight: 600;
+  height: 14px;
+  font-size: 10px;
+  line-height: 14px;
+  text-align: center;
+`;
+ItemLabel.displayName = 'S.ItemLabel';
+
+type SidebarSectionProps = {
+  selectedItem: string | null;
+  items: SidebarItem[];
+};
+
+type UrlParts = {
+  pathname: string;
+  search?: string;
+};
+
+const parseUrl = (path: string): UrlParts => {
+  const [pathname, search] = path.split('?');
+  return {
+    pathname,
+    search: search ? search : undefined,
+  };
+};
+
+const SidebarSection = (props: SidebarSectionProps) => {
+  const isNightMode = isInNightMode();
+
+  const [hoveredItem, setHoveredItem] = React.useState<string | null>(null);
+  return (
+    <>
+      {props.items.map(item => {
+        const onMouseEnter = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+          setHoveredItem(item.id);
+        };
+        const onMouseLeave = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+          setHoveredItem(null);
+        };
+        let colorIconBg: string = TRANSPARENT;
+        let colorIcon: string = isNightMode ? MOON_250 : MOON_800;
+        let colorText: string = isNightMode ? MOON_250 : MOON_800;
+        if (item.id === props.selectedItem) {
+          colorIconBg = hexToRGB(TEAL_550, isNightMode ? 0.16 : 0.1);
+          colorIcon = colorText = isNightMode ? TEAL_450 : TEAL_550;
+        } else if (item.id === hoveredItem) {
+          colorIconBg = isNightMode
+            ? hexToRGB(MOONBEAM, 0.08)
+            : hexToRGB(OBLIVION, 0.04);
+        }
+        const baseLinkProps = {
+          key: item.id,
+          onMouseEnter,
+          onMouseLeave,
+          'data-test': item.id + '-tab',
+        };
+
+        const linkProps = {
+          ...baseLinkProps,
+          to: {
+            ...parseUrl(item.path),
+          },
+        };
+
+        const wrapper = (
+          <SidebarWrapper key={item.name} className="night-aware">
+            <Link {...linkProps}>
+              <SidebarButton>
+                <ItemIcon color={colorIconBg}>
+                  <Icon name={item.iconName} color={colorIcon} />
+                </ItemIcon>
+                <ItemLabel color={colorText}>{item.name}</ItemLabel>
+              </SidebarButton>
+            </Link>
+          </SidebarWrapper>
+        );
+
+        if (item.nameTooltip) {
+          return (
+            <Tooltip
+              key={item.name}
+              content={<span>{item.nameTooltip}</span>}
+              trigger={wrapper}
+              position="right center"
+            />
+          );
+        }
+        return wrapper;
+      })}
+    </>
+  );
+};
+
+export default SidebarSection;

--- a/weave-js/src/components/nightMode.ts
+++ b/weave-js/src/components/nightMode.ts
@@ -1,0 +1,3 @@
+export const isInNightMode = (): boolean => {
+  return document.documentElement.classList.contains('night-mode');
+};


### PR DESCRIPTION
Some commented out code while we decide things like whether we want separate Models/Datasets entries, whether we want section headers, etc. We should be able to remove the Browse3SideNav code once we're happy with this.

<img width="258" alt="Screenshot 2024-01-16 at 1 50 08 PM" src="https://github.com/wandb/weave/assets/112953339/f353da6c-0ee5-438c-9a53-096b6279bfd8">
