### PR TITLE
chore(launch): remove priority from qob type

### DIFF
--- a/weave/panels_py/panel_observability.py
+++ b/weave/panels_py/panel_observability.py
@@ -22,7 +22,6 @@ BOARD_INPUT_WEAVE_TYPE = types.List(
             "trace_id": types.optional(types.String()),
             "state": types.optional(types.String()),
             "error": types.optional(types.String()),
-            "priority": types.optional(types.Number()),
             "metrics": types.TypedDict(
                 {
                     "system": types.TypedDict(


### PR DESCRIPTION
changed my mind, better to have this not in the type, 2 reasons: 
1. priority has only been logged for a couple weeks, anyone visiting the dashboard page in that new time without launching a job might see an error. 
2. we might actually want to play games with the type, seeing as it was causing grief...