### PR TITLE
fix: toggle Latest filter on button click

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage.tsx
@@ -316,8 +316,14 @@ export const CallsTable: React.FC<{
               Object.keys(props.frozenFilter ?? {}).includes('traceRootsOnly')
             }
             disablePadding>
-            <ListItemButton>
-              <ListItemText primary={`Roots Only`} />
+            <ListItemButton
+              onClick={() => {
+                setFilter({
+                  ...filter,
+                  traceRootsOnly: !effectiveFilter.traceRootsOnly,
+                });
+              }}>
+              <ListItemText primary="Roots Only" />
             </ListItemButton>
           </ListItem>
         </>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -278,8 +278,14 @@ export const FilterableObjectVersionsTable: React.FC<{
               latestOnlyOptions.length <= 1
             }
             disablePadding>
-            <ListItemButton>
-              <ListItemText primary={`Latest Only`} />
+            <ListItemButton
+              onClick={() => {
+                setFilter({
+                  ...filter,
+                  latest: !effectiveFilter.latest,
+                });
+              }}>
+              <ListItemText primary="Latest Only" />
             </ListItemButton>
           </ListItem>
         </>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -961,8 +961,13 @@ const LatestOnlyControlListItem: React.FC<{
         options.length <= 1
       }
       disablePadding>
-      <ListItemButton>
-        <ListItemText primary={`Latest Only`} />
+      <ListItemButton
+        onClick={() => {
+          props.updateFilter({
+            isLatest: !props.filter?.isLatest,
+          });
+        }}>
+        <ListItemText primary="Latest Only" />
       </ListItemButton>
     </ListItem>
   );


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Weaveflow-Jan-2024-Tasks-e4f3a053bc8243738ba1dad3c4cff6d4?pvs=4#338afecd952044da949820bc32985548

Clicking the "Latest Only" or "Roots Only" buttons should do the same toggle as clicking on the checkbox itself.