### PR TITLE
feat: highlight table row corresponding to open peek drawer

### DIFF
--- a/weave-js/src/common/css/utils.test.ts
+++ b/weave-js/src/common/css/utils.test.ts
@@ -1,4 +1,4 @@
-import {hexToRGB} from './globals.styles';
+import {Color, hexToRGB} from './utils';
 
 describe('hexToRGB', () => {
   it('converts six value syntax', () => {
@@ -18,5 +18,22 @@ describe('hexToRGB', () => {
   it('throws when given invalid formats', () => {
     expect(() => hexToRGB('#FFFF')).toThrow();
     expect(() => hexToRGB('#ggg')).toThrow();
+  });
+});
+
+describe('Color.fromHex', () => {
+  it('parses six value syntax', () => {
+    const c = Color.fromHex('#123456');
+    expect(c.r).toEqual(18);
+    expect(c.g).toEqual(52);
+    expect(c.b).toEqual(86);
+    expect(c.a).toEqual(undefined);
+  });
+  it('parses three value syntax', () => {
+    const c = Color.fromHex('#fab');
+    expect(c.r).toEqual(255);
+    expect(c.g).toEqual(170);
+    expect(c.b).toEqual(187);
+    expect(c.a).toEqual(undefined);
   });
 });

--- a/weave-js/src/common/css/utils.ts
+++ b/weave-js/src/common/css/utils.ts
@@ -1,31 +1,82 @@
+const interpolate = (c1: number, c2: number, ratio: number) =>
+  (1 - ratio) * c1 + ratio * c2;
+
+const toHex = (value: number) => {
+  const hex = Math.round(value).toString(16);
+  return hex.length === 1 ? '0' + hex : hex;
+};
+
+export class Color {
+  static fromHex(hex: string, alpha?: number): Color {
+    if (!hex.startsWith('#')) {
+      throw new Error(`Color hex code ${hex} missing '#' prefix`);
+    }
+    if (hex.length === 7) {
+      const r = parseInt(hex.substring(1, 3), 16);
+      const g = parseInt(hex.substring(3, 5), 16);
+      const b = parseInt(hex.substring(5, 7), 16);
+      if (isNaN(r) || isNaN(g) || isNaN(b)) {
+        throw new Error(`Invalid hex code: ${hex}`);
+      }
+      return new Color(r, g, b, alpha);
+    }
+    if (hex.length === 4) {
+      const rc = parseInt(hex.charAt(1), 16);
+      const gc = parseInt(hex.charAt(2), 16);
+      const bc = parseInt(hex.charAt(3), 16);
+      if (isNaN(rc) || isNaN(gc) || isNaN(bc)) {
+        throw new Error(`Invalid hex code: ${hex}`);
+      }
+      const r = rc * 16 + rc;
+      const g = gc * 16 + gc;
+      const b = bc * 16 + bc;
+      return new Color(r, g, b, alpha);
+    }
+    throw new Error(`Invalid hex code: ${hex}`);
+  }
+
+  r: number;
+  g: number;
+  b: number;
+  a?: number;
+
+  constructor(r: number, g: number, b: number, a?: number) {
+    this.r = r;
+    this.g = g;
+    this.b = b;
+    this.a = a;
+  }
+
+  alpha(): number {
+    return this.a ?? 1.0;
+  }
+
+  withAlpha(a: number | undefined): Color {
+    return new Color(this.r, this.g, this.b, a);
+  }
+
+  blend(other: Color): Color {
+    const ratio = other.alpha();
+    const r = Math.floor(interpolate(this.r, other.r, ratio));
+    const g = Math.floor(interpolate(this.g, other.g, ratio));
+    const b = Math.floor(interpolate(this.b, other.b, ratio));
+    return new Color(r, g, b);
+  }
+
+  toHexString(): string {
+    const hex = `#${toHex(this.r)}${toHex(this.g)}${toHex(this.b)}`;
+    const suffix = this.a != null ? toHex(this.alpha() * 255) : '';
+    return `${hex}${suffix}`;
+  }
+
+  toString(): string {
+    if (this.a != null) {
+      return `rgba(${this.r}, ${this.g}, ${this.b}, ${this.a})`;
+    }
+    return `rgb(${this.r}, ${this.g}, ${this.b})`;
+  }
+}
+
 export const hexToRGB = (hex: string, alpha?: number) => {
-  if (!hex.startsWith('#')) {
-    throw new Error(`Color hex code ${hex} missing '#' prefix`);
-  }
-  if (hex.length === 7) {
-    const r = parseInt(hex.substring(1, 3), 16);
-    const g = parseInt(hex.substring(3, 5), 16);
-    const b = parseInt(hex.substring(5, 7), 16);
-    if (isNaN(r) || isNaN(g) || isNaN(b)) {
-      throw new Error(`Invalid hex code: ${hex}`);
-    }
-    return alpha !== undefined
-      ? `rgba(${r}, ${g}, ${b}, ${alpha})`
-      : `rgb(${r}, ${g}, ${b})`;
-  }
-  if (hex.length === 4) {
-    const rc = parseInt(hex.charAt(1), 16);
-    const gc = parseInt(hex.charAt(2), 16);
-    const bc = parseInt(hex.charAt(3), 16);
-    if (isNaN(rc) || isNaN(gc) || isNaN(bc)) {
-      throw new Error(`Invalid hex code: ${hex}`);
-    }
-    const r = rc * 16 + rc;
-    const g = gc * 16 + gc;
-    const b = bc * 16 + bc;
-    return alpha !== undefined
-      ? `rgba(${r}, ${g}, ${b}, ${alpha})`
-      : `rgb(${r}, ${g}, ${b})`;
-  }
-  throw new Error(`Invalid hex code: ${hex}`);
+  return Color.fromHex(hex, alpha).toString();
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -4,18 +4,21 @@ import {
   DataGridPro,
   GridColDef,
   GridColumnGroup,
+  GridRowSelectionModel,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import {parseRef} from '@wandb/weave/react';
 import {monthRoundedTime} from '@wandb/weave/time';
 import * as _ from 'lodash';
-import React, {FC, useEffect, useMemo, useRef} from 'react';
+import React, {FC, useEffect, useMemo, useRef, useState} from 'react';
 import {useParams} from 'react-router-dom';
 
 import {Timestamp} from '../../../Timestamp';
 import {CallStatusCodeChip} from '../Browse3/pages/common/CallStatusCodeChip';
 import {CallLink, opVersionText} from '../Browse3/pages/common/Links';
+import {useURLSearchParamsDict} from '../Browse3/pages/util';
 import {useMaybeWeaveflowORMContext} from '../Browse3/pages/wfInterface/context';
+import {StyledDataGrid} from '../Browse3/StyledDataGrid';
 import {flattenObject} from './browse2Util';
 import {SpanWithFeedback} from './callTree';
 import {Browse2RootObjectVersionItemParams} from './CommonLib';
@@ -147,6 +150,32 @@ export const RunsTable: FC<{
       };
     });
   }, [orm?.projectConnection, spans, loading]);
+
+  // Highlight table row if it matches peek drawer.
+  const query = useURLSearchParamsDict();
+  const {peekPath} = query;
+  const peekId = peekPath ? peekPath.split('/').pop() : null;
+  const rowIds = useMemo(() => {
+    return tableData.map(row => row.id);
+  }, [tableData]);
+  const [rowSelectionModel, setRowSelectionModel] =
+    useState<GridRowSelectionModel>([]);
+  useEffect(() => {
+    if (rowIds.length === 0) {
+      // Data may have not loaded
+      return;
+    }
+    if (peekId == null) {
+      // No peek drawer, clear any selection
+      setRowSelectionModel([]);
+    } else {
+      // If peek drawer matches a row, select it.
+      // If not, don't modify selection.
+      if (rowIds.includes(peekId)) {
+        setRowSelectionModel([peekId]);
+      }
+    }
+  }, [rowIds, peekId]);
 
   const columns = useMemo(() => {
     const cols: GridColDef[] = [
@@ -456,21 +485,9 @@ export const RunsTable: FC<{
         },
       };
     }, [loading]);
+
   return (
-    <DataGridPro
-      sx={{
-        // borderTop: 1,
-        borderRight: 0,
-        borderLeft: 0,
-        borderBottom: 0,
-        '& .MuiDataGrid-columnHeader:focus, .MuiDataGrid-cell:focus': {
-          outline: 'none',
-        },
-        '& .MuiDataGrid-columnHeaders': {
-          backgroundColor: '#FAFAFA',
-          color: '#979a9e',
-        },
-      }}
+    <StyledDataGrid
       columnHeaderHeight={40}
       apiRef={apiRef}
       loading={loading}
@@ -481,6 +498,7 @@ export const RunsTable: FC<{
       columns={columns.cols}
       experimentalFeatures={{columnGrouping: true}}
       disableRowSelectionOnClick
+      rowSelectionModel={rowSelectionModel}
       columnGroupingModel={columns.colGroupingModel}
       // onRowClick={({id}) => {
       //   history.push(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
@@ -1,0 +1,47 @@
+import {styled} from '@mui/material/styles';
+import {DataGridPro} from '@mui/x-data-grid-pro';
+import {gridClasses} from '@mui/x-data-grid-pro';
+
+import {
+  Color,
+  hexToRGB,
+  MOON_50,
+  OBLIVION,
+  TEAL_300,
+  WHITE,
+} from '../../../../common/css/globals.styles';
+
+// TODO: Handle night mode
+const backgroundColorHovered = hexToRGB(OBLIVION, 0.04);
+const backgroundColorSelected = hexToRGB(TEAL_300, 0.32);
+const backgroundColorHoveredSelected = Color.fromHex(WHITE)
+  .blend(Color.fromHex(TEAL_300, 0.32))
+  .blend(Color.fromHex(OBLIVION, 0.04))
+  .toString();
+
+export const StyledDataGrid = styled(DataGridPro)(({theme}) => ({
+  borderRight: 0,
+  borderLeft: 0,
+  borderBottom: 0,
+
+  '& .MuiDataGrid-columnHeaders': {
+    backgroundColor: MOON_50,
+    color: '#979a9e',
+  },
+
+  '& .MuiDataGrid-columnHeader:focus, .MuiDataGrid-cell:focus': {
+    outline: 'none',
+  },
+
+  [`& .${gridClasses.row}`]: {
+    '&.Mui-hovered': {
+      backgroundColor: backgroundColorHovered,
+    },
+    '&.Mui-selected': {
+      backgroundColor: backgroundColorSelected,
+      '&.Mui-hovered': {
+        backgroundColor: backgroundColorHoveredSelected,
+      },
+    },
+  },
+}));

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -8,9 +8,9 @@ import {
   TextField,
 } from '@mui/material';
 import {
-  DataGridPro,
   GridColDef,
   GridColumnGroupingModel,
+  GridRowSelectionModel,
   GridRowsProp,
 } from '@mui/x-data-grid-pro';
 import _ from 'lodash';
@@ -18,12 +18,13 @@ import React, {useEffect, useMemo, useState} from 'react';
 
 import {Timestamp} from '../../../../Timestamp';
 import {useWeaveflowRouteContext} from '../context';
+import {StyledDataGrid} from '../StyledDataGrid';
 import {basicField} from './common/DataTable';
 import {ObjectVersionLink, ObjectVersionsLink} from './common/Links';
 import {FilterLayoutTemplate} from './common/SimpleFilterableDataTable';
 import {SimplePageLayout} from './common/SimplePageLayout';
 import {TypeVersionCategoryChip} from './common/TypeVersionCategoryChip';
-import {truncateID} from './util';
+import {truncateID, useURLSearchParamsDict} from './util';
 import {useWeaveflowORMContext} from './wfInterface/context';
 import {
   HackyTypeCategory,
@@ -472,23 +473,39 @@ const ObjectVersionsTable: React.FC<{
     //   }),]
   ];
   const columnGroupingModel: GridColumnGroupingModel = [];
+
+  // Highlight table row if it matches peek drawer.
+  const query = useURLSearchParamsDict();
+  const {peekPath} = query;
+  const peekId = peekPath ? peekPath.split('/').pop() : null;
+  const rowIds = useMemo(() => {
+    return rows.map(row => row.id);
+  }, [rows]);
+  const [rowSelectionModel, setRowSelectionModel] =
+    useState<GridRowSelectionModel>([]);
+  useEffect(() => {
+    if (rowIds.length === 0) {
+      // Data may have not loaded
+      return;
+    }
+    if (peekId == null) {
+      // No peek drawer, clear any selection
+      setRowSelectionModel([]);
+    } else {
+      // If peek drawer matches a row, select it.
+      // If not, don't modify selection.
+      if (rowIds.includes(peekId)) {
+        setRowSelectionModel([peekId]);
+      }
+    }
+  }, [rowIds, peekId]);
+
   return (
-    <DataGridPro
+    <StyledDataGrid
       rows={rows}
       initialState={{
         sorting: {
           sortModel: [{field: 'createdAt', sort: 'desc'}],
-        },
-      }}
-      sx={{
-        // borderTop: 1,
-        borderRight: 0,
-        borderLeft: 0,
-        borderBottom: 0,
-
-        '& .MuiDataGrid-columnHeaders': {
-          backgroundColor: '#FAFAFA',
-          color: '#979a9e',
         },
       }}
       columnHeaderHeight={40}
@@ -496,6 +513,7 @@ const ObjectVersionsTable: React.FC<{
       columns={columns}
       experimentalFeatures={{columnGrouping: true}}
       disableRowSelectionOnClick
+      rowSelectionModel={rowSelectionModel}
       columnGroupingModel={columnGroupingModel}
     />
   );


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Weaveflow-Jan-2024-Tasks-e4f3a053bc8243738ba1dad3c4cff6d4?pvs=4#4ad31d2f2c764ef49b195f983ec82970

Centralizes custom datagrid styling. Adds row selection to various grids, sync'ing it with what's shown in the peek drawer.

![image](https://github.com/wandb/weave/assets/112953339/da036749-2abd-4574-945e-474f5f14b351)
