### PR TITLE
chore: weaveflow status chips have tooltips

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
@@ -6,6 +6,8 @@ import {IconName} from '@wandb/weave/components/Icon';
 import {IconOnlyPill, Pill, TagColorName} from '@wandb/weave/components/Tag';
 import React from 'react';
 
+import {Tooltip} from '../../../../../Tooltip';
+
 export const CALL_STATUS = ['SUCCESS', 'DESCENDANT_ERROR', 'ERROR'];
 export type CallStatusType = (typeof CALL_STATUS)[number];
 
@@ -18,33 +20,37 @@ type CallStatusInfo = {
   icon: IconName;
   label: string;
   color: TagColorName;
+  tooltip: string;
 };
 const STATUS_INFO: Record<CallStatusType, CallStatusInfo> = {
   SUCCESS: {
     icon: 'checkmark-circle',
     label: 'Finished',
     color: 'green',
+    tooltip: 'This call succeeded.',
   },
   DESCENDANT_ERROR: {
     icon: 'warning',
     label: 'Finished',
-    color: 'sienna',
+    color: 'gold',
+    tooltip: 'This call succeeded, but one or more descendants failed.',
   },
   ERROR: {
     icon: 'failed',
     label: 'Error',
     color: 'red',
+    tooltip: 'This call failed.',
   },
 };
 
 export const StatusChip = ({value, iconOnly}: StatusChipProps) => {
   const statusInfo = STATUS_INFO[value];
-  const {icon, color, label} = statusInfo;
+  const {icon, color, label, tooltip} = statusInfo;
 
   const pill = iconOnly ? (
     <IconOnlyPill icon={icon} color={color} />
   ) : (
     <Pill icon={icon} color={color} label={label} />
   );
-  return pill;
+  return <Tooltip trigger={<span>{pill}</span>} content={tooltip} />;
 };


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Weaveflow-Jan-2024-Tasks-e4f3a053bc8243738ba1dad3c4cff6d4?pvs=4#c1b2e1b7cd8a494580952055afa51bbb

Make it clearer what the status icons mean.

<img width="354" alt="Screenshot 2024-01-22 at 9 44 03 AM" src="https://github.com/wandb/weave/assets/112953339/60e7b484-3432-4bb3-b5aa-c4d399e27f8d">
