### PR TITLE
chore: don't print openai message

### DIFF
--- a/weave/autopatch.py
+++ b/weave/autopatch.py
@@ -19,7 +19,6 @@ def autopatch_openai() -> None:
         from weave.monitoring.openai import patch
 
         patch()
-        print("Automatically tracking openai calls")
 
 
 def autopatch() -> None:


### PR DESCRIPTION
E.g. https://wandb.github.io/weave/tutorial-eval#upload-a-dataset - nothing is obviously using OpenAI here, so the message being output is confusing.