### PR TITLE
chore(weave): Quick fix to enable correct ref links for eval use case

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -14,6 +14,7 @@ import {
 import {
   ArtifactRef,
   isWandbArtifactRef,
+  ObjectRef,
   parseRef,
   refUri,
   useNodeValue,
@@ -43,7 +44,7 @@ type WFDBTableType =
   | 'Object'
   | 'ObjectVersion';
 
-export const SmallRef: FC<{objRef: ArtifactRef; wfTable?: WFDBTableType}> = ({
+export const SmallRef: FC<{objRef: ObjectRef; wfTable?: WFDBTableType}> = ({
   objRef,
   wfTable,
 }) => {
@@ -56,7 +57,21 @@ export const SmallRef: FC<{objRef: ArtifactRef; wfTable?: WFDBTableType}> = ({
   const refTypeQuery = useNodeValue(refTypeNode);
   const refType: Type = refTypeQuery.result ?? 'unknown';
   const rootType = getRootType(refType);
-  const label = objRef.artifactName + ':' + objRef.artifactVersion.slice(0, 6);
+  let label = objRef.artifactName + ':' + objRef.artifactVersion.slice(0, 6);
+  let suffix = '';
+
+  // TEMP HACK (Tim): This is a temporary hack to ensure that SmallRef renders
+  // the Evaluation rows with the correct label and link. There is a more full
+  // featured solution here: https://github.com/wandb/weave/pull/1080 that needs
+  // to be finished asap. This is just to fix the demo / first internal release.
+  if (objRef.artifactPath === 'rows%2F0') {
+    label +=
+      '/rows' + (objRef.objectRefExtra ? '/' + objRef.objectRefExtra : '');
+    suffix =
+      '/rows/index' +
+      (objRef.objectRefExtra ? '/' + objRef.objectRefExtra : '');
+  }
+
   const rootTypeName = getTypeName(rootType);
   let icon = <SpokeIcon sx={{height: '100%'}} />;
   if (rootTypeName === 'Dataset') {
@@ -83,7 +98,7 @@ export const SmallRef: FC<{objRef: ArtifactRef; wfTable?: WFDBTableType}> = ({
     return <div>[Error: non wandb ref]</div>;
   }
   return (
-    <Link to={peekingRouter.refUIUrl(rootTypeName, objRef, wfTable)}>
+    <Link to={peekingRouter.refUIUrl(rootTypeName, objRef, wfTable) + suffix}>
       {Item}
     </Link>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -172,6 +172,7 @@ const ObjectVersionPageInner: React.FC<{
           label: 'Values',
           content: (
             <WeaveEditorSourceContext.Provider
+              key={fullUri}
               value={{
                 entityName,
                 projectName,

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -472,13 +472,17 @@ export interface WandbArtifactRef {
 
 export type ArtifactRef = LocalArtifactRef | WandbArtifactRef;
 
+export type ObjectRef = ArtifactRef & {
+  objectRefExtra?: string;
+};
+
 export const isWandbArtifactRef = (
   ref: ArtifactRef
 ): ref is WandbArtifactRef => {
   return 'entityName' in ref;
 };
 
-export const parseRef = (ref: string): ArtifactRef => {
+export const parseRef = (ref: string): ObjectRef => {
   const url = new URL(ref);
   let splitLimit: number;
 
@@ -508,6 +512,7 @@ export const parseRef = (ref: string): ArtifactRef => {
       artifactName: artifactNamePart,
       artifactVersion,
       artifactPath: artifactPathPart,
+      objectRefExtra: url.hash ? url.hash.slice(1) : undefined,
     };
   }
 


### PR DESCRIPTION
// TEMP HACK (Tim): This is a temporary hack to ensure that SmallRef renders
// the Evaluation rows with the correct label and link. There is a more full
// featured solution here: https://github.com/wandb/weave/pull/1080 that needs
// to be finished asap. This is just to fix the demo / first internal release.

<img width="1523" alt="Screenshot 2024-01-22 at 16 25 19" src="https://github.com/wandb/weave/assets/2142768/f11aafc2-e815-46cc-a730-d28f4e5471df">
<img width="1516" alt="Screenshot 2024-01-22 at 16 25 07" src="https://github.com/wandb/weave/assets/2142768/244fe378-6c13-4fc5-a541-a70c1f701c2a">
