### PR TITLE
fix: two little crashes, handle zero case in history3 read path

### DIFF
--- a/weave/ops_domain/run_history/run_history_v3_parquet_stream_optimized.py
+++ b/weave/ops_domain/run_history/run_history_v3_parquet_stream_optimized.py
@@ -346,6 +346,8 @@ def _get_history3(run: wdt.Run, columns=None):
     use_fast_path = _use_fast_path(flattened_object_type)
     if use_fast_path:
         concatted_awl = _fast_history3_concat(raw_history_pa_tables, raw_live_data)
+        if len(concatted_awl) == 0:
+            return convert.to_arrow([], types.List(final_type), artifact=artifact)
         if not isinstance(concatted_awl.object_type, types.TypedDict):
             raise errors.WeaveWBHistoryTranslationError(
                 f"Expected fast_path object_type to be TypedDict, got {concatted_awl.object_type}"
@@ -407,8 +409,8 @@ def _get_history3(run: wdt.Run, columns=None):
             ]
         )
 
-    if len(concatted_awl) == 0:
-        return convert.to_arrow([], types.List(final_type), artifact=artifact)
+        if len(concatted_awl) == 0:
+            return convert.to_arrow([], types.List(final_type), artifact=artifact)
 
     sorted_table = history_op_common.sort_history_pa_table(
         history_op_common.awl_to_pa_table(concatted_awl)

--- a/weave/wandb_interface/wandb_stream_table.py
+++ b/weave/wandb_interface/wandb_stream_table.py
@@ -26,6 +26,7 @@ from .. import environment
 from .. import file_util
 from .. import graph
 from .. import errors
+from .. import box
 from ..core_types.stream_table_type import StreamTableType
 
 if typing.TYPE_CHECKING:
@@ -350,6 +351,7 @@ def obj_to_weave(obj: typing.Any, artifact: WandbLiveRunFiles) -> typing.Any:
         return obj_to_weave(obj, artifact)
 
     # all primitives
+    obj = box.unbox(obj)
     if isinstance(obj, (int, float, str, bool, type(None))):
         return obj
     else:


### PR DESCRIPTION
- unbox in streamtable write path, we were saving boxed booleans as {_type, _val} dicts in streamtable instead of as the raw values
- handle empty calls case in history3 read fast path