### PR TITLE
chore: Swap status and id columns, set status column header and size

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -180,16 +180,6 @@ export const RunsTable: FC<{
   const columns = useMemo(() => {
     const cols: GridColDef[] = [
       {
-        field: 'status_code',
-        headerName: '',
-        sortable: false,
-        disableColumnMenu: true,
-        resizable: false,
-        renderCell: cellParams => {
-          return <StatusChip value={cellParams.row.status_code} />;
-        },
-      },
-      {
         field: 'span_id',
         headerName: 'ID',
         width: 75,
@@ -204,6 +194,19 @@ export const RunsTable: FC<{
               callId={rowParams.row.id}
             />
           );
+        },
+      },
+      {
+        field: 'status_code',
+        headerName: 'Status',
+        sortable: false,
+        disableColumnMenu: true,
+        resizable: false,
+        width: 100,
+        minWidth: 100,
+        maxWidth: 100,
+        renderCell: cellParams => {
+          return <StatusChip value={cellParams.row.status_code} />;
         },
       },
       ...(orm


### PR DESCRIPTION
Feedback from design team.

Before:

<img width="291" alt="Screenshot 2024-01-24 at 1 56 34 PM" src="https://github.com/wandb/weave/assets/112953339/0b7b6d1d-097d-4a95-87d6-1e736154f721">

After:
<img width="265" alt="Screenshot 2024-01-24 at 1 56 24 PM" src="https://github.com/wandb/weave/assets/112953339/71fd3913-075b-4a97-9138-d80abc0ce4c5">

