### PR TITLE
feat: add code tab to call

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -14,6 +14,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 
 import {parseRef} from '../../../../../../react';
+import {Browse2OpDefCode} from '../../../Browse2/Browse2OpDefCode';
 import {Call} from '../../../Browse2/callTree';
 import {SmallRef} from '../../../Browse2/SmallRef';
 import {useWeaveflowCurrentRouteContext} from '../../context';
@@ -67,11 +68,21 @@ export const CallPage: React.FC<{
 };
 
 const useCallTabs = (call: WFCall) => {
+  const opVersion = call.opVersion();
+  const codeURI = opVersion ? opVersion.refUri() : null;
   return [
     {
       label: 'Call',
       content: <CallDetails wfCall={call} />,
     },
+    ...(codeURI
+      ? [
+          {
+            label: 'Code',
+            content: <Browse2OpDefCode uri={codeURI} />,
+          },
+        ]
+      : []),
     // {
     //   label: 'Child Calls',
     //   content: (


### PR DESCRIPTION
Makes the code tab available when viewing a call, not just an op version. Saw in user testing that people are looking for this and having trouble finding it.