### PR TITLE
fix: sorting of latency column

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -112,7 +112,7 @@ export const RunsTable: FC<{
         trace_id: call.trace_id,
         status_code: call.status_code,
         timestampMs: call.timestamp,
-        latency: monthRoundedTime(call.summary.latency_s),
+        latency: call.summary.latency_s,
         ..._.mapValues(
           _.mapKeys(
             _.omitBy(args, v => v == null),
@@ -289,6 +289,9 @@ export const RunsTable: FC<{
         minWidth: 100,
         maxWidth: 100,
         // flex: !showIO ? 1 : undefined,
+        renderCell: cellParams => {
+          return monthRoundedTime(cellParams.row.latency);
+        },
       },
     ];
     const colGroupingModel: DataGridColumnGroupingModel = [];


### PR DESCRIPTION
Was doing a string sort instead of sorting numerically.

Before:
<img width="97" alt="Screenshot 2024-01-25 at 1 10 03 PM" src="https://github.com/wandb/weave/assets/112953339/6629cd16-cbb3-410e-b595-49d542309579">

After:
<img width="99" alt="Screenshot 2024-01-25 at 1 08 51 PM" src="https://github.com/wandb/weave/assets/112953339/03525c8a-9419-4298-b3d6-6f5077ea344b">

