### PR TITLE
chore: hack in duplicate row removal

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/callTreeHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/callTreeHooks.ts
@@ -1,5 +1,6 @@
 import {constNumber, opIndex} from '@wandb/weave/core';
 import {useNodeValue} from '@wandb/weave/react';
+import _ from 'lodash';
 import {useMemo} from 'react';
 
 import {
@@ -166,7 +167,10 @@ export const useRunsWithFeedback = (
     if (runsQuery.loading || feedbackQuery.loading) {
       return {loading: true, result: []};
     }
-    const runs = runsQuery.result;
+    // TODO: (HACK) Not sure why we are getting duplicates yet, but duplicates
+    //        will mess up the UI downstream, so uniquify here.
+    // const runs = runsQuery.result;
+    const runs = _.uniqBy(runsQuery.result, r => r.span_id);
     const feedback = feedbackQuery.result ?? [];
     const result = joinRunsWithFeedback(runs ?? [], feedback);
     return {


### PR DESCRIPTION
Getting a ton of console warnings because of the duplicate row issue. Removing dupes client side as a short term hack.

<img width="1580" alt="Screenshot 2024-01-26 at 4 13 59 PM" src="https://github.com/wandb/weave/assets/112953339/03684512-eee7-409b-a536-c3c9aea82125">
