### PR TITLE
feat: indicate null values explicitly

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/util.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/util.tsx
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import React, {useEffect, useMemo, useState} from 'react';
 import {useLocation} from 'react-router-dom';
 
+import {Pill} from '../../../../Tag';
 import {SmallRef} from '../../Browse2/SmallRef';
 
 export const useURLSearchParamsDict = () => {
@@ -26,6 +27,9 @@ export const truncateID = (id: string, maxLen: number = 9) => {
 };
 
 export const renderCell = (value: any) => {
+  if (value == null) {
+    return <Pill color="moon" label="None" />;
+  }
   if (typeof value === 'string' && value.startsWith('wandb-artifact:///')) {
     return <SmallRef objRef={parseRef(value)} />;
   }


### PR DESCRIPTION
Mostly to queue this up for discussion - I think the user should be able to distinguish in the UI between e.g. a "None" value and an empty string.

Before:
<img width="570" alt="Screenshot 2024-01-29 at 10 44 19 AM" src="https://github.com/wandb/weave/assets/112953339/bb6e50a7-14f5-4c1d-b5b6-18ff83d2e715">


After:
<img width="556" alt="Screenshot 2024-01-29 at 10 44 10 AM" src="https://github.com/wandb/weave/assets/112953339/af336b0c-638c-4243-b066-380878a6a32e">
