### PR TITLE
fix: disallow hiding first col

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -186,6 +186,7 @@ export const RunsTable: FC<{
         width: 75,
         minWidth: 75,
         maxWidth: 75,
+        hideable: false,
         renderCell: rowParams => {
           // return truncateID(rowParams.row.id);
           return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -304,6 +304,7 @@ const ObjectVersionsTable: React.FC<{
   }, [props.objectVersions]);
   const columns: GridColDef[] = [
     basicField('version', 'Object', {
+      hideable: false,
       renderCell: params => {
         // Icon to indicate navigation to the object version
         return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -120,6 +120,7 @@ export const FilterableOpVersionsTable: React.FC<{
           columnLabel: 'Op',
           columnValue: obj => obj.obj.version(),
           gridColDefOptions: {
+            hideable: false,
             renderCell: params => {
               return (
                 <OpVersionLink


### PR DESCRIPTION
By default you can show/hide any column. This PR disables that for the first column in the table. One motivation for doing this is that the user can get stuck if they click the "Hide All" button in the "Manage columns" dialog, as we don't have a GridToolbar to provide them another way to access that.

Before:
<img width="262" alt="Screenshot 2024-01-29 at 2 01 29 PM" src="https://github.com/wandb/weave/assets/112953339/d3ae2525-c84b-4597-b11a-8589971dd1c2">
<img width="316" alt="Screenshot 2024-01-29 at 2 01 36 PM" src="https://github.com/wandb/weave/assets/112953339/18bcd929-c20f-415e-b19e-1f0c14dfdd99">

After:
<img width="261" alt="Screenshot 2024-01-29 at 1 56 17 PM" src="https://github.com/wandb/weave/assets/112953339/f5d2d207-06a4-4c0d-a75b-e1a83283b3db">
<img width="318" alt="Screenshot 2024-01-29 at 1 56 22 PM" src="https://github.com/wandb/weave/assets/112953339/f3bb5f97-5fc5-45d8-b6a3-1ba1d71eb9f5">
