### PR TITLE
feat: add Use tabs to Object and Op pages

### DIFF
--- a/weave-js/src/components/CopyableText.tsx
+++ b/weave-js/src/components/CopyableText.tsx
@@ -1,0 +1,71 @@
+import copyToClipboard from 'copy-to-clipboard';
+import React, {useCallback} from 'react';
+import styled from 'styled-components';
+
+import {toast} from '../common/components/elements/Toast';
+import {MOON_100, MOON_200} from '../common/css/color.styles';
+import {Icon, IconName} from './Icon';
+import {Tooltip} from './Tooltip';
+
+type CopyableTextProps = {
+  text: string;
+
+  // The text to copy to the clipboard. If not provided, `text` will be used.
+  copyText?: string;
+  toastText?: string;
+  icon?: IconName;
+  disabled?: boolean;
+  onClick?(): void;
+};
+
+export const Wrapper = styled.div`
+  background-color: ${MOON_100};
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 8px;
+  &:hover {
+    background-color: ${MOON_200};
+  }
+`;
+Wrapper.displayName = 'S.Wrapper';
+
+export const Text = styled.code`
+  font-size: 0.7em;
+`;
+Text.displayName = 'S.Text';
+
+export const CopyableText = ({
+  text,
+  copyText,
+  toastText = 'Copied to clipboard',
+  icon,
+  disabled,
+  onClick,
+}: CopyableTextProps) => {
+  const copy = useCallback(() => {
+    copyToClipboard(copyText ?? text);
+    toast(toastText);
+  }, [text, copyText, toastText]);
+
+  const trigger = (
+    <Wrapper
+      onClick={e => {
+        e.stopPropagation();
+        if (disabled) {
+          return;
+        }
+        copy();
+        onClick?.();
+      }}>
+      <Icon
+        name={icon ?? 'copy'}
+        width={16}
+        height={16}
+        style={{marginRight: 8}}
+      />
+      <Text>{text}</Text>
+    </Wrapper>
+  );
+  return <Tooltip content="Click to copy to clipboard" trigger={trigger} />;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -22,6 +22,9 @@ import {
 } from './common/SimplePageLayout';
 import {TypeVersionCategoryChip} from './common/TypeVersionCategoryChip';
 import {UnderConstruction} from './common/UnderConstruction';
+import {TabUseDataset} from './TabUseDataset';
+import {TabUseModel} from './TabUseModel';
+import {TabUseObject} from './TabUseObject';
 import {useWeaveflowORMContext} from './wfInterface/context';
 import {WFCall, WFObjectVersion, WFOpVersion} from './wfInterface/types';
 
@@ -194,6 +197,22 @@ const ObjectVersionPageInner: React.FC<{
             </WeaveEditorSourceContext.Provider>
           ),
         },
+        {
+          label: 'Use',
+          content:
+            objectTypeCategory === 'dataset' ? (
+              <TabUseDataset name={objectName} uri={baseUri} />
+            ) : objectTypeCategory === 'model' ? (
+              <TabUseModel
+                name={objectName}
+                uri={baseUri}
+                projectName={projectName}
+              />
+            ) : (
+              <TabUseObject name={objectName} uri={baseUri} />
+            ),
+        },
+
         // {
         //   label: 'Metadata',
         //   content: (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
@@ -4,6 +4,7 @@ import {Browse2OpDefCode} from '../../Browse2/Browse2OpDefCode';
 import {CategoryChip} from './common/CategoryChip';
 import {
   CallsLink,
+  opNiceName,
   OpVersionLink,
   OpVersionsLink,
   opVersionText,
@@ -14,6 +15,7 @@ import {
   SimplePageLayoutWithHeader,
 } from './common/SimplePageLayout';
 import {UnderConstruction} from './common/UnderConstruction';
+import {TabUseOp} from './TabUseOp';
 import {useWeaveflowORMContext} from './wfInterface/context';
 import {WFOpVersion} from './wfInterface/types';
 
@@ -158,6 +160,10 @@ const OpVersionPageInner: React.FC<{
             <Browse2OpDefCode uri={uri} />
             // </Box>
           ),
+        },
+        {
+          label: 'Use',
+          content: <TabUseOp name={opNiceName(opName)} uri={uri} />,
         },
         // {
         //   label: 'Calls',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
@@ -1,0 +1,38 @@
+import {Alert, Box} from '@mui/material';
+import React from 'react';
+
+import {CopyableText} from '../../../../CopyableText';
+import {DocLink} from './common/Links';
+
+type TabUseDatasetProps = {
+  name: string;
+  uri: string;
+};
+
+export const TabUseDataset = ({name, uri}: TabUseDatasetProps) => {
+  return (
+    <Box m={2}>
+      <Alert severity="info" variant="outlined">
+        See{' '}
+        <DocLink
+          path="guides/tracking/objects#getting-an-object-back"
+          text="Weave docs on refs"
+        />{' '}
+        and <DocLink path="guides/core-types/datasets" text="datasets" /> for
+        more information.
+      </Alert>
+
+      <Box mt={2}>
+        The ref for this dataset version is:
+        <CopyableText text={uri} />
+      </Box>
+      <Box mt={2}>
+        Use the following code to retrieve this dataset version:
+        <CopyableText
+          text={`${name} = weave.ref("<ref_uri>").get()`}
+          copyText={`${name} = weave.ref("${uri}").get()`}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
@@ -1,0 +1,55 @@
+import {Alert, Box} from '@mui/material';
+import React from 'react';
+
+import {CopyableText} from '../../../../CopyableText';
+import {DocLink} from './common/Links';
+
+type TabUseModelProps = {
+  name: string;
+  uri: string;
+  projectName: string;
+};
+
+export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
+  return (
+    <Box m={2}>
+      <Alert severity="info" variant="outlined">
+        See{' '}
+        <DocLink
+          path="guides/tracking/objects#getting-an-object-back"
+          text="Weave docs on refs"
+        />{' '}
+        and <DocLink path="guides/core-types/models" text="models" /> for more
+        information.
+      </Alert>
+
+      <Box mt={2}>
+        The ref for this model version is:
+        <CopyableText text={uri} />
+      </Box>
+      <Box mt={2}>
+        Use the following code to retrieve this model version:
+        <CopyableText
+          text={`${name} = weave.ref("<ref_uri>").get()`}
+          copyText={`${name} = weave.ref("${uri}").get()`}
+        />
+      </Box>
+      <Box mt={2}>
+        To <DocLink path="guides/tools/serve" text="serve this model" /> locally
+        with a Swagger UI:
+        <CopyableText
+          text="weave serve <ref_uri>"
+          copyText={`weave serve ${uri}`}
+        />
+      </Box>
+      <Box mt={2}>
+        To <DocLink path="guides/tools/deploy" text="deploy this model" /> to
+        the cloud run:
+        <CopyableText
+          text={`weave deploy gcp --project "${projectName}" <ref_uri>`}
+          copyText={`weave deploy gcp --project "${projectName}" ${uri}`}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
@@ -1,0 +1,37 @@
+import {Alert, Box} from '@mui/material';
+import React from 'react';
+
+import {CopyableText} from '../../../../CopyableText';
+import {DocLink} from './common/Links';
+
+type TabUseObjectProps = {
+  name: string;
+  uri: string;
+};
+
+export const TabUseObject = ({name, uri}: TabUseObjectProps) => {
+  return (
+    <Box m={2}>
+      <Alert severity="info" variant="outlined">
+        See{' '}
+        <DocLink
+          path="guides/tracking/objects#getting-an-object-back"
+          text="Weave docs on refs"
+        />{' '}
+        for more information.
+      </Alert>
+
+      <Box mt={2}>
+        The ref for this object version is:
+        <CopyableText text={uri} />
+      </Box>
+      <Box mt={2}>
+        Use the following code to retrieve this object version:
+        <CopyableText
+          text={`${name} = weave.ref("<ref_uri>").get()`}
+          copyText={`${name} = weave.ref("${uri}").get()`}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseOp.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseOp.tsx
@@ -1,0 +1,37 @@
+import {Alert, Box} from '@mui/material';
+import React from 'react';
+
+import {CopyableText} from '../../../../CopyableText';
+import {DocLink} from './common/Links';
+
+type TabUseOpProps = {
+  name: string;
+  uri: string;
+};
+
+export const TabUseOp = ({name, uri}: TabUseOpProps) => {
+  return (
+    <Box m={2}>
+      <Alert severity="info" variant="outlined">
+        See{' '}
+        <DocLink
+          path="guides/tracking/objects#getting-an-object-back"
+          text="Weave docs on refs"
+        />{' '}
+        for more information.
+      </Alert>
+
+      <Box mt={2}>
+        The ref for this operation version is:
+        <CopyableText text={uri} />
+      </Box>
+      <Box mt={2}>
+        Use the following code to retrieve this operation version:
+        <CopyableText
+          text={`${name} = weave.ref(<ref_url>).get()`}
+          copyText={`${name} = weave.ref("${uri}").get()`}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -3,6 +3,7 @@ import {Link as LinkComp} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {TEAL_500, TEAL_600} from '../../../../../../common/css/color.styles';
+import {TargetBlank} from '../../../../../../common/util/links';
 import {useWeaveflowRouteContext} from '../../context';
 import {WFHighLevelCallFilter} from '../CallsPage/CallsPage';
 import {WFHighLevelObjectVersionFilter} from '../ObjectVersionsPage';
@@ -18,6 +19,14 @@ export const Link = styled(LinkComp)`
   }
 `;
 Link.displayName = 'S.Link';
+
+export const docUrl = (path: string): string => {
+  return 'https://wandb.github.io/weave/' + path;
+};
+
+export const DocLink = (props: {path: string; text: string}) => {
+  return <TargetBlank href={docUrl(props.path)}>{props.text}</TargetBlank>;
+};
 
 export const TypeLink: React.FC<{
   entityName: string;


### PR DESCRIPTION
Adds click-to-copy usage examples for ops and objects.

Note: some of the suggested code may not be quite right since I haven't gotten e.g. weave deploy working myself, but I figure it will be quick to fix after this goes in.

<img width="777" alt="Screenshot 2024-01-30 at 11 50 53 AM" src="https://github.com/wandb/weave/assets/112953339/39b55239-e06d-46e5-97e0-6b9a40770e07">
