### PR TITLE
fix(weave): fix run colors

### DIFF
--- a/weave-js/src/components/Panel2/panellib/libcolors.ts
+++ b/weave-js/src/components/Panel2/panellib/libcolors.ts
@@ -1,6 +1,5 @@
 import {
   constFunction,
-  isAssignableTo,
   isVoidNode,
   Node,
   NodeOrVoidNode,
@@ -8,8 +7,6 @@ import {
   opMapEach,
   opPick,
   opRunId,
-  taggedValue,
-  typedDict,
   voidNode,
   withNamedTag,
 } from '@wandb/weave/core';
@@ -22,11 +19,14 @@ export const useColorNode = (inputNode: Node): NodeOrVoidNode => {
   return useMemo(() => {
     if (
       frame.runColors == null ||
-      isVoidNode(frame.runColors) ||
-      !isAssignableTo(
-        inputNode.type,
-        taggedValue(typedDict({run: 'run'}), 'any')
-      )
+      isVoidNode(frame.runColors)
+      // This was added by this pr https://github.com/wandb/weave/pull/865/files
+      // to fix a slow query, it also as a result broke run colors in charts
+      // I am going to comment out to fix run colors but we should take another look at this later
+      // || !isAssignableTo(
+      //   inputNode.type,
+      //   taggedValue(typedDict({run: 'run'}), 'any')
+      // )
     ) {
       return voidNode();
     }

--- a/weave-js/src/components/Panel2/panellib/libcolors.ts
+++ b/weave-js/src/components/Panel2/panellib/libcolors.ts
@@ -3,14 +3,15 @@ import {
   isAssignableTo,
   isListLike,
   isVoidNode,
-  list,
-  listObjectType,
+  listObjectTypePassTags,
   Node,
   NodeOrVoidNode,
   opGetRunTag,
   opMapEach,
   opPick,
   opRunId,
+  taggedValue,
+  typedDict,
   voidNode,
   withNamedTag,
 } from '@wandb/weave/core';
@@ -22,15 +23,16 @@ export const useColorNode = (inputNode: Node): NodeOrVoidNode => {
   const {frame} = usePanelContext();
   return useMemo(() => {
     let rowType = inputNode.type;
+    // Arbitrarily limit the number of times we unnest
     let limit = 10;
     while (isListLike(rowType) && limit > 0) {
-      rowType = listObjectType(rowType);
+      rowType = listObjectTypePassTags(rowType);
       limit--;
     }
     if (
       frame.runColors == null ||
-      isVoidNode(frame.runColors) //  ||
-      // !isAssignableTo(rowType, taggedValue(typedDict({run: 'run'}), 'any'))
+      isVoidNode(frame.runColors) ||
+      !isAssignableTo(rowType, taggedValue(typedDict({run: 'run'}), 'any'))
     ) {
       return voidNode();
     }

--- a/weave-js/src/components/Panel2/panellib/libcolors.ts
+++ b/weave-js/src/components/Panel2/panellib/libcolors.ts
@@ -1,6 +1,10 @@
 import {
   constFunction,
+  isAssignableTo,
+  isListLike,
   isVoidNode,
+  list,
+  listObjectType,
   Node,
   NodeOrVoidNode,
   opGetRunTag,
@@ -17,16 +21,16 @@ import {usePanelContext} from '.././PanelContext';
 export const useColorNode = (inputNode: Node): NodeOrVoidNode => {
   const {frame} = usePanelContext();
   return useMemo(() => {
+    let rowType = inputNode.type;
+    let limit = 10;
+    while (isListLike(rowType) && limit > 0) {
+      rowType = listObjectType(rowType);
+      limit--;
+    }
     if (
       frame.runColors == null ||
-      isVoidNode(frame.runColors)
-      // This was added by this pr https://github.com/wandb/weave/pull/865/files
-      // to fix a slow query, it also as a result broke run colors in charts
-      // I am going to comment out to fix run colors but we should take another look at this later
-      // || !isAssignableTo(
-      //   inputNode.type,
-      //   taggedValue(typedDict({run: 'run'}), 'any')
-      // )
+      isVoidNode(frame.runColors) //  ||
+      // !isAssignableTo(rowType, taggedValue(typedDict({run: 'run'}), 'any'))
     ) {
       return voidNode();
     }

--- a/weave-js/src/core/model/typeHelpers.test.ts
+++ b/weave-js/src/core/model/typeHelpers.test.ts
@@ -1,9 +1,73 @@
-import {allObjPaths, typedDict} from './helpers';
+import {
+  allObjPaths,
+  isAssignableTo,
+  isListLike,
+  list,
+  listObjectTypePassTags,
+  taggedValue,
+  typedDict,
+} from './helpers';
 
 describe('allObjPaths', () => {
   it('simple case', () => {
     expect(allObjPaths(typedDict({a: 'number'}))).toEqual([
       {path: ['a'], type: 'number'},
     ]);
+  });
+});
+
+describe('listObjectTypePassTags', () => {
+  const runTag = typedDict({run: 'run'});
+  const projectTag = typedDict({project: 'project'});
+  const randValue = typedDict({rand: 'number'});
+  const randList = list(randValue);
+  const taggedList = taggedValue(runTag, randList);
+  it('handles untagged list of objects', () => {
+    expect(listObjectTypePassTags(randList)).toEqual(randValue);
+  });
+  it('handles list of objects with tags', () => {
+    expect(listObjectTypePassTags(taggedList)).toEqual(
+      taggedValue(runTag, randValue)
+    );
+  });
+  it('handles nested lists of objects with tags', () => {
+    const nestedTaggedList = taggedValue(projectTag, list(taggedList));
+    let unnestedTaggedList = listObjectTypePassTags(nestedTaggedList);
+    expect(
+      isAssignableTo(unnestedTaggedList, taggedValue(runTag, 'any'))
+    ).toBeTruthy();
+    expect(
+      isAssignableTo(unnestedTaggedList, taggedValue(projectTag, 'any'))
+    ).toBeTruthy();
+
+    unnestedTaggedList = listObjectTypePassTags(unnestedTaggedList);
+    expect(
+      isAssignableTo(unnestedTaggedList, taggedValue(runTag, 'any'))
+    ).toBeTruthy();
+    expect(
+      isAssignableTo(unnestedTaggedList, taggedValue(projectTag, 'any'))
+    ).toBeTruthy();
+  });
+  it('handles deeply nested lists of objects with tags', () => {
+    let nestedTaggedList = taggedValue(projectTag, list(taggedList));
+    for (let i = 0; i < 10; i++) {
+      nestedTaggedList = taggedValue(projectTag, list(nestedTaggedList));
+    }
+    nestedTaggedList = taggedValue(runTag, list(nestedTaggedList));
+
+    // I want the top level run tag to be preserved as I unnest
+    expect(
+      isAssignableTo(nestedTaggedList, taggedValue(runTag, 'any'))
+    ).toBeTruthy();
+    while (isListLike(nestedTaggedList)) {
+      nestedTaggedList = listObjectTypePassTags(nestedTaggedList);
+      expect(
+        isAssignableTo(nestedTaggedList, taggedValue(runTag, 'any'))
+      ).toBeTruthy();
+    }
+    // Expect the project tag and run tag to be preserved as I unnest
+    expect(
+      isAssignableTo(nestedTaggedList, taggedValue(projectTag, 'any'))
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION
Chart colors were broken here https://github.com/wandb/weave/pull/865/files 

Properly unnest tagged list types for the mapeach so that run colors are properly mapped

before
![Screenshot 2024-01-30 at 1 41 23 PM](https://github.com/wandb/weave/assets/25037002/d634de22-209d-47f0-8113-1d5de2d1858f)

after
![Screenshot 2024-01-30 at 1 40 32 PM](https://github.com/wandb/weave/assets/25037002/145be517-c418-446b-b620-7b60cfeba979)
