### PR TITLE
fix: uniquify and sort name filter for objects

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -559,7 +559,9 @@ const useObjectOptions = (
   }, [allObjectVersions, highLevelFilter]);
 
   return useMemo(() => {
-    return filtered.map(item => item.object().name());
+    return _.uniq(filtered.map(item => item.object().name())).sort((a, b) =>
+      a.localeCompare(b)
+    );
   }, [filtered]);
 };
 


### PR DESCRIPTION
Make object name filter options unique and sorted.

Before:
<img width="385" alt="Screenshot 2024-01-31 at 10 42 33 AM" src="https://github.com/wandb/weave/assets/112953339/3552fb7d-b0e1-4ce3-a52f-02d3b0dee003">

After:
<img width="391" alt="Screenshot 2024-01-31 at 11 26 22 AM" src="https://github.com/wandb/weave/assets/112953339/f0c6b17e-6005-41de-9fb4-411d89a47920">
