### PR TITLE
chore: use common component for object type chip

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/TypeVersionCategoryChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/TypeVersionCategoryChip.tsx
@@ -1,13 +1,12 @@
-import {Chip} from '@mui/material';
 import _ from 'lodash';
 import React from 'react';
 
+import {Pill, TagColorName} from '../../../../../Tag';
 import {HackyTypeCategory} from '../wfInterface/types';
 
-const colorMap: {[key: string]: string} = {
-  model: 'success',
-  dataset: 'info',
-  // 'tune': 'warning',
+const colorMap: Record<HackyTypeCategory, TagColorName> = {
+  model: 'blue',
+  dataset: 'green',
 };
 
 export const TypeVersionCategoryChip: React.FC<{
@@ -16,13 +15,7 @@ export const TypeVersionCategoryChip: React.FC<{
   if (props.typeCategory == null) {
     return <></>;
   }
+  const label = _.capitalize(props.typeCategory);
   const color = colorMap[props.typeCategory];
-  return (
-    <Chip
-      label={_.capitalize(props.typeCategory)}
-      size="small"
-      sx={{height: '20px', lineHeight: 2}}
-      color={color as any}
-    />
-  );
+  return <Pill color={color} label={label} />;
 };


### PR DESCRIPTION
Internal Figma:
https://www.figma.com/file/27JVuBYWHbcAYc8WPb4HqA/Weaveflow-hifi?type=design&node-id=2051-104821&mode=design&t=PXxHLY0uc1XxES1x-4

Before:
<img width="140" alt="Screenshot 2024-01-31 at 11 39 31 AM" src="https://github.com/wandb/weave/assets/112953339/75088ac0-2649-4c68-905e-087ba438e9b7">

After:

<img width="150" alt="Screenshot 2024-01-31 at 11 37 51 AM" src="https://github.com/wandb/weave/assets/112953339/777fd8ea-395d-4eba-81a8-84ffc6e13100">
