### PR TITLE
chore: merge call and op columns, other grid tweaks

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -43,6 +43,7 @@ export type WFHighLevelCallFilter = {
   opCategory?: HackyOpCategory | null;
   opVersionRefs?: string[];
   inputObjectVersionRefs?: string[];
+  outputObjectVersionRefs?: string[];
   parentId?: string | null;
   traceId?: string | null;
   isPivot?: boolean;
@@ -510,6 +511,7 @@ const convertHighLevelFilterToLowLevelFilter = (
     traceRootsOnly: effectiveFilter.traceRootsOnly,
     opUris: Array.from(finalURISet),
     inputUris: effectiveFilter.inputObjectVersionRefs,
+    outputUris: effectiveFilter.outputObjectVersionRefs,
     traceId: effectiveFilter.traceId ?? undefined,
     parentIds: effectiveFilter.parentId ? [effectiveFilter.parentId] : [],
   };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import React, {useMemo} from 'react';
 
 import {constString, opGet} from '../../../../../core';
+import {maybePluralizeWord} from '../../../../../core/util/string';
 import {nodeFromExtra} from '../../Browse2/Browse2ObjectVersionItemPage';
 import {
   WeaveEditor,
@@ -137,24 +138,24 @@ const ObjectVersionPageInner: React.FC<{
             //   />
             // ),
             Ref: <span>{refUri}</span>,
-            // Hide consuming and producing calls since we don't have a
-            // good way to look this up yet
             ...(producingCalls.length > 0
               ? {
-                  'Producing Calls': (
-                    <ObjectVersionProducingCallsItem
-                      objectVersion={objectVersion}
-                    />
-                  ),
+                  [maybePluralizeWord(producingCalls.length, 'Producing Call')]:
+                    (
+                      <ObjectVersionProducingCallsItem
+                        objectVersion={objectVersion}
+                      />
+                    ),
                 }
               : {}),
             ...(consumingCalls.length > 0
               ? {
-                  'Consuming Calls': (
-                    <ObjectVersionConsumingCallsItem
-                      objectVersion={objectVersion}
-                    />
-                  ),
+                  [maybePluralizeWord(producingCalls.length, 'Consuming Call')]:
+                    (
+                      <ObjectVersionConsumingCallsItem
+                        objectVersion={objectVersion}
+                      />
+                    ),
                 }
               : {}),
           }}
@@ -316,44 +317,29 @@ const ObjectVersionProducingCallsItem: React.FC<{
   const producingCalls = props.objectVersion.outputFrom().filter(call => {
     return call.opVersion() != null;
   });
-  if (producingCalls.length === 0) {
-    return <div>-</div>;
-  } else if (producingCalls.length === 1) {
+  if (producingCalls.length === 1) {
     const call = producingCalls[0];
+    const opVersion = call.opVersion();
+    if (opVersion == null) {
+      return <>{call.spanName()}</>;
+    }
     return (
       <CallLink
         entityName={call.entity()}
         projectName={call.project()}
+        opName={opVersion.op().name()}
         callId={call.callID()}
-        simpleText={{
-          opName: call.spanName(),
-          versionIndex: call.opVersion()?.versionIndex() ?? 0,
-        }}
+        variant="secondary"
       />
     );
   }
   return (
-    <ul
-      style={{
-        paddingInlineStart: '22px',
-        margin: 0,
-      }}>
-      {producingCalls.map(call => {
-        return (
-          <li key={call.callID()}>
-            <CallLink
-              entityName={call.entity()}
-              projectName={call.project()}
-              callId={call.callID()}
-              simpleText={{
-                opName: call.spanName(),
-                versionIndex: call.opVersion()?.versionIndex() ?? 0,
-              }}
-            />
-          </li>
-        );
-      })}
-    </ul>
+    <GroupedCalls
+      calls={producingCalls}
+      partialFilter={{
+        outputObjectVersionRefs: [props.objectVersion.refUri()],
+      }}
+    />
   );
 };
 
@@ -363,6 +349,22 @@ const ObjectVersionConsumingCallsItem: React.FC<{
   const consumingCalls = props.objectVersion.inputTo().filter(call => {
     return call.opVersion() != null;
   });
+  if (consumingCalls.length === 1) {
+    const call = consumingCalls[0];
+    const opVersion = call.opVersion();
+    if (opVersion == null) {
+      return <>{call.spanName()}</>;
+    }
+    return (
+      <CallLink
+        entityName={call.entity()}
+        projectName={call.project()}
+        opName={opVersion.op().name()}
+        callId={call.callID()}
+        variant="secondary"
+      />
+    );
+  }
   return (
     <GroupedCalls
       calls={consumingCalls}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -193,6 +193,28 @@ export const OpVersionLink: React.FC<{
   );
 };
 
+export const OpCallLink: React.FC<{
+  entityName: string;
+  projectName: string;
+  opName: string;
+  callId: string;
+}> = props => {
+  const {peekingRouter} = useWeaveflowRouteContext();
+  const opName = opNiceName(props.opName);
+  const truncatedId = truncateID(props.callId);
+  return (
+    <Link
+      to={peekingRouter.callUIUrl(
+        props.entityName,
+        props.projectName,
+        '',
+        props.callId
+      )}>
+      {opName} ({truncatedId})
+    </Link>
+  );
+};
+
 export const CallLink: React.FC<{
   entityName: string;
   projectName: string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -193,17 +193,19 @@ export const OpVersionLink: React.FC<{
   );
 };
 
-export const OpCallLink: React.FC<{
+export const CallLink: React.FC<{
   entityName: string;
   projectName: string;
   opName: string;
   callId: string;
+  variant?: LinkVariant;
 }> = props => {
   const {peekingRouter} = useWeaveflowRouteContext();
   const opName = opNiceName(props.opName);
   const truncatedId = truncateID(props.callId);
   return (
     <Link
+      $variant={props.variant}
       to={peekingRouter.callUIUrl(
         props.entityName,
         props.projectName,
@@ -211,36 +213,6 @@ export const OpCallLink: React.FC<{
         props.callId
       )}>
       {opName} ({truncatedId})
-    </Link>
-  );
-};
-
-export const CallLink: React.FC<{
-  entityName: string;
-  projectName: string;
-  callId: string;
-  simpleText?: {
-    opName: string;
-    versionIndex: number;
-  };
-}> = props => {
-  const {peekingRouter} = useWeaveflowRouteContext();
-  let text = truncateID(props.callId);
-  if (props.simpleText) {
-    text = opVersionText(
-      props.simpleText.opName,
-      props.simpleText.versionIndex
-    );
-  }
-  return (
-    <Link
-      to={peekingRouter.callUIUrl(
-        props.entityName,
-        props.projectName,
-        '',
-        props.callId
-      )}>
-      {text}
     </Link>
   );
 };

--- a/weave-js/src/core/util/string.ts
+++ b/weave-js/src/core/util/string.ts
@@ -59,6 +59,8 @@ export function indent(s: string, level: number) {
 
 export const maybePluralize = (count: number, noun: string, suffix = 's') =>
   `${count} ${noun}${count !== 1 ? suffix : ''}`;
+export const maybePluralizeWord = (count: number, noun: string, suffix = 's') =>
+  `${noun}${count !== 1 ? suffix : ''}`;
 
 // Return a new string with all occurrences of a character at the start of the input removed.
 export const trimStartChar = (str: string, char: string): string => {


### PR DESCRIPTION
Tweaks from design team to calls table:

* Make first column show op name instead of just the abbreviated call id.
* Remove the op column.
* Move latency column to right

Also makes the "Producing calls" rendering more like the "Consuming calls". It's still a little weird because we don't have an autocomplete widget for the outputs the way we do the inputs.

Before:
<img width="353" alt="Screenshot 2024-02-06 at 1 16 14 PM" src="https://github.com/wandb/weave/assets/112953339/703ed545-7df5-477d-83de-e1167113e6a1">

After:
<img width="413" alt="Screenshot 2024-02-06 at 1 16 27 PM" src="https://github.com/wandb/weave/assets/112953339/eec99014-bb7f-4ec3-ba0c-bf792bd2b4bd">
