### PR TITLE
chore: use nice name in drawer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -236,7 +236,7 @@ const CallPageInnerVertical: FC<{
   setVerticalLayout: (vertical: boolean) => void;
 }> = ({call, setVerticalLayout}) => {
   const callId = call.callID();
-  const spanName = call.spanName();
+  const spanName = opNiceName(call.spanName());
   const title = `${spanName} (${truncateID(callId)})`;
   const callTabs = useCallTabs(call);
   return (


### PR DESCRIPTION
Just trims off the "op-" prefix to make the op name at the top of the call peek drawer match the value we show in the grid.

<img width="910" alt="Screenshot 2024-02-02 at 3 39 03 PM" src="https://github.com/wandb/weave/assets/112953339/1bde8d6f-fabd-42cd-8810-84cd7c7aed86">
