### PR TITLE
chore(artifacts): add fileCount ops for artifact version

### DIFF
--- a/weave-js/src/core/ops/domain/artifactVersion.ts
+++ b/weave-js/src/core/ops/domain/artifactVersion.ts
@@ -162,6 +162,23 @@ export const opArtifactVersionCreatedAt = makeArtifactVersionOp({
   resolver: ({artifactVersion}) => artifactVersion.createdAt,
 });
 
+export const opArtifactVersionFileCount = makeArtifactVersionOp({
+  name: 'artifactVersion-fileCount',
+  argTypes: artifactVersionArgTypes,
+  description: `Returns the file count of the artifact ${docType(
+      'artifactVersion'
+  )}`,
+  argDescriptions: {
+    artifactVersion: artifactVersionArgDescription,
+  },
+  returnValueDescription: `Returns the file count of the artifact ${docType(
+      'artifactVersion'
+  )}`,
+  returnType: inputTypes => 'boolean',
+  resolver: ({artifactVersion}) => artifactVersion.fileCount,
+});
+
+
 export const opArtifactVersionFiles = makeArtifactVersionOp({
   name: 'artifactVersion-files',
   argTypes: artifactVersionArgTypes,

--- a/weave-js/src/core/ops/domain/artifactVersion.ts
+++ b/weave-js/src/core/ops/domain/artifactVersion.ts
@@ -166,18 +166,17 @@ export const opArtifactVersionFileCount = makeArtifactVersionOp({
   name: 'artifactVersion-fileCount',
   argTypes: artifactVersionArgTypes,
   description: `Returns the file count of the artifact ${docType(
-      'artifactVersion'
+    'artifactVersion'
   )}`,
   argDescriptions: {
     artifactVersion: artifactVersionArgDescription,
   },
   returnValueDescription: `Returns the file count of the artifact ${docType(
-      'artifactVersion'
+    'artifactVersion'
   )}`,
   returnType: inputTypes => 'boolean',
   resolver: ({artifactVersion}) => artifactVersion.fileCount,
 });
-
 
 export const opArtifactVersionFiles = makeArtifactVersionOp({
   name: 'artifactVersion-files',

--- a/weave-js/src/core/ops/domain/gql.ts
+++ b/weave-js/src/core/ops/domain/gql.ts
@@ -1112,6 +1112,8 @@ export const toGqlField = (
     return gqlBasicField('ttlDurationSeconds');
   } else if (forwardOp.op.name === 'artifactVersion-ttlIsInherited') {
     return gqlBasicField('ttlIsInherited');
+  } else if (forwardOp.op.name === 'artifactVersion-fileCount') {
+    return gqlBasicField('fileCount');
   } else if (forwardOp.op.name === 'artifactVersion-artifactType') {
     return [gqlObjectField(forwardGraph, forwardOp, 'artifactType')];
   } else if (forwardOp.op.name === 'artifactVersion-artifactCollections') {

--- a/weave/ops_domain/artifact_version_ops.py
+++ b/weave/ops_domain/artifact_version_ops.py
@@ -197,6 +197,13 @@ gql_prop_op(
     types.optional(types.Int()),
 )
 
+gql_prop_op(
+    "artifactVersion-fileCount",
+    wdt.ArtifactVersionType,
+    "fileCount",
+    types.Boolean(),
+)
+
 
 @op(plugins=wb_gql_op_plugin(lambda inputs, inner: "metadata"), hidden=True)
 def refine_metadata(


### PR DESCRIPTION
[WB-17216](https://wandb.atlassian.net/browse/WB-17216)

[Gong is facing slow load times](https://weightsandbiases.slack.com/archives/C01KQ5KTDC3/p1706797103944949) for the artifact version overview page, possible because they have an artifact consisting of 100k files, 400GB. 

The artifact overview page calculates the file count by counting the files in the fileTree returned by `opArtifactVersionFiles`. This PR adds an op to fetch the file count directly from the GQL endpoint `fileCount` from the Artifact type.

[WB-17216]: https://wandb.atlassian.net/browse/WB-17216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ