### PR TITLE
feat: add code version diff

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewer.tsx
@@ -1,0 +1,199 @@
+import React, {useState} from 'react';
+import {useHistory} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {Button} from '../../../Button';
+import {Browse2OpDefCode} from '../Browse2/Browse2OpDefCode';
+import {useWeaveflowCurrentRouteContext} from './context';
+import {OpCodeViewerDiff} from './OpCodeViewerDiff';
+import {WFOpVersion} from './pages/wfInterface/types';
+import {SelectOpVersion} from './SelectOpVersion';
+
+type OpCodeViewerProps = {
+  entity: string;
+  project: string;
+  opName: string;
+  opVersions: WFOpVersion[];
+
+  // Op we are currently viewing, and will go back to if we exit diff mode.
+  currentVersionURI: string;
+};
+
+type DiffState = {
+  left: string | null;
+  right: string | null;
+};
+
+const OpCodeViewerContainer = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+OpCodeViewerContainer.displayName = 'S.OpCodeViewerContainer';
+
+const DiffBar = styled.div`
+  padding: 8px;
+`;
+DiffBar.displayName = 'S.DiffBar';
+
+const SelectVersionBar = styled.div`
+  display: flex;
+`;
+SelectVersionBar.displayName = 'S.SelectVersionBar';
+
+const VersionHeader = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+`;
+VersionHeader.displayName = 'S.VersionHeader';
+
+export const OpCodeViewer = ({
+  entity,
+  project,
+  opName,
+  opVersions,
+  currentVersionURI,
+}: OpCodeViewerProps) => {
+  const routerContext = useWeaveflowCurrentRouteContext();
+  const history = useHistory();
+
+  const isDiffAvailable = opVersions.length > 1;
+  const [diffState, setDiffState] = useState<DiffState>({
+    left: null,
+    right: null,
+  });
+  const uris = opVersions.map(opv => opv.refUri());
+
+  const onEnterDiff = () => {
+    const i = uris.indexOf(currentVersionURI);
+    if (i === 0) {
+      setDiffState({left: uris[0], right: uris[1]});
+    } else {
+      setDiffState({left: uris[i - 1], right: uris[i]});
+    }
+  };
+  const hasPrev = diffState.left && uris.indexOf(diffState.left) > 0;
+  const hasNext =
+    diffState.right && uris.indexOf(diffState.right) < uris.length - 1;
+  const onPrevious = () => {
+    const lIndex = uris.indexOf(diffState.left!);
+    setDiffState({left: uris[lIndex - 1], right: uris[lIndex]});
+  };
+  const onNext = () => {
+    const rIndex = uris.indexOf(diffState.right!);
+    setDiffState({left: uris[rIndex], right: uris[rIndex + 1]});
+  };
+  const onSetLeft = (uri: string) => {
+    setDiffState({left: uri, right: diffState.right});
+  };
+  const onSetRight = (uri: string) => {
+    setDiffState({left: diffState.left, right: uri});
+  };
+  const onExitDiff = () => {
+    setDiffState({left: null, right: null});
+  };
+
+  const openVersion = (uri: string) => {
+    const opVersion = opVersions.find(opv => opv.refUri() === uri);
+    const hash = opVersion?.commitHash()!;
+    const url = routerContext.opVersionUIUrl(entity, project, opName, hash);
+    history.push(url);
+    onExitDiff();
+  };
+  const openLeft = () => {
+    openVersion(diffState.left!);
+  };
+  const openRight = () => {
+    openVersion(diffState.right!);
+  };
+
+  const [leftSize, setLeftSize] = useState('50%');
+  const onSplitResize = (left: number) => {
+    setLeftSize(left + 'px');
+  };
+
+  let diffBar = null;
+  if (isDiffAvailable) {
+    diffBar = diffState.left ? (
+      <DiffBar>
+        <Button
+          disabled={!hasPrev}
+          variant="secondary"
+          icon="chevron-back"
+          onClick={onPrevious}
+          tooltip="Compare earlier versions"
+        />
+        <Button
+          disabled={!hasNext}
+          variant="secondary"
+          icon="chevron-next"
+          onClick={onNext}
+          tooltip="Compare later versions"
+        />
+        <Button
+          className="ml-4"
+          variant="secondary"
+          icon="close"
+          onClick={onExitDiff}
+          tooltip="Exit diff mode"
+        />
+      </DiffBar>
+    ) : (
+      <DiffBar>
+        <Button variant="secondary" onClick={onEnterDiff}>
+          Diff versions
+        </Button>
+      </DiffBar>
+    );
+  }
+
+  return (
+    <OpCodeViewerContainer>
+      {diffBar}
+      {diffState.left == null || diffState.right == null ? (
+        <Browse2OpDefCode uri={currentVersionURI} />
+      ) : (
+        <>
+          <SelectVersionBar>
+            <VersionHeader style={{width: leftSize}}>
+              <SelectOpVersion
+                opVersions={opVersions}
+                valueURI={diffState.left}
+                currentVersionURI={currentVersionURI}
+                onChange={uri => onSetLeft(uri)}
+              />
+              <Button
+                className="ml-4"
+                icon="forward-next"
+                variant="ghost"
+                tooltip="Open page for this version"
+                onClick={openLeft}
+              />
+            </VersionHeader>
+            <VersionHeader>
+              <SelectOpVersion
+                opVersions={opVersions}
+                valueURI={diffState.right}
+                currentVersionURI={currentVersionURI}
+                onChange={uri => onSetRight(uri)}
+              />
+              <Button
+                className="ml-4"
+                icon="forward-next"
+                variant="ghost"
+                tooltip="Open page for this version"
+                onClick={openRight}
+              />
+            </VersionHeader>
+          </SelectVersionBar>
+          <OpCodeViewerDiff
+            left={diffState.left}
+            right={diffState.right}
+            onSplitResize={onSplitResize}
+          />
+        </>
+      )}
+    </OpCodeViewerContainer>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewerDiff.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewerDiff.tsx
@@ -1,0 +1,61 @@
+import {DiffEditor, Monaco} from '@monaco-editor/react';
+import {useNodeValue} from '@wandb/weave/react';
+import React, {useMemo} from 'react';
+
+import {opDefCodeNode} from '../Browse2/dataModel';
+
+type OpCodeViewerDiffProps = {
+  left: string;
+  right: string;
+
+  onSplitResize?: (left: number) => void;
+};
+
+export const OpCodeViewerDiff = ({
+  left,
+  right,
+  onSplitResize,
+}: OpCodeViewerDiffProps) => {
+  const opPyContentsLeft = useMemo(() => {
+    return opDefCodeNode(left);
+  }, [left]);
+  const opPyContentsRight = useMemo(() => {
+    return opDefCodeNode(right);
+  }, [right]);
+  const opPyContentsQueryLeft = useNodeValue(opPyContentsLeft);
+  const opPyContentsQueryRight = useNodeValue(opPyContentsRight);
+  const textLeft = opPyContentsQueryLeft.loading
+    ? ''
+    : opPyContentsQueryLeft.result;
+  const textRight = opPyContentsQueryRight.loading
+    ? ''
+    : opPyContentsQueryRight.result;
+  const loading =
+    opPyContentsQueryLeft.loading || opPyContentsQueryRight.loading;
+
+  const onMount = (editor: any, monaco: Monaco) => {
+    if (onSplitResize) {
+      editor.getOriginalEditor().onDidLayoutChange((dimensions: any) => {
+        onSplitResize(dimensions.width);
+      });
+    }
+  };
+
+  return (
+    <DiffEditor
+      height="100%"
+      originalLanguage="python"
+      modifiedLanguage="python"
+      loading={loading}
+      original={textLeft}
+      modified={textRight}
+      onMount={onMount}
+      options={{
+        readOnly: true,
+        minimap: {enabled: false},
+        scrollBeyondLastLine: false,
+        padding: {top: 10, bottom: 10},
+      }}
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/SelectOpVersion.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/SelectOpVersion.tsx
@@ -1,0 +1,77 @@
+import {Autocomplete, TextField} from '@mui/material';
+import {MOON_500} from '@wandb/weave/common/css/globals.styles';
+import React from 'react';
+import styled from 'styled-components';
+
+import {Pill} from '../../../Tag';
+import {Timestamp} from '../../../Timestamp';
+import {WFOpVersion} from './pages/wfInterface/types';
+
+const Option = styled.li`
+  display: flex;
+  align-items: center;
+`;
+Option.displayName = 'S.Option';
+
+export const OptionLabel = styled.div`
+  flex: 1 1 auto;
+`;
+OptionLabel.displayName = 'S.OptionLabel';
+
+export const OptionTimestamp = styled.div`
+  color: ${MOON_500};
+  font-size: 12px;
+`;
+OptionTimestamp.displayName = 'S.OptionTimestamp';
+
+type SelectOpVersionProps = {
+  opVersions: WFOpVersion[];
+
+  valueURI: string;
+
+  // Op page we are currently viewing, not value of the select
+  currentVersionURI: string;
+
+  onChange: (uri: string) => void;
+};
+
+export const SelectOpVersion = ({
+  opVersions,
+  valueURI,
+  currentVersionURI,
+  onChange,
+}: SelectOpVersionProps) => {
+  const options = opVersions.map(opv => ({
+    id: opv.refUri(),
+    label: 'v' + opv.versionIndex(),
+    created: opv.createdAtMs(),
+    isCurrent: opv.refUri() === currentVersionURI,
+  }));
+  const value = options.find(o => o.id === valueURI);
+  return (
+    <Autocomplete
+      options={options}
+      size="small"
+      sx={{width: 260}}
+      disableClearable
+      renderInput={params => <TextField {...params} />}
+      value={value}
+      onChange={(_, newValue) => {
+        onChange(newValue.id);
+      }}
+      renderOption={(props, option) => {
+        return (
+          <Option {...props}>
+            <OptionLabel>{option.label}</OptionLabel>
+            {option.isCurrent && (
+              <Pill color="blue" label="Current" className="mr-12" />
+            )}
+            <OptionTimestamp>
+              <Timestamp value={option.created / 1000} />
+            </OptionTimestamp>
+          </Option>
+        );
+      }}
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Browse2OpDefCode} from '../../Browse2/Browse2OpDefCode';
+import {OpCodeViewer} from '../OpCodeViewer';
 import {CategoryChip} from './common/CategoryChip';
 import {
   CallsLink,
@@ -50,7 +50,8 @@ const OpVersionPageInner: React.FC<{
   const entity = opVersion.entity();
   const project = opVersion.project();
   const opName = opVersion.op().name();
-  const opVersionCount = opVersion.op().opVersions().length;
+  const opVersions = opVersion.op().opVersions();
+  const opVersionCount = opVersions.length;
   const opVersionCallCount = opVersion.calls().length;
   const opVersionIndex = opVersion.versionIndex();
   const opVersionCategory = opVersion.opCategory();
@@ -153,7 +154,13 @@ const OpVersionPageInner: React.FC<{
             //     overflow: 'hidden',
             //     pt: 4,
             //   }}>
-            <Browse2OpDefCode uri={uri} />
+            <OpCodeViewer
+              entity={entity}
+              project={project}
+              opName={opName}
+              opVersions={opVersions.slice().reverse()} // put in increasing order
+              currentVersionURI={uri}
+            />
             // </Box>
           ),
         },


### PR DESCRIPTION
Button to enter diff mode if there is more than one version:
<img width="912" alt="Screenshot 2024-02-05 at 3 49 00 PM" src="https://github.com/wandb/weave/assets/112953339/2c895540-0847-4bac-8e9f-99a7c29bb327">

Diff mode shows you what changed. Arrows let you step through changes incrementally.
<img width="1169" alt="Screenshot 2024-02-05 at 3 49 14 PM" src="https://github.com/wandb/weave/assets/112953339/a4ac8116-8c62-4ebc-a47a-5936342491a9">

Can select specific version to compare:
<img width="269" alt="Screenshot 2024-02-05 at 3 49 24 PM" src="https://github.com/wandb/weave/assets/112953339/add57b91-3fda-47e6-9b0f-ac149c73bd35">
