### PR TITLE
chore(weave): Fix full page crash on very complicated legacy weave tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ yarn-error.log*
 config/.admin.env
 config/.wb_api.env
 weave/tests/zlib.txt
+weave/tests/execute.json
 weave-js/src/generated
 .integration-deps
 

--- a/weave-js/src/components/Panel2/PanelString.styles.ts
+++ b/weave-js/src/components/Panel2/PanelString.styles.ts
@@ -48,13 +48,12 @@ export const PreformattedProportionalString = styled.pre`
 PreformattedProportionalString.displayName = 'S.PreformattedProportionalString';
 
 export const PreformattedJSONString = styled.pre`
-white-space: pre-wrap;
-word-wrap: break-word;
-overflow: auto;
-font-family: monospace;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow: auto;
+  font-family: monospace;
 `;
 PreformattedJSONString.displayName = 'S.PreformattedJSONString';
-
 
 export const PreformattedMonoString = styled.pre`
   margin-top: 0.25em;

--- a/weave-js/src/components/Panel2/PanelString.styles.ts
+++ b/weave-js/src/components/Panel2/PanelString.styles.ts
@@ -47,6 +47,15 @@ export const PreformattedProportionalString = styled.pre`
 `;
 PreformattedProportionalString.displayName = 'S.PreformattedProportionalString';
 
+export const PreformattedJSONString = styled.pre`
+white-space: pre-wrap;
+word-wrap: break-word;
+overflow: auto;
+font-family: monospace;
+`;
+PreformattedJSONString.displayName = 'S.PreformattedJSONString';
+
+
 export const PreformattedMonoString = styled.pre`
   margin-top: 0.25em;
   margin-bottom: 0.25em;

--- a/weave-js/src/components/Panel2/PanelString.tsx
+++ b/weave-js/src/components/Panel2/PanelString.tsx
@@ -214,11 +214,29 @@ export const PanelString: React.FC<PanelStringProps> = props => {
       );
     }
 
-    const contentPlaintext = (
-      <S.PreformattedProportionalString>
-        {fullStr}
-      </S.PreformattedProportionalString>
-    );
+    let parsed: any;
+    if (fullStr.startsWith('{') && fullStr.endsWith('}')) {
+      try {
+        parsed = JSON.parse(fullStr);
+      } catch (e) {
+        // ignore
+        console.error(e);
+      }
+    }
+    let contentPlaintext;
+    if (parsed) {
+      contentPlaintext = (
+        <S.PreformattedJSONString>
+          {JSON.stringify(parsed, null, 2)}
+        </S.PreformattedJSONString>
+      );
+    } else {
+      contentPlaintext = (
+        <S.PreformattedProportionalString>
+          {fullStr}
+        </S.PreformattedProportionalString>
+      );
+    }
 
     // plaintext
     return (

--- a/weave-js/src/components/Panel2/PanelString.tsx
+++ b/weave-js/src/components/Panel2/PanelString.tsx
@@ -215,9 +215,10 @@ export const PanelString: React.FC<PanelStringProps> = props => {
     }
 
     let parsed: any;
-    if (fullStr.startsWith('{') && fullStr.endsWith('}')) {
+    const trimmedStr = fullStr.trim();
+    if (trimmedStr.startsWith('{') && trimmedStr.endsWith('}')) {
       try {
-        parsed = JSON.parse(fullStr);
+        parsed = JSON.parse(trimmedStr);
       } catch (e) {
         // ignore
         console.error(e);

--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -114,6 +114,7 @@ def pre_post_each_test(test_artifact_dir, caplog):
         yield
     del os.environ["WEAVE_LOCAL_ARTIFACT_DIR"]
 
+
 @pytest.fixture(autouse=True)
 def throw_on_error():
     os.environ["WEAVE_VALUE_OR_ERROR_DEBUG"] = "true"

--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -114,6 +114,12 @@ def pre_post_each_test(test_artifact_dir, caplog):
         yield
     del os.environ["WEAVE_LOCAL_ARTIFACT_DIR"]
 
+@pytest.fixture(autouse=True)
+def throw_on_error():
+    os.environ["WEAVE_VALUE_OR_ERROR_DEBUG"] = "true"
+    yield
+    del os.environ["WEAVE_VALUE_OR_ERROR_DEBUG"]
+
 
 @pytest.fixture()
 def cache_mode_minimal():

--- a/weave/ops_domain/table.py
+++ b/weave/ops_domain/table.py
@@ -158,6 +158,7 @@ def _data_is_legacy_run_file_format(data):
 def _data_is_weave_file_format(data):
     return "columns" in data and "data" in data and "column_types" in data
 
+
 def _data_is_weave_file_with_mixed_type_settings(data):
     # This is a special case that occurs when the user constructs a Table with
     # "allow_mixed_types=True". In these cases the client does not report the
@@ -170,7 +171,12 @@ def _data_is_weave_file_with_mixed_type_settings(data):
     if not type_map:
         return False
     return all(
-        v == {"params": {"allowed_types": [{"wb_type": "any"}, {"wb_type": "none"}]}, "wb_type": "union"} for v in type_map.values()
+        v
+        == {
+            "params": {"allowed_types": [{"wb_type": "any"}, {"wb_type": "none"}]},
+            "wb_type": "union",
+        }
+        for v in type_map.values()
     )
 
 
@@ -611,6 +617,7 @@ def _get_rows_and_object_type_from_weave_format(
 
     return rows, object_type
 
+
 def _get_rows_and_object_type_from_weave_format_mixed(
     data: typing.Any,
     file: artifact_fs.FilesystemArtifactFile,
@@ -629,10 +636,15 @@ def _get_rows_and_object_type_from_weave_format_mixed(
     # parse, could error out, and the data is not even useful for the user.
     # Let's at least give them a string representation of the data and ensure
     # that it will be displayed.
-    rows = [{
-        col_key: json.dumps(r[col_ndx]) if type(r[col_ndx]) in [list, dict] else r[col_ndx]
-        for col_ndx, col_key in enumerate(data['columns'])
-    } for r  in data['data']]
+    rows = [
+        {
+            col_key: json.dumps(r[col_ndx])
+            if type(r[col_ndx]) in [list, dict]
+            else r[col_ndx]
+            for col_ndx, col_key in enumerate(data["columns"])
+        }
+        for r in data["data"]
+    ]
     sampled_rows = util.sample_rows(rows, sample_max_rows)
     awl = ops_arrow.to_arrow(sampled_rows, None, file.artifact)
     return rows, awl.object_type

--- a/weave/tests/test_execution_graphs.py
+++ b/weave/tests/test_execution_graphs.py
@@ -55,5 +55,11 @@ if os.path.exists(zlib_path):
     if zlib_str.startswith(prefix):
         zlib_str = zlib_str[len(prefix) :]
 
-# Paste graphs below (from DD or Network tab to test)
+# Paste graphs into execute.json (from network console)
 execute_payloads: list[dict] = []
+execute_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "execute.json")
+if os.path.exists(execute_path):
+    with open(execute_path, "r") as f:
+        execute_str = f.read()
+    if execute_str and execute_str != "":
+        execute_payloads: list[dict] = [json.loads(execute_str)]


### PR DESCRIPTION
Please see the code comments:

```
    # `_data_is_weave_file_format` is known to be fallible, especially
    # with large datasets of heterogenous types.
    # This is a special case that occurs when the user constructs a Table with
    # "allow_mixed_types=True". In these cases the client does not report the
    # type of the data, which results in all columns having the type
    # Optional<Any>. When this occurs, we have absolutely no type information.

    # If the data is small, we could dispatch to the
    # `_get_rows_and_object_type_from_legacy_format`, however, in practice this
    # can be prohibitively expensive. Instead, we will just convert all of the
    # columns to strings and give a slightly better treatment in the UI. This is
    # certainly a sub optimal situation because there could be cases where users
    # set this setting to true, yet their types are homogenous enough where the
    # old logic would be able to parse the content and make sense of it.
    # However, in the degenerate cases, this is prohibitively expensive to
    # parse, could error out, and the data is not even useful for the user.
    # Let's at least give them a string representation of the data and ensure
    # that it will be displayed.
```
