### PR TITLE
fix: use Python-safe var name

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
@@ -1,6 +1,7 @@
 import {Alert, Box} from '@mui/material';
 import React from 'react';
 
+import {isValidVarName} from '../../../../../core/util/var';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 
@@ -10,6 +11,7 @@ type TabUseDatasetProps = {
 };
 
 export const TabUseDataset = ({name, uri}: TabUseDatasetProps) => {
+  const pythonName = isValidVarName(name) ? name : 'dataset';
   return (
     <Box m={2}>
       <Alert severity="info" variant="outlined">
@@ -29,8 +31,8 @@ export const TabUseDataset = ({name, uri}: TabUseDatasetProps) => {
       <Box mt={2}>
         Use the following code to retrieve this dataset version:
         <CopyableText
-          text={`${name} = weave.ref("<ref_uri>").get()`}
-          copyText={`${name} = weave.ref("${uri}").get()`}
+          text={`${pythonName} = weave.ref("<ref_uri>").get()`}
+          copyText={`${pythonName} = weave.ref("${uri}").get()`}
         />
       </Box>
     </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
@@ -1,6 +1,7 @@
 import {Alert, Box} from '@mui/material';
 import React from 'react';
 
+import {isValidVarName} from '../../../../../core/util/var';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 
@@ -11,6 +12,7 @@ type TabUseModelProps = {
 };
 
 export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
+  const pythonName = isValidVarName(name) ? name : 'model';
   return (
     <Box m={2}>
       <Alert severity="info" variant="outlined">
@@ -30,8 +32,8 @@ export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
       <Box mt={2}>
         Use the following code to retrieve this model version:
         <CopyableText
-          text={`${name} = weave.ref("<ref_uri>").get()`}
-          copyText={`${name} = weave.ref("${uri}").get()`}
+          text={`${pythonName} = weave.ref("<ref_uri>").get()`}
+          copyText={`${pythonName} = weave.ref("${uri}").get()`}
         />
       </Box>
       <Box mt={2}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
@@ -11,7 +11,7 @@ type TabUseObjectProps = {
 };
 
 export const TabUseObject = ({name, uri}: TabUseObjectProps) => {
-  const pythonName = isValidVarName(name) ? name : 'object';
+  const pythonName = isValidVarName(name) ? name : 'obj';
   return (
     <Box m={2}>
       <Alert severity="info" variant="outlined">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
@@ -1,6 +1,7 @@
 import {Alert, Box} from '@mui/material';
 import React from 'react';
 
+import {isValidVarName} from '../../../../../core/util/var';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 
@@ -10,6 +11,7 @@ type TabUseObjectProps = {
 };
 
 export const TabUseObject = ({name, uri}: TabUseObjectProps) => {
+  const pythonName = isValidVarName(name) ? name : 'object';
   return (
     <Box m={2}>
       <Alert severity="info" variant="outlined">
@@ -28,8 +30,8 @@ export const TabUseObject = ({name, uri}: TabUseObjectProps) => {
       <Box mt={2}>
         Use the following code to retrieve this object version:
         <CopyableText
-          text={`${name} = weave.ref("<ref_uri>").get()`}
-          copyText={`${name} = weave.ref("${uri}").get()`}
+          text={`${pythonName} = weave.ref("<ref_uri>").get()`}
+          copyText={`${pythonName} = weave.ref("${uri}").get()`}
         />
       </Box>
     </Box>


### PR DESCRIPTION
Was generating code like:
`notion-dataset = weave.ref("...").get()` but `notion-dataset` is not a valid Python variable name.
