### PR TITLE
chore(weave): UI-Side Query Migration Page 1/6: ObjectVersionPage

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -50,18 +50,19 @@ export const CallOverview: React.FC<{
             }
           : {}),
         ...(call.exception ? {Exception: call.exception} : {}),
-        ...(childCalls.length > 0
-          ? {
-              'Child Calls': (
-                <GroupedCalls
-                  calls={childCalls}
-                  partialFilter={{
-                    parentId: wfCall.callID(),
-                  }}
-                />
-              ),
-            }
-          : {}),
+        // Commenting out for now until the interface aligns.
+        // ...(childCalls.length > 0
+        //   ? {
+        //       'Child Calls': (
+        //         <GroupedCalls
+        //           calls={childCalls}
+        //           partialFilter={{
+        //             parentId: wfCall.callID(),
+        //           }}
+        //         />
+        //       ),
+        //     }
+        //   : {}),
         ...(Object.keys(attributes).length > 0 ? {Attributes: attributes} : {}),
         ...(Object.keys(summary).length > 0 ? {Summary: summary} : {}),
       }}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -6,17 +6,18 @@ import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
 import {CategoryChip} from '../common/CategoryChip';
 import {SimpleKeyValueTable} from '../common/SimplePageLayout';
 import {StatusChip} from '../common/StatusChip';
-// import {GroupedCalls} from '../ObjectVersionPage';
+import {GroupedCalls} from '../ObjectVersionPage';
 import {WFCall} from '../wfInterface/types';
+import {useCalls} from '../wfReactInterface/interface';
 
 export const CallOverview: React.FC<{
   wfCall: WFCall;
 }> = ({wfCall}) => {
   const call = wfCall.rawCallSpan();
   const opCategory = wfCall.opVersion()?.opCategory();
-  // const childCalls = wfCall.childCalls().filter(c => {
-  //   return c.opVersion() != null;
-  // });
+  const childCalls = useCalls(wfCall.entity(), wfCall.project(), {
+    parentIds: [wfCall.callID()],
+  });
   const attributes = _.fromPairs(
     Object.entries(call.attributes ?? {}).filter(
       ([k, a]) => !k.startsWith('_') && a != null
@@ -50,19 +51,18 @@ export const CallOverview: React.FC<{
             }
           : {}),
         ...(call.exception ? {Exception: call.exception} : {}),
-        // Commenting out for now until the interface aligns.
-        // ...(childCalls.length > 0
-        //   ? {
-        //       'Child Calls': (
-        //         <GroupedCalls
-        //           calls={childCalls}
-        //           partialFilter={{
-        //             parentId: wfCall.callID(),
-        //           }}
-        //         />
-        //       ),
-        //     }
-        //   : {}),
+        ...((childCalls.result?.length ?? 0) > 0
+          ? {
+              'Child Calls': (
+                <GroupedCalls
+                  calls={childCalls.result!}
+                  partialFilter={{
+                    parentId: wfCall.callID(),
+                  }}
+                />
+              ),
+            }
+          : {}),
         ...(Object.keys(attributes).length > 0 ? {Attributes: attributes} : {}),
         ...(Object.keys(summary).length > 0 ? {Summary: summary} : {}),
       }}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -6,7 +6,7 @@ import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
 import {CategoryChip} from '../common/CategoryChip';
 import {SimpleKeyValueTable} from '../common/SimplePageLayout';
 import {StatusChip} from '../common/StatusChip';
-import {GroupedCalls} from '../ObjectVersionPage';
+// import {GroupedCalls} from '../ObjectVersionPage';
 import {WFCall} from '../wfInterface/types';
 
 export const CallOverview: React.FC<{
@@ -14,9 +14,9 @@ export const CallOverview: React.FC<{
 }> = ({wfCall}) => {
   const call = wfCall.rawCallSpan();
   const opCategory = wfCall.opVersion()?.opCategory();
-  const childCalls = wfCall.childCalls().filter(c => {
-    return c.opVersion() != null;
-  });
+  // const childCalls = wfCall.childCalls().filter(c => {
+  //   return c.opVersion() != null;
+  // });
   const attributes = _.fromPairs(
     Object.entries(call.attributes ?? {}).filter(
       ([k, a]) => !k.startsWith('_') && a != null

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -329,8 +329,7 @@ const ObjectVersionProducingCallsItem: React.FC<{
 }> = props => {
   if (props.producingCalls.length === 1) {
     const call = props.producingCalls[0];
-    const opVersionRef = call.opVersionRef;
-    const spanName = call.spanName;
+    const {opVersionRef, spanName} = call;
     if (opVersionRef == null) {
       return <>{spanName}</>;
     }
@@ -360,8 +359,7 @@ const ObjectVersionConsumingCallsItem: React.FC<{
 }> = props => {
   if (props.consumingCalls.length === 1) {
     const call = props.consumingCalls[0];
-    const opVersionRef = call.opVersionRef;
-    const spanName = call.spanName;
+    const {opVersionRef, spanName} = call;
     if (opVersionRef == null) {
       return <>{spanName}</>;
     }
@@ -397,18 +395,17 @@ export const GroupedCalls: React.FC<{
       };
     } = {};
     calls.forEach(call => {
-      const opVersionRef = call.opVersionRef;
+      const {opVersionRef} = call;
       if (opVersionRef == null) {
         return;
       }
-      const key = opVersionRef;
-      if (groups[key] == null) {
-        groups[key] = {
+      if (groups[opVersionRef] == null) {
+        groups[opVersionRef] = {
           opVersionRef,
           calls: [],
         };
       }
-      groups[key].calls.push(call);
+      groups[opVersionRef].calls.push(call);
     });
     return groups;
   }, [calls]);
@@ -446,9 +443,9 @@ const OpVersionCallsLink: React.FC<{
 }> = ({val, partialFilter}) => {
   const opVersion = useOpVersion(refUriToOpVersionKey(val.opVersionRef));
   if (opVersion.loading) {
-    return <></>;
+    return null;
   } else if (opVersion.result == null) {
-    return <></>;
+    return null;
   }
   return (
     <>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React, {useMemo} from 'react';
 
 import {constString, opGet} from '../../../../../core';
@@ -27,15 +26,14 @@ import {UnderConstruction} from './common/UnderConstruction';
 import {TabUseDataset} from './TabUseDataset';
 import {TabUseModel} from './TabUseModel';
 import {TabUseObject} from './TabUseObject';
-import {WFCall, WFOpVersion} from './wfInterface/types';
 import {
-  CallKey,
   CallSchema,
   objectVersionKeyToRefUri,
   ObjectVersionSchema,
-  useCall,
+  refUriToOpVersionKey,
   useCalls,
   useObjectVersion,
+  useOpVersion,
   useRootObjectVersions,
 } from './wfReactInterface/interface';
 
@@ -406,7 +404,7 @@ export const GroupedCalls: React.FC<{
       const key = opVersionRef;
       if (groups[key] == null) {
         groups[key] = {
-          opVersionRef: opVersionRef,
+          opVersionRef,
           calls: [],
         };
       }
@@ -446,23 +444,29 @@ const OpVersionCallsLink: React.FC<{
   };
   partialFilter?: WFHighLevelCallFilter;
 }> = ({val, partialFilter}) => {
+  const opVersion = useOpVersion(refUriToOpVersionKey(val.opVersionRef));
+  if (opVersion.loading) {
+    return <></>;
+  } else if (opVersion.result == null) {
+    return <></>;
+  }
   return (
     <>
       <OpVersionLink
-        entityName={val.opVersion.entity()}
-        projectName={val.opVersion.project()}
-        opName={val.opVersion.op().name()}
-        version={val.opVersion.commitHash()}
-        versionIndex={val.opVersion.versionIndex()}
+        entityName={opVersion.result.entity}
+        projectName={opVersion.result.project}
+        opName={opVersion.result.opId}
+        version={opVersion.result.versionHash}
+        versionIndex={opVersion.result.versionIndex}
         variant="secondary"
       />{' '}
       [
       <CallsLink
-        entity={val.opVersion.entity()}
-        project={val.opVersion.project()}
+        entity={opVersion.result.entity}
+        project={opVersion.result.project}
         callCount={val.calls.length}
         filter={{
-          opVersionRefs: [val.opVersion.refUri()],
+          opVersionRefs: [val.opVersionRef],
           ...(partialFilter ?? {}),
         }}
         neverPeek

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants.ts
@@ -1,0 +1,2 @@
+export const PROJECT_CALL_STREAM_NAME = 'stream';
+export const WANDB_ARTIFACT_REF_PREFIX = 'wandb-artifact:///';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
@@ -28,9 +28,7 @@ import {
 import {useNodeValue} from '../../../../../../react';
 import {Call as CallTreeSpan} from '../../../Browse2/callTree';
 import {useRuns} from '../../../Browse2/callTreeHooks';
-
-const PROJECT_CALL_STREAM_NAME = 'stream';
-const WANDB_ARTIFACT_REF_PREFIX = 'wandb-artifact:///';
+import {PROJECT_CALL_STREAM_NAME, WANDB_ARTIFACT_REF_PREFIX} from './constants';
 
 type Loadable<T> = {
   loading: boolean;
@@ -173,10 +171,10 @@ export const refUriToOpVersionKey = (refUri: RefUri): OpVersionKey => {
   };
 };
 export const opVersionKeyToRefUri = (key: OpVersionKey): RefUri => {
-  return `wandb-artifact:///${key.entity}/${key.project}/${key.opId}:${key.versionHash}/obj`;
+  return `${WANDB_ARTIFACT_REF_PREFIX}${key.entity}/${key.project}/${key.opId}:${key.versionHash}/obj`;
 };
 
-type MVPOpCategory = 'train' | 'predict' | 'score' | 'evaluate' | 'tune';
+type OpCategory = 'train' | 'predict' | 'score' | 'evaluate' | 'tune';
 
 type OpVersionSchema = OpVersionKey & {
   // TODO: Add more fields & FKs
@@ -236,7 +234,7 @@ export const useOpVersion = (
 
 type OpVersionFilter = {
   // Filters are ANDed across the fields and ORed within the fields
-  category?: MVPOpCategory[];
+  category?: OpCategory[];
   opRefs?: string[];
   latestOnly?: boolean;
 };
@@ -272,24 +270,24 @@ export const refUriToObjectVersionKey = (refUri: RefUri): ObjectVersionKey => {
 };
 
 export const objectVersionKeyToRefUri = (key: ObjectVersionKey): RefUri => {
-  return `wandb-artifact:///${key.entity}/${key.project}/${key.objectId}:${
-    key.versionHash
-  }/${key.path}${key.refExtra ? '#' + key.refExtra : ''}`;
+  return `${WANDB_ARTIFACT_REF_PREFIX}${key.entity}/${key.project}/${
+    key.objectId
+  }:${key.versionHash}/${key.path}${key.refExtra ? '#' + key.refExtra : ''}`;
 };
 
-export type MVPObjectCategory = 'model' | 'dataset';
+export type ObjectCategory = 'model' | 'dataset';
 export type ObjectVersionSchema = ObjectVersionKey & {
   // TODO: Add more fields & FKs
   versionIndex: number;
   typeName: string;
-  category: MVPObjectCategory | null;
+  category: ObjectCategory | null;
 };
 
-const typeNameToCategory = (typeName: string): MVPObjectCategory | null => {
+const typeNameToCategory = (typeName: string): ObjectCategory | null => {
   const categories = ['model', 'dataset'];
   for (const category of categories) {
     if (typeName.toLocaleLowerCase().includes(category)) {
-      return category as MVPObjectCategory;
+      return category as ObjectCategory;
     }
   }
   return null;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
@@ -1,14 +1,36 @@
+import _ from 'lodash';
 import {useMemo} from 'react';
 
 import {
+  constFunction,
   constString,
+  opArray,
+  opArtifactLastMembership,
+  opArtifactMembershipArtifactVersion,
+  opArtifactTypeArtifacts,
+  opArtifactVersionHash,
+  opArtifactVersionIsWeaveObject,
+  opArtifactVersionMetadata,
+  opArtifactVersionName,
+  opArtifactVersions,
   opArtifactVersionVersionId,
   opDict,
+  opFilter,
+  opFlatten,
   opIsNone,
+  opMap,
+  opPick,
+  opProjectArtifact,
+  opProjectArtifactTypes,
   opProjectArtifactVersion,
   opRootProject,
 } from '../../../../../../core';
 import {useNodeValue} from '../../../../../../react';
+import { useRuns } from '../../../Browse2/callTreeHooks';
+import { Call as CallTreeSpan } from '../../../Browse2/callTree';
+
+const PROJECT_CALL_STREAM_NAME = 'stream'
+const WANDB_ARTIFACT_REF_PREFIX = 'wandb-artifact:///'
 
 type Loadable<T> = {
   loading: boolean;
@@ -17,35 +39,101 @@ type Loadable<T> = {
 
 type RefUri = string;
 
-type CallKey = {
+export type CallKey = {
   entity: string;
   project: string;
   callId: string;
 };
-type CallSchema = CallKey & {
+export type CallSchema = CallKey & {
   // TODO: Add more fields & FKs
+  spanName: string;
+  opVersionRef: string | null;
 };
 
+const spanToCallSchema = (entity: string, project: string, span: CallTreeSpan): CallSchema => {
+return {
+    entity: entity,
+    project: project,
+    callId: span.span_id,
+    spanName: span.name.startsWith(WANDB_ARTIFACT_REF_PREFIX) ? refUriToOpVersionKey(span.name).opId : span.name,
+    opVersionRef: span.name.startsWith(WANDB_ARTIFACT_REF_PREFIX) ? span.name : null,
+}
+}
+
+
 export const useCall = (key: CallKey): Loadable<CallSchema | null> => {
-  throw new Error('Not implemented');
+    const calls = useRuns({
+        entityName: key.entity,
+        projectName: key.project,
+        streamName: PROJECT_CALL_STREAM_NAME,
+    }, {
+        callIds: [key.callId],
+    })
+
+    return useMemo(() => {
+        const callResult = calls.result?.[0] ?? null
+        const result = callResult ? spanToCallSchema(key.entity, key.project, callResult) : null
+        if (calls.loading) {
+            return {
+                loading: true,
+                result,
+            };
+        } else {
+            return {
+                loading: false,
+                result,
+            };
+        }
+    }, [calls.loading, calls.result, key.entity, key.project]);
 };
 
 type CallFilter = {
   // Filters are ANDed across the fields and ORed within the fields
-  opRefs?: string[];
-  inputRefs?: string[];
-  outputRefs?: string[];
-  traceIds?: string[];
-  parentIds?: string[];
-  callIds?: string[];
-  traceRootsOnly?: boolean;
+  // Commented out means not yet implemented
+//   opVersionRefs?: string[];
+  inputObjectVersionRefs?: string[];
+  outputObjectVersionRefs?: string[];
+//   traceIds?: string[];
+//   parentIds?: string[];
+//   callIds?: string[];
+//   traceRootsOnly?: boolean;
 };
 export const useCalls = (
   entity: string,
   project: string,
   filter: CallFilter
 ): Loadable<CallSchema[]> => {
-  throw new Error('Not implemented');
+    const calls = useRuns({
+        entityName: entity,
+        projectName: project,
+        streamName: PROJECT_CALL_STREAM_NAME,
+    }, {
+        // opUris?: string[];
+        inputUris: filter.inputObjectVersionRefs,
+        outputUris: filter.outputObjectVersionRefs,
+        // traceId?: string;
+        // parentIds?: string[];
+        // traceRootsOnly?: boolean;
+        // callIds?: string[];
+    })
+  return useMemo(() => {
+    const result = (calls.result ?? []).map(run => (spanToCallSchema(
+        entity,
+        project,
+        run
+      )))
+    if (calls.loading) {
+      return {
+        loading: true,
+        result,
+      };
+    } else {
+      return {
+        loading: false,
+        result,
+      };
+    }
+  }, [entity, project, calls.loading, calls.result]);
 };
 
 type OpVersionKey = {
@@ -75,6 +163,8 @@ export const opVersionKeyToRefUri = (key: OpVersionKey): RefUri => {
   return `wandb-artifact:///${key.entity}/${key.project}/${key.opId}:${key.version}/obj`;
 };
 
+type MVPOpCategory = 'train' | 'predict' | 'score' | 'evaluate' | 'tune';
+
 type OpVersionSchema = OpVersionKey & {
   // TODO: Add more fields & FKs
 };
@@ -87,7 +177,7 @@ export const useOpVersion = (
 
 type OpVersionFilter = {
   // Filters are ANDed across the fields and ORed within the fields
-  category?: string[];
+  category?: MVPOpCategory[];
   opRefs?: string[];
   latestOnly?: boolean;
 };
@@ -95,7 +185,7 @@ export const useOpVersions = (
   entity: string,
   project: string,
   filter: OpVersionFilter
-): Loadable<OpVersionSchema[]> => {
+): Loadable<OpVersionKey[]> => {
   throw new Error('Not implemented');
 };
 
@@ -128,9 +218,22 @@ export const objectVersionKeyToRefUri = (key: ObjectVersionKey): RefUri => {
   }/${key.path}${key.refExtra ? '#' + key.refExtra : ''}`;
 };
 
-type ObjectVersionSchema = ObjectVersionKey & {
+export type MVPObjectCategory = 'model' | 'dataset';
+export type ObjectVersionSchema = ObjectVersionKey & {
   // TODO: Add more fields & FKs
   versionIndex: number;
+  typeName: string;
+  category: MVPObjectCategory | null;
+};
+
+const typeNameToCategory = (typeName: string): MVPObjectCategory | null => {
+  const categories = ['model', 'dataset'];
+  for (const category of categories) {
+    if (typeName.toLocaleLowerCase().includes(category)) {
+      return category as MVPObjectCategory;
+    }
+  }
+  return null;
 };
 
 export const useObjectVersion = (
@@ -147,40 +250,46 @@ export const useObjectVersion = (
   const versionIndexNode = opArtifactVersionVersionId({
     artifactVersion: artifactNode,
   });
+  const metadataNode = opArtifactVersionMetadata({
+    artifactVersion: artifactNode,
+  });
+  const typeNameNode = opPick({
+    obj: metadataNode,
+    key: constString('_weave_meta.type_name'),
+  });
   const dataNode = opDict({
     missing: opIsNone({val: artifactNode}),
+    typeName: typeNameNode,
     versionIndex: versionIndexNode,
   } as any);
   const dataValue = useNodeValue(dataNode);
   return useMemo(() => {
+    const result = dataValue.result == null || dataValue.result.missing
+    ? null
+    : {
+        ...key,
+        versionIndex: dataValue.result.versionIndex as number,
+        typeName: dataValue.result.typeName as string,
+        category: typeNameToCategory(dataValue.result.typeName as string),
+      };
     if (dataValue.loading) {
       return {
         loading: true,
-        result: null,
+        result,
       };
     } else {
       return {
         loading: false,
-        result: dataValue.result.missing
-          ? null
-          : {
-              ...key,
-              versionIndex: dataValue.result.versionIndex as number,
-            },
+        result,
       };
     }
-  }, [
-    dataValue.loading,
-    dataValue.result.missing,
-    dataValue.result.versionIndex,
-    key,
-  ]);
+  }, [dataValue.loading, dataValue.result, key]);
 };
 
 type ObjectVersionFilter = {
   // Filters are ANDed across the fields and ORed within the fields
-  category?: string[];
-  objectRefs?: string[];
+  //   category?: MVPObjectCategory[];
+  objectIds?: string[];
   latestOnly?: boolean;
 };
 
@@ -188,9 +297,97 @@ export const useRootObjectVersions = (
   entity: string,
   project: string,
   filter: ObjectVersionFilter
-): Loadable<ObjectVersionSchema[]> => {
+  // Question: Should this return the entire schema or just the key?
+): Loadable<ObjectVersionKey[]> => {
   // Note: Root objects will always have a single path and refExtra will be null
-  throw new Error('Not implemented');
+  const projectNode = opRootProject({
+    entityName: constString(entity),
+    projectName: constString(project),
+  });
+  let artifactsNode = opArray({} as any);
+
+  if (filter.objectIds == null) {
+    artifactsNode = opFlatten({
+      arr: opArtifactTypeArtifacts({
+        artifactType: opProjectArtifactTypes({
+          project: projectNode,
+        }),
+      }) as any,
+    });
+  } else {
+    artifactsNode = opArray(
+      _.fromPairs(
+        filter.objectIds.map(objId => {
+          return [
+            objId,
+            opProjectArtifact({
+              project: projectNode,
+              artifactName: constString(objId),
+            }),
+          ];
+        })
+      ) as any
+    );
+  }
+
+  let artifactVersionsNode = opArray({} as any);
+  if (filter.latestOnly) {
+    artifactVersionsNode = opArtifactMembershipArtifactVersion({
+      artifactMembership: opArtifactLastMembership({
+        artifact: artifactsNode,
+      }),
+    });
+  } else {
+    artifactVersionsNode = opFlatten({
+      arr: opArtifactVersions({
+        artifact: artifactsNode,
+      }) as any,
+    });
+  }
+
+  // Filter to only Weave Objects
+  const weaveObjectsNode = opFilter({
+    arr: artifactVersionsNode,
+    filterFn: constFunction({row: 'artifactVersion'}, ({row}) => {
+      return opArtifactVersionIsWeaveObject({artifactVersion: row});
+    }),
+  });
+
+  // Build Keys
+  const dataNode = opMap({
+    arr: weaveObjectsNode,
+    mapFn: constFunction({row: 'artifactVersion'}, ({row}) => {
+      return opDict({
+        objectId: opArtifactVersionName({artifactVersion: row}),
+        versionHash: opArtifactVersionHash({artifactVersion: row}),
+      } as any);
+    }),
+  });
+
+  const dataValue = useNodeValue(dataNode);
+
+  return useMemo(() => {
+    const result = (dataValue.result ?? []).map((row: any) => ({
+        entity,
+        project,
+        objectId: row.objectId as string,
+        versionHash: row.versionHash as string,
+        path: 'obj',
+        refExtra: null,
+      }))
+    if (dataValue.loading) {
+      return {
+        loading: true,
+        result,
+      };
+    } else {
+      return {
+        loading: false,
+        result,
+        
+      };
+    }
+  }, [dataValue.loading, dataValue.result, entity, project]);
 };
 
 type WFNaiveRefDict = {
@@ -206,7 +403,7 @@ type WFNaiveRefDict = {
 };
 
 const refStringToRefDict = (uri: string): WFNaiveRefDict => {
-  const scheme = 'wandb-artifact:///';
+  const scheme = WANDB_ARTIFACT_REF_PREFIX;
   if (!uri.startsWith(scheme)) {
     throw new Error('Invalid uri: ' + uri);
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
@@ -106,7 +106,7 @@ type CallFilter = {
   inputObjectVersionRefs?: string[];
   outputObjectVersionRefs?: string[];
   //   traceIds?: string[];
-    parentIds?: string[];
+  parentIds?: string[];
   //   callIds?: string[];
   //   traceRootsOnly?: boolean;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
@@ -106,7 +106,7 @@ type CallFilter = {
   inputObjectVersionRefs?: string[];
   outputObjectVersionRefs?: string[];
   //   traceIds?: string[];
-  //   parentIds?: string[];
+    parentIds?: string[];
   //   callIds?: string[];
   //   traceRootsOnly?: boolean;
 };
@@ -126,7 +126,7 @@ export const useCalls = (
       inputUris: filter.inputObjectVersionRefs,
       outputUris: filter.outputObjectVersionRefs,
       // traceId?: string;
-      // parentIds?: string[];
+      parentIds: filter.parentIds,
       // traceRootsOnly?: boolean;
       // callIds?: string[];
     }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
@@ -1,171 +1,245 @@
+import {useMemo} from 'react';
+
+import {
+  constString,
+  opArtifactVersionVersionId,
+  opDict,
+  opIsNone,
+  opProjectArtifactVersion,
+  opRootProject,
+} from '../../../../../../core';
+import {useNodeValue} from '../../../../../../react';
+
 type Loadable<T> = {
-    loading: boolean;
-    value: T | null;
-}
+  loading: boolean;
+  result: T | null;
+};
 
 type RefUri = string;
 
 type CallKey = {
-    entity: string;
-    project: string;
-    callId: string;
-}
+  entity: string;
+  project: string;
+  callId: string;
+};
 type CallSchema = CallKey & {
-    // TODO: Add more fields & FKs
-}
+  // TODO: Add more fields & FKs
+};
 
-export const useGetCall = (key: CallKey): Loadable<CallSchema | null> => {
-    throw new Error('Not implemented');
-}
+export const useCall = (key: CallKey): Loadable<CallSchema | null> => {
+  throw new Error('Not implemented');
+};
 
 type CallFilter = {
-    // Filters are ANDed across the fields and ORed within the fields
-    opRefs?: string[];
-    inputRefs?: string[];
-    outputRefs?: string[];
-    traceIds?: string[];
-    parentIds?: string[];
-    callIds?: string[];
-    traceRootsOnly?: boolean;
-  }
-export const useGetCalls = (entity: string, project: string, filter: CallFilter): Loadable<CallSchema[]> => {
-    throw new Error('Not implemented');
-}
+  // Filters are ANDed across the fields and ORed within the fields
+  opRefs?: string[];
+  inputRefs?: string[];
+  outputRefs?: string[];
+  traceIds?: string[];
+  parentIds?: string[];
+  callIds?: string[];
+  traceRootsOnly?: boolean;
+};
+export const useCalls = (
+  entity: string,
+  project: string,
+  filter: CallFilter
+): Loadable<CallSchema[]> => {
+  throw new Error('Not implemented');
+};
 
 type OpVersionKey = {
-    entity: string;
-    project: string;
-    opId: string;
-    version: string;
-}
+  entity: string;
+  project: string;
+  opId: string;
+  version: string;
+};
 
 export const refUriToOpVersionKey = (refUri: RefUri): OpVersionKey => {
-    const refDict = refStringToRefDict(refUri);
-    if (refDict.filePathParts.length !== 1 || refDict.refExtraTuples.length !== 0 || refDict.filePathParts[0] !== 'obj') {
-        throw new Error('Invalid refUri: ' + refUri);
-    }
-    return {
-        entity: refDict.entity,
-        project: refDict.project,
-        opId: refDict.artifactName,
-        version: refDict.versionCommitHash,
-    }
-}
+  const refDict = refStringToRefDict(refUri);
+  if (
+    refDict.filePathParts.length !== 1 ||
+    refDict.refExtraTuples.length !== 0 ||
+    refDict.filePathParts[0] !== 'obj'
+  ) {
+    throw new Error('Invalid refUri: ' + refUri);
+  }
+  return {
+    entity: refDict.entity,
+    project: refDict.project,
+    opId: refDict.artifactName,
+    version: refDict.versionCommitHash,
+  };
+};
 export const opVersionKeyToRefUri = (key: OpVersionKey): RefUri => {
-    return `wandb-artifact:///${key.entity}/${key.project}/${key.opId}:${key.version}/obj`;
-}
+  return `wandb-artifact:///${key.entity}/${key.project}/${key.opId}:${key.version}/obj`;
+};
 
+type OpVersionSchema = OpVersionKey & {
+  // TODO: Add more fields & FKs
+};
 
-type OpVersionSchema = OpVersionKey  & {
-    // TODO: Add more fields & FKs
-}
-
-export const useGetOpVersion = (key: OpVersionKey): Loadable<OpVersionSchema | null> => {
-    throw new Error('Not implemented');
-}
+export const useOpVersion = (
+  key: OpVersionKey
+): Loadable<OpVersionSchema | null> => {
+  throw new Error('Not implemented');
+};
 
 type OpVersionFilter = {
-    // Filters are ANDed across the fields and ORed within the fields
-    category?: string[];
-    opRefs?: string[];
-    latestOnly?: boolean;
-  }
-export const useGetOpVersions = (entity: string, project: string, filter: OpVersionFilter): Loadable<OpVersionSchema[]> => {
-    throw new Error('Not implemented');
-}
+  // Filters are ANDed across the fields and ORed within the fields
+  category?: string[];
+  opRefs?: string[];
+  latestOnly?: boolean;
+};
+export const useOpVersions = (
+  entity: string,
+  project: string,
+  filter: OpVersionFilter
+): Loadable<OpVersionSchema[]> => {
+  throw new Error('Not implemented');
+};
 
 type ObjectVersionKey = {
-    entity: string;
-    project: string;
-    objectId: string;
-    versionHash: string;
-    path: string;
-    refExtra?: string;
-}
+  entity: string;
+  project: string;
+  objectId: string;
+  versionHash: string;
+  path: string;
+  refExtra?: string;
+};
 
 export const refUriToObjectVersionKey = (refUri: RefUri): ObjectVersionKey => {
-    const refDict = refStringToRefDict(refUri);
-    return {
-        entity: refDict.entity,
-        project: refDict.project,
-        objectId: refDict.artifactName,
-        versionHash: refDict.versionCommitHash,
-        path: refDict.filePathParts.join('/'),
-        refExtra: refDict.refExtraTuples.map(t => `${t.edgeType}/${t.edgeName}`).join('/')
-    }
-}
+  const refDict = refStringToRefDict(refUri);
+  return {
+    entity: refDict.entity,
+    project: refDict.project,
+    objectId: refDict.artifactName,
+    versionHash: refDict.versionCommitHash,
+    path: refDict.filePathParts.join('/'),
+    refExtra: refDict.refExtraTuples
+      .map(t => `${t.edgeType}/${t.edgeName}`)
+      .join('/'),
+  };
+};
 
 export const objectVersionKeyToRefUri = (key: ObjectVersionKey): RefUri => {
-    return `wandb-artifact:///${key.entity}/${key.project}/${key.objectId}:${key.versionHash}/${key.path}${key.refExtra ? '#' + key.refExtra : ''}`;
-}
+  return `wandb-artifact:///${key.entity}/${key.project}/${key.objectId}:${
+    key.versionHash
+  }/${key.path}${key.refExtra ? '#' + key.refExtra : ''}`;
+};
 
-type ObjectVersionSchema = ObjectVersionKey  & {
-    // TODO: Add more fields & FKs
-}
+type ObjectVersionSchema = ObjectVersionKey & {
+  // TODO: Add more fields & FKs
+  versionIndex: number;
+};
 
-export const useGetObjectVersion = (key: ObjectVersionKey): Loadable<ObjectVersionSchema | null> => {
-    throw new Error('Not implemented');
-}
+export const useObjectVersion = (
+  key: ObjectVersionKey
+): Loadable<ObjectVersionSchema | null> => {
+  const artifactNode = opProjectArtifactVersion({
+    project: opRootProject({
+      entity: constString(key.entity),
+      project: constString(key.project),
+    }),
+    artifactName: constString(key.objectId),
+    artifactVersionAlias: constString(key.versionHash),
+  });
+  const versionIndexNode = opArtifactVersionVersionId({
+    artifactVersion: artifactNode,
+  });
+  const dataNode = opDict({
+    missing: opIsNone({val: artifactNode}),
+    versionIndex: versionIndexNode,
+  } as any);
+  const dataValue = useNodeValue(dataNode);
+  return useMemo(() => {
+    if (dataValue.loading) {
+      return {
+        loading: true,
+        result: null,
+      };
+    } else {
+      return {
+        loading: false,
+        result: dataValue.result.missing
+          ? null
+          : {
+              ...key,
+              versionIndex: dataValue.result.versionIndex as number,
+            },
+      };
+    }
+  }, [
+    dataValue.loading,
+    dataValue.result.missing,
+    dataValue.result.versionIndex,
+    key,
+  ]);
+};
 
 type ObjectVersionFilter = {
-    // Filters are ANDed across the fields and ORed within the fields
-    category?: string[];
-    objectRefs?: string[];
-    latestOnly?: boolean;
-  }
+  // Filters are ANDed across the fields and ORed within the fields
+  category?: string[];
+  objectRefs?: string[];
+  latestOnly?: boolean;
+};
 
-export const useGetRootObjectVersions = (entity: string, project: string, filter: ObjectVersionFilter): Loadable<ObjectVersionSchema[]> => {
-    // Note: Root objects will always have a single path and refExtra will be null
-    throw new Error('Not implemented');
-}
+export const useRootObjectVersions = (
+  entity: string,
+  project: string,
+  filter: ObjectVersionFilter
+): Loadable<ObjectVersionSchema[]> => {
+  // Note: Root objects will always have a single path and refExtra will be null
+  throw new Error('Not implemented');
+};
 
 type WFNaiveRefDict = {
-    entity: string;
-    project: string;
-    artifactName: string;
-    versionCommitHash: string;
-    filePathParts: string[];
-    refExtraTuples: Array<{
-      edgeType: string;
-      edgeName: string;
-    }>;
-  };
+  entity: string;
+  project: string;
+  artifactName: string;
+  versionCommitHash: string;
+  filePathParts: string[];
+  refExtraTuples: Array<{
+    edgeType: string;
+    edgeName: string;
+  }>;
+};
 
 const refStringToRefDict = (uri: string): WFNaiveRefDict => {
-    const scheme = 'wandb-artifact:///';
-    if (!uri.startsWith(scheme)) {
+  const scheme = 'wandb-artifact:///';
+  if (!uri.startsWith(scheme)) {
+    throw new Error('Invalid uri: ' + uri);
+  }
+  const uriWithoutScheme = uri.slice(scheme.length);
+  let uriParts = uriWithoutScheme;
+  let refExtraPath = '';
+  const refExtraTuples = [];
+  if (uriWithoutScheme.includes('#')) {
+    [uriParts, refExtraPath] = uriWithoutScheme.split('#');
+    const refExtraParts = refExtraPath.split('/');
+    if (refExtraParts.length % 2 !== 0) {
       throw new Error('Invalid uri: ' + uri);
     }
-    const uriWithoutScheme = uri.slice(scheme.length);
-    let uriParts = uriWithoutScheme;
-    let refExtraPath = '';
-    const refExtraTuples = [];
-    if (uriWithoutScheme.includes('#')) {
-      [uriParts, refExtraPath] = uriWithoutScheme.split('#');
-      const refExtraParts = refExtraPath.split('/');
-      if (refExtraParts.length % 2 !== 0) {
-        throw new Error('Invalid uri: ' + uri);
-      }
-      for (let i = 0; i < refExtraParts.length; i += 2) {
-        refExtraTuples.push({
-          edgeType: refExtraParts[i],
-          edgeName: refExtraParts[i + 1],
-        });
-      }
+    for (let i = 0; i < refExtraParts.length; i += 2) {
+      refExtraTuples.push({
+        edgeType: refExtraParts[i],
+        edgeName: refExtraParts[i + 1],
+      });
     }
-    const [entity, project, artifactNameAndVersion, filePath] = uriParts.split(
-      '/',
-      4
-    );
-    const [artifactName, versionCommitHash] = artifactNameAndVersion.split(':');
-    const filePathParts = filePath.split('/');
-  
-    return {
-      entity,
-      project,
-      artifactName,
-      versionCommitHash,
-      filePathParts,
-      refExtraTuples,
-    };
+  }
+  const [entity, project, artifactNameAndVersion, filePath] = uriParts.split(
+    '/',
+    4
+  );
+  const [artifactName, versionCommitHash] = artifactNameAndVersion.split(':');
+  const filePathParts = filePath.split('/');
+
+  return {
+    entity,
+    project,
+    artifactName,
+    versionCommitHash,
+    filePathParts,
+    refExtraTuples,
   };
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
@@ -396,7 +396,7 @@ export const useRootObjectVersions = (
       artifactMembership: opArtifactLastMembership({
         artifact: artifactsNode,
       }),
-    });
+    }) as any;
   } else {
     artifactVersionsNode = opFlatten({
       arr: opArtifactVersions({

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts
@@ -1,0 +1,171 @@
+type Loadable<T> = {
+    loading: boolean;
+    value: T | null;
+}
+
+type RefUri = string;
+
+type CallKey = {
+    entity: string;
+    project: string;
+    callId: string;
+}
+type CallSchema = CallKey & {
+    // TODO: Add more fields & FKs
+}
+
+export const useGetCall = (key: CallKey): Loadable<CallSchema | null> => {
+    throw new Error('Not implemented');
+}
+
+type CallFilter = {
+    // Filters are ANDed across the fields and ORed within the fields
+    opRefs?: string[];
+    inputRefs?: string[];
+    outputRefs?: string[];
+    traceIds?: string[];
+    parentIds?: string[];
+    callIds?: string[];
+    traceRootsOnly?: boolean;
+  }
+export const useGetCalls = (entity: string, project: string, filter: CallFilter): Loadable<CallSchema[]> => {
+    throw new Error('Not implemented');
+}
+
+type OpVersionKey = {
+    entity: string;
+    project: string;
+    opId: string;
+    version: string;
+}
+
+export const refUriToOpVersionKey = (refUri: RefUri): OpVersionKey => {
+    const refDict = refStringToRefDict(refUri);
+    if (refDict.filePathParts.length !== 1 || refDict.refExtraTuples.length !== 0 || refDict.filePathParts[0] !== 'obj') {
+        throw new Error('Invalid refUri: ' + refUri);
+    }
+    return {
+        entity: refDict.entity,
+        project: refDict.project,
+        opId: refDict.artifactName,
+        version: refDict.versionCommitHash,
+    }
+}
+export const opVersionKeyToRefUri = (key: OpVersionKey): RefUri => {
+    return `wandb-artifact:///${key.entity}/${key.project}/${key.opId}:${key.version}/obj`;
+}
+
+
+type OpVersionSchema = OpVersionKey  & {
+    // TODO: Add more fields & FKs
+}
+
+export const useGetOpVersion = (key: OpVersionKey): Loadable<OpVersionSchema | null> => {
+    throw new Error('Not implemented');
+}
+
+type OpVersionFilter = {
+    // Filters are ANDed across the fields and ORed within the fields
+    category?: string[];
+    opRefs?: string[];
+    latestOnly?: boolean;
+  }
+export const useGetOpVersions = (entity: string, project: string, filter: OpVersionFilter): Loadable<OpVersionSchema[]> => {
+    throw new Error('Not implemented');
+}
+
+type ObjectVersionKey = {
+    entity: string;
+    project: string;
+    objectId: string;
+    versionHash: string;
+    path: string;
+    refExtra?: string;
+}
+
+export const refUriToObjectVersionKey = (refUri: RefUri): ObjectVersionKey => {
+    const refDict = refStringToRefDict(refUri);
+    return {
+        entity: refDict.entity,
+        project: refDict.project,
+        objectId: refDict.artifactName,
+        versionHash: refDict.versionCommitHash,
+        path: refDict.filePathParts.join('/'),
+        refExtra: refDict.refExtraTuples.map(t => `${t.edgeType}/${t.edgeName}`).join('/')
+    }
+}
+
+export const objectVersionKeyToRefUri = (key: ObjectVersionKey): RefUri => {
+    return `wandb-artifact:///${key.entity}/${key.project}/${key.objectId}:${key.versionHash}/${key.path}${key.refExtra ? '#' + key.refExtra : ''}`;
+}
+
+type ObjectVersionSchema = ObjectVersionKey  & {
+    // TODO: Add more fields & FKs
+}
+
+export const useGetObjectVersion = (key: ObjectVersionKey): Loadable<ObjectVersionSchema | null> => {
+    throw new Error('Not implemented');
+}
+
+type ObjectVersionFilter = {
+    // Filters are ANDed across the fields and ORed within the fields
+    category?: string[];
+    objectRefs?: string[];
+    latestOnly?: boolean;
+  }
+
+export const useGetRootObjectVersions = (entity: string, project: string, filter: ObjectVersionFilter): Loadable<ObjectVersionSchema[]> => {
+    // Note: Root objects will always have a single path and refExtra will be null
+    throw new Error('Not implemented');
+}
+
+type WFNaiveRefDict = {
+    entity: string;
+    project: string;
+    artifactName: string;
+    versionCommitHash: string;
+    filePathParts: string[];
+    refExtraTuples: Array<{
+      edgeType: string;
+      edgeName: string;
+    }>;
+  };
+
+const refStringToRefDict = (uri: string): WFNaiveRefDict => {
+    const scheme = 'wandb-artifact:///';
+    if (!uri.startsWith(scheme)) {
+      throw new Error('Invalid uri: ' + uri);
+    }
+    const uriWithoutScheme = uri.slice(scheme.length);
+    let uriParts = uriWithoutScheme;
+    let refExtraPath = '';
+    const refExtraTuples = [];
+    if (uriWithoutScheme.includes('#')) {
+      [uriParts, refExtraPath] = uriWithoutScheme.split('#');
+      const refExtraParts = refExtraPath.split('/');
+      if (refExtraParts.length % 2 !== 0) {
+        throw new Error('Invalid uri: ' + uri);
+      }
+      for (let i = 0; i < refExtraParts.length; i += 2) {
+        refExtraTuples.push({
+          edgeType: refExtraParts[i],
+          edgeName: refExtraParts[i + 1],
+        });
+      }
+    }
+    const [entity, project, artifactNameAndVersion, filePath] = uriParts.split(
+      '/',
+      4
+    );
+    const [artifactName, versionCommitHash] = artifactNameAndVersion.split(':');
+    const filePathParts = filePath.split('/');
+  
+    return {
+      entity,
+      project,
+      artifactName,
+      versionCommitHash,
+      filePathParts,
+      refExtraTuples,
+    };
+  };


### PR DESCRIPTION
In order to improve query-side performance, we need to move away from the naive-ORM style loading pattern. Instead, implementing a lazy-loading approach that takes advantage of the weave query engine characteristics.

This will be done in 6 parts: 1 for each of the main 6 pages. 

This is part 1. I implement the new model for the ObjectVersionPage and most of the initial interface under weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/interface.ts

Note: for this page alone, using the hooman example, we move from a ~4.3MB data transfer to load the page to ~15kb! As a very practical result - MUCH MUCH more client side caching will take place over time! 

More to come