### PR TITLE
fix(weave): change a file util to use correct path

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -144,6 +144,7 @@ def wandb_base_url() -> str:
     return os.environ.get("WANDB_BASE_URL", settings.base_url).rstrip("/")
 
 
+# use filesystem.get_filesystem_dir() instead of directly accessing the env var
 def weave_filesystem_dir() -> str:
     # WEAVE_LOCAL_ARTIFACT_DIR should be renamed to WEAVE_FILESYSTEM_DIR
     # TODO

--- a/weave/file_util.py
+++ b/weave/file_util.py
@@ -3,6 +3,7 @@ import pathlib
 import typing
 
 from . import environment
+from . import filesystem
 from . import path_util
 from . import cache
 
@@ -13,7 +14,7 @@ def get_allowed_dir() -> pathlib.Path:
     cache_namespace = cache.get_user_cache_key()
     if cache_namespace is None:
         raise ValueError("cache_namespace is None but is_public() is True")
-    return pathlib.Path(environment.weave_filesystem_dir()) / cache_namespace
+    return pathlib.Path(filesystem.get_filesystem_dir()) / cache_namespace
 
 
 def path_ext(path: str) -> str:

--- a/weave/file_util.py
+++ b/weave/file_util.py
@@ -14,7 +14,7 @@ def get_allowed_dir() -> pathlib.Path:
     cache_namespace = cache.get_user_cache_key()
     if cache_namespace is None:
         raise ValueError("cache_namespace is None but is_public() is True")
-    return pathlib.Path(filesystem.get_filesystem_dir()) / cache_namespace
+    return pathlib.Path(filesystem.get_filesystem_dir())
 
 
 def path_ext(path: str) -> str:

--- a/weave/path_util.py
+++ b/weave/path_util.py
@@ -3,11 +3,16 @@ import typing
 
 from . import errors
 
+import logging
+
+logger = logging.getLogger("root")
 
 def safe_join(*args: typing.Union[str, pathlib.Path]) -> str:
     # Ensure result is relative to first dir.
     first_part = pathlib.Path(args[0])
     result = first_part.joinpath(*args[1:])
     if not result.resolve().is_relative_to(first_part.resolve()):
+        logger.error(f"Invalid path: {result}")
+        logger.error(f"First part: {first_part}")
         raise errors.WeaveAccessDeniedError()
     return str(result)

--- a/weave/path_util.py
+++ b/weave/path_util.py
@@ -3,16 +3,11 @@ import typing
 
 from . import errors
 
-import logging
-
-logger = logging.getLogger("root")
 
 def safe_join(*args: typing.Union[str, pathlib.Path]) -> str:
     # Ensure result is relative to first dir.
     first_part = pathlib.Path(args[0])
     result = first_part.joinpath(*args[1:])
     if not result.resolve().is_relative_to(first_part.resolve()):
-        logger.error(f"Invalid path: {result}")
-        logger.error(f"First part: {first_part}")
         raise errors.WeaveAccessDeniedError()
     return str(result)


### PR DESCRIPTION
changes get allowed dir to use filesystem.get_filesystem_dir instead of using the env var 
needed for the cache prefix to apply everywhere