### PR TITLE
chore: Update call link styling

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -216,6 +216,7 @@ export const RunsTable: FC<{
       {
         field: 'span_id',
         headerName: 'Trace',
+        minWidth: 100,
         width: 250,
         hideable: false,
         renderCell: rowParams => {
@@ -229,6 +230,7 @@ export const RunsTable: FC<{
               projectName={params.project}
               opName={opVersion.op().name()}
               callId={rowParams.row.id}
+              fullWidth={true}
             />
           );
         },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-import {Link as LinkComp} from 'react-router-dom';
-import styled from 'styled-components';
-
 import {
+  MOON_150,
+  MOON_200,
   MOON_700,
   TEAL_500,
   TEAL_600,
-} from '../../../../../../common/css/color.styles';
+} from '@wandb/weave/common/css/color.styles';
+import React from 'react';
+import {Link as LinkComp, useHistory} from 'react-router-dom';
+import styled, {css} from 'styled-components';
+
 import {TargetBlank} from '../../../../../../common/util/links';
 import {useWeaveflowRouteContext} from '../../context';
 import {WFHighLevelCallFilter} from '../CallsPage/CallsPage';
@@ -29,6 +31,53 @@ export const Link = styled(LinkComp)<LinkProps>`
   }
 `;
 Link.displayName = 'S.Link';
+
+const CallLinkWrapper = styled.div<{fullWidth?: boolean}>`
+  ${p =>
+    p.fullWidth &&
+    css`
+      width: 100%;
+    `};
+
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px;
+  &:hover {
+    & a {
+      color: ${TEAL_500};
+    }
+    & > .callId {
+      background-color: ${MOON_200};
+      color: ${TEAL_500};
+    }
+  }
+`;
+CallLinkWrapper.displayName = 'S.CallLinkWrapper';
+
+const CallLinkOp = styled.div<{fullWidth?: boolean}>`
+  ${p =>
+    p.fullWidth &&
+    css`
+      flex: 1 1 auto;
+    `};
+
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
+CallLinkOp.displayName = 'S.CallLinkOp';
+
+const CallId = styled.div`
+  padding: 0 4px;
+  background-color: ${MOON_150};
+  border-radius: 4px;
+  margin-left: 4px;
+  font-weight: 600;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 20px;
+`;
+CallId.displayName = 'S.CallId';
 
 export const docUrl = (path: string): string => {
   return 'https://wandb.github.io/weave/' + path;
@@ -198,21 +247,31 @@ export const CallLink: React.FC<{
   opName: string;
   callId: string;
   variant?: LinkVariant;
+  fullWidth?: boolean;
 }> = props => {
+  const history = useHistory();
   const {peekingRouter} = useWeaveflowRouteContext();
   const opName = opNiceName(props.opName);
-  const truncatedId = truncateID(props.callId);
+  const truncatedId = props.callId.slice(-4);
+  const to = peekingRouter.callUIUrl(
+    props.entityName,
+    props.projectName,
+    '',
+    props.callId
+  );
+  const onClick = () => {
+    history.push(to);
+  };
+
   return (
-    <Link
-      $variant={props.variant}
-      to={peekingRouter.callUIUrl(
-        props.entityName,
-        props.projectName,
-        '',
-        props.callId
-      )}>
-      {opName} ({truncatedId})
-    </Link>
+    <CallLinkWrapper onClick={onClick} fullWidth={props.fullWidth}>
+      <CallLinkOp fullWidth={props.fullWidth}>
+        <Link $variant={props.variant} to={to}>
+          {opName}
+        </Link>
+      </CallLinkOp>
+      <CallId className="callId">{truncatedId}</CallId>
+    </CallLinkWrapper>
   );
 };
 


### PR DESCRIPTION
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1707419506214469

Render call links in a more efficient & readable way. Clicking on link, id, or in-between will navigate.
Note: We'll want to make other call references currently using truncateID match, but I want to see if we have agreement on this truncating to four chars before doing that work.

Before:
<img width="237" alt="Screenshot 2024-02-08 at 10 42 07 PM" src="https://github.com/wandb/weave/assets/112953339/9359920e-a952-4b81-871e-cab43fb1b572">
<img width="148" alt="Screenshot 2024-02-08 at 10 42 14 PM" src="https://github.com/wandb/weave/assets/112953339/8ddc9a90-0a9f-48e6-bef2-6b343bc80da5">

After:
<img width="218" alt="Screenshot 2024-02-08 at 10 42 19 PM" src="https://github.com/wandb/weave/assets/112953339/22fecf43-14e5-4101-a3f1-a5e2525cda78">
<img width="177" alt="Screenshot 2024-02-08 at 10 42 27 PM" src="https://github.com/wandb/weave/assets/112953339/f977dcde-43c1-43d1-8cb0-179cc1aa2e37">
