### PR TITLE
fix: keys overlapping values in grid

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/WeaveEditors.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/WeaveEditors.tsx
@@ -59,6 +59,7 @@ import React, {
   useState,
 } from 'react';
 import {useHistory} from 'react-router-dom';
+import styled from 'styled-components';
 
 import {useWeaveflowCurrentRouteContext} from '../Browse3/context';
 import {Link} from '../Browse3/pages/common/Links';
@@ -584,6 +585,18 @@ export const WeaveEditorTypedDict: FC<{
   );
 };
 
+const Table = styled.div`
+  display: grid;
+  grid-template-columns: auto 1fr; /* Two columns */
+  gap: 16px 8px;
+`;
+Table.displayName = 'S.Table';
+
+const Row = styled.div`
+  grid-column: span 2;
+`;
+Row.displayName = 'S.Row';
+
 export const WeaveEditorObject: FC<{
   node: Node;
   path: WeaveEditorPathEl[];
@@ -591,36 +604,44 @@ export const WeaveEditorObject: FC<{
 }> = ({node, path, disableEdits}) => {
   const makeLinkPath = useObjectVersionLinkPathForPath();
   return (
-    <Grid container spacing={2}>
+    <Table>
       {Object.entries(node.type)
         .filter(([key, value]) => key !== 'type' && !key.startsWith('_'))
         .flatMap(([key, valueType]) => {
           const singleRow = displaysAsSingleRow(valueType);
+          const label = (
+            <Typography>
+              <Link
+                to={makeLinkPath([
+                  ...weaveEditorPathUrlPathPart(path),
+                  OBJECT_ATTRIBUTE_EDGE_TYPE,
+                  key,
+                ])}>
+                {key}
+              </Link>
+            </Typography>
+          );
+          const value = (
+            <Box>
+              <WeaveEditorField
+                node={opObjGetAttr({self: node, name: constString(key)})}
+                path={[...path, {type: 'getattr', key}]}
+                disableEdits={disableEdits}
+              />
+            </Box>
+          );
+          if (singleRow) {
+            return [
+              <div key={key + '-key'}>{label}</div>,
+              <div key={key + '-value'}>{value}</div>,
+            ];
+          }
           return [
-            <Grid item key={key + '-key'} xs={singleRow ? 2 : 12}>
-              <Typography>
-                <Link
-                  to={makeLinkPath([
-                    ...weaveEditorPathUrlPathPart(path),
-                    OBJECT_ATTRIBUTE_EDGE_TYPE,
-                    key,
-                  ])}>
-                  {key}
-                </Link>
-              </Typography>
-            </Grid>,
-            <Grid item key={key + '-value'} xs={singleRow ? 10 : 12}>
-              <Box ml={singleRow ? 0 : 2}>
-                <WeaveEditorField
-                  node={opObjGetAttr({self: node, name: constString(key)})}
-                  path={[...path, {type: 'getattr', key}]}
-                  disableEdits={disableEdits}
-                />
-              </Box>
-            </Grid>,
+            <Row key={key + '-key'}>{label}</Row>,
+            <Row key={key + '-value'}>{value}</Row>,
           ];
         })}
-    </Grid>
+    </Table>
   );
 };
 


### PR DESCRIPTION
Use CSS grid with autosizing of first column instead of MUI grid with column sizing based on percent of space. This prevents labels from overlapping values when the grid is narrow or wasting space when the grid is wide.

Before:
<img width="540" alt="Screenshot 2024-02-09 at 10 22 59 PM" src="https://github.com/wandb/weave/assets/112953339/b871090c-9739-4031-b884-f3af2caece21">
<img width="1256" alt="Screenshot 2024-02-09 at 10 22 50 PM" src="https://github.com/wandb/weave/assets/112953339/9a216acf-47d8-4f4e-8cd7-7afb7f57a139">

After:
<img width="684" alt="Screenshot 2024-02-09 at 10 22 13 PM" src="https://github.com/wandb/weave/assets/112953339/bd70c01e-18d3-4ec6-b808-6a69cc29a7b8">
<img width="1254" alt="Screenshot 2024-02-09 at 10 22 26 PM" src="https://github.com/wandb/weave/assets/112953339/82514b53-f85e-475b-bbe7-2477ffcbbc0e">

