### PR TITLE
fix(app): Stop infinite grow on PanelBankFlowSection

### DIFF
--- a/weave-js/src/components/WeavePanelBank/PanelBankFlowSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PanelBankFlowSection.tsx
@@ -256,7 +256,7 @@ const PanelBankFlowSectionInnerComp: React.FC<AllPanelBankFlowSectionProps> = ({
         }
           ${mobile ? 'mobile' : ''}`}
         style={{
-          height: noPanels ? DEFAULT_PANEL_SIZE : pageHeight + paginationHeight,
+          height: DEFAULT_PANEL_SIZE,
         }}>
         <div
           // TODO: do we even still need this div?


### PR DESCRIPTION
for some reason PBSection in flow mode would grow infinitely

https://github.com/wandb/weave/assets/17016170/e8b1c0c4-2032-44ab-a125-a59336e7dba1

honestly still don't know why this happens. i tracked it down to [this](https://github.com/wandb/weave/blob/57542fc68a6176f9525b0a65c2a53f46b8a90718/weave-js/src/components/WeavePanelBank/PBSection.tsx#L70) `onResize` handler, which kept getting triggered with a slightly larger height value each time. however if I set the inner container height to a fixed valued then the issue goes away.

https://github.com/wandb/weave/assets/17016170/a5d0d1f8-0d80-49e0-94cb-7e8d70768de1

I don't know if there's a problem with how we're using `react-measure`, or if it's a bug with `react-measure` itself, but I genuinely could not figure this one out 😅 

I did some quick testing in weave boards -- created a group panel and set it to flow mode (this uses the PanelBankFlowSection component). added a few children to the group and everything rendered correctly. child panels can be resized as well