### PR TITLE
fix(weave): fix jumpiness with drawer on trace view

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -442,6 +442,15 @@ const CallTraceView: FC<{call: CallSchema; treeOnly?: boolean}> = ({
     querySetBoolean(history, 'tracetree', false);
   };
 
+  // This is used because when we first load the trace view in a drawer, the animation cant handle all the rows
+  // so we delay for the first render
+  const [animationBuffer, setAnimationBuffer] = useState(true);
+  useEffect(() => {
+    setTimeout(() => {
+      setAnimationBuffer(false);
+    }, 0);
+  }, []);
+
   return (
     <CallTrace>
       <CallTraceHeader>
@@ -454,9 +463,9 @@ const CallTraceView: FC<{call: CallSchema; treeOnly?: boolean}> = ({
           rowHeight={38}
           columnHeaderHeight={treeOnly ? 0 : 56}
           treeData
-          loading={treeLoading}
+          loading={treeLoading || animationBuffer}
           onRowClick={onRowClick}
-          rows={treeLoading ? [] : rows}
+          rows={treeLoading || animationBuffer ? [] : rows}
           columns={treeOnly ? [] : columns}
           getTreeDataPath={getTreeDataPath}
           groupingColDef={groupingColDef}


### PR DESCRIPTION
The animation of the drawer couldnt handle the full trace tree, thats why the jumpiness only happens when we render the trace tree.

I tried a couple things before landing on this "solution"
- limiting the height of the trace tree on load so that not as many rows load
- fiddling with different position settings like absolute and fixed ("fixed works but then we dont get the correct overscroll behavior and waiting on load till after felt more gross than this)

this seemed like the cleanest, but open to suggestions

before

https://github.com/wandb/weave/assets/25037002/880fc817-e1cb-4720-b527-f45fe8abee89

after

https://github.com/wandb/weave/assets/25037002/257c530d-56ab-40c6-918a-9b5e60789930



