### PR TITLE
chore: move some call information from overview to new summary tab

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -41,11 +41,11 @@ import {
   SimplePageLayoutWithHeader,
 } from '../common/SimplePageLayout';
 import {CallStatusType, StatusChip} from '../common/StatusChip';
-import {UnderConstruction} from '../common/UnderConstruction';
 import {truncateID} from '../util';
 import {CallSchema, useCall, useCalls} from '../wfReactInterface/interface';
 import {CallDetails} from './CallDetails';
 import {CallOverview} from './CallOverview';
+import {CallSummary} from './CallSummary';
 
 // % of screen to give the trace view in horizontal mode
 const TRACE_PCT = 40;
@@ -103,43 +103,8 @@ const useCallTabs = (call: CallSchema) => {
         ]
       : []),
     {
-      label: 'Feedback',
-      content: (
-        <UnderConstruction
-          title="Feedback"
-          message={
-            <>
-              Allows users to add key-value pairs to the Call. TODO: Bring over
-              from browse2.
-            </>
-          }
-        />
-      ),
-    },
-    {
-      label: 'Datasets',
-      content: (
-        <UnderConstruction
-          title="Datasets"
-          message={
-            <>Shows all the datasets which this Call has been added to</>
-          }
-        />
-      ),
-    },
-    {
-      label: 'DAG',
-      content: (
-        <UnderConstruction
-          title="Record DAG"
-          message={
-            <>
-              This page will show a "Record" DAG of Objects and Calls centered
-              at this particular Call.
-            </>
-          }
-        />
-      ),
+      label: 'Summary',
+      content: <CallSummary call={call} />,
     },
   ];
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -1,0 +1,74 @@
+import _ from 'lodash';
+import React, {useMemo} from 'react';
+
+import {Timestamp} from '../../../../../Timestamp';
+import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
+import {SimpleKeyValueTable} from '../common/SimplePageLayout';
+import {GroupedCalls} from '../ObjectVersionPage';
+import {CallSchema, useCalls} from '../wfReactInterface/interface';
+
+export const CallSummary: React.FC<{
+  call: CallSchema;
+}> = ({call}) => {
+  const span = call.rawSpan;
+  const childCalls = useCalls(call.entity, call.project, {
+    parentIds: [call.callId],
+  });
+  const safeChildCalls = useMemo(() => {
+    if (childCalls.loading) {
+      return [];
+    }
+    return (childCalls.result ?? []).filter(c => c.opVersionRef != null);
+  }, [childCalls.loading, childCalls.result]);
+  const attributes = _.fromPairs(
+    Object.entries(span.attributes ?? {}).filter(
+      ([k, a]) => !k.startsWith('_') && a != null
+    )
+  );
+  const summary = _.fromPairs(
+    Object.entries(span.summary ?? {}).filter(
+      ([k, a]) => !k.startsWith('_') && k !== 'latency_s' && a != null
+    )
+  );
+
+  return (
+    <div style={{padding: 8}}>
+      <SimpleKeyValueTable
+        data={{
+          Operation:
+            parseRefMaybe(span.name) != null ? (
+              <SmallRef
+                objRef={parseRefMaybe(span.name)!}
+                wfTable="OpVersion"
+              />
+            ) : (
+              span.name
+            ),
+          Called: <Timestamp value={span.timestamp / 1000} format="relative" />,
+          ...(span.summary.latency_s != null
+            ? {
+                Latency: span.summary.latency_s.toFixed(3) + 's',
+              }
+            : {}),
+          ...(span.exception ? {Exception: span.exception} : {}),
+          ...((safeChildCalls.length ?? 0) > 0
+            ? {
+                'Child Calls': (
+                  <GroupedCalls
+                    calls={safeChildCalls}
+                    partialFilter={{
+                      parentId: call.callId,
+                    }}
+                  />
+                ),
+              }
+            : {}),
+          ...(Object.keys(attributes).length > 0
+            ? {Attributes: attributes}
+            : {}),
+          ...(Object.keys(summary).length > 0 ? {Summary: summary} : {}),
+        }}
+      />
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -67,7 +67,7 @@ const CallLinkOp = styled.div<{fullWidth?: boolean}>`
 `;
 CallLinkOp.displayName = 'S.CallLinkOp';
 
-const CallId = styled.div`
+export const CallId = styled.div`
   padding: 0 4px;
   background-color: ${MOON_150};
   border-radius: 4px;


### PR DESCRIPTION
Moves some of the information currently shown in the call overview to a new Summary tab.

<img width="953" alt="Screenshot 2024-02-13 at 1 59 00 PM" src="https://github.com/wandb/weave/assets/112953339/0139915c-52c7-4a0e-b37f-f02cbe22dbca">

Needs more work to match internal figma. (Which is also a little outdated w.r.t category chip, call id rendering)
https://www.figma.com/file/27JVuBYWHbcAYc8WPb4HqA/Weaveflow-hifi?type=design&node-id=2656-68308&mode=design