### PR TITLE
chore: update trace tree styling

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -626,12 +626,10 @@ const CustomGridTreeDataGroupingCell: FC<
       </Box>
       <Box
         sx={{
-          // ml: 1,
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
           flex: '1 1 auto',
-          fontWeight: 'bold',
         }}>
         {opNiceName(call.spanName)}
       </Box>


### PR DESCRIPTION
Styling change suggested by @Yangyi-wandb in Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1707778615974629?thread_ts=1707761474.511599&cid=C03BSTEBD7F

Before:
<img width="366" alt="Screenshot 2024-02-13 at 7 53 37 PM" src="https://github.com/wandb/weave/assets/112953339/dafcfd95-3a4f-46b6-8b7d-a749b50af192">

After:
<img width="371" alt="Screenshot 2024-02-13 at 7 53 02 PM" src="https://github.com/wandb/weave/assets/112953339/f7c7ae26-9193-428f-910b-6b90981508db">
