### PR TITLE
chore: update error message

### DIFF
--- a/weave-js/src/components/ErrorPanel.tsx
+++ b/weave-js/src/components/ErrorPanel.tsx
@@ -6,7 +6,7 @@ import {Icon} from './Icon';
 import {Tooltip} from './Tooltip';
 
 const DEFAULT_TITLE = 'Something went wrong.';
-const DEFAULT_SUBTITLE = 'Please check the panel configuration for errors.';
+const DEFAULT_SUBTITLE = 'An unexpected error occurred.';
 const DEFAULT_SUBTITLE2 = 'Thank you for your patience while Weave is in beta.';
 
 type ErrorPanelProps = {


### PR DESCRIPTION
<img width="773" alt="image" src="https://github.com/wandb/weave/assets/8557070/1b53a513-cda9-40de-9a0d-4fe5847559cb">
Instead of "please check the panel configuration for errors." it now says "An unexpected error occurred."