### PR TITLE
feat: multiple child call table acts like a button

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ButtonOverlay.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ButtonOverlay.tsx
@@ -1,0 +1,79 @@
+/**
+ * This makes part of the UI work more like a button.
+ */
+
+import React, {ReactNode} from 'react';
+import {useHistory} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {WHITE} from '../../../../../../common/css/color.styles';
+import {hexToRGB} from '../../../../../../common/css/utils';
+import {Button} from '../../../../../Button';
+
+type ButtonOverlayProps = {
+  url: string;
+  text: string;
+  children: ReactNode;
+};
+
+const Container = styled.div`
+  cursor: pointer;
+  position: relative;
+  height: 100%;
+`;
+Container.displayName = 'S.Container';
+
+const ChildWrapper = styled.div`
+  user-select: none;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+`;
+ChildWrapper.displayName = 'S.ChildWrapper';
+
+const Overlay = styled.div`
+  z-index: 1; // Unfortunate, but necessary to appear over the MUI data grid header
+  position: absolute;
+  background-color: ${hexToRGB(WHITE, 0.7)};
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out 0s;
+  &:hover {
+    opacity: 1;
+  }
+`;
+Overlay.displayName = 'S.Overlay';
+
+const OverlayMessage = styled.div`
+  padding: 8px;
+  background-color: ${WHITE};
+`;
+OverlayMessage.displayName = 'S.OverlayMessage';
+
+export const ButtonOverlay = ({url, text, children}: ButtonOverlayProps) => {
+  const history = useHistory();
+  const onClick = () => {
+    history.push(url);
+  };
+  return (
+    <Container onClick={onClick}>
+      <ChildWrapper>{children}</ChildWrapper>
+      <Overlay>
+        <OverlayMessage>
+          <Button variant="ghost" icon="share-export" active={true}>
+            {text}
+          </Button>
+        </OverlayMessage>
+      </Overlay>
+    </Container>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ButtonOverlay.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ButtonOverlay.tsx
@@ -27,10 +27,7 @@ const ChildWrapper = styled.div`
   user-select: none;
   pointer-events: none;
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset: 0;
 `;
 ChildWrapper.displayName = 'S.ChildWrapper';
 
@@ -38,10 +35,7 @@ const Overlay = styled.div`
   z-index: 1; // Unfortunate, but necessary to appear over the MUI data grid header
   position: absolute;
   background-color: ${hexToRGB(WHITE, 0.7)};
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -1,5 +1,4 @@
-import {Box, IconButton} from '@material-ui/core';
-import {OpenInNewRounded} from '@mui/icons-material';
+import {Box} from '@material-ui/core';
 import {Typography} from '@mui/material';
 import _ from 'lodash';
 import React, {FC, useMemo} from 'react';
@@ -7,8 +6,7 @@ import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {MOON_800} from '../../../../../../common/css/color.styles';
-import {parseRef} from '../../../../../../react';
-import {SmallRef} from '../../../Browse2/SmallRef';
+import {Button} from '../../../../../Button';
 import {useWeaveflowRouteContext} from '../../context';
 import {CallsTable} from '../CallsPage/CallsPage';
 import {KeyValueTable} from '../common/KeyValueTable';
@@ -19,6 +17,8 @@ import {
   useCalls,
   useParentCall,
 } from '../wfReactInterface/interface';
+import {ButtonOverlay} from './ButtonOverlay';
+import {OpVersionText} from './OpVersionText';
 
 const Heading = styled.div`
   color: ${MOON_800};
@@ -29,6 +29,17 @@ const Heading = styled.div`
   gap: 4px;
 `;
 Heading.displayName = 'S.Heading';
+
+const MultiCallHeader = styled.div`
+  cursor: pointer;
+  font-family: Source Sans Pro;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 32px;
+  letter-spacing: 0px;
+  text-align: left;
+`;
+MultiCallHeader.displayName = 'S.MultiCallHeader';
 
 export const CallSchemaLink = ({call}: {call: CallSchema}) => {
   const {entity: entityName, project: projectName, callId, spanName} = call;
@@ -116,60 +127,79 @@ export const CallDetails: FC<{
             />
           </Box>
         )}
-        {multipleChildCallOpRefs.map(ref => (
-          <Box
-            key={ref}
-            sx={{
-              flex: '0 0 auto',
-              height: '500px',
-              maxHeight: '95%',
-              p: 2,
-              display: 'flex',
-              flexDirection: 'column',
-            }}>
+        {multipleChildCallOpRefs.map(opVersionRef => {
+          const exampleCall = childCalls.result?.find(
+            c => c.opVersionRef === opVersionRef
+          )!;
+          const multipleChildURL = baseRouter.callsUIUrl(
+            call.entity,
+            call.project,
+            {
+              opVersionRefs: [opVersionRef],
+              parentId: call.callId,
+            }
+          );
+          const onClick = () => {
+            history.push(multipleChildURL);
+          };
+          return (
             <Box
+              key={opVersionRef}
               sx={{
-                display: 'flex',
-                flexDirection: 'row',
                 flex: '0 0 auto',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                height: '50px',
+                height: '500px',
+                maxHeight: '95%',
+                p: 2,
+                display: 'flex',
+                flexDirection: 'column',
               }}>
-              <Typography sx={{display: 'flex', gap: 1}}>
-                Table of <SmallRef objRef={parseRef(ref)} wfTable="OpVersion" />{' '}
-                child calls
-              </Typography>
-              <IconButton
-                onClick={() => {
-                  history.push(
-                    baseRouter.callsUIUrl(call.entity, call.project, {
-                      opVersionRefs: [ref],
-                      parentId: call.callId,
-                    })
-                  );
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'row',
+                  flex: '0 0 auto',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  height: '50px',
                 }}>
-                <OpenInNewRounded />
-              </IconButton>
-            </Box>{' '}
-            <Box
-              sx={{
-                flex: '1 1 auto',
-                overflow: 'hidden',
-              }}>
-              <CallsTable
-                hideControls
-                ioColumnsOnly
-                initialFilter={{
-                  opVersionRefs: [ref],
-                  parentId: call.callId,
-                }}
-                entity={call.entity}
-                project={call.project}
-              />
+                <MultiCallHeader onClick={onClick}>
+                  Child calls of{' '}
+                  <OpVersionText
+                    opVersionRef={opVersionRef}
+                    spanName={exampleCall.spanName}
+                  />
+                </MultiCallHeader>
+                <Button
+                  size="small"
+                  variant="secondary"
+                  icon="share-export"
+                  onClick={onClick}>
+                  Go to table
+                </Button>
+              </Box>{' '}
+              <Box
+                sx={{
+                  flex: '1 1 auto',
+                  overflow: 'hidden',
+                }}>
+                <ButtonOverlay
+                  url={multipleChildURL}
+                  text="Click to view table">
+                  <CallsTable
+                    hideControls
+                    ioColumnsOnly
+                    initialFilter={{
+                      opVersionRefs: [opVersionRef],
+                      parentId: call.callId,
+                    }}
+                    entity={call.entity}
+                    project={call.project}
+                  />
+                </ButtonOverlay>
+              </Box>
             </Box>
-          </Box>
-        ))}
+          );
+        })}
         {childCalls.loading && <CenteredAnimatedLoader />}
         {singularChildCalls.length > 0 && (
           <Box

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -176,7 +176,7 @@ export const CallDetails: FC<{
                   onClick={onClick}>
                   Go to table
                 </Button>
-              </Box>{' '}
+              </Box>
               <Box
                 sx={{
                   flex: '1 1 auto',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OpVersionText.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OpVersionText.tsx
@@ -1,0 +1,35 @@
+/**
+ * Display opname:v# for an opVersionRef as we might get from a call.
+ */
+
+import React from 'react';
+
+import {opNiceName} from '../common/Links';
+import {
+  refUriToOpVersionKey,
+  useOpVersion,
+} from '../wfReactInterface/interface';
+
+const useOpVersionText = (
+  opVersionRef: string | null,
+  spanName: string
+): string => {
+  const opVersion = useOpVersion(
+    opVersionRef ? refUriToOpVersionKey(opVersionRef) : null
+  );
+  if (opVersion.result) {
+    const {opId, versionIndex} = opVersion.result;
+    return `${opId}:v${versionIndex}`;
+  }
+  return opNiceName(spanName);
+};
+
+type OpVersionTextProps = {
+  opVersionRef: string | null;
+  spanName: string;
+};
+
+export const OpVersionText = ({opVersionRef, spanName}: OpVersionTextProps) => {
+  const text = useOpVersionText(opVersionRef, spanName);
+  return <span>{text}</span>;
+};


### PR DESCRIPTION
@shawnlewis asked for this in an internal [slack thread](https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1708533033919989?thread_ts=1708105790.878939&cid=C03BSTEBD7F).

See also [internal figma](https://www.figma.com/file/27JVuBYWHbcAYc8WPb4HqA/Weaveflow-hifi?type=design&node-id=2456%3A29152&mode=design&t=BFVpX6CBNrhEUDzm-1).

Before:
<img width="496" alt="Screenshot 2024-02-21 at 2 30 32 PM" src="https://github.com/wandb/weave/assets/112953339/e8d41261-8e9f-4237-9d19-9a12d39306e7">

After:
<img width="868" alt="Screenshot 2024-02-21 at 2 19 16 PM" src="https://github.com/wandb/weave/assets/112953339/a4dcdef6-6240-4cbc-b6cc-b3676a0f62a5">

If you mouse over the table you get this:
<img width="865" alt="Screenshot 2024-02-21 at 2 19 25 PM" src="https://github.com/wandb/weave/assets/112953339/d55b83ef-4c40-4c3f-b552-f05cc254ff53">
