### PR TITLE
feat: hide trace tree for evaluate

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -523,7 +523,6 @@ export const RunsTable: FC<{
         apiRef={apiRef}
         loading={loading}
         rows={tableData}
-        // density="compact"
         initialState={initialState}
         rowHeight={38}
         columns={columns.cols as any}
@@ -531,16 +530,6 @@ export const RunsTable: FC<{
         disableRowSelectionOnClick
         rowSelectionModel={rowSelectionModel}
         columnGroupingModel={columns.colGroupingModel}
-        // onRowClick={({id}) => {
-        //   history.push(
-        //     peekingRouter.callUIUrl(
-        //       params.entity,
-        //       params.project,
-        //       '',
-        //       id as string
-        //     )
-        //   );
-        // }}
         slots={{
           noRowsOverlay: () => {
             return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -248,16 +248,19 @@ export const CallLink: React.FC<{
   callId: string;
   variant?: LinkVariant;
   fullWidth?: boolean;
+  tracetree?: boolean;
 }> = props => {
   const history = useHistory();
   const {peekingRouter} = useWeaveflowRouteContext();
   const opName = opNiceName(props.opName);
   const truncatedId = props.callId.slice(-4);
+  const tracetree = props.tracetree ?? opName !== 'Evaluation-evaluate';
   const to = peekingRouter.callUIUrl(
     props.entityName,
     props.projectName,
     '',
-    props.callId
+    props.callId,
+    tracetree
   );
   const onClick = () => {
     history.push(to);


### PR DESCRIPTION
Hide trace tree by default for evaluation calls.

Internal notion: https://www.notion.so/wandbai/Default-trace-tree-state-should-be-collapsed-based-on-heurisitics-816a79c376f64b59bdf2bcab8491fc0c?pvs=4