### PR TITLE
feat: hide boring columns, instead show values at top of table

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -22,6 +22,7 @@ import {MOON_250} from '../../../../common/css/color.styles';
 import {A, TargetBlank} from '../../../../common/util/links';
 import {monthRoundedTime} from '../../../../common/util/time';
 import {Timestamp} from '../../../Timestamp';
+import {BoringColumnInfo} from '../Browse3/pages/CallPage/BoringColumnInfo';
 import {CategoryChip} from '../Browse3/pages/common/CategoryChip';
 import {CallLink} from '../Browse3/pages/common/Links';
 import {StatusChip} from '../Browse3/pages/common/StatusChip';
@@ -518,6 +519,7 @@ export const RunsTable: FC<{
           Columns having many empty values have been hidden.
         </Alert>
       )}
+      <BoringColumnInfo tableStats={tableStats} columns={columns.cols as any} />
       <StyledDataGrid
         columnHeaderHeight={40}
         apiRef={apiRef}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
@@ -77,6 +77,9 @@ export const BoringColumnInfo = ({
         }
 
         const col = columns.find((c: any) => c.field === colName);
+        if (!col) {
+          return null;
+        }
 
         let label = col.field;
         if (!label.includes('.') && col.headerName) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import {
+  MOON_100,
+  MOON_150,
+  MOON_200,
+} from '../../../../../../common/css/color.styles';
+import {Tooltip} from '../../../../../Tooltip';
+import {getBoringColumns, TableStats} from '../../../Browse2/tableStats';
+
+type BoringColumnInfoProps = {
+  tableStats: TableStats;
+  columns: any;
+};
+
+const Boring = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+`;
+Boring.displayName = 'S.Boring';
+
+const Header = styled.div`
+  white-space: nowrap;
+  padding: 4px;
+  font-weight: 600;
+`;
+Header.displayName = 'S.Header';
+
+const BoringPair = styled.div`
+  display: flex;
+  align-items: center;
+  align-content: stretch;
+`;
+BoringPair.displayName = 'S.BoringPair';
+
+const BoringLabel = styled.div`
+  background-color: ${MOON_150};
+  padding: 4px 8px;
+  border-right: 1px solid ${MOON_200};
+  border-radius: 8px 0 0 8px;
+`;
+BoringLabel.displayName = 'S.BoringLabel';
+
+const BoringValue = styled.div`
+  height: 32px;
+  display: flex;
+  align-items: center;
+  background-color: ${MOON_100};
+  padding: 4px 8px;
+  border-radius: 0 8px 8px 0;
+`;
+BoringValue.displayName = 'S.BoringValue';
+
+export const BoringColumnInfo = ({
+  tableStats,
+  columns,
+}: BoringColumnInfoProps) => {
+  const boring = getBoringColumns(tableStats);
+  if (boring.length === 0) {
+    return null;
+  }
+  return (
+    <Boring>
+      <Tooltip
+        content="These columns have the same value for every row"
+        trigger={<Header>Common values:</Header>}
+      />
+      {boring.map((colName: string) => {
+        const {valueCounts} = tableStats.column[colName];
+        const boringValue = Object.keys(valueCounts)[0];
+        if (boringValue === 'null') {
+          return null;
+        }
+
+        const col = columns.find((c: any) => c.field === colName);
+
+        let label = col.field;
+        if (!label.includes('.') && col.headerName) {
+          label = col.headerName;
+        }
+
+        let value = boringValue;
+        if (col.renderCell) {
+          const cellParams = {value, row: {[col.field]: value}};
+          value = col.renderCell(cellParams);
+        }
+
+        return (
+          <BoringPair key={colName}>
+            <BoringLabel>{label}</BoringLabel>
+            <BoringValue>{value}</BoringValue>
+          </BoringPair>
+        );
+      })}
+    </Boring>
+  );
+};


### PR DESCRIPTION
Internal notion: https://www.notion.so/wandbai/Factor-common-inputs-out-of-calls-table-1e1823c4de6c4a1986b791e76a33a747?pvs=4

Identify columns that have the same value for all rows and instead render those values above the table. This makes it easier to see the interesting information in the grid.

Before:

![image](https://github.com/wandb/weave/assets/112953339/142f39cb-f82b-4d88-bd46-89782125a30c)

After:

![image](https://github.com/wandb/weave/assets/112953339/33786ff3-02ac-43ea-8df5-4e28f0a6ef16)