### PR TITLE
fix: Include gutterWidth when paginating PB flow section

### DIFF
--- a/weave-js/src/components/WeavePanelBank/PanelBankFlowSection.tsx
+++ b/weave-js/src/components/WeavePanelBank/PanelBankFlowSection.tsx
@@ -271,7 +271,9 @@ const PanelBankFlowSectionInnerComp: React.FC<AllPanelBankFlowSectionProps> = ({
               style={{
                 height: (maxPage + 1) * pageHeight,
                 position: 'relative',
-                transform: `translateY(-${currentPage * pageHeight}px)`,
+                transform: `translateY(-${
+                  currentPage * pageHeight - currentPage * gutterWidth
+                }px)`,
                 transition: 'transform 0.5s',
               }}>
               {renderPanelRefs.map(panelRef => {


### PR DESCRIPTION
Problem: when a `PanelBankFlowSection` has a `gutterWidth` configured and has enough child panels to get paginated, the panels on later pages get gradually shaved off at the top

https://github.com/wandb/weave/assets/17016170/78fc60d8-b206-40a0-87e7-02e8c792afaa

Solution: just need to make sure we account for `gutterWidth` when setting the `translateY` value for paging

https://github.com/wandb/weave/assets/17016170/f9ebb1f4-d185-4ad6-aca7-29314a2bb624

(Context: we're using this component for diet workspaces, and noticed this issue when we added the gutterWidth)