### PR TITLE
chore(weave): limit object table column size, and change to styled datagrid

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
@@ -1,6 +1,7 @@
-import {styled, Theme} from '@mui/material/styles';
-import {DataGridPro} from '@mui/x-data-grid-pro';
+import {styled} from '@mui/material/styles';
+import {DataGridPro, DataGridProProps} from '@mui/x-data-grid-pro';
 import {gridClasses} from '@mui/x-data-grid-pro';
+import React from 'react';
 
 import {
   Color,
@@ -19,34 +20,39 @@ const backgroundColorHoveredSelected = Color.fromHex(WHITE)
   .blend(Color.fromHex(OBLIVION, 0.04))
   .toString();
 
-export const StyledDataGrid = styled(DataGridPro)(
-  ({theme, keepBorders}: {theme?: Theme; keepBorders?: boolean}) => ({
-    ...(!keepBorders ? {borderRight: 0, borderLeft: 0, borderBottom: 0} : {}),
+export const StyledDataGrid = styled(
+  ({
+    keepBorders,
+    ...otherProps
+  }: DataGridProProps & {keepBorders?: boolean}) => (
+    <DataGridPro {...otherProps} />
+  )
+)(({keepBorders}) => ({
+  ...(!keepBorders ? {borderRight: 0, borderLeft: 0, borderBottom: 0} : {}),
 
-    '& .MuiDataGrid-columnHeaders': {
-      backgroundColor: MOON_50,
-      color: '#979a9e',
+  '& .MuiDataGrid-columnHeaders': {
+    backgroundColor: MOON_50,
+    color: '#979a9e',
+  },
+
+  '& .MuiDataGrid-pinnedColumnHeaders': {
+    backgroundColor: MOON_50,
+    color: '#979a9e',
+  },
+
+  '& .MuiDataGrid-columnHeader:focus, .MuiDataGrid-cell:focus': {
+    outline: 'none',
+  },
+
+  [`& .${gridClasses.row}`]: {
+    '&.Mui-hovered': {
+      backgroundColor: backgroundColorHovered,
     },
-
-    '& .MuiDataGrid-pinnedColumnHeaders': {
-      backgroundColor: MOON_50,
-      color: '#979a9e',
-    },
-
-    '& .MuiDataGrid-columnHeader:focus, .MuiDataGrid-cell:focus': {
-      outline: 'none',
-    },
-
-    [`& .${gridClasses.row}`]: {
+    '&.Mui-selected': {
+      backgroundColor: backgroundColorSelected,
       '&.Mui-hovered': {
-        backgroundColor: backgroundColorHovered,
-      },
-      '&.Mui-selected': {
-        backgroundColor: backgroundColorSelected,
-        '&.Mui-hovered': {
-          backgroundColor: backgroundColorHoveredSelected,
-        },
+        backgroundColor: backgroundColorHoveredSelected,
       },
     },
-  })
-);
+  },
+}));

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
@@ -20,7 +20,7 @@ const backgroundColorHoveredSelected = Color.fromHex(WHITE)
   .toString();
 
 export const StyledDataGrid = styled(DataGridPro)(
-  ({theme, keepBorders}: {theme?: Theme; keepBorders: boolean}) => ({
+  ({theme, keepBorders}: {theme?: Theme; keepBorders?: boolean}) => ({
     ...(!keepBorders ? {borderRight: 0, borderLeft: 0, borderBottom: 0} : {}),
 
     '& .MuiDataGrid-columnHeaders': {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
@@ -1,4 +1,4 @@
-import {styled} from '@mui/material/styles';
+import {styled, Theme} from '@mui/material/styles';
 import {DataGridPro} from '@mui/x-data-grid-pro';
 import {gridClasses} from '@mui/x-data-grid-pro';
 
@@ -19,34 +19,34 @@ const backgroundColorHoveredSelected = Color.fromHex(WHITE)
   .blend(Color.fromHex(OBLIVION, 0.04))
   .toString();
 
-export const StyledDataGrid = styled(DataGridPro)(({theme}) => ({
-  borderRight: 0,
-  borderLeft: 0,
-  borderBottom: 0,
+export const StyledDataGrid = styled(DataGridPro)(
+  ({theme, keepBorders}: {theme?: Theme; keepBorders: boolean}) => ({
+    ...(!keepBorders ? {borderRight: 0, borderLeft: 0, borderBottom: 0} : {}),
 
-  '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: MOON_50,
-    color: '#979a9e',
-  },
-
-  '& .MuiDataGrid-pinnedColumnHeaders': {
-    backgroundColor: MOON_50,
-    color: '#979a9e',
-  },
-
-  '& .MuiDataGrid-columnHeader:focus, .MuiDataGrid-cell:focus': {
-    outline: 'none',
-  },
-
-  [`& .${gridClasses.row}`]: {
-    '&.Mui-hovered': {
-      backgroundColor: backgroundColorHovered,
+    '& .MuiDataGrid-columnHeaders': {
+      backgroundColor: MOON_50,
+      color: '#979a9e',
     },
-    '&.Mui-selected': {
-      backgroundColor: backgroundColorSelected,
+
+    '& .MuiDataGrid-pinnedColumnHeaders': {
+      backgroundColor: MOON_50,
+      color: '#979a9e',
+    },
+
+    '& .MuiDataGrid-columnHeader:focus, .MuiDataGrid-cell:focus': {
+      outline: 'none',
+    },
+
+    [`& .${gridClasses.row}`]: {
       '&.Mui-hovered': {
-        backgroundColor: backgroundColorHoveredSelected,
+        backgroundColor: backgroundColorHovered,
+      },
+      '&.Mui-selected': {
+        backgroundColor: backgroundColorSelected,
+        '&.Mui-hovered': {
+          backgroundColor: backgroundColorHoveredSelected,
+        },
       },
     },
-  },
-}));
+  })
+);


### PR DESCRIPTION
sets the max width of the columns to .75 browser when not in peek, and .5 browser in peek
https://www.notion.so/wandbai/Object-Version-View-Max-column-width-too-wide-for-Dataset-rows-table-10c654dda7944f29aabc7127f8ca9b6a?pvs=4

check out

https://beta.wandb.ai/llm-play/ticktock/weaveflow/object-versions?betaVersion=c85db4ce737e0d2fbebf6400ea8c0a6884f722c8