### PR TITLE
chore(weave): hide _result

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -121,12 +121,11 @@ export const RunsTable: FC<{
   const params = useParams<Browse2RootObjectVersionItemParams>();
 
   let onlyOneOutputResult = true;
-  let span: CallSchema;
-  for (span in spans) {
+  for (let i = 0; i < spans.length; i++) {
     // get display keys
     const keys = Object.keys(
       _.omitBy(
-        flattenObject(span.rawSpan.output!),
+        flattenObject(spans[i].rawSpan.output!),
         (v, k) => v == null || (k.startsWith('_') && k !== '_result')
       )
     );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -180,6 +180,7 @@ export const RunsTable: FC<{
               (v, k) => v == null || (k.startsWith('_') && k !== '_result')
             ),
             (v, k) => {
+              // If there is only one output _result, we don't need to nest it
               if (onlyOneOutputResult && k === '_result') {
                 return 'output';
               }
@@ -387,7 +388,18 @@ export const RunsTable: FC<{
       colGroupingModel.push(inputGroup);
 
       // All output keys as we don't have the order key yet.
-      if (!onlyOneOutputResult) {
+      if (onlyOneOutputResult) {
+        // If there is only one output _result, we don't need to do all the work on outputs
+        cols.push({
+          flex: 1,
+          minWidth: 150,
+          field: 'output',
+          headerName: 'output',
+          renderCell: cellParams => {
+            return renderCell((cellParams.row as any).output);
+          },
+        });
+      } else {
         let outputKeys: {[key: string]: true} = {};
         spans.forEach(span => {
           for (const [k, v] of Object.entries(
@@ -425,16 +437,6 @@ export const RunsTable: FC<{
             },
           });
         }
-      } else {
-        cols.push({
-          flex: 1,
-          minWidth: 150,
-          field: 'output',
-          headerName: 'output',
-          renderCell: cellParams => {
-            return renderCell((cellParams.row as any).output);
-          },
-        });
       }
 
       let feedbackKeys: {[key: string]: true} = {};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -121,16 +121,16 @@ export const RunsTable: FC<{
   const params = useParams<Browse2RootObjectVersionItemParams>();
 
   let onlyOneOutputResult = true;
-  for (let i = 0; i < spans.length; i++) {
+  for (const s of spans) {
     // get display keys
     const keys = Object.keys(
       _.omitBy(
-        flattenObject(spans[i].rawSpan.output!),
+        flattenObject(s.rawSpan.output!),
         (v, k) => v == null || (k.startsWith('_') && k !== '_result')
       )
     );
     // ensure there is only one output _result
-    if (keys.length !== 0 || keys[0] !== '_result') {
+    if (keys.length > 1 || (keys[0] && keys[0] !== '_result')) {
       onlyOneOutputResult = false;
       break;
     }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -119,21 +119,22 @@ export const RunsTable: FC<{
     [spans]
   );
   const params = useParams<Browse2RootObjectVersionItemParams>();
-  let onlyOneOutputResult = false;
-  if (spans.length > 0) {
-    const spanOutputKeys = _.uniq(
-      spans.map(s =>
-        Object.keys(
-          _.omitBy(
-            flattenObject(s.rawSpan.output!),
-            (v, k) => v == null || (k.startsWith('_') && k !== '_result')
-          )
-        )
+
+  let onlyOneOutputResult = true;
+  let span: CallSchema;
+  for (span in spans) {
+    // get display keys
+    const keys = Object.keys(
+      _.omitBy(
+        flattenObject(span.rawSpan.output!),
+        (v, k) => v == null || (k.startsWith('_') && k !== '_result')
       )
     );
-    onlyOneOutputResult = spanOutputKeys.every(
-      keys => keys.length === 0 || keys[0] === '_result'
-    );
+    // ensure there is only one output _result
+    if (keys.length !== 0 || keys[0] !== '_result') {
+      onlyOneOutputResult = false;
+      break;
+    }
   }
 
   const tableData = useMemo(() => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -12,7 +12,7 @@ import {CallsTable} from '../CallsPage/CallsPage';
 import {KeyValueTable} from '../common/KeyValueTable';
 import {CallLink, opNiceName} from '../common/Links';
 import {CenteredAnimatedLoader} from '../common/Loader';
-import {isPrimitive, Primitive, getDisplayInputsAndOutput} from '../common/util';
+import {isPrimitive, Primitive} from '../common/util';
 import {
   CallSchema,
   useCalls,
@@ -239,6 +239,25 @@ export const CallDetails: FC<{
       </Box>
     </Box>
   );
+};
+
+const getDisplayInputsAndOutput = (call: CallSchema) => {
+  const span = call.rawSpan;
+  const inputKeys =
+    span.inputs._keys ??
+    Object.entries(span.inputs)
+      .filter(([k, c]) => c != null && !k.startsWith('_'))
+      .map(([k, c]) => k);
+  const inputs = _.fromPairs(inputKeys.map(k => [k, span.inputs[k]]));
+
+  const callOutput = span.output ?? {};
+  const outputKeys =
+    callOutput._keys ??
+    Object.entries(callOutput)
+      .filter(([k, c]) => c != null && (k === '_result' || !k.startsWith('_')))
+      .map(([k, c]) => k);
+  const output = _.fromPairs(outputKeys.map(k => [k, callOutput[k]]));
+  return {inputs, output};
 };
 
 const callGrouping = (childCalls: CallSchema[]) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -12,7 +12,7 @@ import {CallsTable} from '../CallsPage/CallsPage';
 import {KeyValueTable} from '../common/KeyValueTable';
 import {CallLink, opNiceName} from '../common/Links';
 import {CenteredAnimatedLoader} from '../common/Loader';
-import {isPrimitive, Primative} from '../common/util';
+import {isPrimitive, Primitive, getDisplayInputsAndOutput} from '../common/util';
 import {
   CallSchema,
   useCalls,
@@ -132,7 +132,7 @@ export const CallDetails: FC<{
                 output
               }
               result={
-                outputIsOnlyResult ? (output._result as Primative) : undefined
+                outputIsOnlyResult ? (output._result as Primitive) : undefined
               }
             />
           </Box>
@@ -239,25 +239,6 @@ export const CallDetails: FC<{
       </Box>
     </Box>
   );
-};
-
-const getDisplayInputsAndOutput = (call: CallSchema) => {
-  const span = call.rawSpan;
-  const inputKeys =
-    span.inputs._keys ??
-    Object.entries(span.inputs)
-      .filter(([k, c]) => c != null && !k.startsWith('_'))
-      .map(([k, c]) => k);
-  const inputs = _.fromPairs(inputKeys.map(k => [k, span.inputs[k]]));
-
-  const callOutput = span.output ?? {};
-  const outputKeys =
-    callOutput._keys ??
-    Object.entries(callOutput)
-      .filter(([k, c]) => c != null && (k === '_result' || !k.startsWith('_')))
-      .map(([k, c]) => k);
-  const output = _.fromPairs(outputKeys.map(k => [k, callOutput[k]]));
-  return {inputs, output};
 };
 
 const callGrouping = (childCalls: CallSchema[]) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -78,6 +78,28 @@ export const CallDetails: FC<{
   const {baseRouter} = useWeaveflowRouteContext();
   const history = useHistory();
 
+  const outputKeys = Object.keys(output);
+  const outputIsOnlyResult =
+    outputKeys.length === 1 &&
+    outputKeys[0] === '_result' &&
+    typeof output._result === 'string';
+  const outputTable = (
+    <Box
+      sx={{
+        flex: '0 0 auto',
+        p: 2,
+      }}>
+      <KeyValueTable
+        headerTitle="Output"
+        data={
+          // TODO: Consider bringing back openai chat input/output
+          output
+        }
+        result={outputIsOnlyResult ? (output._result as string) : undefined}
+      />
+    </Box>
+  );
+
   return (
     <Box
       style={{
@@ -112,21 +134,7 @@ export const CallDetails: FC<{
             />
           </Box>
         )}
-        {Object.keys(output).length > 0 && (
-          <Box
-            sx={{
-              flex: '0 0 auto',
-              p: 2,
-            }}>
-            <KeyValueTable
-              headerTitle="Output"
-              data={
-                // TODO: Consider bringing back openai chat input/output
-                output
-              }
-            />
-          </Box>
-        )}
+        {Object.keys(output).length > 0 && outputTable}
         {multipleChildCallOpRefs.map(opVersionRef => {
           const exampleCall = childCalls.result?.find(
             c => c.opVersionRef === opVersionRef

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -12,6 +12,7 @@ import {CallsTable} from '../CallsPage/CallsPage';
 import {KeyValueTable} from '../common/KeyValueTable';
 import {CallLink, opNiceName} from '../common/Links';
 import {CenteredAnimatedLoader} from '../common/Loader';
+import {isPrimitive, Primative} from '../common/util';
 import {
   CallSchema,
   useCalls,
@@ -82,23 +83,7 @@ export const CallDetails: FC<{
   const outputIsOnlyResult =
     outputKeys.length === 1 &&
     outputKeys[0] === '_result' &&
-    typeof output._result === 'string';
-  const outputTable = (
-    <Box
-      sx={{
-        flex: '0 0 auto',
-        p: 2,
-      }}>
-      <KeyValueTable
-        headerTitle="Output"
-        data={
-          // TODO: Consider bringing back openai chat input/output
-          output
-        }
-        result={outputIsOnlyResult ? (output._result as string) : undefined}
-      />
-    </Box>
-  );
+    isPrimitive(output._result);
 
   return (
     <Box
@@ -134,7 +119,24 @@ export const CallDetails: FC<{
             />
           </Box>
         )}
-        {Object.keys(output).length > 0 && outputTable}
+        {Object.keys(output).length > 0 && (
+          <Box
+            sx={{
+              flex: '0 0 auto',
+              p: 2,
+            }}>
+            <KeyValueTable
+              headerTitle="Output"
+              data={
+                // TODO: Consider bringing back openai chat input/output
+                output
+              }
+              result={
+                outputIsOnlyResult ? (output._result as Primative) : undefined
+              }
+            />
+          </Box>
+        )}
         {multipleChildCallOpRefs.map(opVersionRef => {
           const exampleCall = childCalls.result?.find(
             c => c.opVersionRef === opVersionRef

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -9,7 +9,7 @@ import {MOON_800} from '../../../../../../common/css/color.styles';
 import {Button} from '../../../../../Button';
 import {useWeaveflowRouteContext} from '../../context';
 import {CallsTable} from '../CallsPage/CallsPage';
-import {KeyValueTable} from '../common/KeyValueTable';
+import {KeyValueTable, SingleValueTable} from '../common/KeyValueTable';
 import {CallLink, opNiceName} from '../common/Links';
 import {CenteredAnimatedLoader} from '../common/Loader';
 import {isPrimitive, Primitive} from '../common/util';
@@ -125,16 +125,20 @@ export const CallDetails: FC<{
               flex: '0 0 auto',
               p: 2,
             }}>
-            <KeyValueTable
-              headerTitle="Output"
-              data={
-                // TODO: Consider bringing back openai chat input/output
-                output
-              }
-              result={
-                outputIsOnlyResult ? (output._result as Primitive) : undefined
-              }
-            />
+            {outputIsOnlyResult ? (
+              <SingleValueTable
+                headerTitle="Output"
+                result={output._result as Primitive}
+              />
+            ) : (
+              <KeyValueTable
+                headerTitle="Output"
+                data={
+                  // TODO: Consider bringing back openai chat input/output
+                  output
+                }
+              />
+            )}
           </Box>
         )}
         {multipleChildCallOpRefs.map(opVersionRef => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import React, {useContext, useEffect, useState} from 'react';
 
 import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
-import {isPrimitive, Primative} from './util';
+import {isPrimitive, Primitive} from './util';
 
 const VALUE_SPACE = 4;
 const ROW_HEIGHT = 26;
@@ -44,11 +44,11 @@ const SimpleTable: React.FC<{
 );
 
 export const SingleValueTable: React.FC<{
-  result: Primative;
+  result: Primitive;
   headerTitle?: string;
 }> = ({headerTitle, result}) => (
   <SimpleTable headerTitle={headerTitle}>
-    <PrimativeRow value={result} />
+    <PrimitiveRow value={result} />
   </SimpleTable>
 );
 
@@ -100,8 +100,8 @@ const valueStyle: React.CSSProperties = {
   borderBottom: `1px solid ${MOON_250}`,
 };
 
-const PrimativeRow: React.FC<{
-  value: Primative;
+const PrimitiveRow: React.FC<{
+  value: Primitive;
 }> = ({value}) => {
   const [open, setOpen] = React.useState(false);
   const cellRef = React.useRef<HTMLTableCellElement>(null);
@@ -127,14 +127,14 @@ const PrimativeRow: React.FC<{
         style={valueStyle}
         colSpan={VALUE_SPACE}
         ref={cellRef}>
-        <PrimativeCell value={value} />
+        <PrimitiveCell value={value} />
       </td>
     </tr>
   );
 };
 
-const PrimativeCell: React.FC<{
-  value: Primative;
+const PrimitiveCell: React.FC<{
+  value: Primitive;
 }> = ({value}) => {
   const valRef = _.isString(value) ? parseRefMaybe(value) : null;
   let useVal: any = value;
@@ -206,7 +206,7 @@ const KeyValueRow: React.FC<{
           {props.rowKey}
         </td>
         <td style={valueStyle} colSpan={VALUE_SPACE} ref={cellRef}>
-          <PrimativeCell value={props.rowValue} />
+          <PrimitiveCell value={props.rowValue} />
         </td>
       </tr>
     );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
@@ -15,6 +15,7 @@ const MAX_HEIGHT_MULT = 5;
 export const KeyValueTable: React.FC<{
   data: {[key: string]: any};
   headerTitle?: string;
+  result?: string;
 }> = props => {
   return (
     <Box
@@ -40,7 +41,11 @@ export const KeyValueTable: React.FC<{
           </thead>
         )}
         <tbody>
-          <KeyValueRowForObject objValue={props.data} />
+          {props.result ? (
+            <RowForString value={props.result} />
+          ) : (
+            <KeyValueRowForObject objValue={props.data} />
+          )}
         </tbody>
       </table>
     </Box>
@@ -86,6 +91,66 @@ const valueStyle: React.CSSProperties = {
   borderBottom: `1px solid ${MOON_250}`,
 };
 
+const StringCell: React.FC<{
+  value: string;
+}> = ({value}) => {
+  return (
+    <Box
+      sx={{
+        // maxHeight: !open ? `${ROW_HEIGHT * MAX_HEIGHT_MULT}px` : '50vh',
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        width: '100%',
+      }}>
+      <pre
+        style={{
+          width: '100%',
+          // See https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
+          // We want to break on spaces, but also on newlines and preserve them
+          whiteSpace: 'break-spaces',
+          fontSize: '16px',
+          margin: '0',
+          fontFamily: 'Source Sans Pro',
+        }}>
+        {value}
+      </pre>
+    </Box>
+  );
+};
+
+const RowForString: React.FC<{
+  value: string;
+}> = ({value}) => {
+  const [open, setOpen] = React.useState(false);
+  const cellRef = React.useRef<HTMLTableCellElement>(null);
+  const [canExpand, setCanExpand] = useState(false);
+
+  useEffect(() => {
+    if (
+      cellRef.current &&
+      cellRef.current.clientHeight >= ROW_HEIGHT * MAX_HEIGHT_MULT - 5
+    ) {
+      setCanExpand(true);
+    }
+  }, []);
+
+  return (
+    <tr>
+      <td
+        onClick={() => {
+          if (open || canExpand) {
+            setOpen(!open);
+          }
+        }}
+        style={valueStyle}
+        colSpan={VALUE_SPACE}
+        ref={cellRef}>
+        <StringCell value={value} />
+      </td>
+    </tr>
+  );
+};
+
 const KeyValueRow: React.FC<{
   rowKey: string;
   rowValue: any;
@@ -113,28 +178,7 @@ const KeyValueRow: React.FC<{
       useVal = <SmallRef objRef={valRef} />;
     } else if (_.isString(props.rowValue)) {
       //   useVal = <SimplePopoverText text={props.rowValue} />;
-      useVal = (
-        <Box
-          sx={{
-            // maxHeight: !open ? `${ROW_HEIGHT * MAX_HEIGHT_MULT}px` : '50vh',
-            overflowY: 'auto',
-            overflowX: 'hidden',
-            width: '100%',
-          }}>
-          <pre
-            style={{
-              width: '100%',
-              // See https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
-              // We want to break on spaces, but also on newlines and preserve them
-              whiteSpace: 'break-spaces',
-              fontSize: '16px',
-              margin: '0',
-              fontFamily: 'Source Sans Pro',
-            }}>
-            {useVal}
-          </pre>
-        </Box>
-      );
+      useVal = <StringCell value={useVal} />;
     } else if (_.isBoolean(props.rowValue)) {
       useVal = (props.rowValue as boolean).toString();
     } else if (_.isDate(props.rowValue)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
@@ -12,45 +12,54 @@ const ROW_HEIGHT = 26;
 const PADDING_GAP = 16;
 const MAX_HEIGHT_MULT = 5;
 
+const SimpleTable: React.FC<{
+  headerTitle?: string;
+  children: React.ReactNode;
+}> = ({headerTitle, children}) => (
+  <Box
+    sx={{
+      border: `1px solid ${MOON_250}`,
+      borderRadius: '4px',
+    }}>
+    <table
+      style={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        tableLayout: 'fixed',
+      }}>
+      {headerTitle && (
+        <thead>
+          <tr
+            style={{
+              borderBottom: `1px solid ${MOON_250}`,
+              backgroundColor: '#FAFAFA',
+            }}>
+            <th colSpan={VALUE_SPACE + 1}>{headerTitle}</th>
+          </tr>
+        </thead>
+      )}
+      <tbody>{children}</tbody>
+    </table>
+  </Box>
+);
+
+export const SingleValueTable: React.FC<{
+  result: Primative;
+  headerTitle?: string;
+}> = ({headerTitle, result}) => (
+  <SimpleTable headerTitle={headerTitle}>
+    <PrimativeRow value={result} />
+  </SimpleTable>
+);
+
 export const KeyValueTable: React.FC<{
   data: {[key: string]: any};
   headerTitle?: string;
-  result?: Primative;
-}> = ({data, headerTitle, result}) => {
-  return (
-    <Box
-      sx={{
-        border: `1px solid ${MOON_250}`,
-        borderRadius: '4px',
-      }}>
-      <table
-        style={{
-          width: '100%',
-          borderCollapse: 'collapse',
-          tableLayout: 'fixed',
-        }}>
-        {headerTitle && (
-          <thead>
-            <tr
-              style={{
-                borderBottom: `1px solid ${MOON_250}`,
-                backgroundColor: '#FAFAFA',
-              }}>
-              <th colSpan={VALUE_SPACE + 1}>{headerTitle}</th>
-            </tr>
-          </thead>
-        )}
-        <tbody>
-          {result ? (
-            <PrimativeRow value={result} />
-          ) : (
-            <KeyValueRowForObject objValue={data} />
-          )}
-        </tbody>
-      </table>
-    </Box>
-  );
-};
+}> = ({data, headerTitle}) => (
+  <SimpleTable headerTitle={headerTitle}>
+    <KeyValueRowForObject objValue={data} />
+  </SimpleTable>
+);
 
 const baseKeyStyle: React.CSSProperties = {
   whiteSpace: 'nowrap',
@@ -89,33 +98,6 @@ const valueStyle: React.CSSProperties = {
   paddingLeft: '8px',
   verticalAlign: 'top',
   borderBottom: `1px solid ${MOON_250}`,
-};
-
-const StringCell: React.FC<{
-  value: string;
-}> = ({value}) => {
-  return (
-    <Box
-      sx={{
-        // maxHeight: !open ? `${ROW_HEIGHT * MAX_HEIGHT_MULT}px` : '50vh',
-        overflowY: 'auto',
-        overflowX: 'hidden',
-        width: '100%',
-      }}>
-      <pre
-        style={{
-          width: '100%',
-          // See https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
-          // We want to break on spaces, but also on newlines and preserve them
-          whiteSpace: 'break-spaces',
-          fontSize: '16px',
-          margin: '0',
-          fontFamily: 'Source Sans Pro',
-        }}>
-        {value}
-      </pre>
-    </Box>
-  );
 };
 
 const PrimativeRow: React.FC<{
@@ -160,7 +142,28 @@ const PrimativeCell: React.FC<{
     useVal = <SmallRef objRef={valRef} />;
   } else if (_.isString(value)) {
     //   useVal = <SimplePopoverText text={props.rowValue} />;
-    useVal = <StringCell value={useVal} />;
+    useVal = (
+      <Box
+        sx={{
+          // maxHeight: !open ? `${ROW_HEIGHT * MAX_HEIGHT_MULT}px` : '50vh',
+          overflowY: 'auto',
+          overflowX: 'hidden',
+          width: '100%',
+        }}>
+        <pre
+          style={{
+            width: '100%',
+            // See https://developer.mozilla.org/en-US/docs/Web/CSS/white-space
+            // We want to break on spaces, but also on newlines and preserve them
+            whiteSpace: 'break-spaces',
+            fontSize: '16px',
+            margin: '0',
+            fontFamily: 'Source Sans Pro',
+          }}>
+          {useVal}
+        </pre>
+      </Box>
+    );
   } else if (_.isBoolean(value)) {
     useVal = (value as boolean).toString();
   } else if (_.isDate(value)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 import React, {useContext, useEffect, useState} from 'react';
 
 import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
-import {isPrimitive} from './util';
+import {isPrimitive, Primative} from './util';
 
 const VALUE_SPACE = 4;
 const ROW_HEIGHT = 26;
@@ -15,8 +15,8 @@ const MAX_HEIGHT_MULT = 5;
 export const KeyValueTable: React.FC<{
   data: {[key: string]: any};
   headerTitle?: string;
-  result?: string;
-}> = props => {
+  result?: Primative;
+}> = ({data, headerTitle, result}) => {
   return (
     <Box
       sx={{
@@ -29,22 +29,22 @@ export const KeyValueTable: React.FC<{
           borderCollapse: 'collapse',
           tableLayout: 'fixed',
         }}>
-        {props.headerTitle && (
+        {headerTitle && (
           <thead>
             <tr
               style={{
                 borderBottom: `1px solid ${MOON_250}`,
                 backgroundColor: '#FAFAFA',
               }}>
-              <th colSpan={VALUE_SPACE + 1}>{props.headerTitle}</th>
+              <th colSpan={VALUE_SPACE + 1}>{headerTitle}</th>
             </tr>
           </thead>
         )}
         <tbody>
-          {props.result ? (
-            <RowForString value={props.result} />
+          {result ? (
+            <PrimativeRow value={result} />
           ) : (
-            <KeyValueRowForObject objValue={props.data} />
+            <KeyValueRowForObject objValue={data} />
           )}
         </tbody>
       </table>
@@ -118,8 +118,8 @@ const StringCell: React.FC<{
   );
 };
 
-const RowForString: React.FC<{
-  value: string;
+const PrimativeRow: React.FC<{
+  value: Primative;
 }> = ({value}) => {
   const [open, setOpen] = React.useState(false);
   const cellRef = React.useRef<HTMLTableCellElement>(null);
@@ -145,10 +145,28 @@ const RowForString: React.FC<{
         style={valueStyle}
         colSpan={VALUE_SPACE}
         ref={cellRef}>
-        <StringCell value={value} />
+        <PrimativeCell value={value} />
       </td>
     </tr>
   );
+};
+
+const PrimativeCell: React.FC<{
+  value: Primative;
+}> = ({value}) => {
+  const valRef = _.isString(value) ? parseRefMaybe(value) : null;
+  let useVal: any = value;
+  if (valRef) {
+    useVal = <SmallRef objRef={valRef} />;
+  } else if (_.isString(value)) {
+    //   useVal = <SimplePopoverText text={props.rowValue} />;
+    useVal = <StringCell value={useVal} />;
+  } else if (_.isBoolean(value)) {
+    useVal = (value as boolean).toString();
+  } else if (_.isDate(value)) {
+    useVal = moment(value as Date).format('YYYY-MM-DD HH:mm:ss');
+  }
+  return useVal;
 };
 
 const KeyValueRow: React.FC<{
@@ -170,20 +188,6 @@ const KeyValueRow: React.FC<{
   }, []);
 
   if (isPrimitive(props.rowValue)) {
-    const valRef = _.isString(props.rowValue)
-      ? parseRefMaybe(props.rowValue)
-      : null;
-    let useVal: any = props.rowValue;
-    if (valRef) {
-      useVal = <SmallRef objRef={valRef} />;
-    } else if (_.isString(props.rowValue)) {
-      //   useVal = <SimplePopoverText text={props.rowValue} />;
-      useVal = <StringCell value={useVal} />;
-    } else if (_.isBoolean(props.rowValue)) {
-      useVal = (props.rowValue as boolean).toString();
-    } else if (_.isDate(props.rowValue)) {
-      useVal = moment(props.rowValue as Date).format('YYYY-MM-DD HH:mm:ss');
-    }
     return (
       <tr>
         <td
@@ -199,7 +203,7 @@ const KeyValueRow: React.FC<{
           {props.rowKey}
         </td>
         <td style={valueStyle} colSpan={VALUE_SPACE} ref={cellRef}>
-          {useVal}
+          <PrimativeCell value={props.rowValue} />
         </td>
       </tr>
     );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/util.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/util.ts
@@ -1,6 +1,14 @@
 import _ from 'lodash';
 import React from 'react';
 
+export type Primative =
+  | string
+  | number
+  | boolean
+  | Date
+  | null
+  | React.ReactElement;
+
 export const isPrimitive = (val: any) => {
   return (
     React.isValidElement(val) ||

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/util.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/util.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 
-export type Primative =
+export type Primitive =
   | string
   | number
   | boolean


### PR DESCRIPTION
a lot of moving code around so i could reuse it

https://www.notion.so/wandbai/hide-_result-in-UI-when-Op-returns-a-string-number-04b8516325e241fd9d71d3238fac732b?pvs=4

before
<img width="840" alt="Screenshot 2024-02-22 at 9 34 06 PM" src="https://github.com/wandb/weave/assets/25037002/99040c92-d0a3-4193-ad77-c0eb2dd79f18">

<img width="429" alt="Screenshot 2024-02-22 at 9 34 00 PM" src="https://github.com/wandb/weave/assets/25037002/c956afee-72f8-42d6-aa54-a19aab243a83">

After
<img width="1334" alt="Screenshot 2024-02-22 at 9 21 48 PM" src="https://github.com/wandb/weave/assets/25037002/7ba7b674-1482-42da-bc34-3e31c2e29a28">

<img width="949" alt="Screenshot 2024-02-22 at 9 23 58 PM" src="https://github.com/wandb/weave/assets/25037002/9403cc50-ed6a-4146-8462-cac83720a51b">
