### PR TITLE
feat: collapsible input/output sections

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -18,6 +18,7 @@ import {
   useParentCall,
 } from '../wfReactInterface/interface';
 import {ButtonOverlay} from './ButtonOverlay';
+import {CollapsibleSection} from './CollapsibleSection';
 import {OpVersionText} from './OpVersionText';
 
 const Heading = styled.div`
@@ -101,30 +102,34 @@ export const CallDetails: FC<{
           <Box
             sx={{
               flex: '0 0 auto',
-              p: 2,
+              px: 2,
+              pb: 2,
             }}>
-            <KeyValueTable
-              headerTitle="Inputs"
-              data={
-                // TODO: Consider bringing back openai chat input/output
-                inputs
-              }
-            />
+            <CollapsibleSection headerTitle="Inputs">
+              <KeyValueTable
+                data={
+                  // TODO: Consider bringing back openai chat input/output
+                  inputs
+                }
+              />
+            </CollapsibleSection>
           </Box>
         )}
         {Object.keys(output).length > 0 && (
           <Box
             sx={{
               flex: '0 0 auto',
-              p: 2,
+              px: 2,
+              pb: 2,
             }}>
-            <KeyValueTable
-              headerTitle="Output"
-              data={
-                // TODO: Consider bringing back openai chat input/output
-                output
-              }
-            />
+            <CollapsibleSection headerTitle="Output">
+              <KeyValueTable
+                data={
+                  // TODO: Consider bringing back openai chat input/output
+                  output
+                }
+              />
+            </CollapsibleSection>
           </Box>
         )}
         {multipleChildCallOpRefs.map(opVersionRef => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CollapsibleSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CollapsibleSection.tsx
@@ -1,0 +1,50 @@
+import {Collapse} from '@mui/material';
+import React, {useState} from 'react';
+import styled from 'styled-components';
+
+import {Button} from '../../../../../Button';
+
+type CollapsibleSectionProps = {
+  headerTitle: string;
+  children: React.ReactNode;
+};
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 8px;
+
+  font-family: Source Sans Pro;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 32px;
+  letter-spacing: 0px;
+  text-align: left;
+`;
+Header.displayName = 'S.Header';
+
+const HeaderTitle = styled.div`
+  cursor: pointer;
+`;
+HeaderTitle.displayName = 'S.HeaderTitle';
+
+export const CollapsibleSection = ({
+  headerTitle,
+  children,
+}: CollapsibleSectionProps) => {
+  const [open, setOpen] = useState(true);
+  const onClick = () => {
+    setOpen(!open);
+  };
+  const icon = open ? 'chevron-down' : 'chevron-next';
+  return (
+    <>
+      <Header>
+        <Button size="small" icon={icon} variant="ghost" onClick={onClick} />
+        <HeaderTitle onClick={onClick}>{headerTitle}</HeaderTitle>
+      </Header>
+      <Collapse in={open}>{children}</Collapse>
+    </>
+  );
+};


### PR DESCRIPTION
Trying out something from design mockups - collapsible input/output sections.

Before:
<img width="658" alt="Screenshot 2024-02-22 at 10 50 17 PM" src="https://github.com/wandb/weave/assets/112953339/5171a02e-5d5a-4052-9276-1ce904058dfa">

After:
<img width="666" alt="Screenshot 2024-02-22 at 10 49 59 PM" src="https://github.com/wandb/weave/assets/112953339/c5ff51d0-b07c-44dd-a51d-c96c23097767">

