### PR TITLE
chore(weave): Various CH Cleanups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,7 @@ jobs:
           DD_SERVICE: weave-python
           DD_ENV: ci
           # PARQUET_ENABLED: true # TODO: Enable parquet after available in CI
-        run: WB_SERVER_HOST=http://wandbservice TEST_CH_SERVER_HOST=weave_clickhouse WEAVE_SERVER_DISABLE_ECOSYSTEM=1 source /root/venv/bin/activate && cd weave && pytest --job-num=${{ matrix.job_num }} --timeout=90 ./tests ./ops_arrow ./ecosystem --ddtrace --durations=5
+        run: WB_SERVER_HOST=http://wandbservice WF_CLICKHOUSE_HOST=weave_clickhouse WEAVE_SERVER_DISABLE_ECOSYSTEM=1 source /root/venv/bin/activate && cd weave && pytest --job-num=${{ matrix.job_num }} --timeout=90 ./tests ./ops_arrow ./ecosystem --ddtrace --durations=5
 
   # nbmake:
   #   name: Run notebooks with nbmake

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -20,7 +20,7 @@ def test_simple_op(trace_client):
     fetched_call = runs[0]._call
     assert (
         fetched_call.name
-        == f"{TRACE_REF_SCHEME}:///test_entity/test_project/op/op-my_op:873a064f5e172ac4dfd1b869028d749b"
+        == f"{TRACE_REF_SCHEME}:///{trace_client.entity}/{trace_client.project}/op/op-my_op:873a064f5e172ac4dfd1b869028d749b"
     )
     assert fetched_call == tsi.CallSchema(
         entity=trace_client.entity,

--- a/weave/tests/trace_server_clickhouse_conftest.py
+++ b/weave/tests/trace_server_clickhouse_conftest.py
@@ -10,6 +10,8 @@ import urllib
 
 import pytest
 
+from weave.trace_server import environment as wf_env
+
 from ..weave_init import InitializedClient
 from ..trace_server import (
     graph_client_trace,
@@ -19,18 +21,18 @@ from ..trace_server import (
 
 @pytest.fixture(scope="session")
 def clickhouse_server():
-    host = os.environ.get("TEST_CH_SERVER_HOST", "localhost")
-    (host, port, server_up) = _check_server_up(host)
+    server_up = _check_server_up(
+        wf_env.wf_clickhouse_host(), wf_env.wf_clickhouse_port()
+    )
     if not server_up:
         pytest.fail("clickhouse server is not running")
-    yield (host, port)
 
 
 @pytest.fixture(scope="session")
 def clickhouse_trace_server(clickhouse_server):
     (host, port) = clickhouse_server
-    clickhouse_trace_server = clickhouse_trace_server_batched.ClickHouseTraceServer(
-        host, port, False
+    clickhouse_trace_server = (
+        clickhouse_trace_server_batched.ClickHouseTraceServer.from_env(False)
     )
     clickhouse_trace_server._run_migrations()
     yield clickhouse_trace_server
@@ -67,7 +69,7 @@ def _check_server_health(
     return False
 
 
-def _check_server_up(host="localhost", port=8123) -> typing.Tuple[str, int, bool]:
+def _check_server_up(host, port) -> bool:
     base_url = f"http://{host}:{port}/"
     endpoint = "ping"
 
@@ -76,10 +78,11 @@ def _check_server_up(host="localhost", port=8123) -> typing.Tuple[str, int, bool
             base_url=base_url, endpoint=endpoint, num_retries=num_retries
         )
 
+    if server_healthy():
+        return True
+
     if os.environ.get("CI") != "true":
         print("CI is not true, not starting clickhouse server")
-        if server_healthy():
-            return (host, port, True)
 
         subprocess.Popen(
             [
@@ -98,7 +101,4 @@ def _check_server_up(host="localhost", port=8123) -> typing.Tuple[str, int, bool
         )
 
     # wait for the server to start
-    if server_healthy(num_retries=30):
-        return (host, port, True)
-    else:
-        return (host, port, False)
+    return server_healthy(num_retries=30)

--- a/weave/tests/trace_server_clickhouse_conftest.py
+++ b/weave/tests/trace_server_clickhouse_conftest.py
@@ -30,7 +30,6 @@ def clickhouse_server():
 
 @pytest.fixture(scope="session")
 def clickhouse_trace_server(clickhouse_server):
-    (host, port) = clickhouse_server
     clickhouse_trace_server = (
         clickhouse_trace_server_batched.ClickHouseTraceServer.from_env(False)
     )
@@ -39,9 +38,10 @@ def clickhouse_trace_server(clickhouse_server):
 
 
 @pytest.fixture()
-def trace_client(clickhouse_trace_server):
+def trace_client(clickhouse_trace_server, user_by_api_key_in_env):
+    user_by_api_key_in_env
     graph_client = graph_client_trace.GraphClientTrace(
-        "test_entity", "test_project", clickhouse_trace_server
+        user_by_api_key_in_env.username, "test_project", clickhouse_trace_server
     )
     inited_client = InitializedClient(graph_client)
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -1,0 +1,26 @@
+import os
+
+
+def wf_clickhouse_host() -> str:
+    """The host of the clickhouse server."""
+    return os.environ.get("WF_CLICKHOUSE_HOST", "localhost")
+
+
+def wf_clickhouse_port() -> int:
+    """The port of the clickhouse server."""
+    return int(os.environ.get("WF_CLICKHOUSE_PORT", 8123))
+
+
+def wf_clickhouse_user() -> str:
+    """The user of the clickhouse server."""
+    return os.environ.get("WF_CLICKHOUSE_USER", "default")
+
+
+def wf_clickhouse_pass() -> str:
+    """The password of the clickhouse server."""
+    return os.environ.get("WF_CLICKHOUSE_PASS", "")
+
+
+def wf_trace_server_url() -> str:
+    """The url of the web server exposing the trace interface endpoints"""
+    return os.environ.get("WF_TRACE_SERVER_URL", "http://127.0.0.1:6345")

--- a/weave/trace_server/graph_client_trace.py
+++ b/weave/trace_server/graph_client_trace.py
@@ -28,6 +28,8 @@ from .. import uris
 from .. import errors
 from .. import ref_base
 from .. import weave_types as types
+from .. import artifact_wandb
+from ..wandb_interface import project_creator
 
 
 from .trace_server_interface_util import (
@@ -459,6 +461,13 @@ class GraphClientTrace(GraphClient[CallSchemaRun]):
         self.project = project
         self.trace_server = trace_server
 
+        # Maybe this should happen on the first write event? For now, let's just ensure
+        # the project exists when the client is initialized. For production, we can move
+        # this to the service layer which will: a) save a round trip, and b) reduce the amount
+        # of client-side logic to duplicate to TS in the future. We already do auth checks
+        # in the service layer, so this is just a matter of convenience.
+        project_creator.ensure_project_exists(entity, project)
+
     ##### Read API
 
     # Implement the required members from the "GraphClient" protocol class
@@ -563,9 +572,7 @@ class GraphClientTrace(GraphClient[CallSchemaRun]):
     def ref_is_own(self, ref: typing.Optional[ref_base.Ref]) -> bool:
         return isinstance(ref, TraceRef)
 
-    def ref_uri(
-        self, name: str, version: str, path: str
-    ) -> artifact_local.WeaveLocalArtifactURI:
+    def ref_uri(self, name: str, version: str, path: str) -> uris.WeaveURI:
         raise NotImplementedError()
 
     def run_ui_url(self, run: Run) -> str:
@@ -706,3 +713,37 @@ def _get_ref(obj: typing.Any) -> typing.Optional[ref_base.Ref]:
     if isinstance(obj, ref_base.Ref):
         return obj
     return ref_base.get_ref(obj)
+
+
+# This is a modified version of the GraphClientTrace that uses the artifact storage
+# to store the objects and ops
+@dataclasses.dataclass
+class GraphClientTraceWithArtifactStorage(GraphClientTrace):
+    def __init__(
+        self, entity: str, project: str, trace_server: tsi.TraceServerInterface
+    ):
+        super().__init__(entity, project, trace_server)
+
+    def ref_is_own(self, ref: typing.Optional[Ref]) -> bool:
+        return isinstance(ref, artifact_wandb.WandbArtifactRef)
+
+    def ref_uri(
+        self, name: str, version: str, path: str
+    ) -> artifact_wandb.WeaveWBArtifactURI:
+        return artifact_wandb.WeaveWBArtifactURI(
+            name, version, self.entity, self.project, path=path
+        )
+
+    def save_object(
+        self, obj: typing.Any, name: str, branch_name: str
+    ) -> artifact_wandb.WandbArtifactRef:
+        from .. import storage
+
+        res = storage._direct_publish(
+            obj,
+            name=name,
+            wb_entity_name=self.entity,
+            wb_project_name=self.project,
+            branch_name=branch_name,
+        )
+        return res

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -3,6 +3,8 @@ import typing as t
 from pydantic import BaseModel
 import requests
 
+from weave.trace_server import environment as wf_env
+
 
 from .flushing_buffer import InMemAutoFlushingBuffer
 from . import trace_server_interface as tsi
@@ -37,6 +39,10 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             self.call_buffer = InMemAutoFlushingBuffer(
                 MAX_FLUSH_COUNT, MAX_FLUSH_AGE, self._flush_calls
             )
+
+    @classmethod
+    def from_env(cls, should_batch: bool = False) -> "RemoteHTTPTraceServer":
+        return cls(wf_env.wf_trace_server_url())
 
     def _flush_calls(self, batch: t.List) -> None:
         if len(batch) == 0:


### PR DESCRIPTION
While working on productionization and UI integration, I needed to fix a handful of little things and it would be good to isolate the land these changes:

* Refactor all environment variable accessing to a single, documented file and share that in all relevant areas. Not only good practice, but also important to inject such variables for different environments (dev, prod, etc...)
* All Clickhouse client to support username/password (allowing connections to secure CH servers like CH Cloud)
* Fix bug in DB aggregation logic regarding the aggregation of null values
* Fix table creation logic in bootstrap SQL to not re-create views/tables
* Move project creation into trace graph client
* Important: created `GraphClientTraceWithArtifactStorage` as a subclass of `GraphClientTrace` which uses artifacts for object storage rather than CH. This allows us to decouple call migration and object migration into two steps. Made this the default for trace client init.