### PR TITLE
fix: improvements to display of common values

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {ReactNode} from 'react';
 import styled from 'styled-components';
 
 import {
@@ -8,6 +8,7 @@ import {
 } from '../../../../../../common/css/color.styles';
 import {Tooltip} from '../../../../../Tooltip';
 import {getBoringColumns, TableStats} from '../../../Browse2/tableStats';
+import {BoringStringValue} from './BoringStringValue';
 
 type BoringColumnInfoProps = {
   tableStats: TableStats;
@@ -15,8 +16,8 @@ type BoringColumnInfoProps = {
 };
 
 const Boring = styled.div`
+  overflow: auto;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   padding: 8px;
@@ -46,9 +47,6 @@ const BoringLabel = styled.div`
 BoringLabel.displayName = 'S.BoringLabel';
 
 const BoringValue = styled.div`
-  height: 32px;
-  display: flex;
-  align-items: center;
   background-color: ${MOON_100};
   padding: 4px 8px;
   border-radius: 0 8px 8px 0;
@@ -86,16 +84,27 @@ export const BoringColumnInfo = ({
           label = col.headerName;
         }
 
-        let value = boringValue;
+        let value: ReactNode = boringValue;
+        let height: number | undefined = 32;
         if (col.renderCell) {
           const cellParams = {value, row: {[col.field]: value}};
           value = col.renderCell(cellParams);
+          if (typeof value === 'string') {
+            value = (
+              <BoringStringValue
+                value={value}
+                maxWidthCollapsed={300}
+                maxWidthExpanded={600}
+              />
+            );
+            height = undefined;
+          }
         }
 
         return (
           <BoringPair key={colName}>
             <BoringLabel>{label}</BoringLabel>
-            <BoringValue>{value}</BoringValue>
+            <BoringValue style={{height}}>{value}</BoringValue>
           </BoringPair>
         );
       })}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringStringValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringStringValue.tsx
@@ -1,0 +1,52 @@
+/**
+ * Render common string values.
+ * Long strings can be toggled between truncated and a larger scrolling panel with a click.
+ */
+
+import React, {CSSProperties, useState} from 'react';
+import {AutoSizer} from 'react-virtualized';
+
+type BoringStringValueProps = {
+  value: string;
+  maxWidthCollapsed: number;
+  maxWidthExpanded: number;
+};
+
+export const BoringStringValue = ({
+  value,
+  maxWidthCollapsed,
+  maxWidthExpanded,
+}: BoringStringValueProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const onClick = () => {
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <AutoSizer style={{width: '100%', height: '100%'}}>
+      {({width, height}) => {
+        const canToggle = isExpanded || width === maxWidthCollapsed;
+        const style: CSSProperties = isExpanded
+          ? {
+              maxWidth: maxWidthExpanded,
+              maxHeight: 200,
+              overflow: 'auto',
+              whiteSpace: 'break-spaces',
+              cursor: canToggle ? 'pointer' : 'default',
+            }
+          : {
+              maxWidth: maxWidthCollapsed,
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+              cursor: canToggle ? 'pointer' : 'default',
+            };
+        return (
+          <div style={style} onClick={canToggle ? onClick : undefined}>
+            {value}
+          </div>
+        );
+      }}
+    </AutoSizer>
+  );
+};


### PR DESCRIPTION
Internal slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1708959561574009

Improvements to the display of "Common values".
* Long string values are now truncated, can be clicked to expand.
* Doesn't show common values when there is a single row
* When there are many values, scroll horizontally instead of wrapping.
* Leave status code indicator in the table if it is the only common value we would display.
