### PR TITLE
chore: hide singular child details

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -201,7 +201,8 @@ export const CallDetails: FC<{
           );
         })}
         {childCalls.loading && <CenteredAnimatedLoader />}
-        {singularChildCalls.length > 0 && (
+        {/* Disabling display of singular children while we decide if we want them here. */}
+        {false && singularChildCalls.length > 0 && (
           <Box
             sx={{
               flex: '0 0 auto',


### PR DESCRIPTION
As discussed in meeting this morning - for now skip rendering of singular child calls, but leave code in place while we decide if this is actually our preference.