### PR TITLE
chore: change drawer heading

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -18,9 +18,9 @@ Overview.displayName = 'S.Overview';
 
 export const CallName = styled.div`
   font-family: Source Sans Pro;
-  font-size: 16px;
+  font-size: 24px;
   font-weight: 600;
-  line-height: 20px;
+  line-height: 32px;
   letter-spacing: 0px;
   text-align: left;
 `;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -180,9 +180,6 @@ const CallPageInnerVertical: FC<{
   call: CallSchema;
   setVerticalLayout: (vertical: boolean) => void;
 }> = ({call, setVerticalLayout}) => {
-  const {callId} = call;
-  const spanName = opNiceName(call.spanName);
-  const title = `${spanName} (${truncateID(callId)})`;
   const callTabs = useCallTabs(call);
   const history = useHistory();
   const showTraceTree = queryGetBoolean(history, 'tracetree', true);
@@ -191,7 +188,6 @@ const CallPageInnerVertical: FC<{
   };
   return (
     <SimplePageLayoutWithHeader
-      title={title}
       headerExtra={
         <Box
           sx={{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -165,7 +165,7 @@ export const SimplePageLayout: FC<{
 };
 
 export const SimplePageLayoutWithHeader: FC<{
-  title: string;
+  title?: string;
   tabs: Array<{
     label: string;
     content: ReactNode;


### PR DESCRIPTION
Don't show call title at the top of drawer, make it more prominent above tabs.

@Yangyi-wandb with this styling the title can get a little squished when you have the trace tree open.

Internal Figma: https://www.figma.com/file/27JVuBYWHbcAYc8WPb4HqA/Weaveflow-hifi?type=design&node-id=2544-113114&mode=design&t=DVq1XHahBd87zaBG-0

Before:
<img width="562" alt="Screenshot 2024-02-27 at 9 50 11 AM" src="https://github.com/wandb/weave/assets/112953339/fd5ce0bc-cc40-4698-bc72-907884228d3f">

After:
<img width="567" alt="Screenshot 2024-02-27 at 9 49 51 AM" src="https://github.com/wandb/weave/assets/112953339/852160ad-c061-4dcb-b871-30d4f1e41322">

