### PR TITLE
feat: fancier input/output tables with ref expansion

### DIFF
--- a/weave-js/src/components/CodeEditor.tsx
+++ b/weave-js/src/components/CodeEditor.tsx
@@ -1,0 +1,109 @@
+/**
+ * Wrap Monaco editor. See also:
+ * import MonacoEditor from '@wandb/weave/common/components/Monaco/Editor';
+ * This is a controlled component that automatically sets its height based on
+ * the text content.
+ */
+
+import {MOON_250} from '@wandb/weave/common/css/globals.styles';
+import React, {useRef, useState} from 'react';
+
+const Editor = React.lazy(async () => {
+  await import('@wandb/weave/common/components/Monaco/bootstrap');
+  return await import('@monaco-editor/react');
+});
+
+type CodeEditorProps = {
+  value: string;
+  language: string;
+  readOnly?: boolean;
+  onChange?: (value: string) => void;
+  maxHeight?: number;
+  minHeight?: number;
+  handleMouseWheel?: boolean;
+};
+
+export const CodeEditor = ({
+  value,
+  language,
+  readOnly,
+  onChange,
+  maxHeight,
+  minHeight,
+  handleMouseWheel,
+}: CodeEditorProps) => {
+  const editorRef = useRef(null);
+  const [height, setHeight] = useState(300);
+
+  const updateHeight = () => {
+    const editor: any = editorRef.current;
+    if (editor) {
+      const contentHeight = editor.getContentHeight();
+      const realMin = minHeight
+        ? Math.max(minHeight, contentHeight)
+        : contentHeight;
+      setHeight(maxHeight ? Math.min(maxHeight, realMin) : realMin);
+    }
+  };
+
+  const handleEditorBeforeMount = (monaco: any) => {
+    monaco.editor.defineTheme('wandb-light', {
+      base: 'vs',
+      inherit: true,
+      rules: [],
+      colors: {
+        'editorWidget.border': MOON_250,
+      },
+    });
+  };
+
+  const handleEditorDidMount = (editor: any, monaco: any) => {
+    monaco.editor.setTheme('wandb-light');
+    editorRef.current = editor;
+    editor.onDidContentSizeChange(updateHeight);
+    updateHeight();
+  };
+
+  const width = '100%';
+  const options = {
+    readOnly,
+    minimap: {
+      enabled: false,
+    },
+    overviewRulerLanes: 0,
+    scrollBeyondLastLine: false,
+
+    // If we are autosizing, don't capture scroll events so we can scroll past editor.
+    // Note that this also means we have to explicitly use horizontal scrollbar to view clipped content.
+    scrollbar: {
+      handleMouseWheel: handleMouseWheel ?? false,
+    },
+  };
+
+  const onValueChange = (newValue: string | undefined) => {
+    if (onChange) {
+      onChange(newValue ?? '');
+    }
+  };
+
+  return (
+    <div
+      style={{
+        width,
+        height: `${height}px`,
+        border: `1px solid ${MOON_250}`,
+      }}>
+      <React.Suspense fallback={<></>}>
+        <Editor
+          height="100%"
+          value={value}
+          language={language}
+          beforeMount={handleEditorBeforeMount}
+          onMount={handleEditorDidMount}
+          onChange={onValueChange}
+          options={options}
+        />
+      </React.Suspense>
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -16,6 +16,7 @@ import {useWFHooks} from '../wfReactInterface/context';
 import {useParentCall} from '../wfReactInterface/utilities';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {ButtonOverlay} from './ButtonOverlay';
+import {ObjectViewerSection} from './ObjectViewerSection';
 import {OpVersionText} from './OpVersionText';
 
 const Heading = styled.div`
@@ -103,13 +104,7 @@ export const CallDetails: FC<{
               flex: '0 0 auto',
               p: 2,
             }}>
-            <KeyValueTable
-              headerTitle="Inputs"
-              data={
-                // TODO: Consider bringing back openai chat input/output
-                inputs
-              }
-            />
+            <ObjectViewerSection title="Inputs" data={inputs} />
           </Box>
         )}
         {Object.keys(output).length > 0 && (
@@ -118,13 +113,7 @@ export const CallDetails: FC<{
               flex: '0 0 auto',
               p: 2,
             }}>
-            <KeyValueTable
-              headerTitle="Output"
-              data={
-                // TODO: Consider bringing back openai chat input/output
-                output
-              }
-            />
+            <ObjectViewerSection title="Outputs" data={output} />
           </Box>
         )}
         {multipleChildCallOpRefs.map(opVersionRef => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -51,6 +51,7 @@ import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CallDetails} from './CallDetails';
 import {CallOverview} from './CallOverview';
 import {CallSummary} from './CallSummary';
+import {CursorBox} from './CursorBox';
 
 // % of screen to give the trace view in horizontal mode
 const TRACE_PCT = 40;
@@ -469,13 +470,6 @@ const CallTraceView: FC<{call: CallSchema; treeOnly?: boolean}> = ({
 const INSET_SPACING = 54;
 const TREE_COLOR = '#aaaeb2';
 const BORDER_STYLE = `1px solid ${TREE_COLOR}`;
-
-// MUI Box doesn't support cursor
-// https://github.com/mui/material-ui/issues/19983
-const CursorBox = styled(Box)<{$isClickable: boolean}>`
-  cursor: ${p => (p.$isClickable ? 'pointer' : 'default')};
-`;
-CursorBox.displayName = 'S.CursorBox';
 
 /**
  * Utility component to render the grouping cell for the trace tree.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CursorBox.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CursorBox.tsx
@@ -1,0 +1,9 @@
+import {Box} from '@material-ui/core';
+import styled from 'styled-components';
+
+// MUI Box doesn't support cursor
+// https://github.com/mui/material-ui/issues/19983
+export const CursorBox = styled(Box)<{$isClickable: boolean}>`
+  cursor: ${p => (p.$isClickable ? 'pointer' : 'default')};
+`;
+CursorBox.displayName = 'S.CursorBox';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -1,0 +1,130 @@
+import {
+  DataGridProProps,
+  GridApiPro,
+  GridColDef,
+  GridRowHeightParams,
+} from '@mui/x-data-grid-pro';
+import _ from 'lodash';
+import React, {useEffect, useMemo, useState} from 'react';
+
+import {useWeaveContext} from '../../../../../../context';
+import {constString, opGet} from '../../../../../../core';
+import {StyledDataGrid} from '../../StyledDataGrid';
+import {ObjectViewerGroupingCell} from './ObjectViewerGroupingCell';
+import {mapObject, traverse, TraverseContext, traversed} from './traverse';
+import {isRef, ValueView} from './ValueView';
+
+type Data = Record<string, any>;
+
+type ObjectViewerProps = {
+  apiRef: React.MutableRefObject<GridApiPro>;
+  data: Data;
+  isExpanded: boolean;
+};
+
+// Traverse the data and find all ref URIs.
+const getRefs = (data: Data): string[] => {
+  const refs = new Set<string>();
+  traverse(data, (context: TraverseContext) => {
+    if (isRef(context.value)) {
+      refs.add(context.value);
+    }
+  });
+  return Array.from(refs);
+};
+
+type RefValues = Record<string, any>; // ref URI to value
+
+export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
+  const weave = useWeaveContext();
+  const {client} = weave;
+  const [resolvedData, setResolvedData] = useState<Data>(data);
+
+  useEffect(() => {
+    const refs = getRefs(data);
+    const refValueNodes = refs.map(ref =>
+      opGet({uri: constString(ref)} as any)
+    );
+    const refQueries = refValueNodes.map(node => client.query(node));
+    Promise.all(refQueries).then(values => {
+      const refValues: RefValues = {};
+      for (const [r, v] of _.zip(refs, values)) {
+        if (!r) {
+          // Shouldn't be possible
+          continue;
+        }
+        v._ref = r;
+        refValues[r] = v;
+      }
+      const resolved = mapObject(data, context => {
+        if (isRef(context.value)) {
+          return refValues[context.value];
+        }
+        return context.value;
+      });
+      setResolvedData(resolved);
+    });
+  }, [data, client]);
+
+  const rows = useMemo(() => {
+    const contexts = traversed(
+      resolvedData,
+      c =>
+        c.depth !== 0 && !c.path.endsWith('_ref') && !c.path.endsWith('_type')
+    );
+    return contexts.map((c, id) => ({id, ...c}));
+  }, [resolvedData]);
+
+  const columns: GridColDef[] = [
+    {
+      field: 'value',
+      headerName: 'Value',
+      flex: 1,
+      sortable: false,
+      renderCell: ({row}) => {
+        return <ValueView data={row} isExpanded={isExpanded} />;
+      },
+    },
+  ];
+
+  const groupingColDef: DataGridProProps['groupingColDef'] = useMemo(
+    () => ({
+      headerName: 'Path',
+      hideDescendantCount: true,
+      renderCell: params => <ObjectViewerGroupingCell {...params} />,
+    }),
+    []
+  );
+
+  return (
+    <div style={{overflow: 'hidden'}}>
+      <StyledDataGrid
+        apiRef={apiRef}
+        treeData
+        getTreeDataPath={row => row.path.toStringArray()}
+        rows={rows}
+        columns={columns}
+        defaultGroupingExpansionDepth={isExpanded ? -1 : 0}
+        columnHeaderHeight={38}
+        getRowHeight={(params: GridRowHeightParams) => {
+          if (
+            params.model.valueType === 'string' &&
+            !isRef(params.model.value)
+          ) {
+            return 'auto';
+          }
+          return 38;
+        }}
+        hideFooter
+        rowSelection={false}
+        disableColumnMenu={true}
+        groupingColDef={groupingColDef}
+        sx={{
+          '& .MuiDataGrid-row:hover': {
+            backgroundColor: 'inherit',
+          },
+        }}
+      />
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerGroupingCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerGroupingCell.tsx
@@ -1,0 +1,118 @@
+import {Box, ButtonProps} from '@mui/material';
+import {GridRenderCellParams, useGridApiContext} from '@mui/x-data-grid-pro';
+import _ from 'lodash';
+import React, {FC, MouseEvent} from 'react';
+
+import {Button} from '../../../../../Button';
+import {Tooltip} from '../../../../../Tooltip';
+import {CursorBox} from './CursorBox';
+
+const INSET_SPACING = 40;
+
+/**
+ * Utility component for the ObjectViewer to allow expanding/collapsing of keys.
+ */
+export const ObjectViewerGroupingCell: FC<
+  GridRenderCellParams & {onClick?: (event: MouseEvent) => void}
+> = props => {
+  const {id, field, rowNode, row} = props;
+  const isGroup = rowNode.type === 'group';
+  const apiRef = useGridApiContext();
+  const onClick: ButtonProps['onClick'] = event => {
+    if (!isGroup) {
+      return;
+    }
+
+    apiRef.current.setRowChildrenExpansion(id, !rowNode.childrenExpanded);
+    apiRef.current.setCellFocus(id, field);
+
+    if (props.onClick) {
+      props.onClick(event);
+    }
+
+    event.stopPropagation();
+  };
+
+  const tooltipContent = row.path.toString();
+  const box = (
+    <CursorBox
+      $isClickable={isGroup}
+      onClick={onClick}
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'left',
+        width: '100%',
+      }}>
+      {_.range(rowNode.depth).map(i => {
+        return (
+          <Box
+            key={i}
+            sx={{
+              flex: `0 0 ${INSET_SPACING / 2}px`,
+              width: `${INSET_SPACING / 2}px`,
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          />
+        );
+      })}
+      <Box
+        sx={{
+          flex: `0 0 ${INSET_SPACING}px`,
+          width: `${INSET_SPACING}px`,
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}>
+        {rowNode.type === 'group' ? (
+          <Button
+            variant="quiet"
+            icon={rowNode.childrenExpanded ? 'chevron-down' : 'chevron-next'}
+          />
+        ) : (
+          <Box
+            sx={{
+              width: '100%',
+              height: '100%',
+              pr: 2,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}>
+            <Box
+              sx={{
+                width: '100%',
+                height: '100%',
+              }}></Box>
+            <Box sx={{width: '100%', height: '100%'}}></Box>
+          </Box>
+        )}
+      </Box>
+      <Tooltip
+        content={tooltipContent}
+        trigger={
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flex: '1 1 auto',
+            }}>
+            {props.value}
+          </Box>
+        }
+      />
+    </CursorBox>
+  );
+
+  return box;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import {MOON_150} from '../../../../../../common/css/color.styles';
+import {parseRef} from '../../../../../../react';
+import {SmallRef} from '../../../Browse2/SmallRef';
+import {WANDB_ARTIFACT_REF_PREFIX} from '../wfReactInterface/constants';
+import {ValueViewNumber} from './ValueViewNumber';
+import {ValueViewString} from './ValueViewString';
+
+type ValueData = Record<string, any>;
+
+type ValueViewProps = {
+  data: ValueData;
+  isExpanded: boolean;
+};
+
+export const Primitive = styled.div`
+  display: inline-block;
+  padding: 0 4px;
+  background-color: ${MOON_150};
+  border-radius: 4px;
+  font-weight: 600;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 20px;
+`;
+Primitive.displayName = 'S.Primitive';
+
+export const isRef = (value: any): boolean => {
+  return (
+    typeof value === 'string' && value.startsWith(WANDB_ARTIFACT_REF_PREFIX)
+  );
+};
+
+export const ValueView = ({data, isExpanded}: ValueViewProps) => {
+  if (!data.isLeaf) {
+    if (data.valueType === 'object' && '_ref' in data.value) {
+      return <SmallRef objRef={parseRef(data.value._ref)} />;
+    }
+    return null;
+  }
+
+  if (data.value === undefined) {
+    return null;
+  }
+  if (data.value === null) {
+    return <Primitive>null</Primitive>;
+  }
+  if (isRef(data.value)) {
+    return <SmallRef objRef={parseRef(data.value)} />;
+  }
+
+  if (data.valueType === 'string') {
+    return <ValueViewString value={data.value} isExpanded={isExpanded} />;
+  }
+
+  if (data.valueType === 'number') {
+    return <ValueViewNumber value={data.value} />;
+  }
+
+  if (data.valueType === 'boolean') {
+    return <Primitive>{data.value.toString()}</Primitive>;
+  }
+
+  return <div>{data.value.toString()}</div>;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewNumber.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewNumber.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import {Tooltip} from '../../../../../Tooltip';
+
+type ValueViewNumberProps = {
+  value: number;
+  fractionDigits?: number;
+};
+
+export const ValueViewNumber = ({
+  value,
+  fractionDigits,
+}: ValueViewNumberProps) => {
+  if (Number.isInteger(value)) {
+    return <span>{value.toLocaleString()}</span>;
+  }
+
+  const str = value.toString();
+  const fixed = value.toFixed(fractionDigits ?? 6);
+  const node = <span>{fixed}</span>;
+  if (str !== fixed) {
+    return <Tooltip content={str} trigger={node} />;
+  }
+  return node;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+
+type ValueViewStringProps = {
+  value: string;
+  isExpanded: boolean;
+};
+
+const Collapsed = styled.div`
+  min-height: 38px;
+  line-height: 38px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+Collapsed.displayName = 'S.Collapsed';
+
+const Expanded = styled.div`
+  min-height: 38px;
+  max-height: 300px;
+  display: flex;
+  align-items: center;
+  overflow: auto;
+  white-space: break-spaces;
+`;
+Expanded.displayName = 'S.Expanded';
+
+const ExpandedInner = styled.div`
+  max-height: 300px;
+`;
+ExpandedInner.displayName = 'S.ExpandedInner';
+
+export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
+  if (isExpanded) {
+    return (
+      <Expanded>
+        <ExpandedInner>{value}</ExpandedInner>
+      </Expanded>
+    );
+  }
+  return <Collapsed>{value}</Collapsed>;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.test.ts
@@ -1,0 +1,187 @@
+import {mapObject, ObjectPath} from './traverse';
+
+describe('ObjectPath.toString', () => {
+  it('handles empty path', () => {
+    expect(new ObjectPath([]).toString()).toEqual('');
+  });
+  it('handles simple cases', () => {
+    expect(new ObjectPath(['foo']).toString()).toEqual('foo');
+    expect(new ObjectPath(['foo', 'bar']).toString()).toEqual('foo.bar');
+  });
+  it('escapes periods', () => {
+    expect(new ObjectPath(['foo.bar.baz']).toString()).toEqual(
+      'foo\\.bar\\.baz'
+    );
+  });
+  it('escapes brackets', () => {
+    expect(new ObjectPath(['foo[5]']).toString()).toEqual('foo\\[5\\]');
+  });
+});
+
+describe('ObjectPath.parseString', () => {
+  it('handles empty path', () => {
+    expect(ObjectPath.parseString('')).toEqual([]);
+  });
+  it('handles simple cases', () => {
+    expect(ObjectPath.parseString('foo')).toEqual(['foo']);
+    expect(ObjectPath.parseString('foo.bar')).toEqual(['foo', 'bar']);
+  });
+  it('handles numeric keys', () => {
+    expect(ObjectPath.parseString('0')).toEqual(['0']);
+    expect(ObjectPath.parseString('42')).toEqual(['42']);
+  });
+  it('handles punctuation in keys', () => {
+    expect(ObjectPath.parseString('a,b!')).toEqual(['a,b!']);
+  });
+  it('handles key access errors', () => {
+    expect(() => {
+      ObjectPath.parseString('.');
+    }).toThrow();
+    expect(() => {
+      ObjectPath.parseString('a[0].');
+    }).toThrow();
+    expect(() => {
+      ObjectPath.parseString('a..b');
+    }).toThrow();
+  });
+  it('handles array index cases', () => {
+    expect(ObjectPath.parseString('foo[2]')).toEqual(['foo', 2]);
+    expect(ObjectPath.parseString('foo[2][3]')).toEqual(['foo', 2, 3]);
+  });
+  it('handles array index errors', () => {
+    expect(() => {
+      ObjectPath.parseString('foo[');
+    }).toThrow();
+    expect(() => {
+      ObjectPath.parseString('foo[]');
+    }).toThrow();
+    expect(() => {
+      ObjectPath.parseString('foo[1e3]');
+    }).toThrow();
+    expect(() => {
+      ObjectPath.parseString('foo.[1]');
+    }).toThrow();
+  });
+  it('handles escaped chars', () => {
+    expect(ObjectPath.parseString('foo\\.bar')).toEqual(['foo.bar']);
+    expect(ObjectPath.parseString('foo\\[')).toEqual(['foo[']);
+  });
+  it('handles escaping error', () => {
+    expect(() => {
+      ObjectPath.parseString('foo\\');
+    }).toThrow();
+  });
+  it('handles complex cases', () => {
+    expect(ObjectPath.parseString('fo\\.o[1].bar.baz.bim[3][5].wat')).toEqual([
+      'fo.o',
+      1,
+      'bar',
+      'baz',
+      'bim',
+      3,
+      5,
+      'wat',
+    ]);
+  });
+});
+
+describe('ObjectPath.apply', () => {
+  const obj = {
+    foo: 'bar',
+    baz: [40, 41, 42, 43, 44],
+    qux: {
+      quux: 'quuz',
+      quub: {
+        quud: 'quul',
+      },
+    },
+    arr: [
+      99,
+      {
+        a: 'b',
+      },
+    ],
+    'a.b': 'c',
+  };
+  it('handles basic cases', () => {
+    expect(new ObjectPath('lol').apply(obj)).toBe(undefined);
+    expect(new ObjectPath('foo').apply(obj)).toEqual('bar');
+    expect(new ObjectPath('baz').apply(obj)).toEqual([40, 41, 42, 43, 44]);
+    expect(new ObjectPath('qux.quux').apply(obj)).toEqual('quuz');
+    expect(new ObjectPath('baz[2]').apply(obj)).toEqual(42);
+    expect(new ObjectPath('baz[99]').apply(obj)).toBe(undefined);
+    expect(new ObjectPath('arr[1].a').apply(obj)).toEqual('b');
+  });
+});
+
+describe('ObjectPath.set', () => {
+  it('can set an existing top-level key', () => {
+    const obj = {
+      foo: 'bar',
+    };
+    new ObjectPath('foo').set(obj, 'abc');
+    expect(obj).toEqual({foo: 'abc'});
+  });
+  it('can set a non-existing top-level key', () => {
+    const obj = {};
+    new ObjectPath('bim').set(obj, 'baz');
+    expect(obj).toEqual({bim: 'baz'});
+  });
+  it('can traverse nested objects', () => {
+    const obj = {foo: {bar: {baz: 42}}};
+    new ObjectPath('foo.bar.baz').set(obj, 19);
+    expect(obj).toEqual({foo: {bar: {baz: 19}}});
+  });
+  it('can set an index within an array', () => {
+    const obj = {
+      foo: [10, 20, 30],
+    };
+    new ObjectPath('foo[1]').set(obj, 'abc');
+    expect(obj).toEqual({foo: [10, 'abc', 30]});
+  });
+});
+
+describe('mapObject', () => {
+  it('can turn integers into strings', () => {
+    const obj = {
+      foo: [10, 20, 30],
+      bar: {
+        baz: 42,
+      },
+    };
+    expect(
+      mapObject(obj, context => {
+        if (typeof context.value === 'number') {
+          return context.value.toString();
+        }
+        return context.value;
+      })
+    ).toEqual({
+      foo: ['10', '20', '30'],
+      bar: {baz: '42'},
+    });
+  });
+  it('can replace a deeply nested object', () => {
+    const obj = {
+      foo: {
+        bar: {
+          baz: 'findme',
+        },
+      },
+    };
+    expect(
+      mapObject(obj, context => {
+        if (context.value === 'findme') {
+          return {found: true};
+        }
+        return context.value;
+      })
+    ).toEqual({
+      foo: {
+        bar: {
+          baz: {found: true},
+        },
+      },
+    });
+  });
+});

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
@@ -1,0 +1,309 @@
+/**
+ * There are are a number of JavaScript/TypeScript libraries for traversing
+ * objects, but none of the ones I looked at were quite what I wanted.
+ */
+
+// String indicates object key access, number indicates array index access
+// This structure allows us to handle corner cases like periods or brackets
+// in object keys.
+type PathElement = string | number;
+type Path = PathElement[];
+
+const escapeKey = (key: string): string => {
+  return key.replace(/\./g, '\\.').replace(/\[/g, '\\[').replace(/\]/g, '\\]');
+};
+
+export class ObjectPath {
+  static parseString(pathString: string): Path {
+    const path = [];
+    let key = '';
+    const n = pathString.length;
+    for (let i = 0; i < n; i++) {
+      const char = pathString[i];
+      if (char === '\\') {
+        if (i === n - 1) {
+          throw new Error('Invalid escape sequence');
+        }
+        key += pathString[i + 1];
+        i++;
+      } else if (char === '.') {
+        if (i === 0 || i === n - 1) {
+          throw new Error('Invalid object access');
+        }
+        const prev = pathString[i - 1];
+        const next = pathString[i + 1];
+        if (!/^[a-z0-9]$/i.test(next) || !/^[a-z0-9\]]$/i.test(prev)) {
+          throw new Error('Invalid object access');
+        }
+        if (key) {
+          path.push(key);
+          key = '';
+        }
+      } else if (char === '[') {
+        if (key) {
+          path.push(key);
+          key = '';
+        }
+        let j = i + 1;
+        while (j < n && pathString[j] !== ']') {
+          j++;
+        }
+        const indexStr = pathString.slice(i + 1, j);
+        if (j === n) {
+          throw new Error(`Invalid array index: '${indexStr}'`);
+        }
+        if (!/^\d+$/.test(indexStr)) {
+          throw new Error(`Invalid array index: '${indexStr}'`);
+        }
+        path.push(parseInt(indexStr, 10));
+        i = j;
+      } else {
+        key += char;
+      }
+    }
+    if (key) {
+      path.push(key);
+    }
+    return path;
+  }
+
+  private path: Path;
+
+  constructor(path: PathElement | Path = []) {
+    if (typeof path === 'string') {
+      this.path = ObjectPath.parseString(path);
+    } else if (typeof path === 'number') {
+      this.path = [path];
+    } else {
+      this.path = path;
+    }
+  }
+
+  plus(element: PathElement): ObjectPath {
+    return new ObjectPath([...this.path, element]);
+  }
+
+  tail(): PathElement | undefined {
+    return this.path[this.path.length - 1];
+  }
+
+  endsWith(element: PathElement): boolean {
+    return this.path[this.path.length - 1] === element;
+  }
+
+  length(): number {
+    return this.path.length;
+  }
+
+  ancestor(depth: number): ObjectPath {
+    return new ObjectPath(this.path.slice(0, depth));
+  }
+
+  toPath(): Path {
+    return [...this.path];
+  }
+
+  toStringArray(): string[] {
+    return this.path.map(e => (typeof e === 'string' ? e : e.toString()));
+  }
+
+  toString(): string {
+    let result = '';
+    for (const element of this.path) {
+      if (typeof element === 'string') {
+        const escaped = escapeKey(element);
+        if (result) {
+          result += '.';
+        }
+        result += escaped;
+      } else {
+        result += '[' + element + ']';
+      }
+    }
+    return result;
+  }
+
+  // Given an object, return what this path points to.
+  apply(obj: any): any {
+    let result = obj;
+    for (const element of this.path) {
+      if (result === undefined) {
+        return undefined;
+      }
+      result = result[element];
+    }
+    return result;
+  }
+
+  // Given an object and value, update the value for the path.
+  set(obj: any, value: any) {
+    let target = obj;
+    const n = this.path.length;
+    for (let i = 0; i < n - 1; i++) {
+      const element = this.path[i];
+      if (!(element in target)) {
+        target[element] = typeof element === 'number' ? [] : {};
+      }
+      target = target[element];
+    }
+    target[this.path[n - 1]] = value;
+  }
+}
+
+type ValueType =
+  | 'null'
+  | 'undefined'
+  | 'boolean'
+  | 'number'
+  | 'string'
+  | 'object'
+  | 'array';
+
+export const getValueType = (value: any): ValueType => {
+  if (value === null) {
+    return 'null';
+  }
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (typeof value === 'boolean') {
+    return 'boolean';
+  }
+  if (typeof value === 'number') {
+    return 'number';
+  }
+  if (typeof value === 'string') {
+    return 'string';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  return 'object';
+};
+
+const isLeafType = (valueType: ValueType): boolean => {
+  return valueType !== 'object' && valueType !== 'array';
+};
+
+export type TraverseContext = {
+  path: ObjectPath;
+  value: any;
+  valueType: ValueType;
+  isLeaf: boolean;
+  depth: number;
+};
+
+type CallbackResult = void | boolean | 'skip';
+
+type Callback = (context: TraverseContext) => CallbackResult;
+
+// For debugging purposes we have a default callback that just prints
+// a line for each visited node in the object.
+const DEFAULT_CALLBACK: Callback = context => {
+  const {value, path, depth} = context;
+  const prefix = depth.toString().padStart(2, '0') + '  ';
+  let valueStr = '';
+  if (value === null) {
+    valueStr = '<null>';
+  } else {
+    valueStr = value.toString();
+    try {
+      valueStr = JSON.stringify(value);
+    } catch (e) {
+      // Ignore
+    }
+  }
+  console.log(`${prefix}${path} ${valueStr}`);
+};
+
+export const traverse = (
+  data: any,
+  callback?: (context: TraverseContext) => CallbackResult
+) => {
+  callback = callback ?? DEFAULT_CALLBACK;
+  const path: ObjectPath = new ObjectPath();
+  const valueType = getValueType(data);
+  const start: TraverseContext = {
+    value: data,
+    valueType,
+    isLeaf: isLeafType(valueType),
+    path,
+    depth: 0,
+  };
+  const stack = [start];
+  while (stack.length) {
+    const context = stack.pop();
+    if (!context) {
+      continue;
+    }
+    const action = callback(context);
+    if (action === 'skip') {
+      continue;
+    } else if (action === false) {
+      break;
+    }
+    if (context.valueType === 'array') {
+      const n = context.value.length;
+      for (let i = n - 1; i >= 0; i--) {
+        const value = context.value[i];
+        const itemValueType = getValueType(value);
+        stack.push({
+          value,
+          valueType: itemValueType,
+          isLeaf: isLeafType(itemValueType),
+          path: context.path.plus(i),
+          depth: context.depth + 1,
+        });
+      }
+    } else if (context.valueType === 'object') {
+      // Reverse so we pop them in the original order
+      const keys = Object.keys(context.value).reverse();
+      for (const key of keys) {
+        const value = context.value[key];
+        const itemValueType = getValueType(value);
+        stack.push({
+          value,
+          valueType: itemValueType,
+          isLeaf: isLeafType(itemValueType),
+          path: context.path.plus(key),
+          depth: context.depth + 1,
+        });
+      }
+    }
+  }
+};
+
+const UNFILTERED = () => true;
+
+// Convenience wrapper around traverse returning an optionally
+// filtered list of context objects.
+export const traversed = (
+  data: any,
+  filter?: (context: TraverseContext) => boolean
+): TraverseContext[] => {
+  const matches: TraverseContext[] = [];
+  const f = filter ?? UNFILTERED;
+  traverse(data, context => {
+    const result = f(context);
+    if (result) {
+      matches.push(context);
+    }
+  });
+  return matches;
+};
+
+export const mapObject = (
+  data: any,
+  transform: (context: TraverseContext) => any
+) => {
+  const result = {};
+  traverse(data, context => {
+    if (context.depth === 0) {
+      return;
+    }
+    const newValue = transform(context);
+    // TODO: Maybe support a special value to indicate deletion?
+    context.path.set(result, newValue);
+  });
+  return result;
+};


### PR DESCRIPTION
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1709147066569379

New features:
* Use material tree grid to render, allowing expanding/collapsing sections and resizing the path/value columns.
* Fetch ref values so they can be displayed.
* JSON view
* Show/hide section
* First pass at rendering primitive values like numbers, null, boolean to better indicate type.

Before:
<img width="708" alt="Screenshot 2024-02-28 at 1 18 42 PM" src="https://github.com/wandb/weave/assets/112953339/3b6c72a8-cbad-4c34-bedc-07da52196fa3">


After:
<img width="706" alt="Screenshot 2024-02-28 at 1 19 10 PM" src="https://github.com/wandb/weave/assets/112953339/9910e57c-d23c-420c-8866-598b3e3402a7">

