### PR TITLE
chore: improve object version page and Use tab

### DIFF
--- a/weave-js/src/components/CopyableText.tsx
+++ b/weave-js/src/components/CopyableText.tsx
@@ -18,7 +18,7 @@ type CopyableTextProps = {
   onClick?(): void;
 };
 
-export const Wrapper = styled.div`
+const Wrapper = styled.div`
   background-color: ${MOON_100};
   display: flex;
   align-items: center;
@@ -30,7 +30,14 @@ export const Wrapper = styled.div`
 `;
 Wrapper.displayName = 'S.Wrapper';
 
-export const Text = styled.code`
+const IconCell = styled.div`
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+`;
+IconCell.displayName = 'S.IconCell';
+
+const Text = styled.code`
   font-size: 0.7em;
 `;
 Text.displayName = 'S.Text';
@@ -58,12 +65,14 @@ export const CopyableText = ({
         copy();
         onClick?.();
       }}>
-      <Icon
-        name={icon ?? 'copy'}
-        width={16}
-        height={16}
-        style={{marginRight: 8}}
-      />
+      <IconCell>
+        <Icon
+          name={icon ?? 'copy'}
+          width={16}
+          height={16}
+          style={{marginRight: 8}}
+        />
+      </IconCell>
       <Text>{text}</Text>
     </Wrapper>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -144,7 +144,6 @@ const ObjectVersionPageInner: React.FC<{
             //     version={typeVersionHash}
             //   />
             // ),
-            Ref: <span>{refUri}</span>,
             ...((producingCalls.result?.length ?? 0) > 0
               ? {
                   [maybePluralizeWord(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
@@ -2,6 +2,7 @@ import {Alert, Box} from '@mui/material';
 import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
+import {parseRef} from '../../../../../react';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 
@@ -10,8 +11,19 @@ type TabUseDatasetProps = {
   uri: string;
 };
 
+const ROW_PATH_PREFIX = 'atr/rows/ndx/';
+
 export const TabUseDataset = ({name, uri}: TabUseDatasetProps) => {
-  const pythonName = isValidVarName(name) ? name : 'dataset';
+  const ref = parseRef(uri);
+  const isParentObject = !ref.artifactRefExtra;
+  const isRow = ref.artifactRefExtra?.startsWith(ROW_PATH_PREFIX) ?? false;
+  const label = isParentObject ? 'dataset version' : isRow ? 'row' : 'object';
+  let pythonName = isValidVarName(name) ? name : 'dataset';
+  if (isRow) {
+    pythonName +=
+      '_row' + ref.artifactRefExtra?.substring(ROW_PATH_PREFIX.length);
+  }
+
   return (
     <Box m={2}>
       <Alert severity="info" variant="outlined">
@@ -25,11 +37,11 @@ export const TabUseDataset = ({name, uri}: TabUseDatasetProps) => {
       </Alert>
 
       <Box mt={2}>
-        The ref for this dataset version is:
+        The ref for this {label} is:
         <CopyableText text={uri} />
       </Box>
       <Box mt={2}>
-        Use the following code to retrieve this dataset version:
+        Use the following code to retrieve this {label}:
         <CopyableText
           text={`${pythonName} = weave.ref("<ref_uri>").get()`}
           copyText={`${pythonName} = weave.ref("${uri}").get()`}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
@@ -2,6 +2,7 @@ import {Alert, Box} from '@mui/material';
 import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
+import {parseRef} from '../../../../../react';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 
@@ -13,6 +14,10 @@ type TabUseModelProps = {
 
 export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
   const pythonName = isValidVarName(name) ? name : 'model';
+  const ref = parseRef(uri);
+  const isParentObject = !ref.artifactRefExtra;
+  const label = isParentObject ? 'model version' : 'object';
+
   return (
     <Box m={2}>
       <Alert severity="info" variant="outlined">
@@ -26,32 +31,36 @@ export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
       </Alert>
 
       <Box mt={2}>
-        The ref for this model version is:
+        The ref for this {label} is:
         <CopyableText text={uri} />
       </Box>
       <Box mt={2}>
-        Use the following code to retrieve this model version:
+        Use the following code to retrieve this {label}:
         <CopyableText
           text={`${pythonName} = weave.ref("<ref_uri>").get()`}
           copyText={`${pythonName} = weave.ref("${uri}").get()`}
         />
       </Box>
-      <Box mt={2}>
-        To <DocLink path="guides/tools/serve" text="serve this model" /> locally
-        with a Swagger UI:
-        <CopyableText
-          text="weave serve <ref_uri>"
-          copyText={`weave serve ${uri}`}
-        />
-      </Box>
-      <Box mt={2}>
-        To <DocLink path="guides/tools/deploy" text="deploy this model" /> to
-        the cloud run:
-        <CopyableText
-          text={`weave deploy gcp --project "${projectName}" <ref_uri>`}
-          copyText={`weave deploy gcp --project "${projectName}" ${uri}`}
-        />
-      </Box>
+      {isParentObject && (
+        <>
+          <Box mt={2}>
+            To <DocLink path="guides/tools/serve" text="serve this model" />{' '}
+            locally with a Swagger UI:
+            <CopyableText
+              text="weave serve <ref_uri>"
+              copyText={`weave serve ${uri}`}
+            />
+          </Box>
+          <Box mt={2}>
+            To <DocLink path="guides/tools/deploy" text="deploy this model" />{' '}
+            to the cloud run:
+            <CopyableText
+              text={`weave deploy gcp --project "${projectName}" <ref_uri>`}
+              copyText={`weave deploy gcp --project "${projectName}" ${uri}`}
+            />
+          </Box>
+        </>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
* Remove "ref" from header because it appears in Use tab.
* Don't shrink copy-to-clipboard icon when panel is narrow
* Use tab now handles subpaths within parent objects better.