### PR TITLE
chore(weave): Fix datetimes coming out of trace server

### DIFF
--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -82,9 +82,6 @@ def test_trace_server_call_start_and_end(clickhouse_trace_server):
     exp_start_datetime = datetime.datetime.fromisoformat(
         start.start_datetime.isoformat(timespec="milliseconds")
     )
-    # TODO: Figure out why this is failing in CI
-    if os.environ.get("CI"):
-        exp_start_datetime = exp_start_datetime.replace(tzinfo=None)
 
     assert res.call.model_dump() == {
         "entity": "test_entity",
@@ -123,9 +120,6 @@ def test_trace_server_call_start_and_end(clickhouse_trace_server):
     exp_end_datetime = datetime.datetime.fromisoformat(
         end.end_datetime.isoformat(timespec="milliseconds")
     )
-    # TODO: Figure out why this is failing in CI
-    if os.environ.get("CI"):
-        exp_end_datetime = exp_end_datetime.replace(tzinfo=None)
 
     assert res.call.model_dump() == {
         "entity": "test_entity",


### PR DESCRIPTION
See comment:
```
  # https://github.com/ClickHouse/clickhouse-connect/issues/210
  # Clickhouse does not support timezone-aware datetimes. You can specify the
  # desired timezone at query time. However according to the issue above,
  # clickhouse will produce a timezone-naive datetime when the preferred
  # timezone is UTC. This is a problem because it does not match the ISO8601
  # standard as datetimes are to be interpreted locally unless specified
  # otherwise. This function ensures that the datetime has a timezone, and if
  # it does not, it adds the UTC timezone to correctly convey that the
  # datetime is in UTC for the caller.
```