### PR TITLE
chore(weave): Makes trace server the new default logger

### DIFF
--- a/weave/api.py
+++ b/weave/api.py
@@ -150,7 +150,10 @@ def init(project_name: str) -> _graph_client.GraphClient:
     Returns:
         A Weave client.
     """
-    return _weave_init.init_wandb(project_name).client
+    # This is the stream-table backend. Disabling it in favor of the new
+    # trace-server backend.
+    # return _weave_init.init_wandb(project_name).client
+    return _weave_init.init_trace_remote(project_name).client
 
 
 @contextlib.contextmanager

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -28,4 +28,4 @@ def wf_clickhouse_database() -> str:
 
 def wf_trace_server_url() -> str:
     """The url of the web server exposing the trace interface endpoints"""
-    return os.environ.get("WF_TRACE_SERVER_URL", "http://127.0.0.1:6345")
+    return os.environ.get("WF_TRACE_SERVER_URL", "https://trace.wandb.ai")


### PR DESCRIPTION
With this change, we now leverage the new trace server for call logging.