### PR TITLE
chore: reorder navigation bar

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/SideNav.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/SideNav.tsx
@@ -4,7 +4,7 @@ import {useParams} from 'react-router-dom';
 
 import {useWeaveflowRouteContext} from './context';
 import {useURLSearchParamsDict} from './pages/util';
-import {refDictToRefString} from './pages/wfInterface/naive';
+// import {refDictToRefString} from './pages/wfInterface/naive';
 import {Sidebar, SidebarItem} from './Sidebar';
 
 export const SideNav = () => {
@@ -76,24 +76,32 @@ export const SideNav = () => {
   const items: SidebarItem[][] = [
     [
       {
-        id: 'evaluation',
-        name: 'Evaluations',
-        iconName: IconNames.TypeNumber,
+        id: 'calls',
+        name: 'Traces',
+        iconName: IconNames.LayoutTabs,
         path: baseRouter.callsUIUrl(entity, project, {
-          opCategory: 'evaluate',
-          opVersionRefs: [
-            refDictToRefString({
-              entity: currentEntity,
-              project: currentProject,
-              artifactName: 'Evaluation-evaluate',
-              versionCommitHash: '*',
-              filePathParts: ['obj'],
-              refExtraTuples: [],
-            }),
-          ],
-          isPivot: true,
+          traceRootsOnly: true,
         }),
       },
+      // {
+      //   id: 'evaluation',
+      //   name: 'Evaluations',
+      //   iconName: IconNames.TypeNumber,
+      //   path: baseRouter.callsUIUrl(entity, project, {
+      //     opCategory: 'evaluate',
+      //     opVersionRefs: [
+      //       refDictToRefString({
+      //         entity: currentEntity,
+      //         project: currentProject,
+      //         artifactName: 'Evaluation-evaluate',
+      //         versionCommitHash: '*',
+      //         filePathParts: ['obj'],
+      //         refExtraTuples: [],
+      //       }),
+      //     ],
+      //     isPivot: true,
+      //   }),
+      // },
       {
         id: 'models',
         name: 'Models',
@@ -117,14 +125,6 @@ export const SideNav = () => {
         name: 'Operations',
         iconName: IconNames.JobProgramCode,
         path: baseRouter.opVersionsUIUrl(entity, project, {}),
-      },
-      {
-        id: 'calls',
-        name: 'Traces',
-        iconName: IconNames.RunningRepeat,
-        path: baseRouter.callsUIUrl(entity, project, {
-          traceRootsOnly: true,
-        }),
       },
       {
         id: 'objects',


### PR DESCRIPTION
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1709239253561709

Move traces to top, hide evaluations for now.

<img width="51" alt="Screenshot 2024-02-29 at 3 44 30 PM" src="https://github.com/wandb/weave/assets/112953339/4df3051b-58b0-4b4e-91c4-b668569bd8c4">
