### PR TITLE
chore: fix dev console Autocomplete warning

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -303,7 +303,7 @@ export const CallsTable: FC<{
                   isPivoting ||
                   Object.keys(props.frozenFilter ?? {}).includes('opVersions')
                 }
-                value={effectiveFilter.opVersionRefs?.[0] ?? null}
+                value={opVersion ? opVersionRef : null}
                 onChange={(event, newValue) => {
                   setFilter({
                     ...filter,


### PR DESCRIPTION
Fix this developer console warning:
<img width="1516" alt="Screenshot 2024-02-29 at 10 15 04 PM" src="https://github.com/wandb/weave/assets/112953339/fc92072a-5b88-4ef6-96a1-605d8dd1e392">

This is coming from the multiple child calls table. `CallsTable` is getting `hideControls={true}`, but that does just hide the filters, they are still there.

The op autocomplete filter gets its options from `useOpVersionOptions` which does two queries. This warning happens because we are specifying the autocomplete value based on the selection, but the query for the selected op versions may not have completed at the time we get the partial list of options back from the other query finishing.
