### PR TITLE
chore: remove op- prefix in op selector

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -498,7 +498,7 @@ const useOpVersionOptions = (
       ov => {
         const ref = opVersionKeyToRefUri(ov);
         result.push({
-          title: ov.opId + ':v' + ov.versionIndex,
+          title: opNiceName(ov.opId) + ':v' + ov.versionIndex,
           ref,
           group: `Versions of ${opNiceName(currentOpId!)}`,
           objectVersion: ov,


### PR DESCRIPTION
Before:
<img width="202" alt="Screenshot 2024-03-01 at 10 29 12 AM" src="https://github.com/wandb/weave/assets/112953339/341cff84-5b04-44a7-9ad3-b6eca5167a10">

After:
<img width="222" alt="Screenshot 2024-03-01 at 10 27 51 AM" src="https://github.com/wandb/weave/assets/112953339/37341a33-061a-46a0-bc74-9c601613c4bb">
