### PR TITLE
chore: remove unused experimental code

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -168,7 +168,7 @@ const CallPageInnerVertical: FC<{
       }
       isSidebarOpen={showTraceTree}
       headerContent={<CallOverview call={call} />}
-      leftSidebar={<CallTraceView call={call} treeOnly />}
+      leftSidebar={<CallTraceView call={call} />}
       tabs={callTabs}
     />
   );


### PR DESCRIPTION
The CallTraceView supported displaying additional input/output columns as an experiment, but that code path was disabled. 

It turns out I introduced a crash when I added the "hidden siblings" indicator if you turned it on. Fixing the crash would be trivial, but it seemed better just to remove the experimental code since I don't think we're going to use this UX.