### PR TITLE
fix: null values in object viewer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/WeaveEditors.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/WeaveEditors.tsx
@@ -61,6 +61,7 @@ import {
   useWeaveflowCurrentRouteContext,
   WeaveflowPeekContext,
 } from '../Browse3/context';
+import {ValueViewPrimitive} from '../Browse3/pages/CallPage/ValueViewPrimitive';
 import {Link} from '../Browse3/pages/common/Links';
 import {
   DICT_KEY_EDGE_TYPE,
@@ -79,6 +80,9 @@ import {parseRefMaybe, SmallRef} from './SmallRef';
 import {useRefPageUrl} from './url';
 
 const displaysAsSingleRow = (valueType: Type) => {
+  if (valueType === 'none') {
+    return true;
+  }
   if (isAssignableTo(valueType, maybe({type: 'list', objectType: 'any'}))) {
     return false;
   }
@@ -374,6 +378,9 @@ const WeaveEditorField: FC<{
   disableEdits?: boolean;
 }> = ({node, path, disableEdits}) => {
   const weave = useWeaveContext();
+  if (node.type === 'none') {
+    return <ValueViewPrimitive>null</ValueViewPrimitive>;
+  }
   if (isAssignableTo(node.type, maybe('boolean'))) {
     return <WeaveEditorBoolean node={node} path={path} disableEdits />;
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import styled from 'styled-components';
 
-import {MOON_150} from '../../../../../../common/css/color.styles';
 import {parseRef} from '../../../../../../react';
 import {SmallRef} from '../../../Browse2/SmallRef';
 import {WANDB_ARTIFACT_REF_PREFIX} from '../wfReactInterface/constants';
 import {ValueViewNumber} from './ValueViewNumber';
+import {ValueViewPrimitive} from './ValueViewPrimitive';
 import {ValueViewString} from './ValueViewString';
 
 type ValueData = Record<string, any>;
@@ -14,18 +13,6 @@ type ValueViewProps = {
   data: ValueData;
   isExpanded: boolean;
 };
-
-export const Primitive = styled.div`
-  display: inline-block;
-  padding: 0 4px;
-  background-color: ${MOON_150};
-  border-radius: 4px;
-  font-weight: 600;
-  font-family: monospace;
-  font-size: 10px;
-  line-height: 20px;
-`;
-Primitive.displayName = 'S.Primitive';
 
 export const isRef = (value: any): boolean => {
   return (
@@ -45,7 +32,7 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
     return null;
   }
   if (data.value === null) {
-    return <Primitive>null</Primitive>;
+    return <ValueViewPrimitive>null</ValueViewPrimitive>;
   }
   if (isRef(data.value)) {
     return <SmallRef objRef={parseRef(data.value)} />;
@@ -60,7 +47,7 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
   }
 
   if (data.valueType === 'boolean') {
-    return <Primitive>{data.value.toString()}</Primitive>;
+    return <ValueViewPrimitive>{data.value.toString()}</ValueViewPrimitive>;
   }
 
   return <div>{data.value.toString()}</div>;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewPrimitive.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewPrimitive.tsx
@@ -1,0 +1,15 @@
+import styled from 'styled-components';
+
+import {MOON_150} from '../../../../../../common/css/color.styles';
+
+export const ValueViewPrimitive = styled.div`
+  display: inline-block;
+  padding: 0 4px;
+  background-color: ${MOON_150};
+  border-radius: 4px;
+  font-weight: 600;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 20px;
+`;
+ValueViewPrimitive.displayName = 'S.ValueViewPrimitive';


### PR DESCRIPTION
We should do a more comprehensive alignment of how we display values, but wanted to get in a quick fix for null values appearing as disabled checkboxes.

Before:
<img width="185" alt="Screenshot 2024-03-02 at 9 49 35 AM" src="https://github.com/wandb/weave/assets/112953339/6bb22709-77f1-4687-a5d1-14bcb37cc2fc">

After:
<img width="177" alt="Screenshot 2024-03-02 at 9 49 55 AM" src="https://github.com/wandb/weave/assets/112953339/b87d561a-660e-4353-aab5-5ba82cfd71ba">
