### PR TITLE
feat: better support for long string values

### DIFF
--- a/weave-js/src/components/CodeEditor.tsx
+++ b/weave-js/src/components/CodeEditor.tsx
@@ -15,7 +15,7 @@ const Editor = React.lazy(async () => {
 
 type CodeEditorProps = {
   value: string;
-  language: string;
+  language?: string;
   readOnly?: boolean;
   onChange?: (value: string) => void;
   maxHeight?: number;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
@@ -1,42 +1,194 @@
-import React from 'react';
+import copyToClipboard from 'copy-to-clipboard';
+import React, {ReactNode, useCallback, useEffect, useState} from 'react';
 import styled from 'styled-components';
+
+import {toast} from '../../../../../../common/components/elements/Toast';
+import Markdown from '../../../../../../common/components/Markdown';
+import {MOON_150} from '../../../../../../common/css/color.styles';
+import {Button} from '../../../../../Button';
+import {CodeEditor} from '../../../../../CodeEditor';
+import {ValueViewStringFormatMenu} from './ValueViewStringFormatMenu';
 
 type ValueViewStringProps = {
   value: string;
   isExpanded: boolean;
 };
 
-const Collapsed = styled.div`
+const MAX_SCROLL_HEIGHT = 300;
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+Column.displayName = 'S.Column';
+
+const Toolbar = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+  border-bottom: 1px solid ${MOON_150};
+`;
+Toolbar.displayName = 'S.Toolbar';
+
+const Spacer = styled.div`
+  flex: 1 1 auto;
+`;
+Spacer.displayName = 'S.Spacer';
+
+const Collapsed = styled.div<{hasScrolling: boolean}>`
   min-height: 38px;
   line-height: 38px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: ${props => (props.hasScrolling ? 'pointer' : 'default')};
 `;
 Collapsed.displayName = 'S.Collapsed';
 
-const Expanded = styled.div`
+const Scrolling = styled.div`
   min-height: 38px;
-  max-height: 300px;
+  max-height: ${MAX_SCROLL_HEIGHT}px;
   display: flex;
   align-items: center;
   overflow: auto;
   white-space: break-spaces;
 `;
-Expanded.displayName = 'S.Expanded';
+Scrolling.displayName = 'S.Scrolling';
 
-const ExpandedInner = styled.div`
-  max-height: 300px;
+const ScrollingInner = styled.div`
+  width: 100%;
+  max-height: ${MAX_SCROLL_HEIGHT}px;
 `;
-ExpandedInner.displayName = 'S.ExpandedInner';
+ScrollingInner.displayName = 'S.ScrollingInner';
+
+const Full = styled.div`
+  white-space: break-spaces;
+`;
+Full.displayName = 'S.Full';
+
+const isJSON = (value: string): boolean => {
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed === 'object') {
+      return true;
+    }
+  } catch (err) {
+    // ignore
+  }
+  return false;
+};
 
 export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
-  if (isExpanded) {
-    return (
-      <Expanded>
-        <ExpandedInner>{value}</ExpandedInner>
-      </Expanded>
+  const trimmed = value.trim();
+  const hasScrolling = trimmed.indexOf('\n') !== -1 || value.length > 100;
+  const [hasFull, setHasFull] = useState(false);
+
+  const json = isJSON(trimmed);
+  const [format, setFormat] = useState(json ? 'JSON' : 'Text');
+
+  const [mode, setMode] = useState(hasScrolling ? (isExpanded ? 1 : 0) : 0);
+
+  useEffect(() => {
+    setMode(hasScrolling ? (isExpanded ? 1 : 0) : 0);
+  }, [hasScrolling, isExpanded]);
+
+  const onClick = hasScrolling
+    ? () => {
+        const numModes = hasFull ? 3 : 2;
+        setMode((mode + 1) % numModes);
+      }
+    : undefined;
+  const copy = useCallback(() => {
+    copyToClipboard(value);
+    toast('Copied to clipboard');
+  }, [value]);
+
+  const onSetFormat = (newFormat: string) => {
+    setFormat(newFormat);
+  };
+
+  const scrollingRef = React.createRef<HTMLDivElement>();
+
+  useEffect(() => {
+    if (scrollingRef.current) {
+      setHasFull(scrollingRef.current.offsetHeight >= MAX_SCROLL_HEIGHT);
+    }
+  }, [mode, value, scrollingRef]);
+
+  let toolbar = null;
+  if (mode !== 0) {
+    toolbar = (
+      <Toolbar>
+        {mode === 1 && hasFull && (
+          <Button
+            size="small"
+            variant="ghost"
+            icon="expand-uncollapse"
+            tooltip="Maximize"
+            onClick={() => setMode(2)}
+          />
+        )}
+        <Button
+          size="small"
+          variant="ghost"
+          icon="collapse"
+          tooltip="Minimize"
+          onClick={() => setMode(0)}
+        />
+        <Button
+          style={{marginLeft: 8}}
+          size="small"
+          variant="ghost"
+          icon="copy"
+          tooltip="Copy to clipboard"
+          onClick={e => {
+            e.stopPropagation();
+            copy();
+          }}
+        />
+        <Spacer />
+        <ValueViewStringFormatMenu format={format} onSetFormat={onSetFormat} />
+      </Toolbar>
     );
   }
-  return <Collapsed>{value}</Collapsed>;
+
+  let content: ReactNode = trimmed;
+  if (format === 'JSON') {
+    let reformatted = trimmed;
+    try {
+      reformatted = JSON.stringify(JSON.parse(trimmed), null, 2);
+    } catch (err) {
+      // ignore
+    }
+    content = <CodeEditor value={reformatted} language="json" readOnly />;
+  } else if (format === 'Markdown') {
+    content = <Markdown content={trimmed} />;
+  } else if (format === 'Code') {
+    content = <CodeEditor value={trimmed} readOnly />;
+  }
+
+  if (mode === 2) {
+    return (
+      <Column>
+        {toolbar}
+        <Full>{content}</Full>
+      </Column>
+    );
+  }
+  if (mode === 1) {
+    return (
+      <Column>
+        {toolbar}
+        <Scrolling ref={scrollingRef}>
+          <ScrollingInner>{content}</ScrollingInner>
+        </Scrolling>
+      </Column>
+    );
+  }
+  return (
+    <Collapsed hasScrolling={hasScrolling} onClick={onClick}>
+      {value}
+    </Collapsed>
+  );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewStringFormatMenu.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewStringFormatMenu.tsx
@@ -1,0 +1,45 @@
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import * as React from 'react';
+
+import {Button} from '../../../../../Button';
+
+type ValueViewStringFormatMenuProps = {
+  format: string;
+  onSetFormat: (format: string) => void;
+};
+
+export const ValueViewStringFormatMenu = ({
+  format,
+  onSetFormat,
+}: ValueViewStringFormatMenuProps) => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const onClickMenuItem = (newFormat: string) => {
+    onSetFormat(newFormat);
+    handleClose();
+  };
+
+  return (
+    <div>
+      <Button size="small" variant="ghost" onClick={onClick}>
+        {format}
+      </Button>
+      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
+        <MenuItem onClick={() => onClickMenuItem('Text')}>Text</MenuItem>
+        <MenuItem onClick={() => onClickMenuItem('JSON')}>JSON</MenuItem>
+        <MenuItem onClick={() => onClickMenuItem('Markdown')}>
+          Markdown
+        </MenuItem>
+        <MenuItem onClick={() => onClickMenuItem('Code')}>Code</MenuItem>
+      </Menu>
+    </div>
+  );
+};


### PR DESCRIPTION
Continuing to iterate on support for long string values.
* Strings that would require scrolling to show now support a third mode where you can expand the value area even more to show the full string.
* A toolbar is added for long strings to switch between render modes and allow copying to clipboard.
* Added support for detecting JSON and switching between JSON/Code/Markdown/text views.

Collapsed mode, cursor will indicate if clickable to expand.
<img width="755" alt="Screenshot 2024-03-04 at 9 25 04 AM" src="https://github.com/wandb/weave/assets/112953339/d5016eb9-6afb-443a-854c-86fb30effe14">

Scrolling mode, will scroll if > 300px
<img width="842" alt="Screenshot 2024-03-04 at 9 25 23 AM" src="https://github.com/wandb/weave/assets/112953339/2da03b81-c672-4cdd-836a-df728868944a">

Full mode
<img width="833" alt="Screenshot 2024-03-04 at 9 25 45 AM" src="https://github.com/wandb/weave/assets/112953339/3de30de1-f7e9-488b-80ca-2afd1c08e663">

Markdown support
<img width="715" alt="Screenshot 2024-03-04 at 9 27 18 AM" src="https://github.com/wandb/weave/assets/112953339/3e77070f-80e1-4ed5-96cc-cdca627ddf6d">

JSON support
<img width="914" alt="Screenshot 2024-03-04 at 9 27 41 AM" src="https://github.com/wandb/weave/assets/112953339/934568e8-f362-4e44-8594-f0ebb4d9ae1e">

