### PR TITLE
fix: broken full page button

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -48,6 +48,7 @@ import {
   useWeaveflowRouteContext,
   WeaveflowPeekContext,
 } from './Browse3/context';
+import {FullPageButton} from './Browse3/FullPageButton';
 import {BoardPage} from './Browse3/pages/BoardPage';
 import {BoardsPage} from './Browse3/pages/BoardsPage';
 import {CallPage} from './Browse3/pages/CallPage/CallPage';
@@ -290,7 +291,6 @@ const Browse3Mounted: FC<{
 };
 
 const MainPeekingLayout: FC = () => {
-  const history = useHistory();
   const {baseRouter} = useWeaveflowRouteContext();
   const params = useParams<Browse3Params>();
   const baseRouterProjectRoot = baseRouter.projectUrl(':entity', ':project');
@@ -384,25 +384,10 @@ const MainPeekingLayout: FC = () => {
                         height: '47px',
                         flex: '0 0 auto',
                       }}>
-                      <Button
-                        tooltip="Open full page for this object"
-                        icon="full-screen-mode-expand"
-                        variant="ghost"
-                        className="ml-4"
-                        onClick={() => {
-                          const pathname = query.peekPath!.replace(
-                            generalBase,
-                            targetBase
-                          );
-                          const preservedQuery = _.pick(query, ['tracetree']);
-                          const search = new URLSearchParams(
-                            preservedQuery
-                          ).toString();
-                          history.push({
-                            pathname,
-                            search,
-                          });
-                        }}
+                      <FullPageButton
+                        query={query}
+                        generalBase={generalBase}
+                        targetBase={targetBase}
                       />
                       <Button
                         tooltip="Close drawer"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/FullPageButton.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/FullPageButton.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {Button} from '../../../Button';
+
+type FullPageButtonProps = {
+  query: Record<string, any>;
+  generalBase: string;
+  targetBase: string;
+};
+
+export const FullPageButton = ({
+  query,
+  generalBase,
+  targetBase,
+}: FullPageButtonProps) => {
+  if (!query.peekPath) {
+    return null;
+  }
+  const [pathname, search] = query.peekPath.split('?');
+  const params = new URLSearchParams(search);
+  if ('tracetree' in query) {
+    params.set('tracetree', query.tracetree);
+  }
+  const paramsStr = params.toString();
+  let to = pathname.replace(generalBase, targetBase);
+  if (paramsStr) {
+    to += `?${paramsStr}`;
+  }
+  return (
+    <Link to={to}>
+      <Button
+        tooltip="Open full page for this object"
+        icon="full-screen-mode-expand"
+        variant="ghost"
+        className="ml-4"
+      />
+    </Link>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -126,7 +126,7 @@ export const browse2Context = {
     projectName: string,
     objectName: string,
     objectVersionHash: string,
-    filePath: string,
+    filePath?: string,
     refExtra?: string
   ) => {
     throw new Error('Not implemented');
@@ -302,16 +302,16 @@ const browse3ContextGen = (
       projectName: string,
       objectName: string,
       objectVersionHash: string,
-      filePath: string,
+      filePath?: string,
       refExtra?: string
     ) => {
-      const extra = refExtra ? `&extra=${encodeURIComponent(refExtra)}` : '';
+      const path = filePath ? `?path=${encodeURIComponent(filePath)}` : '';
+      const extra =
+        path && refExtra ? `&extra=${encodeURIComponent(refExtra)}` : '';
       return `${projectRoot(
         entityName,
         projectName
-      )}/objects/${objectName}/versions/${objectVersionHash}?path=${encodeURIComponent(
-        filePath
-      )}${extra}`;
+      )}/objects/${objectName}/versions/${objectVersionHash}${path}${extra}`;
     },
     opVersionsUIUrl: (
       entityName: string,
@@ -467,7 +467,7 @@ type RouteType = {
     projectName: string,
     objectName: string,
     objectVersionHash: string,
-    filePath: string,
+    filePath?: string,
     refExtra?: string
   ) => string;
   opVersionsUIUrl: (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -143,8 +143,6 @@ const ObjectVersionsTable: React.FC<{
             objectName={obj.objectId}
             version={obj.versionHash}
             versionIndex={obj.versionIndex}
-            filePath={obj.path}
-            refExtra={obj.refExtra}
           />
         );
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -159,7 +159,7 @@ export const ObjectVersionLink: React.FC<{
   objectName: string;
   version: string;
   versionIndex: number;
-  filePath: string;
+  filePath?: string;
   refExtra?: string;
 }> = props => {
   const {peekingRouter} = useWeaveflowRouteContext();
@@ -167,19 +167,15 @@ export const ObjectVersionLink: React.FC<{
   //   ? props.version
   //   : props.objectName + ': ' + truncateID(props.version);
   const text = objectVersionText(props.objectName, props.versionIndex);
-  return (
-    <Link
-      to={peekingRouter.objectVersionUIUrl(
-        props.entityName,
-        props.projectName,
-        props.objectName,
-        props.version,
-        props.filePath,
-        props.refExtra
-      )}>
-      {text}
-    </Link>
+  const to = peekingRouter.objectVersionUIUrl(
+    props.entityName,
+    props.projectName,
+    props.objectName,
+    props.version,
+    props.filePath,
+    props.refExtra
   );
+  return <Link to={to}>{text}</Link>;
 };
 
 export const OpLink: React.FC<{


### PR DESCRIPTION
FYI @jlzhao27 

Internal slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1709568959470889

If you clicked the "Open full page for this object" button you would get an "Object not found" error.

Also made the button a link, which allows you to right click and open the page in a new tab/window.