### PR TITLE
chore(weave): Add User and Run to Calls

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -293,6 +293,40 @@ export const RunsTable: FC<{
           ]
         : []),
       {
+        field: 'user_id',
+        headerName: 'User',
+        sortable: false,
+        disableColumnMenu: true,
+        resizable: false,
+        // width: 70,
+        // minWidth: 70,
+        // maxWidth: 70,
+        renderCell: cellParams => {
+          return (
+            <div style={{margin: 'auto'}}>
+              {cellParams.row.call.userId ?? <NotApplicable />}
+            </div>
+          );
+        },
+      },
+      {
+        field: 'run_id',
+        headerName: 'Run',
+        sortable: false,
+        disableColumnMenu: true,
+        resizable: false,
+        // width: 70,
+        // minWidth: 70,
+        // maxWidth: 70,
+        renderCell: cellParams => {
+          return (
+            <div style={{margin: 'auto'}}>
+              {cellParams.row.call.runId ?? <NotApplicable />}
+            </div>
+          );
+        },
+      },
+      {
         field: 'status_code',
         headerName: 'Status',
         sortable: false,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -292,40 +292,30 @@ export const RunsTable: FC<{
             },
           ]
         : []),
-      {
-        field: 'user_id',
-        headerName: 'User',
-        sortable: false,
-        disableColumnMenu: true,
-        resizable: false,
-        // width: 70,
-        // minWidth: 70,
-        // maxWidth: 70,
-        renderCell: cellParams => {
-          return (
-            <div style={{margin: 'auto'}}>
-              {cellParams.row.call.userId ?? <NotApplicable />}
-            </div>
-          );
-        },
-      },
-      {
-        field: 'run_id',
-        headerName: 'Run',
-        sortable: false,
-        disableColumnMenu: true,
-        resizable: false,
-        // width: 70,
-        // minWidth: 70,
-        // maxWidth: 70,
-        renderCell: cellParams => {
-          return (
-            <div style={{margin: 'auto'}}>
-              {cellParams.row.call.runId ?? <NotApplicable />}
-            </div>
-          );
-        },
-      },
+      // {
+      //   field: 'user_id',
+      //   headerName: 'User',
+      //   disableColumnMenu: true,
+      //   renderCell: cellParams => {
+      //     return (
+      //       <div style={{margin: 'auto'}}>
+      //         {cellParams.row.call.userId ?? <NotApplicable />}
+      //       </div>
+      //     );
+      //   },
+      // },
+      // {
+      //   field: 'run_id',
+      //   headerName: 'Run',
+      //   disableColumnMenu: true,
+      //   renderCell: cellParams => {
+      //     return (
+      //       <div style={{margin: 'auto'}}>
+      //         {cellParams.row.call.runId ?? <NotApplicable />}
+      //       </div>
+      //     );
+      //   },
+      // },
       {
         field: 'status_code',
         headerName: 'Status',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cgDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cgDataModelHooks.ts
@@ -769,6 +769,8 @@ const spanToCallSchema = (
       : null,
     rawSpan,
     rawFeedback: span.feedback,
+    userId: null,
+    runId: null,
   };
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -32,6 +32,8 @@ export type TraceCallSchema = {
   exception?: string;
   outputs?: KeyedDictType;
   summary?: KeyedDictType;
+  wb_run_id?: string;
+  wb_user_id?: string;
 };
 
 type TraceCallReadReq = {
@@ -51,6 +53,8 @@ interface TraceCallsFilter {
   trace_ids?: string[];
   call_ids?: string[];
   trace_roots_only?: boolean;
+  wb_run_ids?: string[];
+  wb_user_ids?: string[];
 }
 
 type TraceCallsQueryReq = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -119,6 +119,8 @@ const useCalls = (
           trace_ids: deepFilter.traceId ? [deepFilter.traceId] : undefined,
           call_ids: deepFilter.callIds,
           trace_roots_only: deepFilter.traceRootsOnly,
+          wb_run_ids: deepFilter.runIds,
+          wb_user_ids: deepFilter.userIds,
         },
         limit,
       })
@@ -168,6 +170,7 @@ const useCalls = (
           call
         );
       });
+      console.log(result)
       return {
         loading: false,
         result,
@@ -342,6 +345,8 @@ const traceCallToUICallSchema = (
       : null,
     rawSpan: traceCallToLegacySpan(traceCall),
     rawFeedback: {},
+    userId: traceCall.wb_user_id ?? null,
+    runId: traceCall.wb_run_id ?? null,
   };
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -170,7 +170,6 @@ const useCalls = (
           call
         );
       });
-      console.log(result)
       return {
         loading: false,
         result,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -33,6 +33,8 @@ export type CallSchema = CallKey & {
   // We should wean off of this and move the needed properties to `CallSchema`.
   rawSpan: RawSpanFromStreamTableEra;
   rawFeedback?: any;
+  userId: string | null;
+  runId: string | null;
 };
 
 export type CallFilter = {
@@ -46,6 +48,8 @@ export type CallFilter = {
   callIds?: string[];
   traceRootsOnly?: boolean;
   opCategory?: OpCategory[];
+  runIds?: string[];
+  userIds?: string[];
 };
 
 export type OpVersionKey = {

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -238,7 +238,10 @@ def simple_line_call_bootstrap() -> OpCallSpec:
     total_calls = sum([op_call.num_calls for op_call in result.values()])
 
     return OpCallSpec(
-        call_summaries=result, total_calls=total_calls, root_calls=root_calls, run_calls=run_calls
+        call_summaries=result,
+        total_calls=total_calls,
+        root_calls=root_calls,
+        run_calls=run_calls,
     )
 
 
@@ -553,6 +556,7 @@ def test_trace_call_query_filter_trace_roots_only(trace_client):
         )
 
         assert len(inner_res.calls) == exp_count
+
 
 def test_trace_call_query_filter_wb_run_ids(trace_client):
     call_spec = simple_line_call_bootstrap()

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -96,6 +96,8 @@ def test_trace_server_call_start_and_end(clickhouse_trace_server):
         "inputs": {"_keys": ["b"], "b": 5},
         "outputs": None,
         "summary": None,
+        "wb_user_id": None,
+        "wb_run_id": None,
     }
 
     end = tsi.EndedCallSchemaForInsert(
@@ -131,6 +133,8 @@ def test_trace_server_call_start_and_end(clickhouse_trace_server):
         "inputs": {"_keys": ["b"], "b": 5},
         "outputs": {"_keys": ["d"], "d": 5},
         "summary": {"_keys": ["c"], "c": 5},
+        "wb_user_id": None,
+        "wb_run_id": None,
     }
 
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -89,6 +89,7 @@ class SelectableCHCallSchema(BaseModel):
     wb_user_id: typing.Optional[str] = None
     wb_run_id: typing.Optional[str] = None
 
+
 all_call_insert_columns = list(
     CallStartCHInsertable.model_fields.keys() | CallEndCHInsertable.model_fields.keys()
 )
@@ -269,11 +270,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
             if req.filter.trace_roots_only:
                 conditions.append("parent_id IS NULL")
-            
+
             if req.filter.wb_user_ids:
                 conditions.append("wb_user_id IN {wb_user_ids: Array(String)}")
                 parameters["wb_user_ids"] = req.filter.wb_user_ids
-            
+
             if req.filter.wb_run_ids:
                 conditions.append("wb_run_id IN {wb_run_ids: Array(String)}")
                 parameters["wb_run_ids"] = req.filter.wb_run_ids

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -44,6 +44,9 @@ class CallStartCHInsertable(BaseModel):
     input_refs: typing.List[str]
     output_refs: typing.List[str] = []  # sadly, this is required
 
+    wb_user_id: typing.Optional[str] = None
+    wb_run_id: typing.Optional[str] = None
+
 
 class CallEndCHInsertable(BaseModel):
     project_id: str
@@ -83,6 +86,8 @@ class SelectableCHCallSchema(BaseModel):
     input_refs: typing.List[str]
     output_refs: typing.List[str]
 
+    wb_user_id: typing.Optional[str] = None
+    wb_run_id: typing.Optional[str] = None
 
 all_call_insert_columns = list(
     CallStartCHInsertable.model_fields.keys() | CallEndCHInsertable.model_fields.keys()
@@ -264,6 +269,14 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
             if req.filter.trace_roots_only:
                 conditions.append("parent_id IS NULL")
+            
+            if req.filter.wb_user_ids:
+                conditions.append("wb_user_id IN {wb_user_ids: Array(String)}")
+                parameters["wb_user_ids"] = req.filter.wb_user_ids
+            
+            if req.filter.wb_run_ids:
+                conditions.append("wb_run_id IN {wb_run_ids: Array(String)}")
+                parameters["wb_run_ids"] = req.filter.wb_run_ids
 
         ch_calls = self._select_calls_query(
             req.project_id,
@@ -659,6 +672,8 @@ def _ch_call_to_call_schema(ch_call: SelectableCHCallSchema) -> tsi.CallSchema:
         outputs=_nullable_dict_dump_to_dict(ch_call.outputs_dump),
         summary=_nullable_dict_dump_to_dict(ch_call.summary_dump),
         exception=ch_call.exception,
+        wb_run_id=ch_call.wb_run_id,
+        wb_user_id=ch_call.wb_user_id,
     )
 
 
@@ -693,6 +708,8 @@ def _start_call_for_insert_to_ch_insertable_start_call(
         attributes_dump=_dict_value_to_dump(start_call.attributes),
         inputs_dump=_dict_value_to_dump(start_call.inputs),
         input_refs=extract_refs_from_values(list(start_call.inputs.values())),
+        wb_run_id=start_call.wb_run_id,
+        wb_user_id=start_call.wb_user_id,
     )
 
 

--- a/weave/trace_server/graph_client_trace.py
+++ b/weave/trace_server/graph_client_trace.py
@@ -658,7 +658,7 @@ class GraphClientTrace(GraphClient[CallSchemaRun]):
             parent_id=parent_id,
             inputs=refs_to_str(inputs),
             attributes={},
-            wb_run_id=current_wb_run_id
+            wb_run_id=current_wb_run_id,
         )
         self.trace_server.call_start(tsi.CallStartReq(start=start))
         return CallSchemaRun(start)
@@ -745,11 +745,14 @@ class GraphClientTraceWithArtifactStorage(GraphClientTrace):
         )
         return res
 
+
 def safe_current_wb_run_id() -> Optional[str]:
     try:
         import wandb
-        if wandb.run == None:
+
+        wandb_run = wandb.run
+        if wandb_run is None:
             return None
-        return f"{wandb.run.entity}/{wandb.run.project}/{wandb.run.id}"
+        return f"{wandb_run.entity}/{wandb_run.project}/{wandb_run.id}"
     except ImportError:
         return None

--- a/weave/trace_server/graph_client_trace.py
+++ b/weave/trace_server/graph_client_trace.py
@@ -648,7 +648,7 @@ class GraphClientTrace(GraphClient[CallSchemaRun]):
         else:
             trace_id = generate_id()
             parent_id = None
-
+        current_wb_run_id = safe_current_wb_run_id()
         start = tsi.StartedCallSchemaForInsert(
             project_id=self.project_id(),
             id=generate_id(),
@@ -658,6 +658,7 @@ class GraphClientTrace(GraphClient[CallSchemaRun]):
             parent_id=parent_id,
             inputs=refs_to_str(inputs),
             attributes={},
+            wb_run_id=current_wb_run_id
         )
         self.trace_server.call_start(tsi.CallStartReq(start=start))
         return CallSchemaRun(start)
@@ -743,3 +744,12 @@ class GraphClientTraceWithArtifactStorage(GraphClientTrace):
             branch_name=branch_name,
         )
         return res
+
+def safe_current_wb_run_id() -> Optional[str]:
+    try:
+        import wandb
+        if wandb.run == None:
+            return None
+        return f"{wandb.run.entity}/{wandb.run.project}/{wandb.run.id}"
+    except ImportError:
+        return None

--- a/weave/trace_server/migrations/003_add_call_meta.down.sql
+++ b/weave/trace_server/migrations/003_add_call_meta.down.sql
@@ -1,0 +1,26 @@
+-- Modify the view
+ALTER TABLE calls_merged_view
+MODIFY QUERY
+SELECT project_id,
+    id,
+    anySimpleState(trace_id) as trace_id,
+    anySimpleState(parent_id) as parent_id,
+    anySimpleState(name) as name,
+    anySimpleState(start_datetime) as start_datetime,
+    anySimpleState(attributes_dump) as attributes_dump,
+    anySimpleState(inputs_dump) as inputs_dump,
+    array_concat_aggSimpleState(input_refs) as input_refs,
+    anySimpleState(end_datetime) as end_datetime,
+    anySimpleState(outputs_dump) as outputs_dump,
+    anySimpleState(summary_dump) as summary_dump,
+    anySimpleState(exception) as exception,
+    array_concat_aggSimpleState(output_refs) as output_refs
+FROM calls_raw
+GROUP BY project_id,
+    id;
+-- User Info
+ALTER TABLE calls_raw DROP COLUMN wb_user_id;
+ALTER TABLE calls_merged DROP COLUMN wb_user_id;
+-- Run Info
+ALTER TABLE calls_raw DROP COLUMN wb_run_id;
+ALTER TABLE calls_merged DROP COLUMN wb_run_id;

--- a/weave/trace_server/migrations/003_add_call_meta.up.sql
+++ b/weave/trace_server/migrations/003_add_call_meta.up.sql
@@ -1,0 +1,32 @@
+-- User Info
+ALTER TABLE calls_raw
+ADD COLUMN wb_user_id Nullable(String);
+ALTER TABLE calls_merged
+ADD COLUMN wb_user_id SimpleAggregateFunction(any, Nullable(String));
+-- Run Info
+ALTER TABLE calls_raw
+ADD COLUMN wb_run_id Nullable(String);
+ALTER TABLE calls_merged
+ADD COLUMN wb_run_id SimpleAggregateFunction(any, Nullable(String));
+-- Modify the view
+ALTER TABLE calls_merged_view
+MODIFY QUERY
+SELECT project_id,
+    id,
+    anySimpleState(wb_run_id) as wb_run_id,
+    anySimpleState(wb_user_id) as wb_user_id,
+    anySimpleState(trace_id) as trace_id,
+    anySimpleState(parent_id) as parent_id,
+    anySimpleState(name) as name,
+    anySimpleState(start_datetime) as start_datetime,
+    anySimpleState(attributes_dump) as attributes_dump,
+    anySimpleState(inputs_dump) as inputs_dump,
+    array_concat_aggSimpleState(input_refs) as input_refs,
+    anySimpleState(end_datetime) as end_datetime,
+    anySimpleState(outputs_dump) as outputs_dump,
+    anySimpleState(summary_dump) as summary_dump,
+    anySimpleState(exception) as exception,
+    array_concat_aggSimpleState(output_refs) as output_refs
+FROM calls_raw
+GROUP BY project_id,
+    id;

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -36,6 +36,10 @@ class CallSchema(BaseModel):
     ## Summary: a summary of the call
     summary: typing.Optional[typing.Dict[str, typing.Any]] = None
 
+    # WB Metadata
+    wb_user_id: typing.Optional[str] = None
+    wb_run_id: typing.Optional[str] = None
+
 
 # Essentially a partial of StartedCallSchema. Mods:
 # - id is not required (will be generated)
@@ -59,6 +63,10 @@ class StartedCallSchemaForInsert(BaseModel):
 
     ## Inputs
     inputs: typing.Dict[str, typing.Any]
+
+    # WB Metadata
+    wb_user_id: typing.Optional[str] = None
+    wb_run_id: typing.Optional[str] = None
 
 
 class EndedCallSchemaForInsert(BaseModel):
@@ -139,6 +147,8 @@ class _CallsFilter(BaseModel):
     trace_ids: typing.Optional[typing.List[str]] = None
     call_ids: typing.Optional[typing.List[str]] = None
     trace_roots_only: typing.Optional[bool] = None
+    wb_user_ids: typing.Optional[typing.List[str]] = None
+    wb_run_ids: typing.Optional[typing.List[str]] = None
 
 
 class CallsQueryReq(BaseModel):


### PR DESCRIPTION
This PR adds tracking of the logging user and current WB run to weave calls. Specifically:

1. Adds these fields to the data model and various apis
2. Adds the logging of the run to the graph client
3. Adds filter functionality
4. Adds tests
5. Uses compatible migration so we don't need to blow away data

Uptake here: https://github.com/wandb/core/pull/19951


