### PR TITLE
fix: minor styling issue with copyable text in use tab

### DIFF
--- a/weave-js/src/components/CopyableText.tsx
+++ b/weave-js/src/components/CopyableText.tsx
@@ -40,6 +40,8 @@ IconCell.displayName = 'S.IconCell';
 const Text = styled.code`
   font-size: 0.7em;
   white-space: pre-line;
+  overflow: auto;
+  text-overflow: ellipsis;
 `;
 Text.displayName = 'S.Text';
 


### PR DESCRIPTION
Before:
<img width="304" alt="Screenshot 2024-03-07 at 7 07 32 AM" src="https://github.com/wandb/weave/assets/112953339/b506875d-f550-452d-bc11-feff7d79a22c">


After:
<img width="278" alt="Screenshot 2024-03-07 at 7 10 59 AM" src="https://github.com/wandb/weave/assets/112953339/6962ed47-6048-48fe-ac55-629ebfffdefe">
