### PR TITLE
fix: show full path in column visibility dialog

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CustomGroupedColumnHeader.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CustomGroupedColumnHeader.tsx
@@ -1,0 +1,20 @@
+/**
+ * When we have grouped columns in the grid we want the headerName,
+ * which defaults to the field name, to be the full dotted path so
+ * that we see that in the column selection dialog, while in the
+ * header itself we only want to show the last segment of the path
+ * so as not to repeat what's shown in the grouping.
+ */
+
+import React from 'react';
+
+type CustomGroupedColumnProps = {
+  field: string;
+};
+
+export const CustomGroupedColumnHeader = ({
+  field,
+}: CustomGroupedColumnProps) => {
+  const tail = field.split('.').slice(-1)[0];
+  return <span>{tail}</span>;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -37,6 +37,7 @@ import {CallSchema} from '../Browse3/pages/wfReactInterface/wfDataModelHooksInte
 import {StyledDataGrid} from '../Browse3/StyledDataGrid';
 import {flattenObject} from './browse2Util';
 import {Browse2RootObjectVersionItemParams} from './CommonLib';
+import {CustomGroupedColumnHeader} from './CustomGroupedColumnHeader';
 import {
   computeTableStats,
   getInputColumns,
@@ -426,15 +427,17 @@ export const RunsTable: FC<{
       children: [],
     };
     for (const key of inputOrder) {
+      const field = 'input.' + key;
       cols.push({
         flex: 1,
         minWidth: 150,
-        field: 'input.' + key,
-        headerName: key,
+        field,
+        renderHeader: headerParams => {
+          return <CustomGroupedColumnHeader field={headerParams.field} />;
+        },
         renderCell: cellParams => {
-          const k = 'input.' + key;
-          if (k in cellParams.row) {
-            return renderCell((cellParams.row as any)[k]);
+          if (field in cellParams.row) {
+            return renderCell((cellParams.row as any)[field]);
           }
           return <NotApplicable />;
         },
@@ -467,15 +470,17 @@ export const RunsTable: FC<{
     const outputGrouping = buildTree(outputOrder, 'output');
     colGroupingModel.push(outputGrouping);
     for (const key of outputOrder) {
+      const field = 'output.' + key;
       cols.push({
         flex: 1,
         minWidth: 150,
-        field: 'output.' + key,
-        headerName: key.split('.').slice(-1)[0],
+        field,
+        renderHeader: headerParams => {
+          return <CustomGroupedColumnHeader field={headerParams.field} />;
+        },
         renderCell: cellParams => {
-          const k = 'output.' + key;
-          if (k in cellParams.row) {
-            return renderCell((cellParams.row as any)[k]);
+          if (field in cellParams.row) {
+            return renderCell((cellParams.row as any)[field]);
           }
           return <NotApplicable />;
         },


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Show-full-path-when-configuring-columns-3fe1209223934a509ff98d88e441ba65?pvs=4

Column visibility configuration uses headerName (defaults to field) which doesn't work well with grouped columns. This PR makes the headerName the full dotted path but then uses a custom header renderer to strip off everything but the last segment.

Before:
<img width="312" alt="Screenshot 2024-03-07 at 8 03 20 AM" src="https://github.com/wandb/weave/assets/112953339/3ac2b93c-fd45-4209-95cf-34cbeeda30ce">

After:
<img width="455" alt="Screenshot 2024-03-07 at 8 03 41 AM" src="https://github.com/wandb/weave/assets/112953339/ca545a7f-5039-4382-b303-002e0964de09">

