### PR TITLE
fix(weave): fix project limit error

### DIFF
--- a/weave/ops_domain/project_ops.py
+++ b/weave/ops_domain/project_ops.py
@@ -54,7 +54,7 @@ def root_all_projects_gql_resolver(gql_result):
     plugins=wb_gql_op_plugin(
         lambda inputs, inner: f"""
     instance {{
-        projects_500: projects(limit: 500) {{
+        projects_500: projects {{
             edges {{
                 node {{
                     {wdt.Project.REQUIRED_FRAGMENT}

--- a/weave/tests/test_wb_domain_ops.py
+++ b/weave/tests/test_wb_domain_ops.py
@@ -243,7 +243,7 @@ def test_all_projects(fake_wandb):
         # this could in theory change in the future.
         """query WeavePythonCG {
             instance {
-                projects_500: projects(limit: 500) {
+                projects_500: projects {
                     edges {
                         node {
                             id
@@ -398,7 +398,7 @@ def test_multi_root_merging(fake_wandb, cache_mode_minimal):
                 }
             }
             instance{
-                projects_500:projects(limit:500){
+                projects_500:projects {
                     edges{
                         node{
                             id 


### PR DESCRIPTION
fixes an obscure error that happens in onprem.
basically instance { project {} } has no limit field 
