### PR TITLE
chore(weave): add max width to boring tags

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
@@ -50,6 +50,9 @@ const BoringValue = styled.div`
   background-color: ${MOON_100};
   padding: 4px 8px;
   border-radius: 0 8px 8px 0;
+  max-width: 300px;
+  display: flex;
+  align-items: center;
 `;
 BoringValue.displayName = 'S.BoringValue';
 


### PR DESCRIPTION
before

https://github.com/wandb/weave/assets/25037002/68f2eec5-5664-4ae6-b0e7-302eb978a63f


after

![Screenshot 2024-03-13 at 1 35 15 PM](https://github.com/wandb/weave/assets/25037002/b780ecd7-c363-4d99-afe5-7dedf6c5384d)
