### PR TITLE
chore(weave): Fixes hook useCall staleness with pagination

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -74,7 +74,6 @@ export class TraceServerClient {
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
   }
-  
 
   callsQuery: (req: TraceCallsQueryReq) => Promise<TraceCallsQueryRes> =
     req => {
@@ -116,27 +115,31 @@ const MAX_CHUNK_SIZE = 10000;
  * Use this function to query calls from the trace server. This function will
  * handle chunking the results if the user requests more than `MAX_CHUNK_SIZE`
  * calls. This is to protect the server from returning too much data at once.
- * 
+ *
  * Note: we should probably roll this into the `callsQuery` directly, but I don't
  * want to change the API right now to support cancelation.
  */
-export const chunkedCallsQuery = (client: TraceServerClient, req: TraceCallsQueryReq,   onSuccess: (res: TraceCallsQueryRes) => void,
-onError: (err: any) => void): ({
+export const chunkedCallsQuery = (
+  client: TraceServerClient,
+  req: TraceCallsQueryReq,
+  onSuccess: (res: TraceCallsQueryRes) => void,
+  onError: (err: any) => void
+): {
   cancel: () => void;
-}) => {
+} => {
   let cancelled = false;
 
   const safeOnSuccess = (res: TraceCallsQueryRes) => {
     if (!cancelled) {
       onSuccess(res);
     }
-  }
+  };
 
   const safeOnError = (err: any) => {
     if (!cancelled) {
       onError(err);
     }
-  }
+  };
 
   const fetchCalls = async () => {
     const userRequestedLimit = req.limit ?? Infinity;
@@ -154,7 +157,7 @@ onError: (err: any) => void): ({
     } else {
       // Do the hard work
       const allCallResults: TraceCallSchema[] = [];
-      let effectiveLimit = Math.min(userRequestedLimit, MAX_CHUNK_SIZE)
+      let effectiveLimit = Math.min(userRequestedLimit, MAX_CHUNK_SIZE);
       let effectiveOffset = userRequestedOffset;
 
       while (effectiveLimit > 0) {
@@ -181,10 +184,8 @@ onError: (err: any) => void): ({
 
       safeOnSuccess({
         calls: allCallResults,
-      })
-
+      });
     }
-
   };
   fetchCalls();
   return {
@@ -192,4 +193,4 @@ onError: (err: any) => void): ({
       cancelled = true;
     },
   };
-}
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -157,7 +157,7 @@ export const chunkedCallsQuery = (
     } else {
       // Do the hard work
       const allCallResults: TraceCallSchema[] = [];
-      const effectiveLimit = MAX_CHUNK_SIZE
+      const effectiveLimit = MAX_CHUNK_SIZE;
       let effectiveOffset = userRequestedOffset;
 
       while (effectiveLimit > 0) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -157,7 +157,7 @@ export const chunkedCallsQuery = (
     } else {
       // Do the hard work
       const allCallResults: TraceCallSchema[] = [];
-      const effectiveLimit = Math.min(userRequestedLimit, MAX_CHUNK_SIZE);
+      const effectiveLimit = MAX_CHUNK_SIZE
       let effectiveOffset = userRequestedOffset;
 
       while (effectiveLimit > 0) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -157,7 +157,7 @@ export const chunkedCallsQuery = (
     } else {
       // Do the hard work
       const allCallResults: TraceCallSchema[] = [];
-      let effectiveLimit = Math.min(userRequestedLimit, MAX_CHUNK_SIZE);
+      const effectiveLimit = Math.min(userRequestedLimit, MAX_CHUNK_SIZE);
       let effectiveOffset = userRequestedOffset;
 
       while (effectiveLimit > 0) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -174,7 +174,6 @@ export const chunkedCallsQuery = (
           return;
         }
         allCallResults.push(...page.calls);
-        effectiveLimit -= page.calls.length;
         effectiveOffset += page.calls.length;
 
         if (page.calls.length < MAX_CHUNK_SIZE) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -4,7 +4,7 @@
  * backed by the "Trace Server" engine.
  */
 
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 import * as Types from '../../../../../../core/model/types';
 import {useDeepMemo} from '../../../../../../hookUtils';
@@ -30,9 +30,6 @@ import {
   TableQuery,
   WFDataModelHooksInterface,
 } from './wfDataModelHooksInterface';
-
-const DEFAULT_PAGE_SIZE = 10000;
-const DEFAULT_MAX_PAGES = 50;
 
 const projectIdFromParts = ({
   entity,
@@ -132,19 +129,24 @@ const useCalls = (
         wb_user_ids: deepFilter.userIds,
       },
       limit,
-    }
+    };
     const onSuccess = (res: traceServerClient.TraceCallsQueryRes) => {
       loadingRef.current = false;
       setCallRes(res);
-    }
+    };
     const onError = (e: any) => {
       loadingRef.current = false;
       console.error(e);
       setCallRes({calls: []});
-    }
-    const {cancel} = traceServerClient.chunkedCallsQuery(getTsClient(), req, onSuccess, onError)
-    currentCancelRef.current = cancel
-    return cancel
+    };
+    const {cancel} = traceServerClient.chunkedCallsQuery(
+      getTsClient(),
+      req,
+      onSuccess,
+      onError
+    );
+    currentCancelRef.current = cancel;
+    return cancel;
   }, [entity, project, deepFilter, limit, opts?.skip, getTsClient]);
 
   return useMemo(() => {


### PR DESCRIPTION
Recent PR here: https://github.com/wandb/weave/commit/a89107a53d1fd97b24226047ac538867b8cea243 implemented client-side batching for large data payloads. There was a bug that the hook would not reset when diff params were provided. I refactored the code to move the paging logic out of a hook and into a helper function. And reverted the hook to it's previous state