### PR TITLE
chore(weave): fix boring refs overflow

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -112,12 +112,25 @@ export const SmallRef: FC<{objRef: ObjectRef; wfTable?: WFDBTableType}> = ({
           width: '22px',
           borderRadius: '16px',
           display: 'flex',
+          flex: '0 0 22px',
           justifyContent: 'center',
           alignItems: 'center',
         }}>
         <Icon name={icon} width={14} height={14} />
       </Box>
-      {label}
+      <Box
+        sx={{
+          height: '22px',
+          // display: 'flex',
+          // alignItems: 'center',
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden', 
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+        }}>
+        {label}
+      </Box>
     </Box>
   );
   if (refTypeQuery.loading) {
@@ -129,6 +142,9 @@ export const SmallRef: FC<{objRef: ObjectRef; wfTable?: WFDBTableType}> = ({
   return (
     <Link
       $variant="secondary"
+      style={{
+        width: '100%',
+      }}
       to={peekingRouter.refUIUrl(rootTypeName, objRef, wfTable)}>
       {Item}
     </Link>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -121,11 +121,9 @@ export const SmallRef: FC<{objRef: ObjectRef; wfTable?: WFDBTableType}> = ({
       <Box
         sx={{
           height: '22px',
-          // display: 'flex',
-          // alignItems: 'center',
           flex: 1,
           minWidth: 0,
-          overflow: 'hidden', 
+          overflow: 'hidden',
           whiteSpace: 'nowrap',
           textOverflow: 'ellipsis',
         }}>


### PR DESCRIPTION
before
![Screenshot 2024-03-14 at 12 39 05 PM](https://github.com/wandb/weave/assets/25037002/2d1ef662-abfc-474b-a8da-dd438bf8112a)

after
<img width="1221" alt="Screenshot 2024-03-14 at 12 45 29 PM" src="https://github.com/wandb/weave/assets/25037002/2df27958-982c-4856-bedf-ecd318856246">
