### PR TITLE
chore(weave): hide _result in runstable

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -202,6 +202,23 @@ export const RunsTable: FC<{
     [spans]
   );
   const params = useParams<Browse2RootObjectVersionItemParams>();
+
+  let onlyOneOutputResult = true;
+  for (const s of spans) {
+    // get display keys
+    const keys = Object.keys(
+      _.omitBy(
+        flattenObject(s.rawSpan.output!),
+        (v, k) => v == null || (k.startsWith('_') && k !== '_result')
+      )
+    );
+    // ensure there is only one output _result
+    if (keys.length > 1 || (keys[0] && keys[0] !== '_result')) {
+      onlyOneOutputResult = false;
+      break;
+    }
+  }
+
   const tableData = useMemo(() => {
     return spans.map((call: CallSchema) => {
       const argOrder = call.rawSpan.inputs._input_order;
@@ -247,6 +264,10 @@ export const RunsTable: FC<{
             (v, k) => v == null || (k.startsWith('_') && k !== '_result')
           ),
           (v, k) => {
+            // If there is only one output _result, we don't need to nest it
+            if (onlyOneOutputResult && k === '_result') {
+              return 'output';
+            }
             return 'output.' + k;
           }
         ),
@@ -260,7 +281,7 @@ export const RunsTable: FC<{
         ),
       };
     });
-  }, [spans, loading]);
+  }, [loading, onlyOneOutputResult, spans]);
   const tableStats = useMemo(() => {
     return computeTableStats(tableData);
   }, [tableData]);
@@ -560,55 +581,68 @@ export const RunsTable: FC<{
     colGroupingModel.push(inputGroup);
 
     // All output keys as we don't have the order key yet.
-    let outputKeys: {[key: string]: true} = {};
-    spans.forEach(span => {
-      for (const [k, v] of Object.entries(
-        flattenObject(span.rawSpan.output ?? {})
-      )) {
-        if (v != null && (!k.startsWith('_') || k === '_result')) {
-          outputKeys[k] = true;
-        }
-      }
-    });
-    // sort shallowest keys first
-    outputKeys = _.fromPairs(
-      Object.entries(outputKeys).sort((a, b) => {
-        const aDepth = a[0].split('.').length;
-        const bDepth = b[0].split('.').length;
-        return aDepth - bDepth;
-      })
-    );
-
-    const outputOrder = Object.keys(outputKeys);
-    const outputGrouping = buildTree(outputOrder, 'output');
-    colGroupingModel.push(outputGrouping);
-    for (const key of outputOrder) {
-      const field = 'output.' + key;
-      const isExpanded = expandedRefCols.has(field);
+    if (onlyOneOutputResult) {
+      // If there is only one output _result, we don't need to do all the work on outputs
       cols.push({
         flex: 1,
         minWidth: 150,
-        field,
-        renderHeader: () => {
-          const hasExpand = columnHasRefs(tableStats, field);
-          const tail = key.split('.').slice(-1)[0];
-          return (
-            <ExpandHeader
-              headerName={isExpanded ? 'Ref' : tail}
-              field={field}
-              hasExpand={hasExpand && !isExpanded}
-              onExpand={onExpand}
-            />
-          );
-        },
+        field: 'output',
+        headerName: 'output',
         renderCell: cellParams => {
-          if (field in cellParams.row) {
-            const value = (cellParams.row as any)[field];
-            return <CellValue value={value} />;
-          }
-          return <NotApplicable />;
+          return <CellValue value={(cellParams.row as any).output} />;
         },
       });
+    } else {
+      let outputKeys: {[key: string]: true} = {};
+      spans.forEach(span => {
+        for (const [k, v] of Object.entries(
+          flattenObject(span.rawSpan.output ?? {})
+        )) {
+          if (v != null && (!k.startsWith('_') || k === '_result')) {
+            outputKeys[k] = true;
+          }
+        }
+      });
+      // sort shallowest keys first
+      outputKeys = _.fromPairs(
+        Object.entries(outputKeys).sort((a, b) => {
+          const aDepth = a[0].split('.').length;
+          const bDepth = b[0].split('.').length;
+          return aDepth - bDepth;
+        })
+      );
+
+      const outputOrder = Object.keys(outputKeys);
+      const outputGrouping = buildTree(outputOrder, 'output');
+      colGroupingModel.push(outputGrouping);
+      for (const key of outputOrder) {
+        const field = 'output.' + key;
+        const isExpanded = expandedRefCols.has(field);
+        cols.push({
+          flex: 1,
+          minWidth: 150,
+          field,
+          renderHeader: () => {
+            const hasExpand = columnHasRefs(tableStats, field);
+            const tail = key.split('.').slice(-1)[0];
+            return (
+              <ExpandHeader
+                headerName={isExpanded ? 'Ref' : tail}
+                field={field}
+                hasExpand={hasExpand && !isExpanded}
+                onExpand={onExpand}
+              />
+            );
+          },
+          renderCell: cellParams => {
+            if (field in cellParams.row) {
+              const value = (cellParams.row as any)[field];
+              return <CellValue value={value} />;
+            }
+            return <NotApplicable />;
+          },
+        });
+      }
     }
 
     let feedbackKeys: {[key: string]: true} = {};
@@ -658,15 +692,16 @@ export const RunsTable: FC<{
 
     return {cols, colGroupingModel};
   }, [
+    expandedColInfo,
+    expandedRefCols,
     ioColumnsOnly,
-    spans,
-    params.entity,
-    params.project,
     isSingleOp,
     isSingleOpVersion,
+    onlyOneOutputResult,
+    params.entity,
+    params.project,
+    spans,
     tableStats,
-    expandedRefCols,
-    expandedColInfo,
   ]);
   const autosized = useRef(false);
   // const {peekingRouter} = useWeaveflowRouteContext();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
@@ -147,7 +147,7 @@ export const getBoringColumns = (tableStats: TableStats): string[] => {
   }
   const allNull = new Set<string>();
   for (const col of columns) {
-    if (col.startsWith('output.')) {
+    if (col.startsWith('output.') || col === 'output') {
       // For now, output is always interesting
       continue;
     }


### PR DESCRIPTION
the previous pr here https://github.com/wandb/weave/pull/1248/files
had a bunch of  changes to keyvalue table and calldetails which was then promptly refactored.
so pulling out the runstable part

before
<img width="1460" alt="Screenshot 2024-03-14 at 12 59 13 PM" src="https://github.com/wandb/weave/assets/25037002/ad8c4455-4430-4484-b2e5-c0cd5a9f23ef">


after
<img width="1449" alt="Screenshot 2024-03-14 at 12 59 20 PM" src="https://github.com/wandb/weave/assets/25037002/c8732328-a63e-495d-b35c-a6130e1f1d76">
