### PR TITLE
chore(weave): auto expand input.example, hide ref string when expanded

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
@@ -12,6 +12,7 @@ import {SmallRef} from './SmallRef';
 
 type CellValueProps = {
   value: any;
+  isExpanded?: boolean;
 };
 
 const Collapsed = styled.div<{hasScrolling: boolean}>`
@@ -24,7 +25,7 @@ const Collapsed = styled.div<{hasScrolling: boolean}>`
 `;
 Collapsed.displayName = 'S.Collapsed';
 
-export const CellValue = ({value}: CellValueProps) => {
+export const CellValue = ({value, isExpanded = false}: CellValueProps) => {
   if (value === undefined) {
     return null;
   }
@@ -32,7 +33,7 @@ export const CellValue = ({value}: CellValueProps) => {
     return <ValueViewPrimitive>null</ValueViewPrimitive>;
   }
   if (isRef(value)) {
-    return <SmallRef objRef={parseRef(value)} />;
+    return <SmallRef objRef={parseRef(value)} iconOnly={isExpanded} />;
   }
   if (typeof value === 'boolean') {
     return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -169,7 +169,7 @@ export const RunsTable: FC<{
   } = useWFHooks();
   const {client} = weave;
   const [expandedRefCols, setExpandedRefCols] = useState<Set<string>>(
-    new Set()
+    new Set<string>().add('input.example')
   );
   const onExpand = (col: string) => {
     setExpandedRefCols(prevState => new Set(prevState).add(col));
@@ -294,10 +294,12 @@ export const RunsTable: FC<{
           const refs = columnRefs(tableStats, col);
           const refTypes = await getRefsType(refs);
           const extraCols = getExtraColumns(refTypes);
-          setExpandedColInfo(prevState => ({
-            ...prevState,
-            [col]: extraCols,
-          }));
+          if (tableStats.rowCount !== 0) {
+            setExpandedColInfo(prevState => ({
+              ...prevState,
+              [col]: extraCols,
+            }));
+          }
         }
       }
     };
@@ -515,8 +517,14 @@ export const RunsTable: FC<{
       const field = 'input.' + key;
       const isExpanded = expandedRefCols.has(field);
       cols.push({
-        flex: 1,
-        minWidth: 150,
+        ...(isExpanded
+          ? {
+              width: 100,
+            }
+          : {
+              flex: 1,
+              minWidth: 150,
+            }),
         field,
         renderHeader: () => {
           const hasExpand = columnHasRefs(tableStats, field);
@@ -532,7 +540,7 @@ export const RunsTable: FC<{
         renderCell: cellParams => {
           if (field in cellParams.row) {
             const value = (cellParams.row as any)[field];
-            return <CellValue value={value} />;
+            return <CellValue value={value} isExpanded={isExpanded} />;
           }
           return <NotApplicable />;
         },
@@ -638,7 +646,7 @@ export const RunsTable: FC<{
           renderCell: cellParams => {
             if (field in cellParams.row) {
               const value = (cellParams.row as any)[field];
-              return <CellValue value={value} />;
+              return <CellValue value={value} isExpanded={isExpanded} />;
             }
             return <NotApplicable />;
           },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -551,6 +551,7 @@ export const RunsTable: FC<{
         for (const col of expandCols) {
           const expandField = field + '.' + col;
           cols.push({
+            flex: 1,
             field: expandField,
             renderHeader: headerParams => (
               <CustomGroupedColumnHeader field={headerParams.field} />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -59,10 +59,11 @@ export const objectRefDisplayName = (
   return {label};
 };
 
-export const SmallRef: FC<{objRef: ObjectRef; wfTable?: WFDBTableType}> = ({
-  objRef,
-  wfTable,
-}) => {
+export const SmallRef: FC<{
+  objRef: ObjectRef;
+  wfTable?: WFDBTableType;
+  iconOnly?: boolean;
+}> = ({objRef, wfTable, iconOnly = false}) => {
   const {
     useObjectVersion,
     derived: {useRefsType},
@@ -118,17 +119,19 @@ export const SmallRef: FC<{objRef: ObjectRef; wfTable?: WFDBTableType}> = ({
         }}>
         <Icon name={icon} width={14} height={14} />
       </Box>
-      <Box
-        sx={{
-          height: '22px',
-          flex: 1,
-          minWidth: 0,
-          overflow: 'hidden',
-          whiteSpace: 'nowrap',
-          textOverflow: 'ellipsis',
-        }}>
-        {label}
-      </Box>
+      {!iconOnly && (
+        <Box
+          sx={{
+            height: '22px',
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
+            textOverflow: 'ellipsis',
+          }}>
+          {label}
+        </Box>
+      )}
     </Box>
   );
   if (refTypeQuery.loading) {


### PR DESCRIPTION
before example is closed, and ref column has string still

https://github.com/wandb/weave/assets/25037002/756c09e7-f415-4d19-b047-9ac99b3fe742

after

https://github.com/wandb/weave/assets/25037002/e31a8548-b37a-4260-88f1-d4c6a378edeb

