### PR TITLE
fix: was losing path when closing trace tree with other button

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -133,6 +133,7 @@ const CallPageInnerVertical: FC<{
             selectedCall={selectedCall}
             rows={rows}
             forcedExpandKeys={expandKeys}
+            path={path}
           />
         )
       }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -49,7 +49,8 @@ export const CallTraceView: FC<{
   selectedCall: CallSchema;
   rows: Row[];
   forcedExpandKeys: Set<string>;
-}> = ({call, selectedCall, rows, forcedExpandKeys}) => {
+  path?: string;
+}> = ({call, selectedCall, rows, forcedExpandKeys, path}) => {
   const apiRef = useGridApiRef();
   const history = useHistory();
   const currentRouter = useWeaveflowCurrentRouteContext();
@@ -233,7 +234,7 @@ export const CallTraceView: FC<{
         call.project,
         call.traceId,
         call.callId,
-        null,
+        path,
         false
       )
     );
@@ -242,6 +243,7 @@ export const CallTraceView: FC<{
     call.entity,
     call.project,
     call.traceId,
+    path,
     currentRouter,
     history,
   ]);
@@ -259,7 +261,12 @@ export const CallTraceView: FC<{
     <CallTrace>
       <CallTraceHeader>
         <CallTraceHeaderTitle>Trace tree</CallTraceHeaderTitle>
-        <Button icon="close" variant="ghost" onClick={onCloseTraceTree} />
+        <Button
+          icon="close"
+          variant="ghost"
+          onClick={onCloseTraceTree}
+          tooltip="Hide trace tree"
+        />
       </CallTraceHeader>
       <CallTraceTree>
         <ErrorBoundary>


### PR DESCRIPTION
We were losing the path when you clicked on the close button that's in the trace tree header. Also added a tooltip to it.

<img width="383" alt="Screenshot 2024-03-18 at 3 54 24 PM" src="https://github.com/wandb/weave/assets/112953339/9c653098-52ad-4465-8387-fb8c9840fd46">
