### PR TITLE
fix: autocomplete value not shown when showing all versions

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -303,7 +303,7 @@ export const CallsTable: FC<{
                   isPivoting ||
                   Object.keys(props.frozenFilter ?? {}).includes('opVersions')
                 }
-                value={opVersion ? opVersionRef : null}
+                value={opVersionRef}
                 onChange={(event, newValue) => {
                   setFilter({
                     ...filter,


### PR DESCRIPTION
On the Calls list page, if you selected an Op (all versions) instead of a single Op version, it would correctly filter the grid and list the specific versions available in the autocomplete, but when you clicked away from the filter the value would disappear and you could not clear it.