### PR TITLE
chore: update grid column header color/weight styles

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
@@ -7,6 +7,7 @@ import {
   Color,
   hexToRGB,
   MOON_50,
+  MOON_500,
   OBLIVION,
   TEAL_300,
   WHITE,
@@ -34,12 +35,16 @@ export const StyledDataGrid = styled(
 
   '& .MuiDataGrid-columnHeaders': {
     backgroundColor: MOON_50,
-    color: '#979a9e',
+    color: MOON_500,
   },
 
   '& .MuiDataGrid-pinnedColumnHeaders': {
     backgroundColor: MOON_50,
-    color: '#979a9e',
+    color: MOON_500,
+  },
+
+  '& .MuiDataGrid-columnHeaderTitle': {
+    fontWeight: 600,
   },
 
   '& .MuiDataGrid-columnHeader:focus, .MuiDataGrid-cell:focus': {


### PR DESCRIPTION
The custom expand/collapse headers will be addressed separately.
Internal Figma: https://www.figma.com/file/27JVuBYWHbcAYc8WPb4HqA/Weaveflow-hifi?type=design&node-id=3562%3A5105&mode=design&t=sLHcN487gXQPAgXZ-1

Before:
<img width="753" alt="Screenshot 2024-03-21 at 2 44 09 PM" src="https://github.com/wandb/weave/assets/112953339/04c71a4d-ba49-4a49-b622-363dadfa15bb">

After:
<img width="753" alt="Screenshot 2024-03-21 at 2 44 19 PM" src="https://github.com/wandb/weave/assets/112953339/9a9a45c0-3771-4a33-8075-2598e3865b13">
