### PR TITLE
chore: use common Alert component instead of Material's on Use tabs

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
@@ -1,8 +1,9 @@
-import {Alert, Box} from '@mui/material';
+import {Box} from '@mui/material';
 import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
 import {parseRef} from '../../../../../react';
+import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 import {
@@ -43,7 +44,7 @@ ${pythonName} = weave.ref('${ref.artifactName}:v${versionIndex}').get()`;
 
   return (
     <Box m={2}>
-      <Alert severity="info" variant="outlined">
+      <Alert icon="lightbulb-info">
         See{' '}
         <DocLink
           path="guides/tracking/objects#getting-an-object-back"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
@@ -1,8 +1,9 @@
-import {Alert, Box} from '@mui/material';
+import {Box} from '@mui/material';
 import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
 import {parseRef} from '../../../../../react';
+import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 
@@ -20,7 +21,7 @@ export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
 
   return (
     <Box m={2}>
-      <Alert severity="info" variant="outlined">
+      <Alert icon="lightbulb-info">
         See{' '}
         <DocLink
           path="guides/tracking/objects#getting-an-object-back"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
@@ -1,7 +1,8 @@
-import {Alert, Box} from '@mui/material';
+import {Box} from '@mui/material';
 import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
+import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 
@@ -14,7 +15,7 @@ export const TabUseObject = ({name, uri}: TabUseObjectProps) => {
   const pythonName = isValidVarName(name) ? name : 'obj';
   return (
     <Box m={2}>
-      <Alert severity="info" variant="outlined">
+      <Alert icon="lightbulb-info">
         See{' '}
         <DocLink
           path="guides/tracking/objects#getting-an-object-back"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseOp.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseOp.tsx
@@ -1,7 +1,8 @@
-import {Alert, Box} from '@mui/material';
+import {Box} from '@mui/material';
 import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
+import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 
@@ -15,7 +16,7 @@ export const TabUseOp = ({name, uri}: TabUseOpProps) => {
 
   return (
     <Box m={2}>
-      <Alert severity="info" variant="outlined">
+      <Alert icon="lightbulb-info">
         See{' '}
         <DocLink
           path="guides/tracking/objects#getting-an-object-back"


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Replace-Material-design-components-dbb5f747b86d44efa5c55ecea2474810?pvs=4#bf7cec9f38044d3a9c0c24336153aab4

Before:
<img width="686" alt="Screenshot 2024-03-21 at 4 14 59 PM" src="https://github.com/wandb/weave/assets/112953339/aff868a5-d04a-4a76-9b50-f38e33d270d1">

After:
<img width="688" alt="Screenshot 2024-03-21 at 4 14 35 PM" src="https://github.com/wandb/weave/assets/112953339/d5906ea9-e1cc-47f2-8677-e2e84651ea97">
