### PR TITLE
chore: show exception information in header instead of summary tab

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react';
 import styled from 'styled-components';
 
+import {Alert} from '../../../../../Alert';
 import {CategoryChip} from '../common/CategoryChip';
 import {CallId, opNiceName} from '../common/Links';
 import {StatusChip} from '../common/StatusChip';
@@ -26,6 +27,11 @@ export const CallName = styled.div`
 `;
 CallName.displayName = 'S.CallName';
 
+const Exception = styled.span`
+  font-weight: 600;
+`;
+Exception.displayName = 'S.Exception';
+
 export const CallOverview: React.FC<{
   call: CallSchema;
 }> = ({call}) => {
@@ -46,11 +52,18 @@ export const CallOverview: React.FC<{
   const statusCode = call.rawSpan.status_code;
 
   return (
-    <Overview>
-      <CallName>{opName}</CallName>
-      <CallId>{truncatedId}</CallId>
-      {opCategory && <CategoryChip value={opCategory} />}
-      <StatusChip value={statusCode} iconOnly />
-    </Overview>
+    <>
+      <Overview>
+        <CallName>{opName}</CallName>
+        <CallId>{truncatedId}</CallId>
+        {opCategory && <CategoryChip value={opCategory} />}
+        <StatusChip value={statusCode} iconOnly />
+      </Overview>
+      {call.rawSpan.exception && (
+        <Alert severity="error">
+          <Exception>Exception:</Exception> {call.rawSpan.exception}
+        </Alert>
+      )}
+    </>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -40,7 +40,6 @@ export const CallSummary: React.FC<{
                 Latency: span.summary.latency_s.toFixed(3) + 's',
               }
             : {}),
-          ...(span.exception ? {Exception: span.exception} : {}),
           ...(Object.keys(attributes).length > 0
             ? {Attributes: attributes}
             : {}),


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Highlight-exceptions-and-show-the-message-64f33fb8708d49f7b2a37be6b12de868?pvs=4

The padding looks weird but that will be addressed separately.

Before:
<img width="683" alt="Screenshot 2024-03-21 at 4 38 11 PM" src="https://github.com/wandb/weave/assets/112953339/4f6728d0-a085-4b21-af35-35c385496e08">

After:
<img width="688" alt="Screenshot 2024-03-21 at 4 38 46 PM" src="https://github.com/wandb/weave/assets/112953339/05b9a669-d3e8-4dd8-a2b3-02a1e3c246e8">
