### PR TITLE
fix: don't show boring info if everything is super boring

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/BoringColumnInfo.tsx
@@ -61,56 +61,62 @@ export const BoringColumnInfo = ({
   columns,
 }: BoringColumnInfoProps) => {
   const boring = getBoringColumns(tableStats);
-  if (boring.length === 0) {
+
+  const boringPairs = boring
+    .map((colName: string) => {
+      const {valueCounts} = tableStats.column[colName];
+      const boringValue = Object.keys(valueCounts)[0];
+      if (boringValue === 'null') {
+        return null;
+      }
+
+      const col = columns.find((c: any) => c.field === colName);
+      if (!col) {
+        return null;
+      }
+
+      let label = col.field;
+      if (!label.includes('.') && col.headerName) {
+        label = col.headerName;
+      }
+
+      let value: ReactNode = boringValue;
+      let height: number | undefined = 32;
+      if (col.renderCell) {
+        const cellParams = {value, row: {[col.field]: value}};
+        value = col.renderCell(cellParams);
+        if (typeof value === 'string') {
+          value = (
+            <BoringStringValue
+              value={value}
+              maxWidthCollapsed={300}
+              maxWidthExpanded={600}
+            />
+          );
+          height = undefined;
+        }
+      }
+
+      return (
+        <BoringPair key={colName}>
+          <BoringLabel>{label}</BoringLabel>
+          <BoringValue style={{height}}>{value}</BoringValue>
+        </BoringPair>
+      );
+    })
+    .filter(pair => pair !== null);
+
+  if (boringPairs.length === 0) {
     return null;
   }
+
   return (
     <Boring>
       <Tooltip
         content="These columns have the same value for every row"
         trigger={<Header>Common values:</Header>}
       />
-      {boring.map((colName: string) => {
-        const {valueCounts} = tableStats.column[colName];
-        const boringValue = Object.keys(valueCounts)[0];
-        if (boringValue === 'null') {
-          return null;
-        }
-
-        const col = columns.find((c: any) => c.field === colName);
-        if (!col) {
-          return null;
-        }
-
-        let label = col.field;
-        if (!label.includes('.') && col.headerName) {
-          label = col.headerName;
-        }
-
-        let value: ReactNode = boringValue;
-        let height: number | undefined = 32;
-        if (col.renderCell) {
-          const cellParams = {value, row: {[col.field]: value}};
-          value = col.renderCell(cellParams);
-          if (typeof value === 'string') {
-            value = (
-              <BoringStringValue
-                value={value}
-                maxWidthCollapsed={300}
-                maxWidthExpanded={600}
-              />
-            );
-            height = undefined;
-          }
-        }
-
-        return (
-          <BoringPair key={colName}>
-            <BoringLabel>{label}</BoringLabel>
-            <BoringValue style={{height}}>{value}</BoringValue>
-          </BoringPair>
-        );
-      })}
+      {boringPairs}
     </Boring>
   );
 };


### PR DESCRIPTION
Boring columns are those where the value is the same for every row. Some columns are _super boring_ and have null for every value. We don't even bother to show the key/value pair for super boring columns. However, we were still counting them when determining whether to show the panel at all, which led to this unfortunate UI, which this PR fixes:

<img width="1329" alt="Screenshot 2024-03-21 at 9 35 02 PM" src="https://github.com/wandb/weave/assets/112953339/320c385e-7ebe-46ea-8de6-c7ffeb6495bb">

