### PR TITLE
feat: actionable error messages for Evaluation construction issues

### DIFF
--- a/weave/trace/errors.py
+++ b/weave/trace/errors.py
@@ -1,0 +1,6 @@
+class Error(Exception):
+    pass
+
+
+class OpCallError(Error):
+    pass

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -5,6 +5,7 @@ import typing
 from typing import TYPE_CHECKING, TypeVar, Callable, Optional, Coroutine
 from typing_extensions import ParamSpec
 
+from weave.trace.errors import OpCallError
 from weave.trace_server.refs import ObjectRef
 from weave import graph_client_context
 from weave import run_context
@@ -44,7 +45,10 @@ class Op:
             return self.resolve_fn(*args, **kwargs)
         client = typing.cast("WeaveClient", maybe_client)
 
-        inputs = self.signature.bind(*args, **kwargs).arguments
+        try:
+            inputs = self.signature.bind(*args, **kwargs).arguments
+        except TypeError as e:
+            raise OpCallError(f"Error calling {self.name}: {e}")
         parent_run = run_context.get_current_run()
         trackable_inputs = client.save_nested_objects(inputs)
         run = client.create_call(self, parent_run, trackable_inputs)
@@ -84,6 +88,9 @@ class Op:
                 print_call_link(run)
 
         return res
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.name})"
 
     @property
     def ref(self) -> Optional[ObjectRef]:


### PR DESCRIPTION
Fix error messages in these scenarios

**Genera: op is called with invalid inputs**
```
weave.trace.errors.OpCallError: Error calling ExtractFinancialDetailsModel.predict: missing a required argument: 'marticle'
```

**Evaluation: model predict function does not have correct arguments**
```
weave.trace.errors.OpCallError: 
Call error: Error calling ExtractFinancialDetailsModel.predict: missing a required argument: 'marticle'

Options for resolving:
a. change ExtractFinancialDetailsModel.predict argument names to match a subset of dataset column names: id, article, extracted
b. change dataset column names to match expected ExtractFinancialDetailsModel.predict argument names: ['marticle']
c. construct Evaluation with a preprocess_model_input function that accepts a dataset example and returns a dict with keys expected by ExtractFinancialDetailsModel.predict
```

**Evaluation: scorer function is missing a prediction key**
```
weave.trace.errors.OpCallError: Scorer name_score must have a 'prediction' argument, to receive the output of the model function.
```

**Evaluation: scorer function does not have correct arguments**
```
weave.trace.errors.OpCallError:
Call error: Error calling name_score: missing a required argument: 'zextracted'

Options for resolving:
a. change name_score argument names to match a subset of dataset column names (id, article, extracted)
b. change dataset column names to match expected name_score argument names: ['zextracted']
```