### PR TITLE
chore(weave): Refactor: Replace all cases of plaintext entity/project with internal project ids

### DIFF
--- a/weave/tests/test_op_versioning.py
+++ b/weave/tests/test_op_versioning.py
@@ -47,8 +47,7 @@ def test_op_versioning_saveload(client):
 def get_saved_code(client, ref):
     resp = client.server.obj_read(
         ObjReadReq(
-            entity=ref.entity,
-            project=ref.project,
+            project_id=f"{ref.entity}/{ref.project}",
             name=ref.name,
             version_digest=ref.version,
         )

--- a/weave/tests/test_trace_server.py
+++ b/weave/tests/test_trace_server.py
@@ -14,8 +14,7 @@ def test_save_object(clickhouse_trace_server):
     )
     read_res = clickhouse_trace_server.obj_read(
         tsi.ObjReadReq(
-            entity="shawn",
-            project="proj",
+            project_id="shawn/proj",
             name="my-obj",
             version_digest=create_res.version_digest,
         )

--- a/weave/tests/test_vals.py
+++ b/weave/tests/test_vals.py
@@ -1,5 +1,5 @@
 import pytest
-from weave.trace_server.refs import ObjectRef
+from weave.trace.refs import ObjectRef
 
 
 def test_dict_refs(client):

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -14,7 +14,7 @@ from weave.trace.refs import (
     KEY_EDGE_TYPE,
 )
 
-from weave.trace_server import refs
+from weave.trace import refs
 from weave.trace.isinstance import weave_isinstance
 from weave.trace_server.trace_server_interface import (
     TableCreateReq,

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -7,7 +7,7 @@ from weave import op_def, Evaluation
 
 from weave import weave_client
 from weave.trace.op import Op
-from weave.trace_server.refs import (
+from weave.trace.refs import (
     ATTRIBUTE_EDGE_TYPE,
     ID_EDGE_TYPE,
     INDEX_EDGE_TYPE,

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, TypeVar, Callable, Optional, Coroutine
 from typing_extensions import ParamSpec
 
 from weave.trace.errors import OpCallError
-from weave.trace_server.refs import ObjectRef
+from weave.trace.refs import ObjectRef
 from weave import graph_client_context
 from weave import run_context
 from weave import box

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -23,7 +23,7 @@ from .. import artifact_fs
 from .. import infer_types
 
 
-from weave.trace_server.refs import ObjectRef
+from weave.trace.refs import ObjectRef
 
 
 if typing.TYPE_CHECKING:

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -1,10 +1,11 @@
 from typing import Union, Any
 import dataclasses
+from ..trace_server import refs_internal
 
-KEY_EDGE_TYPE = "key"
-INDEX_EDGE_TYPE = "ndx"
-ATTRIBUTE_EDGE_TYPE = "atr"
-ID_EDGE_TYPE = "id"
+KEY_EDGE_TYPE = refs_internal.KEY_EDGE_TYPE
+INDEX_EDGE_TYPE = refs_internal.INDEX_EDGE_TYPE
+ATTRIBUTE_EDGE_TYPE = refs_internal.ATTRIBUTE_EDGE_TYPE
+ID_EDGE_TYPE = refs_internal.ID_EDGE_TYPE
 
 
 @dataclasses.dataclass

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -3,7 +3,7 @@ import typing
 
 from weave import box
 from weave.trace import custom_objs
-from weave.trace_server.refs import ObjectRef, TableRef, parse_uri
+from weave.trace.refs import ObjectRef, TableRef, parse_uri
 from weave.trace.object_record import ObjectRecord
 from weave.trace_server.trace_server_interface import (
     TraceServerInterface,

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -5,7 +5,7 @@ import operator
 import typing
 
 from weave.trace.op import Op
-from weave.trace_server.refs import (
+from weave.trace.refs import (
     RefWithExtra,
     ObjectRef,
     TableRef,
@@ -362,8 +362,7 @@ def make_trace_obj(
         extra = val.extra
         read_res = server.obj_read(
             ObjReadReq(
-                entity=val.entity,
-                project=val.project,
+                project_id=f"{val.entity}/{val.project}",
                 name=val.name,
                 version_digest=val.version,
             )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -502,7 +502,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         parsed_raw_refs = [refs_internal.parse_uri(r) for r in req.refs]
         if any(isinstance(r, refs_internal.InternalTableRef) for r in parsed_raw_refs):
             raise ValueError("Table refs not supported")
-        parsed_refs = typing.cast(typing.List[refs_internal.InternalObjectRef], parsed_raw_refs)
+        parsed_refs = typing.cast(
+            typing.List[refs_internal.InternalObjectRef], parsed_raw_refs
+        )
 
         root_val_cache: typing.Dict[str, typing.Any] = {}
 
@@ -551,7 +553,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         def resolve_extra(extra: list[str], val: typing.Any) -> typing.Any:
             for extra_index in range(0, len(extra), 2):
                 op, arg = extra[extra_index], extra[extra_index + 1]
-                if isinstance(val, str) and val.startswith(refs_internal.WEAVE_INTERNAL_SCHEME + "://"):
+                if isinstance(val, str) and val.startswith(
+                    refs_internal.WEAVE_INTERNAL_SCHEME + "://"
+                ):
                     parsed_ref = refs_internal.parse_uri(val)
                     if isinstance(parsed_ref, refs_internal.InternalObjectRef):
                         return PartialRefResult(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -499,7 +499,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         if len(req.refs) > 1000:
             raise ValueError("Too many refs")
 
-        parsed_raw_refs = [refs_internal.parse_uri(r) for r in req.refs]
+        parsed_raw_refs = [refs_internal.parse_internal_uri(r) for r in req.refs]
         if any(isinstance(r, refs_internal.InternalTableRef) for r in parsed_raw_refs):
             raise ValueError("Table refs not supported")
         parsed_refs = typing.cast(
@@ -556,7 +556,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 if isinstance(val, str) and val.startswith(
                     refs_internal.WEAVE_INTERNAL_SCHEME + "://"
                 ):
-                    parsed_ref = refs_internal.parse_uri(val)
+                    parsed_ref = refs_internal.parse_internal_uri(val)
                     if isinstance(parsed_ref, refs_internal.InternalObjectRef):
                         return PartialRefResult(
                             remaining_extra=extra[extra_index:],
@@ -629,7 +629,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             # Resolve any unresolved table refs
             # First batch the table queries by project_id and table digest
             table_queries: dict[
-                typing.Tuple[str, str, str], list[typing.Tuple[int, str]]
+                typing.Tuple[str, str], list[typing.Tuple[int, str]]
             ] = {}
             for i, extra_result in enumerate(extra_results):
                 if extra_result.unresolved_table_ref is not None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -28,7 +28,7 @@ from .trace_server_interface_util import (
 )
 from . import trace_server_interface as tsi
 
-from . import refs
+from . import refs_internal
 
 MAX_FLUSH_COUNT = 10000
 MAX_FLUSH_AGE = 15
@@ -109,8 +109,7 @@ required_call_columns = list(set(all_call_select_columns) - set([]))
 
 
 class ObjCHInsertable(BaseModel):
-    entity: str
-    project: str
+    project_id: str
     type: str
     name: str
     refs: typing.List[str]
@@ -119,8 +118,7 @@ class ObjCHInsertable(BaseModel):
 
 
 class SelectableCHObjSchema(BaseModel):
-    entity: str
-    project: str
+    project_id: str
     name: str
     created_at: datetime.datetime
     refs: typing.List[str]
@@ -307,7 +305,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         ]
         parameters = {"name": req.name, "digest": req.version_hash}
         objs = self._select_objs_query(
-            req.entity, req.project, conditions=conds, parameters=parameters
+            req.project_id, conditions=conds, parameters=parameters
         )
         if len(objs) == 0:
             raise NotFoundError(f"Obj {req.name}:{req.version_hash} not found")
@@ -326,8 +324,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 conds.append("is_latest = 1")
 
         ch_objs = self._select_objs_query(
-            req.entity,
-            req.project,
+            req.project_id,
             conditions=conds,
         )
         objs = [_ch_obj_to_obj_schema(call) for call in ch_objs]
@@ -338,10 +335,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         digest = str_digest(json_val)
 
         req_obj = req.obj
-        entity, project = req_obj.project_id.split("/")
         ch_obj = ObjCHInsertable(
-            entity=entity,
-            project=project,
+            project_id=req_obj.project_id,
             name=req_obj.name,
             type=get_type(req.obj.val),
             refs=[],
@@ -370,7 +365,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 conds.append("digest = {version_digest: String}")
                 parameters["version_digest"] = req.version_digest
         objs = self._select_objs_query(
-            req.entity, req.project, conditions=conds, parameters=parameters
+            req.project_id, conditions=conds, parameters=parameters
         )
         if len(objs) == 0:
             raise NotFoundError(f"Obj {req.name}:{req.version_digest} not found")
@@ -391,10 +386,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 parameters["object_names"] = req.filter.object_names
             if req.filter.latest_only:
                 conds.append("is_latest = 1")
-        entity, project = req.project_id.split("/")
+
         objs = self._select_objs_query(
-            entity,
-            project,
+            req.project_id,
             conditions=conds,
             parameters=parameters,
         )
@@ -402,19 +396,19 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         return tsi.ObjQueryRes(objs=[_ch_obj_to_obj_schema(obj) for obj in objs])
 
     def table_create(self, req: tsi.TableCreateReq) -> tsi.TableCreateRes:
-        entity, project = req.table.project_id.split("/")
+
         insert_rows = []
         for r in req.table.rows:
             if not isinstance(r, dict):
                 raise ValueError("All rows must be dictionaries")
             row_json = json.dumps(r)
             row_digest = str_digest(row_json)
-            insert_rows.append((entity, project, row_digest, row_json))
+            insert_rows.append((req.table.project_id, row_digest, row_json))
 
         self._insert(
             "table_rows",
             data=insert_rows,
-            column_names=["entity", "project", "digest", "val"],
+            column_names=["project_id", "digest", "val"],
         )
 
         row_digests = [r[2] for r in insert_rows]
@@ -426,13 +420,12 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
         self._insert(
             "tables",
-            data=[(entity, project, table_digest, row_digests)],
-            column_names=["entity", "project", "digest", "row_digests"],
+            data=[(req.table.project_id, table_digest, row_digests)],
+            column_names=["project_id", "digest", "row_digests"],
         )
         return tsi.TableCreateRes(digest=table_digest)
 
     def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
-        entity, project = req.project_id.split("/")
         conds = []
         parameters = {}
         if req.filter:
@@ -442,8 +435,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         else:
             conds.append("1 = 1")
         rows = self._table_query(
-            entity,
-            project,
+            req.table.project_id,
             req.table_digest,
             conditions=conds,
             limit=req.limit,
@@ -453,15 +445,14 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
     def _table_query(
         self,
-        entity: str,
-        project: str,
+        project_id: str,
         table_digest: str,
         conditions: typing.Optional[typing.List[str]] = None,
         limit: typing.Optional[int] = None,
         offset: typing.Optional[int] = None,
         parameters: typing.Optional[typing.Dict[str, typing.Any]] = None,
     ) -> typing.List[tsi.TableRowSchema]:
-        conds = ["entity = {entity: String}", "project = {project: String}"]
+        conds = ["project_id = {project_id: String}"]
         if conditions:
             conds.extend(conditions)
 
@@ -469,12 +460,12 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         query = f"""
                 SELECT tr.digest, tr.val
                 FROM (
-                    SELECT entity, project, row_digest
+                    SELECT project_id, row_digest
                     FROM tables_deduped
                     ARRAY JOIN row_digests AS row_digest
                     WHERE digest = {{table_digest:String}}
                 ) AS t
-                JOIN table_rows_deduped tr ON t.entity = tr.entity AND t.project = tr.project AND t.row_digest = tr.digest
+                JOIN table_rows_deduped tr ON t.project_id = tr.project_id AND t.row_digest = tr.digest
                 WHERE {predicate}
             """
         if parameters is None:
@@ -489,8 +480,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         query_result = self.ch_client.query(
             query,
             parameters={
-                "entity": entity,
-                "project": project,
+                "project_id": project_id,
                 "table_digest": table_digest,
                 **parameters,
             },
@@ -509,15 +499,15 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         if len(req.refs) > 1000:
             raise ValueError("Too many refs")
 
-        parsed_raw_refs = [refs.parse_uri(r) for r in req.refs]
-        if any(isinstance(r, refs.TableRef) for r in parsed_raw_refs):
+        parsed_raw_refs = [refs_internal.parse_uri(r) for r in req.refs]
+        if any(isinstance(r, refs_internal.InternalTableRef) for r in parsed_raw_refs):
             raise ValueError("Table refs not supported")
-        parsed_refs = typing.cast(typing.List[refs.ObjectRef], parsed_raw_refs)
+        parsed_refs = typing.cast(typing.List[refs_internal.InternalObjectRef], parsed_raw_refs)
 
         root_val_cache: typing.Dict[str, typing.Any] = {}
 
-        def get_object_ref_root_val(r: refs.ObjectRef) -> typing.Any:
-            cache_key = f"{r.entity}/{r.project}/{r.name}/{r.version}"
+        def get_object_ref_root_val(r: refs_internal.InternalObjectRef) -> typing.Any:
+            cache_key = f"{r.project_id}/{r.name}/{r.version}"
             if cache_key in root_val_cache:
                 val = root_val_cache[cache_key]
             else:
@@ -540,7 +530,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         "version": r.version,
                     }
                 objs = self._select_objs_query(
-                    r.entity, r.project, conditions=conds, parameters=parameters
+                    r.project_id, conditions=conds, parameters=parameters
                 )
                 if len(objs) == 0:
                     raise NotFoundError(f"Obj {r.name}:{r.version} not found")
@@ -554,23 +544,23 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         class PartialRefResult:
             remaining_extra: list[str]
             # unresolved_obj_ref and unresolved_table_ref are mutually exclusive
-            unresolved_obj_ref: typing.Optional[refs.ObjectRef]
-            unresolved_table_ref: typing.Optional[refs.TableRef]
+            unresolved_obj_ref: typing.Optional[refs_internal.InternalObjectRef]
+            unresolved_table_ref: typing.Optional[refs_internal.InternalTableRef]
             val: typing.Any
 
         def resolve_extra(extra: list[str], val: typing.Any) -> typing.Any:
             for extra_index in range(0, len(extra), 2):
                 op, arg = extra[extra_index], extra[extra_index + 1]
-                if isinstance(val, str) and val.startswith("weave://"):
-                    parsed_ref = refs.parse_uri(val)
-                    if isinstance(parsed_ref, refs.ObjectRef):
+                if isinstance(val, str) and val.startswith(refs_internal.WEAVE_INTERNAL_SCHEME + "://"):
+                    parsed_ref = refs_internal.parse_uri(val)
+                    if isinstance(parsed_ref, refs_internal.InternalObjectRef):
                         return PartialRefResult(
                             remaining_extra=extra[extra_index:],
                             unresolved_obj_ref=parsed_ref,
                             unresolved_table_ref=None,
                             val=val,
                         )
-                    elif isinstance(parsed_ref, refs.TableRef):
+                    elif isinstance(parsed_ref, refs_internal.InternalTableRef):
                         return PartialRefResult(
                             remaining_extra=extra[extra_index:],
                             unresolved_obj_ref=None,
@@ -584,11 +574,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         unresolved_table_ref=None,
                         val=None,
                     )
-                if op == refs.KEY_EDGE_TYPE:
+                if op == refs_internal.KEY_EDGE_TYPE:
                     val = val.get(arg)
-                elif op == refs.ATTRIBUTE_EDGE_TYPE:
+                elif op == refs_internal.ATTRIBUTE_EDGE_TYPE:
                     val = val.get(arg)
-                elif op == refs.INDEX_EDGE_TYPE:
+                elif op == refs_internal.INDEX_EDGE_TYPE:
                     index = int(arg)
                     if index >= len(val):
                         return None
@@ -633,7 +623,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     )
 
             # Resolve any unresolved table refs
-            # First batch the table queries by entity, project, and table digest
+            # First batch the table queries by project_id and table digest
             table_queries: dict[
                 typing.Tuple[str, str, str], list[typing.Tuple[int, str]]
             ] = {}
@@ -646,17 +636,16 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         extra_result.remaining_extra[0],
                         extra_result.remaining_extra[1],
                     )
-                    if op != refs.ID_EDGE_TYPE:
+                    if op != refs_internal.ID_EDGE_TYPE:
                         raise ValueError("Table refs must have id extra")
                     table_queries.setdefault(
-                        (table_ref.entity, table_ref.project, table_ref.digest), []
+                        (table_ref.project_id, table_ref.digest), []
                     ).append((i, row_digest))
             # Make the queries
-            for (entity, project, digest), index_digests in table_queries.items():
+            for (project_id, digest), index_digests in table_queries.items():
                 row_digests = [d for i, d in index_digests]
                 rows = self._table_query(
-                    entity=entity,
-                    project=project,
+                    project_id=project_id,
                     table_digest=digest,
                     conditions=["digest IN {digests: Array(String)}"],
                     parameters={"digests": row_digests},
@@ -897,8 +886,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
     def _select_objs_query(
         self,
-        entity: str,
-        project: str,
+        project_id: str,
         conditions: typing.Optional[typing.List[str]] = None,
         limit: typing.Optional[int] = None,
         parameters: typing.Optional[typing.Dict[str, typing.Any]] = None,
@@ -918,11 +906,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             f"""
             SELECT *
             FROM objects_deduped
-            WHERE entity = {{entity: String}} AND project = {{project: String}}
+            WHERE project_id = {{project_id: String}}
             AND {conditions_part}
             {limit_part}
         """,
-            {"entity": entity, "project": project, **parameters},
+            {"project_id": project_id, **parameters},
         )
         result: typing.List[SelectableCHObjSchema] = []
         for row in query_result.result_rows:
@@ -1092,9 +1080,7 @@ def _ch_call_dict_to_call_schema_dict(ch_call_dict: typing.Dict) -> typing.Dict:
 
 def _ch_obj_to_obj_schema(ch_obj: SelectableCHObjSchema) -> tsi.ObjSchema:
     return tsi.ObjSchema(
-        # entity=ch_obj.entity,
-        # project=ch_obj.project,
-        project_id=f"{ch_obj.entity}/{ch_obj.project}",
+        project_id=ch_obj.project_id,
         name=ch_obj.name,
         created_at=_ensure_datetimes_have_tz(ch_obj.created_at),
         version_index=ch_obj.version_index,
@@ -1164,8 +1150,7 @@ def _process_parameters(
 
 #     return ObjCHInsertable(
 #         id=uuid.uuid4(),
-#         entity=partial_obj.entity,
-#         project=partial_obj.project,
+#         project_id=partial_obj.project_id,
 #         name=partial_obj.name,
 #         type="unknown",
 #         refs=[],

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -411,7 +411,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             column_names=["project_id", "digest", "val"],
         )
 
-        row_digests = [r[2] for r in insert_rows]
+        row_digests = [r[1] for r in insert_rows]
 
         table_hasher = hashlib.sha256()
         for row_digest in row_digests:
@@ -435,7 +435,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         else:
             conds.append("1 = 1")
         rows = self._table_query(
-            req.table.project_id,
+            req.project_id,
             req.table_digest,
             conditions=conds,
             limit=req.limit,

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -1,0 +1,91 @@
+# This file contains the definition for "Internal" weave refs. These should never be 
+# exposed to the user and should only be used internally by the weave-trace service.
+# Specifically, the user-space operates on plain-text `entity/project` scopes. While
+# internally, we operate on internal `project_id`s scopes. At rest, and in the database,
+# we store the internal `project_id`. However, over the wire, we use the plain-text. Practically,
+# the trace interface should only ever operate on internal refs.
+
+from typing import Union
+import dataclasses
+
+WEAVE_INTERNAL_SCHEME = "weave-trace-internal"
+
+KEY_EDGE_TYPE = "key"
+INDEX_EDGE_TYPE = "ndx"
+ATTRIBUTE_EDGE_TYPE = "atr"
+ID_EDGE_TYPE = "id"
+
+@dataclasses.dataclass
+class InternalTableRef:
+    project_id: str
+    digest: str
+
+    def uri(self) -> str:
+        return f"{WEAVE_INTERNAL_SCHEME}:///{self.project_id}/table/{self.digest}"
+
+
+@dataclasses.dataclass
+class InternalObjectRef:
+    project_id: str
+    name: str
+    version: str
+    extra: list[str] = dataclasses.field(default_factory=list)
+
+    def uri(self) -> str:
+        u = f"{WEAVE_INTERNAL_SCHEME}:///{self.project_id}/object/{self.name}:{self.version}"
+        if self.extra:
+            u += "/" + "/".join(self.extra)
+        return u
+
+
+@dataclasses.dataclass
+class InternalOpRef(ObjectRef):
+    def uri(self) -> str:
+        u = f"{WEAVE_INTERNAL_SCHEME}:///{self.project_id}/op/{self.name}:{self.version}"
+        if self.extra:
+            u += "/" + "/".join(self.extra)
+        return u
+
+
+@dataclasses.dataclass
+class InternalCallRef:
+    project_id: str
+    id: str
+    extra: list[str] = dataclasses.field(default_factory=list)
+
+    def uri(self) -> str:
+        u = f"{WEAVE_INTERNAL_SCHEME}:///{self.project_id}/call/{self.id}"
+        if self.extra:
+            u += "/" + "/".join(self.extra)
+        return u
+
+
+def parse_internal_uri(uri: str) -> Union[InternalObjectRef, InternalTableRef]:
+    if not uri.startswith(f"{WEAVE_INTERNAL_SCHEME}:///"):
+        raise ValueError(f"Invalid URI: {uri}")
+    path = uri[len(f"{WEAVE_INTERNAL_SCHEME}:///") :]
+    parts = path.split("/")
+    if len(parts) < 2:
+        raise ValueError(f"Invalid URI: {uri}")
+    project_id, kind = parts[:2]
+    remaining = parts[2:]
+    if kind == "table":
+        return InternalTableRef(project_id=project_id, digest=remaining[0])
+    elif kind == "object":
+        name, version = remaining[0].split(":")
+        return InternalObjectRef(
+            project_id=project_id,
+            name=name,
+            version=version,
+            extra=remaining[1:],
+        )
+    elif kind == "op":
+        name, version = remaining[0].split(":")
+        return InternalOpRef(
+            project_id=project_id,
+            name=name,
+            version=version,
+            extra=remaining[1:],
+        )
+    else:
+        raise ValueError(f"Unknown ref kind: {kind}")

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -63,14 +63,24 @@ class InternalCallRef:
 
 
 def parse_internal_uri(uri: str) -> Union[InternalObjectRef, InternalTableRef]:
-    if not uri.startswith(f"{WEAVE_INTERNAL_SCHEME}:///"):
+    if uri.startswith(f"{WEAVE_INTERNAL_SCHEME}:///"):
+        path = uri[len(f"{WEAVE_INTERNAL_SCHEME}:///") :]
+        parts = path.split("/")
+        if len(parts) < 2:
+            raise ValueError(f"Invalid URI: {uri}")
+        project_id, kind = parts[:2]
+        remaining = parts[2:]
+    elif uri.startswith(f"{WEAVE_SCHEME}:///"):
+        # This path should never be hit in production. This is only for testing.
+        path = uri[len(f"{WEAVE_SCHEME}:///") :]
+        parts = path.split("/")
+        if len(parts) < 3:
+            raise ValueError(f"Invalid URI: {uri}")
+        entity, project, kind = parts[:3]
+        project_id = f"{entity}/{project}"
+        remaining = parts[3:]
+    else:
         raise ValueError(f"Invalid URI: {uri}")
-    path = uri[len(f"{WEAVE_INTERNAL_SCHEME}:///") :]
-    parts = path.split("/")
-    if len(parts) < 2:
-        raise ValueError(f"Invalid URI: {uri}")
-    project_id, kind = parts[:2]
-    remaining = parts[2:]
     if kind == "table":
         return InternalTableRef(project_id=project_id, digest=remaining[0])
     elif kind == "object":

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -70,15 +70,6 @@ def parse_internal_uri(uri: str) -> Union[InternalObjectRef, InternalTableRef]:
             raise ValueError(f"Invalid URI: {uri}")
         project_id, kind = parts[:2]
         remaining = parts[2:]
-    elif uri.startswith(f"{WEAVE_SCHEME}:///"):
-        # This path should never be hit in production. This is only for testing.
-        path = uri[len(f"{WEAVE_SCHEME}:///") :]
-        parts = path.split("/")
-        if len(parts) < 3:
-            raise ValueError(f"Invalid URI: {uri}")
-        entity, project, kind = parts[:3]
-        project_id = f"{entity}/{project}"
-        remaining = parts[3:]
     else:
         raise ValueError(f"Invalid URI: {uri}")
     if kind == "table":

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -40,7 +40,7 @@ class InternalObjectRef:
 
 
 @dataclasses.dataclass
-class InternalOpRef(ObjectRef):
+class InternalOpRef(InternalObjectRef):
     def uri(self) -> str:
         u = f"{WEAVE_INTERNAL_SCHEME}:///{self.project_id}/op/{self.name}:{self.version}"
         if self.extra:

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -9,6 +9,7 @@ from typing import Union
 import dataclasses
 
 WEAVE_INTERNAL_SCHEME = "weave-trace-internal"
+WEAVE_SCHEME = "weave"
 
 KEY_EDGE_TYPE = "key"
 INDEX_EDGE_TYPE = "ndx"

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -1,4 +1,4 @@
-# This file contains the definition for "Internal" weave refs. These should never be 
+# This file contains the definition for "Internal" weave refs. These should never be
 # exposed to the user and should only be used internally by the weave-trace service.
 # Specifically, the user-space operates on plain-text `entity/project` scopes. While
 # internally, we operate on internal `project_id`s scopes. At rest, and in the database,
@@ -14,6 +14,7 @@ KEY_EDGE_TYPE = "key"
 INDEX_EDGE_TYPE = "ndx"
 ATTRIBUTE_EDGE_TYPE = "atr"
 ID_EDGE_TYPE = "id"
+
 
 @dataclasses.dataclass
 class InternalTableRef:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -18,7 +18,7 @@ from .trace_server_interface_util import (
 )
 from . import trace_server_interface as tsi
 
-from weave.trace_server import refs
+from weave.trace_server import refs_internal
 from weave.trace_server.trace_server_interface_util import (
     WILDCARD_ARTIFACT_VERSION_AND_PATH,
 )
@@ -85,8 +85,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS objects (
-                entity TEXT,
-                project TEXT,
+                project_id TEXT,
                 name TEXT,
                 created_at TEXT,
                 type TEXT,
@@ -101,8 +100,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS tables (
-                entity TEXT,
-                project TEXT,
+                project_id TEXT,
                 digest TEXT UNIQUE,
                 row_digests STRING)
             """
@@ -110,8 +108,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS table_rows (
-                entity TEXT,
-                project TEXT,
+                project_id TEXT,
                 digest TEXT UNIQUE,
                 val TEXT)
             """
@@ -119,8 +116,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         cursor.execute(
             """
             CREATE TABLE IF NOT EXISTS files (
-                entity TEXT,
-                project TEXT,
+                project_id TEXT,
                 digest TEXT UNIQUE,
                 val BLOB)
             """
@@ -307,21 +303,19 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         digest = str_digest(json_val)
 
         req_obj = req.obj
-        entity, project = req_obj.project_id.split("/")
         # TODO: version index isn't right here, what if we delete stuff?
         with self.lock:
             cursor.execute("BEGIN TRANSACTION")
             # first get version count
             cursor.execute(
-                """SELECT COUNT(*) FROM objects WHERE entity = ? AND project = ? AND name = ?""",
-                (entity, project, req_obj.name),
+                """SELECT COUNT(*) FROM objects WHERE project_id = ? AND name = ?""",
+                (req.obj.project_id, req_obj.name),
             )
             version_index = cursor.fetchone()[0]
 
             cursor.execute(
                 """INSERT OR IGNORE INTO objects (
-                    entity,
-                    project,
+                    project_id,
                     name,
                     created_at,
                     type,
@@ -332,8 +326,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     is_latest
                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
-                    entity,
-                    project,
+                    req_obj.project_id,
                     req_obj.name,
                     datetime.datetime.now().isoformat(),
                     get_type(req_obj.val),
@@ -356,8 +349,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         else:
             conds.append(f"digest = '{req.version_digest}'")
         objs = self._select_objs_query(
-            req.entity,
-            req.project,
+            req.project_id,
             conditions=conds,
         )
         if len(objs) == 0:
@@ -378,10 +370,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 conds.append(f"name IN ({in_list})")
             if req.filter.latest_only:
                 conds.append("is_latest = 1")
-        entity, project = req.project_id.split("/")
+
         objs = self._select_objs_query(
-            entity,
-            project,
+            req.project_id,
             conditions=conds,
         )
 
@@ -389,17 +380,16 @@ class SqliteTraceServer(tsi.TraceServerInterface):
 
     def table_create(self, req: tsi.TableCreateReq) -> tsi.TableCreateRes:
         conn, cursor = get_conn_cursor(self.db_path)
-        entity, project = req.table.project_id.split("/")
         insert_rows = []
         for r in req.table.rows:
             if not isinstance(r, dict):
                 raise ValueError("All rows must be dictionaries")
             row_json = json.dumps(r)
             row_digest = str_digest(row_json)
-            insert_rows.append((entity, project, row_digest, row_json))
+            insert_rows.append(( req.table.project_id, row_digest, row_json))
         with self.lock:
             cursor.executemany(
-                "INSERT OR IGNORE INTO table_rows (entity, project, digest, val) VALUES (?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO table_rows (project_id, digest, val) VALUES (?, ?, ?, ?)",
                 insert_rows,
             )
 
@@ -411,21 +401,20 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             table_digest = table_hasher.hexdigest()
 
             cursor.execute(
-                "INSERT OR IGNORE INTO tables (entity, project, digest, row_digests) VALUES (?, ?, ?, ?)",
-                (entity, project, table_digest, json.dumps(row_digests)),
+                "INSERT OR IGNORE INTO tables (project_id, digest, row_digests) VALUES (?, ?, ?, ?)",
+                (req.table.project_id, table_digest, json.dumps(row_digests)),
             )
             conn.commit()
 
         return tsi.TableCreateRes(digest=table_digest)
 
     def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
-        entity, project = req.project_id.split("/")
         conds = []
         if req.filter:
             raise NotImplementedError("Table filter not implemented")
         else:
             conds.append("1 = 1")
-        rows = self._table_query(entity, project, req.table_digest, conditions=conds)
+        rows = self._table_query(req.project_id, req.table_digest, conditions=conds)
 
         return tsi.TableQueryRes(rows=rows)
 
@@ -437,19 +426,18 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         if len(req.refs) > 1000:
             raise ValueError("Too many refs")
 
-        parsed_refs = [refs.parse_uri(r) for r in req.refs]
-        if any(isinstance(r, refs.TableRef) for r in parsed_refs):
+        parsed_refs = [refs_internal.parse_internal_uri(r) for r in req.refs]
+        if any(isinstance(r, refs_internal.InternalTableRefTableRef) for r in parsed_refs):
             raise ValueError("Table refs not supported")
-        parsed_obj_refs = cast(list[refs.ObjectRef], parsed_refs)
+        parsed_obj_refs = cast(list[refs_internal.InternalObjectRef], parsed_refs)
 
-        def read_ref(r: refs.ObjectRef) -> Any:
+        def read_ref(r: refs_internal.InternalObjectRef) -> Any:
             conds = [
                 f"name = '{r.name}'",
                 f"digest = '{r.version}'",
             ]
             objs = self._select_objs_query(
-                r.entity,
-                r.project,
+                r.project_id,
                 conditions=conds,
             )
             if len(objs) == 0:
@@ -466,15 +454,14 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 elif op == "ndx":
                     val = val[int(arg)]
                 elif op == "id":
-                    if isinstance(val, str) and val.startswith("weave://"):
-                        table_ref = refs.parse_uri(val)
-                        if not isinstance(table_ref, refs.TableRef):
+                    if isinstance(val, str) and val.startswith(refs_internal.WEAVE_INTERNAL_SCHEME + "://"):
+                        table_ref = refs_internal.parse_internal_uri(val)
+                        if not isinstance(table_ref, refs_internal.InternalTableRef):
                             raise ValueError(
                                 "invalid data layout encountered, expected TableRef when resolving id"
                             )
                         row = self._table_row_read(
-                            entity=table_ref.entity,
-                            project=table_ref.project,
+                            project_id=table_ref.project_id,
                             row_digest=arg,
                         )
                         val = row.val
@@ -493,10 +480,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         digest = bytes_digest(req.content)
         with self.lock:
             cursor.execute(
-                "INSERT OR IGNORE INTO files (entity, project, digest, val) VALUES (?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO files (project_id, digest, val) VALUES (?, ?, ?, ?)",
                 (
-                    req.project_id.split("/")[0],
-                    req.project_id.split("/")[1],
+                    req.project_id,
                     digest,
                     req.content,
                 ),
@@ -507,8 +493,8 @@ class SqliteTraceServer(tsi.TraceServerInterface):
     def file_content_read(self, req: tsi.FileContentReadReq) -> tsi.FileContentReadRes:
         conn, cursor = get_conn_cursor(self.db_path)
         cursor.execute(
-            "SELECT val FROM files WHERE entity = ? AND project = ? AND digest = ?",
-            (req.project_id.split("/")[0], req.project_id.split("/")[1], req.digest),
+            "SELECT val FROM files WHERE project_id = ? AND digest = ?",
+            (req.project_id, req.digest),
         )
         query_result = cursor.fetchone()
         if query_result is None:
@@ -517,15 +503,14 @@ class SqliteTraceServer(tsi.TraceServerInterface):
 
     def _table_query(
         self,
-        entity: str,
-        project: str,
+        project_id: str,
         table_digest: str,
         conditions: Optional[list[str]] = None,
         limit: Optional[int] = None,
         parameters: Optional[dict[str, Any]] = None,
     ) -> list[tsi.TableRowSchema]:
         conn, cursor = get_conn_cursor(self.db_path)
-        conds = ["entity = {entity: String}", "project = {project: String}"]
+        conds = ["project_id = {project_id: String}"]
         if conditions:
             conds.extend(conditions)
 
@@ -540,8 +525,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     tables,
                     json_each(tables.row_digests)
                 WHERE
-                    tables.entity = ? AND
-                    tables.project = ? AND
+                    tables.project_id = ? AND
                     tables.digest = ?
                 ORDER BY
                     json_each.id
@@ -553,7 +537,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 OrderedDigests
                 JOIN table_rows ON OrderedDigests.digest = table_rows.digest
             """,
-            (entity, project, table_digest),
+            (project_id, table_digest),
         )
         query_result = cursor.fetchall()
         return [
@@ -561,16 +545,16 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         ]
 
     def _table_row_read(
-        self, entity: str, project: str, row_digest: str
+        self, project_id: str, row_digest: str
     ) -> tsi.TableRowSchema:
         conn, cursor = get_conn_cursor(self.db_path)
         # Now get the rows
         cursor.execute(
             """
             SELECT digest, val FROM table_rows
-            WHERE entity = ? AND project = ? AND digest = ?
+            WHERE project_id = ? AND digest = ?
             """,
-            [entity, project, row_digest],
+            [project_id, row_digest],
         )
         query_result = cursor.fetchone()
         if query_result is None:
@@ -581,16 +565,15 @@ class SqliteTraceServer(tsi.TraceServerInterface):
 
     def _select_objs_query(
         self,
-        entity: str,
-        project: str,
+        project_id: str,
         conditions: Optional[list[str]] = None,
         limit: Optional[int] = None,
     ) -> list[tsi.ObjSchema]:
         conn, cursor = get_conn_cursor(self.db_path)
         pred = " AND ".join(conditions or ["1 = 1"])
         cursor.execute(
-            """SELECT * FROM objects WHERE entity = ? AND project = ? AND """ + pred,
-            (entity, project),
+            """SELECT * FROM objects WHERE project_id = ? AND """ + pred,
+            (project_id),
         )
         query_result = cursor.fetchall()
         result: list[tsi.ObjSchema] = []

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -393,7 +393,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 insert_rows,
             )
 
-            row_digests = [r[2] for r in insert_rows]
+            row_digests = [r[1] for r in insert_rows]
 
             table_hasher = hashlib.sha256()
             for row_digest in row_digests:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -427,9 +427,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             raise ValueError("Too many refs")
 
         parsed_refs = [refs_internal.parse_internal_uri(r) for r in req.refs]
-        if any(
-            isinstance(r, refs_internal.InternalTableRefTableRef) for r in parsed_refs
-        ):
+        if any(isinstance(r, refs_internal.InternalTableRef) for r in parsed_refs):
             raise ValueError("Table refs not supported")
         parsed_obj_refs = cast(list[refs_internal.InternalObjectRef], parsed_refs)
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -386,7 +386,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 raise ValueError("All rows must be dictionaries")
             row_json = json.dumps(r)
             row_digest = str_digest(row_json)
-            insert_rows.append(( req.table.project_id, row_digest, row_json))
+            insert_rows.append((req.table.project_id, row_digest, row_json))
         with self.lock:
             cursor.executemany(
                 "INSERT OR IGNORE INTO table_rows (project_id, digest, val) VALUES (?, ?, ?, ?)",
@@ -427,7 +427,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             raise ValueError("Too many refs")
 
         parsed_refs = [refs_internal.parse_internal_uri(r) for r in req.refs]
-        if any(isinstance(r, refs_internal.InternalTableRefTableRef) for r in parsed_refs):
+        if any(
+            isinstance(r, refs_internal.InternalTableRefTableRef) for r in parsed_refs
+        ):
             raise ValueError("Table refs not supported")
         parsed_obj_refs = cast(list[refs_internal.InternalObjectRef], parsed_refs)
 
@@ -454,7 +456,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 elif op == "ndx":
                     val = val[int(arg)]
                 elif op == "id":
-                    if isinstance(val, str) and val.startswith(refs_internal.WEAVE_INTERNAL_SCHEME + "://"):
+                    if isinstance(val, str) and val.startswith(
+                        refs_internal.WEAVE_INTERNAL_SCHEME + "://"
+                    ):
                         table_ref = refs_internal.parse_internal_uri(val)
                         if not isinstance(table_ref, refs_internal.InternalTableRef):
                             raise ValueError(
@@ -544,9 +548,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             tsi.TableRowSchema(digest=r[0], val=json.loads(r[1])) for r in query_result
         ]
 
-    def _table_row_read(
-        self, project_id: str, row_digest: str
-    ) -> tsi.TableRowSchema:
+    def _table_row_read(self, project_id: str, row_digest: str) -> tsi.TableRowSchema:
         conn, cursor = get_conn_cursor(self.db_path)
         # Now get the rows
         cursor.execute(

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -324,7 +324,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     digest,
                     version_index,
                     is_latest
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     req_obj.project_id,
                     req_obj.name,
@@ -389,7 +389,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             insert_rows.append((req.table.project_id, row_digest, row_json))
         with self.lock:
             cursor.executemany(
-                "INSERT OR IGNORE INTO table_rows (project_id, digest, val) VALUES (?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO table_rows (project_id, digest, val) VALUES (?, ?, ?)",
                 insert_rows,
             )
 
@@ -401,7 +401,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             table_digest = table_hasher.hexdigest()
 
             cursor.execute(
-                "INSERT OR IGNORE INTO tables (project_id, digest, row_digests) VALUES (?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO tables (project_id, digest, row_digests) VALUES (?, ?, ?)",
                 (req.table.project_id, table_digest, json.dumps(row_digests)),
             )
             conn.commit()
@@ -482,7 +482,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         digest = bytes_digest(req.content)
         with self.lock:
             cursor.execute(
-                "INSERT OR IGNORE INTO files (project_id, digest, val) VALUES (?, ?, ?, ?)",
+                "INSERT OR IGNORE INTO files (project_id, digest, val) VALUES (?, ?, ?)",
                 (
                     req.project_id,
                     digest,
@@ -573,21 +573,21 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         pred = " AND ".join(conditions or ["1 = 1"])
         cursor.execute(
             """SELECT * FROM objects WHERE project_id = ? AND """ + pred,
-            (project_id),
+            (project_id,),
         )
         query_result = cursor.fetchall()
         result: list[tsi.ObjSchema] = []
         for row in query_result:
             result.append(
                 tsi.ObjSchema(
-                    project_id=f"{row[0]}/{row[1]}",
-                    name=row[2],
-                    created_at=row[3],
-                    type=row[4],
-                    val=json.loads(row[6]),
-                    digest=row[7],
-                    version_index=row[8],
-                    is_latest=row[9],
+                    project_id=f"{row[0]}",
+                    name=row[1],
+                    created_at=row[2],
+                    type=row[3],
+                    val=json.loads(row[5]),
+                    digest=row[6],
+                    version_index=row[7],
+                    is_latest=row[8],
                 )
             )
 

--- a/weave/trace_server/tests/test_refs.py
+++ b/weave/trace_server/tests/test_refs.py
@@ -1,5 +1,5 @@
 import pytest
-from weave.trace_server.refs import ObjectRef
+from weave.trace.refs import ObjectRef
 
 
 def test_isdescended_from():

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -167,8 +167,7 @@ class OpCreateRes(BaseModel):
 
 
 class OpReadReq(BaseModel):
-    entity: str
-    project: str
+    project_id: str
     name: str
     version_hash: str
 
@@ -184,8 +183,7 @@ class _OpVersionFilter(BaseModel):
 
 
 class OpQueryReq(BaseModel):
-    entity: str
-    project: str
+    project_id: str
     filter: typing.Optional[_OpVersionFilter] = None
 
 
@@ -202,8 +200,7 @@ class ObjCreateRes(BaseModel):
 
 
 class ObjReadReq(BaseModel):
-    entity: str
-    project: str
+    project_id: str
     name: str
     version_digest: str
 

--- a/weave/trace_server/trace_server_interface_util.py
+++ b/weave/trace_server/trace_server_interface_util.py
@@ -5,6 +5,7 @@ import typing
 import uuid
 
 from . import trace_server_interface as tsi
+from . import refs_internal
 
 TRACE_REF_SCHEME = "weave"
 ARTIFACT_REF_SCHEME = "wandb-artifact"
@@ -54,7 +55,11 @@ def decode_b64_to_bytes(contents: typing.Dict[str, str]) -> typing.Dict[str, byt
     return res
 
 
-valid_schemes = [TRACE_REF_SCHEME, ARTIFACT_REF_SCHEME]
+valid_schemes = [
+    TRACE_REF_SCHEME,
+    ARTIFACT_REF_SCHEME,
+    refs_internal.WEAVE_INTERNAL_SCHEME,
+]
 
 
 def extract_refs_from_values(

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -31,7 +31,7 @@ from weave.trace_server.trace_server_interface import (
     _CallsFilter,
     _ObjectVersionFilter,
 )
-from weave.trace_server.refs import (
+from weave.trace.refs import (
     Ref,
     ObjectRef,
     TableRef,
@@ -261,8 +261,7 @@ class WeaveClient:
     def get(self, ref: ObjectRef) -> Any:
         read_res = self.server.obj_read(
             ObjReadReq(
-                entity=self.entity,
-                project=self.project,
+                project_id=self._project_id(),
                 name=ref.name,
                 version_digest=ref.version,
             )


### PR DESCRIPTION
This PR makes a fairly substantial change to the data model and ref structure. In particular, we make the following changes:
1. All trace server interfaces now accept a `project_id` rather than an `entity/project` tuple. Under no circumstances should the trace server implementation make the assumption that the project_id has any format whatsoever - it is just a string ID. This was already the case for calls, but now is true for objects, ops, and refs.
2. Refs are now stored with the following format: `weave-trace-internal:///PROJECT_ID/...` rather than `weave:///entity/project/...`. This sister representation is implemented in `refs_internal` and also gives us the benefit of moving `refs.py` out of the trace_server dependencies completely. With this change, and the change above, the trace server is now completely decoupled from any notion of entities and works purely on the basis of project_ids. 

Please see the uptake PR in core for a further discussion: https://github.com/wandb/core/pull/20371