### PR TITLE
chore(weave): Make OpenAI calls their own ops

### DIFF
--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -395,7 +395,11 @@ class WeaveClient:
     # These are the old client interface terms, op_execute still relies
     # on them.
     def create_run(
-        self, op_name: str, parent_run: typing.Optional[Call], inputs: dict, refs: Any
+        self,
+        op_name: Union[str, Op],
+        parent_run: typing.Optional[Call],
+        inputs: dict,
+        refs: Any,
     ) -> Call:
         return self.create_call(op_name, parent_run, inputs)
 


### PR DESCRIPTION
This PR makes it such that our OpenAI integration logging creates an Op for the OpenAI trace - allowing for viewing all OpenAI calls in a list and code saving.

<img width="2055" alt="Screenshot 2024-03-27 at 10 05 55" src="https://github.com/wandb/weave/assets/2142768/9c02bdd2-dae3-4bd6-914f-56ad96836e17">
<img width="2056" alt="Screenshot 2024-03-27 at 10 06 47" src="https://github.com/wandb/weave/assets/2142768/da98bc16-4a05-476e-b4d9-0b97712f8aa5">
