### PR TITLE
fix: Control eval parallelism from env var

### DIFF
--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -10,6 +10,7 @@ import numpy as np
 import weave
 from weave.trace.op import Op, BoundOp
 from weave.trace.errors import OpCallError
+from weave.trace.env import get_weave_parallelism
 from weave.flow.obj import Object
 from weave.flow.dataset import Dataset
 from weave.flow.model import Model
@@ -225,7 +226,9 @@ class Evaluation(Object):
         # with console.status("Evaluating...") as status:
         dataset = typing.cast(Dataset, self.dataset)
         _rows = dataset.rows
-        async for example, eval_row in util.async_foreach(_rows, eval_example, 30):
+        async for example, eval_row in util.async_foreach(
+            _rows, eval_example, get_weave_parallelism()
+        ):
             n_complete += 1
             duration = time.time() - start_time
             # status.update(

--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -3,5 +3,5 @@ import os
 WEAVE_PARALLELISM = "WEAVE_PARALLELISM"
 
 
-def get_weave_parallelism():
+def get_weave_parallelism() -> int:
     return int(os.getenv(WEAVE_PARALLELISM, "20"))

--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -1,0 +1,7 @@
+import os
+
+WEAVE_PARALLELISM = "WEAVE_PARALLELISM"
+
+
+def get_weave_parallelism():
+    return int(os.getenv(WEAVE_PARALLELISM, "20"))


### PR DESCRIPTION
This is a quick fix to help make progress when client calls hit rate limit errors in the Weave client. For example, when calling the Anthropic API with default rate limits, more than 1 parallelism results in failing requests.

We're going to want changes to how parallelism works. This is just a quick fix to give an out for users to work around the problem manually.