### PR TITLE
chore(weave): Improve default init experience

### DIFF
--- a/weave/init_message.py
+++ b/weave/init_message.py
@@ -1,13 +1,31 @@
 import typing
 
+if typing.TYPE_CHECKING:
+    import packaging.version  # type: ignore[import-not-found]
+
+REQUIRED_WANDB_VERSION = "0.16.4"
+
+
+def _parse_version(version: str) -> "packaging.version.Version":
+    """Parse a version string into a version object.
+
+    This function is a wrapper around the `packaging.version.parse` function, which
+    is used to parse version strings into version objects. If the `packaging` library
+    is not installed, it falls back to the `pkg_resources` library.
+    """
+    try:
+        from packaging.version import parse as parse_version  # type: ignore
+    except ImportError:
+        from pkg_resources import parse_version
+
+    return parse_version(version)
+
 
 def _print_version_check() -> None:
     import wandb
     import weave
 
-    required_wandb_version = "0.16.4"
-    parse_version = wandb.util.parse_version  # type: ignore
-    if parse_version(required_wandb_version) > parse_version(wandb.__version__):
+    if _parse_version(REQUIRED_WANDB_VERSION) > _parse_version(wandb.__version__):
         message = (
             "wandb version >= 0.16.4 is required.  To upgrade, please run:\n"
             " $ pip install wandb --upgrade"

--- a/weave/init_message.py
+++ b/weave/init_message.py
@@ -1,0 +1,57 @@
+import typing
+
+
+def _print_version_check() -> None:
+    import wandb
+    import weave
+
+    required_wandb_version = "0.16.4"
+    parse_version = wandb.util.parse_version  # type: ignore
+    if parse_version(required_wandb_version) > parse_version(wandb.__version__):
+        message = (
+            "wandb version >= 0.16.4 is required.  To upgrade, please run:\n"
+            " $ pip install wandb --upgrade"
+        )
+        print(message)
+    else:
+        wandb_messages = wandb.sdk.internal.update.check_available(wandb.__version__)
+        if wandb_messages:
+            # Don't print the upgrade message, only the delete or yank message
+            use_message = wandb_messages.get("delete_message") or wandb_messages.get(
+                "yank_message"
+            )  #  or wandb_messages.get("upgrade_message")
+            if use_message:
+                print(use_message)
+
+    orig_module = wandb._wandb_module
+    wandb._wandb_module = "weave"
+    weave_messages = wandb.sdk.internal.update.check_available(weave.__version__)
+    wandb._wandb_module = orig_module
+
+    if weave_messages:
+        use_message = (
+            weave_messages.get("delete_message")
+            or weave_messages.get("yank_message")
+            or weave_messages.get("upgrade_message")
+        )
+        if use_message:
+            print(use_message)
+
+
+def print_init_message(
+    username: typing.Optional[str],
+    entity_name: str,
+    project_name: str,
+    host: str = "https://wandb.ai",
+) -> None:
+    try:
+        _print_version_check()
+    except Exception as e:
+        pass
+
+    message = ""
+    if username is not None:
+        message += f"Logged in as W&B user {username}.\n"
+    message += f"View Weave data at {host}/{entity_name}/{project_name}/weave"
+
+    print(message)

--- a/weave/wandb_api.py
+++ b/weave/wandb_api.py
@@ -335,6 +335,7 @@ class WandbApi:
         """
         query DefaultEntity {
             viewer {
+                username
                 defaultEntity {
                     name
                 }
@@ -349,6 +350,14 @@ class WandbApi:
         except gql.transport.exceptions.TransportQueryError as e:
             return None
         return result.get("viewer", {}).get("defaultEntity", {}).get("name", None)
+
+    def username(self) -> typing.Optional[str]:
+        try:
+            result = self.query(self.VIEWER_DEFAULT_ENTITY_QUERY)
+        except gql.transport.exceptions.TransportQueryError as e:
+            return None
+
+        return result.get("viewer", {}).get("username", None)
 
 
 async def get_wandb_api() -> WandbApiAsync:

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -461,6 +461,9 @@ class WeaveClient:
     def ref_uri(self, name: str, version: str, path: str) -> str:
         return ObjectRef(self.entity, self.project, name, version).uri()
 
+    def __repr__(self) -> str:
+        return ""
+
 
 def safe_current_wb_run_id() -> Optional[str]:
     try:

--- a/weave/weave_init.py
+++ b/weave/weave_init.py
@@ -1,3 +1,5 @@
+import typing
+from . import init_message
 from .trace_server import remote_http_trace_server, sqlite_trace_server
 from . import context_state
 from . import errors
@@ -20,6 +22,13 @@ class InitializedClient:
         context_state._ref_tracking_enabled.reset(self.ref_tracking_token)
         context_state._eager_mode.reset(self.eager_mode_token)
         context_state._serverless_io_service.reset(self.serverless_io_service_token)
+
+
+def get_username() -> typing.Optional[str]:
+    from . import wandb_api
+
+    api = wandb_api.get_wandb_api_sync()
+    return api.username()
 
 
 def get_entity_project_from_project_name(project_name: str) -> tuple[str, str]:
@@ -50,17 +59,24 @@ def get_entity_project_from_project_name(project_name: str) -> tuple[str, str]:
 def init_weave(project_name: str) -> InitializedClient:
     from . import wandb_api
 
-    entity_name, project_name = get_entity_project_from_project_name(project_name)
-
-    remote_server = remote_http_trace_server.RemoteHTTPTraceServer.from_env(True)
-    # from .trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
-
     # Must init to read ensure we've read auth from the environment, in
     # case we're on a new thread.
     wandb_api.init()
     wandb_context = wandb_api.get_wandb_api_context()
+    if wandb_context is None:
+        import wandb
+
+        wandb.login()
+        wandb_api.init()
+        wandb_context = wandb_api.get_wandb_api_context()
+
+    remote_server = remote_http_trace_server.RemoteHTTPTraceServer.from_env(True)
+    # from .trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+
     if wandb_context is not None and wandb_context.api_key is not None:
         remote_server.set_auth(("api", wandb_context.api_key))
+
+    entity_name, project_name = get_entity_project_from_project_name(project_name)
 
     # server = ClickHouseTraceServer(host="localhost")
     client = weave_client.WeaveClient(entity_name, project_name, remote_server)
@@ -77,6 +93,9 @@ def init_weave(project_name: str) -> InitializedClient:
     # logged in local mode currently. When that's fixed, this autopatch call can be
     # moved to InitializedClient.__init__
     autopatch.autopatch()
+
+    username = get_username()
+    init_message.print_init_message(username, entity_name, project_name)
 
     return init_client
 


### PR DESCRIPTION
**Before: Not Logged In:**

Note: you must execute a shell command or import `wandb` (a non-weave lib) to fix:

<img width="987" alt="Screenshot 2024-03-27 at 13 07 17" src="https://github.com/wandb/weave/assets/2142768/592a95cd-a04a-4117-8f61-2240b327e67d">

** Before: Successful Init:**

Not helpful for users:

<img width="983" alt="Screenshot 2024-03-27 at 13 06 40" src="https://github.com/wandb/weave/assets/2142768/44f02e7f-60a3-4145-8a6f-8702e123df45">

**After**

Follows the same pattern as `wandb.init`
* (IF NEEDED): Prompt user to login with link to auth page - never need to import wandb
* (IF NEEDED): Warn user to upgrade `wandb` if the version is too low
* (IF NEEDED): Inform user of new weave package available (uses same mechanism as wandb)
* (Always) Informs user of their auth state and target project & link to weave home for logs

All 4 parts shown:
<img width="946" alt="Screenshot 2024-03-27 at 13 02 08 copy" src="https://github.com/wandb/weave/assets/2142768/5c68c28c-0302-4ce4-a578-7716ee410d06">
<img width="946" alt="Screenshot 2024-03-27 at 13 02 08" src="https://github.com/wandb/weave/assets/2142768/1ec9804f-87d8-4ff2-861f-119b7911b6d1">

Normal base case:
<img width="946" alt="Screenshot 2024-03-27 at 13 03 22" src="https://github.com/wandb/weave/assets/2142768/1a746941-0e26-401e-8874-7d7db752db95">
