### PR TITLE
chore: update dropdown to use common component instead of Material

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewStringFormatMenu.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewStringFormatMenu.tsx
@@ -1,6 +1,5 @@
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import * as React from 'react';
+import * as DropdownMenu from '@wandb/weave/components/DropdownMenu';
+import React, {useState} from 'react';
 
 import {Button} from '../../../../../Button';
 
@@ -9,37 +8,39 @@ type ValueViewStringFormatMenuProps = {
   onSetFormat: (format: string) => void;
 };
 
+// Unfortunately necessary to be visible above drawer.
+const STYLE_MENU_CONTENT = {zIndex: 1};
+
 export const ValueViewStringFormatMenu = ({
   format,
   onSetFormat,
 }: ValueViewStringFormatMenuProps) => {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-  const onClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  const onClickMenuItem = (newFormat: string) => {
-    onSetFormat(newFormat);
-    handleClose();
-  };
-
+  const [isOpen, setIsOpen] = useState(false);
   return (
     <div>
-      <Button size="small" variant="ghost" onClick={onClick}>
-        {format}
-      </Button>
-      <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
-        <MenuItem onClick={() => onClickMenuItem('Text')}>Text</MenuItem>
-        <MenuItem onClick={() => onClickMenuItem('JSON')}>JSON</MenuItem>
-        <MenuItem onClick={() => onClickMenuItem('Markdown')}>
-          Markdown
-        </MenuItem>
-        <MenuItem onClick={() => onClickMenuItem('Code')}>Code</MenuItem>
-      </Menu>
+      <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenu.Trigger>
+          <Button size="small" variant="ghost" active={isOpen}>
+            {format}
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content align="end" style={STYLE_MENU_CONTENT}>
+            <DropdownMenu.Item onClick={() => onSetFormat('Text')}>
+              Text
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => onSetFormat('JSON')}>
+              JSON
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => onSetFormat('Markdown')}>
+              Markdown
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => onSetFormat('Code')}>
+              Code
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
     </div>
   );
 };


### PR DESCRIPTION
Use our common component for the string value format dropdown instead of Material's menu. This will make it more consistent with our style guidelines, e.g. using Source Sans Pro, no ripple animation on click.

I suspect this will also fix a problem reported in Slack where the CSS rules were sometimes getting applied in an unexpected order, but I need to double check that.
https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1711575233181359

Before:
<img width="128" alt="Screenshot 2024-03-27 at 10 32 15 PM" src="https://github.com/wandb/weave/assets/112953339/a7c4da24-b628-4b87-b7a6-d0f24363b29b">

After:
<img width="128" alt="Screenshot 2024-03-27 at 10 32 05 PM" src="https://github.com/wandb/weave/assets/112953339/85f49ca9-8eec-40b0-a785-1ce1a1fd90db">
