### PR TITLE
fix: serialize objects when counting them for boring calculation

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
@@ -1,4 +1,5 @@
 import {GridColumnVisibilityModel} from '@mui/x-data-grid-pro';
+import stringify from 'json-stable-stringify';
 import {useState} from 'react';
 
 import {isRef} from '../Browse3/pages/common/util';
@@ -82,10 +83,16 @@ export const computeTableStats = (table: Array<Record<string, any>>) => {
             }
             colStats.refCounts[value] += 1;
           }
-          if (!(value in colStats.valueCounts)) {
-            colStats.valueCounts[value] = 0;
+          let valueStr = null;
+          try {
+            valueStr = stringify(value);
+          } catch (e) {
+            valueStr = `${value}`;
           }
-          colStats.valueCounts[value] += 1;
+          if (!(valueStr in colStats.valueCounts)) {
+            colStats.valueCounts[valueStr] = 0;
+          }
+          colStats.valueCounts[valueStr] += 1;
         }
       }
     }


### PR DESCRIPTION
Stringify objects when computing table stats. Without this, they are converted to `[object Object]` when used as a key of the valueCounts object. This would both incorrectly merge counts for different objects and appear in the boring value display instead of a usable string representation.

Would be interested in an opinion on the use of json-stable-stringify which will more correctly count objects according to JSON semantics vs. just JSON.stringify since in practice people often intend object key order to be meaningful.

Before:
<img width="327" alt="Screenshot 2024-03-28 at 9 49 52 AM" src="https://github.com/wandb/weave/assets/112953339/a77371d5-3a58-4adf-963b-ca2ace704f05">

After: (I turned on the input column so you could see the values)
<img width="545" alt="Screenshot 2024-03-28 at 9 49 42 AM" src="https://github.com/wandb/weave/assets/112953339/d6337836-c04b-4463-8b1f-0fcfe0f54ed8">
