### PR TITLE
chore(weave): Skip before fetching client

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -91,7 +91,7 @@ const makeTraceServerEndpointHook = <
         .catch(err => {
           setState({loading: false, result: null, error: err});
         });
-    }, [input]);
+    }, [getTsClient, input]);
 
     return state;
   };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -69,7 +69,6 @@ const makeTraceServerEndpointHook = <
   ): LoadableWithError<Output> => {
     input = useDeepMemo(input);
     const getTsClient = useGetTraceServerClientContext();
-    const client = getTsClient();
     const [state, setState] = useState<LoadableWithError<Output>>({
       loading: true,
       result: null,
@@ -83,6 +82,7 @@ const makeTraceServerEndpointHook = <
         setState({loading: false, result: null, error: null});
         return;
       }
+      const client = getTsClient();
       client[traceServerFnName](req.params as any)
         .then(res => {
           const output = postprocessFn(res as any, ...input);
@@ -91,7 +91,7 @@ const makeTraceServerEndpointHook = <
         .catch(err => {
           setState({loading: false, result: null, error: err});
         });
-    }, [client, input]);
+    }, [input]);
 
     return state;
   };


### PR DESCRIPTION
if im trying to do something like the function the skip wont be applied until after we try to fetch the trace client which causes the fetch to throw an error if no client. 

this pr moves the getTsClient after the skip is honored
```
export const useProjectHasTraceServerData = (
  entity: string,
  project: string
) => {
  const hasTraceServer = useHasTraceServerClientContext();
  const objs = tsWFDataModelHooks.useRootObjectVersions(
    entity,
    project,
    {},
    1,
    {
      skip: !hasTraceServer,
    }
  );

  const calls = tsWFDataModelHooks.useCalls(entity, project, {}, 1, {
    skip: !hasTraceServer,
  });
  const loading = objs.loading || calls.loading;
  return {
    loading,
    result: (objs.result ?? []).length > 0 || (calls.result ?? []).length > 0,
  };
};
```