### PR TITLE
chore(weave): Unify Edge Names Across Applciation

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RefValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RefValue.tsx
@@ -4,9 +4,9 @@ import React, {useMemo} from 'react';
 import {isListLike, isObjectTypeLike, isTypedDictLike} from '../../../../core';
 import {isRef} from '../Browse3/pages/common/util';
 import {
-  DICT_KEY_EDGE_TYPE,
-  LIST_INDEX_EDGE_TYPE,
-  OBJECT_ATTRIBUTE_EDGE_TYPE,
+  DICT_KEY_EDGE_NAME,
+  LIST_INDEX_EDGE_NAME,
+  OBJECT_ATTR_EDGE_NAME,
 } from '../Browse3/pages/wfReactInterface/constants';
 import {useWFHooks} from '../Browse3/pages/wfReactInterface/context';
 import {CellValue} from './CellValue';
@@ -39,21 +39,21 @@ export const RefValue = ({weaveRef, attribute}: RefValueProps) => {
     return (
       <RefValueWithExtra
         weaveRef={weaveRef}
-        attribute={DICT_KEY_EDGE_TYPE + '/' + attribute}
+        attribute={DICT_KEY_EDGE_NAME + '/' + attribute}
       />
     );
   } else if (isObjectTypeLike(getRefsType.result[0])) {
     return (
       <RefValueWithExtra
         weaveRef={weaveRef}
-        attribute={OBJECT_ATTRIBUTE_EDGE_TYPE + '/' + attribute}
+        attribute={OBJECT_ATTR_EDGE_NAME + '/' + attribute}
       />
     );
   } else if (isListLike(getRefsType.result[0])) {
     return (
       <RefValueWithExtra
         weaveRef={weaveRef}
-        attribute={LIST_INDEX_EDGE_TYPE + '/' + attribute}
+        attribute={LIST_INDEX_EDGE_NAME + '/' + attribute}
       />
     );
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -41,8 +41,8 @@ import {CallLink, opNiceName} from '../Browse3/pages/common/Links';
 import {StatusChip} from '../Browse3/pages/common/StatusChip';
 import {renderCell, useURLSearchParamsDict} from '../Browse3/pages/util';
 import {
-  DICT_KEY_EDGE_TYPE,
-  OBJECT_ATTRIBUTE_EDGE_TYPE,
+  DICT_KEY_EDGE_NAME,
+  OBJECT_ATTR_EDGE_NAME,
 } from '../Browse3/pages/wfReactInterface/constants';
 import {useWFHooks} from '../Browse3/pages/wfReactInterface/context';
 import {opVersionRefOpName} from '../Browse3/pages/wfReactInterface/utilities';
@@ -179,7 +179,7 @@ const getExtraColumns = (
           const subKeys = getExtraColumns([innerType]);
           subKeys.forEach(sk => {
             cols[k + '.' + sk.label] =
-              k + `/${OBJECT_ATTRIBUTE_EDGE_TYPE}/` + sk.path;
+              k + `/${OBJECT_ATTR_EDGE_NAME}/` + sk.path;
           });
         } else {
           cols[k] = k;
@@ -193,7 +193,7 @@ const getExtraColumns = (
         if (isExpandableType(innerType)) {
           const subKeys = getExtraColumns([innerType]);
           subKeys.forEach(sk => {
-            cols[k + '.' + sk.label] = k + `/${DICT_KEY_EDGE_TYPE}/` + sk.path;
+            cols[k + '.' + sk.label] = k + `/${DICT_KEY_EDGE_NAME}/` + sk.path;
           });
         } else {
           cols[k] = k;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/WeaveEditors.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/WeaveEditors.tsx
@@ -54,10 +54,10 @@ import {
 import {ValueViewPrimitive} from '../Browse3/pages/CallPage/ValueViewPrimitive';
 import {Link} from '../Browse3/pages/common/Links';
 import {
-  DICT_KEY_EDGE_TYPE,
-  LIST_INDEX_EDGE_TYPE,
-  OBJECT_ATTRIBUTE_EDGE_TYPE,
-  TABLE_ID_EDGE_TYPE,
+  DICT_KEY_EDGE_NAME,
+  LIST_INDEX_EDGE_NAME,
+  OBJECT_ATTR_EDGE_NAME,
+  TABLE_ID_EDGE_NAME,
 } from '../Browse3/pages/wfReactInterface/constants';
 import {useWFHooks} from '../Browse3/pages/wfReactInterface/context';
 import {TableQuery} from '../Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
@@ -110,9 +110,9 @@ const weaveEditorPathUrlPathPart = (path: WeaveEditorPathEl[]) => {
   // Return the url path for a given editor path
   return path.flatMap(pathEl => {
     if (pathEl.type === 'getattr') {
-      return [OBJECT_ATTRIBUTE_EDGE_TYPE, pathEl.key];
+      return [OBJECT_ATTR_EDGE_NAME, pathEl.key];
     } else if (pathEl.type === 'pick') {
-      return [DICT_KEY_EDGE_TYPE, pathEl.key];
+      return [DICT_KEY_EDGE_NAME, pathEl.key];
     } else {
       throw new Error('invalid pathEl type');
     }
@@ -605,7 +605,7 @@ export const WeaveEditorTypedDict: FC<{
                 <Link
                   to={makeLinkPath([
                     ...weaveEditorPathUrlPathPart(path),
-                    DICT_KEY_EDGE_TYPE,
+                    DICT_KEY_EDGE_NAME,
                     key,
                   ])}>
                   {key}
@@ -624,7 +624,7 @@ export const WeaveEditorTypedDict: FC<{
                     refUri: refUri(
                       objectRefWithExtra(
                         parseRef(refWithType.refUri),
-                        DICT_KEY_EDGE_TYPE + '/' + key
+                        DICT_KEY_EDGE_NAME + '/' + key
                       )
                     ),
                     type: propertyTypes[key] as Type,
@@ -669,7 +669,7 @@ export const WeaveEditorObject: FC<{
               <Link
                 to={makeLinkPath([
                   ...weaveEditorPathUrlPathPart(path),
-                  OBJECT_ATTRIBUTE_EDGE_TYPE,
+                  OBJECT_ATTR_EDGE_NAME,
                   key,
                 ])}>
                 {key}
@@ -683,7 +683,7 @@ export const WeaveEditorObject: FC<{
                   refUri: refUri(
                     objectRefWithExtra(
                       parseRef(refWithType.refUri),
-                      OBJECT_ATTRIBUTE_EDGE_TYPE + '/' + key
+                      OBJECT_ATTR_EDGE_NAME + '/' + key
                     )
                   ),
                   type: (refWithType.type as ObjectType)[key] as Type,
@@ -886,7 +886,7 @@ export const WeaveEditorTable: FC<{
           <Link
             to={makeLinkPath([
               ...weaveEditorPathUrlPathPart(path),
-              LIST_INDEX_EDGE_TYPE,
+              LIST_INDEX_EDGE_NAME,
               params.row._origIndex,
             ])}>
             <LinkIcon />
@@ -997,7 +997,7 @@ export const WeaveCHTable: FC<{
           <Link
             to={makeLinkPath([
               ...weaveEditorPathUrlPathPart(props.path),
-              TABLE_ID_EDGE_TYPE,
+              TABLE_ID_EDGE_NAME,
               params.row._table_row_digest,
             ])}>
             <LinkIcon />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -19,6 +19,11 @@ import {WFHighLevelObjectVersionFilter} from './pages/ObjectVersionsPage';
 import {WFHighLevelOpVersionFilter} from './pages/OpVersionsPage';
 import {WFHighLevelTypeVersionFilter} from './pages/TypeVersionsPage';
 import {useURLSearchParamsDict} from './pages/util';
+import {
+  AWL_ROW_EDGE_NAME,
+  DICT_KEY_EDGE_NAME,
+  OBJECT_ATTR_EDGE_NAME,
+} from './pages/wfReactInterface/constants';
 
 const pruneEmptyFields = (filter: {[key: string]: any} | null | undefined) => {
   if (!filter) {
@@ -238,12 +243,12 @@ const browse3ContextGen = (
       if (isWandbArtifactRef(objRef)) {
         if (objRef.artifactPath.endsWith('rows%2F0')) {
           objRef.artifactPath = 'obj';
-          let newArtifactRefExtra = 'atr/rows';
+          let newArtifactRefExtra = `${OBJECT_ATTR_EDGE_NAME}/rows`;
           objRef.artifactRefExtra?.split('/').forEach(part => {
             if (isNaN(parseInt(part, 10))) {
-              newArtifactRefExtra += '/key/' + part;
+              newArtifactRefExtra += `/${DICT_KEY_EDGE_NAME}/` + part;
             } else {
-              newArtifactRefExtra += '/row/' + part;
+              newArtifactRefExtra += `/${AWL_ROW_EDGE_NAME}/` + part;
             }
           });
           objRef.artifactRefExtra = newArtifactRefExtra;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
@@ -7,8 +7,8 @@ import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 import {
-  LIST_INDEX_EDGE_TYPE,
-  OBJECT_ATTRIBUTE_EDGE_TYPE,
+  LIST_INDEX_EDGE_NAME,
+  OBJECT_ATTR_EDGE_NAME,
 } from './wfReactInterface/constants';
 
 type TabUseDatasetProps = {
@@ -17,7 +17,7 @@ type TabUseDatasetProps = {
   versionIndex: number;
 };
 
-const ROW_PATH_PREFIX = `${OBJECT_ATTRIBUTE_EDGE_TYPE}/rows/${LIST_INDEX_EDGE_TYPE}/`;
+const ROW_PATH_PREFIX = `${OBJECT_ATTR_EDGE_NAME}/rows/${LIST_INDEX_EDGE_NAME}/`;
 
 export const TabUseDataset = ({
   name,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cgDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cgDataModelHooks.ts
@@ -73,12 +73,12 @@ import {
   refTypedNodeCache,
 } from './cache';
 import {
-  DICT_KEY_EDGE_TYPE,
-  LIST_INDEX_EDGE_TYPE,
-  OBJECT_ATTRIBUTE_EDGE_TYPE,
+  AWL_COL_EDGE_NAME,
+  AWL_ROW_EDGE_NAME,
+  DICT_KEY_EDGE_NAME,
+  LIST_INDEX_EDGE_NAME,
+  OBJECT_ATTR_EDGE_NAME,
   PROJECT_CALL_STREAM_NAME,
-  TABLE_COLUMN_EDGE_TYPE,
-  TABLE_ROW_EDGE_TYPE,
   WANDB_ARTIFACT_REF_PREFIX,
 } from './constants';
 import {
@@ -999,7 +999,7 @@ export const nodeFromExtra = (node: Node, extra: string[]): Node => {
   if (extra.length === 0) {
     return node;
   }
-  if (extra[0] === LIST_INDEX_EDGE_TYPE || extra[0] === TABLE_ROW_EDGE_TYPE) {
+  if (extra[0] === LIST_INDEX_EDGE_NAME || extra[0] === AWL_ROW_EDGE_NAME) {
     return nodeFromExtra(
       callOpVeryUnsafe('index', {
         arr: node,
@@ -1008,8 +1008,8 @@ export const nodeFromExtra = (node: Node, extra: string[]): Node => {
       extra.slice(2)
     );
   } else if (
-    extra[0] === DICT_KEY_EDGE_TYPE ||
-    extra[0] === TABLE_COLUMN_EDGE_TYPE
+    extra[0] === DICT_KEY_EDGE_NAME ||
+    extra[0] === AWL_COL_EDGE_NAME
   ) {
     return nodeFromExtra(
       callOpVeryUnsafe('pick', {
@@ -1018,7 +1018,7 @@ export const nodeFromExtra = (node: Node, extra: string[]): Node => {
       }) as Node,
       extra.slice(2)
     );
-  } else if (extra[0] === OBJECT_ATTRIBUTE_EDGE_TYPE) {
+  } else if (extra[0] === OBJECT_ATTR_EDGE_NAME) {
     return nodeFromExtra(
       callOpVeryUnsafe('Object-__getattr__', {
         self: node,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants.ts
@@ -4,12 +4,12 @@ export const WANDB_ARTIFACT_REF_PREFIX = `${WANDB_ARTIFACT_REF_SCHEME}:///`;
 export const WEAVE_REF_SCHEME = 'weave';
 export const WEAVE_REF_PREFIX = `${WEAVE_REF_SCHEME}:///`;
 export const WILDCARD_ARTIFACT_VERSION_AND_PATH = ':*/obj';
-export const DICT_KEY_EDGE_TYPE = 'key';
-export const LIST_INDEX_EDGE_TYPE = 'ndx';
-export const TABLE_ID_EDGE_TYPE = 'id';
-export const OBJECT_ATTRIBUTE_EDGE_TYPE = 'atr';
-export const TABLE_ROW_EDGE_TYPE = 'row';
-export const TABLE_COLUMN_EDGE_TYPE = 'col';
+export const DICT_KEY_EDGE_NAME = 'key';
+export const LIST_INDEX_EDGE_NAME = 'index';
+export const TABLE_ID_EDGE_NAME = 'id';
+export const OBJECT_ATTR_EDGE_NAME = 'attr';
+export const AWL_ROW_EDGE_NAME = 'row';
+export const AWL_COL_EDGE_NAME = 'col';
 export const OP_CATEGORIES = [
   'train',
   'predict',

--- a/weave/arrow/list_.py
+++ b/weave/arrow/list_.py
@@ -583,18 +583,18 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
 
         # The client might send over refs without knowing the underlying list type is a table.
         if (
-            edge_type == ref_util.DICT_KEY_EDGE_TYPE
-            or edge_type == ref_util.OBJECT_ATTRIBUTE_EDGE_TYPE
+            edge_type == ref_util.DICT_KEY_EDGE_NAME
+            or edge_type == ref_util.OBJECT_ATTR_EDGE_NAME
         ):
-            edge_type = ref_util.TABLE_COLUMN_EDGE_TYPE
-        elif edge_type == ref_util.LIST_INDEX_EDGE_TYPE:
-            edge_type = ref_util.TABLE_ROW_EDGE_TYPE
+            edge_type = ref_util.AWL_COL_EDGE_NAME
+        elif edge_type == ref_util.LIST_INDEX_EDGE_NAME:
+            edge_type = ref_util.AWL_ROW_EDGE_NAME
 
         assert edge_type in [
-            ref_util.TABLE_ROW_EDGE_TYPE,
-            ref_util.TABLE_COLUMN_EDGE_TYPE,
+            ref_util.AWL_ROW_EDGE_NAME,
+            ref_util.AWL_COL_EDGE_NAME,
         ]
-        if edge_type == ref_util.TABLE_ROW_EDGE_TYPE:
+        if edge_type == ref_util.AWL_ROW_EDGE_NAME:
             res = self[int(edge_path)]
         else:
             res = self.column(edge_path)
@@ -1121,7 +1121,7 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
         pylist = self.to_pylist_tagged()
         for i, x in enumerate(pylist):
             yield ref_util.val_with_relative_ref(
-                self, x, [ref_util.TABLE_ROW_EDGE_TYPE, str(i)]
+                self, x, [ref_util.AWL_ROW_EDGE_NAME, str(i)]
             )
 
     def __repr__(self):
@@ -1333,7 +1333,7 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
             result = awl.to_pylist_tagged()[0]
 
             return ref_util.val_with_relative_ref(
-                self, result, [ref_util.TABLE_ROW_EDGE_TYPE, str(index)]
+                self, result, [ref_util.AWL_ROW_EDGE_NAME, str(index)]
             )
         return awl
 
@@ -1446,7 +1446,7 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
         )
 
         return ref_util.val_with_relative_ref(
-            self, val, [ref_util.TABLE_COLUMN_EDGE_TYPE, str(name)]
+            self, val, [ref_util.AWL_COL_EDGE_NAME, str(name)]
         )
 
     def unique(self) -> "ArrowWeaveList":

--- a/weave/artifact_fs.py
+++ b/weave/artifact_fs.py
@@ -307,9 +307,9 @@ class FilesystemArtifactRef(artifact_base.ArtifactRef):
                                 f"Cannot get type of {self} with extra {self.extra}"
                             )
                         ot = ot.property_types()[extra_edge_value]  # type: ignore
-                    elif extra_edge_type == ref_util.TABLE_ROW_EDGE_TYPE:
+                    elif extra_edge_type == ref_util.AWL_ROW_EDGE_NAME:
                         ot = ot.object_type  # type: ignore
-                    elif extra_edge_type == ref_util.TABLE_COLUMN_EDGE_TYPE:
+                    elif extra_edge_type == ref_util.AWL_COL_EDGE_NAME:
                         ot = types.List(ot.object_type.property_types[extra_edge_value])  # type: ignore
                     else:
                         raise errors.WeaveInternalError(

--- a/weave/artifact_fs.py
+++ b/weave/artifact_fs.py
@@ -289,19 +289,19 @@ class FilesystemArtifactRef(artifact_base.ArtifactRef):
                 for i in range(0, len(self.extra), 2):
                     extra_edge_type = self.extra[i]
                     extra_edge_value = self.extra[i + 1]
-                    if extra_edge_type == ref_util.DICT_KEY_EDGE_TYPE:
+                    if extra_edge_type == ref_util.DICT_KEY_EDGE_NAME:
                         if not types.is_type_like(ot, types.TypedDict({})):
                             raise errors.WeaveInternalError(
                                 f"Cannot get type of {self} with extra {self.extra}"
                             )
                         ot = ot.property_types[extra_edge_value]  # type: ignore
-                    elif extra_edge_type == ref_util.LIST_INDEX_EDGE_TYPE:
+                    elif extra_edge_type == ref_util.LIST_INDEX_EDGE_NAME:
                         if not types.is_list_like(ot):
                             raise errors.WeaveInternalError(
                                 f"Cannot get type of {self} with extra {self.extra}"
                             )
                         ot = ot.object_type  # type: ignore
-                    elif extra_edge_type == ref_util.OBJECT_ATTRIBUTE_EDGE_TYPE:
+                    elif extra_edge_type == ref_util.OBJECT_ATTR_EDGE_NAME:
                         if not types.is_type_like(ot, types.ObjectType()):
                             raise errors.WeaveInternalError(
                                 f"Cannot get type of {self} with extra {self.extra}"

--- a/weave/box.py
+++ b/weave/box.py
@@ -72,7 +72,7 @@ class BoxedDict(dict):
         assert len(path) > 1
         edge_type = path[0]
         edge_path = path[1]
-        assert edge_type == ref_util.DICT_KEY_EDGE_TYPE
+        assert edge_type == ref_util.DICT_KEY_EDGE_NAME
 
         res = self[edge_path]
         remaining_path = path[2:]
@@ -83,7 +83,7 @@ class BoxedDict(dict):
     def __getitem__(self, __key: typing.Any) -> typing.Any:
         val = super().__getitem__(__key)
         return ref_util.val_with_relative_ref(
-            self, val, [ref_util.DICT_KEY_EDGE_TYPE, str(__key)]
+            self, val, [ref_util.DICT_KEY_EDGE_NAME, str(__key)]
         )
 
 
@@ -92,7 +92,7 @@ class BoxedList(list):
         assert len(path) > 1
         edge_type = path[0]
         edge_path = path[1]
-        assert edge_type == ref_util.LIST_INDEX_EDGE_TYPE
+        assert edge_type == ref_util.LIST_INDEX_EDGE_NAME
 
         res = self[int(edge_path)]
         remaining_path = path[2:]
@@ -109,7 +109,7 @@ class BoxedList(list):
     def __getitem__(self, __index: typing.Any) -> typing.Any:
         val = super().__getitem__(__index)
         return ref_util.val_with_relative_ref(
-            self, val, [ref_util.LIST_INDEX_EDGE_TYPE, str(__index)]
+            self, val, [ref_util.LIST_INDEX_EDGE_NAME, str(__index)]
         )
 
 

--- a/weave/object_type_ref_util.py
+++ b/weave/object_type_ref_util.py
@@ -13,7 +13,7 @@ def make_object_getattribute(
         if name not in allowed_attributes:
             return attribute
         return ref_util.val_with_relative_ref(
-            self, attribute, [ref_util.OBJECT_ATTRIBUTE_EDGE_TYPE, str(name)]
+            self, attribute, [ref_util.OBJECT_ATTR_EDGE_NAME, str(name)]
         )
 
     return object_getattribute
@@ -26,7 +26,7 @@ def make_object_lookup_path() -> (
         assert len(path) > 1
         edge_type = path[0]
         edge_path = path[1]
-        assert edge_type == ref_util.OBJECT_ATTRIBUTE_EDGE_TYPE
+        assert edge_type == ref_util.OBJECT_ATTR_EDGE_NAME
 
         res = getattr(self, edge_path)
         remaining_path = path[2:]

--- a/weave/ref_util.py
+++ b/weave/ref_util.py
@@ -3,12 +3,13 @@ import dataclasses
 from urllib import parse
 
 from . import box
+from .trace_server import refs_internal
 
-DICT_KEY_EDGE_TYPE = "key"
-LIST_INDEX_EDGE_TYPE = "ndx"
-OBJECT_ATTRIBUTE_EDGE_TYPE = "atr"
-TABLE_ROW_EDGE_TYPE = "row"
-TABLE_COLUMN_EDGE_TYPE = "col"
+DICT_KEY_EDGE_NAME = refs_internal.DICT_KEY_EDGE_NAME
+LIST_INDEX_EDGE_NAME = refs_internal.LIST_INDEX_EDGE_NAME
+OBJECT_ATTR_EDGE_NAME = refs_internal.OBJECT_ATTR_EDGE_NAME
+AWL_ROW_EDGE_NAME = "row"
+AWL_COL_EDGE_NAME = "col"
 
 
 def parse_local_ref_str(s: str) -> typing.Tuple[str, typing.Optional[list[str]]]:

--- a/weave/tests/test_vals.py
+++ b/weave/tests/test_vals.py
@@ -1,5 +1,9 @@
 import pytest
 from weave.trace.refs import ObjectRef
+from weave.trace_server.refs_internal import (
+    DICT_KEY_EDGE_NAME,
+    LIST_INDEX_EDGE_NAME,
+)
 
 
 def test_dict_refs(client):
@@ -8,12 +12,12 @@ def test_dict_refs(client):
     assert d["a"] == 1
     assert isinstance(d["a"].ref, ObjectRef)
     assert d["a"].ref.is_descended_from(d.ref)
-    assert d["a"].ref.extra == ["key", "a"]
+    assert d["a"].ref.extra == [DICT_KEY_EDGE_NAME, "a"]
 
     assert d["b"] == 2
     assert isinstance(d["b"].ref, ObjectRef)
     assert d["b"].ref.is_descended_from(d.ref)
-    assert d["b"].ref.extra == ["key", "b"]
+    assert d["b"].ref.extra == [DICT_KEY_EDGE_NAME, "b"]
 
 
 def test_dict_iter(client):
@@ -25,12 +29,12 @@ def test_dict_iter(client):
     assert d["a"] == 1
     assert isinstance(d["a"].ref, ObjectRef)
     assert d["a"].ref.is_descended_from(d_orig.ref)
-    assert d["a"].ref.extra == ["key", "a"]
+    assert d["a"].ref.extra == [DICT_KEY_EDGE_NAME, "a"]
 
     assert d["b"] == 2
     assert isinstance(d["b"].ref, ObjectRef)
     assert d["b"].ref.is_descended_from(d_orig.ref)
-    assert d["b"].ref.extra == ["key", "b"]
+    assert d["b"].ref.extra == [DICT_KEY_EDGE_NAME, "b"]
 
 
 def test_list_refs(client):
@@ -39,12 +43,12 @@ def test_list_refs(client):
     assert l[0] == 1
     assert isinstance(l[0].ref, ObjectRef)
     assert l[0].ref.is_descended_from(l.ref)
-    assert l[0].ref.extra == ["ndx", "0"]
+    assert l[0].ref.extra == [LIST_INDEX_EDGE_NAME, "0"]
 
     assert l[1] == 2
     assert isinstance(l[1].ref, ObjectRef)
     assert l[1].ref.is_descended_from(l.ref)
-    assert l[1].ref.extra == ["ndx", "1"]
+    assert l[1].ref.extra == [LIST_INDEX_EDGE_NAME, "1"]
 
 
 def test_list_iter(client):

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -9,10 +9,10 @@ from weave import op_def, Evaluation
 from weave import weave_client
 from weave.trace.op import Op
 from weave.trace.refs import (
-    ATTRIBUTE_EDGE_TYPE,
-    ID_EDGE_TYPE,
-    INDEX_EDGE_TYPE,
-    KEY_EDGE_TYPE,
+    OBJECT_ATTR_EDGE_NAME,
+    TABLE_ROW_ID_EDGE_NAME,
+    LIST_INDEX_EDGE_NAME,
+    DICT_KEY_EDGE_NAME,
 )
 
 from weave.trace import refs
@@ -43,9 +43,9 @@ def test_table_create(client):
             table=TableSchemaForInsert(
                 project_id="test/test-project",
                 rows=[
-                    {ID_EDGE_TYPE: 1, "val": 1},
-                    {ID_EDGE_TYPE: 2, "val": 2},
-                    {ID_EDGE_TYPE: 3, "val": 3},
+                    {TABLE_ROW_ID_EDGE_NAME: 1, "val": 1},
+                    {TABLE_ROW_ID_EDGE_NAME: 2, "val": 2},
+                    {TABLE_ROW_ID_EDGE_NAME: 3, "val": 3},
                 ],
             )
         )
@@ -123,11 +123,11 @@ def test_dataset_refs(client):
         "my-dataset",
         ref.ref.version,
         [
-            ATTRIBUTE_EDGE_TYPE,
+            OBJECT_ATTR_EDGE_NAME,
             "rows",
-            ID_EDGE_TYPE,
+            TABLE_ROW_ID_EDGE_NAME,
             RegexStringMatcher(".*"),
-            KEY_EDGE_TYPE,
+            DICT_KEY_EDGE_NAME,
             "v",
         ],
     )
@@ -141,11 +141,11 @@ def test_dataset_refs(client):
         "my-dataset",
         ref.ref.version,
         [
-            ATTRIBUTE_EDGE_TYPE,
+            OBJECT_ATTR_EDGE_NAME,
             "rows",
-            ID_EDGE_TYPE,
+            TABLE_ROW_ID_EDGE_NAME,
             RegexStringMatcher(".*"),
-            KEY_EDGE_TYPE,
+            DICT_KEY_EDGE_NAME,
             "v",
         ],
     )
@@ -257,15 +257,15 @@ def test_mutations(client):
     dataset.cows = "moo"
     assert dataset.mutations == [
         weave_client.MutationAppend(
-            path=[ATTRIBUTE_EDGE_TYPE, "rows"],
+            path=[OBJECT_ATTR_EDGE_NAME, "rows"],
             operation="append",
             args=({"doc": "zz", "label": "e"},),
         ),
         weave_client.MutationSetitem(
             path=[
-                ATTRIBUTE_EDGE_TYPE,
+                OBJECT_ATTR_EDGE_NAME,
                 "rows",
-                ID_EDGE_TYPE,
+                TABLE_ROW_ID_EDGE_NAME,
                 RegexStringMatcher(".*,.*"),
             ],
             operation="setitem",
@@ -273,13 +273,13 @@ def test_mutations(client):
         ),
         weave_client.MutationSetitem(
             path=[
-                ATTRIBUTE_EDGE_TYPE,
+                OBJECT_ATTR_EDGE_NAME,
                 "rows",
-                ID_EDGE_TYPE,
+                TABLE_ROW_ID_EDGE_NAME,
                 RegexStringMatcher(".*,.*"),
-                KEY_EDGE_TYPE,
+                DICT_KEY_EDGE_NAME,
                 "somelist",
-                INDEX_EDGE_TYPE,
+                LIST_INDEX_EDGE_NAME,
                 "0",
             ],
             operation="setitem",
@@ -422,7 +422,7 @@ def test_dataset_rows_ref(client):
     saved = client.save(dataset, "my-dataset")
     assert isinstance(saved.rows.ref, weave_client.ObjectRef)
     assert saved.rows.ref.name == "my-dataset"
-    assert saved.rows.ref.extra == [ATTRIBUTE_EDGE_TYPE, "rows"]
+    assert saved.rows.ref.extra == [OBJECT_ATTR_EDGE_NAME, "rows"]
 
 
 # @pytest.mark.skip("failing in ci, due to some kind of /tmp file slowness?")
@@ -491,31 +491,31 @@ def test_evaluate(client):
     example0_obj = child0.inputs["example"]
     assert example0_obj.ref.name == "Dataset"
     assert example0_obj.ref.extra == [
-        ATTRIBUTE_EDGE_TYPE,
+        OBJECT_ATTR_EDGE_NAME,
         "rows",
-        ID_EDGE_TYPE,
+        TABLE_ROW_ID_EDGE_NAME,
         RegexStringMatcher(".*"),
     ]
     example0_obj_input = example0_obj["input"]
     assert example0_obj_input == "1 + 2"
     assert example0_obj_input.ref.name == "Dataset"
     assert example0_obj_input.ref.extra == [
-        ATTRIBUTE_EDGE_TYPE,
+        OBJECT_ATTR_EDGE_NAME,
         "rows",
-        ID_EDGE_TYPE,
+        TABLE_ROW_ID_EDGE_NAME,
         RegexStringMatcher(".*"),
-        KEY_EDGE_TYPE,
+        DICT_KEY_EDGE_NAME,
         "input",
     ]
     example0_obj_target = example0_obj["target"]
     assert example0_obj_target == 3
     assert example0_obj_target.ref.name == "Dataset"
     assert example0_obj_target.ref.extra == [
-        ATTRIBUTE_EDGE_TYPE,
+        OBJECT_ATTR_EDGE_NAME,
         "rows",
-        ID_EDGE_TYPE,
+        TABLE_ROW_ID_EDGE_NAME,
         RegexStringMatcher(".*"),
-        KEY_EDGE_TYPE,
+        DICT_KEY_EDGE_NAME,
         "target",
     ]
 
@@ -531,9 +531,9 @@ def test_evaluate(client):
     example1_obj = child1.inputs["example"]
     assert example1_obj.ref.name == "Dataset"
     assert example1_obj.ref.extra == [
-        ATTRIBUTE_EDGE_TYPE,
+        OBJECT_ATTR_EDGE_NAME,
         "rows",
-        ID_EDGE_TYPE,
+        TABLE_ROW_ID_EDGE_NAME,
         RegexStringMatcher(".*"),
     ]
     # Should be a different row ref

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -2,10 +2,10 @@ from typing import Union, Any
 import dataclasses
 from ..trace_server import refs_internal
 
-KEY_EDGE_TYPE = refs_internal.KEY_EDGE_TYPE
-INDEX_EDGE_TYPE = refs_internal.INDEX_EDGE_TYPE
-ATTRIBUTE_EDGE_TYPE = refs_internal.ATTRIBUTE_EDGE_TYPE
-ID_EDGE_TYPE = refs_internal.ID_EDGE_TYPE
+DICT_KEY_EDGE_NAME = refs_internal.DICT_KEY_EDGE_NAME
+LIST_INDEX_EDGE_NAME = refs_internal.LIST_INDEX_EDGE_NAME
+OBJECT_ATTR_EDGE_NAME = refs_internal.OBJECT_ATTR_EDGE_NAME
+TABLE_ROW_ID_EDGE_TYPE = refs_internal.TABLE_ROW_ID_EDGE_TYPE
 
 
 @dataclasses.dataclass
@@ -32,16 +32,16 @@ class RefWithExtra(Ref):
         return self.__class__(**params)
 
     def with_key(self, key: str) -> "RefWithExtra":
-        return self.with_extra([KEY_EDGE_TYPE, key])
+        return self.with_extra([DICT_KEY_EDGE_NAME, key])
 
     def with_attr(self, attr: str) -> "RefWithExtra":
-        return self.with_extra([ATTRIBUTE_EDGE_TYPE, attr])
+        return self.with_extra([OBJECT_ATTR_EDGE_NAME, attr])
 
     def with_index(self, index: int) -> "RefWithExtra":
-        return self.with_extra([INDEX_EDGE_TYPE, str(index)])
+        return self.with_extra([LIST_INDEX_EDGE_NAME, str(index)])
 
     def with_item(self, item_digest: str) -> "RefWithExtra":
-        return self.with_extra([ID_EDGE_TYPE, f"{item_digest}"])
+        return self.with_extra([TABLE_ROW_ID_EDGE_TYPE, f"{item_digest}"])
 
 
 @dataclasses.dataclass

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -5,7 +5,7 @@ from ..trace_server import refs_internal
 DICT_KEY_EDGE_NAME = refs_internal.DICT_KEY_EDGE_NAME
 LIST_INDEX_EDGE_NAME = refs_internal.LIST_INDEX_EDGE_NAME
 OBJECT_ATTR_EDGE_NAME = refs_internal.OBJECT_ATTR_EDGE_NAME
-AWL_ROW_ID_EDGE_TYPE = refs_internal.AWL_ROW_ID_EDGE_TYPE
+TABLE_ROW_ID_EDGE_TYPE = refs_internal.TABLE_ROW_ID_EDGE_TYPE
 
 
 @dataclasses.dataclass
@@ -41,7 +41,7 @@ class RefWithExtra(Ref):
         return self.with_extra([LIST_INDEX_EDGE_NAME, str(index)])
 
     def with_item(self, item_digest: str) -> "RefWithExtra":
-        return self.with_extra([AWL_ROW_ID_EDGE_TYPE, f"{item_digest}"])
+        return self.with_extra([TABLE_ROW_ID_EDGE_TYPE, f"{item_digest}"])
 
 
 @dataclasses.dataclass

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -5,7 +5,7 @@ from ..trace_server import refs_internal
 DICT_KEY_EDGE_NAME = refs_internal.DICT_KEY_EDGE_NAME
 LIST_INDEX_EDGE_NAME = refs_internal.LIST_INDEX_EDGE_NAME
 OBJECT_ATTR_EDGE_NAME = refs_internal.OBJECT_ATTR_EDGE_NAME
-TABLE_ROW_ID_EDGE_TYPE = refs_internal.TABLE_ROW_ID_EDGE_TYPE
+TABLE_ROW_ID_EDGE_NAME = refs_internal.TABLE_ROW_ID_EDGE_NAME
 
 
 @dataclasses.dataclass
@@ -41,7 +41,7 @@ class RefWithExtra(Ref):
         return self.with_extra([LIST_INDEX_EDGE_NAME, str(index)])
 
     def with_item(self, item_digest: str) -> "RefWithExtra":
-        return self.with_extra([TABLE_ROW_ID_EDGE_TYPE, f"{item_digest}"])
+        return self.with_extra([TABLE_ROW_ID_EDGE_NAME, f"{item_digest}"])
 
 
 @dataclasses.dataclass

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -5,7 +5,7 @@ from ..trace_server import refs_internal
 DICT_KEY_EDGE_NAME = refs_internal.DICT_KEY_EDGE_NAME
 LIST_INDEX_EDGE_NAME = refs_internal.LIST_INDEX_EDGE_NAME
 OBJECT_ATTR_EDGE_NAME = refs_internal.OBJECT_ATTR_EDGE_NAME
-TABLE_ROW_ID_EDGE_TYPE = refs_internal.TABLE_ROW_ID_EDGE_TYPE
+AWL_ROW_ID_EDGE_TYPE = refs_internal.AWL_ROW_ID_EDGE_TYPE
 
 
 @dataclasses.dataclass
@@ -41,7 +41,7 @@ class RefWithExtra(Ref):
         return self.with_extra([LIST_INDEX_EDGE_NAME, str(index)])
 
     def with_item(self, item_digest: str) -> "RefWithExtra":
-        return self.with_extra([TABLE_ROW_ID_EDGE_TYPE, f"{item_digest}"])
+        return self.with_extra([AWL_ROW_ID_EDGE_TYPE, f"{item_digest}"])
 
 
 @dataclasses.dataclass

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -10,10 +10,10 @@ from weave.trace.refs import (
     RefWithExtra,
     ObjectRef,
     TableRef,
-    KEY_EDGE_TYPE,
-    ATTRIBUTE_EDGE_TYPE,
-    INDEX_EDGE_TYPE,
-    ID_EDGE_TYPE,
+    DICT_KEY_EDGE_NAME,
+    OBJECT_ATTR_EDGE_NAME,
+    LIST_INDEX_EDGE_NAME,
+    TABLE_ROW_ID_EDGE_TYPE,
 )
 from weave import box
 from weave.table import Table
@@ -396,13 +396,13 @@ def make_trace_obj(
         # This is where extra resolution happens?
         for extra_index in range(0, len(extra), 2):
             op, arg = extra[extra_index], extra[extra_index + 1]
-            if op == KEY_EDGE_TYPE:
+            if op == DICT_KEY_EDGE_NAME:
                 val = val[arg]
-            elif op == ATTRIBUTE_EDGE_TYPE:
+            elif op == OBJECT_ATTR_EDGE_NAME:
                 val = getattr(val, arg)
-            elif op == INDEX_EDGE_TYPE:
+            elif op == LIST_INDEX_EDGE_NAME:
                 val = val[int(arg)]
-            elif op == ID_EDGE_TYPE:
+            elif op == TABLE_ROW_ID_EDGE_TYPE:
                 val = val[arg]
             else:
                 raise ValueError(f"Unknown ref type: {extra[extra_index]}")

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -13,7 +13,7 @@ from weave.trace.refs import (
     DICT_KEY_EDGE_NAME,
     OBJECT_ATTR_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
-    TABLE_ROW_ID_EDGE_TYPE,
+    TABLE_ROW_ID_EDGE_NAME,
 )
 from weave import box
 from weave.table import Table
@@ -402,7 +402,7 @@ def make_trace_obj(
                 val = getattr(val, arg)
             elif op == LIST_INDEX_EDGE_NAME:
                 val = val[int(arg)]
-            elif op == TABLE_ROW_ID_EDGE_TYPE:
+            elif op == TABLE_ROW_ID_EDGE_NAME:
                 val = val[arg]
             else:
                 raise ValueError(f"Unknown ref type: {extra[extra_index]}")

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -13,7 +13,7 @@ from weave.trace.refs import (
     DICT_KEY_EDGE_NAME,
     OBJECT_ATTR_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
-    TABLE_ROW_ID_EDGE_TYPE,
+    AWL_ROW_ID_EDGE_TYPE,
 )
 from weave import box
 from weave.table import Table
@@ -402,7 +402,7 @@ def make_trace_obj(
                 val = getattr(val, arg)
             elif op == LIST_INDEX_EDGE_NAME:
                 val = val[int(arg)]
-            elif op == TABLE_ROW_ID_EDGE_TYPE:
+            elif op == AWL_ROW_ID_EDGE_TYPE:
                 val = val[arg]
             else:
                 raise ValueError(f"Unknown ref type: {extra[extra_index]}")

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -13,7 +13,7 @@ from weave.trace.refs import (
     DICT_KEY_EDGE_NAME,
     OBJECT_ATTR_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
-    AWL_ROW_ID_EDGE_TYPE,
+    TABLE_ROW_ID_EDGE_TYPE,
 )
 from weave import box
 from weave.table import Table
@@ -402,7 +402,7 @@ def make_trace_obj(
                 val = getattr(val, arg)
             elif op == LIST_INDEX_EDGE_NAME:
                 val = val[int(arg)]
-            elif op == AWL_ROW_ID_EDGE_TYPE:
+            elif op == TABLE_ROW_ID_EDGE_TYPE:
                 val = val[arg]
             else:
                 raise ValueError(f"Unknown ref type: {extra[extra_index]}")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -650,7 +650,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         extra_result.remaining_extra[0],
                         extra_result.remaining_extra[1],
                     )
-                    if op != refs_internal.TABLE_ROW_ID_EDGE_TYPE:
+                    if op != refs_internal.AWL_ROW_ID_EDGE_TYPE:
                         raise ValueError("Table refs must have id extra")
                     table_queries.setdefault(
                         (table_ref.project_id, table_ref.digest), []

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -588,11 +588,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         unresolved_table_ref=None,
                         val=None,
                     )
-                if op == refs_internal.KEY_EDGE_TYPE:
+                if op == refs_internal.DICT_KEY_EDGE_NAME:
                     val = val.get(arg)
-                elif op == refs_internal.ATTRIBUTE_EDGE_TYPE:
+                elif op == refs_internal.OBJECT_ATTR_EDGE_NAME:
                     val = val.get(arg)
-                elif op == refs_internal.INDEX_EDGE_TYPE:
+                elif op == refs_internal.LIST_INDEX_EDGE_NAME:
                     index = int(arg)
                     if index >= len(val):
                         return None
@@ -650,7 +650,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         extra_result.remaining_extra[0],
                         extra_result.remaining_extra[1],
                     )
-                    if op != refs_internal.ID_EDGE_TYPE:
+                    if op != refs_internal.TABLE_ROW_ID_EDGE_TYPE:
                         raise ValueError("Table refs must have id extra")
                     table_queries.setdefault(
                         (table_ref.project_id, table_ref.digest), []

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -650,7 +650,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         extra_result.remaining_extra[0],
                         extra_result.remaining_extra[1],
                     )
-                    if op != refs_internal.TABLE_ROW_ID_EDGE_TYPE:
+                    if op != refs_internal.TABLE_ROW_ID_EDGE_NAME:
                         raise ValueError("Table refs must have id extra")
                     table_queries.setdefault(
                         (table_ref.project_id, table_ref.digest), []

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -650,7 +650,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         extra_result.remaining_extra[0],
                         extra_result.remaining_extra[1],
                     )
-                    if op != refs_internal.AWL_ROW_ID_EDGE_TYPE:
+                    if op != refs_internal.TABLE_ROW_ID_EDGE_TYPE:
                         raise ValueError("Table refs must have id extra")
                     table_queries.setdefault(
                         (table_ref.project_id, table_ref.digest), []

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -14,7 +14,7 @@ WEAVE_SCHEME = "weave"
 DICT_KEY_EDGE_NAME = "key"
 LIST_INDEX_EDGE_NAME = "index"
 OBJECT_ATTR_EDGE_NAME = "attr"
-AWL_ROW_ID_EDGE_TYPE = "id"
+TABLE_ROW_ID_EDGE_TYPE = "id"
 
 
 @dataclasses.dataclass

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -14,7 +14,7 @@ WEAVE_SCHEME = "weave"
 DICT_KEY_EDGE_NAME = "key"
 LIST_INDEX_EDGE_NAME = "index"
 OBJECT_ATTR_EDGE_NAME = "attr"
-TABLE_ROW_ID_EDGE_TYPE = "id"
+TABLE_ROW_ID_EDGE_NAME = "id"
 
 
 @dataclasses.dataclass

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -11,10 +11,10 @@ import dataclasses
 WEAVE_INTERNAL_SCHEME = "weave-trace-internal"
 WEAVE_SCHEME = "weave"
 
-KEY_EDGE_TYPE = "key"
-INDEX_EDGE_TYPE = "ndx"
-ATTRIBUTE_EDGE_TYPE = "atr"
-ID_EDGE_TYPE = "id"
+DICT_KEY_EDGE_NAME = "key"
+LIST_INDEX_EDGE_NAME = "index"
+OBJECT_ATTR_EDGE_NAME = "attr"
+TABLE_ROW_ID_EDGE_TYPE = "id"
 
 
 @dataclasses.dataclass

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -14,7 +14,7 @@ WEAVE_SCHEME = "weave"
 DICT_KEY_EDGE_NAME = "key"
 LIST_INDEX_EDGE_NAME = "index"
 OBJECT_ATTR_EDGE_NAME = "attr"
-TABLE_ROW_ID_EDGE_TYPE = "id"
+AWL_ROW_ID_EDGE_TYPE = "id"
 
 
 @dataclasses.dataclass

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -26,7 +26,7 @@ from weave.trace_server.refs_internal import (
     DICT_KEY_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
     OBJECT_ATTR_EDGE_NAME,
-    AWL_ROW_ID_EDGE_TYPE,
+    TABLE_ROW_ID_EDGE_TYPE,
 )
 
 MAX_FLUSH_COUNT = 10000
@@ -465,7 +465,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     val = val[arg]
                 elif op == LIST_INDEX_EDGE_NAME:
                     val = val[int(arg)]
-                elif op == AWL_ROW_ID_EDGE_TYPE:
+                elif op == TABLE_ROW_ID_EDGE_TYPE:
                     if isinstance(val, str) and val.startswith("weave://"):
                         table_ref = refs.parse_uri(val)
                         if not isinstance(table_ref, refs.TableRef):

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -22,6 +22,12 @@ from weave.trace import refs
 from weave.trace_server.trace_server_interface_util import (
     WILDCARD_ARTIFACT_VERSION_AND_PATH,
 )
+from weave.trace_server.refs_internal import (
+    DICT_KEY_EDGE_NAME,
+    LIST_INDEX_EDGE_NAME,
+    OBJECT_ATTR_EDGE_NAME,
+    AWL_ROW_ID_EDGE_TYPE,
+)
 
 MAX_FLUSH_COUNT = 10000
 MAX_FLUSH_AGE = 15
@@ -453,13 +459,13 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             extra = r.extra
             for extra_index in range(0, len(extra), 2):
                 op, arg = extra[extra_index], extra[extra_index + 1]
-                if op == "key":
+                if op == DICT_KEY_EDGE_NAME:
                     val = val[arg]
-                elif op == "atr":
+                elif op == OBJECT_ATTR_EDGE_NAME:
                     val = val[arg]
-                elif op == "ndx":
+                elif op == LIST_INDEX_EDGE_NAME:
                     val = val[int(arg)]
-                elif op == "id":
+                elif op == AWL_ROW_ID_EDGE_TYPE:
                     if isinstance(val, str) and val.startswith("weave://"):
                         table_ref = refs.parse_uri(val)
                         if not isinstance(table_ref, refs.TableRef):

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -26,7 +26,7 @@ from weave.trace_server.refs_internal import (
     DICT_KEY_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
     OBJECT_ATTR_EDGE_NAME,
-    TABLE_ROW_ID_EDGE_TYPE,
+    TABLE_ROW_ID_EDGE_NAME,
 )
 
 MAX_FLUSH_COUNT = 10000
@@ -465,7 +465,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     val = val[arg]
                 elif op == LIST_INDEX_EDGE_NAME:
                     val = val[int(arg)]
-                elif op == TABLE_ROW_ID_EDGE_TYPE:
+                elif op == TABLE_ROW_ID_EDGE_NAME:
                     if isinstance(val, str) and val.startswith("weave://"):
                         table_ref = refs.parse_uri(val)
                         if not isinstance(table_ref, refs.TableRef):


### PR DESCRIPTION
1. Unifies all declarations of edge names to singles files across both python and typescript
2. Standardizes naming everywhere
3. Changes `atr` to `attr`
4. Changes `ndx` to `index`