### PR TITLE
feat: empty pages

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -15,6 +15,8 @@ import React, {FC, useCallback, useMemo} from 'react';
 
 import {RunsTable} from '../../../Browse2/RunsTable';
 import {useWeaveflowRouteContext} from '../../context';
+import {Empty} from '../common/Empty';
+import {EMPTY_PROPS_TRACES} from '../common/EmptyContent';
 import {isEvaluateOp} from '../common/heuristics';
 import {opNiceName} from '../common/Links';
 import {FilterLayoutTemplate} from '../common/SimpleFilterableDataTable';
@@ -233,6 +235,17 @@ export const CallsTable: FC<{
     return Math.random();
   }, [calls.loading, calls.result]);
 
+  if (calls.loading) {
+    // TODO: Do we want a loading indicator here
+    return null;
+  }
+
+  const spans = calls.result ?? [];
+  const isEmpty = spans.length === 0;
+  if (isEmpty) {
+    return <Empty {...EMPTY_PROPS_TRACES} />;
+  }
+
   return (
     <FilterLayoutTemplate
       showFilterIndicator={Object.keys(effectiveFilter ?? {}).length > 0}
@@ -376,7 +389,7 @@ export const CallsTable: FC<{
         <RunsTable
           key={callsKey}
           loading={calls.loading}
-          spans={calls.result ?? []}
+          spans={spans}
           clearFilters={clearFilters}
           ioColumnsOnly={props.ioColumnsOnly}
         />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -11,6 +11,12 @@ import {Timestamp} from '../../../../Timestamp';
 import {useWeaveflowRouteContext} from '../context';
 import {StyledDataGrid} from '../StyledDataGrid';
 import {basicField} from './common/DataTable';
+import {Empty} from './common/Empty';
+import {
+  EMPTY_PROPS_DATASETS,
+  EMPTY_PROPS_MODEL,
+  EMPTY_PROPS_OBJECTS,
+} from './common/EmptyContent';
 import {ObjectVersionLink, ObjectVersionsLink} from './common/Links';
 import {FilterLayoutTemplate} from './common/SimpleFilterableDataTable';
 import {SimplePageLayout} from './common/SimplePageLayout';
@@ -102,6 +108,20 @@ export const FilterableObjectVersionsTable: React.FC<{
     }
   );
 
+  // TODO: Only show the empty state if no filters other than baseObjectClass
+  const objectVersions = filteredObjectVersions.result ?? [];
+  const isEmpty = objectVersions.length === 0;
+  if (isEmpty) {
+    let propsEmpty = EMPTY_PROPS_OBJECTS;
+    const base = props.initialFilter?.baseObjectClass;
+    if ('Model' === base) {
+      propsEmpty = EMPTY_PROPS_MODEL;
+    } else if ('Dataset' === base) {
+      propsEmpty = EMPTY_PROPS_DATASETS;
+    }
+    return <Empty {...propsEmpty} />;
+  }
+
   return (
     <FilterLayoutTemplate
       showFilterIndicator={Object.keys(effectiveFilter ?? {}).length > 0}
@@ -112,7 +132,7 @@ export const FilterableObjectVersionsTable: React.FC<{
         effectiveFilter
       )}>
       <ObjectVersionsTable
-        objectVersions={filteredObjectVersions.result ?? []}
+        objectVersions={objectVersions}
         usingLatestFilter={effectivelyLatestOnly}
       />
     </FilterLayoutTemplate>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -9,6 +9,8 @@ import React, {useEffect, useMemo, useState} from 'react';
 import {Timestamp} from '../../../../Timestamp';
 import {StyledDataGrid} from '../StyledDataGrid';
 import {basicField} from './common/DataTable';
+import {Empty} from './common/Empty';
+import {EMPTY_PROPS_OPERATIONS} from './common/EmptyContent';
 import {
   CallsLink,
   opNiceName,
@@ -81,13 +83,13 @@ export const FilterableOpVersionsTable: React.FC<{
 
   const effectivelyLatestOnly = !effectiveFilter.opName;
 
-  const filteredObjectVersions = useOpVersions(props.entity, props.project, {
+  const filteredOpVersions = useOpVersions(props.entity, props.project, {
     opIds: effectiveFilter.opName ? [effectiveFilter.opName] : undefined,
     latestOnly: effectivelyLatestOnly,
   });
 
   const rows: GridRowsProp = useMemo(() => {
-    return (filteredObjectVersions.result ?? []).map((ov, i) => {
+    return (filteredOpVersions.result ?? []).map((ov, i) => {
       return {
         ...ov,
         id: opVersionKeyToRefUri(ov),
@@ -95,7 +97,7 @@ export const FilterableOpVersionsTable: React.FC<{
         obj: ov,
       };
     });
-  }, [filteredObjectVersions.result]);
+  }, [filteredOpVersions.result]);
   const columns: GridColDef[] = [
     basicField('op', 'Op', {
       hideable: false,
@@ -173,6 +175,18 @@ export const FilterableOpVersionsTable: React.FC<{
       }
     }
   }, [rowIds, peekId]);
+
+  if (filteredOpVersions.loading) {
+    // TODO: Do we want a loading indicator here
+    return null;
+  }
+
+  // TODO: Only show the empty state if unfiltered
+  const opVersions = filteredOpVersions.result ?? [];
+  const isEmpty = opVersions.length === 0;
+  if (isEmpty) {
+    return <Empty {...EMPTY_PROPS_OPERATIONS} />;
+  }
 
   return (
     <StyledDataGrid

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Empty.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Empty.tsx
@@ -1,0 +1,104 @@
+/**
+ * This component is used when we have no content to show.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+
+import * as Colors from '../../../../../../common/css/color.styles';
+import {Icon, IconName} from '../../../../../Icon';
+
+export type EmptyProps = {
+  icon: IconName;
+  heading: string;
+  description: string;
+  moreInformation: React.ReactNode;
+};
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+Container.displayName = 'S.Container';
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 600px;
+`;
+Content.displayName = 'S.Content';
+
+// TODO: Verify color not from palette with design
+const Circle = styled.div`
+  border-radius: 50%;
+  width: 80px;
+  height: 80px;
+  background-color: #0096ad1a;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+`;
+Circle.displayName = 'S.Circle';
+
+const CircleIcon = styled(Icon)`
+  width: 33px;
+  height: 33px;
+  color: ${Colors.TEAL_550};
+`;
+CircleIcon.displayName = 'S.CircleIcon';
+
+const Heading = styled.div`
+  font-family: Source Sans Pro;
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 32px;
+  text-align: left;
+  color: ${Colors.MOON_950};
+  margin-bottom: 8px;
+`;
+Heading.displayName = 'S.Heading';
+
+const Description = styled.div`
+  font-family: Source Sans Pro;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 25.2px;
+  text-align: center;
+  color: ${Colors.MOON_750};
+  margin-bottom: 8px;
+`;
+Description.displayName = 'S.Description';
+
+const MoreInformation = styled.div`
+  font-family: Source Sans Pro;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 22.4px;
+  text-align: center;
+  color: ${Colors.MOON_500};
+`;
+MoreInformation.displayName = 'S.MoreInformation';
+
+export const Empty = ({
+  icon,
+  heading,
+  description,
+  moreInformation,
+}: EmptyProps) => {
+  return (
+    <Container>
+      <Content>
+        <Circle>
+          <CircleIcon name={icon} />
+        </Circle>
+        <Heading>{heading}</Heading>
+        <Description>{description}</Description>
+        <MoreInformation>{moreInformation}</MoreInformation>
+      </Content>
+    </Container>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+import {TargetBlank} from '../../../../../../common/util/links';
+import {EmptyProps} from './Empty';
+
+export const EMPTY_PROPS_TRACES: EmptyProps = {
+  icon: 'layout-tabs' as const,
+  heading: 'No traces yet',
+  description:
+    'Use traces to track all inputs & outputs of functions within your application. Debug, monitor or drill-down into tricky examples.',
+  moreInformation: (
+    <>
+      Learn{' '}
+      <TargetBlank href="http://wandb.me/weave_traces">
+        tracing basics
+      </TargetBlank>{' '}
+      or see traces in action by{' '}
+      <TargetBlank href="http://wandb.me/weave_quickstart">
+        following our quickstart guide
+      </TargetBlank>
+      .
+    </>
+  ),
+};
+
+export const EMPTY_PROPS_MODEL: EmptyProps = {
+  icon: 'model' as const,
+  heading: 'No models yet',
+  description:
+    "You can use models to collect details of your app that you'd like to evaluate, like the prompts or the LLM settings that you're using.",
+  moreInformation: (
+    <>
+      Learn{' '}
+      <TargetBlank href="http://wandb.me/weave_models">
+        model basics
+      </TargetBlank>{' '}
+      or see how you can{' '}
+      <TargetBlank href="http://wandb.me/weave_eval_tut">
+        use models within an evaluation pipeline
+      </TargetBlank>
+      .
+    </>
+  ),
+};
+
+export const EMPTY_PROPS_DATASETS: EmptyProps = {
+  icon: 'table' as const,
+  heading: 'No datasets yet',
+  description:
+    'You can use datasets to collect difficult examples to use within evaluations of your app.',
+  moreInformation: (
+    <>
+      Learn{' '}
+      <TargetBlank href="http://wandb.me/weave_datasets">
+        dataset basics
+      </TargetBlank>{' '}
+      or see how you can{' '}
+      <TargetBlank href="http://wandb.me/weave_eval_tut">
+        use datasets within an evaluation pipeline
+      </TargetBlank>{' '}
+      .
+    </>
+  ),
+};
+
+export const EMPTY_PROPS_OPERATIONS: EmptyProps = {
+  icon: 'job-program-code' as const,
+  heading: 'No operations yet',
+  description:
+    'You can use operations to track all inputs & outputs of functions within your application and to view how data flows through them.',
+  moreInformation: (
+    <>
+      Learn{' '}
+      <TargetBlank href="https://wandb.github.io/weave/guides/tracking/ops">
+        operations basics
+      </TargetBlank>{' '}
+      or see how to{' '}
+      <TargetBlank href="http://wandb.me/weave_quickstart">
+        use them within our quickstart
+      </TargetBlank>
+      .
+    </>
+  ),
+};
+
+export const EMPTY_PROPS_OBJECTS: EmptyProps = {
+  icon: 'cube-container' as const,
+  heading: 'No objects yet',
+  description:
+    'Use this to keep track of how you use models, evaluation datasets or any other asset within your application.',
+  moreInformation: (
+    <>
+      Learn{' '}
+      <TargetBlank href="http://wandb.me/weave_objects">
+        object basics
+      </TargetBlank>
+      .
+    </>
+  ),
+};


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Empty-states-for-Objects-Models-Datasets-pages-b748c0d705fb46e8ab93b5a90595c5ee?pvs=4

I will follow up with design re: the TODOs around loading indicators and color palette. The others TODOs are pending more confidence about the state of filters on these pages.

Before: 
![image](https://github.com/wandb/weave/assets/112953339/416bca0f-1b9a-402e-a95e-8f415175aa5e)

After:
![image](https://github.com/wandb/weave/assets/112953339/4f750837-a1ff-40e7-a30f-cf6ecd654a8a)
