### PR TITLE
fix: empty page showing during loading

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -108,6 +108,11 @@ export const FilterableObjectVersionsTable: React.FC<{
     }
   );
 
+  if (filteredObjectVersions.loading) {
+    // TODO: Do we want a loading indicator here
+    return null;
+  }
+
   // TODO: Only show the empty state if no filters other than baseObjectClass
   const objectVersions = filteredObjectVersions.result ?? [];
   const isEmpty = objectVersions.length === 0;


### PR DESCRIPTION
We don't want the empty page to appear while the query is still loading.