### PR TITLE
fix: don't stringify ref objects in boring stats

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
@@ -1,5 +1,6 @@
 import {GridColumnVisibilityModel} from '@mui/x-data-grid-pro';
 import stringify from 'json-stable-stringify';
+import _ from 'lodash';
 import {useState} from 'react';
 
 import {isRef} from '../Browse3/pages/common/util';
@@ -84,9 +85,13 @@ export const computeTableStats = (table: Array<Record<string, any>>) => {
             colStats.refCounts[value] += 1;
           }
           let valueStr = null;
-          try {
-            valueStr = stringify(value);
-          } catch (e) {
+          if (Array.isArray(value) || _.isPlainObject(value)) {
+            try {
+              valueStr = stringify(value);
+            } catch (e) {
+              valueStr = `${value}`;
+            }
+          } else {
             valueStr = `${value}`;
           }
           if (!(valueStr in colStats.valueCounts)) {


### PR DESCRIPTION
Fix bug I just introduced in https://github.com/wandb/weave/pull/1391 - limit stringify serialization to just arrays and objects.

Before:
<img width="524" alt="Screenshot 2024-03-29 at 10 08 08 PM" src="https://github.com/wandb/weave/assets/112953339/3a410206-3db7-4384-9dd7-f24f04b06e55">

After:
<img width="360" alt="Screenshot 2024-03-29 at 10 08 12 PM" src="https://github.com/wandb/weave/assets/112953339/6c2dcad9-9454-4ce4-8da2-be06b0fd884f">
