### PR TITLE
feat: loading indicators on pages

### DIFF
--- a/weave-js/src/components/Loading.tsx
+++ b/weave-js/src/components/Loading.tsx
@@ -1,0 +1,56 @@
+/**
+ * We have many progress/loading indicators throughout Weave:
+ * - TrackedWandbLoader - based on Semantic UI loader
+ * - Semantic UI's loader
+ * - Material's CircularProgress
+ * - WeaveAnimatedLoader (spinning logo)
+ * Plus a bunch of additional derivatives and related things like skeletons in the W&B app codebase.
+ *
+ * This is one more loading indicator that has the following properties:
+ * - Circular indeterminate progress indicator
+ * - Based on Material (and not Semantic, which we want to move away from)
+ * - Styled to match our color palette
+ * - Easy to use inline or centered in a container
+ *
+ * TODO: A better solution would be consolidation, e.g. updating TrackedWandbLoader,
+ * but that is a riskier change than we want to make right now because of how many
+ * places it is used.
+ */
+
+import {Box} from '@mui/material';
+import CircularProgress, {
+  CircularProgressProps,
+} from '@mui/material/CircularProgress';
+import React from 'react';
+
+import * as Colors from '../common/css/color.styles';
+
+type LoadingProps = CircularProgressProps & {
+  centered?: boolean;
+};
+
+export const Loading = ({centered, ...props}: LoadingProps) => {
+  const circle = (
+    <CircularProgress
+      {...props}
+      sx={{
+        color: (theme: any) => Colors.TEAL_500,
+      }}
+    />
+  );
+  if (centered) {
+    return (
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}>
+        {circle}
+      </Box>
+    );
+  }
+  return circle;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -13,6 +13,7 @@ import {
 import _ from 'lodash';
 import React, {FC, useCallback, useMemo} from 'react';
 
+import {Loading} from '../../../../../Loading';
 import {RunsTable} from '../../../Browse2/RunsTable';
 import {useWeaveflowRouteContext} from '../../context';
 import {Empty} from '../common/Empty';
@@ -236,8 +237,7 @@ export const CallsTable: FC<{
   }, [calls.loading, calls.result]);
 
   if (calls.loading) {
-    // TODO: Do we want a loading indicator here
-    return null;
+    return <Loading centered />;
   }
 
   const spans = calls.result ?? [];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -7,6 +7,7 @@ import {
 import _ from 'lodash';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import {Loading} from '../../../../Loading';
 import {Timestamp} from '../../../../Timestamp';
 import {useWeaveflowRouteContext} from '../context';
 import {StyledDataGrid} from '../StyledDataGrid';
@@ -109,8 +110,7 @@ export const FilterableObjectVersionsTable: React.FC<{
   );
 
   if (filteredObjectVersions.loading) {
-    // TODO: Do we want a loading indicator here
-    return null;
+    return <Loading centered />;
   }
 
   // TODO: Only show the empty state if no filters other than baseObjectClass

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -6,6 +6,7 @@ import {
 } from '@mui/x-data-grid-pro';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import {Loading} from '../../../../Loading';
 import {Timestamp} from '../../../../Timestamp';
 import {StyledDataGrid} from '../StyledDataGrid';
 import {basicField} from './common/DataTable';
@@ -177,8 +178,7 @@ export const FilterableOpVersionsTable: React.FC<{
   }, [rowIds, peekId]);
 
   if (filteredOpVersions.loading) {
-    // TODO: Do we want a loading indicator here
-    return null;
+    return <Loading centered />;
   }
 
   // TODO: Only show the empty state if unfiltered


### PR DESCRIPTION
Add (yet another) loading indicator.

Internal Notion: https://www.notion.so/wandbai/Replace-Material-design-components-dbb5f747b86d44efa5c55ecea2474810?pvs=4#1f656d27947346f3852d4684deeedb54

Before:
![2024-03-29_hooman-Workspace-–-Weights-Biases2](https://github.com/wandb/weave/assets/112953339/3b23a6ae-270c-4ff5-b58a-ebccbe53ca97)

After:
![2024-03-29_hooman-Workspace-–-Weights-Biases](https://github.com/wandb/weave/assets/112953339/ea4cfbf9-f312-4488-8ea4-77a1c810ff8e)

![2024-03-29_hooman-Workspace-–-Weights-Biasesdark](https://github.com/wandb/weave/assets/112953339/0bb5d90f-f127-408a-af59-4066e7f32376)
