### PR TITLE
chore(weave): Fixes wildcard name matching

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -244,7 +244,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 for name_ndx, name in enumerate(wildcarded_names):
                     param_name = "wildcarded_name_" + str(name_ndx)
                     or_conditions.append("op_name LIKE {" + param_name + ": String}")
-                    like_name = name[: -len(WILDCARD_ARTIFACT_VERSION_AND_PATH)] + "%"
+                    like_name = name[: -len(WILDCARD_ARTIFACT_VERSION_AND_PATH)] + ":%"
                     parameters[param_name] = like_name
 
                 if or_conditions:


### PR DESCRIPTION
Before:
<img width="635" alt="Screenshot 2024-04-01 at 12 57 27" src="https://github.com/wandb/weave/assets/2142768/f53269f4-a71a-4280-bf3f-002626fc38d2">


After:
<img width="835" alt="Screenshot 2024-04-01 at 12 56 58" src="https://github.com/wandb/weave/assets/2142768/f6991b69-f365-44dd-9ca0-5d7bf37f4529">
