### PR TITLE
chore: update visibility alert to use common alert component

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -1,4 +1,4 @@
-import {Alert, Box, Button, Typography} from '@mui/material';
+import {Box, Typography} from '@mui/material';
 import {
   DataGridPro as DataGrid,
   DataGridPro,
@@ -17,6 +17,7 @@ import React, {
   useState,
 } from 'react';
 import {useParams} from 'react-router-dom';
+import styled from 'styled-components';
 
 import {A, TargetBlank} from '../../../../common/util/links';
 import {monthRoundedTime} from '../../../../common/util/time';
@@ -29,6 +30,7 @@ import {
 } from '../../../../core';
 import {useDeepMemo} from '../../../../hookUtils';
 import {parseRef} from '../../../../react';
+import {Alert} from '../../../Alert';
 import {ErrorBoundary} from '../../../ErrorBoundary';
 import {Timestamp} from '../../../Timestamp';
 import {BoringColumnInfo} from '../Browse3/pages/CallPage/BoringColumnInfo';
@@ -67,6 +69,19 @@ export type DataGridColumnGroupingModel = Exclude<
   ComponentProps<typeof DataGrid>['columnGroupingModel'],
   undefined
 >;
+
+const VisibilityAlert = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+VisibilityAlert.displayName = 'S.VisibilityAlert';
+
+const VisibilityAlertAction = styled.div`
+  font-weight: 600;
+  cursor: pointer;
+`;
+VisibilityAlertAction.displayName = 'S.VisibilityAlertAction';
 
 function addToTree(
   node: GridColumnGroup,
@@ -802,17 +817,13 @@ export const RunsTable: FC<{
   return (
     <>
       {showVisibilityAlert && (
-        <Alert
-          severity="info"
-          action={
-            <Button
-              color="inherit"
-              size="small"
-              onClick={() => setForceShowAll(true)}>
+        <Alert>
+          <VisibilityAlert>
+            <div>Columns having many empty values have been hidden.</div>
+            <VisibilityAlertAction onClick={() => setForceShowAll(true)}>
               Show all
-            </Button>
-          }>
-          Columns having many empty values have been hidden.
+            </VisibilityAlertAction>
+          </VisibilityAlert>
         </Alert>
       )}
       <BoringColumnInfo tableStats={tableStats} columns={columns.cols as any} />


### PR DESCRIPTION
A short term change switching this column visibility alert from material components to our own Alert. Ran design by @adamwdraper  

Before: 
<img width="1449" alt="Screenshot 2024-04-01 at 3 31 21 PM" src="https://github.com/wandb/weave/assets/112953339/29ffb0d2-d2dc-43eb-878f-fbfc0b8b465b">

After:
<img width="1506" alt="Screenshot 2024-04-03 at 12 48 16 AM" src="https://github.com/wandb/weave/assets/112953339/be7eb01a-e05c-4030-a916-15e3e5898c02">
