### PR TITLE
fix: hide underscore prefixed keys in object viewer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
@@ -91,6 +91,11 @@ export class ObjectPath {
     return this.path[this.path.length - 1] === element;
   }
 
+  hasHiddenKey(): boolean {
+    const t = this.tail();
+    return typeof t === 'string' && t.startsWith('_');
+  }
+
   length(): number {
     return this.path.length;
   }


### PR DESCRIPTION
We were previously skipping past `_ref` and `_type` fields but we want to actually filter out all keys that are underscore prefixed, for example `_class_name` and `_bases` in the screenshots below.

Before:
<img width="1022" alt="Screenshot 2024-04-01 at 10 00 41 PM" src="https://github.com/wandb/weave/assets/112953339/1827f991-b484-4b1e-88b4-7a0f6f7bbc2b">


After:
<img width="1022" alt="Screenshot 2024-04-01 at 10 01 06 PM" src="https://github.com/wandb/weave/assets/112953339/ca8480ab-9888-4aa0-8c4b-524b10b5ac0b">
