### PR TITLE
fix: dataset row use tab

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
@@ -7,8 +7,8 @@ import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
 import {
-  LIST_INDEX_EDGE_NAME,
   OBJECT_ATTR_EDGE_NAME,
+  TABLE_ID_EDGE_NAME,
 } from './wfReactInterface/constants';
 
 type TabUseDatasetProps = {
@@ -17,7 +17,7 @@ type TabUseDatasetProps = {
   versionIndex: number;
 };
 
-const ROW_PATH_PREFIX = `${OBJECT_ATTR_EDGE_NAME}/rows/${LIST_INDEX_EDGE_NAME}/`;
+const ROW_PATH_PREFIX = `${OBJECT_ATTR_EDGE_NAME}/rows/${TABLE_ID_EDGE_NAME}/`;
 
 export const TabUseDataset = ({
   name,


### PR DESCRIPTION
Seems that we should be using `id` instead of `index` to determine if we are viewing a row ref. Note that even with this fix I think row refs are broken.

Before:
<img width="796" alt="Screenshot 2024-04-01 at 10 22 26 PM" src="https://github.com/wandb/weave/assets/112953339/9ee3317f-ceaa-45b1-847b-d780233bc70a">

After:
<img width="772" alt="Screenshot 2024-04-01 at 10 15 46 PM" src="https://github.com/wandb/weave/assets/112953339/7ac94fe6-e159-4908-87f3-1c913e03c2ce">
