### PR TITLE
feat: shorter links output

### DIFF
--- a/weave/init_message.py
+++ b/weave/init_message.py
@@ -86,6 +86,8 @@ def print_init_message(
     message = ""
     if username is not None:
         message += f"Logged in as W&B user {username}.\n"
-    message += f"View Weave data at {urls.project_root_url(entity_name, project_name)}"
+    message += (
+        f"View Weave data at {urls.project_weave_root_url(entity_name, project_name)}"
+    )
 
     print(message)

--- a/weave/urls.py
+++ b/weave/urls.py
@@ -6,42 +6,46 @@ from . import environment
 from . import context_state
 
 BROWSE3_PATH = "browse3"
-WORKSPACE_SLUG = "weave"
+WEAVE_SLUG = "weave"
 
 
 def remote_project_root_url(entity_name: str, project_name: str) -> str:
-    return f"{wb_util.app_url(environment.wandb_base_url())}/{entity_name}/{quote(project_name)}/{WORKSPACE_SLUG}"
+    return f"{wb_util.app_url(environment.wandb_base_url())}/{entity_name}/{quote(project_name)}"
 
 
-def local_project_root_url(entity_name: str, project_name: str) -> str:
+def remote_project_weave_root_url(entity_name: str, project_name: str) -> str:
+    return f"{remote_project_root_url(entity_name, project_name)}/{WEAVE_SLUG}"
+
+
+def local_project_weave_root_url(entity_name: str, project_name: str) -> str:
     return f"http://localhost:3000/{BROWSE3_PATH}/{entity_name}/{quote(project_name)}"
 
 
-def project_root_url(entity_name: str, project_name: str) -> str:
+def project_weave_root_url(entity_name: str, project_name: str) -> str:
     if context_state._use_local_urls.get():
-        return local_project_root_url(entity_name, project_name)
+        return local_project_weave_root_url(entity_name, project_name)
     else:
-        return remote_project_root_url(entity_name, project_name)
+        return remote_project_weave_root_url(entity_name, project_name)
 
 
 def op_version_path(
     entity_name: str, project_name: str, op_name: str, op_version: str
 ) -> str:
-    return f"{project_root_url(entity_name, project_name)}/ops/{op_name}/versions/{op_version}"
+    return f"{project_weave_root_url(entity_name, project_name)}/ops/{op_name}/versions/{op_version}"
 
 
 def object_version_path(
     entity_name: str, project_name: str, object_name: str, obj_version: str
 ) -> str:
-    return f"{project_root_url(entity_name, project_name)}/objects/{quote(object_name)}/versions/{obj_version}"
+    return f"{project_weave_root_url(entity_name, project_name)}/objects/{quote(object_name)}/versions/{obj_version}"
 
 
 def call_path(entity_name: str, project_name: str, call_id: str) -> str:
-    return f"{project_root_url(entity_name, project_name)}/calls/{call_id}"
+    return f"{project_weave_root_url(entity_name, project_name)}/calls/{call_id}"
 
 
-def call_path_as_peek(entity_name: str, project_name: str, call_id: str) -> str:
-    return f"{call_path(entity_name, project_name, call_id)}?convertToPeek=true"
+def redirect_call(entity_name: str, project_name: str, call_id: str) -> str:
+    return f"{remote_project_root_url(entity_name, project_name)}/r/call/{call_id}"
 
 
 def use_local_urls() -> None:

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -147,7 +147,7 @@ class Call:
         entity, project = project_parts
         if not self.id:
             raise ValueError("Can't get URL for call without ID")
-        return urls.call_path_as_peek(entity, project, self.id)
+        return urls.redirect_call(entity, project, self.id)
 
     # These are the children if we're using Call at read-time
     def children(self) -> "CallsIter":


### PR DESCRIPTION
Shorten the links printed by the SDK by using new redirect page.

Before:
https://wandb.ai/jamie-rasmussen/2024-04-02_quickstart/weave/calls/f5676217-5279-4b47-b8c3-91456a79aef8?convertToPeek=true

After:
https://wandb.ai/jamie-rasmussen/2024-04-02_quickstart/r/call/e833f509-72a0-4abb-b74a-f26d60d16ece

The redirect takes you to a slightly different place than convertToPeek did too, with all versions of the op selected as the filter instead of the current version.