### PR TITLE
chore(weave): Implement Weave Client Sentry Tracking

### DIFF
--- a/weave/api.py
+++ b/weave/api.py
@@ -37,6 +37,7 @@ from . import graph_client_context as _graph_client_context
 from weave.trace import context as trace_context
 from .trace.constants import TRACE_OBJECT_EMOJI
 from weave.trace.refs import ObjectRef
+from . import trace_sentry
 
 # exposed as part of api
 from . import weave_types as types
@@ -185,6 +186,7 @@ def local_client() -> typing.Iterator[_weave_client.WeaveClient]:
         inited_client.reset()
 
 
+@trace_sentry.global_trace_sentry.watch()
 def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.ObjectRef:
     """Save and version a python object.
 
@@ -224,6 +226,7 @@ def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.Object
     return ref
 
 
+@trace_sentry.global_trace_sentry.watch()
 def ref(location: str) -> _weave_client.ObjectRef:
     """Construct a Ref to a Weave object.
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -8,7 +8,7 @@ from typing_extensions import ParamSpec
 from weave.trace.errors import OpCallError
 from weave.trace.refs import ObjectRef
 from weave.trace.context import call_attributes
-from weave import graph_client_context
+from weave import graph_client_context, trace_sentry
 from weave import run_context
 from weave import box
 
@@ -41,6 +41,10 @@ class Op:
         return BoundOp(obj, objtype, self)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._watched_call(*args, **kwargs)
+
+    @trace_sentry.global_trace_sentry.watch()
+    def _watched_call(self, *args: Any, **kwargs: Any) -> Any:
         maybe_client = graph_client_context.get_graph_client()
         if maybe_client is None:
             return self.resolve_fn(*args, **kwargs)

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -44,6 +44,9 @@ class RefWithExtra(Ref):
         return self.with_extra([TABLE_ROW_ID_EDGE_NAME, f"{item_digest}"])
 
 
+from .. import trace_sentry
+
+
 @dataclasses.dataclass
 class ObjectRef(RefWithExtra):
     entity: str
@@ -58,6 +61,7 @@ class ObjectRef(RefWithExtra):
             u += "/" + "/".join(self.extra)
         return u
 
+    @trace_sentry.global_trace_sentry.watch()
     def get(self) -> Any:
         # Move import here so that it only happens when the function is called.
         # This import is invalid in the trace server and represents a dependency

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -1,6 +1,7 @@
 from typing import Union, Any
 import dataclasses
 from ..trace_server import refs_internal
+from .. import trace_sentry
 
 DICT_KEY_EDGE_NAME = refs_internal.DICT_KEY_EDGE_NAME
 LIST_INDEX_EDGE_NAME = refs_internal.LIST_INDEX_EDGE_NAME
@@ -42,9 +43,6 @@ class RefWithExtra(Ref):
 
     def with_item(self, item_digest: str) -> "RefWithExtra":
         return self.with_extra([TABLE_ROW_ID_EDGE_NAME, f"{item_digest}"])
-
-
-from .. import trace_sentry
 
 
 @dataclasses.dataclass

--- a/weave/trace_sentry.py
+++ b/weave/trace_sentry.py
@@ -15,7 +15,7 @@ import functools
 import pathlib
 import sys
 from types import TracebackType
-from typing import  Any, Callable, Dict, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 
 
 if sys.version_info >= (3, 8):
@@ -26,9 +26,7 @@ else:
 import sentry_sdk  # type: ignore
 import sentry_sdk.utils  # type: ignore
 
-SENTRY_DEFAULT_DSN = (
-    "https://99697cf8ca5158250d3dd6cb23cca9b0@o151352.ingest.us.sentry.io/4507019311251456"
-)
+SENTRY_DEFAULT_DSN = "https://99697cf8ca5158250d3dd6cb23cca9b0@o151352.ingest.us.sentry.io/4507019311251456"
 
 SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
 
@@ -60,7 +58,7 @@ class Sentry:
         self.dsn = SENTRY_DEFAULT_DSN
 
         self.hub: Optional[sentry_sdk.hub.Hub] = None
-        
+
         self._disabled = False
 
         # ensure we always end the Sentry session
@@ -133,7 +131,8 @@ class Sentry:
         self.mark_session(status=status)
 
         client, _ = self.hub._stack[-1]  # type: ignore
-        client.flush()
+        if client is not None:
+            client.flush()
 
         return None
 
@@ -210,7 +209,9 @@ class Sentry:
                     raise
 
             return wrapper
+
         return watch_dec
+
 
 global_trace_sentry = Sentry()
 global_trace_sentry.setup()

--- a/weave/trace_sentry.py
+++ b/weave/trace_sentry.py
@@ -75,7 +75,7 @@ class Sentry:
         # these match the environments for gorilla
         return "development" if is_git else "production"
 
-    # @_safe_noop
+    @_safe_noop
     def setup(self) -> None:
         """Setup Sentry SDK.
 
@@ -93,7 +93,7 @@ class Sentry:
         )
         self.hub = sentry_sdk.Hub(client)
 
-    # @_safe_noop
+    @_safe_noop
     def exception(
         self,
         exc: Union[
@@ -137,7 +137,7 @@ class Sentry:
 
         return None
 
-    # @_safe_noop
+    @_safe_noop
     def start_session(self) -> None:
         """Start a new session."""
         assert self.hub is not None
@@ -149,7 +149,7 @@ class Sentry:
         if session is None:
             self.hub.start_session()
 
-    # @_safe_noop
+    @_safe_noop
     def end_session(self) -> None:
         """End the current session."""
         assert self.hub is not None
@@ -161,7 +161,7 @@ class Sentry:
             self.hub.end_session()
             client.flush()
 
-    # @_safe_noop
+    @_safe_noop
     def mark_session(self, status: Optional["SessionStatus"] = None) -> None:
         """Mark the current session with a status."""
         assert self.hub is not None
@@ -171,7 +171,7 @@ class Sentry:
         if session is not None:
             session.update(status=status)
 
-    # @_safe_noop
+    @_safe_noop
     def configure_scope(
         self,
         tags: Optional[Dict[str, Any]] = None,

--- a/weave/trace_sentry.py
+++ b/weave/trace_sentry.py
@@ -1,0 +1,217 @@
+"""
+This module provides a simple interface to the Sentry SDK.
+It is a thin wrapper around the Sentry SDK that provides a few
+convenience methods for logging exceptions and marking sessions.
+Furthermore, it ensures that the Sentry SDK is properly set up
+and that we don't interfere with the user's own Sentry SDK setup.
+
+This file is a trimmed down version of the original WandB Sentry module.
+"""
+
+__all__ = ("Sentry",)
+
+import atexit
+import functools
+import pathlib
+import sys
+from types import TracebackType
+from typing import  Any, Callable, Dict, Optional, Tuple, Type, Union
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+import sentry_sdk  # type: ignore
+import sentry_sdk.utils  # type: ignore
+
+SENTRY_DEFAULT_DSN = (
+    "https://99697cf8ca5158250d3dd6cb23cca9b0@o151352.ingest.us.sentry.io/4507019311251456"
+)
+
+SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
+
+
+def _safe_noop(func: Callable) -> Callable:
+    """Decorator to ensure that Sentry methods do nothing if disabled and don't raise."""
+
+    @functools.wraps(func)
+    def wrapper(self: Type["Sentry"], *args: Any, **kwargs: Any) -> Any:
+        if self._disabled:
+            return None
+        try:
+            return func(self, *args, **kwargs)
+        except Exception as e:
+            # do not call self.exception here to avoid infinite recursion
+            if func.__name__ != "exception":
+                self.exception(f"Error in {func.__name__}: {e}")
+            return None
+
+    return wrapper
+
+
+class Sentry:
+    _disabled: bool
+
+    def __init__(self) -> None:
+        self._sent_messages: set = set()
+
+        self.dsn = SENTRY_DEFAULT_DSN
+
+        self.hub: Optional[sentry_sdk.hub.Hub] = None
+        
+        self._disabled = False
+
+        # ensure we always end the Sentry session
+        atexit.register(self.end_session)
+
+    @property
+    def environment(self) -> str:
+        """Return the environment we're running in."""
+        # check if we're in a git repo
+        is_git = pathlib.Path(__file__).parent.parent.parent.joinpath(".git").exists()
+
+        # these match the environments for gorilla
+        return "development" if is_git else "production"
+
+    # @_safe_noop
+    def setup(self) -> None:
+        """Setup Sentry SDK.
+
+        We use lower-level APIs (i.e., not sentry_sdk.init) here
+        to avoid the possibility of interfering with the user's
+        own Sentry SDK setup.
+        """
+        from . import version
+
+        client = sentry_sdk.Client(
+            dsn=self.dsn,
+            default_integrations=False,
+            environment=self.environment,
+            release=version.VERSION,
+        )
+        self.hub = sentry_sdk.Hub(client)
+
+    # @_safe_noop
+    def exception(
+        self,
+        exc: Union[
+            str,
+            BaseException,
+            Tuple[
+                Optional[Type[BaseException]],
+                Optional[BaseException],
+                Optional[TracebackType],
+            ],
+            None,
+        ],
+        handled: bool = False,
+        status: Optional["SessionStatus"] = None,
+    ) -> None:
+        """Log an exception to Sentry."""
+        error = Exception(exc) if isinstance(exc, str) else exc
+        # based on self.hub.capture_exception(_exc)
+        if error is not None:
+            exc_info = sentry_sdk.utils.exc_info_from_error(error)
+        else:
+            exc_info = sys.exc_info()
+
+        event, hint = sentry_sdk.utils.event_from_exception(
+            exc_info,
+            client_options=self.hub.client.options,  # type: ignore
+            mechanism={"type": "generic", "handled": handled},
+        )
+        try:
+            self.hub.capture_event(event, hint=hint)  # type: ignore
+        except Exception:
+            pass
+
+        # if the status is not explicitly set, we'll set it to "crashed" if the exception
+        # was unhandled, or "errored" if it was handled
+        status = status or ("crashed" if not handled else "errored")  # type: ignore
+        self.mark_session(status=status)
+
+        client, _ = self.hub._stack[-1]  # type: ignore
+        client.flush()
+
+        return None
+
+    # @_safe_noop
+    def start_session(self) -> None:
+        """Start a new session."""
+        assert self.hub is not None
+        # get the current client and scope
+        _, scope = self.hub._stack[-1]
+        session = scope._session
+
+        # if there's no session, start one
+        if session is None:
+            self.hub.start_session()
+
+    # @_safe_noop
+    def end_session(self) -> None:
+        """End the current session."""
+        assert self.hub is not None
+        # get the current client and scope
+        client, scope = self.hub._stack[-1]
+        session = scope._session
+
+        if session is not None and client is not None:
+            self.hub.end_session()
+            client.flush()
+
+    # @_safe_noop
+    def mark_session(self, status: Optional["SessionStatus"] = None) -> None:
+        """Mark the current session with a status."""
+        assert self.hub is not None
+        _, scope = self.hub._stack[-1]
+        session = scope._session
+
+        if session is not None:
+            session.update(status=status)
+
+    # @_safe_noop
+    def configure_scope(
+        self,
+        tags: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Configure the Sentry scope for the current thread.
+
+        This function should be called at the beginning of every thread that
+        will send events to Sentry. It sets the tags that will be applied to
+        all events sent from this thread. It also tries to start a session
+        if one doesn't already exist for this thread.
+        """
+        assert self.hub is not None
+
+        with self.hub.configure_scope() as scope:
+            if tags is not None:
+                for tag in tags:
+                    val = tags.get(tag, None)
+                    if val not in (None, ""):
+                        scope.set_tag(tag, val)
+                    if tag == "user":
+                        scope.user = val
+
+        self.start_session()
+
+    # Not in the original WandB Sentry module
+    def watch(self) -> Callable:
+        def watch_dec(func: Callable) -> Callable:
+            """Decorator to watch a function for exceptions and log them to Sentry."""
+
+            @functools.wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    self.exception(e)
+                    raise
+
+            return wrapper
+        return watch_dec
+
+global_trace_sentry = Sentry()
+global_trace_sentry.setup()
+global_trace_sentry.configure_scope()

--- a/weave/weave_init.py
+++ b/weave/weave_init.py
@@ -5,6 +5,7 @@ from . import context_state
 from . import errors
 from . import autopatch
 from . import weave_client
+from . import trace_sentry
 
 
 class InitializedClient:
@@ -54,9 +55,6 @@ def get_entity_project_from_project_name(project_name: str) -> tuple[str, str]:
         raise ValueError("entity_name must be non-empty")
 
     return entity_name, project_name
-
-
-from . import trace_sentry
 
 
 @trace_sentry.global_trace_sentry.watch()
@@ -112,11 +110,12 @@ def init_weave(project_name: str) -> InitializedClient:
     init_message.assert_min_weave_version(min_required_version)
     init_message.print_init_message(username, entity_name, project_name)
 
+    user_context = {"username": username} if username else None
     trace_sentry.global_trace_sentry.configure_scope(
         {
             "entity_name": entity_name,
             "project_name": project_name,
-            "user": {"username": username},
+            "user": user_context,
         }
     )
 

--- a/weave/weave_init.py
+++ b/weave/weave_init.py
@@ -56,6 +56,10 @@ def get_entity_project_from_project_name(project_name: str) -> tuple[str, str]:
     return entity_name, project_name
 
 
+from . import trace_sentry
+
+
+@trace_sentry.global_trace_sentry.watch()
 def init_weave(project_name: str) -> InitializedClient:
     from . import wandb_api
 
@@ -107,6 +111,14 @@ def init_weave(project_name: str) -> InitializedClient:
         min_required_version = "0.0.0"
     init_message.assert_min_weave_version(min_required_version)
     init_message.print_init_message(username, entity_name, project_name)
+
+    trace_sentry.global_trace_sentry.configure_scope(
+        {
+            "entity_name": entity_name,
+            "project_name": project_name,
+            "user": {"username": username},
+        }
+    )
 
     return init_client
 


### PR DESCRIPTION
https://weights-biases.sentry.io/issues/?project=4507019311251456

* Create a new global `global_trace_sentry` object that follows the same pattern as the `wandb` Sentry module
* Watches the major top level functions:
  * weave.publish()
  * weave.ref()
  * Ref.get()
  * Op.__call__()
  * weave.init()
* After calling Weave.init we also configure the current context.

Caveats:
* Does not generally track everything - we have to manually wrap any function we want to "watch"


<img width="819" alt="Screenshot 2024-04-02 at 16 40 28" src="https://github.com/wandb/weave/assets/2142768/eba8492f-d693-4081-9bba-987457faf7a0">
