### PR TITLE
feat: improved handling of single value results

### DIFF
--- a/weave-js/src/components/Alert.styles.ts
+++ b/weave-js/src/components/Alert.styles.ts
@@ -46,15 +46,18 @@ export const Alert = styled.div<AlertProps>`
   display: flex;
   align-items: center;
 `;
+Alert.displayName = 'S.Alert';
 
 export const Icon = styled(IconComp)`
   font-size: 20px;
   margin-right: 8px;
   flex: 0 0 auto;
 `;
+Icon.displayName = 'S.Icon';
 
 export const Message = styled.div`
   // This value chosen to make the alert the same height as our source select widgets.
   padding: 3px;
   flex: 1 1 auto;
 `;
+Message.displayName = 'S.Message';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -91,24 +91,20 @@ export const CallDetails: FC<{
           gap: 1,
           paddingTop: '8px',
         }}>
-        {Object.keys(inputs).length > 0 && (
-          <Box
-            sx={{
-              flex: '0 0 auto',
-              p: 2,
-            }}>
-            <ObjectViewerSection title="Inputs" data={inputs} />
-          </Box>
-        )}
-        {Object.keys(output).length > 0 && (
-          <Box
-            sx={{
-              flex: '0 0 auto',
-              p: 2,
-            }}>
-            <ObjectViewerSection title="Outputs" data={output} />
-          </Box>
-        )}
+        <Box
+          sx={{
+            flex: '0 0 auto',
+            p: 2,
+          }}>
+          <ObjectViewerSection title="Inputs" data={inputs} />
+        </Box>
+        <Box
+          sx={{
+            flex: '0 0 auto',
+            p: 2,
+          }}>
+          <ObjectViewerSection title="Outputs" data={output} />
+        </Box>
         {multipleChildCallOpRefs.map(opVersionRef => {
           const exampleCall = childCalls.result?.find(
             c => c.opVersionRef === opVersionRef
@@ -226,17 +222,13 @@ const getDisplayInputsAndOutput = (call: CallSchema) => {
   const span = call.rawSpan;
   const inputKeys =
     span.inputs._keys ??
-    Object.entries(span.inputs)
-      .filter(([k, c]) => c != null && !k.startsWith('_'))
-      .map(([k, c]) => k);
+    Object.keys(span.inputs).filter(k => !k.startsWith('_'));
   const inputs = _.fromPairs(inputKeys.map(k => [k, span.inputs[k]]));
 
   const callOutput = span.output ?? {};
   const outputKeys =
     callOutput._keys ??
-    Object.entries(callOutput)
-      .filter(([k, c]) => c != null && (k === '_result' || !k.startsWith('_')))
-      .map(([k, c]) => k);
+    Object.keys(callOutput).filter(k => k === '_result' || !k.startsWith('_'));
   const output = _.fromPairs(outputKeys.map(k => [k, callOutput[k]]));
   return {inputs, output};
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -71,7 +71,7 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
       if (isRef(context.value)) {
         return refValues[context.value];
       }
-      return context.value;
+      return _.clone(context.value);
     });
     setResolvedData(resolved);
   }, [data, client, refsData.result, refs]);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -2,6 +2,7 @@ import {useGridApiRef} from '@mui/x-data-grid-pro';
 import React, {useCallback, useMemo, useState} from 'react';
 import styled from 'styled-components';
 
+import {Alert} from '../../../../../Alert';
 import {Button} from '../../../../../Button';
 import {CodeEditor} from '../../../../../CodeEditor';
 import {isRef} from '../common/util';
@@ -63,7 +64,7 @@ const isSimpleData = (data: Data): boolean => {
   return isSimple;
 };
 
-export const ObjectViewerSection = ({
+const ObjectViewerSectionNonEmpty = ({
   title,
   data,
 }: ObjectViewerSectionProps) => {
@@ -72,18 +73,8 @@ export const ObjectViewerSection = ({
     isSimpleData(data) ? 'expanded' : 'collapsed'
   );
 
-  const isOneValue = '_result' in data;
-
   const body = useMemo(() => {
     if (mode === 'collapsed' || mode === 'expanded') {
-      if (isOneValue) {
-        const oneResultData = {
-          value: data._result,
-          valueType: getValueType(data._result),
-          isLeaf: true,
-        };
-        return <ValueView data={oneResultData} isExpanded={true} />;
-      }
       return (
         <ObjectViewer
           apiRef={apiRef}
@@ -102,7 +93,7 @@ export const ObjectViewerSection = ({
       );
     }
     return null;
-  }, [apiRef, mode, data, isOneValue]);
+  }, [apiRef, mode, data]);
 
   const setTreeExpanded = useCallback(
     (isExpanded: boolean) => {
@@ -167,4 +158,48 @@ export const ObjectViewerSection = ({
       {body}
     </>
   );
+};
+
+export const ObjectViewerSection = ({
+  title,
+  data,
+}: ObjectViewerSectionProps) => {
+  const numKeys = Object.keys(data).length;
+  if (numKeys === 0) {
+    return (
+      <>
+        <TitleRow>
+          <Title>{title}</Title>
+        </TitleRow>
+        <Alert>None</Alert>
+      </>
+    );
+  }
+  if (numKeys === 1 && '_result' in data) {
+    const value = data._result;
+    const valueType = getValueType(value);
+    if (
+      valueType === 'object' ||
+      (valueType === 'array' && value.length > 0) ||
+      isRef(value)
+    ) {
+      return (
+        <ObjectViewerSectionNonEmpty title={title} data={{Value: value}} />
+      );
+    }
+    const oneResultData = {
+      value,
+      valueType,
+      isLeaf: true,
+    };
+    return (
+      <>
+        <TitleRow>
+          <Title>{title}</Title>
+        </TitleRow>
+        <ValueView data={oneResultData} isExpanded={true} />
+      </>
+    );
+  }
+  return <ObjectViewerSectionNonEmpty title={title} data={data} />;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -44,5 +44,11 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
     return <ValueViewPrimitive>{data.value.toString()}</ValueViewPrimitive>;
   }
 
+  if (data.valueType === 'array') {
+    // Compared to toString this keeps the square brackets.
+    // This is particularly helpful for empty lists, for which toString would return an empty string.
+    return <div>{JSON.stringify(data.value)}</div>;
+  }
+
   return <div>{data.value.toString()}</div>;
 };


### PR DESCRIPTION
Internal notion docs:
https://www.notion.so/wandbai/Trace-Detail-View-Handle-Ops-that-return-only-1-object-7f3b0c0c3bfa4bf4b00d4eab29061a1d?pvs=4
https://www.notion.so/wandbai/inputs-output-not-tracked-in-Nicholas-calls-possible-show-nones-in-UI-e33e491fcc9841448feeb3a5b914a5f5?pvs=4

Fixes a few issues:
- We were hiding input/output sections when values were null.
- When the output was a ref or list it was not expandable. 
- Declutter by not showing visibility icons when viewing a single simple value
- Better handling of some special cases like empty array output.

Before - inputs and output sections not shown because of nulls:
<img width="541" alt="Screenshot 2024-04-03 at 12 28 07 AM" src="https://github.com/wandb/weave/assets/112953339/3eee040e-be69-4b8d-9c38-2e7b9b321ac5">

Before - can't expand output ref:
<img width="754" alt="Screenshot 2024-04-03 at 12 29 58 AM" src="https://github.com/wandb/weave/assets/112953339/59e4c926-c48b-416c-a14f-6092a2371653">

Before - empty array shown as empty string:
<img width="539" alt="Screenshot 2024-04-03 at 12 34 04 AM" src="https://github.com/wandb/weave/assets/112953339/89c4b27f-c8e2-4fcb-8533-ffabfd8fef5d">

After - shows inputs and outputs even if null:
<img width="543" alt="Screenshot 2024-04-03 at 12 28 30 AM" src="https://github.com/wandb/weave/assets/112953339/e6c976dc-aa55-42b1-9ac8-e6f03f7168d9">

After - can expand output ref:
<img width="828" alt="Screenshot 2024-04-03 at 12 32 05 AM" src="https://github.com/wandb/weave/assets/112953339/b89392b4-aff8-4beb-8fdc-e823fb00e5bd">

After - empty array output is clear:
<img width="552" alt="Screenshot 2024-04-03 at 12 32 42 AM" src="https://github.com/wandb/weave/assets/112953339/f662c857-c484-4db9-8667-aa706f068f40">



