### PR TITLE
fix: op sort order got reversed

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewer.tsx
@@ -114,6 +114,8 @@ export const OpCodeViewer = ({
     setLeftSize(left + 'px');
   };
 
+  const opVersionsDesc = opVersions.slice().reverse();
+
   let diffBar = null;
   if (isDiffAvailable) {
     diffBar = diffState.left ? (
@@ -159,7 +161,7 @@ export const OpCodeViewer = ({
           <SelectVersionBar>
             <VersionHeader style={{width: leftSize}}>
               <SelectOpVersion
-                opVersions={opVersions}
+                opVersions={opVersionsDesc}
                 valueURI={diffState.left}
                 currentVersionURI={currentVersionURI}
                 onChange={uri => onSetLeft(uri)}
@@ -174,7 +176,7 @@ export const OpCodeViewer = ({
             </VersionHeader>
             <VersionHeader>
               <SelectOpVersion
-                opVersions={opVersions}
+                opVersions={opVersionsDesc}
                 valueURI={diffState.right}
                 currentVersionURI={currentVersionURI}
                 onChange={uri => onSetRight(uri)}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
@@ -115,7 +115,7 @@ const OpVersionPageInner: React.FC<{
               entity={entity}
               project={project}
               opName={opId}
-              opVersions={(opVersions.result ?? []).slice().reverse()} // put in increasing order
+              opVersions={opVersions.result ?? []}
               currentVersionURI={uri}
             />
           ),


### PR DESCRIPTION
The intention is for the select widget to list versions in descending order (newest first) with the navigation showing the previous version on the left and subsequent version on the right by default. This presumably got broken when we switched out the backend APIs.

Internal notion: https://www.notion.so/wandbai/Version-sort-order-got-switched-in-diff-0170f9a22d7c4a3dbfaef32d7316c359?pvs=4