### PR TITLE
fix: simplify trace tree default open state

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -44,7 +44,6 @@ import {
   Browse3WeaveflowRouteContextProvider,
   PATH_PARAM,
   PEEK_PARAM,
-  TRACETREE_PARAM,
   useClosePeek,
   usePeekLocation,
   useWeaveflowCurrentRouteContext,
@@ -696,7 +695,6 @@ const CallPageBinding = () => {
       entity={params.entity}
       project={params.project}
       callId={params.itemName}
-      showTraceTree={query[TRACETREE_PARAM] === '1'}
       path={query[PATH_PARAM]}
     />
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -379,8 +379,8 @@ export const browse3ContextGen = (
       if (path) {
         params.set(PATH_PARAM, path);
       }
-      if (tracetree) {
-        params.set(TRACETREE_PARAM, '1');
+      if (tracetree !== undefined) {
+        params.set(TRACETREE_PARAM, tracetree ? '1' : '0');
       }
       if (params.toString()) {
         url += '?' + params.toString();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -5,9 +5,11 @@ import {Loader} from 'semantic-ui-react';
 
 import {Button} from '../../../../../Button';
 import {Browse2OpDefCode} from '../../../Browse2/Browse2OpDefCode';
-import {useWeaveflowCurrentRouteContext} from '../../context';
+import {TRACETREE_PARAM, useWeaveflowCurrentRouteContext} from '../../context';
+import {isEvaluateOp} from '../common/heuristics';
 import {CenteredAnimatedLoader} from '../common/Loader';
 import {SimplePageLayoutWithHeader} from '../common/SimplePageLayout';
+import {useURLSearchParamsDict} from '../util';
 import {useWFHooks} from '../wfReactInterface/context';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CallDetails} from './CallDetails';
@@ -19,7 +21,6 @@ export const CallPage: FC<{
   entity: string;
   project: string;
   callId: string;
-  showTraceTree?: boolean;
   path?: string;
 }> = props => {
   const {useCall} = useWFHooks();
@@ -61,11 +62,16 @@ const useCallTabs = (call: CallSchema) => {
 
 const CallPageInnerVertical: FC<{
   call: CallSchema;
-  showTraceTree?: boolean;
   path?: string;
-}> = ({call, showTraceTree, path}) => {
+}> = ({call, path}) => {
   const history = useHistory();
   const currentRouter = useWeaveflowCurrentRouteContext();
+
+  const query = useURLSearchParamsDict();
+  const showTraceTree =
+    TRACETREE_PARAM in query
+      ? query[TRACETREE_PARAM] === '1'
+      : !isEvaluateOp(call.spanName);
 
   const onToggleTraceTree = useCallback(() => {
     history.replace(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -12,7 +12,6 @@ import styled, {css} from 'styled-components';
 import {TargetBlank} from '../../../../../../common/util/links';
 import {
   PATH_PARAM,
-  TRACETREE_PARAM,
   usePeekLocation,
   useWeaveflowRouteContext,
 } from '../../context';
@@ -21,7 +20,6 @@ import {WFHighLevelObjectVersionFilter} from '../ObjectVersionsPage';
 import {WFHighLevelOpVersionFilter} from '../OpVersionsPage';
 import {WFHighLevelTypeVersionFilter} from '../TypeVersionsPage';
 import {truncateID} from '../util';
-import {isEvaluateOp} from './heuristics';
 
 type LinkVariant = 'primary' | 'secondary';
 
@@ -264,21 +262,16 @@ export const CallLink: React.FC<{
   // to provide the right abstractions.
   const peekLoc = usePeekLocation();
   const peekParams = new URLSearchParams(peekLoc?.search ?? '');
-  const existingTraceTreeOpen = peekParams.get(TRACETREE_PARAM) === '1';
   const existingPath = peekParams.get(PATH_PARAM) ?? '';
-  // Don't show trace tree by default for Evaluation-evaluate when not already open
-  const tracetree =
-    props.tracetree ?? (existingTraceTreeOpen || !isEvaluateOp(opName));
   // Preserve the path only when showing trace tree
-  const path = props.preservePath && tracetree ? existingPath : null;
+  const path = props.preservePath ? existingPath : null;
 
   const to = peekingRouter.callUIUrl(
     props.entityName,
     props.projectName,
     '',
     props.callId,
-    path,
-    tracetree
+    path
   );
   const onClick = () => {
     history.push(to);


### PR DESCRIPTION
Internal notion: https://www.notion.so/wandbai/Following-link-should-respect-trace-pane-open-heuristics-d3f2dd1fac24439a92a2fe4a60c1eb77?pvs=4

Don't attempt to preserve the shown/hidden state of the tracetree across calls, drive it by whether it is an evaluation or not. This also addresses the problem of the trace tree not being shown for a non-evaluation call when someone is coming from the SDK redirect link.