### PR TITLE
chore: move FancyPage from app to Weave

### DIFF
--- a/weave-js/src/components/FancyPage/FancyPage.tsx
+++ b/weave-js/src/components/FancyPage/FancyPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {FancyPageSidebar, FancyPageSidebarItem} from './FancyPageSidebar';
+
+type FancyPageProps = {
+  baseUrl: string;
+  /**
+   * Slug of the active item on the sidebar.
+   * If undefined, no item will be active.
+   */
+  activeSlug?: string;
+  items: FancyPageSidebarItem[];
+  /**
+   * If specified, children will be rendered in place of
+   * calling `.render` of the active item.
+   */
+  children?: React.ReactNode;
+};
+
+export const FancyPage = React.memo(
+  ({baseUrl, activeSlug, items, children}: FancyPageProps) => {
+    const activeItem =
+      activeSlug === undefined
+        ? undefined
+        : items.find(item => item.slug === activeSlug);
+    return (
+      <div className="fancy-page">
+        <FancyPageSidebar
+          items={items}
+          selectedItem={activeItem}
+          baseUrl={baseUrl}
+        />
+        <div className="fancy-page__content">
+          {children ?? activeItem?.render?.()}
+        </div>
+      </div>
+    );
+  }
+);
+FancyPage.displayName = 'FancyPage';

--- a/weave-js/src/components/FancyPage/FancyPageSidebar.tsx
+++ b/weave-js/src/components/FancyPage/FancyPageSidebar.tsx
@@ -1,0 +1,106 @@
+import {
+  MEDIUM_BREAKPOINT,
+  MOON_250,
+  WHITE,
+} from '@wandb/weave/common/css/globals.styles';
+import {IconName} from '@wandb/weave/components/Icon';
+import React from 'react';
+import styled from 'styled-components';
+
+import FancyPageSidebarSection from './FancyPageSidebarSection';
+
+const Sidebar = styled.div`
+  background-color: ${WHITE};
+  box-sizing: content-box;
+  border-right: 1px solid ${MOON_250};
+  width: 56px;
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    width: 100%;
+    height: 56px;
+    border-right: none;
+    border-bottom: 1px solid ${MOON_250};
+  }
+`;
+Sidebar.displayName = 'S.Sidebar';
+
+const SidebarSections = styled.div`
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: sticky;
+  top: 0;
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    gap: 14px;
+    height: 100%;
+    overflow-x: auto;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    margin: 0;
+    padding: 0 12px;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: stretch;
+  }
+`;
+SidebarSections.displayName = 'S.SidebarSections';
+
+export type FancyPageSidebarItem = {
+  iconName: IconName;
+  name: string;
+  nameTooltip?: string;
+  slug?: string;
+  externalLink?: string;
+  onClick?: () => void;
+  /**
+   * @deprecated Pass children to FancyPage instead to define rendered page contents
+   */
+  render?: () => React.ReactNode;
+  /**
+   * Enables multiple sections with dividers in between. Defaults to 0.
+   */
+  sectionIndex?: number;
+
+  isDisabled?: boolean;
+};
+
+type FancyPageSidebarProps = {
+  selectedItem?: FancyPageSidebarItem;
+  items: FancyPageSidebarItem[];
+  baseUrl: string;
+};
+
+export const FancyPageSidebar = (props: FancyPageSidebarProps) => {
+  if (props.items.length < 2) {
+    return <></>;
+  }
+
+  const sections = new Set<number>();
+  props.items.forEach(item => {
+    sections.add(item.sectionIndex || 0);
+  });
+
+  return (
+    <Sidebar className="fancy-page__sidebar">
+      <SidebarSections>
+        {Array.from(sections)
+          .sort()
+          .map((section, i) => (
+            <React.Fragment key={'section__' + i}>
+              {i !== 0 && (
+                <div className="fancy-page__sidebar__sections__divider" />
+              )}
+              <FancyPageSidebarSection
+                selectedItem={props.selectedItem}
+                items={props.items.filter(
+                  item => section === (item.sectionIndex || 0)
+                )}
+                baseUrl={props.baseUrl}
+              />
+            </React.Fragment>
+          ))}
+      </SidebarSections>
+    </Sidebar>
+  );
+};

--- a/weave-js/src/components/FancyPage/FancyPageSidebarSection.tsx
+++ b/weave-js/src/components/FancyPage/FancyPageSidebarSection.tsx
@@ -1,0 +1,180 @@
+import {
+  hexToRGB,
+  MEDIUM_BREAKPOINT,
+  MOON_250,
+  MOON_800,
+  MOONBEAM,
+  OBLIVION,
+  TEAL_450,
+  TEAL_550,
+} from '@wandb/weave/common/css/globals.styles';
+import {TargetBlank} from '@wandb/weave/common/util/links';
+import {Icon} from '@wandb/weave/components/Icon';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
+import React from 'react';
+import {Link} from 'react-router-dom';
+import styled from 'styled-components';
+
+import {isInNightMode} from '../nightMode';
+import {FancyPageSidebarItem} from './FancyPageSidebar';
+
+const SidebarWrapper = styled.div`
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    display: flex;
+    align-items: center;
+  }
+`;
+SidebarWrapper.displayName = 'S.SidebarWrapper';
+
+const SidebarButton = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+SidebarButton.displayName = 'S.SidebarButton';
+
+type ItemIconProps = {
+  color: string;
+};
+const ItemIcon = styled.div<ItemIconProps>`
+  height: 32px;
+  box-sizing: border-box;
+  border-radius: 8px;
+  padding: 6px 12px;
+  background-color: ${props => props.color};
+  display: flex;
+  align-items: center;
+  @media only screen and (max-width: ${MEDIUM_BREAKPOINT}px) {
+    padding: 0 12px;
+  }
+`;
+ItemIcon.displayName = 'S.ItemIcon';
+
+type ItemLabelProps = {
+  color: string;
+};
+const ItemLabel = styled.div<ItemLabelProps>`
+  color: ${props => props.color};
+  font-family: 'Source Sans Pro';
+  font-weight: 600;
+  height: 14px;
+  font-size: 10px;
+  line-height: 14px;
+  text-align: center;
+`;
+ItemLabel.displayName = 'S.ItemLabel';
+
+type FancyPageSidebarSectionProps = {
+  selectedItem?: FancyPageSidebarItem;
+  items: FancyPageSidebarItem[];
+  baseUrl: string;
+};
+
+const FancyPageSidebarSection = (props: FancyPageSidebarSectionProps) => {
+  const isNightMode = isInNightMode();
+
+  const [hoveredItem, setHoveredItem] =
+    React.useState<FancyPageSidebarItem | null>(null);
+  return (
+    <>
+      {props.items.map(item => {
+        const onMouseEnter = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+          setHoveredItem(item);
+        };
+        const onMouseLeave = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
+          setHoveredItem(null);
+        };
+        let colorIconBg: string = 'transparent';
+        let colorIcon: string = isNightMode ? MOON_250 : MOON_800;
+        let colorText: string = isNightMode ? MOON_250 : MOON_800;
+        if (item === props.selectedItem) {
+          colorIconBg = hexToRGB(TEAL_550, isNightMode ? 0.16 : 0.1);
+          colorIcon = colorText = isNightMode ? TEAL_450 : TEAL_550;
+        } else if (item.isDisabled) {
+          colorIcon = colorText = isNightMode ? MOON_800 : MOON_250;
+        } else if (item === hoveredItem) {
+          colorIconBg = isNightMode
+            ? hexToRGB(MOONBEAM, 0.08)
+            : hexToRGB(OBLIVION, 0.04);
+        }
+        const baseLinkProps = {
+          key: item.name,
+          onClick: () => {
+            item.onClick?.();
+          },
+          onMouseEnter,
+          onMouseLeave,
+          'data-test': item.slug + '-tab',
+        };
+        if (item.externalLink) {
+          const externalLinkProps = {
+            ...baseLinkProps,
+            href: item.externalLink,
+          };
+          return (
+            <SidebarWrapper key={item.name} className="night-aware">
+              <TargetBlank
+                {...externalLinkProps}
+                style={{
+                  pointerEvents: item.isDisabled ? 'none' : 'auto',
+                  cursor: item.isDisabled ? 'default' : 'pointer',
+                }}>
+                <SidebarButton>
+                  <ItemIcon color={colorIconBg}>
+                    <Icon name={item.iconName} color={colorIcon} />
+                  </ItemIcon>
+                  <ItemLabel color={colorText}>{item.name}</ItemLabel>
+                </SidebarButton>
+              </TargetBlank>
+            </SidebarWrapper>
+          );
+        }
+
+        const linkProps = {
+          ...baseLinkProps,
+          to: item.isDisabled
+            ? {}
+            : {
+                pathname: item.slug
+                  ? `${props.baseUrl}/${item.slug}`
+                  : props.baseUrl,
+                // Preserve query string. Gets updated because the component happens to re-render on hover.
+                search: window.location.search,
+              },
+        };
+
+        const wrapper = (
+          <SidebarWrapper key={item.name} className="night-aware">
+            <Link
+              {...linkProps}
+              style={{
+                pointerEvents: item.isDisabled ? 'none' : 'auto',
+                cursor: item.isDisabled ? 'default' : 'pointer',
+              }}>
+              <SidebarButton>
+                <ItemIcon color={colorIconBg}>
+                  <Icon name={item.iconName} color={colorIcon} />
+                </ItemIcon>
+                <ItemLabel color={colorText}>{item.name}</ItemLabel>
+              </SidebarButton>
+            </Link>
+          </SidebarWrapper>
+        );
+
+        if (item.nameTooltip) {
+          return (
+            <Tooltip
+              key={item.name}
+              content={<span>{item.nameTooltip}</span>}
+              trigger={wrapper}
+              position="right center"
+            />
+          );
+        }
+        return wrapper;
+      })}
+    </>
+  );
+};
+
+export default FancyPageSidebarSection;

--- a/weave-js/src/components/FancyPage/index.tsx
+++ b/weave-js/src/components/FancyPage/index.tsx
@@ -1,0 +1,3 @@
+export * from './FancyPage';
+export * from './FancyPageSidebar';
+export * from './FancyPageSidebarSection';


### PR DESCRIPTION
Moving fancy sidebar code from App into Weave. Minor changes to fix deprecated imports and address the lack of a night mode beta feature hook.

This is part of unified side nav work.