### PR TITLE
chore(weave): correctly expand output refs

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RefValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RefValue.tsx
@@ -19,7 +19,6 @@ type RefValueProps = {
   // React key and object key
   weaveRef: string;
   attribute: string;
-  iconOnly?: boolean;
 };
 
 const RENDER_DIRECTLY = new Set([
@@ -29,7 +28,7 @@ const RENDER_DIRECTLY = new Set([
   typeof false,
 ]);
 
-export const RefValue = ({weaveRef, attribute, iconOnly = false}: RefValueProps) => {
+export const RefValue = ({weaveRef, attribute}: RefValueProps) => {
   const {
     derived: {useRefsType},
   } = useWFHooks();
@@ -41,7 +40,6 @@ export const RefValue = ({weaveRef, attribute, iconOnly = false}: RefValueProps)
       <RefValueWithExtra
         weaveRef={weaveRef}
         attribute={DICT_KEY_EDGE_NAME + '/' + attribute}
-        iconOnly={iconOnly}
       />
     );
   } else if (isObjectTypeLike(getRefsType.result[0])) {
@@ -49,7 +47,6 @@ export const RefValue = ({weaveRef, attribute, iconOnly = false}: RefValueProps)
       <RefValueWithExtra
         weaveRef={weaveRef}
         attribute={OBJECT_ATTR_EDGE_NAME + '/' + attribute}
-        iconOnly={iconOnly}
       />
     );
   } else if (isListLike(getRefsType.result[0])) {
@@ -57,14 +54,13 @@ export const RefValue = ({weaveRef, attribute, iconOnly = false}: RefValueProps)
       <RefValueWithExtra
         weaveRef={weaveRef}
         attribute={LIST_INDEX_EDGE_NAME + '/' + attribute}
-        iconOnly={iconOnly}
       />
     );
   }
   return <>Unknown Type</>;
 };
 
-const RefValueWithExtra = ({weaveRef, attribute, iconOnly = false}: RefValueProps) => {
+const RefValueWithExtra = ({weaveRef, attribute}: RefValueProps) => {
   const {useRefsData} = useWFHooks();
   const objRef = parseRef(weaveRef);
   const objRefWithExtra = useMemo(() => {
@@ -86,10 +82,10 @@ const RefValueWithExtra = ({weaveRef, attribute, iconOnly = false}: RefValueProp
   if (refData === null) {
     return <NotApplicable />;
   } else if (isRef(refData)) {
-    return <SmallRef objRef={parseRef(refData)} iconOnly={iconOnly}/>;
+    return <SmallRef objRef={parseRef(refData)} />;
   } else if (RENDER_DIRECTLY.has(typeof refData)) {
-    return <CellValue value={refData} isExpanded={iconOnly}/>;
+    return <CellValue value={refData} />;
   } else {
-    return <SmallRef objRef={objRefWithExtra} iconOnly={iconOnly}/>;
+    return <SmallRef objRef={objRefWithExtra} />;
   }
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RefValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RefValue.tsx
@@ -19,6 +19,7 @@ type RefValueProps = {
   // React key and object key
   weaveRef: string;
   attribute: string;
+  iconOnly?: boolean;
 };
 
 const RENDER_DIRECTLY = new Set([
@@ -28,7 +29,7 @@ const RENDER_DIRECTLY = new Set([
   typeof false,
 ]);
 
-export const RefValue = ({weaveRef, attribute}: RefValueProps) => {
+export const RefValue = ({weaveRef, attribute, iconOnly = false}: RefValueProps) => {
   const {
     derived: {useRefsType},
   } = useWFHooks();
@@ -40,6 +41,7 @@ export const RefValue = ({weaveRef, attribute}: RefValueProps) => {
       <RefValueWithExtra
         weaveRef={weaveRef}
         attribute={DICT_KEY_EDGE_NAME + '/' + attribute}
+        iconOnly={iconOnly}
       />
     );
   } else if (isObjectTypeLike(getRefsType.result[0])) {
@@ -47,6 +49,7 @@ export const RefValue = ({weaveRef, attribute}: RefValueProps) => {
       <RefValueWithExtra
         weaveRef={weaveRef}
         attribute={OBJECT_ATTR_EDGE_NAME + '/' + attribute}
+        iconOnly={iconOnly}
       />
     );
   } else if (isListLike(getRefsType.result[0])) {
@@ -54,13 +57,14 @@ export const RefValue = ({weaveRef, attribute}: RefValueProps) => {
       <RefValueWithExtra
         weaveRef={weaveRef}
         attribute={LIST_INDEX_EDGE_NAME + '/' + attribute}
+        iconOnly={iconOnly}
       />
     );
   }
   return <>Unknown Type</>;
 };
 
-const RefValueWithExtra = ({weaveRef, attribute}: RefValueProps) => {
+const RefValueWithExtra = ({weaveRef, attribute, iconOnly = false}: RefValueProps) => {
   const {useRefsData} = useWFHooks();
   const objRef = parseRef(weaveRef);
   const objRefWithExtra = useMemo(() => {
@@ -82,10 +86,10 @@ const RefValueWithExtra = ({weaveRef, attribute}: RefValueProps) => {
   if (refData === null) {
     return <NotApplicable />;
   } else if (isRef(refData)) {
-    return <SmallRef objRef={parseRef(refData)} />;
+    return <SmallRef objRef={parseRef(refData)} iconOnly={iconOnly}/>;
   } else if (RENDER_DIRECTLY.has(typeof refData)) {
-    return <CellValue value={refData} />;
+    return <CellValue value={refData} isExpanded={iconOnly}/>;
   } else {
-    return <SmallRef objRef={objRefWithExtra} />;
+    return <SmallRef objRef={objRefWithExtra} iconOnly={iconOnly}/>;
   }
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -533,18 +533,14 @@ export const RunsTable: FC<{
       }
     }
 
-    type ColGroupChildren = Array<
-      | {field: string}
-      | {
-          groupId: string;
-          children: ColGroupChildren;
-          headerName: string;
-          renderHeaderGroup: () => JSX.Element;
-        }
-    >;
+    // Gets the children of a expanded group field(a ref that has been expanded)
+    // returns an array of column definitions, for the children
     const getGroupChildren = (groupField: string) => {
-      const colGroupChildren: ColGroupChildren = [{field: groupField}];
+      // start children array with self
+      const colGroupChildren = [{field: groupField}];
+      // get the expanded columns for the group field
       const expandCols = expandedColInfo[groupField] ?? [];
+      // for each expanded column, add a column definition
       for (const col of expandCols) {
         const expandField = groupField + '.' + col.path;
         cols.push({
@@ -584,7 +580,7 @@ export const RunsTable: FC<{
         cols.push({
           ...(isExpanded
             ? {
-                // if the ref is expanded we want to give the ref icon less space
+                // if the ref is expanded it will only be an icon and we want to give the ref icon less column space
                 width: 100,
               }
             : {
@@ -596,7 +592,7 @@ export const RunsTable: FC<{
             const hasExpand = columnHasRefs(tableStats, field);
             return (
               <ExpandHeader
-                // if the field is a flattened field, use the last key as the header 
+                // if the field is a flattened field, use the last key as the header
                 headerName={isExpanded ? 'Ref' : fields.slice(-1)[0]}
                 field={field}
                 hasExpand={hasExpand && !isExpanded}
@@ -613,7 +609,7 @@ export const RunsTable: FC<{
           },
         });
 
-        // if ref is expanded add the children to the colGroup
+        // if ref is expanded add the ref children to the colGroup
         if (isExpanded) {
           colGroup.children.push({
             groupId: field,
@@ -631,6 +627,7 @@ export const RunsTable: FC<{
             },
           });
         } else {
+          // if ref is not expanded add the column to the colGroup
           addToTree(colGroup, fields, field, 0);
         }
       }


### PR DESCRIPTION
Move the input grouping logic into a func addColGroup
Moves nested expansion logic into a func getGroupChildren
this cleanup and moving the logic into functions will help when we want to be able to infinitely drill down into refs

This uses the same logic for both inputs and outputs.
This fixes grouping being broken for expanding output refs, while still maintaining proper nesting

before 
![Screenshot 2024-04-03 at 12 56 01 PM](https://github.com/wandb/weave/assets/25037002/1004af7c-8d1f-43d6-9702-afdc566c6a0c)

after
![Screenshot 2024-04-03 at 12 55 37 PM](https://github.com/wandb/weave/assets/25037002/0d012348-1930-4fcb-8368-aa84a30af776)

maintains proper nesting
![Screenshot 2024-04-03 at 12 57 04 PM](https://github.com/wandb/weave/assets/25037002/fe6e132e-b3f5-4bf9-a2b4-016bee3072dc)
