### PR TITLE
chore: remove trace tree header

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -8,7 +8,6 @@ import React, {FC, useCallback, useEffect, useMemo, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
-import {Button} from '../../../../../Button';
 import {ErrorBoundary} from '../../../../../ErrorBoundary';
 import {useWeaveflowCurrentRouteContext} from '../../context';
 import {CallStatusType} from '../common/StatusChip';
@@ -18,31 +17,10 @@ import {CustomGridTreeDataGroupingCell} from './CustomGridTreeDataGroupingCell';
 import {scorePathSimilarity, updatePath} from './pathPreservation';
 
 const CallTrace = styled.div`
-  display: flex;
-  flex-direction: column;
+  overflow: auto;
   height: 100%;
 `;
 CallTrace.displayName = 'S.CallTrace';
-
-const CallTraceTree = styled.div`
-  overflow: auto;
-  flex: 1 1 auto;
-`;
-CallTraceTree.displayName = 'S.CallTraceTree';
-
-const CallTraceHeader = styled.div`
-  display: flex;
-  align-items: center;
-  padding: 8px 4px 8px 16px;
-`;
-CallTraceHeader.displayName = 'S.CallTraceHeader';
-
-const CallTraceHeaderTitle = styled.div`
-  font-weight: 600;
-  font-size: 18px;
-  flex: 1 1 auto;
-`;
-CallTraceHeaderTitle.displayName = 'S.CallTraceHeaderTitle';
 
 export const CallTraceView: FC<{
   call: CallSchema;
@@ -228,27 +206,6 @@ export const CallTraceView: FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiRef, callId]);
 
-  const onCloseTraceTree = useCallback(() => {
-    history.replace(
-      currentRouter.callUIUrl(
-        call.entity,
-        call.project,
-        call.traceId,
-        call.callId,
-        path,
-        false
-      )
-    );
-  }, [
-    call.callId,
-    call.entity,
-    call.project,
-    call.traceId,
-    path,
-    currentRouter,
-    history,
-  ]);
-
   // This is used because when we first load the trace view in a drawer, the animation cant handle all the rows
   // so we delay for the first render
   const [animationBuffer, setAnimationBuffer] = useState(true);
@@ -260,37 +217,26 @@ export const CallTraceView: FC<{
 
   return (
     <CallTrace>
-      <CallTraceHeader>
-        <CallTraceHeaderTitle>Trace tree</CallTraceHeaderTitle>
-        <Button
-          icon="close"
-          variant="ghost"
-          onClick={onCloseTraceTree}
-          tooltip="Hide trace tree"
+      <ErrorBoundary>
+        <DataGridPro
+          apiRef={apiRef}
+          rowHeight={38}
+          columnHeaderHeight={0}
+          treeData
+          loading={animationBuffer}
+          onRowClick={onRowClick}
+          onRowDoubleClick={onRowDoubleClick}
+          rows={animationBuffer ? [] : rows}
+          columns={[]}
+          getTreeDataPath={getTreeDataPath}
+          groupingColDef={groupingColDef}
+          isGroupExpandedByDefault={isGroupExpandedByDefault}
+          getRowClassName={getRowClassName}
+          hideFooter
+          rowSelection={false}
+          sx={sx}
         />
-      </CallTraceHeader>
-      <CallTraceTree>
-        <ErrorBoundary>
-          <DataGridPro
-            apiRef={apiRef}
-            rowHeight={38}
-            columnHeaderHeight={0}
-            treeData
-            loading={animationBuffer}
-            onRowClick={onRowClick}
-            onRowDoubleClick={onRowDoubleClick}
-            rows={animationBuffer ? [] : rows}
-            columns={[]}
-            getTreeDataPath={getTreeDataPath}
-            groupingColDef={groupingColDef}
-            isGroupExpandedByDefault={isGroupExpandedByDefault}
-            getRowClassName={getRowClassName}
-            hideFooter
-            rowSelection={false}
-            sx={sx}
-          />
-        </ErrorBoundary>
-      </CallTraceTree>
+      </ErrorBoundary>
     </CallTrace>
   );
 };


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Notes-on-Weaveflow-UX-674af4e66c6847248aeff7b93d87dc5c?pvs=4#a38299331f674872913c6ab7b5629d0f

Before - two call tree:
<img width="736" alt="Screenshot 2024-04-03 at 4 02 18 PM" src="https://github.com/wandb/weave/assets/112953339/f6e58aa9-a47b-4678-b3b9-3fb40ecb8b9a">

Before - single call tree:
<img width="810" alt="Screenshot 2024-04-03 at 4 00 51 PM" src="https://github.com/wandb/weave/assets/112953339/61a76af6-a0fa-4dd6-8c5d-ed2806a0d55d">

After - two call tree:
<img width="805" alt="Screenshot 2024-04-03 at 4 02 48 PM" src="https://github.com/wandb/weave/assets/112953339/23c1f2fc-e1d5-45a0-a0ce-d45532f7ad8a">

After - single call tree:
<img width="808" alt="Screenshot 2024-04-03 at 4 00 38 PM" src="https://github.com/wandb/weave/assets/112953339/817eae9e-864a-4ce3-b813-52e24e2cd8ed">

