### PR TITLE
chore(weave): add border radius to table and alert

### DIFF
--- a/weave-js/src/components/Alert.tsx
+++ b/weave-js/src/components/Alert.tsx
@@ -27,15 +27,16 @@ type AlertProps = {
   severity?: AlertSeverity;
   icon?: IconName | null;
   children: React.ReactNode;
+  style?: React.CSSProperties;
 };
 
-export const Alert = ({severity, icon, children}: AlertProps) => {
+export const Alert = ({severity, icon, children, style}: AlertProps) => {
   // User can override icon including to force it not to be shown.
   // Otherwise fallback to show the icon associated with the severity.
   const iconName =
     icon === null || icon ? icon : severity ? ICONS[severity] : null;
   return (
-    <S.Alert severity={severity ?? 'default'}>
+    <S.Alert severity={severity ?? 'default'} style={style}>
       {iconName !== null && <S.Icon name={iconName} width={16} height={16} />}
       <S.Message>{children}</S.Message>
     </S.Alert>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -817,7 +817,7 @@ export const RunsTable: FC<{
   return (
     <>
       {showVisibilityAlert && (
-        <Alert>
+        <Alert style={{borderRadius: 0}}>
           <VisibilityAlert>
             <div>Columns having many empty values have been hidden.</div>
             <VisibilityAlertAction onClick={() => setForceShowAll(true)}>
@@ -840,6 +840,9 @@ export const RunsTable: FC<{
         rowSelectionModel={rowSelectionModel}
         columnGroupingModel={columns.colGroupingModel}
         hideFooterSelectedRowCount
+        sx={{
+          borderRadius: 0,
+        }}
         slots={{
           noRowsOverlay: () => {
             return (


### PR DESCRIPTION
before
![Screenshot 2024-04-03 at 4 47 13 PM](https://github.com/wandb/weave/assets/25037002/fa7180a6-4287-460f-9ab0-a5821acd6b7b)

After
![Screenshot 2024-04-03 at 4 47 33 PM](https://github.com/wandb/weave/assets/25037002/481558a2-826e-438d-bfae-00246285fe52)

i wonder if putting the boring cols above alert would look better
![Screenshot 2024-04-03 at 4 47 08 PM](https://github.com/wandb/weave/assets/25037002/3e663fb5-2338-44a5-bb21-e8745b8379cf)
