### PR TITLE
chore: better loading indicator for cells

### DIFF
--- a/weave-js/src/components/LoadingDots.tsx
+++ b/weave-js/src/components/LoadingDots.tsx
@@ -1,0 +1,54 @@
+/**
+ * A subtle loading indicator for use in cases like Table cells.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+
+import * as Colors from '../common/css/color.styles';
+
+const DotsContainer = styled.div`
+  display: flex;
+  align-items: center;
+
+  @keyframes fade {
+    from {
+      opacity: 0.2;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+DotsContainer.displayName = 'S.DotsContainer';
+
+type DotProps = {
+  marginLeft?: number;
+  animationDelay?: string;
+};
+
+const Dot = styled.span<DotProps>`
+  height: 4px;
+  width: 4px;
+  background-color: ${Colors.MOON_200};
+  border-radius: 50%;
+  display: inline-block;
+  animation-name: fade;
+  animation-duration: 1.4s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-direction: alternate;
+  margin-left: ${props => (props.marginLeft ?? 0) + 'px'};
+  animation-delay: ${props => props.animationDelay};
+`;
+Dot.displayName = 'S.Dot';
+
+export const LoadingDots: React.FC = () => {
+  return (
+    <DotsContainer>
+      <Dot />
+      <Dot marginLeft={4} animationDelay="0.2s" />
+      <Dot marginLeft={4} animationDelay="0.4s" />
+    </DotsContainer>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RefValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RefValue.tsx
@@ -2,6 +2,7 @@ import {objectRefWithExtra, parseRef, refUri} from '@wandb/weave/react';
 import React, {useMemo} from 'react';
 
 import {isListLike, isObjectTypeLike, isTypedDictLike} from '../../../../core';
+import {LoadingDots} from '../../../LoadingDots';
 import {isRef} from '../Browse3/pages/common/util';
 import {
   DICT_KEY_EDGE_NAME,
@@ -69,7 +70,7 @@ const RefValueWithExtra = ({weaveRef, attribute}: RefValueProps) => {
   const refValue = useRefsData([refUri(objRefWithExtra)]);
 
   if (refValue.loading) {
-    return <>loading...</>;
+    return <LoadingDots />;
   }
 
   if (refValue.result == null || refValue.result.length === 0) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -8,6 +8,7 @@ import _ from 'lodash';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {Loading} from '../../../../Loading';
+import {LoadingDots} from '../../../../LoadingDots';
 import {Timestamp} from '../../../../Timestamp';
 import {useWeaveflowRouteContext} from '../context';
 import {StyledDataGrid} from '../StyledDataGrid';
@@ -270,6 +271,9 @@ const PeerVersionsLink: React.FC<{obj: ObjectVersionSchema}> = props => {
     },
     100
   );
+  if (objectVersionsNode.loading) {
+    return <LoadingDots />;
+  }
   const countValue = objectVersionsNode.result?.length ?? 0;
   return (
     <ObjectVersionsLink


### PR DESCRIPTION
Adds a more subtle animated loading indicator for use in table cells. PR uses this to fix the problem of version count column showing "O versions" while loading, which is misleading.

Internal notion: https://www.notion.so/wandbai/Versions-column-shouldn-t-show-0-versions-while-loading-7207cf774b0f4403818da853684eddc1?pvs=4

<img width="128" alt="Screenshot 2024-04-05 at 10 17 34 AM" src="https://github.com/wandb/weave/assets/112953339/0b607e6f-c935-4cb4-bde9-0f7a3e5a7892">
 