### PR TITLE
fix: incorrectly hiding columns for single op

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -366,8 +366,8 @@ export const RunsTable: FC<{
   }, [expandedRefCols, client, tableStats]);
 
   const {allShown, columnVisibilityModel, forceShowAll, setForceShowAll} =
-    useColumnVisibility(tableStats);
-  const showVisibilityAlert = !isSingleOpVersion && !allShown && !forceShowAll;
+    useColumnVisibility(tableStats, isSingleOpVersion);
+  const showVisibilityAlert = !allShown && !forceShowAll;
 
   // Highlight table row if it matches peek drawer.
   const query = useURLSearchParamsDict();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
@@ -109,8 +109,20 @@ export const computeTableStats = (table: Array<Record<string, any>>) => {
   return stats;
 };
 
-export const useColumnVisibility = (tableStats: TableStats) => {
+export const useColumnVisibility = (
+  tableStats: TableStats,
+  isSingleOpVersion: boolean
+) => {
   const [forceShowAll, setForceShowAll] = useState(false);
+  if (isSingleOpVersion) {
+    return {
+      allShown: true,
+      columnVisibilityModel: {},
+      forceShowAll: true,
+      setForceShowAll,
+    };
+  }
+
   const boringColumns = getBoringColumns(tableStats);
 
   const model: GridColumnVisibilityModel = {};


### PR DESCRIPTION
We had previously decided that when we are showing a single op version (either through filtering or there only is one) we would disable the automated column hiding.

However, we were in fact only hiding the UI that indicated columns had been hidden, and were still hiding the columns.
