### PR TITLE
chore: add loading indicators to op versions page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -32,6 +32,7 @@ import {useDeepMemo} from '../../../../hookUtils';
 import {parseRef} from '../../../../react';
 import {Alert} from '../../../Alert';
 import {ErrorBoundary} from '../../../ErrorBoundary';
+import {LoadingDots} from '../../../LoadingDots';
 import {Timestamp} from '../../../Timestamp';
 import {BoringColumnInfo} from '../Browse3/pages/CallPage/BoringColumnInfo';
 import {isPredictAndScoreOp} from '../Browse3/pages/common/heuristics';
@@ -150,6 +151,9 @@ const OpVersionIndexText = ({opVersionRef}: OpVersionIndexTextProps) => {
     };
   }
   const opVersion = useOpVersion(opVersionKey);
+  if (opVersion.loading) {
+    return <LoadingDots />;
+  }
   return opVersion.result ? (
     <span>v{opVersion.result.versionIndex}</span>
   ) : null;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -7,6 +7,7 @@ import {
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {Loading} from '../../../../Loading';
+import {LoadingDots} from '../../../../LoadingDots';
 import {Timestamp} from '../../../../Timestamp';
 import {StyledDataGrid} from '../StyledDataGrid';
 import {basicField} from './common/DataTable';
@@ -223,6 +224,10 @@ const PeerVersionsLink: React.FC<{obj: OpVersionSchema}> = props => {
     },
     100
   );
+  if (ops.loading) {
+    return <LoadingDots />;
+  }
+
   const versionCount = ops?.result?.length ?? 0;
 
   return (
@@ -259,6 +264,9 @@ const OpCallsLink: React.FC<{obj: OpVersionSchema}> = props => {
     },
     100
   );
+  if (calls.loading) {
+    return <LoadingDots />;
+  }
 
   const callCount = calls?.result?.length ?? 0;
 


### PR DESCRIPTION
Use new dots loading indicator on op versions page and traces op version column.