### PR TITLE
chore(weave): Hide name and description for CallDetails and ObjectViewer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -561,6 +561,11 @@ export const RunsTable: FC<{
       const expandCols = expandedColInfo[groupField] ?? [];
       // for each expanded column, add a column definition
       for (const col of expandCols) {
+        // const isNullDescription = col.path === 'description' && col.path === 'null';
+        // Dont show name column for expanded refs
+        if (col.path === 'name') {
+          continue;
+        }
         const expandField = groupField + '.' + col.path;
         cols.push({
           flex: 1,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -561,6 +561,10 @@ export const RunsTable: FC<{
       const expandCols = expandedColInfo[groupField] ?? [];
       // for each expanded column, add a column definition
       for (const col of expandCols) {
+        // Dont show name or description column for expanded refs
+        if (col.path === 'name' || col.path === 'description') {
+          continue;
+        }
         const expandField = groupField + '.' + col.path;
         cols.push({
           flex: 1,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -561,11 +561,6 @@ export const RunsTable: FC<{
       const expandCols = expandedColInfo[groupField] ?? [];
       // for each expanded column, add a column definition
       for (const col of expandCols) {
-        // const isNullDescription = col.path === 'description' && col.path === 'null';
-        // Dont show name column for expanded refs
-        if (col.path === 'name') {
-          continue;
-        }
         const expandField = groupField + '.' + col.path;
         cols.push({
           flex: 1,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/WeaveEditors.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/WeaveEditors.tsx
@@ -661,7 +661,15 @@ export const WeaveEditorObject: FC<{
   return (
     <Table>
       {Object.entries(refWithType.type)
-        .filter(([key, value]) => key !== 'type' && !key.startsWith('_'))
+        .filter(
+          ([key, value]) =>
+            key !== 'type' &&
+            !key.startsWith('_') &&
+            // Hide name because its in the tab already
+            key !== 'name' &&
+            // Hide description if it's none
+            (key !== 'description' || value !== 'none')
+        )
         .flatMap(([key, valueType]) => {
           const singleRow = displaysAsSingleRow(valueType);
           const label = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -80,9 +80,14 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
     const contexts: TraverseContext[] = [];
     traverse(resolvedData, context => {
       if (context.depth !== 0) {
-        // For now we'll hide all keys that start with an underscore.
+        const contextTail = context.path.tail();
+        const isNullDescription =
+          typeof contextTail === 'string' &&
+          contextTail === 'description' &&
+          context.valueType === 'null';
+        // For now we'll hide all keys that start with an underscore, is a name field, or is a null description.
         // Eventually we might offer a user toggle to display them.
-        if (context.path.hasHiddenKey()) {
+        if (context.path.hasHiddenKey() || isNullDescription) {
           return 'skip';
         }
         contexts.push(context);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
@@ -93,7 +93,7 @@ export class ObjectPath {
 
   hasHiddenKey(): boolean {
     const t = this.tail();
-    return typeof t === 'string' && t.startsWith('_');
+    return typeof t === 'string' && (t.startsWith('_') || t === 'name');
   }
 
   length(): number {


### PR DESCRIPTION
before 

![Screenshot 2024-04-08 at 11 36 02 AM](https://github.com/wandb/weave/assets/25037002/dfd57daf-b9f3-444f-a950-8fe91dd822a9)
![Screenshot 2024-04-08 at 12 13 27 PM](https://github.com/wandb/weave/assets/25037002/64b493e0-1b1c-4b62-bd20-e0611ac693d9)


after
![Screenshot 2024-04-08 at 11 36 24 AM](https://github.com/wandb/weave/assets/25037002/118353df-a78e-49d1-aa37-6509b296527d)
![Screenshot 2024-04-08 at 12 13 48 PM](https://github.com/wandb/weave/assets/25037002/465a2793-f18b-4733-8535-938fd085ba4e)

shows description if exists
![Screenshot 2024-04-08 at 11 36 30 AM](https://github.com/wandb/weave/assets/25037002/0e9907d0-c851-402e-a8e3-ca8da400180c)
![Screenshot 2024-04-08 at 12 16 41 PM](https://github.com/wandb/weave/assets/25037002/86caa9f8-9b47-4854-8a89-20e544740c17)

