### PR TITLE
chore(weave): Remove trace roots only

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -376,6 +376,10 @@ export const CallsTable: FC<{
                     opVersionOptionsWithRoots[option]?.title ?? 'loading...'
                   );
                 }}
+                disableClearable={
+                  opVersionRefOrAllTitle === ALL_TRACES_REF_KEY ||
+                  opVersionRefOrAllTitle === ALL_CALLS_REF_KEY
+                }
                 groupBy={option => opVersionOptionsWithRoots[option]?.group}
                 options={Object.keys(opVersionOptionsWithRoots)}
               />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -138,8 +138,12 @@ export const CallsTable: FC<{
     const workingFilter = {...filter, ...props.frozenFilter};
     if (
       !ALLOW_ALL_CALLS_UNFILTERED &&
-      !shouldForceNonTraceRootsOnly(workingFilter)
+      !currentFilterShouldUseNonTraceRoots(workingFilter)
     ) {
+      // If we are not allowing all calls unfiltered (meaning the totally
+      // unfiltered list of all calls is disabled) and the current filter
+      // settings do not call for non-trace roots only, then we should force
+      // trace roots only.
       workingFilter.traceRootsOnly = true;
     }
     return workingFilter;
@@ -447,7 +451,7 @@ export const CallsTable: FC<{
   );
 };
 
-const shouldForceNonTraceRootsOnly = (filter: WFHighLevelCallFilter) => {
+const currentFilterShouldUseNonTraceRoots = (filter: WFHighLevelCallFilter) => {
   return (
     (filter.inputObjectVersionRefs?.length ?? 0) > 0 ||
     (filter.opVersionRefs?.length ?? 0) > 0 ||
@@ -459,7 +463,7 @@ const convertHighLevelFilterToLowLevelFilter = (
   effectiveFilter: WFHighLevelCallFilter
 ): CallFilter => {
   const forcingNonTraceRootsOnly =
-    shouldForceNonTraceRootsOnly(effectiveFilter);
+    currentFilterShouldUseNonTraceRoots(effectiveFilter);
   return {
     traceRootsOnly: !forcingNonTraceRootsOnly && effectiveFilter.traceRootsOnly,
     opVersionRefs: effectiveFilter.opVersionRefs,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -107,11 +107,11 @@ export const CallsPage: FC<{
 
 const ALL_TRACES_REF_KEY = '__all_traces__';
 const ALL_CALLS_REF_KEY = '__all_calls__';
-const OP_FILTER_GROUP_HEADER = 'Op Filter';
+const OP_FILTER_GROUP_HEADER = 'Op';
 const ANY_OP_GROUP_HEADER = '';
-const ALL_TRACES_TITLE = 'Any Op (Trace Roots Only)';
+const ALL_TRACES_TITLE = 'All Ops';
 const ALL_CALLS_TITLE = 'All Calls';
-const OP_GROUP_HEADER = 'Specific Ops';
+const OP_GROUP_HEADER = 'Ops';
 const OP_VERSION_GROUP_HEADER = (currentOpId: string) =>
   `Specific Versions of ${opNiceName(currentOpId)}`;
 const ALLOW_ALL_CALLS_UNFILTERED = false;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -136,7 +136,10 @@ export const CallsTable: FC<{
 
   const effectiveFilter = useMemo(() => {
     const workingFilter = {...filter, ...props.frozenFilter};
-    if (!ALLOW_ALL_CALLS_UNFILTERED) {
+    if (
+      !ALLOW_ALL_CALLS_UNFILTERED &&
+      !shouldForceNonTraceRootsOnly(workingFilter)
+    ) {
       workingFilter.traceRootsOnly = true;
     }
     return workingFilter;


### PR DESCRIPTION
Consolidates op filter and trace roots into a single selection. Removes all calls view

<img width="297" alt="Screenshot 2024-04-09 at 07 06 19" src="https://github.com/wandb/weave/assets/2142768/966090ef-e57f-48e0-91f1-93a13ee7ea1e">
