### PR TITLE
chore(app): remove sets from historyKeyInfo definition

### DIFF
--- a/weave-js/src/core/ops/domain/run.ts
+++ b/weave-js/src/core/ops/domain/run.ts
@@ -328,7 +328,7 @@ export const opRunHistoryKeyInfo = makeRunOp({
     'run'
   )}`,
   returnType: inputTypes => TypeHelpers.typedDict({}),
-  resolver: ({run}) => run.historyKeys ?? {keys: {}, sets: []},
+  resolver: ({run}) => run.historyKeys ?? {keys: {}},
 });
 
 const opRunHistoryTypeResolver = async (run: any, engine: () => Engine) => {


### PR DESCRIPTION
We are in the process of deprecating keySets in the HistoryKeyInfo data - they are no longer needed, so we are trying to remove them fully from core. I noticed that weave is also using history, so this removes the definition from the JS API. The sets data does not appear to be used in the JS code. 

Related question: should I be removing this from any python code as well?