### PR TITLE
fix: don't commify created timestamp

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -4,6 +4,10 @@ import {parseRef} from '../../../../../../react';
 import {SmallRef} from '../../../Browse2/SmallRef';
 import {isRef} from '../common/util';
 import {ValueViewNumber} from './ValueViewNumber';
+import {
+  isProbablyTimestamp,
+  ValueViewNumberTimestamp,
+} from './ValueViewNumberTimestamp';
 import {ValueViewPrimitive} from './ValueViewPrimitive';
 import {ValueViewString} from './ValueViewString';
 
@@ -37,6 +41,9 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
   }
 
   if (data.valueType === 'number') {
+    if (isProbablyTimestamp(data.value)) {
+      return <ValueViewNumberTimestamp value={data.value} />;
+    }
     return <ValueViewNumber value={data.value} />;
   }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewNumberTimestamp.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewNumberTimestamp.tsx
@@ -1,0 +1,32 @@
+import {Timestamp} from '@wandb/weave/components/Timestamp';
+import React from 'react';
+
+// Seconds relative to Unix Epoch
+const JAN_1_2000_S = 946_684_800;
+const JAN_1_2100_S = 4_102_444_800;
+const JAN_1_2000_MS = 1000 * JAN_1_2000_S;
+const JAN_1_2100_MS = 1000 * JAN_1_2100_S;
+
+// TODO: This is only looking at value, but we could also consider the value name, e.g. "created".
+export const isProbablyTimestamp = (value: number) => {
+  const inRangeSec = JAN_1_2000_S <= value && value <= JAN_1_2100_S;
+  if (inRangeSec) {
+    return true;
+  }
+  const inRangeMs = JAN_1_2000_MS <= value && value <= JAN_1_2100_MS;
+  if (inRangeMs) {
+    return true;
+  }
+  return false;
+};
+
+type ValueViewNumberTimestampProps = {
+  value: number;
+};
+
+export const ValueViewNumberTimestamp = ({
+  value,
+}: ValueViewNumberTimestampProps) => {
+  const epochSeconds = value >= JAN_1_2000_MS ? value / 1000 : value;
+  return <Timestamp value={epochSeconds} format="X" />;
+};


### PR DESCRIPTION
Internal notion: https://www.notion.so/wandbai/int-value-timestamps-should-get-better-rendering-c2d6e171d6b24826806bc4eb630c6fca?pvs=4

Before:
<img width="274" alt="Screenshot 2024-04-09 at 2 31 13 PM" src="https://github.com/wandb/weave/assets/112953339/72355b02-b186-4f47-9cdb-924d024458f2">

After:
<img width="344" alt="Screenshot 2024-04-09 at 2 30 24 PM" src="https://github.com/wandb/weave/assets/112953339/9706f73e-e5b3-4a5f-ae74-d47c3baf373f">
