### PR TITLE
chore: note Python version requirements in quickstart

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -7,6 +7,8 @@ hide_table_of_contents: true
 
 ## Installation
 
+Weave requires Python 3.9+.
+
 `pip install weave`
 
 ## Track inputs & outputs of functions


### PR DESCRIPTION
Internal notion: https://www.notion.so/wandbai/Docs-clarify-python-version-req-a612f654efc74ead9d830ac09c070acf?pvs=4