### PR TITLE
feat: log and display error details

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -15,6 +15,7 @@ import {CenteredAnimatedLoader} from '../common/Loader';
 import {useWFHooks} from '../wfReactInterface/context';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {ButtonOverlay} from './ButtonOverlay';
+import {ExceptionDetails, getExceptionInfo} from './Exceptions';
 import {ObjectViewerSection} from './ObjectViewerSection';
 import {OpVersionText} from './OpVersionText';
 
@@ -39,6 +40,24 @@ const MultiCallHeader = styled.div`
 `;
 MultiCallHeader.displayName = 'S.MultiCallHeader';
 
+const TitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 4px;
+`;
+TitleRow.displayName = 'S.TitleRow';
+
+const Title = styled.div`
+  flex: 1 1 auto;
+  font-family: Source Sans Pro;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 32px;
+  letter-spacing: 0px;
+  text-align: left;
+`;
+Title.displayName = 'S.Title';
+
 export const CallSchemaLink = ({call}: {call: CallSchema}) => {
   const {entity: entityName, project: projectName, callId, spanName} = call;
   return (
@@ -55,6 +74,8 @@ export const CallDetails: FC<{
   call: CallSchema;
 }> = ({call}) => {
   const {useCalls} = useWFHooks();
+
+  const excInfo = getExceptionInfo(call.rawSpan.exception);
 
   const {inputs, output} = useMemo(
     () => getDisplayInputsAndOutput(call),
@@ -103,7 +124,16 @@ export const CallDetails: FC<{
             flex: '0 0 auto',
             p: 2,
           }}>
-          <ObjectViewerSection title="Outputs" data={output} />
+          {'traceback' in excInfo ? (
+            <>
+              <TitleRow>
+                <Title>Error</Title>
+              </TitleRow>
+              <ExceptionDetails exceptionInfo={excInfo} />
+            </>
+          ) : (
+            <ObjectViewerSection title="Outputs" data={output} />
+          )}
         </Box>
         {multipleChildCallOpRefs.map(opVersionRef => {
           const exampleCall = childCalls.result?.find(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import {Alert} from '../../../../../Alert';
 import {CallId} from '../common/CallId';
 import {opNiceName} from '../common/Links';
 import {StatusChip} from '../common/StatusChip';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
+import {ExceptionAlert} from './Exceptions';
 
 export const Overview = styled.div`
   display: flex;
@@ -25,11 +25,6 @@ export const CallName = styled.div`
 `;
 CallName.displayName = 'S.CallName';
 
-const Exception = styled.span`
-  font-weight: 600;
-`;
-Exception.displayName = 'S.Exception';
-
 export const CallOverview: React.FC<{
   call: CallSchema;
 }> = ({call}) => {
@@ -45,9 +40,7 @@ export const CallOverview: React.FC<{
         <StatusChip value={statusCode} iconOnly />
       </Overview>
       {call.rawSpan.exception && (
-        <Alert severity="error">
-          <Exception>Exception:</Exception> {call.rawSpan.exception}
-        </Alert>
+        <ExceptionAlert exception={call.rawSpan.exception} />
       )}
     </>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -16,6 +16,7 @@ import {CallDetails} from './CallDetails';
 import {CallOverview} from './CallOverview';
 import {CallSummary} from './CallSummary';
 import {CallTraceView, useCallFlattenedTraceTree} from './CallTraceView';
+import {ExceptionDetails, getExceptionInfo} from './Exceptions';
 
 export const CallPage: FC<{
   entity: string;
@@ -40,6 +41,7 @@ export const CallPage: FC<{
 
 const useCallTabs = (call: CallSchema) => {
   const codeURI = call.opVersionRef;
+  const excInfo = getExceptionInfo(call.rawSpan.exception);
   return [
     {
       label: 'Call',
@@ -57,6 +59,14 @@ const useCallTabs = (call: CallSchema) => {
       label: 'Summary',
       content: <CallSummary call={call} />,
     },
+    ...('traceback' in excInfo
+      ? [
+          {
+            label: 'Error details',
+            content: <ExceptionDetails exceptionInfo={excInfo} />,
+          },
+        ]
+      : []),
   ];
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -16,7 +16,6 @@ import {CallDetails} from './CallDetails';
 import {CallOverview} from './CallOverview';
 import {CallSummary} from './CallSummary';
 import {CallTraceView, useCallFlattenedTraceTree} from './CallTraceView';
-import {ExceptionDetails, getExceptionInfo} from './Exceptions';
 
 export const CallPage: FC<{
   entity: string;
@@ -41,7 +40,6 @@ export const CallPage: FC<{
 
 const useCallTabs = (call: CallSchema) => {
   const codeURI = call.opVersionRef;
-  const excInfo = getExceptionInfo(call.rawSpan.exception);
   return [
     {
       label: 'Call',
@@ -59,14 +57,6 @@ const useCallTabs = (call: CallSchema) => {
       label: 'Summary',
       content: <CallSummary call={call} />,
     },
-    ...('traceback' in excInfo
-      ? [
-          {
-            label: 'Error details',
-            content: <ExceptionDetails exceptionInfo={excInfo} />,
-          },
-        ]
-      : []),
   ];
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
@@ -9,7 +9,6 @@ const AlertExceptionType = styled.span`
 AlertExceptionType.displayName = 'S.AlertExceptionType';
 
 const Traceback = styled.div`
-  padding: 8px;
   font-family: monospace;
   white-space: nowrap;
   overflow: auto;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
@@ -1,0 +1,128 @@
+import * as Colors from '@wandb/weave/common/css/color.styles';
+import {Alert} from '@wandb/weave/components/Alert';
+import React from 'react';
+import styled from 'styled-components';
+
+const AlertExceptionType = styled.span`
+  font-weight: 600;
+`;
+AlertExceptionType.displayName = 'S.AlertExceptionType';
+
+const Traceback = styled.div`
+  padding: 8px;
+  font-family: monospace;
+  white-space: nowrap;
+  overflow: auto;
+  font-size: 12px;
+`;
+Traceback.displayName = 'S.Traceback';
+
+const FileInfo = styled.div`
+  margin-left: 20px;
+`;
+FileInfo.displayName = 'S.FileInfo';
+
+const Filename = styled.span`
+  color: ${Colors.GOLD_600};
+`;
+Filename.displayName = 'S.Filename';
+
+const LineNo = styled.span`
+  color: ${Colors.PURPLE_600};
+`;
+LineNo.displayName = 'S.LineNo';
+
+const FunctionName = styled.span`
+  color: ${Colors.CACTUS_600};
+`;
+FunctionName.displayName = 'S.FunctionName';
+
+const FrameText = styled.div`
+  margin-left: 40px;
+`;
+FrameText.displayName = 'S.FrameText';
+
+const ExceptionType = styled.span`
+  color: ${Colors.RED_500};
+`;
+ExceptionType.displayName = 'S.ExceptionType';
+
+type StackFrame = {
+  filename: string;
+  line_number: number | null;
+  function_name: string;
+  text: string | null;
+};
+
+type Exception = {
+  type: string;
+  message: string;
+  traceback?: StackFrame[];
+};
+
+type NoException = {};
+type ExceptionInfo = Exception | NoException;
+
+export const getExceptionInfo = (
+  exception: string | undefined
+): ExceptionInfo => {
+  if (!exception) {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(exception);
+    if (typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch (err) {
+    // ignore
+  }
+  return {
+    type: 'Exception',
+    message: exception,
+  };
+};
+
+type ExceptionAlertProps = {
+  exception: string;
+};
+
+export const ExceptionAlert = ({exception}: ExceptionAlertProps) => {
+  const info = getExceptionInfo(exception);
+  if (!('type' in info)) {
+    return null;
+  }
+  const {type, message} = info;
+  return (
+    <Alert severity="error">
+      <AlertExceptionType>{type}:</AlertExceptionType> {message}
+    </Alert>
+  );
+};
+
+type ExceptionDetailsProps = {
+  exceptionInfo: Exception;
+};
+
+export const ExceptionDetails = ({exceptionInfo}: ExceptionDetailsProps) => {
+  if (!exceptionInfo.traceback) {
+    return null;
+  }
+  return (
+    <Traceback>
+      <div>Traceback (most recent call last):</div>
+      {exceptionInfo.traceback.map((frame: StackFrame, i: number) => (
+        <React.Fragment key={i}>
+          <FileInfo>
+            File "<Filename>{frame.filename}</Filename>", line{' '}
+            <LineNo>{frame.line_number}</LineNo>, in{' '}
+            <FunctionName>{frame.function_name}</FunctionName>
+          </FileInfo>
+          <FrameText>{frame.text}</FrameText>
+        </React.Fragment>
+      ))}
+      <ExceptionType>{exceptionInfo.type}:</ExceptionType>{' '}
+      {exceptionInfo.message}
+    </Traceback>
+  );
+};

--- a/weave/exception.py
+++ b/weave/exception.py
@@ -1,0 +1,44 @@
+"""
+Utility methods for converting exceptions to JSON.
+"""
+import json
+import traceback
+from typing import Any, Optional, TypedDict
+
+
+class StackFrameDict(TypedDict):
+    filename: str
+    line_number: Optional[int]
+    function_name: str
+    text: Optional[str]
+
+
+class ExceptionDict(TypedDict, total=False):
+    type: str
+    message: str
+    traceback: Optional[list[StackFrameDict]]
+
+
+def frame_summary_to_dict(frame: traceback.FrameSummary) -> StackFrameDict:
+    return {
+        "filename": frame.filename,
+        "line_number": frame.lineno,
+        "function_name": frame.name,
+        "text": frame.line,
+    }
+
+
+def exception_to_dict(exception: BaseException) -> ExceptionDict:
+    result: ExceptionDict = {
+        "type": type(exception).__name__,
+        "message": str(exception),
+    }
+    if exception.__traceback__:
+        stack = traceback.extract_stack(exception.__traceback__.tb_frame)[:-1]
+        stack.extend(traceback.extract_tb(exception.__traceback__))
+        result["traceback"] = [frame_summary_to_dict(fs) for fs in stack]
+    return result
+
+
+def exception_to_json_str(exception: BaseException) -> str:
+    return json.dumps(exception_to_dict(exception))

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -5,11 +5,11 @@ import typing
 import uuid
 import pydantic
 import datetime
-import traceback
 
 
 from requests import HTTPError
 
+from weave.exception import exception_to_json_str
 from weave.table import Table
 from weave import trace_sentry, urls
 from weave import run_context
@@ -513,14 +513,7 @@ class WeaveClient:
 
     @trace_sentry.global_trace_sentry.watch()
     def fail_call(self, call: Call, exception: BaseException) -> None:
-        # Full traceback disabled til we fix UI.
-        # stack_trace = "".join(
-        #     traceback.format_exception(
-        #         type(exception), exception, exception.__traceback__
-        #     )
-        # )
-        # exception_str = f"{stack_trace}\n{type(exception).__name__}: {str(exception)}"
-        exception_str = str(exception)
+        exception_str = exception_to_json_str(exception)
         call.exception = exception_str
 
         # Summary handling


### PR DESCRIPTION
Internal notion: https://www.notion.so/wandbai/Enable-full-stack-trace-logging-and-improve-UI-treatment-c514a45d530b442c916796a19358e223?pvs=4

Changes the Python client to log JSON structured exception information, serialized as a string value. The frontend will use this structured information to show a colorized traceback information instead of an Outputs section on the call tab.

For compatibility with previous releases, if the exception information is not JSON it will just display the string in the alert.

Before:
![image](https://github.com/wandb/weave/assets/112953339/b43aaf00-0060-4b9b-a4b0-7833ff4001a1)

After:
![image](https://github.com/wandb/weave/assets/112953339/19987a60-ce1c-419e-b38f-aa956000365a)

After (dark mode):
![image](https://github.com/wandb/weave/assets/112953339/6350461d-6673-4bfe-bcb0-1f37fed6bbc2)
