### PR TITLE
feat: eval updates

### DIFF
--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -10,7 +10,7 @@ from pydantic import (
 # import pydantic
 
 from weave import box
-from weave.trace.op import Op
+from weave.trace.op import Op, ObjectRef
 from weave.trace.vals import pydantic_getattribute
 from weave.weave_client import get_ref
 from weave.trace.vals import ObjectRecord, TraceObject
@@ -37,6 +37,8 @@ class Object(BaseModel):
     def handle_relocatable_object(
         cls, v: Any, handler: ValidatorFunctionWrapHandler, info: ValidationInfo
     ) -> Any:
+        if isinstance(v, ObjectRef):
+            return v.get()
         if isinstance(v, TraceObject):
             # This is a relocated object, so destructure it into a dictionary
             # so pydantic can validate it.

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -17,7 +17,7 @@ class Scorer(Object):
 
 
 def stderr(data: Sequence[Union[int, float]]) -> float:
-    if data:
+    if len(data) > 1:
         sample_variance = np.var(data, ddof=1)
         return float(np.sqrt(sample_variance / len(data)))
     else:

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import Union, Callable, Optional, Tuple, Any
+from typing import Union, Callable, Optional, Tuple, Any, Sequence
 import weave
 from weave.trace.isinstance import weave_isinstance
 from weave.flow.obj import Object
@@ -14,6 +14,14 @@ class Scorer(Object):
     @weave.op()
     def summarize(self, score_rows: WeaveList) -> Optional[dict]:
         return auto_summarize(score_rows)
+
+
+def stderr(data: Sequence[Union[int, float]]) -> float:
+    if data:
+        sample_variance = np.var(data, ddof=1)
+        return float(np.sqrt(sample_variance / len(data)))
+    else:
+        return 0
 
 
 def auto_summarize(data: WeaveList) -> Optional[dict]:
@@ -46,10 +54,16 @@ def auto_summarize(data: WeaveList) -> Optional[dict]:
         }
     elif data.is_boolean():
         valid_data = [x for x in data if x is not None]
-        count_true = valid_data.count(True)
+        # count_true = list(valid_data).count(True)
+        int_data = [int(x) for x in valid_data]
+        sample_mean = np.mean(int_data) if int_data else 0
+        # standard error
+        # sample_variance = np.var(int_data) if int_data else 0
+        # sample_error = np.sqrt(sample_variance / len(int_data)) if int_data else 0
         return {
-            "true_count": count_true,
-            "true_fraction": count_true / len(valid_data) if valid_data else 0,
+            # "true_count": count_true,
+            "mean": sample_mean,
+            "stderr": stderr(int_data),
             # "none_fraction": (len(data) - len(valid_data)) / len(data),
         }
     elif data.is_dict():

--- a/weave/flow/util.py
+++ b/weave/flow/util.py
@@ -1,4 +1,5 @@
-from typing import AsyncIterator, Callable, Iterable, Tuple, TypeVar, Awaitable
+from typing import AsyncIterator, Callable, Iterable, Tuple, TypeVar, Awaitable, Any
+import multiprocessing
 import asyncio
 
 T = TypeVar("T")
@@ -22,3 +23,51 @@ async def async_foreach(
     for task in asyncio.as_completed(tasks):
         item, result = await task
         yield item, result
+
+
+def _subproc(
+    queue: multiprocessing.Queue, func: Callable, *args: Any, **kwargs: Any
+) -> None:
+    result = func(*args, **kwargs)
+    queue.put(result)
+
+
+def _run_in_process(
+    func: Callable, args: Tuple = (), kwargs: dict = {}
+) -> Tuple[multiprocessing.Process, multiprocessing.Queue]:
+    """Run a function in a separate process and return the process object and a multiprocessing.Queue for the result."""
+
+    queue: multiprocessing.Queue = multiprocessing.Queue()
+    process: multiprocessing.Process = multiprocessing.Process(
+        target=_subproc, args=(queue, func) + args, kwargs=kwargs
+    )
+    process.start()
+    return process, queue
+
+
+async def run_in_process_with_timeout(
+    timeout: float, func: Callable, *args: Any, **kwargs: Any
+) -> Any:
+    """Run a function in a separate process with a timeout. Terminate the process if it exceeds the timeout."""
+    # Note, on osx, multiprocessing uses spawn by default. With span, subprocesses will re-import main,
+    # and incur the cost of bootstrapping python and all imports, which for weave is currently about 1.5s.
+    # Scripts that use this can call 'multiprocessing.set_start_method("fork")' which is much faster (0.05s)
+    # depending on their use case (there are some issues with fork on osx).
+    loop = asyncio.get_running_loop()
+    process, queue = _run_in_process(func, args, kwargs)
+
+    try:
+        # Wait for the process to complete or timeout
+        await asyncio.wait_for(loop.run_in_executor(None, process.join), timeout)
+    except asyncio.TimeoutError:
+        print("Function execution exceeded the timeout. Terminating process.")
+        process.terminate()
+        process.join()  # Ensure process resources are cleaned up
+        raise
+
+    if process.exitcode == 0:
+        return queue.get()  # Retrieve result from the queue
+    else:
+        raise ValueError(
+            "Unhandled exception in subprocess. Exitcode: " + str(process.exitcode)
+        )

--- a/weave/table.py
+++ b/weave/table.py
@@ -23,5 +23,8 @@ class Table:
         self.rows = rows
         self.ref = None
 
+    def __getitem__(self, key: int) -> dict:
+        return self.rows[key]
+
     def __iter__(self) -> Iterator:
         return iter(self.rows)

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -156,7 +156,7 @@ class ExternalVariableFinder(ast.NodeVisitor):
 
     def visit_ExceptHandler(self, node: ExceptHandler) -> None:
         if node.name is None:
-            raise NotImplementedError("ExceptHandler with no name")
+            return
         self.scope_stack[-1].add(node.name)
         self.generic_visit(node)
 


### PR DESCRIPTION
Evaluation updates
- add "trials" argument to Evaluation, to run over the same dataset multiple times
- automatically show model latencies
- show stderr for boolean scores
- change argument ordering of predict_and_score to self, model, example
- print progress
- add run_in_process_with_timeout

Breaking change:
- Changes the name of scorer columns when there are boolean outputs. This makes new evaluation calls incomparable with calls prior to this PR.