### PR TITLE
chore: update styling of op filter

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledAutocomplete.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledAutocomplete.tsx
@@ -1,0 +1,25 @@
+import {Paper, PaperProps} from '@mui/material';
+import {styled} from '@mui/material/styles';
+import * as Colors from '@wandb/weave/common/css/color.styles';
+import {hexToRGB} from '@wandb/weave/common/css/utils';
+import React from 'react';
+
+const COLOR_BG_SELECTED = hexToRGB(Colors.TEAL_300, 0.32);
+const COLOR_FG_SELECTED = Colors.TEAL_600;
+const COLOR_BG_HOVER = Colors.MOON_100;
+
+export const StyledPaper = styled((props: PaperProps) => <Paper {...props} />)(
+  () => ({
+    '& .MuiAutocomplete-option[aria-selected="true"].Mui-focused': {
+      backgroundColor: COLOR_BG_SELECTED,
+      color: COLOR_FG_SELECTED,
+    },
+    '& .MuiAutocomplete-option[aria-selected="true"]': {
+      backgroundColor: COLOR_BG_SELECTED,
+      color: COLOR_FG_SELECTED,
+    },
+    '& .MuiAutocomplete-option:hover': {
+      backgroundColor: COLOR_BG_HOVER,
+    },
+  })
+);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledTextField.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledTextField.tsx
@@ -1,0 +1,32 @@
+import {TextField, TextFieldProps} from '@mui/material';
+import {styled} from '@mui/material/styles';
+import * as Colors from '@wandb/weave/common/css/color.styles';
+import {hexToRGB} from '@wandb/weave/common/css/utils';
+import React from 'react';
+
+const COLOR_LABEL = Colors.TEAL_500;
+const COLOR_BORDER_OVER = hexToRGB(Colors.TEAL_500, 0.4);
+const COLOR_BG_SELECTED_TEXT = Colors.MOON_100;
+
+export const StyledTextField = styled((props: TextFieldProps) => (
+  <TextField {...props} />
+))(() => ({
+  '&:hover label': {
+    color: COLOR_LABEL,
+  },
+  '& label.Mui-focused': {
+    color: COLOR_LABEL,
+  },
+  '& .MuiOutlinedInput-root': {
+    '&:hover fieldset': {
+      borderColor: COLOR_BORDER_OVER,
+      borderWidth: 2,
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: COLOR_BORDER_OVER,
+    },
+    '& ::selection': {
+      backgroundColor: COLOR_BG_SELECTED_TEXT,
+    },
+  },
+}));

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -5,7 +5,6 @@ import {
   FormControl,
   // IconButton,
   ListItem,
-  TextField,
 } from '@mui/material';
 import _ from 'lodash';
 import React, {FC, useCallback, useMemo} from 'react';
@@ -13,6 +12,8 @@ import React, {FC, useCallback, useMemo} from 'react';
 import {Loading} from '../../../../../Loading';
 import {RunsTable} from '../../../Browse2/RunsTable';
 import {useWeaveflowRouteContext} from '../../context';
+import {StyledPaper} from '../../StyledAutocomplete';
+import {StyledTextField} from '../../StyledTextField';
 import {Empty} from '../common/Empty';
 import {
   EMPTY_PROPS_EVALUATIONS,
@@ -339,7 +340,8 @@ export const CallsTable: FC<{
           <ListItem sx={{minWidth: '190px'}}>
             <FormControl fullWidth>
               <Autocomplete
-                size={'small'}
+                PaperComponent={StyledPaper}
+                size="small"
                 // Temp disable multiple for simplicity - may want to re-enable
                 // multiple
                 limitTags={1}
@@ -369,7 +371,7 @@ export const CallsTable: FC<{
                   }
                 }}
                 renderInput={params => (
-                  <TextField
+                  <StyledTextField
                     {...params}
                     label={OP_FILTER_GROUP_HEADER}
                     sx={{maxWidth: '350px'}}


### PR DESCRIPTION
Update op filter styling to better match our palette. Still things that could be improved like the button styling on clear / dropdown.

Part of internal Notion: https://www.notion.so/wandbai/Replace-Material-design-components-dbb5f747b86d44efa5c55ecea2474810?pvs=4

Before:
<img width="365" alt="Screenshot 2024-04-10 at 9 07 57 PM" src="https://github.com/wandb/weave/assets/112953339/d492f25f-c9f4-4a9c-84af-b10b3b3b1b82">

After:
<img width="363" alt="Screenshot 2024-04-10 at 9 05 10 PM" src="https://github.com/wandb/weave/assets/112953339/0452c26b-76d9-41eb-a076-e0878a7b83f9">
