### PR TITLE
chore: update styling of peek drawer resize widget

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -30,7 +30,6 @@ import {
   useParams,
 } from 'react-router-dom';
 
-import {MOON_200} from '../../../common/css/color.styles';
 import {useWeaveContext} from '../../../context';
 import {URL_BROWSE3} from '../../../urls';
 import {Button} from '../../Button';
@@ -350,9 +349,8 @@ const MainPeekingLayout: FC = () => {
               zIndex: 1,
               width: `${drawerWidthPct}%`,
               height: '100%',
-              boxShadow:
-                'rgba(15, 15, 15, 0.04) 0px 0px 0px 1px, rgba(15, 15, 15, 0.03) 0px 3px 6px, rgba(15, 15, 15, 0.06) 0px 9px 24px',
-              borderLeft: `1px solid ${MOON_200}`,
+              boxShadow: '0px 0px 40px 0px rgba(0, 0, 0, 0.16)',
+              borderLeft: 0,
               position: 'absolute',
             },
           }}
@@ -367,7 +365,7 @@ const MainPeekingLayout: FC = () => {
               position: 'absolute',
               inset: '0 auto 0 0',
               zIndex: 2,
-              backgroundColor: '#f4f7f9',
+              backgroundColor: 'transparent',
               cursor: 'col-resize',
               width: '5px',
             }}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -247,7 +247,7 @@ export const SimplePageLayoutWithHeader: FC<{
         {props.headerExtra}
         {simplePageLayoutContextValue.headerSuffix}
       </Box>
-      <div style={{marginLeft: 4, flex: '1 1 auto', overflow: 'hidden'}}>
+      <div style={{flex: '1 1 auto', overflow: 'hidden'}}>
         <SplitPanel
           minWidth={150}
           defaultWidth={200}


### PR DESCRIPTION
Update the styling of the vertical resizer widget for the peek drawer.

Internal Notion: https://www.notion.so/wandbai/Replace-Material-design-components-dbb5f747b86d44efa5c55ecea2474810?pvs=4#033651ea931b4188be668eee45963186
Internal Figma: https://www.figma.com/file/27JVuBYWHbcAYc8WPb4HqA/Weaveflow-hifi?type=design&node-id=2911%3A305278&mode=design&t=JsjE0RCKScpAOud7-1

Before:
![image](https://github.com/wandb/weave/assets/112953339/d92ada22-b25f-45fc-a2f2-62d2eaf69e4a)

After:
![image](https://github.com/wandb/weave/assets/112953339/171ec4bb-fd5b-4051-98b3-cd9a907e02f0)
