### PR TITLE
chore(weave): Use direct object version lookup

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -102,6 +102,16 @@ type TraceObjQueryRes = {
   objs: TraceObjSchema[];
 };
 
+type TraceObjReadReq = {
+  project_id: string;
+  object_id: string;
+  digest: string;
+};
+
+export type TraceObjReadRes = {
+  obj: TraceObjSchema;
+};
+
 export type TraceRefsReadBatchReq = {
   refs: string[];
 };
@@ -247,6 +257,9 @@ export class TraceServerClient {
       '/objs/query',
       req
     );
+  };
+  objRead: (req: TraceObjReadReq) => Promise<TraceObjReadRes> = req => {
+    return this.makeRequest<TraceObjReadReq, TraceObjReadRes>('/obj/read', req);
   };
 
   readBatch: (req: TraceRefsReadBatchReq) => Promise<TraceRefsReadBatchRes> =


### PR DESCRIPTION
Currently we fetch all versions of an object then let the client filter it down to the digest of interest. This is slower because it requires:
a) more data transmission
b) more data to scan.

With this approach we use a full-primary key lookup and directly fetch the data. My manual testing shows about a 2x speedup for these cases.