### PR TITLE
chore(weave): Fix auto expansion with refs

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -151,7 +151,7 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
         isLoader?: boolean;
       }
     > = [];
-    const expandablePaths = new Set<string>();
+    const expandablePathsInner = new Set<string>();
     traverse(resolvedData, context => {
       if (context.depth !== 0) {
         const contextTail = context.path.tail();
@@ -174,7 +174,7 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
           // group header will show the expansion icon when `isExpandableRef` is true. Also,
           // until the ref data is actually resolved, we will show a loader in place of the
           // expanded data.
-          expandablePaths.add(context.path.toString());
+          expandablePathsInner.add(context.path.toString());
           contexts.push({
             ...context,
             isExpandableRef: true,
@@ -196,8 +196,8 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
       }
       return true;
     });
-    const rows = contexts.map((c, id) => ({id: c.path.toString(), ...c}));
-    return {rows, expandablePaths};
+    const rowsInner = contexts.map((c, id) => ({id: c.path.toString(), ...c}));
+    return {rows: rowsInner, expandablePaths: expandablePathsInner};
   }, [resolvedData]);
 
   // Next, we setup the columns. In our case, there is just one column: Value.
@@ -361,7 +361,15 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
         }}
       />
     );
-  }, [apiRef, columns, rows, groupingColDef, isExpanded]);
+  }, [
+    apiRef,
+    rows,
+    columns,
+    groupingColDef,
+    isExpanded,
+    expandedIds,
+    expandablePaths,
+  ]);
 
   // Return the inner data grid wrapped in a div with overflow hidden.
   return <div style={{overflow: 'hidden'}}>{inner}</div>;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -144,13 +144,14 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
 
   // `rows` are the data-grid friendly rows that we will render. This method traverses
   // the data, hiding certain keys and adding loader rows for expandable refs.
-  const rows = useMemo(() => {
+  const {rows, expandablePaths} = useMemo(() => {
     const contexts: Array<
       TraverseContext & {
         isExpandableRef?: boolean;
         isLoader?: boolean;
       }
     > = [];
+    const expandablePaths = new Set<string>();
     traverse(resolvedData, context => {
       if (context.depth !== 0) {
         const contextTail = context.path.tail();
@@ -173,6 +174,7 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
           // group header will show the expansion icon when `isExpandableRef` is true. Also,
           // until the ref data is actually resolved, we will show a loader in place of the
           // expanded data.
+          expandablePaths.add(context.path.toString());
           contexts.push({
             ...context,
             isExpandableRef: true,
@@ -194,8 +196,8 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
       }
       return true;
     });
-
-    return contexts.map((c, id) => ({id: c.path.toString(), ...c}));
+    const rows = contexts.map((c, id) => ({id: c.path.toString(), ...c}));
+    return {rows, expandablePaths};
   }, [resolvedData]);
 
   // Next, we setup the columns. In our case, there is just one column: Value.
@@ -308,7 +310,20 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
         getTreeDataPath={row => row.path.toStringArray()}
         rows={rows}
         columns={columns}
-        defaultGroupingExpansionDepth={isExpanded ? -1 : 0}
+        isGroupExpandedByDefault={node => {
+          console.log(node);
+          if (!isExpanded) {
+            return node.depth === 0;
+          } else {
+            // We do not want to auto-expand the expandable refs as this:
+            // a) requires a network call
+            // b) can be endlessly recursive.
+            return (
+              expandedIds.includes(node.id) ||
+              !expandablePaths.has(node.id.toString())
+            );
+          }
+        }}
         columnHeaderHeight={38}
         getRowHeight={(params: GridRowHeightParams) => {
           const isNonRefString =

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -311,7 +311,6 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
         rows={rows}
         columns={columns}
         isGroupExpandedByDefault={node => {
-          console.log(node);
           if (!isExpanded) {
             return node.depth === 0;
           } else {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -312,14 +312,17 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
         columns={columns}
         isGroupExpandedByDefault={node => {
           if (!isExpanded) {
-            return node.depth === 0;
+            return expandedIds.includes(node.id);
           } else {
             // We do not want to auto-expand the expandable refs as this:
             // a) requires a network call
             // b) can be endlessly recursive.
+            // Note: Shawn does not like auto-expanding top-level refs.
+            const isTopRef = node.depth === 0 && isRef(data[node.id]);
             return (
-              expandedIds.includes(node.id) ||
-              !expandablePaths.has(node.id.toString())
+              !isTopRef &&
+              (expandedIds.includes(node.id) ||
+                !expandablePaths.has(node.id.toString()))
             );
           }
         }}
@@ -367,6 +370,7 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
     groupingColDef,
     isExpanded,
     expandedIds,
+    data,
     expandablePaths,
   ]);
 


### PR DESCRIPTION
With auto expanding objects, we don't want to do that for refs since it could be forever recursive. 