### PR TITLE
chore(weave): Cleanup MUIDataGrid Options

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -877,22 +877,22 @@ export const RunsTable: FC<{
       <StyledDataGrid
         // Start Column Menu
         // ColumnMenu is needed to support pinning and column visibility
-        // disableColumnMenu
+        disableColumnMenu={false}
         // We will likely enable column filtering in soon, but for
         // now let's keep it simple and disable.
-        disableColumnFilter
-        disableMultipleColumnsFiltering
+        disableColumnFilter={true}
+        disableMultipleColumnsFiltering={true}
         // ColumnPinning seems to be required in DataGridPro, else it crashes.
         // However, in this case it is also useful.
-        // disableColumnPinning
+        disableColumnPinning={false}
         // ColumnReorder is definitely useful
-        // disableColumnReorder
+        disableColumnReorder={false}
         // ColumnResize is definitely useful
-        // disableColumnResize
+        disableColumnResize={false}
         // Disable the column selector for now, however, i could see it being useful
         // in the near future.
-        disableColumnSelector
-        disableMultipleColumnsSorting
+        disableColumnSelector={true}
+        disableMultipleColumnsSorting={true}
         // End Column Menu
         columnHeaderHeight={40}
         apiRef={apiRef}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -569,6 +569,8 @@ export const RunsTable: FC<{
         cols.push({
           flex: 1,
           field: expandField,
+          // Sorting on expanded ref columns is not supported
+          sortable: false,
           renderHeader: headerParams => (
             <CustomGroupedColumnHeader field={headerParams.field} />
           ),
@@ -873,6 +875,25 @@ export const RunsTable: FC<{
       )}
       <BoringColumnInfo tableStats={tableStats} columns={columns.cols as any} />
       <StyledDataGrid
+        // Start Column Menu
+        // ColumnMenu is needed to support pinning and column visibility
+        // disableColumnMenu
+        // We will likely enable column filtering in soon, but for
+        // now let's keep it simple and disable.
+        disableColumnFilter
+        disableMultipleColumnsFiltering
+        // ColumnPinning seems to be required in DataGridPro, else it crashes.
+        // However, in this case it is also useful.
+        // disableColumnPinning
+        // ColumnReorder is definitely useful
+        // disableColumnReorder
+        // ColumnResize is definitely useful
+        // disableColumnResize
+        // Disable the column selector for now, however, i could see it being useful
+        // in the near future.
+        disableColumnSelector
+        disableMultipleColumnsSorting
+        // End Column Menu
         columnHeaderHeight={40}
         apiRef={apiRef}
         loading={loading}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
@@ -311,19 +311,19 @@ export const DataTableView: FC<{
           // We need the ColumnMenu to support Pinning.
           // disableColumnMenu
           // Let's disable Filters on Object Data for now
-          disableColumnFilter
-          disableMultipleColumnsFiltering
+          disableColumnFilter={true}
+          disableMultipleColumnsFiltering={true}
           // ColumnPinning seems to be required in DataGridPro, else it crashes.
           // However, in this case it is also useful.
-          // disableColumnPinning
+          disableColumnPinning={false}
           // ColumnReorder is useful for large datasets
-          // disableColumnReorder
+          disableColumnReorder={false}
           // ColumnResize is useful for large datasets
-          // disableColumnResize
+          disableColumnResize={false}
           // Column Selector might be overkill for now, disable it.
-          disableColumnSelector
+          disableColumnSelector={true}
           // No need for sorting on multiple columns MVP
-          disableMultipleColumnsSorting
+          disableMultipleColumnsSorting={true}
           // End Column Menu
           hideFooter={hideFooter}
           slots={{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
@@ -307,6 +307,24 @@ export const DataTableView: FC<{
           width: '100%',
         }}>
         <StyledDataGrid
+          // Start Column Menu
+          // We need the ColumnMenu to support Pinning.
+          // disableColumnMenu
+          // Let's disable Filters on Object Data for now
+          disableColumnFilter
+          disableMultipleColumnsFiltering
+          // ColumnPinning seems to be required in DataGridPro, else it crashes.
+          // However, in this case it is also useful.
+          // disableColumnPinning
+          // ColumnReorder is useful for large datasets
+          // disableColumnReorder
+          // ColumnResize is useful for large datasets
+          // disableColumnResize
+          // Column Selector might be overkill for now, disable it.
+          disableColumnSelector
+          // No need for sorting on multiple columns MVP
+          disableMultipleColumnsSorting
+          // End Column Menu
           hideFooter={hideFooter}
           slots={{
             ...(hideHeader

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -307,22 +307,22 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
         // Start Column Menu
         // ColumnMenu is only needed when we have other actions
         // such as filtering.
-        disableColumnMenu
+        disableColumnMenu={true}
         // In this context, we don't need to filter columns. I suppose
         // we can add this in the future, but we should be intentional
         // about what we enable.
-        disableColumnFilter
-        disableMultipleColumnsFiltering
+        disableColumnFilter={true}
+        disableMultipleColumnsFiltering={true}
         // ColumnPinning seems to be required in DataGridPro, else it crashes.
-        // disableColumnPinning
+        disableColumnPinning={false}
         // There is no need to reorder the 2 columns in this context.
-        disableColumnReorder
+        disableColumnReorder={true}
         // Resizing columns might be helpful to show more data
-        // disableColumnResize
+        disableColumnResize={false}
         // There are only 2 columns, let's not confuse the user.
-        disableColumnSelector
+        disableColumnSelector={true}
         // We don't need to sort multiple columns.
-        disableMultipleColumnsSorting
+        disableMultipleColumnsSorting={true}
         // End Column Menu
         treeData
         getTreeDataPath={row => row.path.toStringArray()}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -304,6 +304,26 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
     return (
       <StyledDataGrid
         apiRef={apiRef}
+        // Start Column Menu
+        // ColumnMenu is only needed when we have other actions
+        // such as filtering.
+        disableColumnMenu
+        // In this context, we don't need to filter columns. I suppose
+        // we can add this in the future, but we should be intentional
+        // about what we enable.
+        disableColumnFilter
+        disableMultipleColumnsFiltering
+        // ColumnPinning seems to be required in DataGridPro, else it crashes.
+        // disableColumnPinning
+        // There is no need to reorder the 2 columns in this context.
+        disableColumnReorder
+        // Resizing columns might be helpful to show more data
+        // disableColumnResize
+        // There are only 2 columns, let's not confuse the user.
+        disableColumnSelector
+        // We don't need to sort multiple columns.
+        disableMultipleColumnsSorting
+        // End Column Menu
         treeData
         getTreeDataPath={row => row.path.toStringArray()}
         rows={rows}
@@ -328,7 +348,6 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
         }}
         hideFooter
         rowSelection={false}
-        disableColumnMenu={true}
         groupingColDef={groupingColDef}
         sx={{
           borderRadius: '0px',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -240,20 +240,20 @@ const ObjectVersionsTable: React.FC<{
       // Start Column Menu
       // ColumnMenu is only needed when we have other actions
       // such as filtering.
-      disableColumnMenu
+      disableColumnMenu={true}
       // We don't have enough columns to justify filtering
-      disableColumnFilter
-      disableMultipleColumnsFiltering
+      disableColumnFilter={true}
+      disableMultipleColumnsFiltering={true}
       // ColumnPinning seems to be required in DataGridPro, else it crashes.
-      // disableColumnPinning
+      disableColumnPinning={false}
       // We don't have enough columns to justify re-ordering
-      disableColumnReorder
+      disableColumnReorder={true}
       // The columns are fairly simple, so we don't need to resize them.
-      // disableColumnResize
+      disableColumnResize={false}
       // We don't have enough columns to justify hiding some of them.
-      disableColumnSelector
+      disableColumnSelector={true}
       // We don't have enough columns to justify sorting by multiple columns.
-      disableMultipleColumnsSorting
+      disableMultipleColumnsSorting={true}
       // End Column Menu
       rows={rows}
       initialState={{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -237,6 +237,24 @@ const ObjectVersionsTable: React.FC<{
 
   return (
     <StyledDataGrid
+      // Start Column Menu
+      // ColumnMenu is only needed when we have other actions
+      // such as filtering.
+      disableColumnMenu
+      // We don't have enough columns to justify filtering
+      disableColumnFilter
+      disableMultipleColumnsFiltering
+      // ColumnPinning seems to be required in DataGridPro, else it crashes.
+      // disableColumnPinning
+      // We don't have enough columns to justify re-ordering
+      disableColumnReorder
+      // The columns are fairly simple, so we don't need to resize them.
+      // disableColumnResize
+      // We don't have enough columns to justify hiding some of them.
+      disableColumnSelector
+      // We don't have enough columns to justify sorting by multiple columns.
+      disableMultipleColumnsSorting
+      // End Column Menu
       rows={rows}
       initialState={{
         sorting: {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -194,20 +194,20 @@ export const FilterableOpVersionsTable: React.FC<{
       // Start Column Menu
       // ColumnMenu is only needed when we have other actions
       // such as filtering.
-      disableColumnMenu
+      disableColumnMenu={true}
       // We don't have enough columns to justify filtering
-      disableColumnFilter
-      disableMultipleColumnsFiltering
+      disableColumnFilter={true}
+      disableMultipleColumnsFiltering={true}
       // ColumnPinning seems to be required in DataGridPro, else it crashes.
-      // disableColumnPinning
+      disableColumnPinning={false}
       // We don't have enough columns to justify re-ordering
-      disableColumnReorder
+      disableColumnReorder={true}
       // The columns are fairly simple, so we don't need to resize them.
-      // disableColumnResize
+      disableColumnResize={false}
       // We don't have enough columns to justify hiding some of them.
-      disableColumnSelector
+      disableColumnSelector={true}
       // We don't have enough columns to justify sorting by multiple columns.
-      disableMultipleColumnsSorting
+      disableMultipleColumnsSorting={true}
       // End Column Menu
       rows={rows}
       initialState={{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -191,6 +191,24 @@ export const FilterableOpVersionsTable: React.FC<{
 
   return (
     <StyledDataGrid
+      // Start Column Menu
+      // ColumnMenu is only needed when we have other actions
+      // such as filtering.
+      disableColumnMenu
+      // We don't have enough columns to justify filtering
+      disableColumnFilter
+      disableMultipleColumnsFiltering
+      // ColumnPinning seems to be required in DataGridPro, else it crashes.
+      // disableColumnPinning
+      // We don't have enough columns to justify re-ordering
+      disableColumnReorder
+      // The columns are fairly simple, so we don't need to resize them.
+      // disableColumnResize
+      // We don't have enough columns to justify hiding some of them.
+      disableColumnSelector
+      // We don't have enough columns to justify sorting by multiple columns.
+      disableMultipleColumnsSorting
+      // End Column Menu
       rows={rows}
       initialState={{
         sorting: {


### PR DESCRIPTION
We have been using the vanilla MUIDataGrid in many contexts and allowing the default options to persist. This has created 3 classes of snags:
1. UI "abilities" that don't make sense - for example, it is not necessary to manage columns for the object versions viewer
2. UI "abilities" that are purely broken: for example: sorting on ref expanded fields
3. UI "abilities" that are broken & hard to maintain moving forward: eg. filtering in the run table.

The point of this PR is to be a little bit aggressive in _disabling_ features. Cleaning this up leaves just the well-supported features so that we can intentionally enable features if/when we want to.

The only real "loss" here is I disable filtering on the Runs Table. I know we will want to bring this back, but i would prefer to do it in a maintainable way rather than let the MUI data grid dictate the possibilities.