### PR TITLE
feat: add User column with tooltip and popup

### DIFF
--- a/wb_schema.gql
+++ b/wb_schema.gql
@@ -14,6 +14,10 @@ directive @constraints(
   max: Int
   pattern: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+directive @accessibleIf(
+  cond: String
+  restrictEvenAdmins: Boolean
+) on FIELD_DEFINITION
 
 type Query {
   user(id: ID, userName: String): User
@@ -161,6 +165,9 @@ type User implements Node {
   id: ID!
   name: String!
   username: String
+  email: String @accessibleIf(cond: "viewerCanReadEmail")
+  photoUrl: String
+  deletedAt: DateTime
   teams(before: String, after: String, first: Int, last: Int): EntityConnection
 }
 

--- a/weave-js/src/components/DraggablePopups.tsx
+++ b/weave-js/src/components/DraggablePopups.tsx
@@ -1,0 +1,56 @@
+/**
+ * Support for a preview tooltip combined with a draggable popup on click.
+ */
+
+import Grow from '@material-ui/core/Grow';
+import Tooltip, {tooltipClasses, TooltipProps} from '@mui/material/Tooltip';
+import * as Colors from '@wandb/weave/common/css/color.styles';
+import React from 'react';
+import Draggable from 'react-draggable';
+import styled from 'styled-components';
+
+export const Popped = styled.div`
+  border-radius: 4px;
+  word-wrap: break-word;
+  background-color: #fff;
+  color: ${Colors.MOON_700};
+  border: 1px solid ${Colors.MOON_300};
+`;
+Popped.displayName = 'S.Popped';
+
+export const PoppedBody = styled.div`
+  width: 600px;
+  max-height: 60vh;
+  overflow: auto;
+`;
+PoppedBody.displayName = 'S.PoppedBody';
+
+export const StyledTooltip = styled(
+  ({className, padding, ...props}: TooltipProps & {padding?: number}) => (
+    <Tooltip {...props} classes={{popper: className}} />
+  )
+)(({theme, padding}) => ({
+  [`& .${tooltipClasses.tooltip}`]: {
+    backgroundColor: '#fff',
+    color: Colors.MOON_700,
+    border: `1px solid ${Colors.MOON_300}`,
+    maxWidth: 600,
+    padding,
+  },
+}));
+
+export const DraggableWrapper = ({children, ...other}: any) => {
+  return (
+    <Draggable handle=".handle">
+      {React.cloneElement(children, {...other})}
+    </Draggable>
+  );
+};
+
+export const DraggableGrow = ({children, ...other}: any) => {
+  return (
+    <Grow {...other} timeout={0}>
+      <DraggableWrapper>{children}</DraggableWrapper>
+    </Grow>
+  );
+};

--- a/weave-js/src/components/DraggablePopups.tsx
+++ b/weave-js/src/components/DraggablePopups.tsx
@@ -39,6 +39,13 @@ export const StyledTooltip = styled(
   },
 }));
 
+export const TooltipHint = styled.div`
+  color: ${Colors.MOON_500};
+  text-align: center;
+  font-size: 0.8em;
+`;
+TooltipHint.displayName = 'S.TooltipHint';
+
 export const DraggableWrapper = ({children, ...other}: any) => {
   return (
     <Draggable handle=".handle">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -18,6 +18,7 @@ import {
   DraggableGrow,
   PoppedBody,
   StyledTooltip,
+  TooltipHint,
 } from '../../../DraggablePopups';
 
 const isJSON = (value: string): boolean => {
@@ -59,13 +60,6 @@ const TooltipText = styled.div<{isJSON: boolean}>`
   ${props => props.isJSON && 'font-family: monospace;'}
 `;
 TooltipText.displayName = 'S.TooltipText';
-
-const TooltipHint = styled.div`
-  color: ${Colors.MOON_500};
-  text-align: center;
-  font-size: 0.8em;
-`;
-TooltipHint.displayName = 'S.TooltipHint';
 
 const Popped = styled.div`
   border-radius: 4px;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -2,13 +2,10 @@
  * TODO: Combine common functionality between this and ValueViewString
  */
 
-import Grow from '@material-ui/core/Grow';
 import {Popover} from '@mui/material';
-import Tooltip, {tooltipClasses, TooltipProps} from '@mui/material/Tooltip';
 import copyToClipboard from 'copy-to-clipboard';
 import isUrl from 'is-url';
 import React, {ReactNode, useCallback, useRef, useState} from 'react';
-import Draggable from 'react-draggable';
 import styled from 'styled-components';
 
 import {toast} from '../../../../common/components/elements/Toast';
@@ -17,6 +14,11 @@ import * as Colors from '../../../../common/css/color.styles';
 import {TargetBlank} from '../../../../common/util/links';
 import {Button} from '../../../Button';
 import {CodeEditor} from '../../../CodeEditor';
+import {
+  DraggableGrow,
+  PoppedBody,
+  StyledTooltip,
+} from '../../../DraggablePopups';
 
 const isJSON = (value: string): boolean => {
   try {
@@ -76,13 +78,6 @@ const Popped = styled.div`
 `;
 Popped.displayName = 'S.Popped';
 
-const PoppedBody = styled.div`
-  width: 600px;
-  max-height: 60vh;
-  overflow: auto;
-`;
-PoppedBody.displayName = 'S.PoppedBody';
-
 const Toolbar = styled.div`
   display: flex;
   align-items: center;
@@ -95,33 +90,6 @@ const Spacer = styled.div`
   flex: 1 1 auto;
 `;
 Spacer.displayName = 'S.Spacer';
-
-const StyledTooltip = styled(({className, ...props}: TooltipProps) => (
-  <Tooltip {...props} classes={{popper: className}} />
-))(({theme}) => ({
-  [`& .${tooltipClasses.tooltip}`]: {
-    backgroundColor: '#fff',
-    color: Colors.MOON_700,
-    border: `1px solid ${Colors.MOON_300}`,
-    maxWidth: 600,
-  },
-}));
-
-const DraggableWrapper = ({children, ...other}: any) => {
-  return (
-    <Draggable handle=".handle">
-      {React.cloneElement(children, {...other})}
-    </Draggable>
-  );
-};
-
-const DraggableGrow = ({children, ...other}: any) => {
-  return (
-    <Grow {...other} timeout={0}>
-      <DraggableWrapper>{children}</DraggableWrapper>
-    </Grow>
-  );
-};
 
 const CellValueStringWithPopup = ({value}: CellValueStringProps) => {
   const ref = useRef<HTMLDivElement>(null);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -7,6 +7,7 @@ import {
   GridRowSelectionModel,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
+import {UserLink} from '@wandb/weave/components/UserLink';
 import * as _ from 'lodash';
 import React, {
   ComponentProps,
@@ -313,6 +314,7 @@ export const RunsTable: FC<{
         trace_id: call.traceId,
         status_code: call.rawSpan.status_code,
         timestampMs: call.rawSpan.timestamp,
+        userId: call.userId,
         latency: call.rawSpan.summary.latency_s,
         ..._.mapKeys(
           _.omitBy(args, v => v == null),
@@ -449,18 +451,13 @@ export const RunsTable: FC<{
             },
           ]
         : []),
-      // {
-      //   field: 'user_id',
-      //   headerName: 'User',
-      //   disableColumnMenu: true,
-      //   renderCell: cellParams => {
-      //     return (
-      //       <div style={{margin: 'auto'}}>
-      //         {cellParams.row.call.userId ?? <NotApplicable />}
-      //       </div>
-      //     );
-      //   },
-      // },
+      {
+        field: 'userId',
+        headerName: 'User',
+        width: 150,
+        disableColumnMenu: true,
+        renderCell: cellParams => <UserLink username={cellParams.row.userId} />,
+      },
       // {
       //   field: 'run_id',
       //   headerName: 'Run',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -454,7 +454,10 @@ export const RunsTable: FC<{
       {
         field: 'userId',
         headerName: 'User',
-        width: 150,
+        width: 50,
+        align: 'center',
+        sortable: false,
+        resizable: false,
         disableColumnMenu: true,
         renderCell: cellParams => <UserLink username={cellParams.row.userId} />,
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
@@ -51,7 +51,12 @@ export const computeTableStats = (table: Array<Record<string, any>>) => {
   };
 
   // Determine set of possible columns and value types
-  const colPatterns: RegExp[] = [/opCategory/, /input\.*/, /output\.*/];
+  const colPatterns: RegExp[] = [
+    /^userId$/,
+    /^opCategory$/,
+    /^input\.*$/,
+    /^output\.*$/,
+  ];
   for (const row of table) {
     stats.rowCount++;
     for (const colName of Object.keys(row)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import React from 'react';
 
 import {Timestamp} from '../../../../../Timestamp';
+import {UserLink} from '../../../../../UserLink';
 import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
 import {SimpleKeyValueTable} from '../common/SimplePageLayout';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
@@ -34,6 +35,7 @@ export const CallSummary: React.FC<{
             ) : (
               span.name
             ),
+          User: <UserLink username={call.userId} placement="bottom-start" />,
           Called: <Timestamp value={span.timestamp / 1000} format="relative" />,
           ...(span.summary.latency_s != null && span.status_code !== 'UNSET'
             ? {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -35,7 +35,13 @@ export const CallSummary: React.FC<{
             ) : (
               span.name
             ),
-          User: <UserLink username={call.userId} placement="bottom-start" />,
+          User: (
+            <UserLink
+              username={call.userId}
+              placement="bottom-start"
+              includeName
+            />
+          ),
           Called: <Timestamp value={span.timestamp / 1000} format="relative" />,
           ...(span.summary.latency_s != null && span.status_code !== 'UNSET'
             ? {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -25,6 +25,15 @@ type LinkProps = {
   $variant?: LinkVariant;
 };
 
+export const A = styled.a<LinkProps>`
+  font-weight: 600;
+  color: ${p => (p.$variant === 'secondary' ? MOON_700 : TEAL_600)};
+  &:hover {
+    color: ${TEAL_500};
+  }
+`;
+A.displayName = 'S.A';
+
 export const Link = styled(LinkComp)<LinkProps>`
   font-weight: 600;
   color: ${p => (p.$variant === 'secondary' ? MOON_700 : TEAL_600)};

--- a/weave-js/src/components/UserLink.tsx
+++ b/weave-js/src/components/UserLink.tsx
@@ -1,0 +1,254 @@
+import {gql} from '@apollo/client';
+import {Avatar, Popover, TooltipProps} from '@mui/material';
+import {apolloClient} from '@wandb/weave/apollo';
+import * as Colors from '@wandb/weave/common/css/color.styles';
+import {NotApplicable} from '@wandb/weave/components/PagePanelComponents/Home/Browse2/NotApplicable';
+import React, {useEffect, useRef, useState} from 'react';
+import styled from 'styled-components';
+
+import {Button} from './Button';
+import {DraggableGrow, Popped, StyledTooltip} from './DraggablePopups';
+import {LoadingDots} from './LoadingDots';
+import {A, Link} from './PagePanelComponents/Home/Browse3/pages/common/Links';
+
+const FIND_USER_QUERY = gql`
+  query FindUser($username: String!) {
+    users(usernames: [$username], first: 1) {
+      edges {
+        node {
+          id
+          name
+          email
+          photoUrl
+          deletedAt
+        }
+      }
+    }
+  }
+`;
+
+const UserTrigger = styled.div`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  &:hover {
+    & a {
+      color: ${Colors.TEAL_500};
+    }
+
+`;
+UserTrigger.displayName = 'S.UserTrigger';
+
+const UserContentHeader = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 2px 2px 2px 8px;
+  background-color: ${Colors.MOON_100};
+`;
+UserContentHeader.displayName = 'S.UserContentHeader';
+
+const UserName = styled.div`
+  font-weight: 600;
+  flex: 1 1 auto;
+`;
+UserName.displayName = 'S.UserName';
+
+const UserContentBody = styled.div`
+  padding: 4px;
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+`;
+UserContentBody.displayName = 'S.UserContentBody';
+
+const Grid = styled.div`
+  display: grid;
+  grid-template-columns: auto auto;
+  column-gap: 8px;
+`;
+Grid.displayName = 'S.Grid';
+
+const Th = styled.th`
+  text-align: right;
+`;
+Th.displayName = 'S.Th';
+
+type UserInfo = {
+  id: string;
+  name: string;
+  email: string;
+  username: string;
+  photoUrl: string;
+};
+
+type UserResult = 'NA' | 'load' | 'loading' | 'error' | UserInfo;
+
+const onClickDoNothing = (e: React.MouseEvent) => {
+  e.preventDefault();
+};
+
+type UserContentProps = {
+  user: UserInfo;
+  mode: 'tooltip' | 'popover';
+  onClose?: () => void;
+};
+const UserContent = ({user, mode, onClose}: UserContentProps) => {
+  const isPopover = mode === 'popover';
+  const imgSize = isPopover ? 100 : 50;
+  const username = isPopover ? (
+    <Link to={`/${user.username}`}>{user.username}</Link>
+  ) : (
+    user.username
+  );
+  const email = isPopover ? (
+    <A href={`mailto:${user.email}`}>{user.email}</A>
+  ) : (
+    user.email
+  );
+  const bodyStyle = isPopover ? {fontSize: '0.9em'} : undefined;
+  const onCloseClick = onClose ? () => onClose() : undefined;
+  return (
+    <>
+      <UserContentHeader className="handle">
+        <UserName>{user.name}</UserName>
+        {isPopover && (
+          <Button
+            size="small"
+            variant="ghost"
+            icon="close"
+            tooltip="Close"
+            onClick={onCloseClick}
+          />
+        )}
+      </UserContentHeader>
+      <UserContentBody style={bodyStyle}>
+        <Avatar src={user.photoUrl} sx={{width: imgSize, height: imgSize}} />
+        <Grid>
+          <Th>Username</Th>
+          <div>{username}</div>
+          <Th>Email</Th>
+          <div>{email}</div>
+        </Grid>
+      </UserContentBody>
+    </>
+  );
+};
+
+type UserInnerProps = {
+  user: UserInfo;
+  placement?: TooltipProps['placement'];
+};
+const UserInner = ({user, placement}: UserInnerProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const onClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(anchorEl ? null : ref.current);
+  };
+  const onClose = () => setAnchorEl(null);
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popper' : undefined;
+
+  const title = open ? (
+    '' // Suppress tooltip when popper is open.
+  ) : (
+    <UserContent user={user} mode="tooltip" />
+  );
+
+  // Unfortunate but necessary to get appear on top of peek drawer.
+  const stylePopper = {zIndex: 1};
+
+  const size = 22; // Chosen to match SmallRef circle.
+  return (
+    <>
+      <StyledTooltip
+        enterDelay={500}
+        title={title}
+        placement={placement ?? 'right'}
+        padding={0}>
+        <UserTrigger ref={ref} onClick={onClick}>
+          <Avatar
+            src={user.photoUrl}
+            sx={{width: size, height: size, marginRight: '4px'}}
+          />
+          <Link
+            to={`/${user.username}`}
+            onClick={onClickDoNothing}
+            $variant="secondary">
+            {user.name}
+          </Link>
+        </UserTrigger>
+      </StyledTooltip>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        style={stylePopper}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        onClose={onClose}
+        TransitionComponent={DraggableGrow}>
+        <Popped>
+          <UserContent user={user} mode="popover" onClose={onClose} />
+        </Popped>
+      </Popover>
+    </>
+  );
+};
+
+type UserLinkProps = {
+  username: string | null;
+  placement?: TooltipProps['placement'];
+};
+
+export const UserLink = ({username, placement}: UserLinkProps) => {
+  const [user, setUser] = useState<UserResult>(username ? 'load' : 'NA');
+  useEffect(
+    () => {
+      if (user !== 'load') {
+        return;
+      }
+      setUser('loading');
+      apolloClient
+        .query({
+          query: FIND_USER_QUERY as any,
+          variables: {
+            username,
+          },
+        })
+        .then(result => {
+          const {edges} = result.data.users;
+          if (edges.length > 0) {
+            const u = edges[0].node;
+            setUser({
+              ...u,
+              username,
+            });
+          } else {
+            setUser('error');
+          }
+        })
+        .catch(err => {
+          setUser('error');
+        });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+  if (user === 'NA') {
+    return <NotApplicable />;
+  }
+  if (user === 'load' || user === 'loading') {
+    return <LoadingDots />;
+  }
+  if (user === 'error') {
+    return <div>{username}</div>;
+  }
+  return <UserInner user={user} placement={placement} />;
+};

--- a/weave-js/src/components/UserLink.tsx
+++ b/weave-js/src/components/UserLink.tsx
@@ -7,7 +7,12 @@ import React, {useEffect, useRef, useState} from 'react';
 import styled from 'styled-components';
 
 import {Button} from './Button';
-import {DraggableGrow, Popped, StyledTooltip} from './DraggablePopups';
+import {
+  DraggableGrow,
+  Popped,
+  StyledTooltip,
+  TooltipHint,
+} from './DraggablePopups';
 import {LoadingDots} from './LoadingDots';
 import {A, Link} from './PagePanelComponents/Home/Browse3/pages/common/Links';
 
@@ -130,15 +135,17 @@ const UserContent = ({user, mode, onClose}: UserContentProps) => {
           <div>{email}</div>
         </Grid>
       </UserContentBody>
+      {!isPopover && <TooltipHint>Click to open card</TooltipHint>}
     </>
   );
 };
 
 type UserInnerProps = {
   user: UserInfo;
+  includeName?: boolean;
   placement?: TooltipProps['placement'];
 };
-const UserInner = ({user, placement}: UserInnerProps) => {
+const UserInner = ({user, includeName, placement}: UserInnerProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const onClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -171,12 +178,14 @@ const UserInner = ({user, placement}: UserInnerProps) => {
             src={user.photoUrl}
             sx={{width: size, height: size, marginRight: '4px'}}
           />
-          <Link
-            to={`/${user.username}`}
-            onClick={onClickDoNothing}
-            $variant="secondary">
-            {user.name}
-          </Link>
+          {includeName && (
+            <Link
+              to={`/${user.username}`}
+              onClick={onClickDoNothing}
+              $variant="secondary">
+              {user.name}
+            </Link>
+          )}
         </UserTrigger>
       </StyledTooltip>
       <Popover
@@ -204,10 +213,11 @@ const UserInner = ({user, placement}: UserInnerProps) => {
 
 type UserLinkProps = {
   username: string | null;
+  includeName?: boolean; // Default is to show avatar image only.
   placement?: TooltipProps['placement'];
 };
 
-export const UserLink = ({username, placement}: UserLinkProps) => {
+export const UserLink = ({username, includeName, placement}: UserLinkProps) => {
   const [user, setUser] = useState<UserResult>(username ? 'load' : 'NA');
   useEffect(
     () => {
@@ -250,5 +260,7 @@ export const UserLink = ({username, placement}: UserLinkProps) => {
   if (user === 'error') {
     return <div>{username}</div>;
   }
-  return <UserInner user={user} placement={placement} />;
+  return (
+    <UserInner user={user} placement={placement} includeName={includeName} />
+  );
 };


### PR DESCRIPTION
Adds a User column to traces table. The widget works similarly to CellValueString, where you can hover over the in-page representation to get more information in a tooltip and you can click on the cell value to get a popup that can be repositioned, can have interactive links, etc.

@Yangyi-wandb @adamwdraper - could use design review.

In table cell shows avatar image (if available) and name.
<img width="585" alt="Screenshot 2024-04-11 at 10 33 05 PM" src="https://github.com/wandb/weave/assets/112953339/1788f8d8-0e57-4f49-af67-afa790f6cd10">

Hovering over either image or name will show the link with hover color (this screenshot also showing night mode)
<img width="158" alt="Screenshot 2024-04-11 at 10 51 37 PM" src="https://github.com/wandb/weave/assets/112953339/93388578-4e5d-4d0a-adbb-929b15c9ae60">

A tooltip appears when you hover with a larger photo and more information about the user.
<img width="455" alt="Screenshot 2024-04-11 at 10 33 11 PM" src="https://github.com/wandb/weave/assets/112953339/086f7f24-8b10-43c2-90cd-897ad2412d41">

Clicking makes the user info panel larger still, and the user properties become links you can interact with, e.g. to go to the profile page for that user or send them an email.
<img width="408" alt="Screenshot 2024-04-11 at 10 33 15 PM" src="https://github.com/wandb/weave/assets/112953339/c74511cb-1665-42e8-bdf7-0283305b48ed">

Commonly, all calls will be from a single user. The column can be selected as a boring value. The tooltip etc continue to work.
<img width="472" alt="Screenshot 2024-04-11 at 10 34 06 PM" src="https://github.com/wandb/weave/assets/112953339/7830cb52-c642-4820-a8a9-194d4283589b">

Also added to Call Summary tab
<img width="388" alt="Screenshot 2024-04-12 at 10 03 23 AM" src="https://github.com/wandb/weave/assets/112953339/a13fbc79-6648-4613-a684-f2f78f0a45c3">

