### PR TITLE
fix: markdown CSS

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
@@ -55,7 +55,6 @@ const Scrolling = styled.div`
   display: flex;
   align-items: center;
   overflow: auto;
-  white-space: break-spaces;
 `;
 Scrolling.displayName = 'S.Scrolling';
 
@@ -65,10 +64,13 @@ const ScrollingInner = styled.div`
 `;
 ScrollingInner.displayName = 'S.ScrollingInner';
 
-const Full = styled.div`
+const Full = styled.div``;
+Full.displayName = 'S.Full';
+
+const PreserveWrapping = styled.div`
   white-space: break-spaces;
 `;
-Full.displayName = 'S.Full';
+PreserveWrapping.displayName = 'S.PreserveWrapping';
 
 export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
   const trimmed = value.trim();
@@ -168,6 +170,8 @@ export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
     content = <CodeEditor value={trimmed} readOnly />;
   } else if (isUrl(trimmed)) {
     content = <TargetBlank href={trimmed}>{trimmed}</TargetBlank>;
+  } else if (mode !== 0) {
+    content = <PreserveWrapping>{content}</PreserveWrapping>;
   } else {
     content = value;
   }


### PR DESCRIPTION
Fix Markdown rendering problem reported by @ash0ts in internal Slack: https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1712945416423219

We should only apply the CSS rule `white-space: break-spaces;` when format is Text and we are not collapsed.

Before:
<img width="1221" alt="Screenshot 2024-04-12 at 10 21 58 PM" src="https://github.com/wandb/weave/assets/112953339/f58b84fd-d639-4972-8d2f-6fc156fe5ee8">

After:
<img width="1218" alt="Screenshot 2024-04-12 at 10 21 12 PM" src="https://github.com/wandb/weave/assets/112953339/d14465d6-2f88-4d60-9b27-257f790bd5d6">

