### PR TITLE
fix: incorrect regexp in table stats computation

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
@@ -54,8 +54,8 @@ export const computeTableStats = (table: Array<Record<string, any>>) => {
   const colPatterns: RegExp[] = [
     /^userId$/,
     /^opCategory$/,
-    /^input\.*$/,
-    /^output\.*$/,
+    /^input\..*$/,
+    /^output\..*$/,
   ];
   for (const row of table) {
     stats.rowCount++;


### PR DESCRIPTION
I introduced a bug in https://github.com/wandb/weave/pull/1518

RegExp.test will match the pattern anywhere in the string. I added `^` and `$` to only match the complete string because I didn't want e.g. `/opCategory/` to match a column like "mopCategory".

However, there was already a bug in the regular expression to begin with, i.e. `/input\.*/` - the intention was to match an "input." prefix, but this would actually match 0 or more literal periods because it was missing a period before the Kleene star.
