### PR TITLE
chore(weave): Fixes primitive expansion in object viewer / call viewer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -123,6 +123,12 @@ export const ObjectViewer = ({apiRef, data, isExpanded}: ObjectViewerProps) => {
             ...v,
             _ref: r,
           };
+        } else {
+          // This makes it so that runs pointing to primitives can still be expanded in the table.
+          val = {
+            '': v,
+            _ref: r,
+          };
         }
       }
       refValues[r] = val;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -105,6 +105,19 @@ const ObjectVersionPageInner: React.FC<{
     return data.result?.[0] ?? {};
   }, [data.loading, data.result]);
 
+  const viewerDataAsObject = useMemo(() => {
+    const dataIsPrimitive =
+      typeof viewerData !== 'object' ||
+      viewerData === null ||
+      Array.isArray(viewerData);
+    if (dataIsPrimitive) {
+      // _result is a special key that is automatically removed by the
+      // ObjectViewerSection component.
+      return {_result: viewerData};
+    }
+    return viewerData;
+  }, [viewerData]);
+
   return (
     <SimplePageLayoutWithHeader
       title={objectVersionText(objectName, objectVersionIndex)}
@@ -195,7 +208,7 @@ const ObjectVersionPageInner: React.FC<{
                   <WeaveCHTableSourceRefContext.Provider value={refUri}>
                     <ObjectViewerSection
                       title=""
-                      data={viewerData}
+                      data={viewerDataAsObject}
                       noHide
                       isExpanded
                     />


### PR DESCRIPTION
Fixes data expansion in the viewer panels when the ref is a primitive 

<img width="1003" alt="Screenshot 2024-04-14 at 19 57 00" src="https://github.com/wandb/weave/assets/2142768/3b28286e-59f0-466f-805d-11c63b7e6048">
<img width="1009" alt="Screenshot 2024-04-14 at 19 56 55" src="https://github.com/wandb/weave/assets/2142768/702c419e-fffe-478c-8ceb-59dc43a85587">
