### PR TITLE
fix: show all doesn't show boring columns

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
@@ -119,26 +119,17 @@ export const useColumnVisibility = (
   isSingleOpVersion: boolean
 ) => {
   const [forceShowAll, setForceShowAll] = useState(false);
-  if (isSingleOpVersion) {
-    return {
-      allShown: true,
-      columnVisibilityModel: {},
-      forceShowAll: true,
-      setForceShowAll,
-    };
-  }
 
   const boringColumns = getBoringColumns(tableStats);
 
   const model: GridColumnVisibilityModel = {};
   for (const colName in tableStats.column) {
-    if (forceShowAll) {
-      // This will include columns that are entirely empty,
-      // but that seemed less confusing than a "Show all" not actually
-      // showing all?
-      model[colName] = true;
-    } else if (boringColumns.includes(colName)) {
+    if (boringColumns.includes(colName)) {
       model[colName] = false;
+    } else if (forceShowAll) {
+      model[colName] = true;
+    } else if (isSingleOpVersion) {
+      model[colName] = true;
     } else {
       const colStats = tableStats.column[colName];
       if (colStats.typeCounts.null === tableStats.rowCount) {


### PR DESCRIPTION
Internal slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1713202274928129

The "boring columns" feature didn't combine well with the "show all columns" feature. This makes them more independent, where "Show all" really just impacts the autohiding of mostly blank columns.