### PR TITLE
chore(weave): Fix incorrect cache storage

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -322,7 +322,8 @@ const useOpVersion = (
       };
     }
 
-    const cachableResult: OpVersionSchema = convertTraceServerObjectVersionToOpSchema(opVersionRes.obj)
+    const cachableResult: OpVersionSchema =
+      convertTraceServerObjectVersionToOpSchema(opVersionRes.obj);
 
     if (key.opId !== cachableResult.opId) {
       return {
@@ -453,7 +454,8 @@ const useObjectVersion = (
       };
     }
 
-    const cachableResult: ObjectVersionSchema = convertTraceServerObjectVersionToSchema(objectVersionRes.obj)
+    const cachableResult: ObjectVersionSchema =
+      convertTraceServerObjectVersionToSchema(objectVersionRes.obj);
     if (key.objectId !== cachableResult.objectId) {
       return {
         loading: true,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -322,10 +322,15 @@ const useOpVersion = (
       };
     }
 
-    const cachableResult: OpVersionSchema = {
-      ...key,
-      ...convertTraceServerObjectVersionToOpSchema(opVersionRes.obj),
-    };
+    const cachableResult: OpVersionSchema = convertTraceServerObjectVersionToOpSchema(opVersionRes.obj)
+
+    if (key.opId !== cachableResult.opId) {
+      return {
+        loading: true,
+        result: null,
+      };
+    }
+
     opVersionCache.set(key, cachableResult);
     return {
       loading: false,
@@ -448,10 +453,14 @@ const useObjectVersion = (
       };
     }
 
-    const cachableResult: ObjectVersionSchema = {
-      ...key,
-      ...convertTraceServerObjectVersionToSchema(objectVersionRes.obj),
-    };
+    const cachableResult: ObjectVersionSchema = convertTraceServerObjectVersionToSchema(objectVersionRes.obj)
+    if (key.objectId !== cachableResult.objectId) {
+      return {
+        loading: true,
+        result: null,
+      };
+    }
+
     objectVersionCache.set(key, cachableResult);
     return {
       loading: false,


### PR DESCRIPTION
When toggling between ObjectVersion views (for example) the stale data was getting cached under the last key - resulting in incorrect data being shown to the user.