### PR TITLE
fix: crash when clicking on cell

### DIFF
--- a/weave-js/src/components/DraggablePopups.tsx
+++ b/weave-js/src/components/DraggablePopups.tsx
@@ -57,7 +57,9 @@ export const DraggableWrapper = ({children, ...other}: any) => {
 export const DraggableGrow = ({children, ...other}: any) => {
   return (
     <Grow {...other} timeout={0}>
-      <DraggableWrapper>{children}</DraggableWrapper>
+      <div>
+        <DraggableWrapper>{children}</DraggableWrapper>
+      </div>
     </Grow>
   );
 };


### PR DESCRIPTION
Internal slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1713306383328969

Material 4 was apparently more forgiving than v5, just putting a warning in dev console instead of throwing.

```
utils.js:1 Uncaught TypeError: Cannot read properties of null (reading 'scrollTop')
    at reflow (utils.js:1:36)
    at Grow.js:77:5
    at Object.onEnter (Grow.js:71:9)
    at Transition2.performEnter (Transition.js:271:16)
    at Transition2.updateStatus (Transition.js:237:14)
    at Transition2.componentDidMount (Transition.js:173:10)
    at commitLifeCycles (react-dom.development.js:20663:24)
    at commitLayoutEffects (react-dom.development.js:23426:7)
    at HTMLUnknownElement.callCallback2 (react-dom.development.js:3945:14)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:3994:16)
```

```
Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `FocusTrap`.
    at DraggableGrow (http://localhost:9000/@fs/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave-js/src/components/DraggablePopups.tsx?t=1713307176731:69:3)
```