### PR TITLE
chore: fix ref forwarding warning

### DIFF
--- a/weave-js/src/components/DraggablePopups.tsx
+++ b/weave-js/src/components/DraggablePopups.tsx
@@ -54,12 +54,14 @@ export const DraggableWrapper = ({children, ...other}: any) => {
   );
 };
 
-export const DraggableGrow = ({children, ...other}: any) => {
-  return (
-    <Grow {...other} timeout={0}>
-      <div>
-        <DraggableWrapper>{children}</DraggableWrapper>
-      </div>
-    </Grow>
-  );
-};
+export const DraggableGrow = React.forwardRef(
+  ({children, ...other}: any, ref) => {
+    return (
+      <Grow ref={ref} {...other} timeout={0}>
+        <div>
+          <DraggableWrapper>{children}</DraggableWrapper>
+        </div>
+      </Grow>
+    );
+  }
+);


### PR DESCRIPTION
Fix this dev console warning:
<img width="1384" alt="Screenshot 2024-04-16 at 4 35 12 PM" src="https://github.com/wandb/weave/assets/112953339/47e4b5d0-37ca-4e06-be1a-99f8202d4f6c">
