### PR TITLE
chore: remove top border on peek drawer dragger

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -361,7 +361,6 @@ const MainPeekingLayout: FC = () => {
             id="dragger"
             onMouseDown={handleMousedown}
             style={{
-              borderTop: '1px solid #ddd',
               position: 'absolute',
               inset: '0 auto 0 0',
               zIndex: 2,


### PR DESCRIPTION
Remove this little line - FYI @adamwdraper 

![image](https://github.com/wandb/weave/assets/112953339/547ddde3-4725-47c8-b669-c8b86512dd90)
