### PR TITLE
chore: Op and Obj clickable area expands across grid cell

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -172,6 +172,7 @@ const ObjectVersionsTable: React.FC<{
             objectName={obj.objectId}
             version={obj.versionHash}
             versionIndex={obj.versionIndex}
+            fullWidth={true}
           />
         );
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -113,6 +113,7 @@ export const FilterableOpVersionsTable: React.FC<{
             opName={obj.opId}
             version={obj.versionHash}
             versionIndex={obj.versionIndex}
+            fullWidth={true}
           />
         );
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -204,23 +204,31 @@ export const OpVersionLink: React.FC<{
   version: string;
   versionIndex: number;
   variant?: LinkVariant;
+  fullWidth?: boolean;
 }> = props => {
+  const history = useHistory();
   const {peekingRouter} = useWeaveflowRouteContext();
   // const text = props.hideName
   //   ? props.version
   //   : props.opName + ': ' + truncateID(props.version);
   const text = opVersionText(props.opName, props.versionIndex);
+  const to = peekingRouter.opVersionUIUrl(
+    props.entityName,
+    props.projectName,
+    props.opName,
+    props.version
+  );
+  const onClick = () => {
+    history.push(to);
+  };
   return (
-    <Link
-      $variant={props.variant}
-      to={peekingRouter.opVersionUIUrl(
-        props.entityName,
-        props.projectName,
-        props.opName,
-        props.version
-      )}>
-      {text}
-    </Link>
+    <LinkWrapper onClick={onClick} fullWidth={props.fullWidth}>
+      <LinkTruncater fullWidth={props.fullWidth}>
+        <Link $variant={props.variant} to={to}>
+          {text}
+        </Link>
+      </LinkTruncater>
+    </LinkWrapper>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -43,7 +43,7 @@ export const Link = styled(LinkComp)<LinkProps>`
 `;
 Link.displayName = 'S.Link';
 
-const CallLinkWrapper = styled.div<{fullWidth?: boolean}>`
+const LinkWrapper = styled.div<{fullWidth?: boolean}>`
   ${p =>
     p.fullWidth &&
     css`
@@ -64,9 +64,9 @@ const CallLinkWrapper = styled.div<{fullWidth?: boolean}>`
     }
   }
 `;
-CallLinkWrapper.displayName = 'S.CallLinkWrapper';
+LinkWrapper.displayName = 'S.LinkWrapper';
 
-const CallLinkOp = styled.div<{fullWidth?: boolean}>`
+const LinkTruncater = styled.div<{fullWidth?: boolean}>`
   ${p =>
     p.fullWidth &&
     css`
@@ -76,7 +76,7 @@ const CallLinkOp = styled.div<{fullWidth?: boolean}>`
   text-overflow: ellipsis;
   overflow: hidden;
 `;
-CallLinkOp.displayName = 'S.CallLinkOp';
+LinkTruncater.displayName = 'S.LinkTruncater';
 
 export const docUrl = (path: string): string => {
   return 'https://wandb.github.io/weave/' + path;
@@ -136,7 +136,9 @@ export const ObjectVersionLink: React.FC<{
   versionIndex: number;
   filePath?: string;
   refExtra?: string;
+  fullWidth?: boolean;
 }> = props => {
+  const history = useHistory();
   const {peekingRouter} = useWeaveflowRouteContext();
   // const text = props.hideName
   //   ? props.version
@@ -150,7 +152,17 @@ export const ObjectVersionLink: React.FC<{
     props.filePath,
     props.refExtra
   );
-  return <Link to={to}>{text}</Link>;
+  const onClick = () => {
+    history.push(to);
+  };
+
+  return (
+    <LinkWrapper onClick={onClick} fullWidth={props.fullWidth}>
+      <LinkTruncater>
+        <Link to={to}>{text}</Link>
+      </LinkTruncater>
+    </LinkWrapper>
+  );
 };
 
 export const OpLink: React.FC<{
@@ -248,14 +260,14 @@ export const CallLink: React.FC<{
   };
 
   return (
-    <CallLinkWrapper onClick={onClick} fullWidth={props.fullWidth}>
-      <CallLinkOp fullWidth={props.fullWidth}>
+    <LinkWrapper onClick={onClick} fullWidth={props.fullWidth}>
+      <LinkTruncater fullWidth={props.fullWidth}>
         <Link $variant={props.variant} to={to}>
           {opName}
         </Link>
-      </CallLinkOp>
+      </LinkTruncater>
       <CallId callId={props.callId} />
-    </CallLinkWrapper>
+    </LinkWrapper>
   );
 };
 


### PR DESCRIPTION
This makes those first grid columns consistent with the calls table and makes it easier to open the peek drawer.