### PR TITLE
chore: show trimmed instead of raw string in tooltip

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -123,7 +123,7 @@ const CellValueStringWithPopup = ({value}: CellValueStringProps) => {
     '' // Suppress tooltip when popper is open.
   ) : (
     <TooltipContent onClick={onClick}>
-      <TooltipText isJSON={json}>{value}</TooltipText>
+      <TooltipText isJSON={json}>{trimmed}</TooltipText>
       <TooltipHint>Cilck for more details</TooltipHint>
     </TooltipContent>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -124,7 +124,7 @@ const CellValueStringWithPopup = ({value}: CellValueStringProps) => {
   ) : (
     <TooltipContent onClick={onClick}>
       <TooltipText isJSON={json}>{trimmed}</TooltipText>
-      <TooltipHint>Cilck for more details</TooltipHint>
+      <TooltipHint>Click for more details</TooltipHint>
     </TooltipContent>
   );
 


### PR DESCRIPTION
We trim whitespace before displaying a string value in the cell. This also trims it from the tooltip shown on hover. We should have a broader conversation about where to show less useful but sometimes important raw characters.

<img width="761" alt="Screenshot 2024-04-17 at 1 10 35 PM" src="https://github.com/wandb/weave/assets/112953339/80213f80-adb9-46bb-8d0b-b3c509a58120">

Before:
<img width="627" alt="Screenshot 2024-04-17 at 1 12 38 PM" src="https://github.com/wandb/weave/assets/112953339/0fa8a1ba-dac3-4678-9c2f-b4cc723c93b7">

After:
<img width="632" alt="Screenshot 2024-04-17 at 1 10 28 PM" src="https://github.com/wandb/weave/assets/112953339/7dc10037-16ec-49a4-ae58-80ecd7244db9">
