### PR TITLE
chore: show loading dots while counting versions

### DIFF
--- a/weave-js/src/components/LoadingDots.tsx
+++ b/weave-js/src/components/LoadingDots.tsx
@@ -8,8 +8,10 @@ import styled from 'styled-components';
 import * as Colors from '../common/css/color.styles';
 
 const DotsContainer = styled.div`
-  display: flex;
+  display: inline-flex;
+  vertical-align: middle;
   align-items: center;
+  padding: 0 4px;
 
   @keyframes fade {
     from {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -2,6 +2,7 @@ import Box from '@mui/material/Box';
 import React, {useMemo} from 'react';
 
 import {maybePluralizeWord} from '../../../../../core/util/string';
+import {LoadingDots} from '../../../../LoadingDots';
 import {WeaveCHTableSourceRefContext} from './CallPage/DataTableView';
 import {ObjectViewerSection} from './CallPage/ObjectViewerSection';
 import {WFHighLevelCallFilter} from './CallsPage/CallsPage';
@@ -126,18 +127,25 @@ const ObjectVersionPageInner: React.FC<{
           data={{
             [refExtra ? 'Parent Object' : 'Name']: (
               <>
-                {objectName} [
-                <ObjectVersionsLink
-                  entity={entityName}
-                  project={projectName}
-                  filter={{
-                    objectName,
-                  }}
-                  versionCount={objectVersionCount}
-                  neverPeek
-                  variant="secondary"
-                />
-                ]
+                {objectName}{' '}
+                {objectVersions.loading ? (
+                  <LoadingDots />
+                ) : (
+                  <>
+                    [
+                    <ObjectVersionsLink
+                      entity={entityName}
+                      project={projectName}
+                      filter={{
+                        objectName,
+                      }}
+                      versionCount={objectVersionCount}
+                      neverPeek
+                      variant="secondary"
+                    />
+                    ]
+                  </>
+                )}
               </>
             ),
             Version: <>{objectVersionIndex}</>,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionPage.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react';
 
+import {LoadingDots} from '../../../../LoadingDots';
 import {OpCodeViewer} from '../OpCodeViewer';
 import {
   CallsLink,
@@ -70,7 +71,9 @@ const OpVersionPageInner: React.FC<{
             Name: (
               <>
                 {opId}{' '}
-                {(!opVersions.loading || opVersionCount > 0) && (
+                {opVersions.loading ? (
+                  <LoadingDots />
+                ) : (
                   <>
                     [
                     <OpVersionsLink


### PR DESCRIPTION
Before, while loading version count ops would display nothing, objects would display a misleading `[0 versions]`.

This makes them consistent with each other and show the small "dots" loading indicator.