### PR TITLE
fix: dev console dom nesting warning

### DIFF
--- a/weave-js/src/components/UserLink.tsx
+++ b/weave-js/src/components/UserLink.tsx
@@ -73,10 +73,11 @@ const Grid = styled.div`
 `;
 Grid.displayName = 'S.Grid';
 
-const Th = styled.th`
+const Label = styled.div`
   text-align: right;
+  font-weight: 600;
 `;
-Th.displayName = 'S.Th';
+Label.displayName = 'S.Label';
 
 type UserInfo = {
   id: string;
@@ -129,9 +130,9 @@ const UserContent = ({user, mode, onClose}: UserContentProps) => {
       <UserContentBody style={bodyStyle}>
         <Avatar src={user.photoUrl} sx={{width: imgSize, height: imgSize}} />
         <Grid>
-          <Th>Username</Th>
+          <Label>Username</Label>
           <div>{username}</div>
-          <Th>Email</Th>
+          <Label>Email</Label>
           <div>{email}</div>
         </Grid>
       </UserContentBody>


### PR DESCRIPTION
Fix `Warning: validateDOMNesting(...): <th> cannot appear as a child of <div>.`

<img width="1120" alt="Screenshot 2024-04-17 at 8 37 00 PM" src="https://github.com/wandb/weave/assets/112953339/57bc6ca3-78eb-49f8-ad2d-400db961c3d5">
