### PR TITLE
chore: diff version select styling

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/SelectOpVersion.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/SelectOpVersion.tsx
@@ -1,4 +1,4 @@
-import {Autocomplete, TextField} from '@mui/material';
+import {Autocomplete} from '@mui/material';
 import {MOON_500} from '@wandb/weave/common/css/globals.styles';
 import React from 'react';
 import styled from 'styled-components';
@@ -7,6 +7,8 @@ import {Pill} from '../../../Tag';
 import {Timestamp} from '../../../Timestamp';
 import {opVersionKeyToRefUri} from './pages/wfReactInterface/utilities';
 import {OpVersionSchema} from './pages/wfReactInterface/wfDataModelHooksInterface';
+import {StyledPaper} from './StyledAutocomplete';
+import {StyledTextField} from './StyledTextField';
 
 const Option = styled.li`
   display: flex;
@@ -55,7 +57,8 @@ export const SelectOpVersion = ({
       size="small"
       sx={{width: 260}}
       disableClearable
-      renderInput={params => <TextField {...params} />}
+      renderInput={params => <StyledTextField {...params} />}
+      PaperComponent={paperProps => <StyledPaper {...paperProps} />}
       value={value}
       onChange={(_, newValue) => {
         onChange(newValue.id);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -340,7 +340,7 @@ export const CallsTable: FC<{
           <ListItem sx={{minWidth: '190px'}}>
             <FormControl fullWidth>
               <Autocomplete
-                PaperComponent={StyledPaper}
+                PaperComponent={paperProps => <StyledPaper {...paperProps} />}
                 size="small"
                 // Temp disable multiple for simplicity - may want to re-enable
                 // multiple


### PR DESCRIPTION
Use custom styling for code diff version select widget. Also fixes dropdown styling for op version select on traces page.

Before:
<img width="278" alt="Screenshot 2024-04-17 at 11 05 41 PM" src="https://github.com/wandb/weave/assets/112953339/d09167f0-54ea-4a9e-9b81-18db05d13553">

After:
<img width="273" alt="Screenshot 2024-04-17 at 11 04 49 PM" src="https://github.com/wandb/weave/assets/112953339/8f7ee80a-5de0-4c27-a51d-050b1d542209">
