### PR TITLE
chore: show loading indicator until both sides load

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewerDiff.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewerDiff.tsx
@@ -1,6 +1,7 @@
 import {DiffEditor, Monaco} from '@monaco-editor/react';
 import React from 'react';
 
+import {Loading} from '../../../Loading';
 import {useWFHooks} from './pages/wfReactInterface/context';
 
 type OpCodeViewerDiffProps = {
@@ -32,6 +33,10 @@ export const OpCodeViewerDiff = ({
       });
     }
   };
+
+  if (loading) {
+    return <Loading centered size={25} />;
+  }
 
   return (
     <DiffEditor


### PR DESCRIPTION
When one side of diff loads before the other it momentarily compares an empty string to actual contents making it look like the entire definition has changed. This shows the loading indicator until both sides are ready.