### PR TITLE
fix: ObjectViewer collapsing when autorefresh enabled

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -71,6 +71,14 @@ const isSimpleData = (data: Data): boolean => {
   return isSimple;
 };
 
+// Use a deep comparison to avoid re-rendering when the data object hasn't really changed.
+const ObjectViewerSectionNonEmptyMemoed = React.memo(
+  (props: ObjectViewerSectionProps) => (
+    <ObjectViewerSectionNonEmpty {...props} />
+  ),
+  (prevProps, nextProps) => _.isEqual(prevProps, nextProps)
+);
+
 const ObjectViewerSectionNonEmpty = ({
   title,
   data,
@@ -199,7 +207,7 @@ export const ObjectViewerSection = ({
       isRef(value)
     ) {
       return (
-        <ObjectViewerSectionNonEmpty
+        <ObjectViewerSectionNonEmptyMemoed
           title={title}
           data={{Value: value}}
           noHide={noHide}


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Expanded-view-resets-after-a-few-seconds-clicking-to-expand-particular-fields-8fc4e993dd934bc68cf8279dd074c3e4?pvs=4

When you have the auto-refresh option enabled it causes the object viewer component to lose its expanded state.