### PR TITLE
fix: don't reset column visibility state on ref expansion

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -4,6 +4,7 @@ import {
   DataGridPro,
   GridColDef,
   GridColumnGroup,
+  GridColumnVisibilityModel,
   GridRowSelectionModel,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
@@ -387,8 +388,19 @@ export const RunsTable: FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedRefCols, client, tableStats]);
 
-  const {allShown, columnVisibilityModel, forceShowAll, setForceShowAll} =
+  const [forceShowAll, setForceShowAll] = useState(false);
+  const {allShown, columnVisibilityModel: defaultVisibilityModel} =
     useColumnVisibility(tableStats, isSingleOpVersion);
+  const [columnVisibilityModel, setColumnVisibilityModel] =
+    useState<GridColumnVisibilityModel>(defaultVisibilityModel);
+
+  useEffect(() => {
+    if (forceShowAll) {
+      // If not specified, columns default to visible.
+      setColumnVisibilityModel({});
+    }
+  }, [forceShowAll]);
+
   const showVisibilityAlert = !allShown && !forceShowAll;
 
   // Highlight table row if it matches peek drawer.
@@ -849,11 +861,8 @@ export const RunsTable: FC<{
         sorting: {
           sortModel: [{field: 'timestampMs', sort: 'desc'}],
         },
-        columns: {
-          columnVisibilityModel,
-        },
       };
-    }, [loading, columnVisibilityModel]);
+    }, [loading]);
 
   // Various interactions (correctly) cause new data to be loaded, which causes
   // a trickle of state updates. However, if the ultimate state is the same,
@@ -904,6 +913,10 @@ export const RunsTable: FC<{
         loading={loading}
         rows={tableData}
         initialState={initialState}
+        onColumnVisibilityModelChange={newModel =>
+          setColumnVisibilityModel(newModel)
+        }
+        columnVisibilityModel={columnVisibilityModel}
         rowHeight={38}
         columns={columns.cols as any}
         experimentalFeatures={{columnGrouping: true}}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/tableStats.ts
@@ -1,7 +1,6 @@
 import {GridColumnVisibilityModel} from '@mui/x-data-grid-pro';
 import stringify from 'json-stable-stringify';
 import _ from 'lodash';
-import {useState} from 'react';
 
 import {isRef} from '../Browse3/pages/common/util';
 
@@ -118,16 +117,12 @@ export const useColumnVisibility = (
   tableStats: TableStats,
   isSingleOpVersion: boolean
 ) => {
-  const [forceShowAll, setForceShowAll] = useState(false);
-
   const boringColumns = getBoringColumns(tableStats);
 
   const model: GridColumnVisibilityModel = {};
   for (const colName in tableStats.column) {
     if (boringColumns.includes(colName)) {
       model[colName] = false;
-    } else if (forceShowAll) {
-      model[colName] = true;
     } else if (isSingleOpVersion) {
       model[colName] = true;
     } else {
@@ -145,8 +140,6 @@ export const useColumnVisibility = (
   return {
     allShown,
     columnVisibilityModel: model,
-    forceShowAll,
-    setForceShowAll,
   };
 };
 


### PR DESCRIPTION
Internal Notion: https://www.notion.so/wandbai/Expanding-calls-table-ref-brings-back-hidden-columns-f00c7b210f934d9a9a8fdc0fa28cdc07

Change visibility model to be controlled rather than setting initial state. This prevents us from losing user's changes when they manually hide a column but then expand a ref column.