### PR TITLE
fix: show error instead of crash on invalid project

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -47,9 +47,13 @@ type TraceCallReadReq = {
   id: string;
 };
 
-export type TraceCallReadRes = {
+export type TraceCallReadSuccess = {
   call: TraceCallSchema;
 };
+export type TraceCallReadError = {
+  detail: string;
+};
+export type TraceCallReadRes = TraceCallReadSuccess | TraceCallReadError;
 
 interface TraceCallsFilter {
   op_names?: string[];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -176,7 +176,10 @@ const useCall = (key: CallKey | null): Loadable<CallSchema | null> => {
         result: cachedCall,
       };
     }
-    const result = callRes ? traceCallToUICallSchema(callRes.call) : null;
+    const result =
+      callRes && 'call' in callRes
+        ? traceCallToUICallSchema(callRes.call)
+        : null;
     if (callRes == null || loadingRef.current) {
       return {
         loading: true,


### PR DESCRIPTION
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1714067557396989

`callRead` can return a 403 with `{"detail":"Project not found"}`. Displaying an error is better than a crash. This doesn't address the related problem of why we are generating a bad link.

Before:
![image](https://github.com/wandb/weave/assets/112953339/f1f9683d-a8da-4e22-b714-1e01036e2769)

After:
![image](https://github.com/wandb/weave/assets/112953339/e61a3a83-18d7-4ddb-b041-d5e86a2b764e)
