### PR TITLE
chore: remove @mui/x-data-grid

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -39,7 +39,6 @@
     "@mui/icons-material": "^5.14.12",
     "@mui/lab": "^5.0.0-alpha.147",
     "@mui/material": "^5.14.12",
-    "@mui/x-data-grid": "^6.16.0",
     "@mui/x-data-grid-pro": "^6.16.0",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -3167,7 +3167,7 @@
     prop-types "^15.8.1"
     reselect "^4.1.8"
 
-"@mui/x-data-grid@6.18.1", "@mui/x-data-grid@^6.16.0":
+"@mui/x-data-grid@6.18.1":
   version "6.18.1"
   resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-6.18.1.tgz#0b34d7aebd5d8319524f78c9078dcc57becf06f0"
   integrity sha512-ibsrWwzM2lRRWB1xs/eop63kaxlXH/qar1S1rQx3fycJiYvK6fsM72jsScBNRlRZQQwRVSGI0ZPBsOZ+/tg7Qw==


### PR DESCRIPTION
We don't need to declare @mui/x-data-grid if we have @mui/x-data-grid-pro