### PR TITLE
fix: using mouse wheel with code editor

### DIFF
--- a/weave-js/src/components/CodeEditor.tsx
+++ b/weave-js/src/components/CodeEditor.tsx
@@ -13,6 +13,8 @@ const Editor = React.lazy(async () => {
   return await import('@monaco-editor/react');
 });
 
+const BORDER_PX = 1;
+
 type CodeEditorProps = {
   value: string;
   language?: string;
@@ -20,7 +22,11 @@ type CodeEditorProps = {
   onChange?: (value: string) => void;
   maxHeight?: number;
   minHeight?: number;
+
+  // To enable horizontal scrolling with the mouse wheel and not just the scrollbar,
+  // set handleMouseWheel to true and alwaysConsumeMouseWheel to false.
   handleMouseWheel?: boolean;
+  alwaysConsumeMouseWheel?: boolean;
 };
 
 export const CodeEditor = ({
@@ -31,6 +37,7 @@ export const CodeEditor = ({
   maxHeight,
   minHeight,
   handleMouseWheel,
+  alwaysConsumeMouseWheel,
 }: CodeEditorProps) => {
   const editorRef = useRef(null);
   const [height, setHeight] = useState(300);
@@ -38,7 +45,8 @@ export const CodeEditor = ({
   const updateHeight = () => {
     const editor: any = editorRef.current;
     if (editor) {
-      const contentHeight = editor.getContentHeight();
+      // box-sizing is border-box, so include border in height.
+      const contentHeight = editor.getContentHeight() + 2 * BORDER_PX;
       const realMin = minHeight
         ? Math.max(minHeight, contentHeight)
         : contentHeight;
@@ -72,11 +80,9 @@ export const CodeEditor = ({
     },
     overviewRulerLanes: 0,
     scrollBeyondLastLine: false,
-
-    // If we are autosizing, don't capture scroll events so we can scroll past editor.
-    // Note that this also means we have to explicitly use horizontal scrollbar to view clipped content.
     scrollbar: {
       handleMouseWheel: handleMouseWheel ?? false,
+      alwaysConsumeMouseWheel: alwaysConsumeMouseWheel ?? true,
     },
   };
 
@@ -91,7 +97,7 @@ export const CodeEditor = ({
       style={{
         width,
         height: `${height}px`,
-        border: `1px solid ${MOON_250}`,
+        border: `${BORDER_PX}px solid ${MOON_250}`,
       }}>
       <React.Suspense fallback={<></>}>
         <Editor

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -105,6 +105,8 @@ const ObjectViewerSectionNonEmpty = ({
         <CodeEditor
           value={JSON.stringify(data, null, 2)}
           language="json"
+          handleMouseWheel
+          alwaysConsumeMouseWheel={false}
           readOnly
         />
       );


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-18500

When rendering inputs/outputs as JSON, allow the user to use the mouse wheel to scroll horizontally.

Also fixes the height calculation - the 2px for top & bottom border were not being taken into account when setting the height in CSS, but should be as we are using `box-sizing: border-box`. This was causing the unwanted display of a vertical scrollbar to move up and down 2px.