### PR TITLE
chore: wrap more calls grid cells in error boundaries

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/RunsTable.tsx
@@ -626,7 +626,11 @@ export const RunsTable: FC<{
           renderCell: cellParams => {
             if (field in cellParams.row) {
               const value = (cellParams.row as any)[field];
-              return <CellValue value={value} isExpanded={isExpanded} />;
+              return (
+                <ErrorBoundary>
+                  <CellValue value={value} isExpanded={isExpanded} />
+                </ErrorBoundary>
+              );
             }
             return <NotApplicable />;
           },
@@ -727,10 +731,12 @@ export const RunsTable: FC<{
         },
         renderCell: cellParams => {
           return (
-            <CellValue
-              value={(cellParams.row as any).output}
-              isExpanded={isExpanded}
-            />
+            <ErrorBoundary>
+              <CellValue
+                value={(cellParams.row as any).output}
+                isExpanded={isExpanded}
+              />
+            </ErrorBoundary>
           );
         },
       });


### PR DESCRIPTION
A user is experiencing a total crash of the calls page coming from errors in SmallRef. (We believe that problem is due to bad ref parsing when delimiters are used as part of the object name - will be handled separately.)

This PR adds an error boundary around more cells (some already had it), keeping the page a bit useful.