### PR TITLE
fix: validate object name

### DIFF
--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1,7 +1,7 @@
 import abc
 import datetime
 import typing
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class CallSchema(BaseModel):
@@ -98,9 +98,12 @@ class ObjSchema(BaseModel):
     val: typing.Any
 
 
+RE_VALID_OBJECT_ID = r"^[A-Za-z0-9._-]+$"
+
+
 class ObjSchemaForInsert(BaseModel):
     project_id: str
-    object_id: str
+    object_id: str = Field(min_length=1, max_length=128, pattern=RE_VALID_OBJECT_ID)
     val: typing.Any
 
 


### PR DESCRIPTION
Using Pydantic for validation should give us enforcement in both SDK and server.

Please let me know if you have thoughts on what the max length / valid characters should be if different than what I have here.

With this change, trying to do something like:
`weave.publish(['felix', 'jimbo', 'billie'], 'foo/bar')`

Would yield:
```
ValidationError: 1 validation error for ObjSchemaForInsert
object_id
  String should match pattern '^[A-Za-z0-9._-]+$' [type=string_pattern_mismatch, input_value='foo/bar', input_type=str]
    For further information visit https://errors.pydantic.dev/2.6/v/string_pattern_mismatch
```

