### PR TITLE
chore: close lightbox on backdrop click

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueImage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueImage.tsx
@@ -36,6 +36,9 @@ export const CellValueImage = ({value}: CellValueImageProps) => {
         plugins={[Fullscreen, Zoom]}
         open={lightboxOpen}
         close={() => setLightboxOpen(false)}
+        controller={{
+          closeOnBackdropClick: true,
+        }}
         slides={[{src: value}]}
         render={{
           // Hide previous and next buttons because we only have one image.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewImage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewImage.tsx
@@ -77,6 +77,9 @@ export const ValueViewImage = ({value}: ValueViewImageProps) => {
         plugins={[Fullscreen, Zoom]}
         open={lightboxOpen}
         close={() => setLightboxOpen(false)}
+        controller={{
+          closeOnBackdropClick: true,
+        }}
         slides={[{src: value}]}
         render={{
           // Hide previous and next buttons because we only have one image.


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-18661
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1715084757272079?thread_ts=1715016670.672359&cid=C03BSTEBD7F

Seems convenient / expected to close the image viewing lightbox when you click on the backdrop.