### PR TITLE
chore(ui): Allow disabling search in ModifiedDropdown

### DIFF
--- a/weave-js/src/common/components/elements/ModifiedDropdown.tsx
+++ b/weave-js/src/common/components/elements/ModifiedDropdown.tsx
@@ -433,7 +433,7 @@ const ModifiedDropdown: FC<ModifiedDropdownProps> = React.memo(
         lazyLoad
         selectOnNavigation={false}
         searchQuery={searchQuery}
-        search={opts => opts}
+        search={search !== false ? opts => opts : false}
         renderLabel={renderLabel}
         onSearchChange={(e, data) => {
           props.onSearchChange?.(e, data);


### PR DESCRIPTION
The component `ModifiedDropdown` takes in prop `search` of type `boolean | ((options: DropdownItemProps[], value: string) => DropdownItemProps[])`. But `ModifiedDropdown` didn't handle passing in `search={false}` like the `semantic-ui-react` `Dropdown`, so all components using `ModifiedDropdown` had to be searchable. This fixes it so that `false` is correctly passed through to the `Dropdown` component.

Tested locally with the organization roles dropdown - it is no longer unnecessarily searchable.
<img width="189" alt="image" src="https://github.com/wandb/weave/assets/156136421/3306caf7-682d-4cc4-b82e-2cf32b090de0">
