### PR TITLE
chore(ui): Avoid searching if search is false in ModifiedDropdown

### DIFF
--- a/weave-js/src/common/components/elements/ModifiedDropdown.tsx
+++ b/weave-js/src/common/components/elements/ModifiedDropdown.tsx
@@ -131,13 +131,15 @@ const ModifiedDropdown: FC<ModifiedDropdownProps> = React.memo(
       if (firstRenderRef.current) {
         return;
       }
-      doSearch(searchQuery);
-      if (prevDoSearch !== doSearch) {
-        prevDoSearch?.cancel();
-        doSearch.flush();
+      if (search !== false) {
+        doSearch(searchQuery);
+        if (prevDoSearch !== doSearch) {
+          prevDoSearch?.cancel();
+          doSearch.flush();
+        }
       }
       // eslint-disable-next-line
-    }, [searchQuery, doSearch]);
+    }, [searchQuery, doSearch, search]);
     useEffect(() => {
       firstRenderRef.current = false;
     }, []);


### PR DESCRIPTION
We should avoid wasting time searching if the component isn't even searchable. This comes up because `doSearch` seems to be triggered onChange.

Tested locally with a `console.log` to verify that `doSearch` is no longer triggered when changing options if `search={false}`