### PR TITLE
chore: fix generated variable name for table row ref use

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
@@ -30,8 +30,7 @@ export const TabUseDataset = ({
   const label = isParentObject ? 'dataset version' : isRow ? 'row' : 'object';
   let pythonName = isValidVarName(name) ? name : 'dataset';
   if (isRow) {
-    pythonName +=
-      '_row' + ref.artifactRefExtra?.substring(ROW_PATH_PREFIX.length);
+    pythonName += '_row';
   }
 
   // TODO: Row references are not yet supported, you get:


### PR DESCRIPTION
We used to use the row index as part of the generated variable name. After it got switched to a digest it is no longer nice to append that.

Before:
<img width="635" alt="Screenshot 2024-05-08 at 7 33 08 PM" src="https://github.com/wandb/weave/assets/112953339/173a3efd-cb11-4f74-a82e-ec92864199c3">

After:
<img width="336" alt="Screenshot 2024-05-08 at 7 33 21 PM" src="https://github.com/wandb/weave/assets/112953339/4256ca9b-5281-4518-b0ad-71cd92051ce7">
