### PR TITLE
chore(weave): fix migration down

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -154,7 +154,7 @@ class ClickHouseTraceServerMigrator:
             for i in range(current_version, target_version, -1):
                 if migration_map[i]["down"] is None:
                     raise Exception(f"Missing down migration file for version {i}")
-                res.append((i-1, f"{migration_map[i]['down']}"))
+                res.append((i - 1, f"{migration_map[i]['down']}"))
             return res
 
         return []

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -154,7 +154,7 @@ class ClickHouseTraceServerMigrator:
             for i in range(current_version, target_version, -1):
                 if migration_map[i]["down"] is None:
                     raise Exception(f"Missing down migration file for version {i}")
-                res.append((i, f"{migration_map[i]['down']}"))
+                res.append((i-1, f"{migration_map[i]['down']}"))
             return res
 
         return []


### PR DESCRIPTION
Off by 1 error, resulting in `curr_version` always being behind by 1.  

credit @jamie-rasmussen with the fix

This branch: 
<img width="847" alt="Screenshot 2024-05-09 at 5 56 06 PM" src="https://github.com/wandb/weave/assets/19414170/f5e064ba-a201-4a01-950b-b99ca6ecd901">
