### PR TITLE
chore(weave): fix initial down migration

### DIFF
--- a/weave/trace_server/migrations/001_init.down.sql
+++ b/weave/trace_server/migrations/001_init.down.sql
@@ -1,7 +1,7 @@
 DROP TABLE call_parts;
 DROP TABLE calls_merged;
 
-DROP TABLE objects;
+DROP TABLE object_versions;
 DROP TABLE objects_deduped;
 
 DROP TABLE tables;

--- a/weave/trace_server/migrations/001_init.down.sql
+++ b/weave/trace_server/migrations/001_init.down.sql
@@ -2,7 +2,7 @@ DROP TABLE call_parts;
 DROP TABLE calls_merged;
 
 DROP TABLE object_versions;
-DROP TABLE objects_deduped;
+DROP TABLE object_versions_deduped;
 
 DROP TABLE tables;
 DROP TABLE tables_deduped;

--- a/weave/trace_server/migrations/001_init.down.sql
+++ b/weave/trace_server/migrations/001_init.down.sql
@@ -1,14 +1,15 @@
 DROP TABLE call_parts;
 DROP TABLE calls_merged;
+DROP VIEW calls_merged_view;
 
 DROP TABLE object_versions;
-DROP TABLE object_versions_deduped;
+DROP VIEW object_versions_deduped;
 
 DROP TABLE tables;
-DROP TABLE tables_deduped;
+DROP VIEW tables_deduped;
 
 DROP TABLE table_rows;
-DROP TABLE table_rows_deduped;
+DROP VIEW table_rows_deduped;
 
 DROP TABLE files;
-DROP TABLE files_deduped;
+DROP VIEW files_deduped;


### PR DESCRIPTION
Literally of zero practical value but the 001 initial down migration is broken. 