### PR TITLE
chore(weave): Fixes issue where graph client is closed but trace object still in memory

### DIFF
--- a/weave/tests/test_pydantic.py
+++ b/weave/tests/test_pydantic.py
@@ -81,3 +81,20 @@ def test_pydantic_nested_type():
         },
         "b": "int",
     }
+
+
+def test_pydantic_v1(client):
+    from pydantic import v1
+
+    class MyV1Object(v1.BaseModel):
+        val: int
+
+    class MyWeaveObject(weave.Object):
+        inner: MyV1Object
+
+    @weave.op
+    def get_inner(obj: MyWeaveObject) -> int:
+        return obj.inner.val
+
+    res = get_inner(MyWeaveObject(inner=MyV1Object(val=1)))
+    assert res == 1

--- a/weave/tests/test_pydantic.py
+++ b/weave/tests/test_pydantic.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 import pydantic
 
 import weave
@@ -90,7 +90,8 @@ def test_pydantic_v1(client):
         val: int
 
     class MyWeaveObject(weave.Object):
-        inner: MyV1Object
+        inner: Any
+        # inner: MyV1Object # v1 properties not yet supported
 
     @weave.op
     def get_inner(obj: MyWeaveObject) -> int:

--- a/weave/trace/tests/test_vals.py
+++ b/weave/trace/tests/test_vals.py
@@ -1,6 +1,7 @@
 import pytest
 
 from weave.trace.vals import TraceObject
+import weave
 
 
 def test_traceobject_properties():
@@ -11,3 +12,28 @@ def test_traceobject_properties():
 
     to = TraceObject(A(), None, None, None)
     assert to.x == 1
+
+
+def test_traceobject_access_after_init_termination(client):
+    my_obj = None
+
+    class MyObj(weave.Object):
+        val: int
+
+    @weave.op()
+    def my_op(obj: MyObj) -> None:
+        nonlocal my_obj
+        my_obj = obj
+
+    my_op(MyObj(val=1))
+
+    assert my_obj.val == 1
+
+    # Here we explicitly close the client in order to
+    # simulate a situation where the client is closed
+    # but a reference to a trace object still exists.
+    from weave import context_state
+
+    context_state._graph_client.set(None)
+
+    assert my_obj.val == 1

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -20,7 +20,7 @@ from weave.table import Table
 from weave.trace.serialize import from_json
 from weave.trace.errors import InternalError
 from weave.trace.object_record import ObjectRecord
-from weave.graph_client_context import require_graph_client
+from weave.graph_client_context import get_graph_client
 from weave.trace_server.trace_server_interface import (
     TraceServerInterface,
     _TableRowFilter,
@@ -133,7 +133,14 @@ def attribute_access_result(self: object, val_attr_val: Any, attr_name: str) -> 
 
     new_ref = ref.with_attr(attr_name)
 
-    gc = require_graph_client()
+    gc = get_graph_client()
+
+    if gc is None:
+        # In the case that the graph client has been closed but the user still
+        # maintains a reference to this object, we should gracefully fallback
+        # to the raw value.
+        return val_attr_val
+
     return make_trace_obj(
         val_attr_val,
         new_ref,

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -4,6 +4,7 @@ import dataclasses
 import operator
 import typing
 from pydantic import BaseModel
+from pydantic import v1 as pydantic_v1
 
 from weave.trace.op import Op
 from weave.trace.refs import (
@@ -460,7 +461,10 @@ def make_trace_obj(
             )
         val = val.__get__(parent, type(parent))
     box_val = box.box(val)
-    setattr(box_val, "ref", new_ref)
+    if isinstance(box_val, pydantic_v1.BaseModel):
+        box_val.__dict__["ref"] = new_ref
+    else:
+        setattr(box_val, "ref", new_ref)
     return box_val
 
 


### PR DESCRIPTION
Fixes 2 of the issues reported in: https://github.com/wandb/weave/issues/1584

1. Fixes error caused by using a PydanticV1 object as a property
2. Fixes the error caused by having no graph client, but retaining a reference to a trace object

Does not fix:

* [ ] Calling `await` inside of a colab cell will destroy the weave init context
    * This is almost certainly always going to break until google updates their ipython kernel to > 5.x.x. Workarounds: call weave.init after any cell that uses `await`. Or manually upgrade the kernel (which might have unintended consequences with google colab)
* [ ] Typing a weave object with a pydanticv1 property type does not work still
    * This will need to be a followup

