### PR TITLE
security(dev): upgrade python packages

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,6 +8,7 @@ COPY requirements.* /root/
 WORKDIR /root
 RUN python3 -m venv venv
 RUN --mount=type=cache,target=/root/.cache /bin/bash -c "source venv/bin/activate && \
+    pip install --upgrade pip && \
     pip install -r requirements.test.txt -r requirements.dev.txt && \
     pip install \"spacy>=3.0.0,<4.0.0\" && python3 -m spacy download en_core_web_sm"
 

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -21,6 +21,8 @@ supervisor>=4.2.5
 clickhouse_connect==0.7.0
 uvicorn>=0.27.0
 fastapi>=0.110.0
+tqdm>=4.66.3  # CVE 2024-34062
+cryptography>=42.0.7  # CVE 2023-23931
 
 # Integration Tests
 pytest-recording==0.13.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ rich>=13.7.0
 aiohttp>=3.8.3
 aiofiles>=22.1.0
 aioprocessing>=2.0.1
-Werkzeug>=2.0.0
+Werkzeug>=3.0.3  # CVE 2024-34069 
 janus>=1.0.0
 
 # we use this for logger, could probably skip it


### PR DESCRIPTION
Addresses the following CVEs:
```
tqdm>=4.66.3  # CVE 2024-34062
cryptography>=42.0.7  # CVE 2023-23931
Werkzeug>=3.0.3 # CVE 2024-34069
```