### PR TITLE
fix: table ref parsing

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
@@ -176,12 +176,14 @@ const weaveRefStringToRefDict = (uri: string): WFNaiveRefDict => {
     scheme,
     entityName: entity,
     projectName: project,
-    artifactName,
     weaveKind,
-    artifactVersion: versionCommitHash,
     artifactRefExtra,
   } = parsed;
-
+  let {artifactName, artifactVersion: versionCommitHash} = parsed;
+  if (parsed.weaveKind === 'table') {
+    artifactName = versionCommitHash;
+    versionCommitHash = '';
+  }
   const refExtraTuples: WFNaiveRefDict['refExtraTuples'] = [];
   if (artifactRefExtra) {
     const refExtraParts = artifactRefExtra.split('/');

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -585,14 +585,14 @@ export const parseRef = (ref: string): ObjectRef => {
     const trimmed = trimStartChar(url.pathname, '/');
     const tableMatch = trimmed.match(RE_WEAVE_TABLE_REF_PATHNAME);
     if (tableMatch !== null) {
-      const [entity, project, artifactVer] = tableMatch.slice(1);
+      const [entity, project, digest] = tableMatch.slice(1);
       return {
         scheme: 'weave',
         entityName: entity,
         projectName: project,
         weaveKind: 'table' as WeaveKind,
         artifactName: '',
-        artifactVersion: artifactVer,
+        artifactVersion: digest,
         artifactRefExtra: '',
       };
     }


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-18860

This one is a little confusing. The problem addressed here is that my change in https://github.com/wandb/weave/pull/1625 broke dataset rendering in the UI.

We have multiple functions that parse ref strings into objects. 
A table ref looks like: `weave:///entity/project/table/b8dfcb84974c481fd98fd9878e56be02ebef3e2da44becb59d1863cd643b83fe`
My understanding from Shawn is that the long identifier is its "digest" - a checksum of its rows.

The `parseRef` function puts that value in the `artifactVersion` field and sets `artifactName` to ''. When I rewrote parseRef to fix the user problems of slashes in artifact names I preserved that behavior.

The `refStringToRefDict` function was putting that value in the `artifactName` field and setting `versionCommitHash` to ''. I (unintentionally) did not preserve this behavior when I rewrote it to use `parseRef` for more consistent ref parsing.

This PR unbreaks things by making the functions act as they used to. But it would be good to clean things up more properly to handle table ref paring consistently. 