### PR TITLE
fix: when there is a network error, display error panel instead of no results

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -7,6 +7,7 @@ import {
 import _ from 'lodash';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import {ErrorPanel} from '../../../../ErrorPanel';
 import {Loading} from '../../../../Loading';
 import {LoadingDots} from '../../../../LoadingDots';
 import {Timestamp} from '../../../../Timestamp';
@@ -112,6 +113,9 @@ export const FilterableObjectVersionsTable: React.FC<{
 
   if (filteredObjectVersions.loading) {
     return <Loading centered />;
+  }
+  if (filteredObjectVersions.error) {
+    return <ErrorPanel />;
   }
 
   // TODO: Only show the empty state if no filters other than baseObjectClass

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -6,6 +6,7 @@ import {
 } from '@mui/x-data-grid-pro';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import {ErrorPanel} from '../../../../ErrorPanel';
 import {Loading} from '../../../../Loading';
 import {LoadingDots} from '../../../../LoadingDots';
 import {Timestamp} from '../../../../Timestamp';
@@ -181,6 +182,9 @@ export const FilterableOpVersionsTable: React.FC<{
 
   if (filteredOpVersions.loading) {
     return <Loading centered />;
+  }
+  if (filteredOpVersions.error) {
+    return <ErrorPanel />;
   }
 
   // TODO: Only show the empty state if unfiltered

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cgDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cgDataModelHooks.ts
@@ -91,6 +91,7 @@ import {
   CallKey,
   CallSchema,
   Loadable,
+  LoadableWithError,
   ObjectVersionFilter,
   ObjectVersionKey,
   ObjectVersionSchema,
@@ -277,7 +278,7 @@ const useOpVersions = (
   filter: OpVersionFilter,
   limit?: number,
   opts?: {skip?: boolean}
-): Loadable<OpVersionSchema[]> => {
+): LoadableWithError<OpVersionSchema[]> => {
   let dataNode = useOpVersionsNode(entity, project, filter);
   if (limit) {
     dataNode = opLimit({arr: dataNode, limit: constNumber(limit)});
@@ -289,6 +290,7 @@ const useOpVersions = (
     if (opts?.skip) {
       return {
         loading: false,
+        error: null,
         result: [],
       };
     }
@@ -308,6 +310,7 @@ const useOpVersions = (
     if (dataValue.loading) {
       return {
         loading: true,
+        error: null,
         result,
       };
     } else {
@@ -324,6 +327,7 @@ const useOpVersions = (
       });
       return {
         loading: false,
+        error: null,
         result,
       };
     }
@@ -397,7 +401,7 @@ const useRootObjectVersions = (
   filter: ObjectVersionFilter,
   limit?: number,
   opts?: {skip?: boolean}
-): Loadable<ObjectVersionSchema[]> => {
+): LoadableWithError<ObjectVersionSchema[]> => {
   let dataNode = useRootObjectVersionsNode(entity, project, filter);
   if (limit) {
     dataNode = opLimit({arr: dataNode, limit: constNumber(limit)});
@@ -408,6 +412,7 @@ const useRootObjectVersions = (
     if (opts?.skip) {
       return {
         loading: false,
+        error: null,
         result: [],
       };
     }
@@ -438,6 +443,7 @@ const useRootObjectVersions = (
     if (dataValue.loading) {
       return {
         loading: true,
+        error: null,
         result,
       };
     } else {
@@ -457,6 +463,7 @@ const useRootObjectVersions = (
       });
       return {
         loading: false,
+        error: null,
         result,
       };
     }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -161,7 +161,7 @@ export type WFDataModelHooksInterface = {
     filter: OpVersionFilter,
     limit?: number,
     opts?: {skip?: boolean}
-  ) => Loadable<OpVersionSchema[]>;
+  ) => LoadableWithError<OpVersionSchema[]>;
   useObjectVersion: (
     key: ObjectVersionKey | null
   ) => Loadable<ObjectVersionSchema | null>;
@@ -171,7 +171,7 @@ export type WFDataModelHooksInterface = {
     filter: ObjectVersionFilter,
     limit?: number,
     opts?: {skip?: boolean}
-  ) => Loadable<ObjectVersionSchema[]>;
+  ) => LoadableWithError<ObjectVersionSchema[]>;
   // `useRefsData` is in beta while we integrate Shawn's new Object DB
   useRefsData: (refUris: string[], tableQuery?: TableQuery) => Loadable<any[]>;
   // `useApplyMutationsToRef` is in beta while we integrate Shawn's new Object DB


### PR DESCRIPTION
When we have a network error, the Operations and Objects pages show our "No objects yet" UI instead of indicating that there was an error. Network errors are common in development (fix-gov issue), and it can be confusing what has happened given that you are possibly switching between a prod and local datastore.

The traces page also has this issue, but saving that for a different PR (need to think about export button in header for example).  Also, @tssweeney could we get rid of cgDataModelHooks.ts entirely?

Misleading current behavior:
![image](https://github.com/wandb/weave/assets/112953339/19b80542-42c3-4ea1-882a-a84db724e5c7)

After this PR:
![image](https://github.com/wandb/weave/assets/112953339/ca8fea89-a64e-40eb-bf0c-224b6a315f1b)
