### PR TITLE
feat: Pluggable object serialization

### DIFF
--- a/weave/tests/test_anonymous_ops.py
+++ b/weave/tests/test_anonymous_ops.py
@@ -17,7 +17,7 @@ def test_named_op(client: weave_client.WeaveClient) -> str:
     call = calls[0]
     assert (
         call.op_name
-        == "weave:///shawn/test-project/op/anonymous_op:SP4LIwNDvmCFjxXhKSA1JysAqEB0x39RH03gXjBLOkc"
+        == "weave:///shawn/test-project/op/anonymous_op:tzUhDyzVm5bqQsuqh5RT4axEXSosyLIYZn9zbRyenaw"
     )
     assert call.inputs == {"a": 1}
     assert call.output == {"c": 3}
@@ -39,7 +39,7 @@ def test_anonymous_op(client: weave_client.WeaveClient) -> str:
     call = calls[0]
     assert (
         call.op_name
-        == "weave:///shawn/test-project/op/anonymous_op:SP4LIwNDvmCFjxXhKSA1JysAqEB0x39RH03gXjBLOkc"
+        == "weave:///shawn/test-project/op/anonymous_op:tzUhDyzVm5bqQsuqh5RT4axEXSosyLIYZn9zbRyenaw"
     )
     assert call.inputs == {"a": 1}
     assert call.output == {"c": 3}
@@ -65,7 +65,7 @@ def test_anonymous_op_with_config(client: weave_client.WeaveClient) -> str:
     call = calls[0]
     assert (
         call.op_name
-        == "weave:///shawn/test-project/op/anonymous_op:KGg1k36GykT4eYSaanEY7KEptRZxz0DYcLtvyjX890A"
+        == "weave:///shawn/test-project/op/anonymous_op:MhzyATsFCgR3S91607RSLd2JrqA8Esk2F6hjKfwtwA0"
     )
     assert call.inputs == {"a": 1}
     assert call.output == {"c": 3}

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -680,7 +680,7 @@ def test_trace_call_sort(client):
     for i in range(3):
         basic_op({"prim": i, "list": [i], "dict": {"inner": i}}, i / 10)
 
-    for (first, last, sort_by) in [
+    for first, last, sort_by in [
         (2, 0, [tsi._SortBy(field="started_at", direction="desc")]),
         (2, 0, [tsi._SortBy(field="inputs.in_val.prim", direction="desc")]),
         (2, 0, [tsi._SortBy(field="inputs.in_val.list.0", direction="desc")]),

--- a/weave/tests/test_op_versioning.py
+++ b/weave/tests/test_op_versioning.py
@@ -480,6 +480,39 @@ def test_op_return_return_custom_class(client, strict_op_saving):
     assert saved_code == EXPECTED_RETURN_CUSTOM_CLASS_CODE
 
 
+EXPECTED_NESTED_FUNCTION_CODE = """import weave
+
+@weave.op()
+def some_d(v: int):
+    def internal_fn(x):
+        return x + 3
+
+    return internal_fn(v)
+"""
+
+
+def test_op_nested_function(client, strict_op_saving):
+
+    @weave.op()
+    def some_d(v: int):
+        def internal_fn(x):
+            return x + 3
+
+        return internal_fn(v)
+
+    assert some_d(1) == 4
+
+    ref = weave.obj_ref(some_d)
+    assert ref is not None
+
+    saved_code = get_saved_code(client, ref)
+    print("SAVED_CODE")
+    print(saved_code)
+
+    assert saved_code == EXPECTED_NESTED_FUNCTION_CODE
+    assert weave.ref(ref.uri()).get()(2) == 5
+
+
 def test_op_basic_execution(client):
     @weave.op()
     def adder(v: int) -> int:

--- a/weave/tests/test_op_versioning.py
+++ b/weave/tests/test_op_versioning.py
@@ -443,6 +443,43 @@ def test_op_return_typeddict_annotation(client, strict_op_saving):
     assert op2(2) == {"val": 2}
 
 
+EXPECTED_RETURN_CUSTOM_CLASS_CODE = """import weave
+
+class MyCoolClass:
+    val: int
+
+    def __init__(self, val):
+        self.val = val
+
+@weave.op()
+def some_d(v: int):
+    return MyCoolClass(v)
+"""
+
+
+def test_op_return_return_custom_class(client, strict_op_saving):
+    class MyCoolClass:
+        val: int
+
+        def __init__(self, val):
+            self.val = val
+
+    @weave.op()
+    def some_d(v: int):
+        return MyCoolClass(v)
+
+    assert some_d(1).val == 1
+
+    ref = weave.obj_ref(some_d)
+    assert ref is not None
+
+    saved_code = get_saved_code(client, ref)
+    print("SAVED_CODE")
+    print(saved_code)
+
+    assert saved_code == EXPECTED_RETURN_CUSTOM_CLASS_CODE
+
+
 def test_op_basic_execution(client):
     @weave.op()
     def adder(v: int) -> int:

--- a/weave/tests/test_op_versioning.py
+++ b/weave/tests/test_op_versioning.py
@@ -420,7 +420,7 @@ def some_d(v: int) -> SomeDict:
 """
 
 
-def test_op_return_typeddict_annotation(client):
+def test_op_return_typeddict_annotation(client, strict_op_saving):
     class SomeDict(typing.TypedDict):
         val: int
 

--- a/weave/tests/test_op_versioning.py
+++ b/weave/tests/test_op_versioning.py
@@ -492,7 +492,6 @@ def some_d(v: int):
 
 
 def test_op_nested_function(client, strict_op_saving):
-
     @weave.op()
     def some_d(v: int):
         def internal_fn(x):

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -371,7 +371,6 @@ def test_saveload_op(client):
 
 
 def test_saveload_customtype(client):
-
     class MyCustomObj:
         a: int
         b: str

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -200,7 +200,7 @@ def test_call_create(client):
     client.finish_call(call, "hello")
     result = client.call(call.id)
     expected = weave_client.Call(
-        op_name="weave:///shawn/test-project/op/x:SP4LIwNDvmCFjxXhKSA1JysAqEB0x39RH03gXjBLOkc",
+        op_name="weave:///shawn/test-project/op/x:tzUhDyzVm5bqQsuqh5RT4axEXSosyLIYZn9zbRyenaw",
         project_id="shawn/test-project",
         trace_id=RegexStringMatcher(".*"),
         parent_id=None,
@@ -221,7 +221,7 @@ def test_calls_query(client):
     result = list(client.calls(weave_client._CallsFilter(op_names=[call1.op_name])))
     assert len(result) == 2
     assert result[0] == weave_client.Call(
-        op_name="weave:///shawn/test-project/op/x:SP4LIwNDvmCFjxXhKSA1JysAqEB0x39RH03gXjBLOkc",
+        op_name="weave:///shawn/test-project/op/x:tzUhDyzVm5bqQsuqh5RT4axEXSosyLIYZn9zbRyenaw",
         project_id="shawn/test-project",
         trace_id=RegexStringMatcher(".*"),
         parent_id=None,
@@ -229,7 +229,7 @@ def test_calls_query(client):
         id=call0.id,
     )
     assert result[1] == weave_client.Call(
-        op_name="weave:///shawn/test-project/op/x:SP4LIwNDvmCFjxXhKSA1JysAqEB0x39RH03gXjBLOkc",
+        op_name="weave:///shawn/test-project/op/x:tzUhDyzVm5bqQsuqh5RT4axEXSosyLIYZn9zbRyenaw",
         project_id="shawn/test-project",
         trace_id=RegexStringMatcher(".*"),
         parent_id=call0.id,

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -108,7 +108,9 @@ def encode_custom_obj(obj: Any) -> Optional[dict]:
     serializer.save(obj, art, "obj")
 
     # Save the load_instance function as an op, and store a reference
-    # to that op in the saved value record.
+    # to that op in the saved value record. We don't do this if what
+    # we're saving is actually an op, since that would be self-referential
+    # (the op loading code is always present, we don't need to save/load it).
     load_op_uri = None
     if serializer.id() != "Op":
         # Ensure load_instance is an op

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -146,19 +146,17 @@ def decode_custom_obj(
         if not isinstance(ref, ObjectRef):
             raise ValueError(f"Expected ObjectRef, got {load_instance_op_uri}")
         wc = require_graph_client()
-        # Can return None if op load fails. I think this might happen
-        # if a library is not installed?
-        # TODO: check this. We need to raise an error in this case
-        # if a library is not installed!
         load_instance_op = wc.get(ref)
+        if load_instance_op == None:  # == to check for None or BoxedNone
+            raise ValueError(
+                f"Failed to load op needed to decoded object of type {weave_type}. See logs above for more information."
+            )
 
     if load_instance_op is None:
         serializer = get_serializer_by_id(weave_type["type"])
         if serializer is None:
             raise ValueError(f"No serializer found for {weave_type}")
         load_instance_op = serializer.load
-        # wb_type = types.TypeRegistry.type_from_dict(weave_type)
-        # load_instance_op = wb_type.load_instance
 
     art = MemTraceFilesArtifact(
         encoded_path_contents,

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -14,7 +14,6 @@ from weave import box
 
 from weave import context_state
 
-from weave.trace.op_type import OpType
 from .constants import TRACE_CALL_EMOJI
 
 if TYPE_CHECKING:
@@ -152,9 +151,6 @@ class Op:
         if self._on_output_handler is not None:
             raise ValueError("Cannot set on_output_handler multiple times")
         self._on_output_handler = on_output
-
-
-OpType.instance_classes = Op
 
 
 class BoundOp(Op):

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -256,7 +256,9 @@ def get_code_deps(
     import_code = []
     code = []
     for var_name in external_vars:
-        var_value = resolve_var(fn, var_name)
+        var_value = None
+        if isinstance(fn, py_types.FunctionType):
+            var_value = resolve_var(fn, var_name)
         # var_value = fn.__globals__.get(var_name)
         if var_value is None:
             if getattr(builtins, var_name, None):
@@ -270,7 +272,7 @@ def get_code_deps(
             if var_value.__name__ != var_name:
                 import_line += f" as {var_name}"
             import_code.append(import_line)
-        elif isinstance(var_value, py_types.FunctionType):
+        elif isinstance(var_value, (py_types.FunctionType, type)):
             if var_value.__module__ == fn.__module__:
                 # For now, if the function is in another module.
                 # we just import it. This is ok for libraries, but not
@@ -284,7 +286,7 @@ def get_code_deps(
                 import_code += fn_import_code
 
                 code += fn_code
-                code.append(inspect.getsource(var_value))
+                code.append(textwrap.dedent(inspect.getsource(var_value)))
 
                 warnings += fn_warnings
             else:

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -220,13 +220,12 @@ def get_code_deps(
                 dependencies are available for the function body.
             warnings: list[str], any warnings that occurred during the process.
     """
+    warnings: list[str] = []
     if depth > 20:
         warnings = [
             "Recursion depth exceeded in get_code_deps, this may indicate circular depenencies, which are not yet handled."
         ]
         return {"import_code": [], "code": [], "warnings": warnings}
-    # Generates repeats.
-    warnings: list[str] = []
 
     source = textwrap.dedent(inspect.getsource(fn))
     try:

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -45,7 +45,7 @@ def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
         "_type": encoded["_type"],
         "weave_type": encoded["weave_type"],
         "files": file_digests,
-        # "load_op": encoded["load_op"],
+        "load_op": encoded["load_op"],
     }
 
 

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -46,9 +46,9 @@ def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
         "weave_type": encoded["weave_type"],
         "files": file_digests,
     }
-    load_op_uri = encoded.get("load_op_uri")
+    load_op_uri = encoded.get("load_op")
     if load_op_uri:
-        result["load_op_uri"] = load_op_uri
+        result["load_op"] = load_op_uri
     return result
 
 

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -41,12 +41,15 @@ def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
             FileCreateReq(project_id=project_id, name=name, content=val)
         )
         file_digests[name] = file_response.digest
-    return {
+    result = {
         "_type": encoded["_type"],
         "weave_type": encoded["weave_type"],
         "files": file_digests,
-        "load_op": encoded["load_op"],
     }
+    load_op_uri = encoded.get("load_op_uri")
+    if load_op_uri:
+        result["load_op_uri"] = load_op_uri
+    return result
 
 
 REP_LIMIT = 1000

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -45,6 +45,7 @@ def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
         "_type": encoded["_type"],
         "weave_type": encoded["weave_type"],
         "files": file_digests,
+        # "load_op": encoded["load_op"],
     }
 
 
@@ -97,7 +98,9 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
                 )
             elif val_type == "CustomWeaveType":
                 files = _load_custom_obj_files(project_id, server, obj["files"])
-                return custom_objs.decode_custom_obj(obj["weave_type"], files)
+                return custom_objs.decode_custom_obj(
+                    obj["weave_type"], files, obj.get("load_op")
+                )
             else:
                 return ObjectRecord(
                     {k: from_json(v, project_id, server) for k, v in obj.items()}

--- a/weave/trace/serializer.py
+++ b/weave/trace/serializer.py
@@ -15,7 +15,7 @@ class Serializer:
 SERIALIZERS = []
 
 
-def register_serializer(target_class: type, save: Callable, load: Callable):
+def register_serializer(target_class: type, save: Callable, load: Callable) -> None:
     SERIALIZERS.append(Serializer(target_class, save, load))
 
 

--- a/weave/trace/serializer.py
+++ b/weave/trace/serializer.py
@@ -1,0 +1,33 @@
+from typing import Callable, Any, Optional
+from dataclasses import dataclass
+
+
+@dataclass
+class Serializer:
+    target_class: type
+    save: Callable
+    load: Callable
+
+    def id(self) -> str:
+        return self.target_class.__name__
+
+
+SERIALIZERS = []
+
+
+def register_serializer(target_class: type, save: Callable, load: Callable):
+    SERIALIZERS.append(Serializer(target_class, save, load))
+
+
+def get_serializer_by_id(id: str) -> Optional[Serializer]:
+    for serializer in SERIALIZERS:
+        if serializer.id() == id:
+            return serializer
+    return None
+
+
+def get_serializer_for_obj(obj: Any) -> Optional[Serializer]:
+    for serializer in SERIALIZERS:
+        if isinstance(obj, serializer.target_class):
+            return serializer
+    return None

--- a/weave/trace/serializer.py
+++ b/weave/trace/serializer.py
@@ -1,3 +1,39 @@
+"""Pluggable object serializers for Weave
+
+Example:
+
+```
+import faiss
+
+
+from weave.trace import serializer
+
+
+def save_instance(obj: faiss.Index, artifact, name: str) -> None:
+    with artifact.writeable_file_path(f"{name}.faissindex") as write_path:
+        faiss.write_index(obj, write_path)
+
+
+def load_instance(
+    artifact,
+    name: str,
+) -> faiss.Index:
+    return faiss.read_index(artifact.path(f"{name}.faissindex"))
+
+
+serializer.register_serializer(faiss.Index, save_instance, load_instance)
+```
+
+After the register_serializer call, if the user tries to save an object
+that has a faiss.Index attribute, Weave will store the full FAISS index
+instead of just a repr string.
+
+We will also save the load_instance method as an op, and add a reference
+to the load op from the saved object, so that the object can be correctly
+deserialized in a Python runtime that does not have the serializer
+registered.
+"""
+
 from typing import Callable, Any, Optional
 from dataclasses import dataclass
 

--- a/weave/trace/serializer.py
+++ b/weave/trace/serializer.py
@@ -45,6 +45,13 @@ class Serializer:
     load: Callable
 
     def id(self) -> str:
+        ser_id = self.target_class.__module__ + "." + self.target_class.__name__
+        if ser_id.startswith("weave."):
+            # Special case for weave.Op (which is current weave.trace.op.Op).
+            # The id is just Op, since we've already already stored this as
+            # "Op" in the database.
+            if ser_id.endswith(".Op"):
+                return "Op"
         return self.target_class.__name__
 
 

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -419,10 +419,12 @@ class WeaveClient:
         )
         return response.objs
 
-    def _save_op(self, op: Op) -> Ref:
+    def _save_op(self, op: Op, name: Optional[str] = None) -> Ref:
         if op.ref is not None:
             return op.ref
-        op_def_ref = self._save_object(op, op.name)
+        if name is None:
+            name = op.name
+        op_def_ref = self._save_object(op, name)
         op.ref = op_def_ref  # type: ignore
         return op_def_ref
 


### PR DESCRIPTION
This enables users to register Serializers with Weave, like so:

```python
import faiss


from weave.trace import serializer


def save_instance(obj: faiss.Index, artifact, name: str) -> None:
    with artifact.writeable_file_path(f"{name}.faissindex") as write_path:
        faiss.write_index(obj, write_path)


def load_instance(
    artifact,
    name: str,
) -> faiss.Index:
    return faiss.read_index(artifact.path(f"{name}.faissindex"))


serializer.register_serializer(faiss.Index, save_instance, load_instance)
```

After the `register_serializer` call, if the user tries to save an object that has a `faiss.Index` attribute, Weave will store the full FAISS index instead of just a __repr__ string.

This replaces the prior mechanism that relied on the older weave.Type. We were only relying on that for Op saving. The new implementation is fully compatible and generates objects with the same digests.

We will also save the load_instance method as an op, and add a reference to the load op from the saved object, so that the object can be correctly deserialized in a Python runtime that does not have the serializer registered.

So the effect is that objects with custom typed attributes are fully relocatable.

This PR also improves op serialization, notably it makes it so that ops that classes refered to by ops are captured correctly.

TODO:
- [x] Fix anonymous op issues, they are now annotated with @weave.op so I need to fix digests
- [x] Consider if we want `<module>.<name>` in the encoded weave type string, or just `<name>`
- [x] Register Serializers by ID string instead of class, so we don't need to import libraries to register serializers.
  - I chose not to do this. It's complicated to handle registering superclasses.