### PR TITLE
feat(weave): backend for deletion of calls

### DIFF
--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -139,6 +139,7 @@ def test_trace_server_call_start_and_end(client):
         "summary": None,
         "wb_user_id": MaybeStringMatcher(client.entity),
         "wb_run_id": None,
+        "deleted_at": None,
     }
 
     end = tsi.EndedCallSchemaForInsert(
@@ -176,6 +177,7 @@ def test_trace_server_call_start_and_end(client):
         "summary": {"c": 5},
         "wb_user_id": MaybeStringMatcher(client.entity),
         "wb_run_id": None,
+        "deleted_at": None,
     }
 
 

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -239,6 +239,69 @@ def test_calls_query(client):
     client.finish_call(call0, None)
 
 
+def test_calls_delete(client):
+    call0 = client.create_call("x", None, {"a": 5, "b": 10})
+    call0_child1 = client.create_call("x", call0, {"a": 5, "b": 11})
+    _call0_child2 = client.create_call("x", call0_child1, {"a": 5, "b": 12})
+    call1 = client.create_call("y", None, {"a": 6, "b": 11})
+
+    assert len(list(client.calls())) == 4
+
+    result = list(client.calls(weave_client._CallsFilter(op_names=[call0.op_name])))
+    assert len(result) == 3
+
+    # should deleted call0_child1, _call0_child2, call1, but not call0
+    client.delete_call(call0_child1)
+
+    result = list(client.calls(weave_client._CallsFilter(op_names=[call0.op_name])))
+    assert len(result) == 1
+
+    result = list(client.calls(weave_client._CallsFilter(op_names=[call1.op_name])))
+    assert len(result) == 0
+
+    # no-op if already deleted
+    client.delete_call(call0_child1)
+    call1.delete()
+    call1.delete()
+
+    result = list(client.calls())
+    # only call0 should be left
+    assert len(result) == 1
+
+
+def test_calls_delete_cascade(client):
+    # run an evaluation, then delete the evaluation and its children
+    @weave.op()
+    async def model_predict(input) -> str:
+        return eval(input)
+
+    dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
+
+    @weave.op()
+    async def score(target, model_output):
+        return target == model_output
+
+    evaluation = Evaluation(
+        name="my-eval",
+        dataset=dataset_rows,
+        scorers=[score],
+    )
+    asyncio.run(evaluation.evaluate(model_predict))
+
+    evaluate_calls = list(weave.as_op(evaluation.evaluate).calls())
+    assert len(evaluate_calls) == 1
+    eval_call = evaluate_calls[0]
+    eval_call_children = list(eval_call.children())
+    assert len(eval_call_children) == 3
+
+    # delete the evaluation, should cascade to all the calls and sub-calls
+    client.delete_call(eval_call)
+
+    # check that all the calls are gone
+    result = list(client.calls())
+    assert len(result) == 0
+
+
 def test_dataset_calls(client):
     ref = client.save(
         weave.Dataset(rows=[{"doc": "xx", "label": "c"}, {"doc": "yy", "label": "d"}]),

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1,5 +1,6 @@
 # Clickhouse Trace Server
 
+from collections import defaultdict
 import threading
 from contextlib import contextmanager
 import datetime
@@ -35,6 +36,8 @@ MAX_FLUSH_AGE = 15
 
 FILE_CHUNK_SIZE = 100000
 
+MAX_DELETE_CALLS_COUNT = 100
+
 
 class NotFoundError(Exception):
     pass
@@ -67,7 +70,20 @@ class CallEndCHInsertable(BaseModel):
     output_refs: typing.List[str]
 
 
-CallCHInsertable = typing.Union[CallStartCHInsertable, CallEndCHInsertable]
+class CallDeleteCHInsertable(BaseModel):
+    project_id: str
+    id: str
+    deleted_at: datetime.datetime
+    wb_user_id: typing.Optional[str]
+
+    # boo
+    input_refs: typing.List[str] = []
+    output_refs: typing.List[str] = []
+
+
+CallCHInsertable = typing.Union[
+    CallStartCHInsertable, CallEndCHInsertable, CallDeleteCHInsertable
+]
 
 
 # Very critical that this matches the calls table schema! This should
@@ -97,9 +113,13 @@ class SelectableCHCallSchema(BaseModel):
     wb_user_id: typing.Optional[str] = None
     wb_run_id: typing.Optional[str] = None
 
+    deleted_at: typing.Optional[datetime.datetime] = None
+
 
 all_call_insert_columns = list(
-    CallStartCHInsertable.model_fields.keys() | CallEndCHInsertable.model_fields.keys()
+    CallStartCHInsertable.model_fields.keys()
+    | CallEndCHInsertable.model_fields.keys()
+    | CallDeleteCHInsertable.model_fields.keys()
 )
 
 all_call_select_columns = list(SelectableCHCallSchema.model_fields.keys())
@@ -301,6 +321,52 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             yield tsi.CallSchema.model_validate(
                 _ch_call_dict_to_call_schema_dict(ch_dict)
             )
+
+    def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
+        if len(req.call_ids) > MAX_DELETE_CALLS_COUNT:
+            raise RequestTooLarge(
+                f"Cannot delete more than {MAX_DELETE_CALLS_COUNT} calls at once"
+            )
+
+        proj_cond = "project_id = {project_id: String}"
+        proj_params = {"project_id": req.project_id}
+
+        # get all parents
+        parents = self._select_calls_query(
+            req.project_id,
+            conditions=[proj_cond, "id IN {ids: Array(String)}"],
+            parameters=proj_params | {"ids": req.call_ids},
+        )
+
+        # get all calls with trace_ids matching parents
+        all_calls = self._select_calls_query(
+            req.project_id,
+            conditions=[proj_cond, "trace_id IN {trace_ids: Array(String)}"],
+            parameters=proj_params | {"trace_ids": [p.trace_id for p in parents]},
+        )
+
+        all_descendants = find_call_descendants(
+            root_ids=req.call_ids,
+            all_calls=all_calls,
+        )
+
+        deleted_at = datetime.datetime.now()
+        insertables = [
+            CallDeleteCHInsertable(
+                project_id=req.project_id,
+                id=call_id,
+                wb_user_id=req.wb_user_id,
+                deleted_at=deleted_at,
+            )
+            for call_id in all_descendants
+        ]
+        self._flush_immediately = False
+        for insertable in insertables:
+            self._insert_call(insertable)
+        self._flush_calls()
+        self._flush_immediately = True
+
+        return tsi.CallsDeleteRes()
 
     def op_create(self, req: tsi.OpCreateReq) -> tsi.OpCreateRes:
         raise NotImplementedError()
@@ -927,7 +993,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             FROM calls_merged
             WHERE project_id = {{project_id: String}}
             GROUP BY project_id, id
-            HAVING {conditions_part}
+            HAVING deleted_at IS NULL AND
+                {conditions_part}
             {order_by_part}
             {limit_part}
             {offset_part}
@@ -973,8 +1040,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 version_count,
                 is_latest
             FROM object_versions_deduped
-            WHERE project_id = {{project_id: String}}
-            AND {conditions_part}
+            WHERE project_id = {{project_id: String}} AND
+                {conditions_part}
             {limit_part}
         """,
             {"project_id": project_id, **parameters},
@@ -1294,3 +1361,32 @@ def _combine_conditions(conditions: typing.List[str], operator: str) -> str:
         raise ValueError(f"Invalid operator: {operator}")
     combined = f" {operator} ".join([f"({c})" for c in conditions])
     return f"({combined})"
+
+
+def find_call_descendants(
+    root_ids: typing.List[str],
+    all_calls: typing.List[SelectableCHCallSchema],
+) -> typing.List[str]:
+    # make a map of call_id to children list
+    children_map = defaultdict(list)
+    for call in all_calls:
+        if call.parent_id is not None:
+            children_map[call.parent_id].append(call.id)
+
+    # do DFS to get all descendants
+    def find_all_descendants(root_ids: typing.List[str]) -> typing.Set[str]:
+        descendants = set()
+        stack = root_ids
+
+        while stack:
+            current_id = stack.pop()
+            if current_id not in descendants:
+                descendants.add(current_id)
+                stack += children_map.get(current_id, [])
+
+        return descendants
+
+    # Find descendants for each initial id
+    descendants = find_all_descendants(root_ids)
+
+    return list(descendants)

--- a/weave/trace_server/migrations/002_add_deleted_at.down.sql
+++ b/weave/trace_server/migrations/002_add_deleted_at.down.sql
@@ -1,0 +1,75 @@
+/*
+This migration undoes adding the `deleted_at` column to: 
+    - the object_versions, call_parts, and calls_merged tables
+    - the object_versions_deduped and calls_merged_view views
+*/
+
+ALTER TABLE object_versions DROP COLUMN deleted_at;
+
+CREATE OR REPLACE VIEW object_versions_deduped as
+    SELECT project_id,
+        object_id,
+        created_at,
+        -- **** remove deleted_at from view ****
+        kind,
+        base_object_class,
+        refs,
+        val_dump,
+        digest,
+        if (kind = 'op', 1, 0) AS is_op,
+        row_number() OVER (
+            PARTITION BY project_id,
+            kind,
+            object_id
+            ORDER BY created_at ASC
+        ) AS _version_index_plus_1,
+        _version_index_plus_1 - 1 AS version_index,
+        count(*) OVER (PARTITION BY project_id, kind, object_id) as version_count,
+        if(_version_index_plus_1 = version_count, 1, 0) AS is_latest
+    FROM (
+            SELECT *,
+                row_number() OVER (
+                    PARTITION BY project_id,
+                    kind,
+                    object_id,
+                    digest
+                    ORDER BY created_at ASC
+                ) AS rn
+            FROM object_versions
+        )
+    WHERE rn = 1 WINDOW w AS (
+            PARTITION BY project_id,
+            kind,
+            object_id
+            ORDER BY created_at ASC
+        )
+    ORDER BY project_id,
+        kind,
+        object_id,
+        created_at;
+
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_user_id) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs
+        -- **** remove deleted_at from view ****
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+ALTER TABLE calls_merged DROP COLUMN deleted_at;
+
+ALTER TABLE call_parts DROP COLUMN deleted_at;

--- a/weave/trace_server/migrations/002_add_deleted_at.up.sql
+++ b/weave/trace_server/migrations/002_add_deleted_at.up.sql
@@ -1,0 +1,81 @@
+/*
+This migration adds:
+    * `deleted_at` to
+        - the object_versions, call_parts, and calls_merged tables
+        - the object_versions_deduped and calls_merged_view views
+*/
+
+ALTER TABLE object_versions
+    ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL;
+
+CREATE OR REPLACE VIEW object_versions_deduped as
+    SELECT project_id,
+        object_id,
+        created_at,
+        deleted_at,  -- **** Add deleted_at to the view ****
+        kind,
+        base_object_class,
+        refs,
+        val_dump,
+        digest,
+        if (kind = 'op', 1, 0) AS is_op,
+        row_number() OVER (
+            PARTITION BY project_id,
+            kind,
+            object_id
+            ORDER BY created_at ASC
+        ) AS _version_index_plus_1,
+        _version_index_plus_1 - 1 AS version_index,
+        count(*) OVER (PARTITION BY project_id, kind, object_id) as version_count,
+        if(_version_index_plus_1 = version_count, 1, 0) AS is_latest
+    FROM (
+            SELECT *,
+                row_number() OVER (
+                    PARTITION BY project_id,
+                    kind,
+                    object_id,
+                    digest
+                    ORDER BY created_at ASC
+                ) AS rn
+            FROM object_versions
+        )
+    WHERE rn = 1 WINDOW w AS (
+            PARTITION BY project_id,
+            kind,
+            object_id
+            ORDER BY created_at ASC
+        )
+    ORDER BY project_id,
+        kind,
+        object_id,
+        created_at;
+
+ALTER TABLE call_parts
+    ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL;
+
+ALTER TABLE calls_merged
+    ADD COLUMN deleted_at SimpleAggregateFunction(any, Nullable(DateTime64(3)));
+
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        -- *** Ensure wb_user_id is grabbed from valid call rather than deleted row ***
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        -- **** Add deleted_at to the view ****
+        anySimpleState(deleted_at) as deleted_at
+    FROM call_parts
+    GROUP BY project_id,
+        id;

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -253,6 +253,13 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/calls/query", req, tsi.CallsQueryReq, tsi.CallsQueryRes
         )
 
+    def calls_delete(
+        self, req: t.Union[tsi.CallsDeleteReq, t.Dict[str, t.Any]]
+    ) -> tsi.CallsDeleteRes:
+        return self._generic_request(
+            "/calls/delete", req, tsi.CallsDeleteReq, tsi.CallsDeleteRes
+        )
+
     # Op API
 
     def op_create(

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -346,7 +346,6 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     summary=json.loads(row[13]) if row[13] else None,
                     wb_user_id=row[14],
                     wb_run_id=row[15],
-                    updated_by=row[17],
                 )
                 for row in query_result
             ]

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -85,7 +85,8 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 output_refs TEXT,
                 summary TEXT,
                 wb_user_id TEXT,
-                wb_run_id TEXT
+                wb_run_id TEXT,
+                deleted_at TEXT
             )
         """
         )
@@ -101,7 +102,8 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 val_dump TEXT,
                 digest TEXT UNIQUE,
                 version_index INTEGER,
-                is_latest INTEGER
+                is_latest INTEGER,
+                deleted_at TEXT
             )
         """
         )
@@ -272,7 +274,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 in_expr = ", ".join((f"'{x}'" for x in filter.wb_run_ids))
                 conds += [f"wb_run_id IN ({in_expr})"]
 
-        query = f"SELECT * FROM calls WHERE project_id = '{req.project_id}'"
+        query = f"SELECT * FROM calls WHERE deleted_at IS NULL AND project_id = '{req.project_id}'"
 
         conditions_part = " AND ".join(conds)
 
@@ -314,7 +316,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 order_parts.append(f"{field} {direction}")
 
             order_by_part = ", ".join(order_parts)
-            query += f"ORDER BY {order_by_part}"
+            query += f" ORDER BY {order_by_part}"
 
         limit = req.limit or -1
         if limit:
@@ -344,10 +346,54 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     summary=json.loads(row[13]) if row[13] else None,
                     wb_user_id=row[14],
                     wb_run_id=row[15],
+                    updated_by=row[17],
                 )
                 for row in query_result
             ]
         )
+
+    def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
+        # update row with a deleted_at field set to now
+        conn, cursor = get_conn_cursor(self.db_path)
+        with self.lock:
+            recursive_query = """
+                WITH RECURSIVE Descendants AS (
+                    SELECT id
+                    FROM calls
+                    WHERE project_id = ? AND 
+                        deleted_at IS NULL AND 
+                        parent_id IN (SELECT id FROM calls WHERE id IN ({}))
+                    
+                    UNION ALL
+                    
+                    SELECT c.id
+                    FROM calls c
+                    JOIN Descendants d ON c.parent_id = d.id
+                    WHERE c.deleted_at IS NULL
+                )
+                SELECT id FROM Descendants;
+            """.format(
+                ", ".join("?" * len(req.call_ids))
+            )
+
+            params = [req.project_id] + req.call_ids
+            cursor.execute(recursive_query, params)
+            all_ids = [x[0] for x in cursor.fetchall()] + req.call_ids
+
+            # set deleted_at for all children and parents
+            delete_query = """
+                UPDATE calls
+                SET deleted_at = CURRENT_TIMESTAMP
+                WHERE deleted_at is NULL AND 
+                    id IN ({})
+            """.format(
+                ", ".join("?" * len(all_ids))
+            )
+            print("MUTATION", delete_query)
+            cursor.execute(delete_query, all_ids)
+            conn.commit()
+
+        return tsi.CallsDeleteRes()
 
     def op_create(self, req: tsi.OpCreateReq) -> tsi.OpCreateRes:
         raise NotImplementedError()
@@ -404,9 +450,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         return tsi.ObjCreateRes(digest=digest)
 
     def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
-        conds = [
-            f"object_id = '{req.object_id}'",
-        ]
+        conds = [f"object_id = '{req.object_id}'"]
         if req.digest == "latest":
             conds.append("is_latest = 1")
         else:
@@ -636,7 +680,8 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         conn, cursor = get_conn_cursor(self.db_path)
         pred = " AND ".join(conditions or ["1 = 1"])
         cursor.execute(
-            """SELECT * FROM objects WHERE project_id = ? AND """ + pred,
+            """SELECT * FROM objects WHERE deleted_at IS NULL AND project_id = ? AND """
+            + pred,
             (project_id,),
         )
         query_result = cursor.fetchall()

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -40,6 +40,8 @@ class CallSchema(BaseModel):
     wb_user_id: typing.Optional[str] = None
     wb_run_id: typing.Optional[str] = None
 
+    deleted_at: typing.Optional[datetime.datetime] = None
+
 
 # Essentially a partial of StartedCallSchema. Mods:
 # - id is not required (will be generated)
@@ -90,6 +92,7 @@ class ObjSchema(BaseModel):
     project_id: str
     object_id: str
     created_at: datetime.datetime
+    deleted_at: typing.Optional[datetime.datetime] = None
     digest: str
     version_index: int
     is_latest: int
@@ -133,6 +136,17 @@ class CallReadReq(BaseModel):
 
 class CallReadRes(BaseModel):
     call: CallSchema
+
+
+class CallsDeleteReq(BaseModel):
+    project_id: str
+    # wb_user_id gets generated from auth params
+    wb_user_id: typing.Optional[str] = None
+    call_ids: typing.List[str]
+
+
+class CallsDeleteRes(BaseModel):
+    pass
 
 
 class _CallsFilter(BaseModel):
@@ -308,6 +322,10 @@ class TraceServerInterface:
 
     @abc.abstractmethod
     def calls_query(self, req: CallsQueryReq) -> CallsQueryRes:
+        ...
+
+    @abc.abstractmethod
+    def calls_delete(self, req: CallsDeleteReq) -> CallsDeleteRes:
         ...
 
     # Op API


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-18625
https://wandb.atlassian.net/browse/WB-18626
https://wandb.atlassian.net/browse/WB-18628

Adds: 
- `calls_delete` on the client
- `call.delete()` on the call object
- `calls_delete()` server method 

depends on https://github.com/wandb/core/pull/21555 for `wb_user_id` to appear on deletion rows.

(old pr: https://github.com/wandb/weave/pull/1655)
