### PR TITLE
chore(app): add hide text option to ModifiedDropdown

### DIFF
--- a/weave-js/src/common/components/elements/ModifiedDropdown.tsx
+++ b/weave-js/src/common/components/elements/ModifiedDropdown.tsx
@@ -215,12 +215,9 @@ const ModifiedDropdown: FC<ModifiedDropdownProps> = React.memo(
 
     const getOptionProps = (opt: Option, hideText: boolean) => {
       const {text, ...props} = opt;
-      props.text = hideText ? (
-        {}
-      ) : (
+      props.text = hideText ? null : (
         <OptionWithTooltip text={opt.text as string} />
       );
-
       return props;
     };
 

--- a/weave-js/src/common/components/elements/ModifiedDropdown.tsx
+++ b/weave-js/src/common/components/elements/ModifiedDropdown.tsx
@@ -58,6 +58,14 @@ const simpleSearch = (options: DropdownItemProps[], query: string) => {
     .value();
 };
 
+const getOptionProps = (opt: Option, hideText: boolean) => {
+  const {text, ...props} = opt;
+  props.text = hideText ? null : (
+    <OptionWithTooltip text={opt.text as string} />
+  );
+  return props;
+};
+
 export interface ModifiedDropdownExtraProps {
   debounceTime?: number;
   enableReordering?: boolean;
@@ -212,14 +220,6 @@ const ModifiedDropdown: FC<ModifiedDropdownProps> = React.memo(
       }
       return itemCount() >= itemLimit;
     }, [itemLimit, itemCount]);
-
-    const getOptionProps = (opt: Option, hideText: boolean) => {
-      const {text, ...props} = opt;
-      props.text = hideText ? null : (
-        <OptionWithTooltip text={opt.text as string} />
-      );
-      return props;
-    };
 
     const computedOptions = searchQuery ? options : propsOptions;
     const displayOptions = getDisplayOptions(

--- a/weave-js/src/common/components/elements/ModifiedDropdown.tsx
+++ b/weave-js/src/common/components/elements/ModifiedDropdown.tsx
@@ -66,6 +66,7 @@ export interface ModifiedDropdownExtraProps {
   resultLimit?: number;
   resultLimitMessage?: string;
   style?: CSSProperties;
+  hideText?: boolean;
 
   optionTransform?(option: Option): Option;
 }
@@ -82,6 +83,7 @@ const ModifiedDropdown: FC<ModifiedDropdownProps> = React.memo(
       options: propsOptions,
       search,
       value,
+      hideText = false,
     } = props;
 
     const {
@@ -211,20 +213,22 @@ const ModifiedDropdown: FC<ModifiedDropdownProps> = React.memo(
       return itemCount() >= itemLimit;
     }, [itemLimit, itemCount]);
 
+    const getOptionProps = (opt: Option, hideText: boolean) => {
+      const {text, ...props} = opt;
+      props.text = hideText ? (
+        {}
+      ) : (
+        <OptionWithTooltip text={opt.text as string} />
+      );
+
+      return props;
+    };
+
     const computedOptions = searchQuery ? options : propsOptions;
     const displayOptions = getDisplayOptions(
       multiple
         ? computedOptions
-        : computedOptions.map(opt => ({
-            key: opt.key,
-            value: opt.value,
-            text: opt.text,
-            content: opt.label ? (
-              opt.label
-            ) : (
-              <OptionWithTooltip text={opt.text as string} />
-            ),
-          })),
+        : computedOptions.map(opt => getOptionProps(opt, hideText) as Option),
       resultLimit,
       searchQuery,
       value

--- a/weave-js/src/common/components/elements/ModifiedDropdown.tsx
+++ b/weave-js/src/common/components/elements/ModifiedDropdown.tsx
@@ -216,8 +216,14 @@ const ModifiedDropdown: FC<ModifiedDropdownProps> = React.memo(
       multiple
         ? computedOptions
         : computedOptions.map(opt => ({
-            ...opt,
-            content: <OptionWithTooltip text={opt.text as string} />,
+            key: opt.key,
+            value: opt.value,
+            text: opt.text,
+            content: opt.label ? (
+              opt.label
+            ) : (
+              <OptionWithTooltip text={opt.text as string} />
+            ),
           })),
       resultLimit,
       searchQuery,
@@ -477,7 +483,7 @@ type OptionWithTooltipProps = {
   text: string | null;
 };
 
-const OptionWithTooltip: React.FC<OptionWithTooltipProps> = ({text}) => {
+export const OptionWithTooltip: React.FC<OptionWithTooltipProps> = ({text}) => {
   const [showTooltip, setShowTooltip] = useState(false);
   const optionRef = useRef<HTMLDivElement>(null);
 


### PR DESCRIPTION
Jira: https://wandb.atlassian.net/browse/WB-18777

Updates the `ModifiedDropdown` component to support hiding the input text prop so that we can display a JSX label as a dropdown option on its own. This will be used in the clone/ create report modal in an upcoming PR, https://github.com/wandb/core/pull/21754.

Before: 

<img width="591" alt="Screenshot 2024-05-29 at 12 50 58 PM" src="https://github.com/wandb/weave/assets/126013019/9c1c6d0b-186e-4663-8f7e-19ad2090b991">


After:

https://github.com/wandb/core/assets/126013019/e5c35eed-c45f-4e93-bbe1-05f18f15ede6

