### PR TITLE
chore(weave): Fix sorting by created at column

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -381,6 +381,7 @@ function buildCallsTableColumns(
     // Should have custom timestamp filter here.
     filterOperators: allOperators.filter(o => o.value.startsWith('(date)')),
     sortable: true,
+    sortingOrder: ['desc', 'asc'],
     width: 100,
     minWidth: 100,
     maxWidth: 100,


### PR DESCRIPTION
The CallsTable defaults to sorting by CreatedAt DESC, however the MUI Data grid defaults to cycling through ASC -> DESC -> Null when clicking the sort arrow. So, then in the "DESC" (default) state, clicking the arrow changes to Null, which then reverts to DESC, which feels like nothing happens. This change removes NULL from the cycle for this column, making it work again