### PR TITLE
perf: Fix full table scans for objects, files, tables

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -582,7 +582,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                                 SELECT *,
                                     row_number() OVER (PARTITION BY project_id, digest) AS rn
                                 FROM tables
-                                WHERE project_id = {{project_id:String}}
+                                WHERE project_id = {{project_id:String}} AND digest = {{digest:String}}
                             )
                         WHERE rn = 1
                         ORDER BY project_id, digest

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -864,8 +864,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         SELECT *,
                             row_number() OVER (PARTITION BY project_id, digest, chunk_index) AS rn
                         FROM files
+                        WHERE project_id = {project_id:String} AND digest = {digest:String}
                     )
-                WHERE rn = 1 AND project_id = {project_id:String} AND digest = {digest:String}
+                WHERE rn = 1
                 ORDER BY project_id, digest, chunk_index
             )
             WHERE project_id = {project_id:String} AND digest = {digest:String}""",


### PR DESCRIPTION
We were scanning the whole clickhouse tables for object, file, and table reads, all the time.

Fix so that we only scan the subset of those tables that we need for the specific project referenced in the user query.

This should speed up W&B production reads from about 3s for object_versions, down to just 20ms in many cases (2 orders of magnitude faster). We should get similar improvements for files and table reads. as well. 

```
# There are four major kinds of things that we query:
# - calls,
# - object_versions,
# - tables
# - files
#
# calls are identified by ID.
#
# object_versions, tables, and files are identified by digest. For these kinds of
# things, we dedupe at merge time using Clickhouse's ReplacingMergeTree, but we also
# need to dedupe at query time.
#
# Previously, we did query time deduping in *_deduped VIEWs. But it turns out
# clickhouse doesn't push down the project_id predicate into those views, so we were
# always scanning whole tables.
#
# Now, we've just written the what were views before into this file directly as
# subqueries, and put the project_id predicate in the innermost subquery, which fixes
# the problem.
```