### PR TITLE
chore: make it clearer that unabridged text is copied in use tabs

### DIFF
--- a/weave-js/src/components/CopyableText.tsx
+++ b/weave-js/src/components/CopyableText.tsx
@@ -12,6 +12,7 @@ type CopyableTextProps = {
 
   // The text to copy to the clipboard. If not provided, `text` will be used.
   copyText?: string;
+  tooltipText?: string;
   toastText?: string;
   icon?: IconName;
   disabled?: boolean;
@@ -49,6 +50,7 @@ Text.displayName = 'S.Text';
 export const CopyableText = ({
   text,
   copyText,
+  tooltipText = 'Click to copy to clipboard',
   toastText = 'Copied to clipboard',
   icon,
   disabled,
@@ -80,5 +82,5 @@ export const CopyableText = ({
       <Text>{text}</Text>
     </Wrapper>
   );
-  return <Tooltip content="Click to copy to clipboard" trigger={trigger} />;
+  return <Tooltip content={tooltipText} trigger={trigger} />;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseDataset.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
 import {parseRef} from '../../../../../react';
+import {abbreviateRef} from '../../../../../util/refs';
 import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
@@ -60,8 +61,9 @@ ${pythonName} = weave.ref('${ref.artifactName}:v${versionIndex}').get()`;
       <Box mt={2}>
         Use the following code to retrieve this {label}:
         <CopyableText
-          text={`${pythonName} = weave.ref("<ref_uri>").get()`}
+          text={`${pythonName} = weave.ref("${abbreviateRef(uri)}").get()`}
           copyText={`${pythonName} = weave.ref("${uri}").get()`}
+          tooltipText="Click to copy unabridged string"
         />
         {long && (
           <>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseModel.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
 import {parseRef} from '../../../../../react';
+import {abbreviateRef} from '../../../../../util/refs';
 import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
@@ -38,8 +39,9 @@ export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
       <Box mt={2}>
         Use the following code to retrieve this {label}:
         <CopyableText
-          text={`${pythonName} = weave.ref("<ref_uri>").get()`}
+          text={`${pythonName} = weave.ref("${abbreviateRef(uri)}").get()`}
           copyText={`${pythonName} = weave.ref("${uri}").get()`}
+          tooltipText="Click to copy unabridged string"
         />
       </Box>
       {isParentObject && (
@@ -48,16 +50,20 @@ export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
             To <DocLink path="guides/tools/serve" text="serve this model" />{' '}
             locally with a Swagger UI:
             <CopyableText
-              text="weave serve <ref_uri>"
-              copyText={`weave serve ${uri}`}
+              text={`weave serve "${abbreviateRef(uri)}"`}
+              copyText={`weave serve "${uri}"`}
+              tooltipText="Click to copy unabridged string"
             />
           </Box>
           <Box mt={2}>
             To <DocLink path="guides/tools/deploy" text="deploy this model" />{' '}
             to the cloud run:
             <CopyableText
-              text={`weave deploy gcp --project "${projectName}" <ref_uri>`}
-              copyText={`weave deploy gcp --project "${projectName}" ${uri}`}
+              text={`weave deploy gcp --project "${projectName}" "${abbreviateRef(
+                uri
+              )}"`}
+              copyText={`weave deploy gcp --project "${projectName}" "${uri}"`}
+              tooltipText="Click to copy unabridged string"
             />
           </Box>
         </>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseObject.tsx
@@ -2,6 +2,7 @@ import {Box} from '@mui/material';
 import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
+import {abbreviateRef} from '../../../../../util/refs';
 import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
@@ -31,8 +32,9 @@ export const TabUseObject = ({name, uri}: TabUseObjectProps) => {
       <Box mt={2}>
         Use the following code to retrieve this object version:
         <CopyableText
-          text={`${pythonName} = weave.ref("<ref_uri>").get()`}
+          text={`${pythonName} = weave.ref("${abbreviateRef(uri)}").get()`}
           copyText={`${pythonName} = weave.ref("${uri}").get()`}
+          tooltipText="Click to copy unabridged string"
         />
       </Box>
     </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseOp.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseOp.tsx
@@ -2,6 +2,7 @@ import {Box} from '@mui/material';
 import React from 'react';
 
 import {isValidVarName} from '../../../../../core/util/var';
+import {abbreviateRef} from '../../../../../util/refs';
 import {Alert} from '../../../../Alert';
 import {CopyableText} from '../../../../CopyableText';
 import {DocLink} from './common/Links';
@@ -32,8 +33,9 @@ export const TabUseOp = ({name, uri}: TabUseOpProps) => {
       <Box mt={2}>
         Use the following code to retrieve this operation version:
         <CopyableText
-          text={`${pythonName} = weave.ref(<ref_url>).get()`}
+          text={`${pythonName} = weave.ref("${abbreviateRef(uri)}").get()`}
           copyText={`${pythonName} = weave.ref("${uri}").get()`}
+          tooltipText="Click to copy unabridged string"
         />
       </Box>
     </Box>

--- a/weave-js/src/util/refs.ts
+++ b/weave-js/src/util/refs.ts
@@ -1,0 +1,28 @@
+const PROTOCOL = 'weave://';
+
+export const makeRefCall = (
+  entity: string,
+  project: string,
+  callId: string
+): string => {
+  return `${PROTOCOL}/${entity}/${project}/call/${callId}`;
+};
+
+export const makeRefObject = (
+  entity: string,
+  project: string,
+  objectType: string,
+  objectId: string,
+  objectVersion: string,
+  refExtra: string | undefined
+): string => {
+  let ref = `${PROTOCOL}/${entity}/${project}/${objectType}/${objectId}:${objectVersion}`;
+  if (refExtra) {
+    ref += `/${refExtra}`;
+  }
+  return ref;
+};
+
+export const abbreviateRef = (ref: string): string => {
+  return PROTOCOL + '/...' + ref.slice(-6);
+};


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-19087

Multiple people have reported not realizing that the `<ref_uri>` placeholder  in code examples is replaced with the full ref string in the copied text.

This updates replaces that placeholder with an abridged version of the ref string and updates the tooltip content to indicate that the unabridged string is copied.

Before:
<img width="389" alt="Screenshot 2024-05-31 at 10 11 13 PM" src="https://github.com/wandb/weave/assets/112953339/00fb2bcb-10c4-4573-82e7-79e53567a9b0">

After:
<img width="385" alt="Screenshot 2024-05-31 at 10 11 01 PM" src="https://github.com/wandb/weave/assets/112953339/3b1414b9-4a7f-4dfa-8840-149e43c5d14a">
