### PR TITLE
chore(weave): Implement Predicate Pushdown for Calls

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1741,7 +1741,7 @@ def _process_calls_filter_to_conditions(
 ) -> FilterToConditions:
     """Converts a CallsFilter to a list of conditions for a clickhouse query."""
     param_builder = param_builder or ParamBuilder()
-    conditions = []
+    having_conditions = []
     raw_fields_used = set()
 
     if filter.op_names:
@@ -1773,55 +1773,55 @@ def _process_calls_filter_to_conditions(
             raw_fields_used.add("op_name")
 
         if or_conditions:
-            conditions.append(_combine_conditions(or_conditions, "OR"))
+            having_conditions.append(_combine_conditions(or_conditions, "OR"))
 
     if filter.input_refs:
-        conditions.append(
+        having_conditions.append(
             f"hasAny(input_refs, {_param_slot(param_builder.add_param(filter.input_refs), 'Array(String)')})"
         )
         raw_fields_used.add("input_refs")
 
     if filter.output_refs:
-        conditions.append(
+        having_conditions.append(
             f"hasAny(output_refs, {_param_slot(param_builder.add_param(filter.output_refs), 'Array(String)')})"
         )
         raw_fields_used.add("output_refs")
 
     if filter.parent_ids:
-        conditions.append(
+        having_conditions.append(
             f"parent_id IN {_param_slot(param_builder.add_param(filter.parent_ids), 'Array(String)')}"
         )
         raw_fields_used.add("parent_id")
 
     if filter.trace_ids:
-        conditions.append(
+        having_conditions.append(
             f"trace_id IN {_param_slot(param_builder.add_param(filter.trace_ids), 'Array(String)')}"
         )
         raw_fields_used.add("trace_id")
 
     if filter.call_ids:
-        conditions.append(
+        having_conditions.append(
             f"id IN {_param_slot(param_builder.add_param(filter.call_ids), 'Array(String)')}"
         )
         raw_fields_used.add("id")
 
     if filter.trace_roots_only:
-        conditions.append("parent_id IS NULL")
+        having_conditions.append("parent_id IS NULL")
         raw_fields_used.add("parent_id")
 
     if filter.wb_user_ids:
-        conditions.append(
+        having_conditions.append(
             f"wb_user_id IN {_param_slot(param_builder.add_param(filter.wb_user_ids), 'Array(String)')})"
         )
         raw_fields_used.add("wb_user_id")
 
     if filter.wb_run_ids:
-        conditions.append(
+        having_conditions.append(
             f"wb_run_id IN {_param_slot(param_builder.add_param(filter.wb_run_ids), 'Array(String)')})"
         )
         raw_fields_used.add("wb_run_id")
 
-    return FilterToConditions(conditions=conditions, fields_used=raw_fields_used)
+    return FilterToConditions(conditions=having_conditions, fields_used=raw_fields_used)
 
 
 def _process_query_to_conditions(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1961,7 +1961,7 @@ def _make_calls_where_condition_from_event_conditions(
             ["isNotNull(started_at)", *start_event_conditions], "AND"
         )
         event_conds.append(
-            f"(calls_merged.id IN (SELECT id FROM calls_merged WHERE {conds})"
+            f"calls_merged.id IN (SELECT id FROM calls_merged WHERE {conds})"
         )
 
     if end_event_conditions is not None and len(end_event_conditions) > 0:
@@ -1969,7 +1969,7 @@ def _make_calls_where_condition_from_event_conditions(
             ["isNotNull(ended_at)", *end_event_conditions], "AND"
         )
         event_conds.append(
-            f"(calls_merged.id IN (SELECT id FROM calls_merged WHERE {conds})"
+            f"calls_merged.id IN (SELECT id FROM calls_merged WHERE {conds})"
         )
 
     where_conditions_part = "(1 = 1)"

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1838,7 +1838,7 @@ def _process_calls_filter_to_conditions(
         raw_fields_used.add("wb_run_id")
 
     return FilterToConditions(
-        conditions=having_conditions,
+        having_conditions=having_conditions,
         start_event_conditions=start_event_conditions,
         end_event_conditions=end_event_conditions,
         fields_used=raw_fields_used,


### PR DESCRIPTION
This PR implements predicate pushdown for the primary filter clause (not yet implemented for the dynamic mongo queries). It was raised that our filter conditions are being applied after grouping, which is certainly not as efficient as applying the filter pre-grouped (since applying after grouping requires operating on far more rows than needed). In this PR we do the following:
1. Refactor many symbols/params from `conditions` to `having_conditions` to specifically mean the conditions applied after the group by (in the `having` clause of the query)
2. Modify the query builder functions to accept `start_event_conditions` and `end_event_conditions` which can be used to apply filters _before_ the aggregation. If these conditions are supplied, an inner query is executed which generates an `id IN (...)` condition that is applied in the `WHERE` clause.
3. Modify the filter builder to produce these more specific conditions when appropriate

Testing:
* Current filter tests cover all sorts of cases here
* Also tested in the UI manually