### PR TITLE
chore(weave): Add a fast path for simple queries

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1155,7 +1155,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 WHERE project_id = {{project_id: String}}
                     AND {where_conditions_part}
                 GROUP BY project_id, id
-                HAVING {having_conditions_part}
+                HAVING deleted_at IS NULL AND
+                    {having_conditions_part}
             )
         """
 
@@ -1980,7 +1981,12 @@ def _make_calls_where_condition_from_event_conditions(
     event_conds = []
     if start_event_conditions is not None and len(start_event_conditions) > 0:
         conds = _combine_conditions(
-            ["isNotNull(started_at)", *start_event_conditions], "AND"
+            [
+                "project_id = {{project_id: String}}",
+                "isNotNull(started_at)",
+                *start_event_conditions,
+            ],
+            "AND",
         )
         event_conds.append(
             f"calls_merged.id IN (SELECT id FROM calls_merged WHERE {conds})"
@@ -1988,7 +1994,12 @@ def _make_calls_where_condition_from_event_conditions(
 
     if end_event_conditions is not None and len(end_event_conditions) > 0:
         conds = _combine_conditions(
-            ["isNotNull(ended_at)", *end_event_conditions], "AND"
+            [
+                "project_id = {{project_id: String}}",
+                "isNotNull(ended_at)",
+                *end_event_conditions,
+            ],
+            "AND",
         )
         event_conds.append(
             f"calls_merged.id IN (SELECT id FROM calls_merged WHERE {conds})"

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -56,6 +56,7 @@ from .interface import query as tsi_query
 from . import refs_internal
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 MAX_FLUSH_COUNT = 10000
 MAX_FLUSH_AGE = 15

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1104,7 +1104,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 calls_merged.id IN (
                     SELECT id from calls_merged WHERE (
                         project_id = {{project_id: String}}
-                        AND 
+                            AND 
                         {where_conditions_part}
                     )
                     {order_by_part}
@@ -2031,13 +2031,13 @@ def _make_calls_where_condition_from_event_conditions(
             f"calls_merged.id IN (SELECT id FROM calls_merged WHERE {conds})"
         )
 
+
     # Exclude deleted calls
-    conds = _combine_conditions(
-        ["project_id = {project_id: String}", "isNotNull(deleted_at)"], "AND"
-    )
+    conds = _combine_conditions(["project_id = {project_id: String}", "isNotNull(deleted_at)"], "AND")
     event_conds.append(
         f"calls_merged.id NOT IN (SELECT id FROM calls_merged WHERE {conds})"
     )
+
 
     where_conditions_part = _combine_conditions(event_conds, "AND")
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1284,17 +1284,21 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         column_formats: typing.Optional[typing.Dict[str, typing.Any]] = None,
     ) -> typing.Iterator[QueryResult]:
         """Streams the results of a query from the database."""
-        logger.info(
-            {
-                "event": "clickhouse_stream_query",
-                "query": query,
-                "parameters": parameters,
-            }
-        )
+        summary = None
         parameters = _process_parameters(parameters)
         with self.ch_client.query_rows_stream(
             query, parameters=parameters, column_formats=column_formats, use_none=True
         ) as stream:
+            if isinstance(stream.source, QueryResult):
+                summary = stream.source.summary
+            logger.info(
+                {
+                    "event": "clickhouse_stream_query",
+                    "query": query,
+                    "parameters": parameters,
+                    "summary": summary,
+                }
+            )
             for row in stream:
                 yield row
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1982,7 +1982,7 @@ def _make_calls_where_condition_from_event_conditions(
     if start_event_conditions is not None and len(start_event_conditions) > 0:
         conds = _combine_conditions(
             [
-                "project_id = {{project_id: String}}",
+                "project_id = {project_id: String}",
                 "isNotNull(started_at)",
                 *start_event_conditions,
             ],
@@ -1995,7 +1995,7 @@ def _make_calls_where_condition_from_event_conditions(
     if end_event_conditions is not None and len(end_event_conditions) > 0:
         conds = _combine_conditions(
             [
-                "project_id = {{project_id: String}}",
+                "project_id = {project_id: String}",
                 "isNotNull(ended_at)",
                 *end_event_conditions,
             ],


### PR DESCRIPTION
Builds off of https://github.com/wandb/weave/pull/1715 ... another step in making queries faster! In this PR, we take advantage of the case where there are no group-by conditions. In such cases we can push the sort/limit down into an inner-clause.

This PR does 1 thing:
1. Under the condition that there are 0 `having_conditions` and we only need to sort based on data in 1 event type or the other (start or end), then we can use a fast path that pushes the sort condition down to the inner clause, avoiding extra aggregations! 