### PR TITLE
chore: add emoji to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ rich>=13.7.0
 aiohttp>=3.8.3
 aiofiles>=22.1.0
 aioprocessing>=2.0.1
-Werkzeug>=3.0.3  # CVE 2024-34069 
+Werkzeug>=3.0.3  # CVE 2024-34069
 janus>=1.0.0
 
 # we use this for logger, could probably skip it
@@ -40,3 +40,6 @@ analytics-python>=1.2.9
 packaging>=21.0
 
 tenacity>=8.3.0
+
+# Used for emoji shortcode support in feedback
+emoji>=2.12.1


### PR DESCRIPTION
I moved the emoji shortcode augmentation from the HTTP layer to the storage layer. It is no longer only used for ClickHouse, but also for our sqlite backend implementation. Although the sqlite implementation is only used in tests today, it gets imported and so the dependency needs to be there.

Traceback from @davidwallacejackson 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/gunicorn/app/base.py", line 111, in get_config_from_filename
    spec.loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/weave-root/gunicorn_config.py", line 1, in <module>
    from middleware import patch_tracer_to_send_traces_to_streamtable
  File "/weave-root/middleware/__init__.py", line 1, in <module>
    from .middleware import WBAuthMiddleware
  File "/weave-root/middleware/middleware.py", line 7, in <module>
    from weave import wandb_api, engine_trace, server_error_handling
  File "/weave-root/weave-public/weave/__init__.py", line 16, in <module>
    from .api import *
  File "/weave-root/weave-public/weave/api.py", line 34, in <module>
    from . import weave_init as _weave_init
  File "/weave-root/weave-public/weave/weave_init.py", line 3, in <module>
    from .trace_server import remote_http_trace_server, sqlite_trace_server
  File "/weave-root/weave-public/weave/trace_server/sqlite_trace_server.py", line 14, in <module>
    import emoji
ModuleNotFoundError: No module named 'emoji'
```