### PR TITLE
fix(weave): decode url before parsing weave ref 

### DIFF
--- a/weave-js/src/react.test.ts
+++ b/weave-js/src/react.test.ts
@@ -72,6 +72,20 @@ describe('parseRef', () => {
         weaveKind: 'object',
       });
     });
+    it('parses a ref with escaped spaces in name and projectName', () => {
+      const parsed = parseRef(
+        'weave:///entity/project%20with%20spaces/object/artifact%20name%20with%20spaces:artifactversion'
+      );
+      expect(parsed).toEqual({
+        artifactName: 'artifact name with spaces',
+        artifactRefExtra: '',
+        artifactVersion: 'artifactversion',
+        entityName: 'entity',
+        projectName: 'project with spaces',
+        scheme: 'weave',
+        weaveKind: 'object',
+      });
+    });
   });
   it('parses a weave table ref', () => {
     const parsed = parseRef(

--- a/weave-js/src/react.test.ts
+++ b/weave-js/src/react.test.ts
@@ -58,6 +58,20 @@ describe('parseRef', () => {
         weaveKind: 'object',
       });
     });
+    it('parses a ref with spaces in name and projectName', () => {
+      const parsed = parseRef(
+        'weave:///entity/project with spaces/object/artifact name with spaces:artifactversion'
+      );
+      expect(parsed).toEqual({
+        artifactName: 'artifact name with spaces',
+        artifactRefExtra: '',
+        artifactVersion: 'artifactversion',
+        entityName: 'entity',
+        projectName: 'project with spaces',
+        scheme: 'weave',
+        weaveKind: 'object',
+      });
+    });
   });
   it('parses a weave table ref', () => {
     const parsed = parseRef(

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -585,7 +585,7 @@ export const parseRef = (ref: string): ObjectRef => {
   }
 
   if (isWeaveRef) {
-    const trimmed = trimStartChar(url.pathname, '/');
+    const trimmed = trimStartChar(decodedUri, '/');
     const tableMatch = trimmed.match(RE_WEAVE_TABLE_REF_PATHNAME);
     if (tableMatch !== null) {
       const [entity, project, digest] = tableMatch.slice(1);

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -553,7 +553,7 @@ export const parseRef = (ref: string): ObjectRef => {
 
   // Decode the URI pathname to handle URL-encoded characters, required
   // in some browsers (safari)
-  const decodedUri = decodeURI(url.pathname);
+  const decodedUri = decodeURIComponent(url.pathname);
   const splitUri = decodedUri.replace(/^\/+/, '').split('/', splitLimit);
 
   if (splitUri.length !== splitLimit) {

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -582,7 +582,7 @@ export const parseRef = (ref: string): ObjectRef => {
   }
 
   if (isWeaveRef) {
-    const trimmed = trimStartChar(url.pathname, '/').replace(/%20/g, ' ');
+    const trimmed = trimStartChar(decodeURI(url.pathname), '/');
     const tableMatch = trimmed.match(RE_WEAVE_TABLE_REF_PATHNAME);
     if (tableMatch !== null) {
       const [entity, project, digest] = tableMatch.slice(1);

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -551,7 +551,10 @@ export const parseRef = (ref: string): ObjectRef => {
     throw new Error(`Unknown protocol: ${url.protocol}`);
   }
 
-  const splitUri = url.pathname.replace(/^\/+/, '').split('/', splitLimit);
+  // Decode the URI pathname to handle URL-encoded characters, required
+  // in some browsers (safari)
+  const decodedUri = decodeURI(url.pathname);
+  const splitUri = decodedUri.replace(/^\/+/, '').split('/', splitLimit);
 
   if (splitUri.length !== splitLimit) {
     throw new Error(`Invalid Artifact URI: ${url}`);
@@ -582,7 +585,7 @@ export const parseRef = (ref: string): ObjectRef => {
   }
 
   if (isWeaveRef) {
-    const trimmed = trimStartChar(decodeURI(url.pathname), '/');
+    const trimmed = trimStartChar(url.pathname, '/');
     const tableMatch = trimmed.match(RE_WEAVE_TABLE_REF_PATHNAME);
     if (tableMatch !== null) {
       const [entity, project, digest] = tableMatch.slice(1);

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -582,7 +582,7 @@ export const parseRef = (ref: string): ObjectRef => {
   }
 
   if (isWeaveRef) {
-    const trimmed = trimStartChar(url.pathname, '/');
+    const trimmed = trimStartChar(url.pathname, '/').replace(/%20/g, ' ');
     const tableMatch = trimmed.match(RE_WEAVE_TABLE_REF_PATHNAME);
     if (tableMatch !== null) {
       const [entity, project, digest] = tableMatch.slice(1);


### PR DESCRIPTION
hotfix for url encoding differences between safari and chrome. spaces are allowed in ref names and get set to `%20` in safari, which then breaks ref parsing...

https://wandb.atlassian.net/browse/WB-19213