### PR TITLE
fix(weave): format values for csv export in datagrid

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -326,7 +326,11 @@ function buildCallsTableColumns(
       valueGetter: cellParams => {
         const val = (cellParams.row as any)[key];
         if (Array.isArray(val) || typeof val === 'object') {
-          return JSON.stringify(val);
+          try {
+            return JSON.stringify(val);
+          } catch {
+            return val;
+          }
         }
         return val;
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -428,9 +428,6 @@ function buildCallsTableColumns(
     filterable: false,
     sortable: false,
     valueGetter: cellParams => {
-      return monthRoundedTime(traceCallLatencyS(cellParams.row));
-    },
-    renderCell: cellParams => {
       if (traceCallStatusCode(cellParams.row) === 'UNSET') {
         // Call is still in progress, latency will be 0.
         // Displaying nothing seems preferable to being misleading.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -175,6 +175,13 @@ function buildCallsTableColumns(
       filterable: false,
       width: 250,
       hideable: false,
+      valueGetter: rowParams => {
+        const op_name = rowParams.row.op_name;
+        if (!isRef(op_name)) {
+          return op_name;
+        }
+        return opVersionRefOpName(op_name);
+      },
       renderCell: rowParams => {
         const op_name = rowParams.row.op_name;
         if (!isRef(op_name)) {
@@ -234,6 +241,9 @@ function buildCallsTableColumns(
       // type: 'singleSelect',
       // valueOptions: ['SUCCESS', 'ERROR', 'PENDING'],
       width: 59,
+      valueGetter: cellParams => {
+        return traceCallStatusCode(cellParams.row);
+      },
       renderCell: cellParams => {
         return (
           <div style={{margin: 'auto'}}>
@@ -312,6 +322,13 @@ function buildCallsTableColumns(
             {key.split('.').slice(-1)[0]}
           </div>
         );
+      },
+      valueGetter: cellParams => {
+        const val = (cellParams.row as any)[key];
+        if (Array.isArray(val) || typeof val === 'object') {
+          return JSON.stringify(val);
+        }
+        return val;
       },
       renderCell: cellParams => {
         const val = (cellParams.row as any)[key];
@@ -406,6 +423,9 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
+    valueGetter: cellParams => {
+      return monthRoundedTime(traceCallLatencyS(cellParams.row));
+    },
     renderCell: cellParams => {
       if (traceCallStatusCode(cellParams.row) === 'UNSET') {
         // Call is still in progress, latency will be 0.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -433,6 +433,14 @@ function buildCallsTableColumns(
         // Displaying nothing seems preferable to being misleading.
         return null;
       }
+      return traceCallLatencyS(cellParams.row);
+    },
+    renderCell: cellParams => {
+      if (traceCallStatusCode(cellParams.row) === 'UNSET') {
+        // Call is still in progress, latency will be 0.
+        // Displaying nothing seems preferable to being misleading.
+        return null;
+      }
       return monthRoundedTime(traceCallLatencyS(cellParams.row));
     },
   });


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-19203

This pr: 
- adds getter methods to datagrid for csv export. we use renderCell methods that prevent clean export. 
- dump objects and lists to string using `JSON.stringify`, otherwise lists mess up the columns of export, and objects just show up as `[object Object]`


Before:
<img width="1135" alt="Screenshot 2024-06-11 at 9 50 51 AM" src="https://github.com/wandb/weave/assets/19414170/1fc9cbf7-76fa-4c39-a6da-4764e4b5c2e1">


After: 
<img width="1279" alt="Screenshot 2024-06-11 at 10 26 07 AM" src="https://github.com/wandb/weave/assets/19414170/2cb51081-5f3f-4429-bc9c-0b2c9c26f582">
