### PR TITLE
chore: add ORM with no clickhouse dependency

### DIFF
--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -1,0 +1,609 @@
+"""
+A lightweight ORM layer for ClickHouse/SQLite.
+Abstracts away some of their differences and allows building up SQL queries in a safe way.
+"""
+
+import datetime
+import json
+import typing
+from typing_extensions import TypeAlias
+
+from pydantic import BaseModel
+
+from . import trace_server_interface as tsi
+from .interface import query as tsi_query
+
+
+DatabaseType = typing.Literal["clickhouse", "sqlite"]
+
+
+param_builder_count = 0
+
+
+class ParamBuilder:
+    """ParamBuilder helps with the construction of parameterized clickhouse queries.
+    It is used in a number of functions/routines that build queries to ensure that
+    the queries are parameterized and safe from injection attacks. Specifically, a caller
+    would use it as follows:
+
+    ```
+    pb = ParamBuilder()
+    param_name = pb.add_param("some_value")
+    query = f"SELECT * FROM some_table WHERE some_column = {{{param_name}:String}}"
+    parameters = pb.get_params()
+    # Execute the query with the parameters
+    ```
+
+    With queries that have many construction phases, it is recommended to use the
+    same ParamBuilder instance to ensure that the parameter names are unique across
+    the query.
+    """
+
+    def __init__(
+        self,
+        prefix: typing.Optional[str] = None,
+        database_type: DatabaseType = "clickhouse",
+    ):
+        global param_builder_count
+        param_builder_count += 1
+        self._params: typing.Dict[str, typing.Any] = {}
+        self._prefix = (prefix or f"pb_{param_builder_count}") + "_"
+        self._database_type = database_type
+
+    def add_param(self, param_value: typing.Any) -> str:
+        param_name = self._prefix + str(len(self._params))
+        self._params[param_name] = param_value
+        return param_name
+
+    def add(
+        self,
+        param_value: typing.Any,
+        param_name: typing.Optional[str] = None,
+        param_type: typing.Optional[str] = None,
+    ) -> str:
+        """Returns the placeholder for the target database type.
+
+        e.g. SQLite -> :limit
+        e.g. ClickHouse -> {limit:UInt64}
+        """
+        param_name = param_name or self._prefix + str(len(self._params))
+        self._params[param_name] = param_value
+        if self._database_type == "clickhouse":
+            ptype = param_type or _python_value_to_ch_type(param_value)
+            return f"{{{param_name}:{ptype}}}"
+        return ":" + param_name
+
+    def get_params(self) -> typing.Dict[str, typing.Any]:
+        return {**self._params}
+
+
+Value: TypeAlias = typing.Optional[
+    typing.Union[str, float, datetime.datetime, list[str], list[float]]
+]
+Row: TypeAlias = dict[str, Value]
+Rows: TypeAlias = list[Row]
+
+
+ColumnType = typing.Literal[
+    "string",
+    "datetime",
+    "json",  # Represented as string in ClickHouse
+]
+
+
+class Column:
+    # This is the name of the column from a user perspective.
+    name: str
+
+    # If specified, this is the name of the column in the database.
+    # Normally we just use name, but sometimes we have an internal convention like
+    # a "_dump" suffix that we don't want to expose in the API.
+    db_name: typing.Optional[str]
+    type: ColumnType
+    nullable: bool
+    # TODO: Description?
+    # TODO: Default?
+
+    def __init__(
+        self,
+        name: str,
+        type: ColumnType,
+        nullable: bool = False,
+        db_name: typing.Optional[str] = None,
+    ) -> None:
+        self.name = name
+        self.db_name = db_name
+        self.type = type
+        self.nullable = nullable
+
+    def dbname(self) -> str:
+        return self.db_name or self.name
+
+    def create_sql(self) -> str:
+        sql_type = "TEXT"
+        sql = f"{self.dbname()} {sql_type}"
+        return sql
+
+
+Columns = list[Column]
+
+
+class Table:
+    name: str
+    cols: Columns
+
+    # Fields derived from cols
+    col_types: dict[str, ColumnType]
+    json_cols: list[str]
+
+    def __init__(self, name: str, cols: typing.Optional[Columns] = None):
+        self.name = name
+        self.cols = cols or []
+        self.col_types = {c.name: c.type for c in self.cols}
+        self.json_cols = [c.name for c in self.cols if c.type == "json"]
+
+    def create_sql(self) -> str:
+        sql = f"CREATE TABLE IF NOT EXISTS {self.name} (\n"
+        sql += ",\n".join("    " + col.create_sql() for col in self.cols)
+        sql += "\n)"
+        return sql
+
+    def drop_sql(self) -> str:
+        return f"DROP TABLE IF EXISTS {self.name}"
+
+    def select(self) -> "Select":
+        return Select(self)
+
+    def insert(self, row: typing.Optional[Row] = None) -> "Insert":
+        ins = Insert(self)
+        if row:
+            ins.row(row)
+        return ins
+
+    def purge(self) -> "Select":
+        return Select(self, action="DELETE")
+
+    def truncate_sql(self, database_type: DatabaseType) -> str:
+        if database_type == "clickhouse":
+            return f"TRUNCATE TABLE {self.name}"
+        if database_type == "sqlite":
+            return f"DELETE FROM {self.name}"
+
+    def tuple_to_row(self, tuple: typing.Tuple, fields: list[str]) -> Row:
+        d = {}
+        for i, field in enumerate(fields):
+            if field.endswith("_dump"):
+                field = field[:-5]
+            value = tuple[i]
+            if field in self.col_types and self.col_types[field] == "json":
+                d[field] = json.loads(value)
+            else:
+                d[field] = value
+        return d
+
+    def tuples_to_rows(self, tuples: list[typing.Tuple], fields: list[str]) -> Rows:
+        rows = []
+        for t in tuples:
+            rows.append(self.tuple_to_row(t, fields))
+        return rows
+
+
+Action = typing.Literal["SELECT", "DELETE"]
+
+
+class PreparedSelect(BaseModel):
+    sql: str
+    parameters: dict[str, typing.Any]
+    fields: list[str]
+
+
+class Select:
+    table: Table
+    all_columns: list[str]
+
+    action: Action
+
+    _project_id: typing.Optional[str]
+    _fields: typing.Optional[list[str]]
+    _query: typing.Optional[tsi.Query]
+    _order_by: typing.Optional[typing.List[tsi._SortBy]]
+    _limit: typing.Optional[int]
+    _offset: typing.Optional[int]
+
+    def __init__(self, table: Table, action: Action = "SELECT"):
+        self.table = table
+        self.action = action
+        self.all_columns = [c.dbname() for c in table.cols]
+
+        self._project_id = None
+        self._fields = []
+        self._query = None
+        self._order_by = None
+        self._limit = None
+        self._offset = None
+
+    def project_id(self, project_id: typing.Optional[str]) -> "Select":
+        self._project_id = project_id
+        return self
+
+    def fields(self, fields: typing.Optional[list[str]]) -> "Select":
+        self._fields = fields
+        return self
+
+    def where(self, query: typing.Optional[tsi.Query]) -> "Select":
+        self._query = query
+        return self
+
+    def order_by(self, order_by: typing.Optional[typing.List[tsi._SortBy]]) -> "Select":
+        if order_by:
+            for o in order_by:
+                assert o.direction in (
+                    "ASC",
+                    "DESC",
+                    "asc",
+                    "desc",
+                ), f"Invalid order_by direction: {o.direction}"
+        self._order_by = order_by
+        return self
+
+    def limit(self, limit: typing.Optional[int]) -> "Select":
+        if limit is not None and limit < 0:
+            raise ValueError("Limit must be non-negative")
+        self._limit = limit
+        return self
+
+    def offset(self, offset: typing.Optional[int]) -> "Select":
+        if offset is not None and offset < 0:
+            raise ValueError("Offset must be non-negative")
+        self._offset = offset
+        return self
+
+    def prepare(
+        self,
+        database_type: DatabaseType,
+        param_builder: typing.Optional[ParamBuilder] = None,
+    ) -> PreparedSelect:
+        param_builder = param_builder or ParamBuilder(None, database_type)
+        assert database_type == param_builder._database_type
+
+        sql = ""
+        if self.action == "SELECT":
+            fieldnames = self._fields or self.all_columns
+            internal_fields = [
+                _transform_external_field_to_internal_field(
+                    f,
+                    self.all_columns,
+                    self.table.json_cols,
+                    param_builder=param_builder,
+                )[0]
+                for f in fieldnames
+            ]
+            joined_fields = ", ".join(internal_fields)
+            sql = f"SELECT {joined_fields}\n"
+        elif self.action == "DELETE":
+            fieldnames = []
+            sql = "DELETE "
+
+        sql += f"FROM {self.table.name}"
+
+        conditions = []
+        if self._project_id:
+            param_project_id = param_builder.add(
+                self._project_id, "project_id", "String"
+            )
+            conditions = [f"project_id = {param_project_id}"]
+        if self._query:
+            query_conds, fields_used = _process_query_to_conditions(
+                self._query, self.all_columns, self.table.json_cols, param_builder
+            )
+            conditions.extend(query_conds)
+
+        joined = _combine_conditions(conditions, "AND")
+        if joined:
+            sql += f"\nWHERE {joined}"
+
+        if self._order_by is not None:
+            order_parts = []
+            for clause in self._order_by:
+                field = clause.field
+                direction = clause.direction
+                # For each order by field, if it is a dynamic field, we generate
+                # 3 order by terms: one for existence, one for float casting, and one for string casting.
+                # The effect of this is that we will have stable sorting for nullable, mixed-type fields.
+                if _is_dynamic_field(field, self.table.json_cols):
+                    # Prioritize existence, then cast to float, then str
+                    options = [
+                        ("exists", "desc"),
+                        ("float", direction),
+                        ("str", direction),
+                    ]
+                else:
+                    options = [(field, direction)]
+
+                # For each option, build the order by term
+                for cast, direct in options:
+                    # Future refactor: this entire section should be moved into its own helper
+                    # method and hoisted out of this function
+                    (inner_field, _, _,) = _transform_external_field_to_internal_field(
+                        field,
+                        self.all_columns,
+                        self.table.json_cols,
+                        cast,
+                        param_builder=param_builder,
+                    )
+                    order_parts.append(f"{inner_field} {direct}")
+            order_by_part = ", ".join(order_parts)
+            if order_by_part:
+                sql += f"\nORDER BY {order_by_part}"
+
+        if self._limit is not None:
+            param_limit = param_builder.add(self._limit, "limit", "UInt64")
+            sql += f"\nLIMIT {param_limit}"
+        if self._offset is not None:
+            param_offset = param_builder.add(self._offset, "offset", "UInt64")
+            sql += f"\nOFFSET {param_offset}"
+
+        parameters = param_builder.get_params()
+        return PreparedSelect(sql=sql, parameters=parameters, fields=fieldnames)
+
+
+class PreparedInsert(BaseModel):
+    sql: str
+    column_names: list[str]
+    data: typing.Sequence[typing.Sequence[typing.Any]]
+
+
+class Insert:
+    table: Table
+    dbnames: dict[str, str]
+    rows: list[Row]
+
+    def __init__(self, table: Table) -> None:
+        self.table = table
+        self.dbnames = {c.name: c.db_name for c in table.cols if c.db_name}
+        self.rows = []
+
+    def row(self, row: Row) -> None:
+        """Queue a row for insertion."""
+        self.rows.append(row)
+
+    def prepare(self, database_type: DatabaseType) -> PreparedInsert:
+        if not self.rows:
+            raise ValueError("No rows added for insertion")
+
+        # TODO: Do we want to allow different columns per row?
+        first_row = self.rows[0]
+        given_column_names = first_row.keys()
+        column_names = [self.dbnames.get(k, k) for k in given_column_names]
+
+        data = []
+        for row in self.rows:
+            r: list[typing.Any] = []
+            for field in given_column_names:
+                if (
+                    field in self.table.col_types
+                    and self.table.col_types[field] == "json"
+                ):
+                    r.append(json.dumps(row[field]))
+                else:
+                    r.append(row[field])
+            data.append(r)
+
+        if database_type == "sqlite":
+            sql = f"INSERT INTO {self.table.name} (\n    "
+            sql += ", ".join(column_names)
+            sql += "\n) VALUES (\n    "
+            sql += ", ".join("?" for _ in column_names)
+            sql += "\n)"
+        elif database_type == "clickhouse":
+            # We could implement this, but we don't need to given the ClickHouse Python Client API
+            sql = ""
+        return PreparedInsert(sql=sql, column_names=column_names, data=data)
+
+
+def _combine_conditions(conditions: typing.List[str], operator: str) -> str:
+    if operator not in ("AND", "OR"):
+        raise ValueError(f"Invalid operator: {operator}")
+    if not conditions:
+        return ""
+    if len(conditions) == 1:
+        return conditions[0]
+    combined = f" {operator} ".join(f"({c})" for c in conditions)
+    return f"({combined})"
+
+
+def _python_value_to_ch_type(value: typing.Any) -> str:
+    """Helper function to convert python types to clickhouse types."""
+    if isinstance(value, str):
+        return "String"
+    elif isinstance(value, int):
+        return "UInt64"
+    elif isinstance(value, float):
+        return "Float64"
+    elif isinstance(value, bool):
+        return "UInt8"
+    elif value is None:
+        return "Nullable(String)"
+    else:
+        raise ValueError(f"Unknown value type: {value}")
+
+
+def _quote_json_path(path: str) -> str:
+    """Helper function to quote a json path for use in a clickhouse query. Moreover,
+    this converts index operations from dot notation (conforms to Mongo) to bracket
+    notation (required by clickhouse)
+
+    See comments on `GetFieldOperator` for current limitations
+    """
+    parts = path.split(".")
+    parts_final = []
+    for part in parts:
+        try:
+            int(part)
+            parts_final.append("[" + part + "]")
+        except ValueError:
+            parts_final.append('."' + part + '"')
+    return "$" + "".join(parts_final)
+
+
+def _transform_external_field_to_internal_field(
+    field: str,
+    all_columns: typing.Sequence[str],
+    json_columns: typing.Sequence[str],
+    cast: typing.Optional[str] = None,
+    param_builder: typing.Optional[ParamBuilder] = None,
+) -> tuple[str, ParamBuilder, set[str]]:
+    """Transforms a request for a dot-notation field to a clickhouse field."""
+    param_builder = param_builder or ParamBuilder()
+    raw_fields_used = set()
+    json_path = None
+    for prefix in json_columns:
+        if field == prefix:
+            field = prefix + "_dump"
+        elif field.startswith(prefix + "."):
+            json_path = _quote_json_path(field[len(prefix + ".") :])
+            field = prefix + "_dump"
+
+    # validate field
+    if field not in all_columns and field.lower() != "count(*)":
+        raise ValueError(f"Unknown field: {field}")
+
+    raw_fields_used.add(field)
+    if json_path is not None:
+        json_path_param = param_builder.add(json_path, None, "String")
+        if cast == "exists":
+            field = "(JSON_EXISTS(" + field + ", " + json_path_param + "))"
+        else:
+            method = "toString"
+            if cast is not None:
+                if cast == "int":
+                    method = "toInt64OrNull"
+                elif cast == "float":
+                    method = "toFloat64OrNull"
+                elif cast == "bool":
+                    method = "toUInt8OrNull"
+                elif cast == "str":
+                    method = "toString"
+                else:
+                    raise ValueError(f"Unknown cast: {cast}")
+            is_sqlite = param_builder._database_type == "sqlite"
+            json_func = "json_extract(" if is_sqlite else "JSON_VALUE("
+            field = json_func + field + ", " + json_path_param + ")"
+            if not is_sqlite:
+                field = method + "(" + field + ")"
+
+    return field, param_builder, raw_fields_used
+
+
+def _process_query_to_conditions(
+    query: tsi.Query,
+    all_columns: typing.Sequence[str],
+    json_columns: typing.Sequence[str],
+    param_builder: typing.Optional[ParamBuilder] = None,
+) -> tuple[list[str], set[str]]:
+    """Converts a Query to a list of conditions for a clickhouse query."""
+    pb = param_builder or ParamBuilder()
+    conditions = []
+    raw_fields_used = set()
+
+    # This is the mongo-style query
+    def process_operation(operation: tsi_query.Operation) -> str:
+        cond = None
+
+        if isinstance(operation, tsi_query.AndOperation):
+            if len(operation.and_) == 0:
+                raise ValueError("Empty AND operation")
+            elif len(operation.and_) == 1:
+                return process_operand(operation.and_[0])
+            parts = [process_operand(op) for op in operation.and_]
+            cond = f"({' AND '.join(parts)})"
+        elif isinstance(operation, tsi_query.OrOperation):
+            if len(operation.or_) == 0:
+                raise ValueError("Empty OR operation")
+            elif len(operation.or_) == 1:
+                return process_operand(operation.or_[0])
+            parts = [process_operand(op) for op in operation.or_]
+            cond = f"({' OR '.join(parts)})"
+        elif isinstance(operation, tsi_query.NotOperation):
+            operand_part = process_operand(operation.not_[0])
+            cond = f"(NOT ({operand_part}))"
+        elif isinstance(operation, tsi_query.EqOperation):
+            lhs_part = process_operand(operation.eq_[0])
+            rhs_part = process_operand(operation.eq_[1])
+            cond = f"({lhs_part} = {rhs_part})"
+        elif isinstance(operation, tsi_query.GtOperation):
+            lhs_part = process_operand(operation.gt_[0])
+            rhs_part = process_operand(operation.gt_[1])
+            cond = f"({lhs_part} > {rhs_part})"
+        elif isinstance(operation, tsi_query.GteOperation):
+            lhs_part = process_operand(operation.gte_[0])
+            rhs_part = process_operand(operation.gte_[1])
+            cond = f"({lhs_part} >= {rhs_part})"
+        elif isinstance(operation, tsi_query.ContainsOperation):
+            lhs_part = process_operand(operation.contains_.input)
+            rhs_part = process_operand(operation.contains_.substr)
+            position_operation = "position"
+            if operation.contains_.case_insensitive:
+                position_operation = "positionCaseInsensitive"
+            cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
+        else:
+            raise ValueError(f"Unknown operation type: {operation}")
+
+        return cond
+
+    def process_operand(operand: tsi_query.Operand) -> str:
+        if isinstance(operand, tsi_query.LiteralOperation):
+            return pb.add(
+                operand.literal_, None, _python_value_to_ch_type(operand.literal_)
+            )
+        elif isinstance(operand, tsi_query.GetFieldOperator):
+            (field, _, fields_used,) = _transform_external_field_to_internal_field(
+                operand.get_field_, all_columns, json_columns, None, pb
+            )
+            raw_fields_used.update(fields_used)
+            return field
+        elif isinstance(operand, tsi_query.ConvertOperation):
+            field = process_operand(operand.convert_.input)
+            convert_to = operand.convert_.to
+            if convert_to == "int":
+                method = "toInt64OrNull"
+            elif convert_to == "double":
+                method = "toFloat64OrNull"
+            elif convert_to == "bool":
+                method = "toUInt8OrNull"
+            elif convert_to == "string":
+                method = "toString"
+            else:
+                raise ValueError(f"Unknown cast: {convert_to}")
+            return f"{method}({field})"
+        elif isinstance(
+            operand,
+            (
+                tsi_query.AndOperation,
+                tsi_query.OrOperation,
+                tsi_query.NotOperation,
+                tsi_query.EqOperation,
+                tsi_query.GtOperation,
+                tsi_query.GteOperation,
+                tsi_query.ContainsOperation,
+            ),
+        ):
+            return process_operation(operand)
+        else:
+            raise ValueError(f"Unknown operand type: {operand}")
+
+    filter_cond = process_operation(query.expr_)
+
+    conditions.append(filter_cond)
+
+    return conditions, raw_fields_used
+
+
+def _is_dynamic_field(field: str, json_columns: list[str]) -> bool:
+    """Dynamic fields are fields that are arbitrary values produced by the user."""
+    if field in json_columns:
+        return True
+    for col in json_columns:
+        if field.startswith(col + "."):
+            return True
+    return False

--- a/weave/trace_server/tests/test_orm.py
+++ b/weave/trace_server/tests/test_orm.py
@@ -1,0 +1,175 @@
+import pytest
+
+from weave.trace_server.orm import (
+    ParamBuilder,
+    Table,
+    Column,
+    _combine_conditions,
+    _transform_external_field_to_internal_field,
+)
+
+
+def test_parambuilder_clickhouse():
+    pb = ParamBuilder(database_type="clickhouse")
+    name = pb.add("bar", "foo", "String")
+    assert name == "{foo:String}"
+    name = pb.add(12, "bim")
+    assert name == "{bim:UInt64}"
+    assert pb.get_params() == {
+        "foo": "bar",
+        "bim": 12,
+    }
+
+
+def test_parambuilder_sqlite():
+    pb = ParamBuilder(database_type="sqlite")
+    placeholder = pb.add("bar", "foo", "String")
+    assert placeholder == ":foo"
+    placeholder = pb.add(12, "bim")
+    assert placeholder == ":bim"
+    assert pb.get_params() == {
+        "foo": "bar",
+        "bim": 12,
+    }
+
+
+def test_combine_conditions():
+    with pytest.raises(ValueError):
+        _combine_conditions([], "NOT")
+
+    assert _combine_conditions([], "AND") == ""
+    assert _combine_conditions(["foo = 'bar'"], "AND") == "foo = 'bar'"
+    assert _combine_conditions(["foo = 'bar'"], "OR") == "foo = 'bar'"
+    assert (
+        _combine_conditions(["foo = 'bar'", "bim = 12"], "AND")
+        == "((foo = 'bar') AND (bim = 12))"
+    )
+    assert (
+        _combine_conditions(["foo = 'bar'", "bim = 12"], "OR")
+        == "((foo = 'bar') OR (bim = 12))"
+    )
+
+
+def test_transform_external_field_to_internal_field():
+    all_columns = ["id", "creator", "payload_dump"]
+    json_columns = ["payload"]
+
+    # Transforming a column that doesn't exist should raise
+    with pytest.raises(ValueError):
+        _transform_external_field_to_internal_field("foo", all_columns, json_columns)
+
+    result = _transform_external_field_to_internal_field(
+        "id", all_columns, json_columns
+    )
+    assert result[0] == "id"
+    assert result[2] == {"id"}
+    result = _transform_external_field_to_internal_field(
+        "payload", all_columns, json_columns
+    )
+    assert result[0] == "payload_dump"
+    assert result[2] == {"payload_dump"}
+    pb = ParamBuilder(prefix="pb", database_type="sqlite")
+    result = _transform_external_field_to_internal_field(
+        "payload.address", all_columns, json_columns, param_builder=pb
+    )
+    assert result[0] == "json_extract(payload_dump, :pb_0)"
+    assert result[2] == {"payload_dump"}
+    pb = ParamBuilder(prefix="pb", database_type="clickhouse")
+    result = _transform_external_field_to_internal_field(
+        "payload.address", all_columns, json_columns, param_builder=pb
+    )
+    assert result[0] == "toString(JSON_VALUE(payload_dump, {pb_0:String}))"
+    assert result[2] == {"payload_dump"}
+
+
+def test_table_create_sql():
+    table = Table(
+        "users",
+        [
+            Column("id", "string"),
+            Column("creator", "string", nullable=True),
+            Column("payload", "json", db_name="payload_dump"),
+        ],
+    )
+    assert (
+        table.create_sql()
+        == "CREATE TABLE IF NOT EXISTS users (\n    id TEXT,\n    creator TEXT,\n    payload_dump TEXT\n)"
+    )
+
+
+def test_table_drop_sql():
+    table = Table(
+        "users",
+        [
+            Column("id", "string"),
+            Column("creator", "string", nullable=True),
+            Column("payload", "json", db_name="payload_dump"),
+        ],
+    )
+    assert table.drop_sql() == "DROP TABLE IF EXISTS users"
+
+
+def test_select_basic():
+    table = Table(
+        "users",
+        [
+            Column("id", "string"),
+            Column("creator", "string", nullable=True),
+            Column("payload", "json", db_name="payload_dump"),
+        ],
+    )
+    select = table.select()
+    select = select.limit(10)
+    prepared = select.prepare(database_type="clickhouse")
+    assert (
+        prepared.sql
+        == """SELECT id, creator, payload_dump
+FROM users
+LIMIT {limit:UInt64}"""
+    )
+    assert prepared.parameters == {"limit": 10}
+    assert prepared.fields == ["id", "creator", "payload_dump"]
+
+    prepared = select.prepare(database_type="sqlite")
+    assert (
+        prepared.sql
+        == """SELECT id, creator, payload_dump
+FROM users
+LIMIT :limit"""
+    )
+    assert prepared.parameters == {"limit": 10}
+    assert prepared.fields == ["id", "creator", "payload_dump"]
+
+
+def test_select_fields():
+    table = Table(
+        "users",
+        [
+            Column("id", "string"),
+            Column("creator", "string", nullable=True),
+            Column("payload", "json", db_name="payload_dump"),
+        ],
+    )
+    select = table.select()
+    select = select.fields(["id", "payload.address"])
+
+    # More complicated than normal usage to fix the ParamBuilder prefix.
+    pb = ParamBuilder(prefix="pb", database_type="sqlite")
+    prepared = select.prepare(database_type="sqlite", param_builder=pb)
+    assert (
+        prepared.sql
+        == """SELECT id, json_extract(payload_dump, :pb_0)
+FROM users"""
+    )
+    assert prepared.parameters == {"pb_0": '$."address"'}
+    assert prepared.fields == ["id", "payload.address"]
+
+    pb = ParamBuilder(prefix="pb", database_type="clickhouse")
+    prepared = select.prepare(database_type="clickhouse", param_builder=pb)
+    assert (
+        prepared.sql
+        == """SELECT id, toString(JSON_VALUE(payload_dump, {pb_0:String}))
+FROM users"""
+    )
+    assert prepared.parameters == {"pb_0": '$."address"'}
+    assert prepared.fields == ["id", "payload.address"]


### PR DESCRIPTION
This is an updated version of the ORM code that previously went in as part of reverted PR https://github.com/wandb/weave/pull/1718

The previous version of this class used ClickHouse classes like QuerySummary and Client. This created an unfortunate dependency chain:
* SqliteTraceServer depended on the TABLE_FEEDBACK definition for table create/drop/query.
* TABLE_FEEDBACK was implemented using this ORM layer
* This ORM layer depended on the ClickHouse library.

This is already undesirable as we don't want to introduce a dependency on the ClickHouse library to the Weave client library.

But there was a bigger problem, which is that the WBAuthMiddleware depends on importing weave, which in turn depends on SqliteTraceServer. So through this unfortunate dependency chain (which we should probably also break in other places) the feedback trace server APIs change broke all the SaaS integration tests. And unfortunately that breakage was not caught in CI because of https://github.com/wandb/core/pull/21936

This lightly updated version of the code has "prepare" methods which return sql + parameters for the caller to execute rather than directly executing them through a ClickHouse client or sqlite3.Cursor.

If we decide to add support for more databases (DuckDB say) we would probably want to revisit this ORM layer again, but this version should be sufficient for the feedback feature.