### PR TITLE
feat: Adding trace server feedback APIs using updated ORM

### DIFF
--- a/weave/tests/test_client_feedback.py
+++ b/weave/tests/test_client_feedback.py
@@ -1,0 +1,216 @@
+import pytest
+
+from ..trace_server import trace_server_interface as tsi
+from ..trace_server.errors import InvalidRequest
+from ..trace_server.interface.query import Query
+
+
+def test_feedback_apis(client):
+
+    project_id = client._project_id()
+
+    # Emoji from Jamie
+    req = tsi.FeedbackCreateReqForInsert(
+        project_id=project_id,
+        wb_user_id="VXNlcjo0NTI1NDQ=",
+        weave_ref="weave:///entity/project/object/name:digest",
+        feedback_type="wandb.reaction.1",
+        payload={"emoji": "🎱"},
+    )
+    res = client.server.feedback_create(req)
+    assert len(res.id) == 36
+    assert res.payload["alias"] == ":pool_8_ball:"
+    id_emoji_1 = res.id
+
+    # Another emoji from Jamie
+    req = tsi.FeedbackCreateReqForInsert(
+        project_id=project_id,
+        wb_user_id="VXNlcjo0NTI1NDQ=",
+        weave_ref="weave:///entity/project/object/name:digest",
+        feedback_type="wandb.reaction.1",
+        payload={"emoji": "👍🏻"},
+    )
+    res = client.server.feedback_create(req)
+    assert len(res.id) == 36
+    assert res.payload["detoned_alias"] == ":thumbs_up:"
+    id_emoji_2 = res.id
+
+    # Emoji from Shawn
+    req = tsi.FeedbackCreateReqForInsert(
+        project_id=project_id,
+        wb_user_id="VXNlcjoxOQ==",
+        weave_ref="weave:///entity/project/object/name:digest",
+        feedback_type="wandb.reaction.1",
+        payload={"emoji": "👍"},
+    )
+    res = client.server.feedback_create(req)
+    assert len(res.id) == 36
+    assert res.payload["detoned_alias"] == ":thumbs_up:"
+    id_emoji_3 = res.id
+
+    # Note from Jamie
+    req = tsi.FeedbackCreateReqForInsert(
+        project_id=project_id,
+        wb_user_id="VXNlcjo0NTI1NDQ=",
+        weave_ref="weave:///entity/project/object/name:digest",
+        feedback_type="wandb.note.1",
+        payload={"note": "this is a note"},
+    )
+    res = client.server.feedback_create(req)
+    assert len(res.id) == 36
+    id_note = res.id
+
+    # Custom from Jamie
+    req = tsi.FeedbackCreateReqForInsert(
+        project_id=project_id,
+        wb_user_id="VXNlcjo0NTI1NDQ=",
+        weave_ref="weave:///entity/project/object/name:digest",
+        feedback_type="custom",
+        payload={"key": "value"},
+    )
+    res = client.server.feedback_create(req)
+    assert len(res.id) == 36
+    id_custom_1 = res.id
+
+    # Custom on another object
+    req = tsi.FeedbackCreateReqForInsert(
+        project_id=project_id,
+        wb_user_id="VXNlcjo0NTI1NDQ=",
+        weave_ref="weave:///entity/project/object/name2:digest",
+        feedback_type="custom",
+        payload={"key": "value"},
+    )
+    res = client.server.feedback_create(req)
+    assert len(res.id) == 36
+    id_custom_2 = res.id
+
+    # Try querying on the published feedback
+    req = tsi.FeedbackQueryReq(
+        project_id=project_id,
+        fields=["count(*)"],
+    )
+    res = client.server.feedback_query(req)
+    assert res.result[0]["count(*)"] == 6
+
+    req = tsi.FeedbackQueryReq(
+        project_id=project_id,
+        fields=["count(*)"],
+        query=Query(
+            **{
+                "$expr": {
+                    "$eq": [
+                        {"$getField": "feedback_type"},
+                        {"$literal": "wandb.reaction.1"},
+                    ],
+                }
+            }
+        ),
+    )
+    res = client.server.feedback_query(req)
+    assert res.result[0]["count(*)"] == 3
+
+    req = tsi.FeedbackQueryReq(
+        project_id=project_id,
+        fields=["count(*)"],
+        query=Query(
+            **{
+                "$expr": {
+                    "$eq": [
+                        {"$getField": "weave_ref"},
+                        {"$literal": "weave:///entity/project/object/name:digest"},
+                    ],
+                }
+            }
+        ),
+    )
+    res = client.server.feedback_query(req)
+    assert res.result[0]["count(*)"] == 5
+
+    # Purge one feedback
+    req = tsi.FeedbackPurgeReq(
+        project_id=project_id,
+        query=Query(
+            **{
+                "$expr": {
+                    "$eq": [
+                        {"$getField": "id"},
+                        {"$literal": id_note},
+                    ],
+                }
+            }
+        ),
+    )
+    res = client.server.feedback_purge(req)
+
+    req = tsi.FeedbackQueryReq(
+        project_id=project_id,
+        fields=["count(*)"],
+    )
+    res = client.server.feedback_query(req)
+    assert res.result[0]["count(*)"] == 5
+
+    # Purge multiple feedbacks
+    req = tsi.FeedbackPurgeReq(
+        project_id=project_id,
+        query=Query(
+            **{
+                "$expr": {
+                    "$or": [
+                        {
+                            "$eq": [
+                                {"$getField": "id"},
+                                {"$literal": id_custom_1},
+                            ],
+                        },
+                        {
+                            "$eq": [
+                                {"$getField": "id"},
+                                {"$literal": id_custom_2},
+                            ],
+                        },
+                    ]
+                }
+            }
+        ),
+    )
+    res = client.server.feedback_purge(req)
+
+    req = tsi.FeedbackQueryReq(
+        project_id=project_id,
+        fields=["count(*)"],
+    )
+    res = client.server.feedback_query(req)
+    assert res.result[0]["count(*)"] == 3
+
+    # Purging with a different shaped query raises
+    with pytest.raises(InvalidRequest):
+        req = tsi.FeedbackPurgeReq(
+            project_id=project_id,
+            query=Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "feedback_type"},
+                            {"$literal": "wandb.reaction.1"},
+                        ],
+                    }
+                }
+            ),
+        )
+        client.server.feedback_purge(req)
+
+
+def test_feedback_create_too_large(client):
+
+    project_id = client._project_id()
+
+    value = "a" * 10000
+    req = tsi.FeedbackCreateReqForInsert(
+        project_id=project_id,
+        wb_user_id="VXNlcjo0NTI1NDQ=",
+        weave_ref="weave:///entity/project/object/name:digest",
+        feedback_type="custom",
+        payload={"value": value},
+    )
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(req)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -31,17 +31,26 @@ import typing
 import hashlib
 import dataclasses
 import logging
+from zoneinfo import ZoneInfo
 
+import emoji
 from clickhouse_connect.driver.client import Client as CHClient
 from clickhouse_connect.driver.query import QueryResult, StreamContext
 from clickhouse_connect.driver.summary import QuerySummary
 
 import clickhouse_connect
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from . import environment as wf_env
 from . import clickhouse_trace_server_migrator as wf_migrator
-from .errors import RequestTooLarge
+from .errors import InvalidRequest, RequestTooLarge
+from .emoji_util import detone_emojis
+from .feedback import (
+    TABLE_FEEDBACK,
+    validate_feedback_create_req,
+    validate_feedback_purge_req,
+)
+from .orm import Table, Column, ParamBuilder, Row
 
 from .trace_server_interface_util import (
     extract_refs_from_values,
@@ -214,7 +223,7 @@ all_obj_insert_columns = list(ObjCHInsertable.model_fields.keys())
 required_obj_select_columns = list(set(all_obj_select_columns) - set([]))
 
 
-class ClickHouseTraceServer(tsi.TraceServerInterface):
+class ClickHouseTraceServer(tsi.TraceServerInterfacePostAuth):
     def __init__(
         self,
         *,
@@ -952,6 +961,78 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             raise ValueError("Missing chunks")
         return tsi.FileContentReadRes(content=b"".join(chunks))
 
+    def feedback_create(
+        self, req: tsi.FeedbackCreateReqForInsert
+    ) -> tsi.FeedbackCreateRes:
+        validate_feedback_create_req(req)
+
+        # Augment emoji with alias.
+        res_payload = {}
+        if req.feedback_type == "wandb.reaction.1":
+            em = req.payload["emoji"]
+            if emoji.emoji_count(em) != 1:
+                raise InvalidRequest(
+                    "Value of emoji key in payload must be exactly one emoji"
+                )
+            req.payload["alias"] = emoji.demojize(em)
+            detoned = detone_emojis(em)
+            req.payload["detoned"] = detoned
+            req.payload["detoned_alias"] = emoji.demojize(detoned)
+            res_payload = req.payload
+
+        feedback_id = generate_id()
+        created_at = datetime.datetime.now(ZoneInfo("UTC"))
+        # TODO: Any validation on weave_ref?
+        payload = _dict_value_to_dump(req.payload)
+        MAX_PAYLOAD = 1024
+        if len(payload) > MAX_PAYLOAD:
+            raise InvalidRequest("Feedback payload too large")
+        row: Row = {
+            "id": feedback_id,
+            "project_id": req.project_id,
+            "weave_ref": req.weave_ref,
+            "wb_user_id": req.wb_user_id,
+            "creator": req.creator,
+            "feedback_type": req.feedback_type,
+            "payload": payload,
+            "created_at": created_at,
+        }
+        prepared = TABLE_FEEDBACK.insert(row).prepare(database_type="clickhouse")
+        self._insert(TABLE_FEEDBACK.name, prepared.data, prepared.column_names)
+        return tsi.FeedbackCreateRes(
+            id=feedback_id,
+            created_at=created_at,
+            wb_user_id=req.wb_user_id,
+            payload=res_payload,
+        )
+
+    def feedback_query(self, req: tsi.FeedbackQueryReq) -> tsi.FeedbackQueryRes:
+        query = TABLE_FEEDBACK.select()
+        query = query.project_id(req.project_id)
+        query = query.fields(req.fields)
+        query = query.where(req.query)
+        query = query.order_by(req.sort_by)
+        query = query.limit(req.limit).offset(req.offset)
+        prepared = query.prepare(database_type="clickhouse")
+        query_result = self.ch_client.query(prepared.sql, prepared.parameters)
+        result = TABLE_FEEDBACK.tuples_to_rows(
+            query_result.result_rows, prepared.fields
+        )
+        return tsi.FeedbackQueryRes(result=result)
+
+    def feedback_purge(self, req: tsi.FeedbackPurgeReq) -> tsi.FeedbackPurgeRes:
+        # TODO: Instead of passing conditions to DELETE FROM,
+        #       should we select matching ids, and then DELETE FROM WHERE id IN (...)?
+        #       This would allow us to return the number of rows deleted, and complain
+        #       if too many things would be deleted.
+        validate_feedback_purge_req(req)
+        query = TABLE_FEEDBACK.purge()
+        query = query.project_id(req.project_id)
+        query = query.where(req.query)
+        prepared = query.prepare(database_type="clickhouse")
+        self.ch_client.query(prepared.sql, prepared.parameters)
+        return tsi.FeedbackPurgeRes()
+
     # Private Methods
     @property
     def ch_client(self) -> CHClient:
@@ -1202,7 +1283,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 calls_merged.id IN (
                     SELECT id from calls_merged WHERE (
                         project_id = {{project_id: String}}
-                            AND 
+                            AND
                         {where_conditions_part}
                     )
                     {order_by_side}
@@ -1721,7 +1802,9 @@ def _digest_is_version_like(digest: str) -> typing.Tuple[bool, int]:
 def _combine_conditions(conditions: typing.List[str], operator: str) -> str:
     if operator not in ("AND", "OR"):
         raise ValueError(f"Invalid operator: {operator}")
-    combined = f" {operator} ".join([f"({c})" for c in conditions])
+    if len(conditions) == 1:
+        return conditions[0]
+    combined = f" {operator} ".join(f"({c})" for c in conditions)
     return f"({combined})"
 
 
@@ -1752,43 +1835,6 @@ def find_call_descendants(
     descendants = find_all_descendants(root_ids)
 
     return list(descendants)
-
-
-param_builder_count = 0
-
-
-class ParamBuilder:
-    """ParamBuilder helps with the construction of parameterized clickhouse queries.
-    It is used in a number of functions/routines that build queries to ensure that
-    the queries are parameterized and safe from injection attacks. Specifically, a caller
-    would use it as follows:
-
-    ```
-    pb = ParamBuilder()
-    param_name = pb.add_param("some_value")
-    query = f"SELECT * FROM some_table WHERE some_column = {{{param_name}:String}}"
-    parameters = pb.get_params()
-    # Execute the query with the parameters
-    ```
-
-    With queries that have many construction phases, it is recommended to use the
-    same ParamBuilder instance to ensure that the parameter names are unique across
-    the query.
-    """
-
-    def __init__(self, prefix: typing.Optional[str] = None):
-        global param_builder_count
-        param_builder_count += 1
-        self._params: typing.Dict[str, typing.Any] = {}
-        self._prefix = (prefix or f"pb_{param_builder_count}") + "_"
-
-    def add_param(self, param_value: typing.Any) -> str:
-        param_name = self._prefix + str(len(self._params))
-        self._params[param_name] = param_value
-        return param_name
-
-    def get_params(self) -> typing.Dict[str, typing.Any]:
-        return {**self._params}
 
 
 def _python_value_to_ch_type(value: typing.Any) -> str:

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+from pydantic import ValidationError, BaseModel
+
+from . import trace_server_interface as tsi
+from .errors import InvalidRequest
+from .orm import Table, Column
+
+
+TABLE_FEEDBACK = Table(
+    "feedback",
+    [
+        Column("id", "string"),
+        Column("project_id", "string"),
+        Column("weave_ref", "string"),
+        Column("wb_user_id", "string"),
+        Column("creator", "string", nullable=True),
+        Column("created_at", "datetime"),
+        Column("feedback_type", "string"),
+        Column("payload", "json", db_name="payload_dump"),
+    ],
+)
+
+
+FEEDBACK_PAYLOAD_SCHEMAS: dict[str, type[BaseModel]] = {
+    "wandb.reaction.1": tsi.FeedbackPayloadReactionReq,
+    "wandb.note.1": tsi.FeedbackPayloadNoteReq,
+}
+
+
+def validate_feedback_create_req(req: tsi.FeedbackCreateReqForInsert) -> None:
+    payload_schema = FEEDBACK_PAYLOAD_SCHEMAS.get(req.feedback_type)
+    if payload_schema:
+        try:
+            payload_schema(**req.payload)
+        except ValidationError as e:
+            raise InvalidRequest(
+                f"Invalid payload for feedback_type {req.feedback_type}: {e}"
+            )
+
+
+MESSAGE_INVALID_PURGE = "Can only purge feedback by specifying one or more ids"
+
+
+def validate_dict_one_key(d: dict, key: str, typ: type) -> Any:
+    if not isinstance(d, dict):
+        raise InvalidRequest(f"Expected a dictionary, got {d}")
+    keys = list(d.keys())
+    if len(keys) != 1:
+        raise InvalidRequest(f"Expected a dictionary with one key, got {d}")
+    if keys[0] != key:
+        raise InvalidRequest(f"Expected key {key}, got {keys[0]}")
+    val = d[key]
+    if not isinstance(val, typ):
+        raise InvalidRequest(f"Expected value of type {typ}, got {type(val)}")
+    return val
+
+
+def validate_feedback_purge_req_one(value: Any) -> None:
+    tup = validate_dict_one_key(value, "eq_", tuple)
+    if len(tup) != 2:
+        raise InvalidRequest(MESSAGE_INVALID_PURGE)
+    get_field = validate_dict_one_key(tup[0], "get_field_", str)
+    if get_field != "id":
+        raise InvalidRequest(MESSAGE_INVALID_PURGE)
+    literal = validate_dict_one_key(tup[1], "literal_", str)
+    if not isinstance(literal, str):
+        raise InvalidRequest(MESSAGE_INVALID_PURGE)
+
+
+def validate_feedback_purge_req_multiple(value: Any) -> None:
+    if not isinstance(value, list):
+        raise InvalidRequest(MESSAGE_INVALID_PURGE)
+    for item in value:
+        validate_feedback_purge_req_one(item)
+
+
+def validate_feedback_purge_req(req: tsi.FeedbackPurgeReq) -> None:
+    """For safety, we currently only allow purging by feedback id."""
+    expr = req.query.expr_.model_dump()
+    keys = list(expr.keys())
+    if len(keys) != 1:
+        raise InvalidRequest(MESSAGE_INVALID_PURGE)
+    if keys[0] == "eq_":
+        validate_feedback_purge_req_one(expr)
+    elif keys[0] == "or_":
+        validate_feedback_purge_req_multiple(expr["or_"])
+    else:
+        raise InvalidRequest(MESSAGE_INVALID_PURGE)

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -390,3 +390,24 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         bytes.writelines(r.iter_content())
         bytes.seek(0)
         return tsi.FileContentReadRes(content=bytes.read())
+
+    def feedback_create(
+        self, req: t.Union[tsi.FeedbackCreateReq, t.Dict[str, t.Any]]
+    ) -> tsi.FeedbackCreateRes:
+        return self._generic_request(
+            "/feedback/create", req, tsi.FeedbackCreateReq, tsi.FeedbackCreateRes
+        )
+
+    def feedback_query(
+        self, req: t.Union[tsi.FeedbackQueryReq, t.Dict[str, t.Any]]
+    ) -> tsi.FeedbackQueryRes:
+        return self._generic_request(
+            "/feedback/query", req, tsi.FeedbackQueryReq, tsi.FeedbackQueryRes
+        )
+
+    def feedback_purge(
+        self, req: t.Union[tsi.FeedbackPurgeReq, t.Dict[str, t.Any]]
+    ) -> tsi.FeedbackPurgeRes:
+        return self._generic_request(
+            "/feedback/purge", req, tsi.FeedbackPurgeReq, tsi.FeedbackPurgeRes
+        )

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -9,7 +9,9 @@ import datetime
 import json
 import hashlib
 import sqlite3
+from zoneinfo import ZoneInfo
 
+import emoji
 
 from .trace_server_interface_util import (
     extract_refs_from_values,
@@ -20,7 +22,15 @@ from . import trace_server_interface as tsi
 from .interface import query as tsi_query
 
 from weave.trace import refs
+from weave.trace_server.emoji_util import detone_emojis
+from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.feedback import (
+    TABLE_FEEDBACK,
+    validate_feedback_create_req,
+    validate_feedback_purge_req,
+)
 from weave.trace_server.trace_server_interface_util import (
+    generate_id,
     WILDCARD_ARTIFACT_VERSION_AND_PATH,
 )
 from weave.trace_server.refs_internal import (
@@ -29,6 +39,7 @@ from weave.trace_server.refs_internal import (
     OBJECT_ATTR_EDGE_NAME,
     TABLE_ROW_ID_EDGE_NAME,
 )
+from weave.trace_server.orm import Row
 
 MAX_FLUSH_COUNT = 10000
 MAX_FLUSH_AGE = 15
@@ -54,13 +65,14 @@ def get_conn_cursor(db_path: str) -> tuple[sqlite3.Connection, sqlite3.Cursor]:
     return conn_cursor
 
 
-class SqliteTraceServer(tsi.TraceServerInterface):
+class SqliteTraceServer(tsi.TraceServerInterfacePostAuth):
     def __init__(self, db_path: str):
         self.lock = threading.Lock()
         self.db_path = db_path
 
     def drop_tables(self) -> None:
         conn, cursor = get_conn_cursor(self.db_path)
+        cursor.execute(TABLE_FEEDBACK.drop_sql())
         cursor.execute("DROP TABLE IF EXISTS calls")
         cursor.execute("DROP TABLE IF EXISTS objects")
         cursor.execute("DROP TABLE IF EXISTS tables")
@@ -133,6 +145,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 val BLOB)
             """
         )
+        cursor.execute(TABLE_FEEDBACK.create_sql())
 
     # Creates a new call
     def call_start(self, req: tsi.CallStartReq) -> tsi.CallStartRes:
@@ -456,12 +469,12 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 WITH RECURSIVE Descendants AS (
                     SELECT id
                     FROM calls
-                    WHERE project_id = ? AND 
-                        deleted_at IS NULL AND 
+                    WHERE project_id = ? AND
+                        deleted_at IS NULL AND
                         parent_id IN (SELECT id FROM calls WHERE id IN ({}))
-                    
+
                     UNION ALL
-                    
+
                     SELECT c.id
                     FROM calls c
                     JOIN Descendants d ON c.parent_id = d.id
@@ -480,7 +493,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             delete_query = """
                 UPDATE calls
                 SET deleted_at = CURRENT_TIMESTAMP
-                WHERE deleted_at is NULL AND 
+                WHERE deleted_at is NULL AND
                     id IN ({})
             """.format(
                 ", ".join("?" * len(all_ids))
@@ -693,6 +706,83 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             return val
 
         return tsi.RefsReadBatchRes(vals=[read_ref(r) for r in parsed_obj_refs])
+
+    def feedback_create(
+        self, req: tsi.FeedbackCreateReqForInsert
+    ) -> tsi.FeedbackCreateRes:
+        validate_feedback_create_req(req)
+
+        # Augment emoji with alias.
+        res_payload = {}
+        if req.feedback_type == "wandb.reaction.1":
+            em = req.payload["emoji"]
+            if emoji.emoji_count(em) != 1:
+                raise InvalidRequest(
+                    "Value of emoji key in payload must be exactly one emoji"
+                )
+            req.payload["alias"] = emoji.demojize(em)
+            detoned = detone_emojis(em)
+            req.payload["detoned"] = detoned
+            req.payload["detoned_alias"] = emoji.demojize(detoned)
+            res_payload = req.payload
+
+        feedback_id = generate_id()
+        created_at = datetime.datetime.now(ZoneInfo("UTC"))
+        # TODO: Any validation on weave_ref?
+        payload = json.dumps(req.payload)
+        MAX_PAYLOAD = 1024
+        if len(payload) > MAX_PAYLOAD:
+            raise InvalidRequest("Feedback payload too large")
+        row: Row = {
+            "id": feedback_id,
+            "project_id": req.project_id,
+            "weave_ref": req.weave_ref,
+            "wb_user_id": req.wb_user_id,
+            "creator": req.creator,
+            "feedback_type": req.feedback_type,
+            "payload": payload,
+            "created_at": created_at,
+        }
+        conn, cursor = get_conn_cursor(self.db_path)
+        with self.lock:
+            prepared = TABLE_FEEDBACK.insert(row).prepare(database_type="sqlite")
+            cursor.executemany(prepared.sql, prepared.data)
+            conn.commit()
+        return tsi.FeedbackCreateRes(
+            id=feedback_id,
+            created_at=created_at,
+            wb_user_id=req.wb_user_id,
+            payload=res_payload,
+        )
+
+    def feedback_query(self, req: tsi.FeedbackQueryReq) -> tsi.FeedbackQueryRes:
+        conn, cursor = get_conn_cursor(self.db_path)
+        query = TABLE_FEEDBACK.select()
+        query = query.project_id(req.project_id)
+        query = query.fields(req.fields)
+        query = query.where(req.query)
+        query = query.order_by(req.sort_by)
+        query = query.limit(req.limit).offset(req.offset)
+        prepared = query.prepare(database_type="sqlite")
+        r = cursor.execute(prepared.sql, prepared.parameters)
+        result = TABLE_FEEDBACK.tuples_to_rows(r.fetchall(), prepared.fields)
+        return tsi.FeedbackQueryRes(result=result)
+
+    def feedback_purge(self, req: tsi.FeedbackPurgeReq) -> tsi.FeedbackPurgeRes:
+        # TODO: Instead of passing conditions to DELETE FROM,
+        #       should we select matching ids, and then DELETE FROM WHERE id IN (...)?
+        #       This would allow us to return the number of rows deleted, and complain
+        #       if too many things would be deleted.
+        validate_feedback_purge_req(req)
+        conn, cursor = get_conn_cursor(self.db_path)
+        query = TABLE_FEEDBACK.purge()
+        query = query.project_id(req.project_id)
+        query = query.where(req.query)
+        prepared = query.prepare(database_type="sqlite")
+        with self.lock:
+            cursor.execute(prepared.sql, prepared.parameters)
+            conn.commit()
+        return tsi.FeedbackPurgeRes()
 
     def file_create(self, req: tsi.FileCreateReq) -> tsi.FileCreateRes:
         conn, cursor = get_conn_cursor(self.db_path)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1,7 +1,7 @@
 import abc
 import datetime
 import typing
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .interface.query import Query
 
@@ -322,6 +322,74 @@ class RefsReadBatchRes(BaseModel):
     vals: typing.List[typing.Any]
 
 
+class FeedbackPayloadReactionReq(BaseModel):
+    emoji: str
+
+
+class FeedbackPayloadNoteReq(BaseModel):
+    note: str = Field(min_length=1, max_length=1024)
+
+
+class FeedbackCreateReq(BaseModel):
+    project_id: str = Field(examples=["entity/project"])
+    weave_ref: str = Field(examples=["weave:///entity/project/object/name:digest"])
+    creator: typing.Optional[str] = Field(default=None, examples=["Jane Smith"])
+    feedback_type: str = Field(examples=["custom"])
+    payload: typing.Dict[str, typing.Any] = Field(
+        examples=[
+            {
+                "key": "value",
+            }
+        ]
+    )
+
+
+class FeedbackCreateReqForInsert(FeedbackCreateReq):
+    wb_user_id: str
+
+
+# The response provides the additional fields needed to convert a request
+# into a complete Feedback.
+class FeedbackCreateRes(BaseModel):
+    id: str
+    created_at: datetime.datetime
+    wb_user_id: str
+    payload: typing.Dict[str, typing.Any]  # If not empty, replace payload
+
+
+class Feedback(FeedbackCreateReqForInsert):
+    id: str
+    created_at: datetime.datetime
+
+
+class FeedbackQueryReq(BaseModel):
+    project_id: str = Field(examples=["entity/project"])
+    fields: typing.Optional[list[str]] = Field(
+        default=None, examples=[["id", "feedback_type", "payload.note"]]
+    )
+    query: typing.Optional[Query] = None
+    # TODO: I think I would prefer to call this order_by to match SQL, but this is what calls API uses
+    # TODO: Might be nice to have shortcut for single field and implied ASC direction
+    # TODO: I think _SortBy shouldn't have leading underscore
+    sort_by: typing.Optional[typing.List[_SortBy]] = None
+    limit: typing.Optional[int] = Field(default=None, examples=[10])
+    offset: typing.Optional[int] = Field(default=None, examples=[0])
+
+
+class FeedbackQueryRes(BaseModel):
+    # Note: this is not a list of Feedback because user can request any fields.
+    result: list[dict[str, typing.Any]]
+
+
+class FeedbackPurgeReq(BaseModel):
+    project_id: str = Field(examples=["entity/project"])
+    query: Query
+
+
+class FeedbackPurgeRes(BaseModel):
+    pass
+
+
 class FileCreateReq(BaseModel):
     project_id: str
     name: str
@@ -420,6 +488,18 @@ class TraceServerInterface:
     def file_content_read(self, req: FileContentReadReq) -> FileContentReadRes:
         raise NotImplementedError()
 
+    @abc.abstractmethod
+    def feedback_create(self, req: FeedbackCreateReq) -> FeedbackCreateRes:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def feedback_query(self, req: FeedbackQueryReq) -> FeedbackQueryRes:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def feedback_purge(self, req: FeedbackPurgeReq) -> FeedbackPurgeRes:
+        raise NotImplementedError()
+
 
 class TraceServerInterfacePostAuth(TraceServerInterface):
     @abc.abstractmethod
@@ -428,4 +508,8 @@ class TraceServerInterfacePostAuth(TraceServerInterface):
 
     @abc.abstractmethod
     def calls_delete(self, req: CallsDeleteReqForInsert) -> CallsDeleteRes:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def feedback_create(self, req: FeedbackCreateReqForInsert) -> FeedbackCreateRes:
         raise NotImplementedError()


### PR DESCRIPTION
This is an updated version of the trace server APIs code that previously went in as part of reverted PR https://github.com/wandb/weave/pull/1718

The changes are mostly just to use the new ORM library methods.