### PR TITLE
chore(weave): Add `ExternalTraceServer` Class

### DIFF
--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -42,6 +42,7 @@ def get_client_trace_server(
 def get_client_project_id(client: weave_client.WeaveClient) -> str:
     return client._project_id()
 
+
 def client_is_sqlite(client: weave_client.WeaveClient) -> bool:
     return isinstance(get_client_trace_server(client), SqliteTraceServer)
 
@@ -1299,8 +1300,8 @@ def test_dataset_row_ref(client):
     d2 = weave.ref(ref.uri()).get()
 
     inner = d2.rows[0]["a"]
-    digest_for_sqlite = 'aF7lCSKo9BTXJaPxYHEBsH51dOKtwzxS6Hqvw4RmAdc'
-    digest_for_ext_ch = '4tE9AJg5bXktQggg1khnRXnV3IcDgmWd9b9Hdd3udZs'
+    digest_for_sqlite = "aF7lCSKo9BTXJaPxYHEBsH51dOKtwzxS6Hqvw4RmAdc"
+    digest_for_ext_ch = "4tE9AJg5bXktQggg1khnRXnV3IcDgmWd9b9Hdd3udZs"
 
     # This feels pretty bad (that the digest is different between sqlite and ext-ch)
     if client_is_sqlite(client):

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -1290,7 +1290,6 @@ def test_bound_op_retrieval_no_self(client):
         my_op2 = my_op_ref.get()
 
 
-@pytest.mark.skip_clickhouse_client
 def test_dataset_row_ref(client):
     d = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
     ref = weave.publish(d)

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -808,7 +808,6 @@ def test_op_query(client):
     assert len(res) == 1
 
 
-@pytest.mark.skip_clickhouse_client  # TODO: Make client work with external ref URLS
 def test_refs_read_batch_noextra(client):
     ref = client.save_object([1, 2, 3], "my-list")
     ref2 = client.save_object({"a": [3, 4, 5]}, "my-obj")
@@ -818,7 +817,6 @@ def test_refs_read_batch_noextra(client):
     assert res.vals[1] == {"a": [3, 4, 5]}
 
 
-@pytest.mark.skip_clickhouse_client  # TODO: Make client work with external ref URLS
 def test_refs_read_batch_with_extra(client):
     saved = client.save([{"a": 5}, {"a": 6}], "my-list")
     ref1 = saved[0]["a"].ref
@@ -829,7 +827,6 @@ def test_refs_read_batch_with_extra(client):
     assert res.vals[1] == {"a": 6}
 
 
-@pytest.mark.skip_clickhouse_client  # TODO: Make client work with external ref URLS
 def test_refs_read_batch_dataset_rows(client):
     saved = client.save(weave.Dataset(rows=[{"a": 5}, {"a": 6}]), "my-dataset")
     ref1 = saved.rows[0]["a"].ref

--- a/weave/trace_server/README.md
+++ b/weave/trace_server/README.md
@@ -7,23 +7,100 @@ sequenceDiagram
     participant UserCode
     participant OpExecution
     participant GraphClient as graph_client_trace.py<br><br>GraphClientTrace<br><GraphClient>
-    box Web service can be bypassed with `trace_client` pytest fixture
+    box Trace Service
     participant RemoteHTTPTraceServer as remote_http_trace_server.py<br><br>RemoteHTTPTraceServer<br><TraceServerInterface>
-    participant TraceWebServer as (in core) trace_server.py<br><br>TraceWebServer<br><FlaskApp>
+    participant TraceWebServer as (in core) trace_server.py<br><br>TraceWebServer<br><TraceServerInterface>
     end
+    
+    box Clickhouse Trace Server
     participant ClickHouseTraceServer as clickhouse_trace_server_batched.py<br><br>ClickHouseTraceServer<br><TraceServerInterface>
     participant ClickHouseDB
+    end
+    
+    box SQLLite Trace Server
+    participant SQLiteTraceServer as sqlite_trace_server.py<br><br>SQLiteTraceServer<br><TraceServerInterface>
+    participant SQLiteDB
+    end
 
     UserCode->>OpExecution: Calls an @op decorated fn
     OpExecution->>GraphClient: `start_run`
+    
+    rect rgb(200, 255, 255) 
+    note right of GraphClient: PRODUCTION
     GraphClient->>RemoteHTTPTraceServer: call_start
     RemoteHTTPTraceServer->>TraceWebServer: POST /call/start
     TraceWebServer->>ClickHouseTraceServer: call_start
+    ClickHouseTraceServer->>ClickHouseDB: INSERT INTO `calls_raw`
     ClickHouseTraceServer->>TraceWebServer: 
     TraceWebServer->>RemoteHTTPTraceServer: 
     RemoteHTTPTraceServer->>GraphClient: 
-    GraphClient->>OpExecution: 
-
-    ClickHouseTraceServer-->ClickHouseDB: ... inserts are batched async ...
+    end
+    
+    rect rgb(200, 255, 255) 
+    note right of GraphClient: TEST_CLICKHOUSE
+    GraphClient->>ClickHouseTraceServer: call_start
     ClickHouseTraceServer->>ClickHouseDB: INSERT INTO `calls_raw`
+    ClickHouseTraceServer->>GraphClient: 
+    end
+    
+    rect rgb(200, 255, 255) 
+    note right of GraphClient: LOCAL_SQLITE
+    GraphClient->>SQLiteTraceServer: call_start
+    SQLiteTraceServer->>SQLiteDB: INSERT INTO `calls`
+    SQLiteTraceServer->>GraphClient: 
+    end
+    
+
+    GraphClient->>OpExecution: 
 ```
+
+### TraceServerInterface Inconsistencies:
+In the beginning, having a single `TraceServerInterface` was nice because there was a standard data format used across multiple interface boundaries. However, we are now in a situation where each layer has deviated:
+* `remote_http_trace_server.py`
+  * Additional: server info
+* `trace_server.py`
+  * Has additional methods for for:
+    * call batching
+    * server info
+    * calls_stream_query
+* `clickhouse_trace_server_batched.py`
+  * Expects refs in the format of `weave-trace-internal://project_id/...` instead of `weave://entity/project/...`
+  * Expects `project_id` to not contain slashes `/`
+  * Does not implement `ensure_project_exists`
+  * Has additional `calls_query_stream`
+  * Expects `wb_user_id` to be set for call update/delete
+* `sqlite_trace_server.py`
+  * Does not implement `ensure_project_exists`
+  * Expects `wb_user_id` to be set for call update/delete
+
+As a result of this deviation:
+1. You cannot just hot-swap `remote_http_trace_server` and `clickhouse_trace_server_batched` and `sqlite_trace_server`.
+   1. Rather, the closest equivalent interfaces are `remote_http_trace_server` and `sqlite_trace_server`, since effectively working with `clickhouse_trace_server_batched` requires the business logic that has been baked into the `trace_server.py` layer.
+2. These differences meaningfully effect the data payloads, meaning the object digests differ when using different server implementations - this is pretty bad! Note: even with my fix below, this means that clients (TS) can't calculate the digest of a thing without the server! Eek - maybe when calculating the digest of a thing, we actually use the object digest, not the ref value? That might be the correct move.
+3. Testing the trace_server itself has become challenging since business logic has been moved there (auth, id converting, ref converting, etc...)
+4. Not all tests work equally for clickhouse and sqlite (specifically ref-related tests)
+
+Why is this a problem now?
+* Only recently was the `Expects wb_user_id to be set for call update/delete` deviation added. The result is that we have had to do some monkeypatching in our tests to fake the wb_user_id resolution inside of `trace_server`
+* I am now working on filtering/sorting through refs which means the ref parsing needs to be implemented at the DB layer. Currently, we have special ref parsing for the `clickhouse_trace_server_batched` implemented in application code. This is pretty minimal. However, the work to make filtering/sorting work requires baking more ref-parsing logic into sql queries, which i'd rather have consistent between the implementations.
+
+Possible paths forward:
+1. Should we just make our lives easier and make `wb_user_id` an optional field? Would this be OK, or will there be other cases like this in the future where we really do want to make it a required field?
+2. The big problem is with `project` and refs. I think what we want is probably:
+   1. `clickhouse_trace_server_batched` and `sqlite_trace_server` both have the same rules / "internal" interface: 
+      1. No slashes in project name (or other names for that matter)
+      2. only operates on `weave-trace-internal://` scheme refs.
+      3. Either Require or not require wb_user_name, but be consistent.
+   2. Either do #1 above, or acknowledge that `remote_http_trace_server` + `trace_server` will have an interface definition slightly different than the others (at least with respect to the `wb_user_id`)
+   3. Create a `external_server` which is constructed with an internal server (either clickhouse or sqlite) as well as a converter object is used to convert refs of type `weave://` into `weave-trace-internal://`. This converter object will need to know how to convert:
+      1. ProjectID, UserId, RunID to-from External to Internal
+      2. In tests, this can be super simple and just swap `project/entity` for `project_entity`, everything else is identity
+      3. The `trace_server` will then use this `external_server` constructor to facilitate the real W&B lookup and replacement
+         1. In theory, we could make it easier to plugin a W&B instance for testing purposes, moving the conversion & auth logic down a layer, but that is probably not preferred to put in open source.
+   4. Finally, we then have 3 configurations:
+      1. PRODUCTION: `remote_http_trace_server` -> `trace_server` -> `external_server(clickhouse_trace_server_batched, wb_connected_converter)`
+      2. TEST_CLICKHOUSE: `external_server(clickhouse_trace_server_batched, identity)`
+      3. LOCAL_SQLITE: `external_server(sqlite_trace_server, identity)`
+      4. At this point each of these would behave the same across all interactions, with the exception of:
+         1. digests would be different in production (since the conversion is getting hashed)
+            1. However, tests would both use the identity, so we are fine.

--- a/weave/trace_server/external_trace_server.py
+++ b/weave/trace_server/external_trace_server.py
@@ -155,7 +155,9 @@ class ExternalTraceServer(tsi.TraceServerInterface):
             req.project_id
         )
         if req.wb_user_id:
-            req.wb_user_id = self._id_converter.convert_ext_to_int_user_id(req.user_id)
+            req.wb_user_id = self._id_converter.convert_ext_to_int_user_id(
+                req.wb_user_id
+            )
         return self._universal_int_to_ext_ref_converter(
             self._internal_trace_server.call_update(
                 self._universal_ext_to_int_ref_converter(req)

--- a/weave/trace_server/external_trace_server.py
+++ b/weave/trace_server/external_trace_server.py
@@ -150,6 +150,18 @@ class ExternalTraceServer(tsi.TraceServerInterface):
             )
         )
 
+    def call_update(self, req: tsi.CallUpdateReq) -> tsi.CallUpdateRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        if req.wb_user_id:
+            req.wb_user_id = self._id_converter.convert_ext_to_int_user_id(req.user_id)
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.call_update(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
     # Op API
 
     def op_create(self, req: tsi.OpCreateReq) -> tsi.OpCreateRes:

--- a/weave/trace_server/external_trace_server.py
+++ b/weave/trace_server/external_trace_server.py
@@ -60,7 +60,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
             )
         if req.start.wb_user_id:
             req.start.wb_user_id = self._id_converter.convert_ext_to_int_user_id(
-                req.start.user_id
+                req.start.wb_user_id
             )
 
         return self._universal_int_to_ext_ref_converter(
@@ -98,7 +98,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
             )
         if res.call.wb_user_id:
             res.call.wb_user_id = self._id_converter.convert_int_to_ext_user_id(
-                res.call.user_id
+                res.call.wb_user_id
             )
 
         return res
@@ -123,7 +123,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
                 )
             if item.wb_user_id:
                 item.wb_user_id = self._id_converter.convert_int_to_ext_user_id(
-                    item.user_id
+                    item.wb_user_id
                 )
 
         return res
@@ -143,7 +143,9 @@ class ExternalTraceServer(tsi.TraceServerInterface):
             req.project_id
         )
         if req.wb_user_id:
-            req.wb_user_id = self._id_converter.convert_ext_to_int_user_id(req.user_id)
+            req.wb_user_id = self._id_converter.convert_ext_to_int_user_id(
+                req.wb_user_id
+            )
         return self._universal_int_to_ext_ref_converter(
             self._internal_trace_server.calls_delete(
                 self._universal_ext_to_int_ref_converter(req)

--- a/weave/trace_server/external_trace_server.py
+++ b/weave/trace_server/external_trace_server.py
@@ -1,0 +1,326 @@
+import abc
+import io
+import json
+import sys
+import typing as t
+
+from pydantic import BaseModel
+
+from . import refs_internal as ri
+
+
+from . import trace_server_interface as tsi
+
+
+class IdConverter:
+    @abc.abstractmethod
+    def convert_ext_to_int_project_id(self, project_id: str) -> str:
+        ...
+
+    @abc.abstractmethod
+    def convert_int_to_ext_project_id(self, project_id: str) -> str:
+        ...
+
+    @abc.abstractmethod
+    def convert_ext_to_int_run_id(self, run_id: str) -> str:
+        ...
+
+    @abc.abstractmethod
+    def convert_int_to_ext_run_id(self, run_id: str) -> str:
+        ...
+
+    @abc.abstractmethod
+    def convert_ext_to_int_user_id(self, user_id: str) -> str:
+        ...
+
+    @abc.abstractmethod
+    def convert_int_to_ext_user_id(self, user_id: str) -> str:
+        ...
+
+
+class ExternalTraceServer(tsi.TraceServerInterface):
+    _internal_trace_server: tsi.TraceServerInterface
+    _id_converter: IdConverter
+
+    def __init__(
+        self, internal_trace_server: tsi.TraceServerInterface, id_converter: IdConverter
+    ):
+        super().__init__()
+        self._internal_trace_server = internal_trace_server
+        self._id_converter = id_converter
+
+    # Call API
+    def call_start(self, req: tsi.CallStartReq) -> tsi.CallStartRes:
+        req.start.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.start.project_id
+        )
+        if req.start.wb_run_id:
+            req.start.wb_run_id = self._id_converter.convert_ext_to_int_run_id(
+                req.start.run_id
+            )
+        if req.start.wb_user_id:
+            req.start.wb_user_id = self._id_converter.convert_ext_to_int_user_id(
+                req.start.user_id
+            )
+
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.call_start(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def call_end(self, req: tsi.CallEndReq) -> tsi.CallEndRes:
+        req.end.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.end.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.call_end(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def call_read(self, req: tsi.CallReadReq) -> tsi.CallReadRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        res = self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.call_read(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+        res.call.project_id = self._id_converter.convert_int_to_ext_project_id(
+            res.call.project_id
+        )
+        if res.call.wb_run_id:
+            res.call.wb_run_id = self._id_converter.convert_int_to_ext_run_id(
+                res.call.run_id
+            )
+        if res.call.wb_user_id:
+            res.call.wb_user_id = self._id_converter.convert_int_to_ext_user_id(
+                res.call.user_id
+            )
+
+        return res
+
+    def calls_query(self, req: tsi.CallsQueryReq) -> tsi.CallsQueryRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        res = self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.calls_query(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+        for item in res.calls:
+            item.project_id = self._id_converter.convert_int_to_ext_project_id(
+                item.project_id
+            )
+            if item.wb_run_id:
+                item.wb_run_id = self._id_converter.convert_int_to_ext_run_id(
+                    item.run_id
+                )
+            if item.wb_user_id:
+                item.wb_user_id = self._id_converter.convert_int_to_ext_user_id(
+                    item.user_id
+                )
+
+        return res
+
+    def calls_query_stats(self, req: tsi.CallsQueryStatsReq) -> tsi.CallsQueryStatsRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.calls_query_stats(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        if req.wb_user_id:
+            req.wb_user_id = self._id_converter.convert_ext_to_int_user_id(req.user_id)
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.calls_delete(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    # Op API
+
+    def op_create(self, req: tsi.OpCreateReq) -> tsi.OpCreateRes:
+        req.op_obj.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.op_obj.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.op_create(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def op_read(self, req: tsi.OpReadReq) -> tsi.OpReadRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.op_read(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def ops_query(self, req: tsi.OpQueryReq) -> tsi.OpQueryRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.ops_query(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    # Obj API
+
+    def obj_create(self, req: tsi.ObjCreateReq) -> tsi.ObjCreateRes:
+        req.obj.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.obj.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.obj_create(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.obj_read(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def objs_query(self, req: tsi.ObjQueryReq) -> tsi.ObjQueryRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.objs_query(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def table_create(self, req: tsi.TableCreateReq) -> tsi.TableCreateRes:
+        req.table.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.table.project_id
+        )
+
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.table_create(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
+        req.project_id = self._id_converter.convert_ext_to_int_project_id(
+            req.project_id
+        )
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.table_query(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def refs_read_batch(self, req: tsi.RefsReadBatchReq) -> tsi.RefsReadBatchRes:
+        return self._universal_int_to_ext_ref_converter(
+            self._internal_trace_server.refs_read_batch(
+                self._universal_ext_to_int_ref_converter(req)
+            )
+        )
+
+    def file_create(self, req: tsi.FileCreateReq) -> tsi.FileCreateRes:
+        return self._internal_trace_server.file_create(req)
+
+    def file_content_read(self, req: tsi.FileContentReadReq) -> tsi.FileContentReadRes:
+        return self._internal_trace_server.file_content_read(req)
+
+    def _universal_ext_to_int_ref_converter(self, obj: t.Any) -> t.Any:
+        ext_to_int_project_cache: t.Dict[str, str] = {}
+        weave_prefix = ri.WEAVE_SCHEME + ":///"
+
+        def replace_ref(ref_str: str) -> str:
+            if not ref_str.startswith(weave_prefix):
+                raise ValueError(f"Invalid URI: {ref_str}")
+            rest = ref_str[len(weave_prefix) :]
+            parts = rest.split("/", 2)
+            if len(parts) != 3:
+                raise ValueError(f"Invalid URI: {ref_str}")
+            entity, project, tail = parts
+            project_key = f"{entity}/{project}"
+            if project_key not in ext_to_int_project_cache:
+                ext_to_int_project_cache[
+                    project_key
+                ] = self._id_converter.convert_ext_to_int_project_id(project_key)
+            internal_project_id = ext_to_int_project_cache[project_key]
+            return f"{ri.WEAVE_INTERNAL_SCHEME}:///{internal_project_id}/{tail}"
+
+        def mapper(obj: t.Any) -> t.Any:
+            if isinstance(obj, str) and obj.startswith(weave_prefix):
+                return replace_ref(obj)
+            return obj
+
+        return _map_values(obj, mapper)
+
+    def _universal_int_to_ext_ref_converter(
+        self,
+        obj: t.Any,
+    ) -> t.Any:
+        int_to_ext_project_cache: t.Dict[str, str] = {}
+
+        weave_internal_prefix = ri.WEAVE_INTERNAL_SCHEME + ":///"
+
+        def replace_ref(ref_str: str) -> str:
+            if not ref_str.startswith(weave_internal_prefix):
+                raise ValueError(f"Invalid URI: {ref_str}")
+            rest = ref_str[len(weave_internal_prefix) :]
+            parts = rest.split("/", 1)
+            if len(parts) != 2:
+                raise ValueError(f"Invalid URI: {ref_str}")
+            project_id, tail = parts
+            if project_id not in int_to_ext_project_cache:
+                int_to_ext_project_cache[
+                    project_id
+                ] = self._id_converter.convert_int_to_ext_project_id(project_id)
+            external_project_id = int_to_ext_project_cache[project_id]
+            return f"{ri.WEAVE_SCHEME}:///{external_project_id}/{tail}"
+
+        def mapper(obj: t.Any) -> t.Any:
+            if isinstance(obj, str) and obj.startswith(weave_internal_prefix):
+                return replace_ref(obj)
+            return obj
+
+        return _map_values(obj, mapper)
+
+
+def _map_values(obj: t.Any, func: t.Callable[[t.Any], t.Any]) -> t.Any:
+    if isinstance(obj, BaseModel):
+        # `by_alias` is required since we have Mongo-style properties in the
+        # query models that are aliased to conform to start with `$`. Without
+        # this, the model_dump will use the internal property names which are
+        # not valid for the `model_validate` step.
+        orig = obj.model_dump(by_alias=True)
+        new = _map_values(orig, func)
+        return obj.model_validate(new)
+    if isinstance(obj, dict):
+        return {k: _map_values(v, func) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_map_values(v, func) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(_map_values(v, func) for v in obj)
+    if isinstance(obj, set):
+        return {_map_values(v, func) for v in obj}
+    return func(obj)

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -1,0 +1,84 @@
+import typing
+
+from pydantic import BaseModel
+
+from . import refs_internal as ri
+
+# def testing_universal_ext_to_int_ref_converter(obj: typing.Any) -> typing.Any:
+#     return universal_ext_to_int_ref_converter(obj, lambda x: "__".join(x.split("/")))
+
+# def testing_universal_int_to_ext_ref_converter(obj: typing.Any) -> typing.Any:
+#     return universal_int_to_ext_ref_converter(obj, lambda x: "/".join(x.split("__")))
+
+
+def universal_ext_to_int_ref_converter(
+    obj: typing.Any, convert_ext_to_int_project_id: typing.Callable[[str], str]
+) -> typing.Any:
+    weave_prefix = ri.WEAVE_SCHEME + ":///"
+
+    def replace_ref(ref_str: str) -> str:
+        if not ref_str.startswith(weave_prefix):
+            raise ValueError(f"Invalid URI: {ref_str}")
+        rest = ref_str[len(weave_prefix) :]
+        parts = rest.split("/", 2)
+        if len(parts) != 3:
+            raise ValueError(f"Invalid URI: {ref_str}")
+        entity, project, tail = parts
+        project_key = f"{entity}/{project}"
+        internal_project_id = convert_ext_to_int_project_id(project_key)
+        return f"{ri.WEAVE_INTERNAL_SCHEME}:///{internal_project_id}/{tail}"
+
+    def mapper(obj: typing.Any) -> typing.Any:
+        if isinstance(obj, str) and obj.startswith(weave_prefix):
+            return replace_ref(obj)
+        return obj
+
+    return _map_values(obj, mapper)
+
+
+def universal_int_to_ext_ref_converter(
+    obj: typing.Any,
+    convert_int_to_ext_project_id: typing.Callable[[str], str],
+) -> typing.Any:
+
+    weave_internal_prefix = ri.WEAVE_INTERNAL_SCHEME + ":///"
+
+    def replace_ref(ref_str: str) -> str:
+        if not ref_str.startswith(weave_internal_prefix):
+            raise ValueError(f"Invalid URI: {ref_str}")
+        rest = ref_str[len(weave_internal_prefix) :]
+        parts = rest.split("/", 1)
+        if len(parts) != 2:
+            raise ValueError(f"Invalid URI: {ref_str}")
+        project_id, tail = parts
+        external_project_id = convert_int_to_ext_project_id(project_id)
+        return f"{ri.WEAVE_SCHEME}:///{external_project_id}/{tail}"
+
+    def mapper(obj: typing.Any) -> typing.Any:
+        if isinstance(obj, str) and obj.startswith(weave_internal_prefix):
+            return replace_ref(obj)
+        return obj
+
+    return _map_values(obj, mapper)
+
+
+def _map_values(
+    obj: typing.Any, func: typing.Callable[[typing.Any], typing.Any]
+) -> typing.Any:
+    if isinstance(obj, BaseModel):
+        # `by_alias` is required since we have Mongo-style properties in the
+        # query models that are aliased to conform to start with `$`. Without
+        # this, the model_dump will use the internal property names which are
+        # not valid for the `model_validate` step.
+        orig = obj.model_dump(by_alias=True)
+        new = _map_values(orig, func)
+        return obj.model_validate(new)
+    if isinstance(obj, dict):
+        return {k: _map_values(v, func) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_map_values(v, func) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(_map_values(v, func) for v in obj)
+    if isinstance(obj, set):
+        return {_map_values(v, func) for v in obj}
+    return func(obj)

--- a/weave/trace_server/unit_test_external_trace_server.py
+++ b/weave/trace_server/unit_test_external_trace_server.py
@@ -1,0 +1,29 @@
+from . import external_trace_server
+from . import clickhouse_trace_server_batched
+
+
+class DummyIdConverter(external_trace_server.IdConverter):
+    def convert_ext_to_int_project_id(self, project_id: str) -> str:
+        return "___".join(project_id.split("/"))
+
+    def convert_int_to_ext_project_id(self, project_id: str) -> str:
+        return "/".join(project_id.split("___"))
+
+    def convert_ext_to_int_run_id(self, run_id: str) -> str:
+        return run_id
+
+    def convert_int_to_ext_run_id(self, run_id: str) -> str:
+        return run_id
+
+    def convert_ext_to_int_user_id(self, user_id: str) -> str:
+        return user_id
+
+    def convert_int_to_ext_user_id(self, user_id: str) -> str:
+        return user_id
+
+
+def make_local_clickhouse_trace_server() -> external_trace_server.ExternalTraceServer:
+    ch_server = clickhouse_trace_server_batched.ClickHouseTraceServer.from_env(
+        use_async_insert=False
+    )
+    return external_trace_server.ExternalTraceServer(ch_server, DummyIdConverter())


### PR DESCRIPTION
Currently, our non open source server which servers the FastAPI interface performs some critical business logic. This is primarily a problem because it makes testing challenging - specifically when the behavior for certain paths would be different when such logic is applied.

Practically speaking, this has to do with internal <> external id swaps, which ultimately relates to project ids and refs.

TODO: Add more context here.