### PR TITLE
chore: add Use tab to call details

### DIFF
--- a/weave-js/src/components/CopyableText.tsx
+++ b/weave-js/src/components/CopyableText.tsx
@@ -1,5 +1,5 @@
 import copyToClipboard from 'copy-to-clipboard';
-import React, {useCallback} from 'react';
+import React, {CSSProperties, useCallback} from 'react';
 import styled from 'styled-components';
 
 import {toast} from '../common/components/elements/Toast';
@@ -19,10 +19,10 @@ type CopyableTextProps = {
   onClick?(): void;
 };
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{isMultiline?: boolean}>`
   background-color: ${MOON_100};
   display: flex;
-  align-items: center;
+  align-items: ${props => (props.isMultiline ? 'flex-start' : 'center')};
   cursor: pointer;
   padding: 8px;
   border-radius: 8px;
@@ -61,8 +61,15 @@ export const CopyableText = ({
     toast(toastText);
   }, [text, copyText, toastText]);
 
+  const style: CSSProperties = {marginRight: 8};
+  const isMultiline = text.includes('\n');
+  if (isMultiline) {
+    style.marginTop = 4;
+  }
+
   const trigger = (
     <Wrapper
+      isMultiline={isMultiline}
       onClick={e => {
         e.stopPropagation();
         if (disabled) {
@@ -72,12 +79,7 @@ export const CopyableText = ({
         onClick?.();
       }}>
       <IconCell>
-        <Icon
-          name={icon ?? 'copy'}
-          width={16}
-          height={16}
-          style={{marginRight: 8}}
-        />
+        <Icon name={icon ?? 'copy'} width={16} height={16} style={style} />
       </IconCell>
       <Text>{text}</Text>
     </Wrapper>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -17,6 +17,7 @@ import {FeedbackGrid} from '../../feedback/FeedbackGrid';
 import {isEvaluateOp} from '../common/heuristics';
 import {CenteredAnimatedLoader} from '../common/Loader';
 import {SimplePageLayoutWithHeader} from '../common/SimplePageLayout';
+import {TabUseCall} from '../TabUseCall';
 import {useURLSearchParamsDict} from '../util';
 import {useWFHooks} from '../wfReactInterface/context';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
@@ -89,6 +90,10 @@ const useCallTabs = (call: CallSchema) => {
     {
       label: 'Summary',
       content: <CallSummary call={call} />,
+    },
+    {
+      label: 'Use',
+      content: <TabUseCall call={call} />,
     },
   ];
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseCall.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseCall.tsx
@@ -1,0 +1,58 @@
+import {Box} from '@mui/material';
+import React from 'react';
+
+import {Alert} from '../../../../Alert';
+import {CopyableText} from '../../../../CopyableText';
+import {DocLink} from './common/Links';
+import {CallSchema} from './wfReactInterface/wfDataModelHooksInterface';
+
+type TabUseCallProps = {
+  call: CallSchema;
+};
+
+export const TabUseCall = ({call}: TabUseCallProps) => {
+  const {entity, project, callId} = call;
+  let codeFetch = `import weave
+client = weave.init("${entity}/${project}")
+call = client.call("${callId}")`;
+
+  const backend = (window as any).CONFIG.TRACE_BACKEND_BASE_URL;
+  if (backend.endsWith('.wandb.test')) {
+    codeFetch =
+      `import os
+os.environ["WF_TRACE_SERVER_URL"] = "http://127.0.0.1:6345"
+
+` + codeFetch;
+  }
+
+  const codeReaction = `call.feedback.add_reaction("👍")`;
+  const codeNote = `call.feedback.add_note("This is delightful!")`;
+  const codeFeedback = `call.feedback.add("correctness", {"value": 4})`;
+
+  return (
+    <Box m={2}>
+      <Alert icon="lightbulb-info">
+        See{' '}
+        <DocLink path="guides/tracking/tracing" text="Weave docs on tracing" />{' '}
+        for more information.
+      </Alert>
+
+      <Box mt={2}>
+        Use the following code to retrieve this call:
+        <CopyableText text={codeFetch} copyText={codeFetch} />
+      </Box>
+      <Box mt={2}>
+        You can add a reaction like this:
+        <CopyableText text={codeReaction} copyText={codeReaction} />
+      </Box>
+      <Box mt={2}>
+        or a note like this:
+        <CopyableText text={codeNote} copyText={codeNote} />
+      </Box>
+      <Box mt={2}>
+        or custom feedback like this:
+        <CopyableText text={codeFeedback} copyText={codeFeedback} />
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
Adds a "Use" tab with copyable examples to calls, making them more consistent with ops and objects.

We should hold off deploying this until we've released a Weave Python SDK with feedback APIs.

The CopyableText component was updated to top align the copy icon (instead of center align) for multi-line text which looked better to me.

<img width="963" alt="Screenshot 2024-06-12 at 9 48 52 AM" src="https://github.com/wandb/weave/assets/112953339/506af734-6dd6-4084-9ae2-9a32a42b6843">
