### PR TITLE
chore: add small margin in UserLink

### DIFF
--- a/weave-js/src/components/UserLink.tsx
+++ b/weave-js/src/components/UserLink.tsx
@@ -175,7 +175,10 @@ const UserInner = ({user, includeName, placement}: UserInnerProps) => {
         placement={placement ?? 'right'}
         padding={0}>
         <UserTrigger ref={ref} onClick={onClick}>
-          <Avatar src={user.photoUrl} sx={{width: size, height: size}} />
+          <Avatar
+            src={user.photoUrl}
+            sx={{width: size, height: size, marginRight: '4px'}}
+          />
           {includeName && (
             <Link
               to={`/${user.username}`}


### PR DESCRIPTION
Tiny CSS adjustment to user link to make it align with small ref better and be less crowded.

Before:
<img width="306" alt="Screenshot 2024-06-12 at 10 12 13 AM" src="https://github.com/wandb/weave/assets/112953339/748387ca-b01d-4479-8768-d2291a3a8d25">

After:
<img width="295" alt="Screenshot 2024-06-12 at 10 10 45 AM" src="https://github.com/wandb/weave/assets/112953339/06ef7cd4-65d4-4971-97e8-3d0dabccbe4f">
