### PR TITLE
chore(weave): Simplify TraceServerInterface definition and fix inheritance 

### DIFF
--- a/weave/tests/test_client_feedback.py
+++ b/weave/tests/test_client_feedback.py
@@ -10,7 +10,7 @@ def test_feedback_apis(client):
     project_id = client._project_id()
 
     # Emoji from Jamie
-    req = tsi.FeedbackCreateReqForInsert(
+    req = tsi.FeedbackCreateReq(
         project_id=project_id,
         wb_user_id="VXNlcjo0NTI1NDQ=",
         weave_ref="weave:///entity/project/object/name:digest",
@@ -23,7 +23,7 @@ def test_feedback_apis(client):
     id_emoji_1 = res.id
 
     # Another emoji from Jamie
-    req = tsi.FeedbackCreateReqForInsert(
+    req = tsi.FeedbackCreateReq(
         project_id=project_id,
         wb_user_id="VXNlcjo0NTI1NDQ=",
         weave_ref="weave:///entity/project/object/name:digest",
@@ -36,7 +36,7 @@ def test_feedback_apis(client):
     id_emoji_2 = res.id
 
     # Emoji from Shawn
-    req = tsi.FeedbackCreateReqForInsert(
+    req = tsi.FeedbackCreateReq(
         project_id=project_id,
         wb_user_id="VXNlcjoxOQ==",
         weave_ref="weave:///entity/project/object/name:digest",
@@ -49,7 +49,7 @@ def test_feedback_apis(client):
     id_emoji_3 = res.id
 
     # Note from Jamie
-    req = tsi.FeedbackCreateReqForInsert(
+    req = tsi.FeedbackCreateReq(
         project_id=project_id,
         wb_user_id="VXNlcjo0NTI1NDQ=",
         weave_ref="weave:///entity/project/object/name:digest",
@@ -61,7 +61,7 @@ def test_feedback_apis(client):
     id_note = res.id
 
     # Custom from Jamie
-    req = tsi.FeedbackCreateReqForInsert(
+    req = tsi.FeedbackCreateReq(
         project_id=project_id,
         wb_user_id="VXNlcjo0NTI1NDQ=",
         weave_ref="weave:///entity/project/object/name:digest",
@@ -73,7 +73,7 @@ def test_feedback_apis(client):
     id_custom_1 = res.id
 
     # Custom on another object
-    req = tsi.FeedbackCreateReqForInsert(
+    req = tsi.FeedbackCreateReq(
         project_id=project_id,
         wb_user_id="VXNlcjo0NTI1NDQ=",
         weave_ref="weave:///entity/project/object/name2:digest",
@@ -205,7 +205,7 @@ def test_feedback_create_too_large(client):
     project_id = client._project_id()
 
     value = "a" * 10000
-    req = tsi.FeedbackCreateReqForInsert(
+    req = tsi.FeedbackCreateReq(
         project_id=project_id,
         wb_user_id="VXNlcjo0NTI1NDQ=",
         weave_ref="weave:///entity/project/object/name:digest",

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -250,7 +250,7 @@ def test_calls_delete(client):
     original_calls_delete = client.server.calls_delete
 
     def patched_delete(req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
-        post_auth_req = tsi.CallsDeleteReqForInsert(
+        post_auth_req = tsi.CallsDeleteReq(
             project_id=req.project_id,
             call_ids=req.call_ids,
             wb_user_id="test-user-id",
@@ -294,7 +294,7 @@ def test_calls_delete_cascade(client):
     original_calls_delete = client.server.calls_delete
 
     def patched_delete(req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
-        post_auth_req = tsi.CallsDeleteReqForInsert(
+        post_auth_req = tsi.CallsDeleteReq(
             project_id=req.project_id,
             call_ids=req.call_ids,
             wb_user_id="test-user-id",

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -28,7 +28,7 @@ FEEDBACK_PAYLOAD_SCHEMAS: dict[str, type[BaseModel]] = {
 }
 
 
-def validate_feedback_create_req(req: tsi.FeedbackCreateReqForInsert) -> None:
+def validate_feedback_create_req(req: tsi.FeedbackCreateReq) -> None:
     payload_schema = FEEDBACK_PAYLOAD_SCHEMAS.get(req.feedback_type)
     if payload_schema:
         try:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -73,7 +73,9 @@ class StartedCallSchemaForInsert(BaseModel):
     inputs: typing.Dict[str, typing.Any]
 
     # WB Metadata
-    wb_user_id: typing.Optional[str] = None
+    wb_user_id: typing.Optional[str] = Field(
+        None, description="will be automatically set by the server - leave as None."
+    )
     wb_run_id: typing.Optional[str] = None
 
 
@@ -149,7 +151,9 @@ class CallsDeleteReq(BaseModel):
     call_ids: typing.List[str]
 
     # wb_user_id is automatically populated by the server
-    wb_user_id: typing.Optional[str] = None
+    wb_user_id: typing.Optional[str] = Field(
+        None, description="will be automatically set by the server - leave as None."
+    )
 
 
 class CallsDeleteRes(BaseModel):
@@ -210,7 +214,9 @@ class CallUpdateReq(BaseModel):
     display_name: typing.Optional[str] = None
 
     # wb_user_id is automatically populated by the server
-    wb_user_id: typing.Optional[str] = None
+    wb_user_id: typing.Optional[str] = Field(
+        None, description="will be automatically set by the server - leave as None."
+    )
 
 
 class CallUpdateRes(BaseModel):
@@ -342,7 +348,9 @@ class FeedbackCreateReq(BaseModel):
     )
 
     # wb_user_id is automatically populated by the server
-    wb_user_id: typing.Optional[str] = None
+    wb_user_id: typing.Optional[str] = Field(
+        None, description="will be automatically set by the server - leave as None."
+    )
 
 
 # The response provides the additional fields needed to convert a request

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -148,9 +148,8 @@ class CallsDeleteReq(BaseModel):
     project_id: str
     call_ids: typing.List[str]
 
-
-class CallsDeleteReqForInsert(CallsDeleteReq):
-    wb_user_id: str
+    # wb_user_id is automatically populated by the server
+    wb_user_id: typing.Optional[str] = None
 
 
 class CallsDeleteRes(BaseModel):
@@ -210,9 +209,8 @@ class CallUpdateReq(BaseModel):
     # optional update fields
     display_name: typing.Optional[str] = None
 
-
-class CallUpdateReqForInsert(CallUpdateReq):
-    wb_user_id: str
+    # wb_user_id is automatically populated by the server
+    wb_user_id: typing.Optional[str] = None
 
 
 class CallUpdateRes(BaseModel):
@@ -343,9 +341,8 @@ class FeedbackCreateReq(BaseModel):
         ]
     )
 
-
-class FeedbackCreateReqForInsert(FeedbackCreateReq):
-    wb_user_id: str
+    # wb_user_id is automatically populated by the server
+    wb_user_id: typing.Optional[str] = None
 
 
 # The response provides the additional fields needed to convert a request
@@ -357,7 +354,7 @@ class FeedbackCreateRes(BaseModel):
     payload: typing.Dict[str, typing.Any]  # If not empty, replace payload
 
 
-class Feedback(FeedbackCreateReqForInsert):
+class Feedback(FeedbackCreateReq):
     id: str
     created_at: datetime.datetime
 
@@ -498,18 +495,4 @@ class TraceServerInterface:
 
     @abc.abstractmethod
     def feedback_purge(self, req: FeedbackPurgeReq) -> FeedbackPurgeRes:
-        raise NotImplementedError()
-
-
-class TraceServerInterfacePostAuth(TraceServerInterface):
-    @abc.abstractmethod
-    def call_update(self, req: CallUpdateReqForInsert) -> CallUpdateRes:
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def calls_delete(self, req: CallsDeleteReqForInsert) -> CallsDeleteRes:
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def feedback_create(self, req: FeedbackCreateReqForInsert) -> FeedbackCreateRes:
         raise NotImplementedError()

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -496,3 +496,11 @@ class TraceServerInterface:
     @abc.abstractmethod
     def feedback_purge(self, req: FeedbackPurgeReq) -> FeedbackPurgeRes:
         raise NotImplementedError()
+
+
+# These symbols are used in the WB Trace Server and it is not safe
+# to remove them, else it will break the server. Once the server
+# is updated to use the new symbols, these can be removed.
+CallsDeleteReqForInsert = CallsDeleteReq
+CallUpdateReqForInsert = CallUpdateReq
+FeedbackCreateReqForInsert = FeedbackCreateReq

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -5,6 +5,10 @@ from pydantic import BaseModel, Field
 
 from .interface.query import Query
 
+WB_USER_ID_DESCRIPTION = (
+    "Do not set directly. Server will automatically populate this field."
+)
+
 
 class CallSchema(BaseModel):
     id: str
@@ -73,9 +77,7 @@ class StartedCallSchemaForInsert(BaseModel):
     inputs: typing.Dict[str, typing.Any]
 
     # WB Metadata
-    wb_user_id: typing.Optional[str] = Field(
-        None, description="will be automatically set by the server - leave as None."
-    )
+    wb_user_id: typing.Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)
     wb_run_id: typing.Optional[str] = None
 
 
@@ -151,9 +153,7 @@ class CallsDeleteReq(BaseModel):
     call_ids: typing.List[str]
 
     # wb_user_id is automatically populated by the server
-    wb_user_id: typing.Optional[str] = Field(
-        None, description="will be automatically set by the server - leave as None."
-    )
+    wb_user_id: typing.Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)
 
 
 class CallsDeleteRes(BaseModel):
@@ -214,9 +214,7 @@ class CallUpdateReq(BaseModel):
     display_name: typing.Optional[str] = None
 
     # wb_user_id is automatically populated by the server
-    wb_user_id: typing.Optional[str] = Field(
-        None, description="will be automatically set by the server - leave as None."
-    )
+    wb_user_id: typing.Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)
 
 
 class CallUpdateRes(BaseModel):
@@ -348,9 +346,7 @@ class FeedbackCreateReq(BaseModel):
     )
 
     # wb_user_id is automatically populated by the server
-    wb_user_id: typing.Optional[str] = Field(
-        None, description="will be automatically set by the server - leave as None."
-    )
+    wb_user_id: typing.Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)
 
 
 # The response provides the additional fields needed to convert a request

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -501,6 +501,8 @@ class TraceServerInterface:
 # These symbols are used in the WB Trace Server and it is not safe
 # to remove them, else it will break the server. Once the server
 # is updated to use the new symbols, these can be removed.
+#
+# Remove once https://github.com/wandb/core/pull/22040 lands
 CallsDeleteReqForInsert = CallsDeleteReq
 CallUpdateReqForInsert = CallUpdateReq
 FeedbackCreateReqForInsert = FeedbackCreateReq

--- a/weave/trace_server/trace_server_interface_util.py
+++ b/weave/trace_server/trace_server_interface_util.py
@@ -86,3 +86,8 @@ def extract_refs_from_values(
 def assert_non_null_wb_user_id(obj: typing.Any) -> None:
     if not hasattr(obj, "wb_user_id") or obj.wb_user_id is None:
         raise ValueError("wb_user_id cannot be None")
+
+
+def assert_null_wb_user_id(obj: typing.Any) -> None:
+    if not hasattr(obj, "wb_user_id") or obj.wb_user_id is not None:
+        raise ValueError("wb_user_id must be be None")

--- a/weave/trace_server/trace_server_interface_util.py
+++ b/weave/trace_server/trace_server_interface_util.py
@@ -81,3 +81,8 @@ def extract_refs_from_values(
 
     _visit(vals)
     return refs
+
+
+def assert_non_null_wb_user_id(obj: typing.Any) -> None:
+    if not hasattr(obj, "wb_user_id") or obj.wb_user_id is None:
+        raise ValueError("wb_user_id cannot be None")


### PR DESCRIPTION
We introduced a violation of inheritance rules with `TraceServerInterfacePostAuth`. We added this because the interface definition for the HTTP server differs slightly from that of the internal trace storage layers (namely the inclusion of wb_user_id which is populated by the server - and therefore not required).

This was problematic for a few reasons:
1. Most importantly: it made it so that `RemoteHTTPTraceServer` was no longer compatible with the other servers. This is not a good place to be in.
2. It violates inheritance rules
3. It introduces additional complexity (not that big of a deal

To remedy this, I:
1. Removed the `TraceServerInterfacePostAuth`
2. Added runtime checks to assert the presence of the required field in the implementations which require it.