### PR TITLE
chore(weave): Add Call Query Stream to the Interface

### DIFF
--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -2011,3 +2011,31 @@ def test_call_stack_order_mixed(client):
         },
         terminal_root_call.id: {},
     }
+
+
+def test_call_query_stream_equality(client):
+    @weave.op
+    def calculate(a: int, b: int) -> int:
+        return a + b
+
+    for i in range(10):
+        calculate(i, i * i)
+
+    calls = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=client._project_id(),
+        )
+    )
+
+    calls_stream = client.server.calls_query_stream(
+        tsi.CallsQueryReq(
+            project_id=client._project_id(),
+        )
+    )
+
+    i = 0
+    for call in calls_stream:
+        assert call == calls.calls[i]
+        i += 1
+
+    assert i == len(calls.calls)

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -296,7 +296,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
 
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> t.Iterator[tsi.CallSchema]:
         return self._generic_stream_request(
-            "/calls/stream_query", req, tsi.CallsQueryReq, tsi.CallsQueryRes
+            "/calls/stream_query", req, tsi.CallsQueryReq, tsi.CallSchema
         )
 
     def calls_query_stats(

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -169,15 +169,13 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         retry_error_callback=_log_failure,
         reraise=True,
     )
-    def _generic_request(
+    def _generic_request_executor(
         self,
         url: str,
         req: BaseModel,
-        req_model: t.Type[BaseModel],
-        res_model: t.Type[BaseModel],
-    ) -> BaseModel:
-        if isinstance(req, dict):
-            req = req_model.model_validate(req)
+        stream: bool = False,
+    ) -> requests.Response:
+
         r = requests.post(
             self.trace_server_url + url,
             # `by_alias` is required since we have Mongo-style properties in the
@@ -186,6 +184,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             # not valid for the `model_validate` step.
             data=req.model_dump_json(by_alias=True).encode("utf-8"),
             auth=self._auth,
+            stream=stream,
         )
         if r.status_code == 413 and "obj/create" in url:
             raise requests.HTTPError(
@@ -202,7 +201,34 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
                 response=r,
             )
         r.raise_for_status()
+
+        return r
+
+    def _generic_request(
+        self,
+        url: str,
+        req: BaseModel,
+        req_model: t.Type[BaseModel],
+        res_model: t.Type[BaseModel],
+    ) -> BaseModel:
+        if isinstance(req, dict):
+            req = req_model.model_validate(req)
+        r = self._generic_request_executor(url, req)
         return res_model.model_validate(r.json())
+
+    def _generic_stream_request(
+        self,
+        url: str,
+        req: BaseModel,
+        req_model: t.Type[BaseModel],
+        res_model: t.Type[BaseModel],
+    ) -> t.Iterator[BaseModel]:
+        if isinstance(req, dict):
+            req = req_model.model_validate(req)
+        r = self._generic_request_executor(url, req, stream=True)
+        for line in r.iter_lines():
+            if line:
+                yield res_model.model_validate(json.loads(line))
 
     @tenacity.retry(
         stop=tenacity.stop_after_delay(REMOTE_REQUEST_RETRY_DURATION),
@@ -266,6 +292,11 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
     ) -> tsi.CallsQueryRes:
         return self._generic_request(
             "/calls/query", req, tsi.CallsQueryReq, tsi.CallsQueryRes
+        )
+
+    def calls_query_stream(self, req: tsi.CallsQueryReq) -> t.Iterator[tsi.CallSchema]:
+        return self._generic_stream_request(
+            "/calls/stream_query", req, tsi.CallsQueryReq, tsi.CallsQueryRes
         )
 
     def calls_query_stats(

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1,6 +1,6 @@
 # Sqlite Trace Server
 
-from typing import cast, Optional, Any, Union
+from typing import Iterator, cast, Optional, Any, Union
 import threading
 
 import contextvars
@@ -449,6 +449,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 for row in query_result
             ]
         )
+
+    def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
+        return iter(self.calls_query(req).calls)
 
     def calls_query_stats(self, req: tsi.CallsQueryStatsReq) -> tsi.CallsQueryStatsRes:
         calls = self.calls_query(

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -417,57 +417,61 @@ class TraceServerInterface:
     # Call API
     @abc.abstractmethod
     def call_start(self, req: CallStartReq) -> CallStartRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def call_end(self, req: CallEndReq) -> CallEndRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def call_read(self, req: CallReadReq) -> CallReadRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def calls_query(self, req: CallsQueryReq) -> CallsQueryRes:
-        ...
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def calls_query_stream(self, req: CallsQueryReq) -> typing.Iterator[CallSchema]:
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def calls_delete(self, req: CallsDeleteReq) -> CallsDeleteRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def calls_query_stats(self, req: CallsQueryStatsReq) -> CallsQueryStatsRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def call_update(self, req: CallUpdateReq) -> CallUpdateRes:
-        ...
+        raise NotImplementedError()
 
     # Op API
     @abc.abstractmethod
     def op_create(self, req: OpCreateReq) -> OpCreateRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def op_read(self, req: OpReadReq) -> OpReadRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def ops_query(self, req: OpQueryReq) -> OpQueryRes:
-        ...
+        raise NotImplementedError()
 
     # Obj API
     @abc.abstractmethod
     def obj_create(self, req: ObjCreateReq) -> ObjCreateRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def obj_read(self, req: ObjReadReq) -> ObjReadRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def objs_query(self, req: ObjQueryReq) -> ObjQueryRes:
-        ...
+        raise NotImplementedError()
 
     @abc.abstractmethod
     def table_create(self, req: TableCreateReq) -> TableCreateRes:


### PR DESCRIPTION
Currently, only the `ClickhouseTraceServerBatched` implements the call query stream method. However, in my crusade to align `RemoteHTTPTraceServer` and `SQLiteTraceServer` these both need to properly implement this API.

As an added bonus, we now get call streaming at the python client level!

And more practically, this is one step closer to being able to generalize and extract the converter components