### PR TITLE
chore(weave): remove call naming from op kwarg

### DIFF
--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -405,7 +405,7 @@ def test_op_display_name(client):
     assert len(result) == 1
     assert not result[0].display_name
 
-    @weave.op(display_name="op name")
+    @weave.op(trace_name="op name")
     def my_op_1():
         return "fake"
 
@@ -414,7 +414,7 @@ def test_op_display_name(client):
     assert len(result) == 2
     assert result[1].display_name == "op name"
 
-    @weave.op(display_name="op name 2")
+    @weave.op(trace_name="op name 2")
     def my_op_2():
         return "fake"
 

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -394,36 +394,6 @@ def test_call_display_name(client):
     assert call0.display_name == None
 
 
-def test_op_display_name(client):
-    @weave.op()
-    def my_op():
-        return "fake"
-
-    my_op()
-
-    result = list(client.calls())
-    assert len(result) == 1
-    assert not result[0].display_name
-
-    @weave.op(trace_name="op name")
-    def my_op_1():
-        return "fake"
-
-    my_op_1()
-    result = list(client.calls())
-    assert len(result) == 2
-    assert result[1].display_name == "op name"
-
-    @weave.op(trace_name="op name 2")
-    def my_op_2():
-        return "fake"
-
-    my_op_2()
-    result = list(client.calls())
-    assert len(result) == 3
-    assert result[2].display_name == "op name 2"
-
-
 def test_dataset_calls(client):
     ref = client.save(
         weave.Dataset(rows=[{"doc": "xx", "label": "c"}, {"doc": "yy", "label": "d"}]),

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -52,7 +52,6 @@ class Op:
         self.name = resolve_fn.__name__
         self.signature = inspect.signature(resolve_fn)
         self._on_output_handler = None
-        self.trace_name = None
 
     def __get__(
         self, obj: Optional[object], objtype: Optional[type[object]] = None
@@ -85,7 +84,6 @@ class Op:
             inputs_with_defaults,
             parent_run,
             attributes=attributes,
-            display_name=self.trace_name,
         )
 
         has_finished = False
@@ -174,7 +172,6 @@ class BoundOp(Op):
         self.signature = inspect.signature(op.resolve_fn)
         self.resolve_fn = op.resolve_fn
         self._on_output_handler = op._on_output_handler
-        self.trace_name = op.trace_name
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return Op.__call__(self, self.arg0, *args, **kwargs)
@@ -195,9 +192,7 @@ R = TypeVar("R")
 
 
 # The decorator!
-def op(
-    trace_name: Optional[str] = None, *args: Any, **kwargs: Any
-) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def op(*args: Any, **kwargs: Any) -> Callable[[Callable[P, R]], Callable[P, R]]:
     if context_state.get_loading_built_ins():
         from weave.decorator_op import op
 
@@ -206,8 +201,6 @@ def op(
     def wrap(f: Callable[P, R]) -> Callable[P, R]:
         op = Op(f)
         functools.update_wrapper(op, f)
-        if trace_name:
-            op.trace_name = trace_name
         return op  # type: ignore
 
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):


### PR DESCRIPTION
calls can be "named" with: 
```
weave.weave_client.set_call_display_name(call, "new name")

call = weave.weave_client.calls()[0]
call.set_display_name("new name")
```