### PR TITLE
chore: fix double json encoding of feedback payload

### DIFF
--- a/weave/tests/test_client_feedback.py
+++ b/weave/tests/test_client_feedback.py
@@ -200,6 +200,33 @@ def test_feedback_apis(client):
         client.server.feedback_purge(req)
 
 
+def test_feedback_payload(client):
+
+    project_id = client._project_id()
+
+    # Emoji from Jamie
+    req = tsi.FeedbackCreateReq(
+        project_id=project_id,
+        wb_user_id="VXNlcjo0NTI1NDQ=",
+        weave_ref="weave:///entity/project/object/name:digest",
+        feedback_type="wandb.reaction.1",
+        payload={"emoji": "🎱"},
+    )
+    res = client.server.feedback_create(req)
+    assert len(res.id) == 36
+    assert res.payload["alias"] == ":pool_8_ball:"
+    id_emoji_1 = res.id
+
+    # Try querying on the published feedback
+    req = tsi.FeedbackQueryReq(
+        project_id=project_id,
+    )
+    res = client.server.feedback_query(req)
+    payload = res.result[0]["payload"]
+    assert isinstance(payload, dict)
+    assert payload["emoji"] == "🎱"
+
+
 def test_feedback_create_too_large(client):
 
     project_id = client._project_id()

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -996,7 +996,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             "wb_user_id": req.wb_user_id,
             "creator": req.creator,
             "feedback_type": req.feedback_type,
-            "payload": payload,
+            "payload": req.payload,
             "created_at": created_at,
         }
         prepared = TABLE_FEEDBACK.insert(row).prepare(database_type="clickhouse")

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -78,7 +78,9 @@ class ParamBuilder:
 
 
 Value: TypeAlias = typing.Optional[
-    typing.Union[str, float, datetime.datetime, list[str], list[float]]
+    typing.Union[
+        str, float, datetime.datetime, list[str], list[float], dict[str, typing.Any]
+    ]
 ]
 Row: TypeAlias = dict[str, Value]
 Rows: TypeAlias = list[Row]
@@ -169,12 +171,12 @@ class Table:
         if database_type == "sqlite":
             return f"DELETE FROM {self.name}"
 
-    def tuple_to_row(self, tuple: typing.Tuple, fields: list[str]) -> Row:
+    def tuple_to_row(self, tup: typing.Tuple, fields: list[str]) -> Row:
         d = {}
         for i, field in enumerate(fields):
             if field.endswith("_dump"):
                 field = field[:-5]
-            value = tuple[i]
+            value = tup[i]
             if field in self.col_types and self.col_types[field] == "json":
                 d[field] = json.loads(value)
             else:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -745,7 +745,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             "wb_user_id": req.wb_user_id,
             "creator": req.creator,
             "feedback_type": req.feedback_type,
-            "payload": payload,
+            "payload": req.payload,
             "created_at": created_at,
         }
         conn, cursor = get_conn_cursor(self.db_path)


### PR DESCRIPTION
The ORM layer is supposed to handle the dump/load of json columns from a dict to a string column in the db. I had added a separate JSON dump to string when I added a size limit check on the payload, but I should have still been passing in the payload as a dict. Added a test for this.