### PR TITLE
chore(weave): Mark test as flaky

### DIFF
--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -583,6 +583,7 @@ def test_save_model(client):
     assert model2.predict("x") == "input is: x"
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=2)
 def test_saved_nested_modellike(client):
     class A(weave.Object):
         x: int


### PR DESCRIPTION
This test seems to flake periodically in CI.  I haven't been able to reproduce, but based on the error message I think this might be a case where the object doesn't de-ref as expected.