### PR TITLE
fix: output column was missing for single values

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumnsUtil.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumnsUtil.ts
@@ -15,6 +15,9 @@ export function pathToString(path: Path): string {
 }
 
 export function isDynamicCallColumn(path: Path): boolean {
+  if (path.length === 1) {
+    return path[0] === 'output';
+  }
   return (
     path.length > 1 &&
     ['attributes', 'inputs', 'output', 'summary'].includes(path[0])


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-19326

We weren't creating an output column for ops that just return e.g. a string.

Before:
![image](https://github.com/wandb/weave/assets/112953339/654d0b37-7c20-4afe-91bb-7b6759e7ca9f)

After:

![image](https://github.com/wandb/weave/assets/112953339/f0d6256e-45d1-4b2f-9b80-0230c0b29731)
