### PR TITLE
chore(app): Enhance getTimeSegmentsInTimeZone Function to Include Day Property

### DIFF
--- a/weave-js/src/common/util/time.ts
+++ b/weave-js/src/common/util/time.ts
@@ -236,7 +236,7 @@ type TimeSegments = {
   second: number;
 };
 
-export function getTimeSegmentsInTimeZone(timeZone: string): TimeSegments {
+export function getTimeSegmentsInTimeZone(timeZone: string): TimeSegments & { day: string } { 
   const timeStr = new Date().toLocaleTimeString('en-US', {
     timeZone,
     hourCycle: 'h23',
@@ -245,11 +245,17 @@ export function getTimeSegmentsInTimeZone(timeZone: string): TimeSegments {
     second: '2-digit',
   });
 
+  const dateStr = new Date().toLocaleDateString('en-US', {
+    timeZone,
+    weekday: 'long',
+  });
+
   const [hour, minute, second] = timeStr.split(':').map(Number);
 
   return {
     hour,
     minute,
     second,
+    day: dateStr,
   };
 }

--- a/weave-js/src/common/util/time.ts
+++ b/weave-js/src/common/util/time.ts
@@ -236,7 +236,11 @@ type TimeSegments = {
   second: number;
 };
 
-export function getTimeSegmentsInTimeZone(timeZone: string): TimeSegments & { day: string } { 
+type WeekTimeSegments = TimeSegments & {
+  day: string;
+};
+
+export function getTimeSegmentsInTimeZone(timeZone: string): WeekTimeSegments {
   const timeStr = new Date().toLocaleTimeString('en-US', {
     timeZone,
     hourCycle: 'h23',


### PR DESCRIPTION
Jira Reference:
https://wandb.atlassian.net/browse/WB-19359

Support team will be reducing support hours for non paying users to Tuesday, Wednesday, Thursday

This PR enhances the getTimeSegmentsInTimeZone function by including the day of the week in its return value to use as part of conditional logic in core

Change:
Definition of New Types:
WeekTimeSegments: An extended type of TimeSegments that also includes the day property.

Function Update:
The getTimeSegmentsInTimeZone function is updated to return an object of type WeekTimeSegments, which includes the time segments (hour, minute, second) and now the day of the week.