### PR TITLE
fix: safari scrolling issue

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -329,7 +329,7 @@ const MainPeekingLayout: FC = () => {
           PaperProps={{
             style: {
               overflow: 'hidden',
-              display: 'flex',
+              display: isDrawerOpen ? 'flex' : 'none',
               zIndex: 1,
               width: `${drawerWidthPct}%`,
               height: '100%',


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/issues/WB-18752

In Safari if you horizontally overscroll our pages you get into a bad state where the entire page is positioned off screen.
Setting the peek drawer to display: none when closed seems to fix it in FeatureBee. (Local debugging in Safari has challenges we should address at some point, same kind of thing the authtool helps with in Chrome I'm guessing.)

Example:
<img width="1645" alt="Screenshot 2024-06-18 at 11 23 23 AM" src="https://github.com/wandb/weave/assets/112953339/b9245814-5f51-4a96-abe1-b3e66dc072f1">

