### PR TITLE
feat: add feedback tab to call details page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGrid.tsx
@@ -1,0 +1,80 @@
+import {Box} from '@mui/material';
+import _ from 'lodash';
+import React from 'react';
+
+import {Alert} from '../../../../Alert';
+import {Loading} from '../../../../Loading';
+import {Tailwind} from '../../../../Tailwind';
+import {useWFHooks} from '../pages/wfReactInterface/context';
+import {FeedbackGridInner} from './FeedbackGridInner';
+
+type FeedbackGridProps = {
+  entity: string;
+  project: string;
+  weaveRef: string;
+  objectType?: string;
+};
+
+export const FeedbackGrid = ({
+  entity,
+  project,
+  weaveRef,
+  objectType,
+}: FeedbackGridProps) => {
+  const {useFeedback} = useWFHooks();
+  const query = useFeedback({
+    entity,
+    project,
+    weaveRef,
+    includeExtra: true,
+  });
+
+  if (query.loading) {
+    return (
+      <Box
+        sx={{
+          height: '38px',
+          width: '100%',
+        }}>
+        <Loading centered size={25} />
+      </Box>
+    );
+  }
+  if (query.error) {
+    return (
+      <div className="m-16 flex flex-col gap-8">
+        <Alert severity="error">
+          Error: {query.error.message ?? JSON.stringify(query.error)}
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!query.result || !query.result.length) {
+    const obj = objectType ?? 'object';
+    return (
+      <div className="m-16 flex flex-col gap-8">
+        <Alert>No feedback added to this {obj}.</Alert>
+      </div>
+    );
+  }
+
+  // Group by feedback on this object vs. descendent objects
+  const grouped = _.groupBy(query.result, f =>
+    f.weave_ref.substring(weaveRef.length)
+  );
+  const paths = Object.keys(grouped).sort();
+
+  return (
+    <Tailwind>
+      {paths.map(path => {
+        return (
+          <div key={path}>
+            {path && <div className="text-sm text-moon-500">On {path}</div>}
+            <FeedbackGridInner feedback={grouped[path]} />
+          </div>
+        );
+      })}
+    </Tailwind>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGrid.tsx
@@ -26,7 +26,6 @@ export const FeedbackGrid = ({
     entity,
     project,
     weaveRef,
-    includeExtra: true,
   });
 
   if (query.loading) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -1,0 +1,116 @@
+import {GridColDef, GridRowHeightParams} from '@mui/x-data-grid-pro';
+import React from 'react';
+
+import {Timestamp} from '../../../../Timestamp';
+import {UserLink} from '../../../../UserLink';
+import {CellValueString} from '../../Browse2/CellValueString';
+import {CopyableId} from '../pages/common/Id';
+import {Feedback} from '../pages/wfReactInterface/traceServerClient';
+import {StyledDataGrid} from '../StyledDataGrid';
+import {FeedbackTypeChip} from './FeedbackTypeChip';
+
+type FeedbackGridInnerProps = {
+  feedback: Feedback[];
+};
+
+export const FeedbackGridInner = ({feedback}: FeedbackGridInnerProps) => {
+  const columns: GridColDef[] = [
+    {
+      field: 'feedback_type',
+      headerName: 'Type',
+      renderCell: params => (
+        <FeedbackTypeChip feedbackType={params.row.feedback_type} />
+      ),
+    },
+    {
+      field: 'payload',
+      headerName: 'Feedback',
+      sortable: false,
+      flex: 1,
+      renderCell: params => {
+        if (params.row.feedback_type === 'wandb.note.1') {
+          return <CellValueString value={params.row.payload.note} />;
+        }
+        if (params.row.feedback_type === 'wandb.reaction.1') {
+          return params.row.payload.emoji;
+        }
+        return <CellValueString value={JSON.stringify(params.row.payload)} />;
+      },
+    },
+    {
+      field: 'created_at',
+      headerName: 'Timestamp',
+      width: 120,
+      renderCell: params => (
+        <Timestamp value={params.row.created_at} format="relative" />
+      ),
+    },
+    {
+      field: 'id',
+      headerName: 'ID',
+      width: 50,
+      renderCell: params => <CopyableId id={params.row.id} type="Feedback" />,
+    },
+    {
+      field: 'wb_user_id',
+      headerName: 'Creator',
+      width: 150,
+      // Might be confusing to enable as-is, because the user sees name /
+      // email but the underlying data is userId.
+      filterable: false,
+      sortable: false,
+      resizable: false,
+      disableColumnMenu: true,
+      renderCell: params => {
+        if (
+          params.row.creator &&
+          params.row.creator !== params.row.wb_user_id
+        ) {
+          return params.row.creator;
+        }
+        return <UserLink username={params.row.wb_user_id} includeName />;
+      },
+    },
+  ];
+  const rows = feedback;
+  return (
+    <StyledDataGrid
+      // Start Column Menu
+      // ColumnMenu is only needed when we have other actions
+      // such as filtering.
+      disableColumnMenu={true}
+      // We don't have enough columns to justify filtering
+      disableColumnFilter={true}
+      disableMultipleColumnsFiltering={true}
+      // ColumnPinning seems to be required in DataGridPro, else it crashes.
+      disableColumnPinning={false}
+      // We don't have enough columns to justify re-ordering
+      disableColumnReorder={true}
+      // The columns are fairly simple, so we don't need to resize them.
+      disableColumnResize={false}
+      // We don't have enough columns to justify hiding some of them.
+      disableColumnSelector={true}
+      // We don't have enough columns to justify sorting by multiple columns.
+      disableMultipleColumnsSorting={true}
+      // End Column Menu
+      rows={rows}
+      initialState={{
+        sorting: {
+          sortModel: [{field: 'created_at', sort: 'desc'}],
+        },
+      }}
+      columnHeaderHeight={40}
+      getRowHeight={(params: GridRowHeightParams) => {
+        if (
+          params.model.feedback_type !== 'wandb.reaction.1' &&
+          params.model.feedback_type !== 'wandb.note.1'
+        ) {
+          return 'auto';
+        }
+        return 38;
+      }}
+      columns={columns}
+      disableRowSelectionOnClick
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackTypeChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackTypeChip.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import {Pill, TagColorName} from '../../../../Tag';
+
+type FeedbackTypeChipProps = {
+  feedbackType: string;
+};
+
+export const FeedbackTypeChip = ({feedbackType}: FeedbackTypeChipProps) => {
+  let color: TagColorName = 'teal';
+  let label = feedbackType;
+  if (feedbackType === 'wandb.reaction.1') {
+    color = 'purple';
+    label = 'Reaction';
+  } else if (feedbackType === 'wandb.note.1') {
+    color = 'gold';
+    label = 'Note';
+  }
+  return <Pill color={color} label={label} />;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -4,13 +4,16 @@ import {Loading} from '@wandb/weave/components/Loading';
 import React, {FC, useCallback} from 'react';
 import {useHistory} from 'react-router-dom';
 
+import {makeRefCall} from '../../../../../../util/refs';
 import {Button} from '../../../../../Button';
+import {Tailwind} from '../../../../../Tailwind';
 import {Browse2OpDefCode} from '../../../Browse2/Browse2OpDefCode';
 import {
   TRACETREE_PARAM,
   useClosePeek,
   useWeaveflowCurrentRouteContext,
 } from '../../context';
+import {FeedbackGrid} from '../../feedback/FeedbackGrid';
 import {isEvaluateOp} from '../common/heuristics';
 import {CenteredAnimatedLoader} from '../common/Loader';
 import {SimplePageLayoutWithHeader} from '../common/SimplePageLayout';
@@ -55,6 +58,8 @@ export const CallPage: FC<{
 
 const useCallTabs = (call: CallSchema) => {
   const codeURI = call.opVersionRef;
+  const {entity, project, callId} = call;
+  const weaveRef = makeRefCall(entity, project, callId);
   return [
     {
       label: 'Call',
@@ -68,6 +73,19 @@ const useCallTabs = (call: CallSchema) => {
           },
         ]
       : []),
+    {
+      label: 'Feedback',
+      content: (
+        <Tailwind style={{height: '100%', overflow: 'auto'}}>
+          <FeedbackGrid
+            entity={entity}
+            project={project}
+            weaveRef={weaveRef}
+            objectType="call"
+          />
+        </Tailwind>
+      ),
+    },
     {
       label: 'Summary',
       content: <CallSummary call={call} />,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -99,6 +99,53 @@ export type TraceCallsDeleteReq = {
   call_ids: string[];
 };
 
+export type FeedbackCreateReq = {
+  project_id: string;
+  weave_ref: string;
+  feedback_type: string;
+  payload: Record<string, any>;
+};
+
+export type FeedbackCreateSuccess = {};
+export type FeedbackCreateError = {
+  detail: string;
+};
+export type FeedbackCreateRes = FeedbackCreateSuccess | FeedbackCreateError;
+
+export type FeedbackQueryReq = {
+  project_id: string;
+  query?: Query;
+  sort_by?: SortBy[];
+};
+
+export type Feedback = {
+  id: string;
+  weave_ref: string;
+  wb_user_id: string; // authenticated creator username
+  creator: string; // display name
+  created_at: string;
+  feedback_type: string;
+  payload: Record<string, any>;
+};
+
+export type FeedbackQuerySuccess = {
+  result: Feedback[];
+};
+export type FeedbackQueryError = {
+  detail: string;
+};
+export type FeedbackQueryRes = FeedbackQuerySuccess | FeedbackQueryError;
+
+export type FeedbackPurgeReq = {
+  project_id: string;
+  id: string;
+};
+export type FeedbackPurgeSuccess = {};
+export type FeedbackPurgeError = {
+  detail: string;
+};
+export type FeedbackPurgeRes = FeedbackPurgeSuccess | FeedbackPurgeError;
+
 interface TraceObjectsFilter {
   base_object_classes?: string[];
   object_ids?: string[];
@@ -338,6 +385,28 @@ export class TraceServerClient {
         req
       );
     };
+
+  feedbackCreate: (req: FeedbackCreateReq) => Promise<FeedbackCreateRes> =
+    req => {
+      return this.makeRequest<FeedbackCreateReq, FeedbackCreateRes>(
+        '/feedback/create',
+        req
+      );
+    };
+
+  feedbackQuery: (req: FeedbackQueryReq) => Promise<FeedbackQueryRes> = req => {
+    return this.makeRequest<FeedbackQueryReq, FeedbackQueryRes>(
+      '/feedback/query',
+      req
+    );
+  };
+
+  feedbackPurge: (req: FeedbackPurgeReq) => Promise<FeedbackPurgeRes> = req => {
+    return this.makeRequest<FeedbackPurgeReq, FeedbackPurgeRes>(
+      '/feedback/purge',
+      req
+    );
+  };
 
   fileContent: (
     req: TraceFileContentReadReq

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -27,6 +27,7 @@ import {
   CallFilter,
   CallKey,
   CallSchema,
+  FeedbackKey,
   Loadable,
   LoadableWithError,
   ObjectVersionFilter,
@@ -416,6 +417,53 @@ const useCallsDeleteFunc = () => {
   );
 
   return callsDelete;
+};
+
+const useFeedback = (
+  key: FeedbackKey | null
+): LoadableWithError<traceServerClient.Feedback[]> => {
+  const getTsClient = useGetTraceServerClientContext();
+
+  const [result, setResult] = useState<
+    LoadableWithError<traceServerClient.Feedback[]>
+  >({
+    loading: false,
+    result: null,
+    error: null,
+  });
+
+  const deepKey = useDeepMemo(key);
+
+  useEffect(() => {
+    if (!deepKey) {
+      return;
+    }
+    setResult({loading: true, result: null, error: null});
+    getTsClient()
+      .feedbackQuery({
+        project_id: projectIdFromParts({
+          entity: deepKey.entity,
+          project: deepKey.project,
+        }),
+        query: {
+          $expr: {
+            $eq: [{$getField: 'weave_ref'}, {$literal: deepKey.weaveRef}],
+          },
+        },
+        sort_by: [{field: 'created_at', direction: 'desc'}],
+      })
+      .then(res => {
+        if ('result' in res) {
+          setResult({loading: false, result: res.result, error: null});
+        }
+        // TODO: handle error case
+      })
+      .catch(err => {
+        setResult({loading: false, result: null, error: err});
+      });
+  }, [deepKey, getTsClient]);
+
+  return result;
 };
 
 const useOpVersion = (
@@ -1230,6 +1278,7 @@ export const tsWFDataModelHooks: WFDataModelHooksInterface = {
   useRootObjectVersions,
   useRefsData,
   useApplyMutationsToRef,
+  useFeedback,
   useFileContent,
   derived: {
     useChildCallsForCompare,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -152,8 +152,6 @@ export type FeedbackKey = {
   entity: string;
   project: string;
   weaveRef: string;
-  // If true, do a prefix search on weaveRef instead of an exact match
-  includeExtra?: boolean;
 };
 
 export type WFDataModelHooksInterface = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -148,6 +148,14 @@ type AppendRefMutation = {
 
 export type RefMutation = SetRefMutation | AppendRefMutation;
 
+export type FeedbackKey = {
+  entity: string;
+  project: string;
+  weaveRef: string;
+  // If true, do a prefix search on weaveRef instead of an exact match
+  includeExtra?: boolean;
+};
+
 export type WFDataModelHooksInterface = {
   useCall: (key: CallKey | null) => Loadable<CallSchema | null>;
   useCalls: (
@@ -207,6 +215,7 @@ export type WFDataModelHooksInterface = {
     digest: string,
     opts?: {skip?: boolean}
   ) => Loadable<string>;
+  useFeedback: (key: FeedbackKey | null) => LoadableWithError<any[] | null>;
   derived: {
     useChildCallsForCompare: (
       entity: string,


### PR DESCRIPTION
Add a tab to the Call details page for displaying feedback.

Feedback:
<img width="876" alt="Screenshot 2024-06-18 at 3 35 19 PM" src="https://github.com/wandb/weave/assets/112953339/64c18f33-b4b2-4a1d-a6cc-ac9bb4daedaf">

No feedback case:
<img width="874" alt="Screenshot 2024-06-18 at 3 35 06 PM" src="https://github.com/wandb/weave/assets/112953339/7564b464-1dd6-4c3d-8356-f899d725605c">
