### PR TITLE
chore: add useProjectHasTraceServerData method back

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
@@ -10,6 +10,7 @@
 
 import React, {createContext, FC, useContext} from 'react';
 
+import {useHasTraceServerClientContext} from './traceServerClientContext';
 import {tsWFDataModelHooks} from './tsDataModelHooks';
 import {WFDataModelHooksInterface} from './wfDataModelHooksInterface';
 
@@ -34,4 +35,43 @@ export const WFDataModelAutoProvider: FC<{
       {children}
     </WFDataModelHooksContext.Provider>
   );
+};
+
+/**
+ * Returns true if the client can connect to trace server and the project has
+ * objects or calls.
+ */
+export const useProjectHasTraceServerData = (
+  entity: string,
+  project: string
+) => {
+  const hasTraceServer = useHasTraceServerClientContext();
+  const objs = tsWFDataModelHooks.useRootObjectVersions(
+    entity,
+    project,
+    {},
+    1,
+    {
+      skip: !hasTraceServer,
+    }
+  );
+
+  const calls = tsWFDataModelHooks.useCalls(
+    entity,
+    project,
+    {},
+    1,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      skip: !hasTraceServer,
+    }
+  );
+  const loading = objs.loading || calls.loading;
+  return {
+    loading,
+    result: (objs.result ?? []).length > 0 || (calls.result ?? []).length > 0,
+  };
 };


### PR DESCRIPTION
This method was removed in https://github.com/wandb/weave/pull/1694/files because it was unused at the time. Adding it back in because we will need it for upcoming core UI changes where we conditionalize things like the default quickstart choice based on whether the project has published Weave data.