### PR TITLE
chore: enable Ruff W391 too-many-newlines-at-end-of-file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,12 +64,14 @@ testpaths = ["weave"]
 filterwarnings = ["error"]
 
 [tool.ruff.lint]
+preview = true
 select = [
   "D200", # https://docs.astral.sh/ruff/rules/fits-on-one-line/
   "FIX001", # https://beta.ruff.rs/docs/rules/#flake8-fixme-fix
   "FIX003",
   "F541",
   "I", # https://docs.astral.sh/ruff/rules/#isort-i
+  "W391", # https://docs.astral.sh/ruff/rules/too-many-newlines-at-end-of-file/
 ]
 exclude = [
   "weave/api.py",


### PR DESCRIPTION
Enables support for preview rules, see https://docs.astral.sh/ruff/preview/
Also turns on a specific rule that is not currently violated: https://docs.astral.sh/ruff/rules/too-many-newlines-at-end-of-file/