### PR TITLE
feat(weave): Increase maximum number of runs to resolve from 50 to 100

### DIFF
--- a/weave-js/src/core/util/constants.ts
+++ b/weave-js/src/core/util/constants.ts
@@ -1,4 +1,4 @@
-export const MAX_RUN_LIMIT = 50;
+export const MAX_RUN_LIMIT = 100;
 export const MAX_DATE_MS = 8640000000000000; // max date value, https://stackoverflow.com/a/28425951/15867258
 
 // If true, attach useful debugging fn's to globalThis:


### PR DESCRIPTION
In reports, we can and should support runsets with more than 50 runs selected.  This is important for leaderboard-style reports such as [this](https://api.wandb.ai/links/wandb-japan/xm2pju5m)