### PR TITLE
fix: include token counts and costs in CSV export

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/TraceUsageStats.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/TraceUsageStats.tsx
@@ -147,12 +147,10 @@ export const getTokensAndCostFromUsage = (usage: {
       metrics.outputs.tokens.total += outputTokens;
     }
   }
-  const cost = formatTokenCost(
-    metrics.inputs.cost.total + metrics.outputs.cost.total
-  );
-  const tokens = formatTokenCount(
-    metrics.inputs.tokens.total + metrics.outputs.tokens.total
-  );
+  const costNum = metrics.inputs.cost.total + metrics.outputs.cost.total;
+  const cost = formatTokenCost(costNum);
+  const tokensNum = metrics.inputs.tokens.total + metrics.outputs.tokens.total;
+  const tokens = formatTokenCount(tokensNum);
 
   const tooltipRowStyles = {
     display: 'flex',
@@ -210,7 +208,7 @@ export const getTokensAndCostFromUsage = (usage: {
       ))}
     </Box>
   );
-  return {cost, tokens, costToolTip, tokenToolTip};
+  return {costNum, cost, tokensNum, tokens, costToolTip, tokenToolTip};
 };
 
 const TraceStat = ({

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -451,6 +451,11 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
+    valueGetter: cellParams => {
+      const usage = getUsageFromCellParams(cellParams.row);
+      const {tokensNum} = getTokensAndCostFromUsage(usage);
+      return tokensNum;
+    },
     renderCell: cellParams => {
       const usage = getUsageFromCellParams(cellParams.row);
       const {tokens, tokenToolTip} = getTokensAndCostFromUsage(usage);
@@ -467,6 +472,11 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
+    valueGetter: cellParams => {
+      const usage = getUsageFromCellParams(cellParams.row);
+      const {costNum} = getTokensAndCostFromUsage(usage);
+      return costNum;
+    },
     renderCell: cellParams => {
       const usage = getUsageFromCellParams(cellParams.row);
       const {cost, costToolTip} = getTokensAndCostFromUsage(usage);


### PR DESCRIPTION
Internal Slack: https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1718913564028869
Internal Jira: https://wandb.atlassian.net/browse/WB-19396

Exports the raw numeric values for token count and cost columns.

<img width="222" alt="Screenshot 2024-06-20 at 3 23 35 PM" src="https://github.com/wandb/weave/assets/112953339/e12811d8-8ffa-40ed-bcf1-71801d59a79d">
