### PR TITLE
fix: diff editor version selector header could overlap

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewerDiff.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewerDiff.tsx
@@ -29,7 +29,9 @@ export const OpCodeViewerDiff = ({
   const onMount = (editor: any, monaco: Monaco) => {
     if (onSplitResize) {
       editor.getOriginalEditor().onDidLayoutChange((dimensions: any) => {
-        onSplitResize(dimensions.width);
+        if (dimensions.contentWidth >= 0) {
+          onSplitResize(dimensions.width);
+        }
       });
     }
   };


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-19432

Before, could get into this state:

<img width="335" alt="Screenshot 2024-06-26 at 3 55 34 PM" src="https://github.com/wandb/weave/assets/112953339/009c4de5-8997-4408-b714-e9d58c28a18f">
