### PR TITLE
chore(weave): Fix Object Versions Link

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -14,7 +14,6 @@ import {useWindowSize} from '@wandb/weave/common/hooks/useWindowSize';
 import {Loading} from '@wandb/weave/components/Loading';
 import {EVALUATE_OP_NAME_POST_PYDANTIC} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/heuristics';
 import {opVersionKeyToRefUri} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities';
-import {KnownBaseObjectClassType} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
 import _ from 'lodash';
 import React, {
   ComponentProps,
@@ -61,7 +60,10 @@ import {EMPTY_NO_TRACE_SERVER} from './Browse3/pages/common/EmptyContent';
 import {SimplePageLayoutContext} from './Browse3/pages/common/SimplePageLayout';
 import {ObjectPage} from './Browse3/pages/ObjectPage';
 import {ObjectVersionPage} from './Browse3/pages/ObjectVersionPage';
-import {ObjectVersionsPage} from './Browse3/pages/ObjectVersionsPage';
+import {
+  ObjectVersionsPage,
+  WFHighLevelObjectVersionFilter,
+} from './Browse3/pages/ObjectVersionsPage';
 import {OpPage} from './Browse3/pages/OpPage';
 import {OpsPage} from './Browse3/pages/OpsPage';
 import {OpVersionPage} from './Browse3/pages/OpVersionPage';
@@ -673,16 +675,26 @@ const CallsPageBinding = () => {
 // TODO(tim/weaveflow_improved_nav): Generalize this
 const ObjectVersionsPageBinding = () => {
   const {entity, project, tab} = useParams<Browse3TabParams>();
-  const filters = useMemo(() => {
-    let baseObjectClass: KnownBaseObjectClassType | null = null;
+  const query = useURLSearchParamsDict();
+  const filters: WFHighLevelObjectVersionFilter = useMemo(() => {
+    let queryFilter: WFHighLevelObjectVersionFilter = {};
+    // Parse the filter from the query string
+    try {
+      queryFilter = JSON.parse(query.filter) as WFHighLevelObjectVersionFilter;
+    } catch (e) {
+      console.log(e);
+    }
+
+    // If the tab is models or datasets, set the baseObjectClass filter
+    // directly from the tab
     if (tab === 'models') {
-      baseObjectClass = 'Model';
+      queryFilter.baseObjectClass = 'Model';
     }
     if (tab === 'datasets') {
-      baseObjectClass = 'Dataset';
+      queryFilter.baseObjectClass = 'Dataset';
     }
-    return {baseObjectClass};
-  }, [tab]);
+    return queryFilter;
+  }, [query.filter, tab]);
 
   const history = useHistory();
   const routerContext = useWeaveflowCurrentRouteContext();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -435,7 +435,7 @@ const Browse3ProjectRoot: FC<{
         <Route
           path={[
             `${projectRoot}/:tab(datasets|models|objects)`,
-            `${projectRoot}/object-versions`, // deprecated
+            `${projectRoot}/object-versions`,
           ]}>
           <ObjectVersionsPageBinding />
         </Route>
@@ -450,10 +450,7 @@ const Browse3ProjectRoot: FC<{
           <OpsPageBinding />
         </Route>
         <Route
-          path={[
-            `${projectRoot}/operations`,
-            `${projectRoot}/op-versions`, // deprecated
-          ]}>
+          path={[`${projectRoot}/operations`, `${projectRoot}/op-versions`]}>
           <OpVersionsPageBinding />
         </Route>
         {/* CALLS */}


### PR DESCRIPTION
In our recent sidebar refactor we accidentally introduced a regression where the "X Versions" link on objects no longer worked - resulting in the all objects view. This PR puts back functionality that was accidentally removed.


https://github.com/wandb/weave/assets/2142768/6b060626-e153-4e42-aa03-253c7f5a8ee4

