### PR TITLE
chore: hide scrollbars in feedback cell

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/ReactionsLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/ReactionsLoaded.tsx
@@ -120,6 +120,7 @@ export const ReactionsLoaded = ({
 
   const wrapperStyles = {
     overflow: 'auto',
+    scrollbarWidth: 'none' as const,
     ...twWrapperStyles,
   };
 


### PR DESCRIPTION
Internal Slack: https://weightsandbiases.slack.com/archives/C05DURZNT41/p1719439840146599

Before: 
<img width="147" alt="Screenshot 2024-06-26 at 8 59 20 PM" src="https://github.com/wandb/weave/assets/112953339/f566f2ac-f978-4f1c-98ee-3c6b3dfcc912">

After:
<img width="157" alt="Screenshot 2024-06-26 at 8 59 43 PM" src="https://github.com/wandb/weave/assets/112953339/37f8cd3a-bab3-45d7-a7a6-6a5fc0025917">

