### PR TITLE
feat: render anthropic input images as thumbnails

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -33,6 +33,10 @@ import {
   WeaveCHTableSourceRefContext,
 } from './DataTableView';
 import {ObjectViewerGroupingCell} from './ObjectViewerGroupingCell';
+import {
+  getKnownImageDictContexts,
+  isKnownImageDictFormat,
+} from './objectViewerUtilities';
 import {mapObject, ObjectPath, traverse, TraverseContext} from './traverse';
 import {ValueView} from './ValueView';
 
@@ -188,6 +192,14 @@ export const ObjectViewer = ({
             value: '',
             valueType: 'undefined',
           });
+        } else if (
+          context.valueType === 'object' &&
+          isKnownImageDictFormat(context.value)
+        ) {
+          // If we detect an object with base64 encoded image data in a known schema,
+          // replace it with a patched version that can be rendered as a thumbnail.
+          contexts.push(...getKnownImageDictContexts(context));
+          return 'skip';
         } else {
           contexts.push(context);
         }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/objectViewerUtilities.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/objectViewerUtilities.ts
@@ -1,0 +1,82 @@
+/**
+ * Helpers for detecting and patching base64 encoded image data in a known
+ * JSON format (such as that expected by Anthropic's API) to render thumbnail
+ * instead of string.
+ */
+
+import _ from 'lodash';
+
+import {TraverseContext} from './traverse';
+
+const SUPPORTED_IMAGE_TYPES = [
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+];
+
+// Check if dictionary contains base64 encoded image data with a known schema.
+export const isKnownImageDictFormat = (value: Record<string, any>): boolean => {
+  if (value.type === 'image' && _.isPlainObject(value.source)) {
+    const source = value.source as Record<string, any>;
+    if (
+      source.type === 'base64' &&
+      SUPPORTED_IMAGE_TYPES.includes(source.media_type) &&
+      _.isString(source.data)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+// Return the replacement context rows for a detected image.
+export const getKnownImageDictContexts = (
+  context: TraverseContext
+): TraverseContext[] => {
+  const pathSource = context.path.plus('source');
+  const mimetype = context.value.source.media_type;
+  const data = `data:${mimetype};base64,${context.value.source.data}`;
+  return [
+    context,
+    {
+      depth: context.depth + 1,
+      isLeaf: true,
+      path: context.path.plus('type'),
+      value: 'image',
+      valueType: 'string',
+    },
+    {
+      depth: context.depth + 2,
+      isLeaf: false,
+      path: pathSource,
+      value: {
+        type: 'base64',
+        media_type: mimetype,
+        data,
+      },
+      valueType: 'object',
+    },
+    {
+      depth: context.depth + 3,
+      isLeaf: true,
+      path: pathSource.plus('type'),
+      value: 'base64',
+      valueType: 'string',
+    },
+    {
+      depth: context.depth + 3,
+      isLeaf: true,
+      path: pathSource.plus('media_type'),
+      value: mimetype,
+      valueType: 'string',
+    },
+    {
+      depth: context.depth + 3,
+      isLeaf: true,
+      path: pathSource.plus('data'),
+      value: data,
+      valueType: 'string',
+    },
+  ];
+};


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-19507

Before:
<img width="490" alt="Screenshot 2024-06-26 at 11 25 03 PM" src="https://github.com/wandb/weave/assets/112953339/e2f64589-9b51-41d5-bbf1-369ca51cd2d1">

After:
<img width="622" alt="Screenshot 2024-06-26 at 11 25 16 PM" src="https://github.com/wandb/weave/assets/112953339/8e37b6cf-00cf-4c69-84bc-2dc49445f326">
