### PR TITLE
feat(Improve Datasets)

### DIFF
--- a/weave/flow/dataset.py
+++ b/weave/flow/dataset.py
@@ -73,6 +73,17 @@ class Dataset(Object):
                     "Attempted to construct a Dataset row with an empty dict."
                 )
         return rows
+    
+    def __iter__(self):
+        return ((k, v) for k, v in self.rows.items())
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __str__(self) -> str:
+        features = list(self.rows.rows[0].keys()) if self.rows.rows else []
+        return f"Dataset({{\n    name: '{self.name}',\n    features: {features},\n    num_rows: {len(self.rows)}\n}})"
+
 
     @weave.op()
     async def map(self, model_or_func: Union[Callable, Model], *args, **kwargs) -> "Dataset":

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -19,22 +19,9 @@ from weave.flow.scorer import Scorer, auto_summarize, get_scorer_attributes, std
 from weave.trace.env import get_weave_parallelism
 from weave.trace.errors import OpCallError
 from weave.trace.op import BoundOp, Op
+from weave.flow.util import async_call
 
 console = Console()
-
-
-def async_call(
-    func: typing.Union[Callable, Op], *args: Any, **kwargs: Any
-) -> typing.Coroutine:
-    is_async = False
-    if isinstance(func, Op):
-        is_async = inspect.iscoroutinefunction(func.resolve_fn)
-    else:
-        is_async = inspect.iscoroutinefunction(func)
-    if is_async:
-        return func(*args, **kwargs)  # type: ignore
-    return asyncio.to_thread(func, *args, **kwargs)
-
 
 class Evaluation(Object):
     """

--- a/weave/table.py
+++ b/weave/table.py
@@ -28,3 +28,10 @@ class Table:
 
     def __iter__(self) -> Iterator:
         return iter(self.rows)
+
+    def __len__(self) -> int:
+        return len(self.rows)
+
+    def __str__(self) -> str:
+        return f"Table(rows={len(self.rows)})"
+


### PR DESCRIPTION
- Add some convinience str, len, iter methods
```python
>> print(ds)
Dataset({
    name: 'cape_dev',
    features: ['id', 'text', 'length'],
    num_rows: 10
})
```
- Adds a map method:
```python
import asyncio
from weave import Dataset


rows = [
    {"id": 1, "text": "The quick brown fox jumps over the lazy dog.", "length": 43},
    {"id": 2, "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "length": 56},
    {"id": 3, "text": "To be or not to be, that is the question.", "length": 41},
    {"id": 4, "text": "All that glitters is not gold.", "length": 30},
    {"id": 5, "text": "A journey of a thousand miles begins with a single step.", "length": 58},
]


ds = Dataset(name="cape_dev", rows=rows)

def f(*args, **kwargs):
    return {"other_text": kwargs["text"][0:4]}

mapped_ds = asyncio.run(ds.map(f))
print(mapped_ds)

Mapped 5 of 5 examples in 0.00 seconds
Dataset({
    name: 'cape_dev',
    features: ['id', 'text', 'length', 'other_text'],
    num_rows: 5
})

```
