### PR TITLE
fix(weave): Move metadata into its own field to avoid collisions with other pkgs

### DIFF
--- a/weave/api.py
+++ b/weave/api.py
@@ -206,8 +206,10 @@ def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.Object
     save_name: str
     if name:
         save_name = name
-    elif hasattr(obj, "name"):
-        save_name = obj.name
+    elif hasattr(obj, 'metadata') and obj.metadata and obj.metadata.name:
+        save_name = obj.metadata.name
+    # elif hasattr(obj, "name"):
+    #     save_name = obj.name
     else:
         save_name = obj.__class__.__name__
 

--- a/weave/api.py
+++ b/weave/api.py
@@ -208,8 +208,6 @@ def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.Object
         save_name = name
     elif hasattr(obj, 'metadata') and obj.metadata and obj.metadata.name:
         save_name = obj.metadata.name
-    # elif hasattr(obj, "name"):
-    #     save_name = obj.name
     else:
         save_name = obj.__class__.__name__
 

--- a/weave/api.py
+++ b/weave/api.py
@@ -206,7 +206,7 @@ def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.Object
     save_name: str
     if name:
         save_name = name
-    elif hasattr(obj, 'metadata') and obj.metadata and obj.metadata.name:
+    elif (metadata := getattr(obj, "metadata", None)) and metadata.name:
         save_name = obj.metadata.name
     else:
         save_name = obj.__class__.__name__

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -107,8 +107,8 @@ class Evaluation(Object):
         if isinstance(self.dataset, list):
             self.dataset = Dataset(rows=self.dataset)
 
-        if self.name == None and self.dataset.name != None:
-            self.name = self.dataset.name + "-evaluation"  # type: ignore
+        if self.object_name == None and self.dataset.object_name != None:
+            self.object_name = self.dataset.object_name + "-evaluation"  # type: ignore
 
     @weave.op()
     async def predict_and_score(

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -107,8 +107,8 @@ class Evaluation(Object):
         if isinstance(self.dataset, list):
             self.dataset = Dataset(rows=self.dataset)
 
-        if self.object_name == None and self.dataset.object_name != None:
-            self.object_name = self.dataset.object_name + "-evaluation"  # type: ignore
+        if self.metadata.name == None and self.dataset.metadata.name != None:
+            self.metadata.name = self.dataset.metadata.name + "-evaluation"  # type: ignore
 
     @weave.op()
     async def predict_and_score(

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -38,7 +38,9 @@ class Object(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def check_metadata(cls, data: Any) -> Any:
-        if not isinstance(data["metadata"], Metadata):
+        if (metadata := data.get("metadata", None)) and not isinstance(
+            metadata, Metadata
+        ):
             raise ValueError(
                 "`metadata` is a reserved keyword arg in Weave for labeling objects.  Do not override!"
             )

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -16,9 +16,13 @@ from weave.trace.vals import ObjectRecord, TraceObject, pydantic_getattribute
 from weave.weave_client import get_ref
 
 
+class Metadata(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
 class Object(BaseModel):
-    object_name: Optional[str] = Field(None, kw_only=True)
-    object_description: Optional[str] = Field(None, kw_only=True)
+    metadata: Optional[Metadata] = Field(default_factory=Metadata)
 
     # Allow Op attributes
     model_config = ConfigDict(
@@ -51,6 +55,15 @@ class Object(BaseModel):
                 if isinstance(val, box.BoxedNone):
                     val = None
                 fields[k] = val
+
+            metadata = None
+            if "object_name" in fields or "object_description" in fields:
+                metadata = Metadata(
+                    name=fields.pop("object_name", None),
+                    description=fields.pop("object_description", None),
+                )
+            if metadata:
+                fields["metadata"] = metadata
 
             # pydantic validation will construct a new pydantic object
             def is_ignored_type(v: type) -> bool:

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -35,17 +35,6 @@ class Object(BaseModel):
 
     __str__ = BaseModel.__repr__
 
-    @model_validator(mode="before")
-    @classmethod
-    def check_metadata(cls, data: Any) -> Any:
-        if (metadata := data.get("metadata", None)) and not isinstance(
-            metadata, Metadata
-        ):
-            raise ValueError(
-                "`metadata` is a reserved keyword arg in Weave for labeling objects.  Do not override!"
-            )
-        return data
-
     # This is a "wrap" validator meaning we can run our own logic before
     # and after the standard pydantic validation.
     @model_validator(mode="wrap")

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -16,8 +16,8 @@ from weave.weave_client import get_ref
 
 
 class Object(BaseModel):
-    name: Optional[str] = None
-    description: Optional[str] = None
+    object_name: Optional[str] = None
+    object_description: Optional[str] = None
 
     # Allow Op attributes
     model_config = ConfigDict(

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     ValidationInfo,
     ValidatorFunctionWrapHandler,
     model_validator,
@@ -16,8 +17,8 @@ from weave.weave_client import get_ref
 
 
 class Object(BaseModel):
-    object_name: Optional[str] = None
-    object_description: Optional[str] = None
+    object_name: Optional[str] = Field(None, kw_only=True)
+    object_description: Optional[str] = Field(None, kw_only=True)
 
     # Allow Op attributes
     model_config = ConfigDict(

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -12,14 +12,10 @@ from pydantic import (
 
 # import pydantic
 from weave.legacy import box
+from weave.trace.metadata import Metadata
 from weave.trace.op import ObjectRef, Op
 from weave.trace.vals import ObjectRecord, TraceObject, pydantic_getattribute
 from weave.weave_client import get_ref
-
-
-class Metadata(BaseModel):
-    name: Optional[str] = None
-    description: Optional[str] = None
 
 
 class Object(BaseModel):

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Optional
 
 from pydantic import (
@@ -22,7 +23,7 @@ class Metadata(BaseModel):
 
 
 class Object(BaseModel):
-    metadata: Metadata = Field(default_factory=Metadata)
+    metadata: Metadata = Field(default_factory=Metadata, repr=False)
 
     # Allow Op attributes
     model_config = ConfigDict(
@@ -33,6 +34,15 @@ class Object(BaseModel):
     )
 
     __str__ = BaseModel.__repr__
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_metadata(cls, data: Any) -> Any:
+        if not isinstance(data["metadata"], Metadata):
+            raise ValueError(
+                "`metadata` is a reserved keyword arg in Weave for labeling objects.  Do not override!"
+            )
+        return data
 
     # This is a "wrap" validator meaning we can run our own logic before
     # and after the standard pydantic validation.

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -85,7 +85,7 @@ def get_scorer_attributes(
     scorer: Union[Callable, Op, Scorer],
 ) -> Tuple[str, Callable, Callable]:
     if weave_isinstance(scorer, Scorer):
-        scorer_name = scorer.name
+        scorer_name = scorer.object_name
         if scorer_name == None:
             scorer_name = scorer.__class__.__name__
         try:

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -85,7 +85,7 @@ def get_scorer_attributes(
     scorer: Union[Callable, Op, Scorer],
 ) -> Tuple[str, Callable, Callable]:
     if weave_isinstance(scorer, Scorer):
-        scorer_name = scorer.object_name
+        scorer_name = scorer.metadata.name
         if scorer_name == None:
             scorer_name = scorer.__class__.__name__
         try:

--- a/weave/legacy/arrow/list_.py
+++ b/weave/legacy/arrow/list_.py
@@ -1192,7 +1192,7 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
                 # with different methods correctly.
                 # TODO: fix
 
-                from weave.flow.obj import Metadata
+                from weave.trace.metadata import Metadata
                 if isinstance(v, Metadata):
                     v = v.model_dump()
 

--- a/weave/legacy/arrow/list_.py
+++ b/weave/legacy/arrow/list_.py
@@ -1191,6 +1191,11 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
                 # So we don't yet correctly deserialize lists of relocatable objects
                 # with different methods correctly.
                 # TODO: fix
+
+                from weave.flow.obj import Metadata
+                if isinstance(v, Metadata):
+                    v = v.model_dump()
+
                 return (
                     None
                     if v is None

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -1345,7 +1345,7 @@ def test_dataset_row_ref(client):
     d2 = weave.ref(ref.uri()).get()
 
     inner = d2.rows[0]["a"]
-    exp_ref = "weave:///shawn/test-project/object/Dataset:T41nPvr6zpAr4ClFpZeH1p4xXE2x2bH2JeUXyOsQ4nY/attr/rows/id/XfhC9dNA5D4taMvhKT4MKN2uce7F56Krsyv4Q6mvVMA/key/a"
+    exp_ref = "weave:///shawn/test-project/object/Dataset:mKjx6QUaOQ3cDTRubJUAVQ2I6n0bOn8I4RK2ETbKzvk/attr/rows/id/XfhC9dNA5D4taMvhKT4MKN2uce7F56Krsyv4Q6mvVMA/key/a"
     assert inner == 5
     assert inner.ref.uri() == exp_ref
     gotten = weave.ref(exp_ref).get()

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -1408,8 +1408,6 @@ def test_named_reuse(client):
     d_ref = weave.publish(d, "test_dataset")
     dataset = weave.ref(d_ref.uri()).get()
 
-    print(f"{dataset=}")
-
     @weave.op()
     async def dummy_score(model_output):
         return 1

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -1408,6 +1408,8 @@ def test_named_reuse(client):
     d_ref = weave.publish(d, "test_dataset")
     dataset = weave.ref(d_ref.uri()).get()
 
+    print(f"{dataset=}")
+
     @weave.op()
     async def dummy_score(model_output):
         return 1
@@ -1440,6 +1442,8 @@ def test_named_reuse(client):
     # There are a lot of additional assertions that could be made here!
     print(res.objs)
     assert len(res.objs) == 1
+
+    raise
 
 
 def test_unknown_input_and_output_types(client):

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -1345,7 +1345,7 @@ def test_dataset_row_ref(client):
     d2 = weave.ref(ref.uri()).get()
 
     inner = d2.rows[0]["a"]
-    exp_ref = "weave:///shawn/test-project/object/Dataset:PHOGkwSOn7DqLgIUNgUAq7d2vXpOmG8NGLltn6slzeU/attr/rows/id/XfhC9dNA5D4taMvhKT4MKN2uce7F56Krsyv4Q6mvVMA/key/a"
+    exp_ref = "weave:///shawn/test-project/object/Dataset:T41nPvr6zpAr4ClFpZeH1p4xXE2x2bH2JeUXyOsQ4nY/attr/rows/id/XfhC9dNA5D4taMvhKT4MKN2uce7F56Krsyv4Q6mvVMA/key/a"
     assert inner == 5
     assert inner.ref.uri() == exp_ref
     gotten = weave.ref(exp_ref).get()
@@ -1442,8 +1442,6 @@ def test_named_reuse(client):
     # There are a lot of additional assertions that could be made here!
     print(res.objs)
     assert len(res.objs) == 1
-
-    raise
 
 
 def test_unknown_input_and_output_types(client):

--- a/weave/tests/test_graph_client.py
+++ b/weave/tests/test_graph_client.py
@@ -37,7 +37,7 @@ def test_flask_server(flask_server):
     url = flask_server
     response = requests.get(url)
     assert response.status_code == 200
-    assert response.text == "T41nPvr6zpAr4ClFpZeH1p4xXE2x2bH2JeUXyOsQ4nY"
+    assert response.text == "PHOGkwSOn7DqLgIUNgUAq7d2vXpOmG8NGLltn6slzeU"
 
 
 def test_graph_client_global_accessible_in_thread(client):

--- a/weave/tests/test_graph_client.py
+++ b/weave/tests/test_graph_client.py
@@ -40,7 +40,7 @@ def test_flask_server(flask_server):
     assert response.text == "T41nPvr6zpAr4ClFpZeH1p4xXE2x2bH2JeUXyOsQ4nY"
 
 
-def test_weave_client_global_accessible_in_thread(client):
+def test_graph_client_global_accessible_in_thread(client):
     def thread_func(q: queue.Queue):
         try:
             d = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])

--- a/weave/tests/test_graph_client.py
+++ b/weave/tests/test_graph_client.py
@@ -37,7 +37,7 @@ def test_flask_server(flask_server):
     url = flask_server
     response = requests.get(url)
     assert response.status_code == 200
-    assert response.text == "PHOGkwSOn7DqLgIUNgUAq7d2vXpOmG8NGLltn6slzeU"
+    assert response.text == "mKjx6QUaOQ3cDTRubJUAVQ2I6n0bOn8I4RK2ETbKzvk"
 
 
 def test_graph_client_global_accessible_in_thread(client):

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -288,7 +288,7 @@ def test_calls_delete_cascade(client):
         return target == model_output
 
     evaluation = Evaluation(
-        name="my-eval",
+        object_name="my-eval",
         dataset=dataset_rows,
         scorers=[score],
     )
@@ -598,7 +598,7 @@ def test_evaluate(client):
         return target == model_output
 
     evaluation = Evaluation(
-        name="my-eval",
+        object_name="my-eval",
         dataset=dataset_rows,
         scorers=[score],
     )
@@ -708,7 +708,7 @@ def test_nested_ref_is_inner(client):
         return target == model_output
 
     evaluation = Evaluation(
-        name="my-eval",
+        object_name="my-eval",
         dataset=dataset_rows,
         scorers=[score],
     )

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -288,7 +288,7 @@ def test_calls_delete_cascade(client):
         return target == model_output
 
     evaluation = Evaluation(
-        object_name="my-eval",
+        metadata={"name": "my-eval"},
         dataset=dataset_rows,
         scorers=[score],
     )
@@ -598,7 +598,7 @@ def test_evaluate(client):
         return target == model_output
 
     evaluation = Evaluation(
-        object_name="my-eval",
+        metadata={"name": "my-eval"},
         dataset=dataset_rows,
         scorers=[score],
     )
@@ -708,7 +708,7 @@ def test_nested_ref_is_inner(client):
         return target == model_output
 
     evaluation = Evaluation(
-        object_name="my-eval",
+        metadata={"name": "my-eval"},
         dataset=dataset_rows,
         scorers=[score],
     )

--- a/weave/tests/test_weave_client_threaded.py
+++ b/weave/tests/test_weave_client_threaded.py
@@ -37,7 +37,7 @@ def test_flask_server(flask_server):
     url = flask_server
     response = requests.get(url)
     assert response.status_code == 200
-    assert response.text == "T41nPvr6zpAr4ClFpZeH1p4xXE2x2bH2JeUXyOsQ4nY"
+    assert response.text == "mKjx6QUaOQ3cDTRubJUAVQ2I6n0bOn8I4RK2ETbKzvk"
 
 
 def test_weave_client_global_accessible_in_thread(client):

--- a/weave/trace/metadata.py
+++ b/weave/trace/metadata.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel
 
 

--- a/weave/trace/metadata.py
+++ b/weave/trace/metadata.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class Metadata(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -474,7 +474,7 @@ def make_trace_obj(
     if isinstance(box_val, pydantic_v1.BaseModel):
         box_val.__dict__["ref"] = new_ref
     else:
-        from weave.flow.obj import Metadata
+        from weave.trace.metadata import Metadata
 
         if not isinstance(box_val, Metadata):
             setattr(box_val, "ref", new_ref)

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -474,7 +474,10 @@ def make_trace_obj(
     if isinstance(box_val, pydantic_v1.BaseModel):
         box_val.__dict__["ref"] = new_ref
     else:
-        setattr(box_val, "ref", new_ref)
+        from weave.flow.obj import Metadata
+
+        if not isinstance(box_val, Metadata):
+            setattr(box_val, "ref", new_ref)
     return box_val
 
 

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -659,13 +659,22 @@ class WeaveClient:
         return ref
 
     def _save_nested_objects(self, obj: Any, name: Optional[str] = None) -> Any:
+        from weave.flow.obj import Metadata
+
         if get_ref(obj) is not None:
+            return
+        if isinstance(obj, Metadata):
             return
         if isinstance(obj, pydantic.BaseModel):
             obj_rec = pydantic_object_record(obj)
             for v in obj_rec.__dict__.values():
                 self._save_nested_objects(v)
-            ref = self._save_object_basic(obj_rec, name or get_obj_name(obj_rec))
+            save_name = (
+                name
+                or (obj.metadata.name if obj.metadata else None)
+                or get_obj_name(obj_rec)
+            )
+            ref = self._save_object_basic(obj_rec, save_name)
             obj.__dict__["ref"] = ref
         elif dataclasses.is_dataclass(obj):
             obj_rec = dataclass_object_record(obj)

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -660,7 +660,7 @@ class WeaveClient:
         return ref
 
     def _save_nested_objects(self, obj: Any, name: Optional[str] = None) -> Any:
-        from weave.flow.obj import Metadata
+        from weave.trace.metadata import Metadata
 
         if get_ref(obj) is not None:
             return

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -81,7 +81,8 @@ def dataclasses_asdict_one_level(obj: Any) -> typing.Dict[str, Any]:
 
 
 def get_obj_name(val: Any) -> str:
-    name = getattr(val, "name", None)
+    metadata = getattr(val, "metadata", None)
+    name = getattr(metadata, "name", None)
     if name == None:
         if isinstance(val, ObjectRecord):
             name = val._class_name
@@ -669,18 +670,15 @@ class WeaveClient:
             obj_rec = pydantic_object_record(obj)
             for v in obj_rec.__dict__.values():
                 self._save_nested_objects(v)
-            save_name = (
-                name
-                or (obj.metadata.name if obj.metadata else None)
-                or get_obj_name(obj_rec)
-            )
+            save_name = name or get_obj_name(obj_rec)
             ref = self._save_object_basic(obj_rec, save_name)
             obj.__dict__["ref"] = ref
         elif dataclasses.is_dataclass(obj):
             obj_rec = dataclass_object_record(obj)
             for v in obj_rec.__dict__.values():
                 self._save_nested_objects(v)
-            ref = self._save_object_basic(obj_rec, name or get_obj_name(obj_rec))
+            save_name = name or get_obj_name(obj_rec)
+            ref = self._save_object_basic(obj_rec, save_name)
             obj.__dict__["ref"] = ref
         elif isinstance(obj, Table):
             table_ref = self._save_table(obj)


### PR DESCRIPTION
Resolves:
- https://wandb.atlassian.net/browse/WB-19388

This PR moves metadata that was previously top level (`name`, `description`) to a new top-level `metadata` field which prevents collision with other libraries that also have `name` as a top-level field (e.g. `openai`)