### PR TITLE
fix(weave): Add support for class saving in ipython

### DIFF
--- a/weave/trace/ipython.py
+++ b/weave/trace/ipython.py
@@ -1,0 +1,51 @@
+"""Utilities for working with IPython/Jupyter notebooks."""
+
+import ast
+
+
+def is_running_interactively():
+    """Check if the code is running in an interactive environment."""
+    try:
+        from IPython import get_ipython
+
+        return get_ipython() is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def get_notebook_source():
+    """Get the source code of the running notebook."""
+    from IPython import get_ipython
+
+    shell = get_ipython()
+    if shell is None:
+        return "Not running in IPython/Jupyter environment"
+
+    if not hasattr(shell, "user_ns"):
+        return "Cannot access user namespace"
+
+    # This is the list of input cells in the notebook
+    in_list = shell.user_ns["In"]
+
+    # Stitch them back into a single "file"
+    full_source = "\n\n".join(cell for cell in in_list[1:] if cell)
+
+    return full_source
+
+
+def get_class_source(cls):
+    """Get the latest source definition of a class in the notebook."""
+    notebook_source = get_notebook_source()
+    tree = ast.parse(notebook_source)
+    class_name = cls.__name__
+
+    # We need to walk the entire tree and get the last one since that's the most version of the cls
+    segment = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            segment = ast.get_source_segment(notebook_source, node)
+
+    if segment is not None:
+        return segment
+
+    raise ValueError(f"Class '{class_name}' not found in the notebook")

--- a/weave/trace/ipython.py
+++ b/weave/trace/ipython.py
@@ -1,9 +1,13 @@
 """Utilities for working with IPython/Jupyter notebooks."""
 
 import ast
+from typing import Callable
 
 
-def is_running_interactively():
+class NotInteractiveEnvironmentError(Exception): ...
+
+
+def is_running_interactively() -> bool:
     """Check if the code is running in an interactive environment."""
     try:
         from IPython import get_ipython
@@ -13,16 +17,16 @@ def is_running_interactively():
         return False
 
 
-def get_notebook_source():
+def get_notebook_source() -> str:
     """Get the source code of the running notebook."""
     from IPython import get_ipython
 
     shell = get_ipython()
     if shell is None:
-        return "Not running in IPython/Jupyter environment"
+        raise NotInteractiveEnvironmentError
 
     if not hasattr(shell, "user_ns"):
-        return "Cannot access user namespace"
+        raise AttributeError("Cannot access user namespace")
 
     # This is the list of input cells in the notebook
     in_list = shell.user_ns["In"]
@@ -33,7 +37,7 @@ def get_notebook_source():
     return full_source
 
 
-def get_class_source(cls):
+def get_class_source(cls: Callable) -> str:
     """Get the latest source definition of a class in the notebook."""
     notebook_source = get_notebook_source()
     tree = ast.parse(notebook_source)

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -281,7 +281,7 @@ def get_code_deps(
                 import_code += fn_import_code
 
                 code += fn_code
-                code.append(get_source_notebook_safe(fn))
+                code.append(get_source_notebook_safe(var_value))
 
                 warnings += fn_warnings
             else:

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -14,6 +14,7 @@ from _ast import AsyncFunctionDef, ExceptHandler
 from typing import Any, Callable, Optional, Union
 
 from weave.legacy import artifact_fs, context_state
+from weave.trace.ipython import get_class_source, is_running_interactively
 from weave.trace.refs import ObjectRef
 
 from .. import environment, errors, storage
@@ -190,6 +191,15 @@ class GetCodeDepsResult(typing.TypedDict):
     warnings: list[str]
 
 
+def get_source_notebook_safe(fn: typing.Callable) -> str:
+    # In ipython, we can't use inspect.getsource on classes defined in the notebook
+    if is_running_interactively() and inspect.isclass(fn):
+        src = get_class_source(fn)
+    else:
+        src = inspect.getsource(fn)
+    return textwrap.dedent(src)
+
+
 def get_code_deps(
     fn: Union[typing.Callable, type],  # A function or a class
     artifact: artifact_fs.FilesystemArtifact,
@@ -224,7 +234,7 @@ def get_code_deps(
         ]
         return {"import_code": [], "code": [], "warnings": warnings}
 
-    source = textwrap.dedent(inspect.getsource(fn))
+    source = get_source_notebook_safe(fn)
     try:
         parsed = ast.parse(source)
     except SyntaxError:
@@ -271,7 +281,7 @@ def get_code_deps(
                 import_code += fn_import_code
 
                 code += fn_code
-                code.append(textwrap.dedent(inspect.getsource(var_value)))
+                code.append(get_source_notebook_safe(fn))
 
                 warnings += fn_warnings
             else:
@@ -388,7 +398,7 @@ def save_instance(
             # print(message)
             pass
 
-    op_function_code = textwrap.dedent(inspect.getsource(obj.resolve_fn))
+    op_function_code = get_source_notebook_safe(obj.resolve_fn)
 
     if not WEAVE_OP_PATTERN.search(op_function_code):
         op_function_code = "@weave.op()\n" + op_function_code


### PR DESCRIPTION
Resolves:
- https://wandb.atlassian.net/browse/WB-19574

This PR adds support for saving classes that are created inside an interactive environment.  

Previously, we would raise an error like:
```
TypeError: Source for <class '__main__.MyClass'> not found
```

This seems to be a common issue raised in ipython:
- https://github.com/ipython/ipython/issues/11249
- https://bugs.python.org/issue33826
- https://stackoverflow.com/questions/51566497/getting-the-source-of-an-object-defined-in-a-jupyter-notebook/65806216#65806216

The solution suggested in the threads above will not work with classes that don't have methods.  The approach here works for all classes, which is helpful because `BaseModel`s can be used like plain structs (with no methods)

TODO: This PR needs a nb test