### PR TITLE
fix(weave): Handle exceptions raised by scoring funcs during evaluation

### DIFF
--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -18,7 +18,6 @@ from weave.flow.scorer import (
     Scorer,
     auto_summarize,
     get_scorer_attributes,
-    new_auto_summarize,
     transpose,
 )
 from weave.trace.env import get_weave_parallelism
@@ -256,7 +255,7 @@ class Evaluation(Object):
                     scored = summarize_fn(score_table)
                     summary[scorer_name] = scored
             else:
-                model_output_summary = new_auto_summarize(vals)
+                model_output_summary = auto_summarize(vals)
                 if model_output_summary:
                     summary[name] = model_output_summary
 

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -18,6 +18,7 @@ from weave.flow.scorer import (
     Scorer,
     auto_summarize,
     get_scorer_attributes,
+    new_auto_summarize,
     transpose,
 )
 from weave.trace.env import get_weave_parallelism
@@ -255,7 +256,7 @@ class Evaluation(Object):
                     scored = summarize_fn(score_table)
                     summary[scorer_name] = scored
             else:
-                model_output_summary = auto_summarize(vals)
+                model_output_summary = new_auto_summarize(vals)
                 if model_output_summary:
                     summary[name] = model_output_summary
 

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -234,7 +234,16 @@ class Evaluation(Object):
                 raise OpCallError(message)
             # this is a catchall in case the user's scorer function throws
             except Exception as e:
-                result = {"error": str(e), "example": example}
+                exc_type = type(e).__name__
+                exc_val = str(e)
+                exc_traceback = traceback.format_exc()
+
+                result = {
+                    "exception_type": exc_type,
+                    "exception_value": exc_val,
+                    "exception_traceback": exc_traceback,
+                    "example": example,
+                }
             scores[scorer_name] = result
 
         return {
@@ -257,7 +266,9 @@ class Evaluation(Object):
                     score_table = scorer_stats[scorer_name]
 
                     if errs := [
-                        s for s in score_table if isinstance(s, dict) and "error" in s
+                        s
+                        for s in score_table
+                        if isinstance(s, dict) and "exception_type" in s
                     ]:
                         summary[scorer_name] = {"errors": errs}
                     else:

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -234,17 +234,9 @@ class Evaluation(Object):
                 raise OpCallError(message)
             # this is a catchall in case the user's scorer function throws
             except Exception as e:
-                exc_type = type(e).__name__
-                exc_val = str(e)
-                exc_traceback = traceback.format_exc()
-
-                result = {
-                    "exception_type": exc_type,
-                    "exception_value": exc_val,
-                    "exception_traceback": exc_traceback,
-                    "example": example,
-                }
-            scores[scorer_name] = result
+                pass
+            else:
+                scores[scorer_name] = result
 
         return {
             "model_output": model_output,
@@ -264,16 +256,8 @@ class Evaluation(Object):
                     scorer_name, _, summarize_fn = get_scorer_attributes(scorer)
                     scorer_stats = transpose(vals)
                     score_table = scorer_stats[scorer_name]
-
-                    if errs := [
-                        s
-                        for s in score_table
-                        if isinstance(s, dict) and "exception_type" in s
-                    ]:
-                        summary[scorer_name] = {"errors": errs}
-                    else:
-                        scored = summarize_fn(score_table)
-                        summary[scorer_name] = scored
+                    scored = summarize_fn(score_table)
+                    summary[scorer_name] = scored
             else:
                 model_output_summary = auto_summarize(vals)
                 if model_output_summary:

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -232,6 +232,9 @@ class Evaluation(Object):
                     """
                 )
                 raise OpCallError(message)
+            # this is a catchall in case the user's scorer function throws
+            except Exception as e:
+                result = {"error": str(e), "example": example}
             scores[scorer_name] = result
 
         return {
@@ -252,8 +255,14 @@ class Evaluation(Object):
                     scorer_name, _, summarize_fn = get_scorer_attributes(scorer)
                     scorer_stats = transpose(vals)
                     score_table = scorer_stats[scorer_name]
-                    scored = summarize_fn(score_table)
-                    summary[scorer_name] = scored
+
+                    if errs := [
+                        s for s in score_table if isinstance(s, dict) and "error" in s
+                    ]:
+                        summary[scorer_name] = {"errors": errs}
+                    else:
+                        scored = summarize_fn(score_table)
+                        summary[scorer_name] = scored
             else:
                 model_output_summary = auto_summarize(vals)
                 if model_output_summary:

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -89,7 +89,7 @@ def get_scorer_attributes(
         else:
             scorer_name = scorer.__name__
         score_fn = scorer
-        summarize_fn = auto_summarize  # type: ignore
+        summarize_fn = new_auto_summarize  # type: ignore
     else:
         raise ValueError(f"Unknown scorer type: {scorer}")
     return (scorer_name, score_fn, summarize_fn)  # type: ignore

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -41,9 +41,11 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     Returns:
       dict of summary stats, with structure matching input dict structure.
     """
+    data = [x for x in data if x is not None]
+
     if not data:
         return {}
-    data = [x for x in data if x is not None]
+
     val = data[0]
 
     if isinstance(val, bool):

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -49,13 +49,13 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     if isinstance(val, bool):
         return {
             "true_count": (true_count := sum(1 for x in data if x)),
-            "true_proportion": true_count / len(data),
-            "none_proportion": sum(1 for x in data if x is None) / len(data),
+            "true_fraction": true_count / len(data),
+            "none_fraction": sum(1 for x in data if x is None) / len(data),
         }
     elif isinstance(val, Number):
         return {
             "mean": np.mean(data).item(),
-            "none_proportion": sum(1 for x in data if x is None) / len(data),
+            "none_fraction": sum(1 for x in data if x is None) / len(data),
         }
     elif isinstance(val, dict):
         result = {}

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -41,9 +41,7 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     Returns:
       dict of summary stats, with structure matching input dict structure.
     """
-    data = [x for x in data if x is not None]
-
-    if not data:
+    if not (data := [x for x in data if x is not None]):
         return {}
 
     val = data[0]

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -41,7 +41,9 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     Returns:
       dict of summary stats, with structure matching input dict structure.
     """
-    if not (data := [x for x in data if x is not None]):
+    data = [x for x in data if x is not None]
+
+    if not data:
         return {}
 
     val = data[0]

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -89,7 +89,7 @@ def get_scorer_attributes(
         else:
             scorer_name = scorer.__name__
         score_fn = scorer
-        summarize_fn = new_auto_summarize  # type: ignore
+        summarize_fn = auto_summarize  # type: ignore
     else:
         raise ValueError(f"Unknown scorer type: {scorer}")
     return (scorer_name, score_fn, summarize_fn)  # type: ignore

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -32,8 +32,8 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     """Automatically summarize a list of (potentially nested) dicts.
 
     Computes:
-        - avg for numeric cols
-        - count and fraction for boolean cols
+        - avg and none fraction for numeric cols
+        - count, true fraction, and none fraction for boolean cols
         - other col types are ignored
 
     If col is all None, result is None
@@ -41,8 +41,6 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     Returns:
       dict of summary stats, with structure matching input dict structure.
     """
-    data = [x for x in data if x is not None]
-
     if not data:
         return {}
 
@@ -51,10 +49,14 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     if isinstance(val, bool):
         return {
             "true_count": (true_count := sum(1 for x in data if x)),
-            "true_fraction": true_count / len(data),
+            "true_proportion": true_count / len(data),
+            "none_proportion": sum(1 for x in data if x is None) / len(data),
         }
     elif isinstance(val, Number):
-        return {"mean": np.mean(data).item()}
+        return {
+            "mean": np.mean(data).item(),
+            "none_proportion": sum(1 for x in data if x is None) / len(data),
+        }
     elif isinstance(val, dict):
         result = {}
         for k in val:

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -58,7 +58,7 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     elif isinstance(val, dict):
         result = {}
         for k in val:
-            if (summary := auto_summarize([x[k] for x in data])) is not None:
+            if (summary := auto_summarize([x.get(k) for x in data])) is not None:
                 if k in summary:
                     result.update(summary)
                 else:

--- a/weave/tests/test_evaluate.py
+++ b/weave/tests/test_evaluate.py
@@ -213,7 +213,7 @@ def test_score_with_errors(client):
     ]
 
     assert result["model_output"] == {"mean": 2.5}
-    assert result["model_latency"] == {"mean": pytest.approx(0, abs=0.05)}
+    assert result["model_latency"] == {"mean": pytest.approx(0, abs=0.1)}
 
     # Errors may be in a different order because they are processed in parallel
     errors = result["raise_above_2_score"]["errors"]

--- a/weave/tests/test_evaluate.py
+++ b/weave/tests/test_evaluate.py
@@ -206,13 +206,16 @@ def test_score_with_errors(client):
         return pred
 
     result = asyncio.run(evaluation.evaluate(return_pred))
-    assert result == {
-        "model_output": {"mean": 2.5},
-        "model_latency": {"mean": pytest.approx(0, abs=0.05)},
-        "raise_above_2_score": {
-            "errors": [
-                {"error": "actual is too big", "example": {"actual": 3, "pred": 3}},
-                {"error": "actual is too big", "example": {"actual": 4, "pred": 4}},
-            ]
-        },
-    }
+
+    expected_errors = [
+        {"error": "actual is too big", "example": {"actual": 3, "pred": 3}},
+        {"error": "actual is too big", "example": {"actual": 4, "pred": 4}},
+    ]
+
+    assert result["model_output"] == {"mean": 2.5}
+    assert result["model_latency"] == {"mean": pytest.approx(0, abs=0.05)}
+
+    # Errors may be in a different order because they are processed in parallel
+    errors = result["raise_above_2_score"]["errors"]
+    for expected_error in expected_errors:
+        assert expected_error in errors

--- a/weave/tests/test_evaluate.py
+++ b/weave/tests/test_evaluate.py
@@ -16,16 +16,16 @@ dataset = Dataset(rows=dataset_rows)
 expected_eval_result = {
     "model_output": {
         "mean": 9.5,
-        "none_proportion": 0.0,
+        "none_fraction": 0.0,
     },
     "score": {
         "true_count": 1,
-        "true_proportion": 0.5,
-        "none_proportion": 0.0,
+        "true_fraction": 0.5,
+        "none_fraction": 0.0,
     },
     "model_latency": {
         "mean": pytest.approx(0, abs=0.05),
-        "none_proportion": 0.0,
+        "none_fraction": 0.0,
     },
 }
 
@@ -72,16 +72,16 @@ def test_predict_can_receive_other_params(client):
     assert result == {
         "model_output": {
             "mean": 18.5,
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
         "score": {
             "true_count": 0,
-            "true_proportion": 0.0,
-            "none_proportion": 0.0,
+            "true_fraction": 0.0,
+            "none_fraction": 0.0,
         },
         "model_latency": {
             "mean": pytest.approx(0, abs=0.05),
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
     }
 
@@ -144,16 +144,16 @@ def test_score_as_class(client):
     assert result == {
         "model_output": {
             "mean": 9.5,
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
         "MyScorer": {
             "true_count": 1,
-            "true_proportion": 0.5,
-            "none_proportion": 0.0,
+            "true_fraction": 0.5,
+            "none_fraction": 0.0,
         },
         "model_latency": {
             "mean": pytest.approx(0, abs=0.05),
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
     }
 
@@ -178,12 +178,12 @@ def test_score_with_custom_summarize(client):
     assert result == {
         "model_output": {
             "mean": 9.5,
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
         "MyScorer": {"awesome": 3},
         "model_latency": {
             "mean": pytest.approx(0, abs=0.05),
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
     }
 
@@ -203,13 +203,13 @@ def test_multiclass_f1_score(client):
         "model_output": {
             "a": {
                 "true_count": 1,
-                "true_proportion": 1.0,
-                "none_proportion": 0.0,
+                "true_fraction": 1.0,
+                "none_fraction": 0.0,
             },
             "b": {
                 "true_count": 0,
-                "true_proportion": 0.0,
-                "none_proportion": 0.0,
+                "true_fraction": 0.0,
+                "none_fraction": 0.0,
             },
         },
         "MultiTaskBinaryClassificationF1": {
@@ -218,7 +218,7 @@ def test_multiclass_f1_score(client):
         },
         "model_latency": {
             "mean": pytest.approx(0, abs=0.05),
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
     }
 
@@ -249,17 +249,17 @@ def test_score_with_errors(client):
     assert result == {
         "model_output": {
             "mean": 2.5,
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
         "raise_above_2_score": {
             "actual": {
                 "true_count": 2,
-                "true_proportion": 0.5,
-                "none_proportion": 0.5,  # for cases 3,4 which raise because they are > 2
+                "true_fraction": 0.5,
+                "none_fraction": 0.5,  # for cases 3,4 which raise because they are > 2
             }
         },
         "model_latency": {
             "mean": pytest.approx(0, abs=0.1),
-            "none_proportion": 0.0,
+            "none_fraction": 0.0,
         },
     }

--- a/weave/trace/ipython.py
+++ b/weave/trace/ipython.py
@@ -52,4 +52,4 @@ def get_class_source(cls: Callable) -> str:
     if segment is not None:
         return segment
 
-    raise ValueError(f"Class '{class_name}' not found in the notebook")
+    return ""


### PR DESCRIPTION
Resolves:
- https://wandb.atlassian.net/browse/WB-18523

This PR changes `Evaluation.evaluate` to not crash the user script if an exception is raised in a scoring function.  Instead, the error is captured and relayed to the user as part of the eval