### PR TITLE
fix: deinit crash

### DIFF
--- a/weave/weave_init.py
+++ b/weave/weave_init.py
@@ -1,7 +1,6 @@
 import typing
 
 from weave import client_context
-from weave.legacy import context_state
 
 from . import autopatch, errors, init_message, trace_sentry, weave_client
 from .trace_server import remote_http_trace_server, sqlite_trace_server
@@ -13,17 +12,9 @@ class InitializedClient:
     def __init__(self, client: weave_client.WeaveClient):
         self.client = client
         client_context.weave_client.set_weave_client_global(client)
-        self.ref_tracking_token = context_state._ref_tracking_enabled.set(True)
-        self.eager_mode_token = context_state._eager_mode.set(True)
-        self.serverless_io_service_token = context_state._serverless_io_service.set(
-            True
-        )
 
     def reset(self) -> None:
         client_context.weave_client.set_weave_client_global(None)
-        context_state._ref_tracking_enabled.reset(self.ref_tracking_token)
-        context_state._eager_mode.reset(self.eager_mode_token)
-        context_state._serverless_io_service.reset(self.serverless_io_service_token)
 
 
 def get_username() -> typing.Optional[str]:


### PR DESCRIPTION
Fix an issue where reseting client caused a crash. This would occur in streamlit for example:

```
2024-07-01 21:46:39.095 Uncaught app exception
Traceback (most recent call last):
  File "/Users/adamdraper/.pyenv/versions/weave-starter/lib/python3.11/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 567, in _run_script
    self._session_state.on_script_will_rerun(
  File "/Users/adamdraper/.pyenv/versions/weave-starter/lib/python3.11/site-packages/streamlit/runtime/state/safe_session_state.py", line 66, in on_script_will_rerun
    self._state.on_script_will_rerun(latest_widget_states)
  File "/Users/adamdraper/.pyenv/versions/weave-starter/lib/python3.11/site-packages/streamlit/runtime/state/session_state.py", line 514, in on_script_will_rerun
    self._call_callbacks()
  File "/Users/adamdraper/.pyenv/versions/weave-starter/lib/python3.11/site-packages/streamlit/runtime/state/session_state.py", line 527, in _call_callbacks
    self._new_widget_state.call_callback(wid)
  File "/Users/adamdraper/.pyenv/versions/weave-starter/lib/python3.11/site-packages/streamlit/runtime/state/session_state.py", line 271, in call_callback
    callback(*args, **kwargs)
  File "/Users/adamdraper/Documents/Code/weave-starter/apps/playground/app.py", line 45, in reset_page
    weave.finish()
  File "/Users/adamdraper/.pyenv/versions/weave-starter/lib/python3.11/site-packages/weave/api.py", line 359, in finish
    _weave_init.finish()
  File "/Users/adamdraper/.pyenv/versions/weave-starter/lib/python3.11/site-packages/weave/weave_init.py", line 179, in finish
    _current_inited_client.reset()
  File "/Users/adamdraper/.pyenv/versions/weave-starter/lib/python3.11/site-packages/weave/weave_init.py", line 24, in reset
    context_state._ref_tracking_enabled.reset(self.ref_tracking_token)
ValueError: <Token var=<ContextVar name='ref_tracking_enabled' default=False at 0x1072cb420> at 0x1460b0680> was created in a different Context
```