### PR TITLE
feat: new column management popup

### DIFF
--- a/weave-js/src/components/DraggablePopups.tsx
+++ b/weave-js/src/components/DraggablePopups.tsx
@@ -5,7 +5,8 @@
 import Grow from '@mui/material/Grow';
 import Tooltip, {tooltipClasses, TooltipProps} from '@mui/material/Tooltip';
 import * as Colors from '@wandb/weave/common/css/color.styles';
-import React from 'react';
+import classNames from 'classnames';
+import React, {useCallback, useState} from 'react';
 import Draggable from 'react-draggable';
 import styled from 'styled-components';
 
@@ -65,3 +66,25 @@ export const DraggableGrow = React.forwardRef(
     );
   }
 );
+
+type DraggableHandleProps = {
+  children: React.ReactNode;
+};
+
+export const DraggableHandle = ({children}: DraggableHandleProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const onMouseDown = useCallback(() => setIsDragging(true), [setIsDragging]);
+  const onMouseUp = useCallback(() => setIsDragging(false), [setIsDragging]);
+
+  return (
+    <div
+      className={classNames(
+        'handle',
+        isDragging ? 'cursor-grabbing' : 'cursor-grab'
+      )}
+      onMouseDown={onMouseDown}
+      onMouseUp={onMouseUp}>
+      {children}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -9,6 +9,7 @@ import {
   Toolbar,
   Typography,
 } from '@mui/material';
+import {GridColumnVisibilityModel} from '@mui/x-data-grid-pro';
 import {LicenseInfo} from '@mui/x-license-pro';
 import {useWindowSize} from '@wandb/weave/common/hooks/useWindowSize';
 import {Loading} from '@wandb/weave/components/Loading';
@@ -29,6 +30,7 @@ import {
   Route,
   Switch,
   useHistory,
+  useLocation,
   useParams,
 } from 'react-router-dom';
 
@@ -666,12 +668,29 @@ const CallsPageBinding = () => {
     },
     [history, entity, project, routerContext]
   );
+
+  const location = useLocation();
+  const columnVisibilityModel = useMemo(() => {
+    try {
+      return JSON.parse(query.cols);
+    } catch (e) {
+      return {};
+    }
+  }, [query.cols]);
+  const setColumnVisibilityModel = (newModel: GridColumnVisibilityModel) => {
+    const newQuery = new URLSearchParams(location.search);
+    newQuery.set('cols', JSON.stringify(newModel));
+    history.push({search: newQuery.toString()});
+  };
+
   return (
     <CallsPage
       entity={entity}
       project={project}
       initialFilter={filters}
       onFilterUpdate={onFilterUpdate}
+      columnVisibilityModel={columnVisibilityModel}
+      setColumnVisibilityModel={setColumnVisibilityModel}
     />
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCustomColumnMenu.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCustomColumnMenu.tsx
@@ -1,0 +1,22 @@
+/**
+ * Override the grid column menu to not show the "Manage columns" item
+ * as we implement our own UI outside the grid for this. We still want the "Hide column" item,
+ * which is inconveniently tied to the "Manage columns" item in `columnMenuColumnsItem`.
+ */
+import {
+  GridColumnMenu,
+  GridColumnMenuHideItem,
+  GridColumnMenuProps,
+} from '@mui/x-data-grid-pro';
+import React from 'react';
+
+type Slots = Record<string, React.JSXElementConstructor<any> | null>;
+
+// See: https://mui.com/x/react-data-grid/column-menu/#customize-column-menu-items
+export const CallsCustomColumnMenu = (props: GridColumnMenuProps) => {
+  const slots: Slots = {columnMenuColumnsItem: null};
+  if (props.colDef.hideable ?? true) {
+    slots.columnMenuUserItem = GridColumnMenuHideItem;
+  }
+  return <GridColumnMenu {...props} slots={slots} />;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -1,3 +1,4 @@
+import {GridColumnVisibilityModel} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
 import React, {FC, useMemo} from 'react';
 
@@ -28,6 +29,9 @@ export const CallsPage: FC<{
   // Setting this will make the component a controlled component. The parent
   // is responsible for updating the filter.
   onFilterUpdate?: (filter: WFHighLevelCallFilter) => void;
+
+  columnVisibilityModel: GridColumnVisibilityModel;
+  setColumnVisibilityModel: (newModel: GridColumnVisibilityModel) => void;
 }> = props => {
   const [filter, setFilter] = useControllableState(
     props.initialFilter ?? {},
@@ -72,6 +76,8 @@ export const CallsPage: FC<{
                 hideControls={filter.frozen}
                 initialFilter={filter}
                 onFilterUpdate={setFilter}
+                columnVisibilityModel={props.columnVisibilityModel}
+                setColumnVisibilityModel={props.setColumnVisibilityModel}
               />
             ),
           },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -16,6 +16,7 @@ import {
 import {Box, Typography} from '@mui/material';
 import {
   GridApiPro,
+  GridColumnVisibilityModel,
   GridFilterModel,
   GridPaginationModel,
   GridPinnedColumns,
@@ -60,6 +61,7 @@ import {useWFHooks} from '../wfReactInterface/context';
 import {TraceCallSchema} from '../wfReactInterface/traceServerClient';
 import {objectVersionNiceString} from '../wfReactInterface/utilities';
 import {OpVersionKey} from '../wfReactInterface/wfDataModelHooksInterface';
+import {CallsCustomColumnMenu} from './CallsCustomColumnMenu';
 import {useCurrentFilterIsEvaluationsFilter} from './CallsPage';
 import {useCallsTableColumns} from './callsTableColumns';
 import {prepareFlattenedCallDataForTable} from './callsTableDataProcessing';
@@ -70,6 +72,7 @@ import {ALL_TRACES_OR_CALLS_REF_KEY} from './callsTableFilter';
 import {useInputObjectVersionOptions} from './callsTableFilter';
 import {useOutputObjectVersionOptions} from './callsTableFilter';
 import {useCallsForQuery} from './callsTableQuery';
+import {ManageColumnsButton} from './ManageColumnsButton';
 
 const OP_FILTER_GROUP_HEADER = 'Op';
 
@@ -82,6 +85,9 @@ export const CallsTable: FC<{
   // is responsible for updating the filter.
   onFilterUpdate?: (filter: WFHighLevelCallFilter) => void;
   hideControls?: boolean;
+
+  columnVisibilityModel?: GridColumnVisibilityModel;
+  setColumnVisibilityModel?: (newModel: GridColumnVisibilityModel) => void;
 }> = ({
   entity,
   project,
@@ -89,6 +95,8 @@ export const CallsTable: FC<{
   onFilterUpdate,
   frozenFilter,
   hideControls,
+  columnVisibilityModel,
+  setColumnVisibilityModel,
 }) => {
   const {addExtra, removeExtra} = useContext(WeaveHeaderExtrasContext);
 
@@ -411,6 +419,13 @@ export const CallsTable: FC<{
     history,
   ]);
 
+  // Called in reaction to Hide column menu
+  const onColumnVisibilityModelChange = setColumnVisibilityModel
+    ? (newModel: GridColumnVisibilityModel) => {
+        setColumnVisibilityModel(newModel);
+      }
+    : undefined;
+
   // CPR (Tim) - (GeneralRefactoring): Pull out different inline-properties and create them above
   return (
     <FilterLayoutTemplate
@@ -500,6 +515,16 @@ export const CallsTable: FC<{
               }}
             />
           )}
+          <div style={{flex: '1 1 auto'}} />
+          {columnVisibilityModel && setColumnVisibilityModel && (
+            <div>
+              <ManageColumnsButton
+                columnInfo={columns}
+                columnVisibilityModel={columnVisibilityModel}
+                setColumnVisibilityModel={setColumnVisibilityModel}
+              />
+            </div>
+          )}
         </>
       }>
       <StyledDataGrid
@@ -528,10 +553,8 @@ export const CallsTable: FC<{
         loading={callsLoading}
         rows={tableData}
         // initialState={initialState}
-        // onColumnVisibilityModelChange={newModel =>
-        //   setColumnVisibilityModel(newModel)
-        // }
-        // columnVisibilityModel={columnVisibilityModel}
+        onColumnVisibilityModelChange={onColumnVisibilityModelChange}
+        columnVisibilityModel={columnVisibilityModel}
         // SORT SECTION START
         sortingMode="server"
         sortModel={sortModel}
@@ -622,6 +645,7 @@ export const CallsTable: FC<{
               </Box>
             );
           },
+          columnMenu: CallsCustomColumnMenu,
         }}
       />
     </FilterLayoutTemplate>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/ManageColumnsButton.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/ManageColumnsButton.tsx
@@ -1,0 +1,192 @@
+/**
+ * Button/popup for grid column visibility state.
+ */
+
+import {Popover} from '@mui/material';
+import {GridColDef, GridColumnVisibilityModel} from '@mui/x-data-grid-pro';
+import {Switch} from '@wandb/weave/components';
+import classNames from 'classnames';
+import React, {useCallback, useRef, useState} from 'react';
+
+import {Button} from '../../../../../Button';
+import {DraggableGrow} from '../../../../../DraggablePopups';
+import {TextField} from '../../../../../Form/TextField';
+import {Tailwind} from '../../../../../Tailwind';
+import {ColumnInfo} from '../../types';
+import {TraceCallSchema} from '../wfReactInterface/traceServerClient';
+
+type ManageColumnsButtonProps = {
+  columnInfo: ColumnInfo;
+  columnVisibilityModel: GridColumnVisibilityModel;
+  setColumnVisibilityModel: (model: GridColumnVisibilityModel) => void;
+};
+
+export const ManageColumnsButton = ({
+  columnInfo,
+  columnVisibilityModel,
+  setColumnVisibilityModel,
+}: ManageColumnsButtonProps) => {
+  const [search, setSearch] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const onClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(anchorEl ? null : ref.current);
+    setSearch('');
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popper' : undefined;
+
+  const toggleColumnShow = useCallback(
+    (key: string) => {
+      const on = columnVisibilityModel[key] ?? true;
+      const newModel = {
+        ...columnVisibilityModel,
+        [key]: !on,
+      };
+      setColumnVisibilityModel(newModel);
+    },
+    [columnVisibilityModel, setColumnVisibilityModel]
+  );
+  const onHideAll = () => {
+    const newModel = columnInfo.cols.reduce((acc, col) => {
+      if (col.hideable ?? true) {
+        acc[col.field] = false;
+      }
+      return acc;
+    }, {} as GridColumnVisibilityModel);
+    setColumnVisibilityModel(newModel);
+  };
+  const onShowAll = () => {
+    const newModel = columnInfo.cols.reduce((acc, col) => {
+      // If a column is not hideable, we also don't need to explicitly show it.
+      if (col.hideable ?? true) {
+        acc[col.field] = true;
+      }
+      return acc;
+    }, {} as GridColumnVisibilityModel);
+    setColumnVisibilityModel(newModel);
+  };
+
+  return (
+    <>
+      <span ref={ref}>
+        <Button
+          variant="ghost"
+          icon="column"
+          tooltip="Manage columns"
+          onClick={onClick}
+        />
+      </span>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        slotProps={{
+          paper: {
+            sx: {
+              overflow: 'visible',
+            },
+          },
+        }}
+        onClose={() => setAnchorEl(null)}
+        TransitionComponent={DraggableGrow}>
+        <Tailwind>
+          <div className="min-w-[300px] p-12">
+            <div className="handle flex items-center pb-8">
+              <div className="flex-auto font-semibold">Manage columns</div>
+              <div>
+                <Button
+                  size="small"
+                  variant="ghost"
+                  icon="close"
+                  tooltip="Close column management"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setAnchorEl(null);
+                  }}
+                />
+              </div>
+            </div>
+            <div className="mb-8">
+              <TextField
+                placeholder="Filter columns"
+                autoFocus
+                value={search}
+                onChange={setSearch}
+              />
+            </div>
+            <div className="max-h-[300px] overflow-auto">
+              {columnInfo.cols.map((col: GridColDef<TraceCallSchema>) => {
+                const value = col.field;
+                const idSwitch = `toggle-vis_${value}`;
+                const checked = columnVisibilityModel[col.field] ?? true;
+                const label = col.headerName ?? value;
+                const disabled = !(col.hideable ?? true);
+                if (
+                  search &&
+                  !label.toLowerCase().includes(search.toLowerCase())
+                ) {
+                  return null;
+                }
+                return (
+                  <div key={value}>
+                    <div
+                      className={classNames(
+                        'flex items-center py-2',
+                        disabled ? 'opacity-40' : ''
+                      )}>
+                      <Switch.Root
+                        id={idSwitch}
+                        size="small"
+                        checked={checked}
+                        onCheckedChange={isOn => {
+                          toggleColumnShow(col.field);
+                        }}
+                        disabled={disabled}>
+                        <Switch.Thumb size="small" checked={checked} />
+                      </Switch.Root>
+                      <label
+                        htmlFor={idSwitch}
+                        className={classNames(
+                          'ml-4',
+                          disabled ? '' : 'cursor-pointer'
+                        )}>
+                        {label}
+                      </label>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div className="mt-8 flex items-center">
+              <Button
+                size="small"
+                variant="quiet"
+                icon="hide-hidden"
+                onClick={onHideAll}>
+                Hide all
+              </Button>
+              <div className="flex-auto" />
+              <Button
+                size="small"
+                variant="quiet"
+                icon="show-visible"
+                onClick={onShowAll}>
+                Show all
+              </Button>
+            </div>
+          </div>
+        </Tailwind>
+      </Popover>
+    </>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/ManageColumnsButton.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/ManageColumnsButton.tsx
@@ -9,7 +9,7 @@ import classNames from 'classnames';
 import React, {useCallback, useRef, useState} from 'react';
 
 import {Button} from '../../../../../Button';
-import {DraggableGrow} from '../../../../../DraggablePopups';
+import {DraggableGrow, DraggableHandle} from '../../../../../DraggablePopups';
 import {TextField} from '../../../../../Form/TextField';
 import {Tailwind} from '../../../../../Tailwind';
 import {ColumnInfo} from '../../types';
@@ -101,21 +101,23 @@ export const ManageColumnsButton = ({
         TransitionComponent={DraggableGrow}>
         <Tailwind>
           <div className="min-w-[300px] p-12">
-            <div className="handle flex items-center pb-8">
-              <div className="flex-auto font-semibold">Manage columns</div>
-              <div>
-                <Button
-                  size="small"
-                  variant="ghost"
-                  icon="close"
-                  tooltip="Close column management"
-                  onClick={e => {
-                    e.stopPropagation();
-                    setAnchorEl(null);
-                  }}
-                />
+            <DraggableHandle>
+              <div className="flex items-center pb-8">
+                <div className="flex-auto font-semibold">Manage columns</div>
+                <div>
+                  <Button
+                    size="small"
+                    variant="ghost"
+                    icon="close"
+                    tooltip="Close column management"
+                    onClick={e => {
+                      e.stopPropagation();
+                      setAnchorEl(null);
+                    }}
+                  />
+                </div>
               </div>
-            </div>
+            </DraggableHandle>
             <div className="mb-8">
               <TextField
                 placeholder="Filter columns"
@@ -157,7 +159,7 @@ export const ManageColumnsButton = ({
                       <label
                         htmlFor={idSwitch}
                         className={classNames(
-                          'ml-4',
+                          'ml-6',
                           disabled ? '' : 'cursor-pointer'
                         )}>
                         {label}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/types.ts
@@ -1,0 +1,8 @@
+import {GridColDef, GridColumnGroupingModel} from '@mui/x-data-grid-pro';
+
+import {TraceCallSchema} from './pages/wfReactInterface/traceServerClient';
+
+export type ColumnInfo = {
+  cols: Array<GridColDef<TraceCallSchema>>;
+  colGroupingModel: GridColumnGroupingModel;
+};


### PR DESCRIPTION
For the Calls grid, replace the built-in column management popup with our own. This addresses several issues:

* Action to open dialog was buried in the column overflow menu, hard to discover
* State is not kept in the URL, which is a pain for sharing with others or if you spent a lot of time customizing to get the view you want
* Popup is not movable and obscures the grid content underneath
* Does not use W&B styling so inconsistent with rest of app.

Before:
<img width="313" alt="Screenshot 2024-07-03 at 4 50 58 PM" src="https://github.com/wandb/weave/assets/112953339/cb592acb-8e14-4398-aae5-0a78cd75b0ee">

After:
<img width="394" alt="Screenshot 2024-07-03 at 4 50 38 PM" src="https://github.com/wandb/weave/assets/112953339/3c4690b5-1af6-4647-92d6-8386aa954f40">
