### PR TITLE
chore(weave): Rename Trace* objs to Weave* (e.g. TraceList -> WeaveList)

### DIFF
--- a/weave/flow/dataset.py
+++ b/weave/flow/dataset.py
@@ -4,7 +4,7 @@ from pydantic import field_validator
 
 import weave
 from weave.flow.obj import Object
-from weave.trace.vals import TraceTable
+from weave.trace.vals import WeaveTable
 
 
 def short_str(obj: Any, limit: int = 25) -> str:
@@ -44,7 +44,7 @@ class Dataset(Object):
     def convert_to_table(cls, rows: Any) -> weave.Table:
         if not isinstance(rows, weave.Table):
             table_ref = getattr(rows, "table_ref", None)
-            if isinstance(rows, TraceTable):
+            if isinstance(rows, WeaveTable):
                 rows = list(rows)
             rows = weave.Table(rows)
             if table_ref:

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -11,7 +11,7 @@ from pydantic import (
 # import pydantic
 from weave.legacy import box
 from weave.trace.op import ObjectRef, Op
-from weave.trace.vals import ObjectRecord, TraceObject, pydantic_getattribute
+from weave.trace.vals import ObjectRecord, WeaveObject, pydantic_getattribute
 from weave.weave_client import get_ref
 
 
@@ -38,7 +38,7 @@ class Object(BaseModel):
     ) -> Any:
         if isinstance(v, ObjectRef):
             return v.get()
-        if isinstance(v, TraceObject):
+        if isinstance(v, WeaveObject):
             # This is a relocated object, so destructure it into a dictionary
             # so pydantic can validate it.
             keys = v._val.__dict__.keys()
@@ -66,7 +66,7 @@ class Object(BaseModel):
             # TODO: fix this. I think dedupe may make it so the user data ends up
             #    working fine, but not setting a ref here will cause the client
             #    to do extra work.
-            if isinstance(v, TraceObject):
+            if isinstance(v, WeaveObject):
                 ref = get_ref(v)
                 new_obj.__dict__["ref"] = ref
             # return new_obj

--- a/weave/refs.py
+++ b/weave/refs.py
@@ -7,7 +7,7 @@ from rich.table import Table
 from weave import client_context
 from weave.rich_container import AbstractRichContainer
 from weave.trace.refs import AnyRef, CallRef, parse_uri
-from weave.trace.vals import TraceObject
+from weave.trace.vals import WeaveObject
 
 
 class Refs(AbstractRichContainer[str]):
@@ -29,7 +29,7 @@ class Refs(AbstractRichContainer[str]):
         return Refs(ref for ref in self.items if isinstance(parse_uri(ref), CallRef))
 
     # TODO: Perhaps there should be a Calls that extends AbstractRichContainer
-    def calls(self) -> list[TraceObject]:
+    def calls(self) -> list[WeaveObject]:
         client = client_context.weave_client.require_weave_client()
         objs = []
         for ref in self.call_refs():

--- a/weave/serve_fastapi.py
+++ b/weave/serve_fastapi.py
@@ -17,7 +17,7 @@ from weave.legacy.artifact_wandb import WandbArtifactRef
 from weave.legacy.wandb_api import WandbApiAsync, WandbApiContext, wandb_api_context
 from weave.trace import op
 from weave.trace.refs import ObjectRef, OpRef
-from weave.trace.vals import TraceObject
+from weave.trace.vals import WeaveObject
 
 from . import errors, pyfunc_type_util, weave_pydantic
 from . import weave_types as types

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ValidationError
 import weave
 from weave import weave_client
 from weave.legacy import context_state
-from weave.trace.vals import MissingSelfInstanceError, TraceObject
+from weave.trace.vals import MissingSelfInstanceError, WeaveObject
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 
 from ..trace_server import trace_server_interface as tsi

--- a/weave/trace/isinstance.py
+++ b/weave/trace/isinstance.py
@@ -3,7 +3,7 @@ from typing import Any, TypeVar
 from typing_extensions import TypeGuard
 
 from weave.trace.object_record import ObjectRecord
-from weave.trace.vals import TraceObject
+from weave.trace.vals import WeaveObject
 
 C = TypeVar("C")
 
@@ -15,7 +15,7 @@ def weave_isinstance(obj: Any, cls: type[C]) -> TypeGuard[C]:
         return obj._class_name == cls.__name__ or any(
             b == cls.__name__ for b in obj._bases
         )
-    if isinstance(obj, TraceObject):
+    if isinstance(obj, WeaveObject):
         return obj._class_name == cls.__name__ or any(
             b == cls.__name__ for b in obj._bases
         )

--- a/weave/trace/tests/test_vals.py
+++ b/weave/trace/tests/test_vals.py
@@ -1,7 +1,7 @@
 import pytest
 
 import weave
-from weave.trace.vals import TraceObject
+from weave.trace.vals import WeaveObject
 
 
 def test_traceobject_properties():
@@ -10,7 +10,7 @@ def test_traceobject_properties():
         def x(self):
             return 1
 
-    to = TraceObject(A(), None, None, None)
+    to = WeaveObject(A(), None, None, None)
     assert to.x == 1
 
 

--- a/weave/trace/tests/test_vals.py
+++ b/weave/trace/tests/test_vals.py
@@ -4,7 +4,7 @@ import weave
 from weave.trace.vals import WeaveObject
 
 
-def test_traceobject_properties():
+def test_weaveobject_properties():
     class A:
         @property
         def x(self):
@@ -14,7 +14,7 @@ def test_traceobject_properties():
     assert to.x == 1
 
 
-def test_traceobject_access_after_init_termination(client):
+def test_weaveobject_access_after_init_termination(client):
     my_obj = None
 
     class MyObj(weave.Object):

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -28,7 +28,7 @@ from weave.trace.refs import (
     parse_uri,
 )
 from weave.trace.serialize import from_json, isinstance_namedtuple, to_json
-from weave.trace.vals import TraceObject, TraceTable, make_trace_obj
+from weave.trace.vals import WeaveObject, WeaveTable, make_trace_obj
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallSchema,
@@ -97,10 +97,10 @@ def get_ref(obj: Any) -> Optional[ObjectRef]:
 
 
 def _get_direct_ref(obj: Any) -> Optional[Ref]:
-    if isinstance(obj, TraceTable):
+    if isinstance(obj, WeaveTable):
         # TODO: this path is odd. We want to use table_ref when serializing
-        # which is the direct ref to the table. But .ref on TraceTable is
-        # the "container ref", ie a ref to the root object that the TraceTable
+        # which is the direct ref to the table. But .ref on WeaveTable is
+        # the "container ref", ie a ref to the root object that the WeaveTable
         # is within, with extra pointing to the table.
         return obj.table_ref
     return getattr(obj, "ref", None)
@@ -215,7 +215,7 @@ class CallsIter:
         self.project_id = project_id
         self.filter = filter
 
-    def __getitem__(self, key: Union[slice, int]) -> TraceObject:
+    def __getitem__(self, key: Union[slice, int]) -> WeaveObject:
         if isinstance(key, slice):
             raise NotImplementedError("Slicing not supported")
         for i, call in enumerate(self):
@@ -223,7 +223,7 @@ class CallsIter:
                 return call
         raise IndexError(f"Index {key} out of range")
 
-    def __iter__(self) -> typing.Iterator[TraceObject]:
+    def __iter__(self) -> typing.Iterator[WeaveObject]:
         page_index = 0
         page_size = 10
         entity, project = self.project_id.split("/")
@@ -249,7 +249,7 @@ class CallsIter:
 
 def make_client_call(
     entity: str, project: str, server_call: CallSchema, server: TraceServerInterface
-) -> TraceObject:
+) -> WeaveObject:
     output = server_call.output
     call = Call(
         op_name=server_call.op_name,
@@ -265,7 +265,7 @@ def make_client_call(
     )
     if call.id is None:
         raise ValueError("Call ID is None")
-    return TraceObject(call, CallRef(entity, project, call.id), server, None)
+    return WeaveObject(call, CallRef(entity, project, call.id), server, None)
 
 
 def sum_dict_leaves(dicts: list[dict]) -> dict:
@@ -377,7 +377,7 @@ class WeaveClient:
         return CallsIter(self.server, self._project_id(), filter)
 
     @trace_sentry.global_trace_sentry.watch()
-    def call(self, call_id: str) -> TraceObject:
+    def call(self, call_id: str) -> WeaveObject:
         response = self.server.calls_query(
             CallsQueryReq(
                 project_id=self._project_id(),


### PR DESCRIPTION
This PR updates naming:
- `TraceObject` -> `WeaveObject`
- `TraceTable` -> `WeaveTable`
- `TraceList` -> `WeaveList`
- `TraceDict` -> `WeaveDict`

And corrects spelling:
- `Tracable` -> `Traceable`