### PR TITLE
fix: allow spaces and other chars in entity names

### DIFF
--- a/weave-js/src/react.test.ts
+++ b/weave-js/src/react.test.ts
@@ -16,7 +16,8 @@ describe('parseRef', () => {
         weaveKind: 'object',
       });
     });
-    // Capital letters in team names seen in the wild.
+    // Entities are not supposed to have uppercase letters, spaces, etc.
+    // But in the wild they do, so the ref parser shouldn't throw an error.
     it('parses a ref with capital letters in entity', () => {
       const parsed = parseRef(
         'weave:///Entity/project/object/artifact-name:artifactversion'
@@ -26,6 +27,20 @@ describe('parseRef', () => {
         artifactRefExtra: '',
         artifactVersion: 'artifactversion',
         entityName: 'Entity',
+        projectName: 'project',
+        scheme: 'weave',
+        weaveKind: 'object',
+      });
+    });
+    it('parses a ref with spaces in entity', () => {
+      const parsed = parseRef(
+        'weave:///Entity%20Name/project/object/artifact-name:artifactversion'
+      );
+      expect(parsed).toEqual({
+        artifactName: 'artifact-name',
+        artifactRefExtra: '',
+        artifactVersion: 'artifactversion',
+        entityName: 'Entity Name',
         projectName: 'project',
         scheme: 'weave',
         weaveKind: 'object',

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -501,9 +501,9 @@ export const isWeaveObjectRef = (ref: ObjectRef): ref is WeaveObjectRef => {
   return ref.scheme === 'weave';
 };
 
-// Entity name: lowercase, digits, dash, underscore
-// Note: Also adding uppercase because team names allow it. Not sure if that was intentional.
-const PATTERN_ENTITY = '([A-Za-z0-9-_]+)';
+// Entity name should be lowercase, digits, dash, underscore
+// Unfortunately many teams have been created that violate this.
+const PATTERN_ENTITY = '([^/]+)';
 const PATTERN_PROJECT = '([^\\#?%:]{1,128})'; // Project name
 const RE_WEAVE_OBJECT_REF_PATHNAME = new RegExp(
   [


### PR DESCRIPTION
See internal Notion doc: https://www.notion.so/wandbai/Team-naming-issue-792e4ae4d0014a178a9369a6137f365d?pvs=4