### PR TITLE
chore(weave): add rename button to overflow menu

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -64,9 +64,9 @@ export const CallOverview: React.FC<{
           <OverflowMenu
             selectedCalls={[call]}
             setIsRenaming={() => {
-              // TODO(gst): fix hack
-              const event = new Event('click') as unknown as SyntheticEvent;
-              editableCallDisplayNameRef.current?.startEditing(event);
+              editableCallDisplayNameRef.current?.startEditing(
+                new MouseEvent('click') as unknown as SyntheticEvent
+              );
             }}
           />
         </OverflowBin>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, {SyntheticEvent} from 'react';
 import styled from 'styled-components';
 
+import EditableField from '../../../../../../common/components/EditableField';
 import {makeRefCall} from '../../../../../../util/refs';
 import {Reactions} from '../../feedback/Reactions';
 import {EditableCallName} from '../common/EditableCallName';
@@ -44,19 +45,30 @@ export const CallOverview: React.FC<{
 }> = ({call}) => {
   const statusCode = call.rawSpan.status_code;
   const refCall = makeRefCall(call.entity, call.project, call.callId);
+  const editableCallDisplayNameRef = React.useRef<EditableField>(null);
 
   return (
     <>
       <Overview>
         <CallName>
-          <EditableCallName call={call} />
+          <EditableCallName
+            call={call}
+            editableFieldRef={editableCallDisplayNameRef}
+          />
         </CallName>
         <CopyableId id={call.callId} type="Call" />
         <StatusChip value={statusCode} iconOnly />
         <Spacer />
         <Reactions weaveRef={refCall} forceVisible={true} />
         <OverflowBin>
-          <OverflowMenu selectedCalls={[call]} />
+          <OverflowMenu
+            selectedCalls={[call]}
+            setIsRenaming={() => {
+              // TODO(gst): fix hack
+              const event = new Event('click') as unknown as SyntheticEvent;
+              editableCallDisplayNameRef.current?.startEditing(event);
+            }}
+          />
         </OverflowBin>
       </Overview>
       {call.rawSpan.exception && (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
@@ -7,7 +7,8 @@ import {opNiceName} from './Links';
 
 export const EditableCallName: React.FC<{
   call: CallSchema;
-}> = ({call}) => {
+  editableFieldRef: React.RefObject<EditableField>;
+}> = ({call, editableFieldRef}) => {
   const defaultDisplayName = opNiceName(call.spanName);
   const displayNameIsEmpty =
     call.displayName == null || call.displayName === '';
@@ -47,6 +48,7 @@ export const EditableCallName: React.FC<{
 
   return (
     <EditableField
+      ref={editableFieldRef}
       value={currNameToDisplay}
       onFinish={saveName}
       placeholder={defaultDisplayName}


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-19669

Allow a button in the overflow menu to control the editable field in the call overview page.

![rename-overflow-synthetic](https://github.com/wandb/weave/assets/19414170/a498d536-9041-4dae-bc2b-a8423489c084)
