### PR TITLE
chore(weave): Fix cost calc model compare

### DIFF
--- a/weave-js/src/util/llmTokenCosts.ts
+++ b/weave-js/src/util/llmTokenCosts.ts
@@ -1,6 +1,6 @@
 export type Model = keyof typeof LLM_TOKEN_COSTS;
 export const isValidLLMModel = (model: string): model is Model => {
-  return model in Object.keys(LLM_TOKEN_COSTS);
+  return Object.keys(LLM_TOKEN_COSTS).includes(model);
 };
 
 export const LLM_TOKEN_COSTS = {


### PR DESCRIPTION
we were not properly checking if the model was valid, and defaulting for all strings