### PR TITLE
chore(weave): weave_options dict for setting display name at op call time

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -10,6 +10,7 @@ from typing import (
     Mapping,
     Optional,
     TypeVar,
+    TypedDict,
 )
 
 from typing_extensions import ParamSpec
@@ -29,6 +30,10 @@ try:
     from openai._types import NOT_GIVEN as OPENAI_NOT_GIVEN
 except ImportError:
     OPENAI_NOT_GIVEN = None
+
+
+class WeaveOptions(TypedDict):
+    display_name: Optional[str]
 
 
 def print_call_link(call: "Call") -> None:
@@ -78,7 +83,9 @@ class Op:
         call = self._create_call(weave_options, *args, **kwargs)
         return self._execute_call(call, *args, **kwargs)
 
-    def _create_call(self, weave_options, *args: Any, **kwargs: Any) -> Any:
+    def _create_call(
+        self, weave_options: WeaveOptions, *args: Any, **kwargs: Any
+    ) -> Any:
         client = client_context.weave_client.require_weave_client()
 
         try:

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -74,10 +74,11 @@ class Op:
         if maybe_client is None:
             return self.resolve_fn(*args, **kwargs)
 
-        call = self._create_call(*args, **kwargs)
+        weave_options = kwargs.pop("weave_options", {})
+        call = self._create_call(weave_options, *args, **kwargs)
         return self._execute_call(call, *args, **kwargs)
 
-    def _create_call(self, *args: Any, **kwargs: Any) -> Any:
+    def _create_call(self, weave_options, *args: Any, **kwargs: Any) -> Any:
         client = client_context.weave_client.require_weave_client()
 
         try:
@@ -101,6 +102,7 @@ class Op:
             inputs_with_defaults,
             parent_call,
             attributes=attributes,
+            display_name=weave_options.get("display_name", None),
         )
 
     def _execute_call(self, call: Any, *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
```python

@op
def floor(x, y):
   return x // y

weave_options = {"display_name": "Mathematical division without remainder"}
out = floor(82, 9, weave_options=weave_options)
```

<img width="564" alt="Screenshot 2024-07-08 at 4 19 07 PM" src="https://github.com/wandb/weave/assets/19414170/a68e1e76-c33d-4b0a-8f66-a2bbe8fbd6c5">

TODO:
- type the weave_options to a class with defaults? 