### PR TITLE
chore(weave): EvalCompare: Fixes issues when models are same version in scorecard section

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
@@ -513,6 +513,7 @@ export const ExampleCompareSection: React.FC<{
 
                         const lowerIsBetter =
                           dimensionShouldMinimize(dimension);
+
                         return (
                           <React.Fragment key={scoreId}>
                             <GridCell

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
@@ -41,7 +41,7 @@ type ScorecardSpecificLegacyScoresType = {
         displayName: string;
         unit: string;
         lowerIsBetter: boolean;
-        modelScores: {[modelRef: string]: number | undefined};
+        evalScores: {[evalCallId: string]: number | undefined};
       };
     };
   };
@@ -55,10 +55,6 @@ const GridCell = styled.div`
 export const ScorecardSection: React.FC<{
   state: EvaluationComparisonState;
 }> = props => {
-  const baselineRef =
-    props.state.data.evaluationCalls[props.state.baselineEvaluationCallId]
-      .modelRef;
-
   const modelRefs = useMemo(
     () => getOrderedModelRefs(props.state),
     [props.state]
@@ -128,12 +124,12 @@ export const ScorecardSection: React.FC<{
                   displayName: dimensionLabel(scorerMetricsDimension),
                   unit,
                   lowerIsBetter,
-                  modelScores: {},
+                  evalScores: {},
                 };
               }
 
-              res[scorerRef].metrics[metricDimensionId].modelScores[
-                evaluationCall.modelRef
+              res[scorerRef].metrics[metricDimensionId].evalScores[
+                evaluationCall.callId
               ] = adjustValueForDisplay(
                 resolveDimensionValueForEvaluateCall(
                   scorerMetricsDimension,
@@ -159,12 +155,12 @@ export const ScorecardSection: React.FC<{
                   displayName: dimensionLabel(derivedMetricsDimension),
                   unit,
                   lowerIsBetter,
-                  modelScores: {},
+                  evalScores: {},
                 };
               }
 
-              res[scorerRef].metrics[metricDimensionId].modelScores[
-                evaluationCall.modelRef
+              res[scorerRef].metrics[metricDimensionId].evalScores[
+                evaluationCall.callId
               ] = adjustValueForDisplay(
                 resolveDimensionValueForEvaluateCall(
                   derivedMetricsDimension,
@@ -391,12 +387,12 @@ export const ScorecardSection: React.FC<{
                       {def.metrics[metricKey].displayName}
                     </GridCell>
                     {evalCallIds.map((evalCallId, mNdx) => {
-                      const modelRef =
-                        props.state.data.evaluationCalls[evalCallId].modelRef;
                       const baseline =
-                        def.metrics[metricKey].modelScores[baselineRef];
+                        def.metrics[metricKey].evalScores[
+                          props.state.baselineEvaluationCallId
+                        ];
                       const value =
-                        def.metrics[metricKey].modelScores[modelRef];
+                        def.metrics[metricKey].evalScores[evalCallId];
                       return (
                         <GridCell
                           key={evalCallId}


### PR DESCRIPTION
Example: https://app.wandb.test/l2k2/hellaswag/weave/compare-evaluations?evaluationCallIds=%5B%22ff014327-f0b8-4959-a828-2a617b2969a4%22%2C%22403b9bd6-eda4-4908-b79d-06b68cac33c0%22%5D

When comparisons share the same model version, the scorecard was not showing different values