### PR TITLE
chore: fixes call link spacing

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -303,6 +303,7 @@ export const CallLink: React.FC<{
             display: 'flex',
             alignItems: 'center',
             gap: '4px',
+            justifyContent: 'space-between',
           }}>
           {props.icon}
           {opName}


### PR DESCRIPTION
Before
<img width="408" alt="Screenshot 2024-07-09 at 11 23 58" src="https://github.com/wandb/weave/assets/2142768/98b6daff-2ea5-4215-9700-53b2a65e1a88">


After
<img width="414" alt="Screenshot 2024-07-09 at 11 23 43" src="https://github.com/wandb/weave/assets/2142768/44313174-59ae-4aea-917d-a500bbb3cb1c">
