### PR TITLE
feat(weave): bulk deletion and selective export -- OLD

### DIFF
--- a/weave-js/src/components/Checkbox/Checkbox.tsx
+++ b/weave-js/src/components/Checkbox/Checkbox.tsx
@@ -46,6 +46,7 @@ export const Checkbox = ({
           'rounded border-[1.5px]  dark:border-moon-250',
           'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
           checked ? 'border-moon-800' : 'border-moon-500',
+          props.disabled && 'cursor-not-allowed opacity-30',
           {
             'h-14 w-14': isSmall,
             'h-18 w-18': isMedium,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -62,6 +62,8 @@ export const CallOverview: React.FC<{
         <Reactions weaveRef={refCall} forceVisible={true} />
         <OverflowBin>
           <OverflowMenu
+            entity={call.entity}
+            project={call.project}
             selectedCalls={[call]}
             setIsRenaming={() => {
               editableCallDisplayNameRef.current?.startEditing(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -378,7 +378,6 @@ export const CallsTable: FC<{
           const rowId = params.id as string;
           return (
             <Checkbox
-              // disabled={rowDisabled(params.row)}
               checked={selectedCalls.includes(rowId)}
               onCheckedChange={() => {
                 if (selectedCalls.includes(rowId)) {
@@ -866,7 +865,7 @@ const CompareEvaluationsTableButton: FC<{
       alignItems: 'center',
     }}>
     <Button
-      className="mr-4"
+      className="ml-4 mr-16"
       size="medium"
       variant="ghost"
       disabled={disabled}


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-19700

- adds delete button in traces/evaluations table for bulk delete
- changes checkbox to wandb checkbox 
- changes export button to ghost variant without text

TODO:
- [ ] export flow needs design pass (follow on?)
- [x] checkbox when disabled needs visual state

![eval-check-delete-july9](https://github.com/wandb/weave/assets/19414170/3dcb017a-c643-4806-bac9-bece1ab2ea1b)

