### PR TITLE
chore(docs):  Added gemini, together, open router and local models pages support docs via our OpenAI sdk compatibility

### DIFF
--- a/docs/docs/guides/integrations/google-gemini.md
+++ b/docs/docs/guides/integrations/google-gemini.md
@@ -1,0 +1,30 @@
+---
+sidebar_position: 1
+hide_table_of_contents: true
+---
+
+# Google Gemini
+
+Google offers two ways of calling Gemini via API:
+
+1. Via the Vertex APIs ([docs](https://cloud.google.com/vertexai/docs))
+2. Via the Gemini API ([docs](https://ai.google.dev/gemini-api/docs/quickstart?lang=python))
+
+## Vertex API
+
+Full Weave support for the `Vertex AI SDK` python package is currently in development, however there is a way you can integrate Weave with the Vertex API. 
+
+Vertex API supports OpenAI SDK compatibility ([docs](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library)), and if this is a way you build your application, Weave will automatically track your LLM calls via our [OpenAI](/guides/integrations/openai) SDK integration.
+
+\* Please note that some features may not fully work as Vertex API doesn't implement the full OpenAI SDK capabilities.
+
+## Gemini API
+
+:::info
+
+Weave native client integration with the `google-generativeai` python package is currently in development
+:::
+
+While we build the native integration with the Gemini API native python package, you can easily integrate Weave with the Gemini API yourself simply by initializing Weave with `weave.init('name of your project')` and then wrapping the calls that call your LLMs with `weave.op()` 
+
+See [Quickstart](/quickstart) for more details.

--- a/docs/docs/guides/integrations/local_models.md
+++ b/docs/docs/guides/integrations/local_models.md
@@ -1,0 +1,34 @@
+---
+sidebar_position: 0
+hide_table_of_contents: true
+---
+
+# Local Models
+
+Many developers download and run open source models like LLama-3, Mixtral, Gemma, Phi and more locally. There are quite a few ways of running these models locally and Weave supports a few of them out of the box, as long as they support OpenAI SDK compatibility.
+
+## Updating your OpenAI SDK code to use local models
+
+All of the frameworks of services that support OpenAI SDK compatibility require a few minor changes. 
+
+First and most important, is the `base_url` change during the `openai.OpenAI()` initialization. 
+
+```python
+client = openai.OpenAI(
+    api_key='fake',
+    base_url="http://localhost:1234",
+)
+```
+
+In the case of local models, the `api_key` can be any string but it should be overriden, as otherwise OpenAI will try to use it from environment variables and show you an error. 
+
+## OpenAI SDK supported Local Model runners 
+
+Here's a list of apps that allows you to download and run models from Hugging Face on your computer, that support OpenAI SDK compatibility.
+
+
+1. Nomic [GPT4All](https://www.nomic.ai/gpt4all) - support via Local Server in settings ([FAQ](https://docs.gpt4all.io/gpt4all_help/faq.html))
+1. [LMStudio](https://lmstudio.ai/) - Local Server OpenAI SDK support [docs](https://lmstudio.ai/docs/local-server)
+1. [Ollama](https://ollama.com/) - [Experimental Support](https://github.com/ollama/ollama/blob/main/docs/openai.md) for OpenAI SDK
+1. llama.cpp via [llama-cpp-python](https://llama-cpp-python.readthedocs.io/en/latest/server/) python package
+1. [llamafile](https://github.com/Mozilla-Ocho/llamafile#other-example-llamafiles) - `http://localhost:8080/v1` automatically supports OpenAI SDK on Llamafile run 

--- a/docs/docs/guides/integrations/openrouter.md
+++ b/docs/docs/guides/integrations/openrouter.md
@@ -1,0 +1,50 @@
+---
+sidebar_position: 1
+hide_table_of_contents: true
+---
+
+# Open Router
+
+Openrouter.ai is a unified interface for many LLMs, supporting both foundational models like OpenAI GPT-4, Anthropic Claude, Google Gemini but also open source models like LLama-3, Mixtral and [many more](https://openrouter.ai/models), some models are even offered for free. 
+
+Open Router offers a Rest API and an OpenAI SDK compatibility ([docs](https://docs.together.ai/docs/openai-api-compatibility)) which Weave automatically detects and integrates with (see Open Router [quick start](https://openrouter.ai/docs/quick-start) for more details).
+
+To get switch your OpenAI SDK code to Open Router, simply switch out the API key to your [Open Router API](https://openrouter.ai/docs/api-keys) key, `base_url` to `https://openrouter.ai/api/v1`, and model to one of their many [chat models](https://openrouter.ai/docs/models).
+
+```python
+import os
+import openai
+import weave
+
+# highlight-next-line
+weave.init('together-weave')
+
+system_content = "You are a travel agent. Be descriptive and helpful."
+user_content = "Tell me about San Francisco"
+
+# highlight-next-line
+client = openai.OpenAI(
+# highlight-next-line
+    api_key=os.environ.get("OPENROUTER_API_KEY"),
+# highlight-next-line
+    base_url="https://api.together.xyz/v1",
+# highlight-next-line
+)
+chat_completion = client.chat.completions.create(
+    extra_headers={
+    "HTTP-Referer": $YOUR_SITE_URL, # Optional, for including your app on openrouter.ai rankings.
+    "X-Title": $YOUR_APP_NAME, # Optional. Shows in rankings on openrouter.ai.
+    },
+    model="microsoft/phi-3-mini-128k-instruct:free",
+    messages=[
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ],
+    temperature=0.7,
+    max_tokens=1024,
+)
+response = chat_completion.choices[0].message.content
+print("Model response:\n", response)
+```
+
+While this is a simple example to get started, see our [OpenAI](/guides/integrations/openai#track-your-own-ops) guide for more details on how to integrate Weave with your own functions for more complex use cases.

--- a/docs/docs/guides/integrations/together_ai.md
+++ b/docs/docs/guides/integrations/together_ai.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 0
+hide_table_of_contents: true
+---
+
+# Together AI
+
+Togeher AI is a platform for building and finetuning generative AI models, focusing on Open Source LLMs, and allowing customers to fine-tune and host their own models. 
+
+:::info
+
+Full Weave `together` python package support is currently in development
+
+:::
+
+While full Weave support for the `together` python package is currently in development, Together supports the OpenAI SDK compatibility ([docs](https://docs.together.ai/docs/openai-api-compatibility)) which Weave automatically detects and integrates with.
+
+To switch to using the Together API, simply switch out the API key to your [Together API](https://docs.together.ai/docs/get-started#access-your-api-key) key, `base_url` to `https://api.together.xyz/v1`, and model to one of their [chat models](https://docs.together.ai/docs/inference-models#chat-models).
+
+```python
+import os
+import openai
+import weave
+
+# highlight-next-line
+weave.init('together-weave')
+
+system_content = "You are a travel agent. Be descriptive and helpful."
+user_content = "Tell me about San Francisco"
+
+# highlight-next-line
+client = openai.OpenAI(
+# highlight-next-line
+    api_key=os.environ.get("TOGETHER_API_KEY"),
+# highlight-next-line
+    base_url="https://api.together.xyz/v1",
+# highlight-next-line
+)
+chat_completion = client.chat.completions.create(
+    model="mistralai/Mixtral-8x7B-Instruct-v0.1",
+    messages=[
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": user_content},
+    ],
+    temperature=0.7,
+    max_tokens=1024,
+)
+response = chat_completion.choices[0].message.content
+print("Together response:\n", response)
+```
+
+While this is a simple example to get started, see our [OpenAI](/guides/integrations/openai#track-your-own-ops) guide for more details on how to integrate Weave with your own functions for more complex use cases.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -58,6 +58,10 @@ const sidebars: SidebarsConfig = {
             "guides/integrations/mistral",
             "guides/integrations/llamaindex",
             "guides/integrations/dspy",
+            "guides/integrations/google-gemini",
+            "guides/integrations/together_ai",
+            "guides/integrations/openrouter",
+            "guides/integrations/local_models",
           ],
         },
         {


### PR DESCRIPTION
Given our native support of OpenAI SDK and many companies supporting that format by default, as per slack discussion, added a few pages that outline how Weave can be utilized with those companies even before we have a native integration with their pytho clients. 

Also added a local models category, with links to the most popular local model runners with support for OpenAI SDK