### PR TITLE
fix: Show filters when there are 2 evals, not just two models

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -165,7 +165,7 @@ const CompareEvaluationsPageInner: React.FC = props => {
         <ComparisonDefinitionSection state={state} />
         <SummaryPlots state={state} />
         <ScorecardSection state={state} />
-        {Object.keys(state.data.models).length === 2 && (
+        {Object.keys(state.data.evaluationCalls).length === 2 && (
           <ExampleFilterSection state={state} />
         )}
         <ResultExplorer state={state} />


### PR DESCRIPTION
Bug fix: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1720626468726109

Fixes issue where the filter condition was on evals, not models