### PR TITLE
fix: UI crash when example is not a ref string

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -251,6 +251,10 @@ const RE_TRAILING_INT = /\d+$/;
 const getCallSortExampleRow = (call: CallSchema): number => {
   const {example} = call.rawSpan.inputs;
   if (example) {
+    // If not a string, we don't know how to sort.
+    if (!_.isString(example)) {
+      return Number.POSITIVE_INFINITY;
+    }
     const match = example.match(RE_TRAILING_INT);
     if (match) {
       return parseInt(match[0], 10);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooksEvaluationComparison.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooksEvaluationComparison.ts
@@ -333,7 +333,7 @@ const fetchEvaluationComparisonData = async (
       const evaluationCallId = parentPredictAndScore.parent_id!;
 
       const split = '/attr/rows/id/';
-      if (exampleRef.includes(split)) {
+      if (typeof exampleRef === 'string' && exampleRef.includes(split)) {
         const parts = exampleRef.split(split);
         if (parts.length === 2) {
           const maybeDigest = parts[1];


### PR DESCRIPTION
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1720659743682469