### PR TITLE
fix: error in console on objects page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -702,10 +702,14 @@ const ObjectVersionsPageBinding = () => {
   const filters: WFHighLevelObjectVersionFilter = useMemo(() => {
     let queryFilter: WFHighLevelObjectVersionFilter = {};
     // Parse the filter from the query string
-    try {
-      queryFilter = JSON.parse(query.filter) as WFHighLevelObjectVersionFilter;
-    } catch (e) {
-      console.log(e);
+    if (query.filter) {
+      try {
+        queryFilter = JSON.parse(
+          query.filter
+        ) as WFHighLevelObjectVersionFilter;
+      } catch (e) {
+        console.log(e);
+      }
     }
 
     // If the tab is models or datasets, set the baseObjectClass filter


### PR DESCRIPTION
If filters are not specified, `query.filter` will be undefined and JSON parsing will fail, logging an error.

<img width="435" alt="Screenshot 2024-07-10 at 10 40 18 PM" src="https://github.com/wandb/weave/assets/112953339/74c742f9-9318-48d6-8cf4-547e6267c973">
