### PR TITLE
chore: add grab cursor to more popups

### DIFF
--- a/weave-js/src/components/DraggablePopups.tsx
+++ b/weave-js/src/components/DraggablePopups.tsx
@@ -5,7 +5,6 @@
 import Grow from '@mui/material/Grow';
 import Tooltip, {tooltipClasses, TooltipProps} from '@mui/material/Tooltip';
 import * as Colors from '@wandb/weave/common/css/color.styles';
-import classNames from 'classnames';
 import React, {useCallback, useState} from 'react';
 import Draggable from 'react-draggable';
 import styled from 'styled-components';
@@ -75,13 +74,14 @@ export const DraggableHandle = ({children}: DraggableHandleProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const onMouseDown = useCallback(() => setIsDragging(true), [setIsDragging]);
   const onMouseUp = useCallback(() => setIsDragging(false), [setIsDragging]);
+  const style: React.CSSProperties = {
+    cursor: isDragging ? 'grabbing' : 'grab',
+  };
 
   return (
     <div
-      className={classNames(
-        'handle',
-        isDragging ? 'cursor-grabbing' : 'cursor-grab'
-      )}
+      className="handle"
+      style={style}
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}>
       {children}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -16,6 +16,7 @@ import {Button} from '../../../Button';
 import {CodeEditor} from '../../../CodeEditor';
 import {
   DraggableGrow,
+  DraggableHandle,
   PoppedBody,
   StyledTooltip,
   TooltipHint,
@@ -155,63 +156,65 @@ const CellValueStringWithPopup = ({value}: CellValueStringProps) => {
         TransitionComponent={DraggableGrow}>
         <Popped>
           <TooltipContent>
-            <Toolbar className="handle">
-              <Button
-                size="small"
-                variant="ghost"
-                icon="copy"
-                tooltip="Copy to clipboard"
-                onClick={e => {
-                  e.stopPropagation();
-                  copy();
-                }}
-              />
-              <Spacer />
-              <Button
-                size="small"
-                variant="quiet"
-                active={format === 'Text'}
-                icon="text-language"
-                tooltip="Text mode"
-                onClick={e => {
-                  e.stopPropagation();
-                  setFormat('Text');
-                }}
-              />
-              <Button
-                size="small"
-                variant="quiet"
-                active={format === 'Markdown'}
-                icon="document"
-                tooltip="Markdown mode"
-                onClick={e => {
-                  e.stopPropagation();
-                  setFormat('Markdown');
-                }}
-              />
-              <Button
-                size="small"
-                variant="quiet"
-                active={format === 'Code'}
-                icon="job-program-code"
-                tooltip="Code mode"
-                onClick={e => {
-                  e.stopPropagation();
-                  setFormat('Code');
-                }}
-              />
-              <Spacer />
-              <Button
-                size="small"
-                variant="ghost"
-                icon="close"
-                tooltip="Close preview"
-                onClick={e => {
-                  e.stopPropagation();
-                  setAnchorEl(null);
-                }}
-              />
-            </Toolbar>
+            <DraggableHandle>
+              <Toolbar>
+                <Button
+                  size="small"
+                  variant="ghost"
+                  icon="copy"
+                  tooltip="Copy to clipboard"
+                  onClick={e => {
+                    e.stopPropagation();
+                    copy();
+                  }}
+                />
+                <Spacer />
+                <Button
+                  size="small"
+                  variant="quiet"
+                  active={format === 'Text'}
+                  icon="text-language"
+                  tooltip="Text mode"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setFormat('Text');
+                  }}
+                />
+                <Button
+                  size="small"
+                  variant="quiet"
+                  active={format === 'Markdown'}
+                  icon="document"
+                  tooltip="Markdown mode"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setFormat('Markdown');
+                  }}
+                />
+                <Button
+                  size="small"
+                  variant="quiet"
+                  active={format === 'Code'}
+                  icon="job-program-code"
+                  tooltip="Code mode"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setFormat('Code');
+                  }}
+                />
+                <Spacer />
+                <Button
+                  size="small"
+                  variant="ghost"
+                  icon="close"
+                  tooltip="Close preview"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setAnchorEl(null);
+                  }}
+                />
+              </Toolbar>
+            </DraggableHandle>
             <PoppedBody>{content}</PoppedBody>
           </TooltipContent>
         </Popped>

--- a/weave-js/src/components/UserLink.tsx
+++ b/weave-js/src/components/UserLink.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import {Button} from './Button';
 import {
   DraggableGrow,
+  DraggableHandle,
   Popped,
   StyledTooltip,
   TooltipHint,
@@ -115,18 +116,20 @@ const UserContent = ({user, mode, onClose}: UserContentProps) => {
   const onCloseClick = onClose ? () => onClose() : undefined;
   return (
     <>
-      <UserContentHeader className="handle">
-        <UserName>{user.name}</UserName>
-        {isPopover && (
-          <Button
-            size="small"
-            variant="ghost"
-            icon="close"
-            tooltip="Close"
-            onClick={onCloseClick}
-          />
-        )}
-      </UserContentHeader>
+      <DraggableHandle>
+        <UserContentHeader>
+          <UserName>{user.name}</UserName>
+          {isPopover && (
+            <Button
+              size="small"
+              variant="ghost"
+              icon="close"
+              tooltip="Close"
+              onClick={onCloseClick}
+            />
+          )}
+        </UserContentHeader>
+      </DraggableHandle>
       <UserContentBody style={bodyStyle}>
         <Avatar src={user.photoUrl} sx={{width: imgSize, height: imgSize}} />
         <Grid>


### PR DESCRIPTION
For the user and string popups, it was not obvious that the header could be grabbed and dragged to reposition the popup. This adds the same cursor treatment that was added for the column management popup in https://github.com/wandb/weave/pull/1881

Recommend viewing diff with "Hide whitespace"

Before:

![Screenshot 2024-07-10 at 11 20 26 PM](https://github.com/wandb/weave/assets/112953339/eea2e09d-2834-424e-a4ba-a1fdcd644db7)

After:

![Screenshot 2024-07-10 at 11 20 13 PM](https://github.com/wandb/weave/assets/112953339/a20ceb6b-b781-4072-b240-3f1c31049318)
![Screenshot 2024-07-10 at 11 19 57 PM](https://github.com/wandb/weave/assets/112953339/7c97f852-d85a-4a74-b765-b7a606eb8978)
