### PR TITLE
chore: update Ruff version

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,7 +12,7 @@ twine>=4.0.0
 sqlalchemy>=2.0.1
 duckdb # TODO: Remove me once we refactor runs2
 mypy==1.0.0
-ruff==0.0.275
+ruff==0.4.7
 types-pytz
 types-Pillow
 types-Flask-Cors


### PR DESCRIPTION
Currently, when trying to fix the lint using `ruff`, we get the following error:
```
error: TOML parse error at line 66, column 12
   |
66 | [tool.ruff.lint]
   |            ^^^^
unknown field `lint`, expected one of `allowed-confusables`, `builtins`, `cache-dir`, `dummy-variable-rgx`, `exclude`, `extend`, `extend-exclude`, `extend-include`, `extend-ignore`, `extend-select`, `extend-fixable`, `extend-unfixable`, `external`, `fix`, `fix-only`, `fixable`, `format`, `force-exclude`, `ignore`, `ignore-init-module-imports`, `include`, `line-length`, `tab-size`, `required-version`, `respect-gitignore`, `select`, `show-source`, `show-fixes`, `src`, `namespace-packages`, `target-version`, `task-tags`, `typing-modules`, `unfixable`, `flake8-annotations`, `flake8-bandit`, `flake8-bugbear`, `flake8-builtins`, `flake8-comprehensions`, `flake8-copyright`, `flake8-errmsg`, `flake8-quotes`, `flake8-self`, `flake8-tidy-imports`, `flake8-type-checking`, `flake8-gettext`, `flake8-implicit-str-concat`, `flake8-import-conventions`, `flake8-pytest-style`, `flake8-unused-arguments`, `isort`, `mccabe`, `pep8-naming`, `pycodestyle`, `pydocstyle`, `pyflakes`, `pylint`, `per-file-ignores`, `extend-per-file-ignores`
```

This PR aims to fix this issue.