### PR TITLE
feat(weave): Add Progressbar to `weave.Evaluation` + parameter `max_concurrent_tasks`

### DIFF
--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -283,8 +283,6 @@ class Evaluation(Object):
     ) -> dict:
         eval_rows = []
 
-        start_time = time.time()
-
         async def eval_example(example: dict) -> dict:
             try:
                 eval_row = await self.predict_and_score(model, example)

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -328,8 +328,9 @@ def evaluate(
     model: Union[Callable, Model],
     scores: Optional[list[Union[Callable, Scorer]]] = None,
     preprocess_model_input: Optional[Callable] = None,
+    max_concurrent_tasks: Optional[int] = None,
 ) -> dict:
     eval = Evaluation(
         dataset=dataset, scorers=scores, preprocess_model_input=preprocess_model_input
     )
-    return asyncio.run(eval.evaluate(model))
+    return asyncio.run(eval.evaluate(model, max_concurrent_tasks))


### PR DESCRIPTION
This PR adds two features to `weave.Evaluation`:
- [x] Add an optional parameter `max_concurrent_tasks` to the `evaluate` function which is passed to `util.async_foreach`.
- [x] Add a `rich.progress.Progress` that wraps `util.async_foreach`.

This is how the console logs look like with the progressbar:
<img width="652" alt="image" src="https://github.com/wandb/weave/assets/19887676/2af37366-2d17-4b40-9035-4deafcf2b584">
