### PR TITLE
Allow `op.call` to work with async ops

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -156,7 +156,7 @@ class Op:
 
     def call(self, *args: Any, **kwargs: Any) -> "Call":
         _call = self._create_call(*args, **kwargs)
-        self._execute_call(_call, *args, **kwargs)
+        await self._execute_call(_call, *args, **kwargs)
         return _call
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Hi! Not sure how much we broke with this one change, but - we're trying to leverage this new API, which is very promising, and we had a "this coroutine is never awaited" error, which we traced to this place in your code. Hopefully this gives you an idea of how to provide a proper fix, and it helps you troubleshoot this problem faster.

Feel free to close/delete this PR when it has served its purpose!