### PR TITLE
fix: use single row for exported CSV header

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -749,7 +749,9 @@ const ExportRunsTableButton = ({
       className="mx-16"
       size="medium"
       variant="secondary"
-      onClick={() => tableRef.current?.exportDataAsCsv()}
+      onClick={() =>
+        tableRef.current?.exportDataAsCsv({includeColumnGroupsHeaders: false})
+      }
       icon="export-share-upload">
       Export to CSV
     </Button>


### PR DESCRIPTION
Internal slack thread: https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1720725155135389

Having multiple header rows doesn't work well with some external tools.

Before:
<img width="1534" alt="Screenshot 2024-07-11 at 2 42 09 PM" src="https://github.com/user-attachments/assets/6e8f246c-0350-46c7-895d-d93b0b41a6d5">

After:
<img width="1085" alt="Screenshot 2024-07-11 at 2 43 06 PM" src="https://github.com/user-attachments/assets/ad7c55d4-572a-4685-8162-9eb2a20160b2">
