### PR TITLE
feat(weave): Improved ergonomics for interacting with private weave instances

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -143,6 +143,14 @@ def weave_server_url() -> str:
     return os.getenv("WEAVE_SERVER_URL", default)
 
 
+def weave_trace_server_url() -> str:
+    base_url = wandb_frontend_base_url()
+    default = "https://trace.wandb.ai"
+    if base_url != "https://api.wandb.ai":
+        default = base_url + "/traces"
+    return os.getenv("WF_TRACE_SERVER_URL", default)
+
+
 def wandb_base_url() -> str:
     settings = Settings()
     return os.environ.get("WANDB_BASE_URL", settings.base_url).rstrip("/")

--- a/weave/legacy/wandb_api.py
+++ b/weave/legacy/wandb_api.py
@@ -438,6 +438,7 @@ def get_wandb_api_sync() -> WandbApi:
 
 DEFAULT_WANDB_BASE_URL = "https://api.wandb.ai/"
 
+
 # Currently weave only supports WANDB_BASE_URL="https://api.wandb.ai/"
 # Remove once we expand to support other base urls
 def check_base_url() -> None:
@@ -447,13 +448,4 @@ def check_base_url() -> None:
     if base_url not in DEFAULT_WANDB_BASE_URL and not is_testing:
         raise errors.WeaveConfigurationError(
             f"The target WANDB_BASE_URL {base_url} points to a server that does not currently support Weave. Try setting WANDB_BASE_URL to https://api.wandb.ai/."
-        )
-
-
-# Currently weave only supports normal apikeys not local apikeys
-# Remove once we expand to support other base urls
-def check_api_key(api_key: str) -> None:
-    if "local" in api_key:
-        raise errors.WeaveConfigurationError(
-            f'The current logged in users api key {api_key} points to a server that does not currently support Weave. Try logging in with "wandb login --host https://api.wandb.ai".'
         )

--- a/weave/legacy/wandb_api.py
+++ b/weave/legacy/wandb_api.py
@@ -434,18 +434,3 @@ async def get_wandb_api() -> WandbApiAsync:
 
 def get_wandb_api_sync() -> WandbApi:
     return WandbApi()
-
-
-DEFAULT_WANDB_BASE_URL = "https://api.wandb.ai/"
-
-
-# Currently weave only supports WANDB_BASE_URL="https://api.wandb.ai/"
-# Remove once we expand to support other base urls
-def check_base_url() -> None:
-    base_url = os.environ.get("WANDB_BASE_URL", DEFAULT_WANDB_BASE_URL)
-    is_testing = os.environ.get("CI") or base_url == "http://localhost:8080"
-    # Check that base url is either localhost for testing, or the default WANDB_BASE_URL
-    if base_url not in DEFAULT_WANDB_BASE_URL and not is_testing:
-        raise errors.WeaveConfigurationError(
-            f"The target WANDB_BASE_URL {base_url} points to a server that does not currently support Weave. Try setting WANDB_BASE_URL to https://api.wandb.ai/."
-        )

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -24,8 +24,3 @@ def wf_clickhouse_pass() -> str:
 def wf_clickhouse_database() -> str:
     """The name of the clickhouse database."""
     return os.environ.get("WF_CLICKHOUSE_DATABASE", "default")
-
-
-def wf_trace_server_url() -> str:
-    """The url of the web server exposing the trace interface endpoints"""
-    return os.environ.get("WF_TRACE_SERVER_URL", "https://trace.wandb.ai")

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -7,8 +7,8 @@ import requests
 import tenacity
 from pydantic import BaseModel, ValidationError
 
+from weave.environment import weave_trace_server_url
 from weave.legacy.wandb_interface import project_creator
-from weave.trace_server import environment as wf_env
 
 from . import trace_server_interface as tsi
 from .async_batch_processor import AsyncBatchProcessor
@@ -108,7 +108,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
 
     @classmethod
     def from_env(cls, should_batch: bool = False) -> "RemoteHTTPTraceServer":
-        return cls(wf_env.wf_trace_server_url(), should_batch)
+        return cls(weave_trace_server_url(), should_batch)
 
     def set_auth(self, auth: t.Tuple[str, str]) -> None:
         self._auth = auth

--- a/weave/weave_init.py
+++ b/weave/weave_init.py
@@ -82,7 +82,6 @@ def init_weave(
     # case we're on a new thread.
     wandb_api.init()
     wandb_context = wandb_api.get_wandb_api_context()
-    wandb_api.check_base_url()
     if wandb_context is None:
         import wandb
 

--- a/weave/weave_init.py
+++ b/weave/weave_init.py
@@ -98,7 +98,6 @@ def init_weave(
     api_key = None
     if wandb_context is not None and wandb_context.api_key is not None:
         api_key = wandb_context.api_key
-        wandb_api.check_api_key(api_key)
     remote_server = init_weave_get_server(api_key)
     # from .trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 


### PR DESCRIPTION
- [x] Remove the checks that prevent weave from being used against backend hosts other than prod
- [x] If `WF_TRACE_SERVER_URL` is unset, we'll derive a default value from other existing `WANDB_*` env variables.  This is currently limited to local installs; MT SaaS environments like QA will still need `WF_TRACE_SERVER_URL` to be set manually.