### PR TITLE
feat(weave): Add threading helpers to simplify thread usage

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -39,7 +39,7 @@ from weave.flow.dataset import Dataset
 from weave.flow.model import Model
 from weave.flow.eval import Evaluation, Scorer
 from weave.flow.agent import Agent, AgentState
-
+from weave.trace.util import ThreadPoolExecutor
 
 # See the comment above pre_init_modules above. This is check to ensure we don't accidentally
 # introduce loading weave.legacy.ops or weave.legacy.panels when importing weave.

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -39,7 +39,7 @@ from weave.flow.dataset import Dataset
 from weave.flow.model import Model
 from weave.flow.eval import Evaluation, Scorer
 from weave.flow.agent import Agent, AgentState
-from weave.trace.util import ThreadPoolExecutor
+from weave.trace.util import ThreadPoolExecutor, Thread
 
 # See the comment above pre_init_modules above. This is check to ensure we don't accidentally
 # introduce loading weave.legacy.ops or weave.legacy.panels when importing weave.

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -1746,7 +1746,6 @@ def test_mapped_execution(client, mapper):
     assert_valid_trace(roots[root_ndx], first_val)
     root_ndx += 1
     for outer in middle_vals_outer:
-        print(f"{middle_vals_outer=}")
         assert_valid_trace(roots[root_ndx], outer)
         root_ndx += 1
 

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -1610,15 +1610,16 @@ def map_with_threads_no_executor(fn, vals):
 
     for v in vals:
         thread = Thread(target=task_wrapper, args=(v,))
+        thread.start()
         threads.append(thread)
 
-    # run threads in batches
-    for i in range(0, len(threads), max_workers):
-        batch = threads[i : i + max_workers]
-        for thread in batch:
-            thread.start()
-        for thread in batch:
-            thread.join()
+        if len(threads) >= max_workers:
+            for thread in threads:
+                thread.join()
+            threads = []
+
+    for thread in threads:
+        thread.join()
 
 
 def map_with_thread_executor(fn, vals):

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -1606,19 +1606,9 @@ def map_with_threads_no_executor(fn, vals):
     def task_wrapper(v):
         return fn(v)
 
-    threads = []
-
     for v in vals:
         thread = Thread(target=task_wrapper, args=(v,))
         thread.start()
-        threads.append(thread)
-
-        if len(threads) >= max_workers:
-            for thread in threads:
-                thread.join()
-            threads = []
-
-    for thread in threads:
         thread.join()
 
 

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -4,7 +4,6 @@ import datetime
 import os
 import typing
 from collections import defaultdict, namedtuple
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from contextvars import copy_context
 
@@ -13,7 +12,7 @@ import wandb
 from pydantic import BaseModel, ValidationError
 
 import weave
-from weave import weave_client
+from weave import ThreadPoolExecutor, weave_client
 from weave.legacy import context_state
 from weave.trace.vals import MissingSelfInstanceError, WeaveObject
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
@@ -1625,7 +1624,7 @@ def map_with_copying_thread_executor(fn, vals):
     "mapper",
     [
         map_simple,
-        # map_with_thread_executor, # <-- Currently this is failing! Fix me (:
+        map_with_thread_executor,  # <-- Currently this is failing! Fix me (:
         # map_with_copying_thread_executor, # <-- Flakes in CI
     ],
 )

--- a/weave/trace/util.py
+++ b/weave/trace/util.py
@@ -1,0 +1,32 @@
+from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
+from contextvars import copy_context
+from functools import partial
+
+
+class ContextAwareThreadPoolExecutor(_ThreadPoolExecutor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.contexts = []
+
+    def submit(self, fn, *args, **kwargs):
+        context = copy_context()
+        self.contexts.append(context)
+
+        wrapped_fn = partial(self._run_with_context, context, fn)
+        return super().submit(wrapped_fn, *args, **kwargs)
+
+    def map(self, fn, *iterables, timeout=None, chunksize=1):
+        contexts = [copy_context() for _ in range(len(list(iterables[0])))]
+        self.contexts.extend(contexts)
+
+        wrapped_fn = partial(self._run_with_context, None, fn)
+        return super().map(wrapped_fn, *iterables, timeout=timeout, chunksize=chunksize)
+
+    def _run_with_context(self, context, fn, *args, **kwargs):
+        if context is None:
+            context = self.contexts.pop(0)
+        return context.run(fn, *args, **kwargs)
+
+
+# rename for cleaner export
+ThreadPoolExecutor = ContextAwareThreadPoolExecutor

--- a/weave/trace/util.py
+++ b/weave/trace/util.py
@@ -6,6 +6,21 @@ from typing import Any, Callable, Iterable, Iterator, Optional
 
 
 class ContextAwareThreadPoolExecutor(_ThreadPoolExecutor):
+    """A ThreadPoolExecutor that runs functions with the context of the caller.
+
+    This is a drop-in replacement for ThreadPoolExecutor that ensures that calls
+    behave as expected inside the executor.  You can achieve the same effect
+    without this class by instead writing:
+
+    with ThreadPoolExecutor() as executor:
+        contexts = [copy_context() for _ in range(len(vals))]
+
+        def _wrapped_fn(*args):
+            return contexts.pop().run(fn, *args)
+
+        executor.map(_wrapped_fn, vals)
+    """
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.contexts: list[Context] = []
@@ -41,6 +56,13 @@ class ContextAwareThreadPoolExecutor(_ThreadPoolExecutor):
 
 
 class ContextAwareThread(_Thread):
+    """A Thread that runs functions with the context of the caller.
+
+    This is a drop-in replacement for Thread that ensures that calls behave as
+    expected inside the thread.  You can achieve the same effect without this
+    class by instead writing:
+    """
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.context = copy_context()

--- a/weave/trace/util.py
+++ b/weave/trace/util.py
@@ -1,42 +1,52 @@
 from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
-from contextvars import copy_context
+from contextvars import Context, copy_context
 from functools import partial
 from threading import Thread as _Thread
+from typing import Any, Callable, Iterable, Iterator, Optional
 
 
 class ContextAwareThreadPoolExecutor(_ThreadPoolExecutor):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.contexts = []
+        self.contexts: list[Context] = []
 
-    def submit(self, fn, *args, **kwargs):
+    # ignoring type here for convenience because otherwise you have to write a bunch of overloads
+    # for py310+ and py39-
+    def submit(self, fn: Callable, *args: Any, **kwargs: Any) -> Any:  # type: ignore
         context = copy_context()
         self.contexts.append(context)
 
         wrapped_fn = partial(self._run_with_context, context, fn)
         return super().submit(wrapped_fn, *args, **kwargs)
 
-    def map(self, fn, *iterables, timeout=None, chunksize=1):
+    def map(
+        self,
+        fn: Callable,
+        *iterables: Iterable[Iterable],
+        timeout: Optional[float] = None,
+        chunksize: int = 1,
+    ) -> Iterator:
         contexts = [copy_context() for _ in range(len(list(iterables[0])))]
         self.contexts.extend(contexts)
 
         wrapped_fn = partial(self._run_with_context, None, fn)
         return super().map(wrapped_fn, *iterables, timeout=timeout, chunksize=chunksize)
 
-    def _run_with_context(self, context, fn, *args, **kwargs):
+    def _run_with_context(
+        self, context: Context, fn: Callable, *args: Any, **kwargs: Any
+    ) -> Any:
         if context is None:
             context = self.contexts.pop(0)
         return context.run(fn, *args, **kwargs)
 
 
 class ContextAwareThread(_Thread):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.context = copy_context()
-        self.result = None
 
-    def run(self):
-        self.result = self.context.run(super().run)
+    def run(self) -> None:
+        self.context.run(super().run)
 
 
 # rename for cleaner export

--- a/weave/trace/util.py
+++ b/weave/trace/util.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
 from contextvars import copy_context
 from functools import partial
+from threading import Thread as _Thread
 
 
 class ContextAwareThreadPoolExecutor(_ThreadPoolExecutor):
@@ -28,5 +29,16 @@ class ContextAwareThreadPoolExecutor(_ThreadPoolExecutor):
         return context.run(fn, *args, **kwargs)
 
 
+class ContextAwareThread(_Thread):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.context = copy_context()
+        self.result = None
+
+    def run(self):
+        self.result = self.context.run(super().run)
+
+
 # rename for cleaner export
 ThreadPoolExecutor = ContextAwareThreadPoolExecutor
+Thread = ContextAwareThread


### PR DESCRIPTION
Resolves:
- https://wandb.atlassian.net/browse/WB-19692

This PR adds `concurrent.futures.ThreadPoolExecutor` and `threading.Thread` variants that behave like the original and also copy context to each of the threads.  This should resolve issues users have where the context is not copied by default.