### PR TITLE
feat: store calls grid sort state in URL

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -9,7 +9,7 @@ import {
   Toolbar,
   Typography,
 } from '@mui/material';
-import {GridColumnVisibilityModel} from '@mui/x-data-grid-pro';
+import {GridColumnVisibilityModel, GridSortModel} from '@mui/x-data-grid-pro';
 import {LicenseInfo} from '@mui/x-license-pro';
 import {useWindowSize} from '@wandb/weave/common/hooks/useWindowSize';
 import {Loading} from '@wandb/weave/components/Loading';
@@ -53,10 +53,12 @@ import {
   WeaveflowPeekContext,
 } from './Browse3/context';
 import {FullPageButton} from './Browse3/FullPageButton';
+import {getValidSortModel} from './Browse3/grid/sort';
 import {BoardPage} from './Browse3/pages/BoardPage';
 import {BoardsPage} from './Browse3/pages/BoardsPage';
 import {CallPage} from './Browse3/pages/CallPage/CallPage';
 import {CallsPage} from './Browse3/pages/CallsPage/CallsPage';
+import {DEFAULT_SORT_CALLS} from './Browse3/pages/CallsPage/CallsTable';
 import {Empty} from './Browse3/pages/common/Empty';
 import {EMPTY_NO_TRACE_SERVER} from './Browse3/pages/common/EmptyContent';
 import {SimplePageLayoutContext} from './Browse3/pages/common/SimplePageLayout';
@@ -683,6 +685,20 @@ const CallsPageBinding = () => {
     history.push({search: newQuery.toString()});
   };
 
+  const sortModel = useMemo(
+    () => getValidSortModel(query.sort, DEFAULT_SORT_CALLS),
+    [query.sort]
+  );
+  const setSortModel = (newModel: GridSortModel) => {
+    const newQuery = new URLSearchParams(location.search);
+    if (newModel.length === 0) {
+      newQuery.delete('sort');
+    } else {
+      newQuery.set('sort', JSON.stringify(newModel));
+    }
+    history.push({search: newQuery.toString()});
+  };
+
   return (
     <CallsPage
       entity={entity}
@@ -691,6 +707,8 @@ const CallsPageBinding = () => {
       onFilterUpdate={onFilterUpdate}
       columnVisibilityModel={columnVisibilityModel}
       setColumnVisibilityModel={setColumnVisibilityModel}
+      sortModel={sortModel}
+      setSortModel={setSortModel}
     />
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/sort.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/sort.test.ts
@@ -1,0 +1,36 @@
+import {GridSortModel} from '@mui/x-data-grid-pro';
+
+import {getValidSortModel} from './sort';
+
+describe('getValidSortModel', () => {
+  it('parses a valid sort model', () => {
+    const parsed = getValidSortModel(
+      '[{"field": "name", "sort": "asc"}, {"field": "age", "sort": "desc"}]'
+    );
+    expect(parsed).toEqual([
+      {
+        field: 'name',
+        sort: 'asc',
+      },
+      {
+        field: 'age',
+        sort: 'desc',
+      },
+    ]);
+  });
+  it('returns null on non-array with no explicit default', () => {
+    const parsed = getValidSortModel('{}');
+    expect(parsed).toEqual(null);
+  });
+  it('returns null on invalid sort value with no explicit default', () => {
+    const parsed = getValidSortModel(
+      '[{"field": "name", "sort": "ascending"}, {"field": "age", "sort": "desc"}]'
+    );
+    expect(parsed).toEqual(null);
+  });
+  it('returns default on non-array (invalid GridSortModel)', () => {
+    const def: GridSortModel = [{field: 'name', sort: 'asc'}];
+    const parsed = getValidSortModel('{}', def);
+    expect(parsed).toEqual(def);
+  });
+});

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/sort.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/sort.ts
@@ -1,0 +1,41 @@
+import {
+  GridSortDirection,
+  GridSortItem,
+  GridSortModel,
+} from '@mui/x-data-grid-pro';
+import _ from 'lodash';
+
+const isValidSortDirection = (obj: any): obj is GridSortDirection => {
+  return obj === 'asc' || obj === 'desc' || obj === null || obj === undefined;
+};
+
+const isValidSortItem = (obj: any): obj is GridSortItem => {
+  if (!_.isPlainObject(obj)) {
+    return false;
+  }
+  if (!_.isString(obj.field)) {
+    return false;
+  }
+  if (!isValidSortDirection(obj.sort)) {
+    return false;
+  }
+  if (Object.keys(obj).length > 2) {
+    return false;
+  }
+  return true;
+};
+
+export const getValidSortModel = <T extends GridSortModel | null>(
+  jsonString: string,
+  def: T = null as T
+): T => {
+  try {
+    const parsed = JSON.parse(jsonString);
+    if (_.isArray(parsed) && parsed.every(isValidSortItem)) {
+      return parsed as T;
+    }
+  } catch (e) {
+    // Ignore
+  }
+  return def;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -1,4 +1,4 @@
-import {GridColumnVisibilityModel} from '@mui/x-data-grid-pro';
+import {GridColumnVisibilityModel, GridSortModel} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
 import React, {FC, useMemo} from 'react';
 
@@ -32,6 +32,9 @@ export const CallsPage: FC<{
 
   columnVisibilityModel: GridColumnVisibilityModel;
   setColumnVisibilityModel: (newModel: GridColumnVisibilityModel) => void;
+
+  sortModel: GridSortModel;
+  setSortModel: (newModel: GridSortModel) => void;
 }> = props => {
   const [filter, setFilter] = useControllableState(
     props.initialFilter ?? {},
@@ -78,6 +81,8 @@ export const CallsPage: FC<{
                 onFilterUpdate={setFilter}
                 columnVisibilityModel={props.columnVisibilityModel}
                 setColumnVisibilityModel={props.setColumnVisibilityModel}
+                sortModel={props.sortModel}
+                setSortModel={props.setSortModel}
               />
             ),
           },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -78,6 +78,10 @@ import {ManageColumnsButton} from './ManageColumnsButton';
 const OP_FILTER_GROUP_HEADER = 'Op';
 const MAX_EVAL_COMPARISONS = 5;
 
+export const DEFAULT_SORT_CALLS: GridSortModel = [
+  {field: 'started_at', sort: 'desc'},
+];
+
 export const CallsTable: FC<{
   entity: string;
   project: string;
@@ -90,6 +94,9 @@ export const CallsTable: FC<{
 
   columnVisibilityModel?: GridColumnVisibilityModel;
   setColumnVisibilityModel?: (newModel: GridColumnVisibilityModel) => void;
+
+  sortModel?: GridSortModel;
+  setSortModel?: (newModel: GridSortModel) => void;
 }> = ({
   entity,
   project,
@@ -99,6 +106,8 @@ export const CallsTable: FC<{
   hideControls,
   columnVisibilityModel,
   setColumnVisibilityModel,
+  sortModel,
+  setSortModel,
 }) => {
   const {addExtra, removeExtra} = useContext(WeaveHeaderExtrasContext);
 
@@ -139,15 +148,7 @@ export const CallsTable: FC<{
   const [filterModel, setFilterModel] = useState<GridFilterModel>({items: []});
 
   // 3. Sort
-  const [sortModelInner, setSortModel] = useState<GridSortModel>([
-    {field: 'started_at', sort: 'desc'},
-  ]);
-  // Ensure that we always have a default sort
-  const sortModel: GridSortModel = useMemo(() => {
-    return sortModelInner.length === 0
-      ? [{field: 'started_at', sort: 'desc'}]
-      : sortModelInner;
-  }, [sortModelInner]);
+  const sortModelResolved = sortModel ?? DEFAULT_SORT_CALLS;
 
   const defaultPageSize = 100;
   // 4. Pagination
@@ -196,7 +197,7 @@ export const CallsTable: FC<{
     project,
     effectiveFilter,
     filterModel,
-    sortModel,
+    sortModelResolved,
     paginationModel,
     expandedRefCols
   );
@@ -445,6 +446,23 @@ export const CallsTable: FC<{
       }
     : undefined;
 
+  const onSortModelChange = useCallback(
+    (newModel: GridSortModel) => {
+      if (!setSortModel || callsLoading) {
+        return;
+      }
+      // The Grid calls this function when the columns change, removing
+      // sort items whose field is no longer in the columns. However, the user
+      // might have been sorting on an output, and the output columns might
+      // not have been determined yet. So skip setting the sort model in this case.
+      if (!muiColumns.some(col => col.field.startsWith('output'))) {
+        return;
+      }
+      setSortModel(newModel);
+    },
+    [callsLoading, setSortModel, muiColumns]
+  );
+
   // CPR (Tim) - (GeneralRefactoring): Pull out different inline-properties and create them above
   return (
     <FilterLayoutTemplate
@@ -577,7 +595,7 @@ export const CallsTable: FC<{
         // SORT SECTION START
         sortingMode="server"
         sortModel={sortModel}
-        onSortModelChange={newModel => setSortModel(newModel)}
+        onSortModelChange={onSortModelChange}
         // SORT SECTION END
         // FILTER SECTION START
         filterMode="server"


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-19839

Store the calls grid column sort state in the URL rather than in local component state. This is another step towards having URLs that a user can bookmark or share and not have to spend a lot of time re-configuring.