### PR TITLE
fix: multi-ref and project-mismatch trace server

### DIFF
--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -768,6 +768,24 @@ def test_refs_read_batch_dataset_rows(client):
     assert res.vals[1] == 6
 
 
+def test_refs_read_batch_multi_project(client):
+    client.project = "test111"
+    ref = client._save_object([1, 2, 3], "my-list")
+
+    client.project = "test222"
+    ref2 = client._save_object({"a": [3, 4, 5]}, "my-obj")
+
+    client.project = "test333"
+    ref3 = client._save_object({"ab": [3, 4, 5]}, "my-obj-2")
+
+    refs = [ref.uri(), ref2.uri(), ref3.uri()]
+    res = client.server.refs_read_batch(RefsReadBatchReq(refs=refs))
+    assert len(res.vals) == 3
+    assert res.vals[0] == [1, 2, 3]
+    assert res.vals[1] == {"a": [3, 4, 5]}
+    assert res.vals[2] == {"ab": [3, 4, 5]}
+
+
 def test_large_files(client):
     class CoolCustomThing:
         a: str

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -725,9 +725,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         ) -> typing.Any:
             conds = []
             parameters = {}
-            refs_by_project_id: dict[
-                str, list[refs_internal.InternalObjectRef]
-            ] = defaultdict(list)
+            refs_by_project_id: dict[str, list[refs_internal.InternalObjectRef]] = (
+                defaultdict(list)
+            )
             for ref in refs:
                 refs_by_project_id[ref.project_id].append(ref)
             for project_id, project_refs in refs_by_project_id.items():


### PR DESCRIPTION
This PR:
- fixes a bug that uses an unbound reference to `ref` which prevents cross project resolution [@tssweeney]

TODO:
* [ ] Unit Tests
* [ ] Manual Test
* [ ] SQLite