### PR TITLE
fix(weave): Don't raise when calling `call` special func, and return both res and `Call` obj

### DIFF
--- a/weave/integrations/anthropic/anthropic_sdk.py
+++ b/weave/integrations/anthropic/anthropic_sdk.py
@@ -90,7 +90,9 @@ def create_wrapper_async(
     def wrapper(fn: typing.Callable) -> typing.Callable:
         def _fn_wrapper(fn: typing.Callable) -> typing.Callable:
             @wraps(fn)
-            async def _async_wrapper(*args, **kwargs):
+            async def _async_wrapper(
+                *args: typing.Any, **kwargs: typing.Any
+            ) -> typing.Any:
                 return await fn(*args, **kwargs)
 
             return _async_wrapper

--- a/weave/integrations/anthropic/anthropic_sdk.py
+++ b/weave/integrations/anthropic/anthropic_sdk.py
@@ -1,5 +1,6 @@
 import importlib
 import typing
+from functools import wraps
 
 import weave
 from weave.trace.op_extensions.accumulator import add_accumulator
@@ -64,10 +65,38 @@ def should_use_accumulator(inputs: typing.Dict) -> bool:
     return isinstance(inputs, dict) and bool(inputs.get("stream"))
 
 
-def create_wrapper(name: str) -> typing.Callable[[typing.Callable], typing.Callable]:
+def create_wrapper_sync(
+    name: str,
+) -> typing.Callable[[typing.Callable], typing.Callable]:
     def wrapper(fn: typing.Callable) -> typing.Callable:
         "We need to do this so we can check if `stream` is used"
         op = weave.op()(fn)
+        op.name = name  # type: ignore
+        return add_accumulator(
+            op,  # type: ignore
+            make_accumulator=lambda inputs: anthropic_accumulator,
+            should_accumulate=should_use_accumulator,
+        )
+
+    return wrapper
+
+
+# Surprisingly, the async `client.chat.completions.create` does not pass
+# `inspect.iscoroutinefunction`, so we can't dispatch on it and must write
+# it manually here...
+def create_wrapper_async(
+    name: str,
+) -> typing.Callable[[typing.Callable], typing.Callable]:
+    def wrapper(fn: typing.Callable) -> typing.Callable:
+        def _fn_wrapper(fn: typing.Callable) -> typing.Callable:
+            @wraps(fn)
+            async def _async_wrapper(*args, **kwargs):
+                return await fn(*args, **kwargs)
+
+            return _async_wrapper
+
+        "We need to do this so we can check if `stream` is used"
+        op = weave.op()(_fn_wrapper(fn))
         op.name = name  # type: ignore
         return add_accumulator(
             op,  # type: ignore
@@ -84,12 +113,12 @@ anthropic_patcher = MultiPatcher(
         SymbolPatcher(
             lambda: importlib.import_module("anthropic.resources.messages"),
             "Messages.create",
-            create_wrapper(name="anthropic.Messages.create"),
+            create_wrapper_sync(name="anthropic.Messages.create"),
         ),
         SymbolPatcher(
             lambda: importlib.import_module("anthropic.resources.messages"),
             "AsyncMessages.create",
-            create_wrapper(name="anthropic.AsyncMessages.create"),
+            create_wrapper_async(name="anthropic.AsyncMessages.create"),
         ),
     ]
 )

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -235,7 +235,9 @@ def should_use_accumulator(inputs: typing.Dict) -> bool:
     return isinstance(inputs, dict) and bool(inputs.get("stream"))
 
 
-def create_wrapper(name: str) -> typing.Callable[[typing.Callable], typing.Callable]:
+def create_wrapper_sync(
+    name: str,
+) -> typing.Callable[[typing.Callable], typing.Callable]:
     def wrapper(fn: typing.Callable) -> typing.Callable:
         "We need to do this so we can check if `stream` is used"
 
@@ -309,7 +311,7 @@ symbol_patchers = [
     SymbolPatcher(
         lambda: importlib.import_module("openai.resources.chat.completions"),
         "Completions.create",
-        create_wrapper(name="openai.chat.completions.create"),
+        create_wrapper_sync(name="openai.chat.completions.create"),
     ),
     SymbolPatcher(
         lambda: importlib.import_module("openai.resources.chat.completions"),

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -274,7 +274,9 @@ def create_wrapper_sync(
 # Surprisingly, the async `client.chat.completions.create` does not pass
 # `inspect.iscoroutinefunction`, so we can't dispatch on it and must write
 # it manually here...
-def create_wrapper_async(name: str):
+def create_wrapper_async(
+    name: str,
+) -> typing.Callable[[typing.Callable], typing.Callable]:
     def wrapper(fn: typing.Callable) -> typing.Callable:
         "We need to do this so we can check if `stream` is used"
 

--- a/weave/tests/test_op_call_method.py
+++ b/weave/tests/test_op_call_method.py
@@ -12,7 +12,8 @@ def test_op_call_method(client):
     assert res == 3
 
     # call that returns a Call obj
-    c = add.call(1, 2)
-    assert isinstance(c, weave.weave_client.Call)
-    assert c.inputs == {"a": 1, "b": 2}
-    assert c.output == 3
+    res2, call = add.call(1, 2)
+    assert isinstance(call, weave.weave_client.Call)
+    assert call.inputs == {"a": 1, "b": 2}
+    assert call.output == 3
+    assert res2 == 3

--- a/weave/tests/test_op_decorator_behaviour.py
+++ b/weave/tests/test_op_decorator_behaviour.py
@@ -71,18 +71,20 @@ def test_sync_func(client, func):
 
 
 def test_sync_func_call(client, func):
-    call = func.call(1)
+    res, call = func.call(1)
     assert isinstance(call, Call)
     assert call.inputs == {"a": 1}
     assert call.output == 2
+    assert res == 2
 
     ref = weave.publish(func)
     func2 = ref.get()
 
-    call2 = func2.call(1)
+    res2, call2 = func2.call(1)
     assert isinstance(call2, Call)
     assert call2.inputs == {"a": 1}
     assert call2.output == 2
+    assert res2 == 2
 
 
 @pytest.mark.asyncio
@@ -97,18 +99,20 @@ async def test_async_func(client, afunc):
 
 @pytest.mark.asyncio
 async def test_async_func_call(client, afunc):
-    call = await afunc.call(1)
+    res, call = await afunc.call(1)
     assert isinstance(call, Call)
     assert call.inputs == {"a": 1}
     assert call.output == 2
+    assert res == 2
 
     ref = weave.publish(afunc)
     afunc2 = ref.get()
 
-    call2 = await afunc2.call(1)
+    res2, call2 = await afunc2.call(1)
     assert isinstance(call2, Call)
     assert call2.inputs == {"a": 1}
     assert call2.output == 2
+    assert res2 == 2
 
 
 def test_sync_method(client, weave_obj, py_obj):
@@ -121,7 +125,7 @@ def test_sync_method(client, weave_obj, py_obj):
 
 
 def test_sync_method_call(client, weave_obj, py_obj):
-    call = weave_obj.method.call(1)
+    res, call = weave_obj.method.call(1)
     assert isinstance(call, Call)
     assert call.inputs == {
         "self": ObjectRef(
@@ -134,6 +138,7 @@ def test_sync_method_call(client, weave_obj, py_obj):
         "a": 1,
     }
     assert call.output == 2
+    assert res == 2
 
     weave_obj_method_ref = weave.publish(weave_obj.method)
     with pytest.raises(MissingSelfInstanceError):
@@ -155,7 +160,7 @@ async def test_async_method(client, weave_obj, py_obj):
 
 @pytest.mark.asyncio
 async def test_async_method_call(client, weave_obj, py_obj):
-    call = await weave_obj.amethod.call(1)
+    res, call = await weave_obj.amethod.call(1)
     assert isinstance(call, Call)
     assert call.inputs == {
         "self": ObjectRef(
@@ -168,6 +173,7 @@ async def test_async_method_call(client, weave_obj, py_obj):
         "a": 1,
     }
     assert call.output == 2
+    assert res == 2
 
     weave_obj_amethod_ref = weave.publish(weave_obj.amethod)
     with pytest.raises(MissingSelfInstanceError):

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -6,12 +6,12 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Coroutine,
     Dict,
     Literal,
     Mapping,
     Optional,
     Protocol,
-    TypeVar,
     Union,
     cast,
     overload,
@@ -165,9 +165,6 @@ def _create_call(func: Op, *args: Any, **kwargs: Any) -> "Call":
     )
 
 
-T = TypeVar("T")
-
-
 def create_finish_func(call: "Call", client: Any) -> Callable:
     has_finished = False
 
@@ -207,11 +204,11 @@ def _execute_call(
     finish = create_finish_func(call, client)
     on_output = create_on_output_func(__op, finish, call)
 
-    def process(res):
+    def process(res: Any) -> Any:
         res = box.box(res)
         return call if __return_type == "call" else on_output(res)
 
-    def handle_exception(e):
+    def handle_exception(e: Exception) -> Any:
         finish(exception=e)
         if __should_raise:
             raise
@@ -219,7 +216,7 @@ def _execute_call(
 
     if inspect.iscoroutinefunction(func):
 
-        async def _call_async():
+        async def _call_async() -> Coroutine[Any, Any, Any]:
             call_context.push_call(call)
             try:
                 res = await func(*args, **kwargs)

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -217,9 +217,12 @@ def _execute_call(
                 finish(exception=e)
                 if __should_raise:
                     raise
+                else:
+                    return call if __return_type == "call" else None
             else:
                 res = box.box(res)
-                return on_output(res)
+                res2 = on_output(res)
+                return call if __return_type == "call" else res2
             finally:
                 call_context.pop_call(call.id)
 
@@ -231,9 +234,12 @@ def _execute_call(
             finish(exception=e)
             if __should_raise:
                 raise
+            else:
+                return call if __return_type == "call" else None
         else:
             res = box.box(res)
-            return on_output(res)
+            res2 = on_output(res)
+            return call if __return_type == "call" else res2
 
 
 def call(op: Op, *args: Any, **kwargs: Any) -> Any:

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -346,7 +346,7 @@ def op(*args: Any, **kwargs: Any) -> Union[Callable[[Any], Op], Op]:
                     if client_context.weave_client.get_weave_client() is None:
                         return func(*args, **kwargs)
                     call = _create_call(wrapper, *args, **kwargs)  # type: ignore
-                    res, _ = _execute_call(wrapper, call, *args, **kwarg)  # type: ignore
+                    res, _ = _execute_call(wrapper, call, *args, **kwargs)  # type: ignore
                     return res
 
             # Tack these helpers on to our wrapper

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -337,13 +337,8 @@ def op(*args: Any, **kwargs: Any) -> Union[Callable[[Any], Op], Op]:
                     if client_context.weave_client.get_weave_client() is None:
                         return await func(*args, **kwargs)
                     call = _create_call(wrapper, *args, **kwargs)  # type: ignore
-                    return await _execute_call(
-                        wrapper,  # type: ignore
-                        call,
-                        *args,
-                        __return_type="value",
-                        **kwargs,
-                    )
+                    res, _ = await _execute_call(wrapper, call, *args, **kwargs)  # type: ignore
+                    return res
             else:
 
                 @wraps(func)
@@ -351,13 +346,8 @@ def op(*args: Any, **kwargs: Any) -> Union[Callable[[Any], Op], Op]:
                     if client_context.weave_client.get_weave_client() is None:
                         return func(*args, **kwargs)
                     call = _create_call(wrapper, *args, **kwargs)  # type: ignore
-                    return _execute_call(
-                        wrapper,  # type: ignore
-                        call,
-                        *args,
-                        __return_type="value",
-                        **kwargs,
-                    )
+                    res, _ = _execute_call(wrapper, call, *args, **kwarg)  # type: ignore
+                    return res
 
             # Tack these helpers on to our wrapper
             wrapper.resolve_fn = func  # type: ignore


### PR DESCRIPTION
## Resolves:
- https://wandb.atlassian.net/browse/WB-19805
- https://wandb.atlassian.net/browse/WB-19853

This PR changes the `call` special func to:
1. Return both the result and call
2. Never raise -- any exceptions are captured in the `call` and the result is `None`.

NB:
1. I'm slightly concerned about the "return async wrapper" pattern we have because it may introduce complexity when we try to cover other types of funcs like generators, async generators, etc.
2. For now, this is OK.
