### PR TITLE
chore(artifacts): new op to check if artifact is linked to a collection in the global registry

### DIFF
--- a/weave-js/src/core/ops/domain/artifactVersion.ts
+++ b/weave-js/src/core/ops/domain/artifactVersion.ts
@@ -241,6 +241,22 @@ export const opArtifactVersionIsGenerated = makeArtifactVersionOp({
   resolver: ({artifactVersion}) => artifactVersion.isGenerated,
 });
 
+export const opArtifactVersionIsLinkedToGlobalRegistry = makeArtifactVersionOp({
+  name: 'artifactVersion-isLinkedToGlobalRegistry',
+  argTypes: artifactVersionArgTypes,
+  description: `Returns if the artifact is linked to a collection in the global registry ${docType(
+    'artifactVersion'
+  )}`,
+  argDescriptions: {
+    artifactVersion: artifactVersionArgDescription,
+  },
+  returnValueDescription: `Returns if the artifact is linked to a collection in the global registry ${docType(
+    'artifactVersion'
+  )}`,
+  returnType: inputTypes => 'boolean',
+  resolver: ({artifactVersion}) => artifactVersion.isLinkedToGlobalRegistry,
+});
+
 const mediaTypeExtensions = BASIC_MEDIA_TYPES.map(mediaType => mediaType.type);
 const isMediaFilePath = (path: string) =>
   mediaTypeExtensions.some(extension => path.endsWith(`.${extension}.json`));

--- a/weave-js/src/core/ops/domain/gql.ts
+++ b/weave-js/src/core/ops/domain/gql.ts
@@ -1118,6 +1118,8 @@ export const toGqlField = (
     return [gqlObjectField(forwardGraph, forwardOp, 'artifactType')];
   } else if (forwardOp.op.name === 'artifactVersion-isGenerated') {
     return gqlBasicField('isGenerated');
+  } else if (forwardOp.op.name === 'artifactVersion-isLinkedToGlobalRegistry') {
+    return gqlBasicField('isLinkedToGlobalRegistry');
   } else if (forwardOp.op.name === 'artifactVersion-artifactCollections') {
     return [
       {

--- a/weave/legacy/ops_domain/artifact_version_ops.py
+++ b/weave/legacy/ops_domain/artifact_version_ops.py
@@ -206,6 +206,13 @@ gql_prop_op(
     types.Boolean(),
 )
 
+gql_prop_op(
+    "artifactVersion-isLinkedToGlobalRegistry",
+    wdt.ArtifactVersionType,
+    "isLinkedToGlobalRegistry",
+    types.Boolean(),
+)
+
 
 @op(plugins=wb_gql_op_plugin(lambda inputs, inner: "metadata"), hidden=True)
 def refine_metadata(


### PR DESCRIPTION
[WB-19874](https://wandb.atlassian.net/browse/WB-19874)

[WB-19874]: https://wandb.atlassian.net/browse/WB-19874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Should only be merged after this is deployed: https://github.com/wandb/core/pull/22735

Exposes the artifact attribute that tells us whether it is linked to a collection in the org registry. This is needed to add additional warnings which deleting artifacts in a run or via the artifacts UI

Tested the op by temporarily adding it to the `PanelArtifactMembershipOverview/index.tsx` file and logging the value in the console:

```
artifactIsLinkedToRegistry: opArtifactVersionIsLinkedToGlobalRegistry({
      artifactVersion: artifactVersionNode,
    }),
```

![image](https://github.com/user-attachments/assets/5c5a247a-db89-49df-8e1e-58065847189c)
