### PR TITLE
feat(weave): Add limited support for mutations

### DIFF
--- a/weave/api.py
+++ b/weave/api.py
@@ -218,7 +218,8 @@ def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.Object
     # When mutating an object, clear the ref so we can save a new one
     # TODO: Still have a problem with hashes...
     if isinstance(obj, Traceable) and obj.mutations:
-        obj.ref = None
+        ...
+        # obj.ref = None
 
     ref = client._save_object(obj, save_name, "latest")
 

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -1244,6 +1244,3 @@ def test_mutation_saving_nested(client):
     assert g3.b.d == [["p", "q"], ["r", "s"]]
     assert g3.b.e == {"c": 9}
     assert g3.b.f == {"d": {"e": "f"}}
-
-    print(f"{g3=}")
-    raise

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -1093,6 +1093,8 @@ def test_list_mutation_saving(client):
     ref = weave.publish(lst)
 
     lst2 = ref.get()
+    print(f"{lst2=}")
+    print(f"{lst2.ref=}")
     assert lst2 == [1, 2, 3]
 
     lst2[0] = 100
@@ -1121,7 +1123,7 @@ def test_dict_mutation_saving(client):
     assert d3 == {"a": 1, "b": "new_value", "new_key": 3}
 
 
-def test_object_composite_mutation_saving(client):
+def test_object_mutation_saving_nested(client):
     class A(weave.Object):
         b: int = 1
 
@@ -1148,13 +1150,100 @@ def test_object_composite_mutation_saving(client):
     assert d3.c.a.b == 3
 
 
-def test_list_composite_mutation_saving(client):
-    raise
+def test_list_mutation_saving_nested(client):
+    lst = [1, 2, 3]
+    ref = weave.publish(lst)
+
+    lst2 = [4, 5, 6]
+    ref2 = weave.publish(lst2)
+
+    lst3 = ref.get()
+    assert lst3 == [1, 2, 3]
+
+    lst4 = ref2.get()
+    assert lst4 == [4, 5, 6]
+
+    lst3.append(lst4)
+    ref5 = weave.publish(lst3)
+
+    lst5 = ref5.get()
+    assert lst5 == [1, 2, 3, [4, 5, 6]]
 
 
-def test_dict_composite_mutation_saving(client):
-    raise
+def test_dict_mutation_saving_nested(client):
+    d = {"a": 1, "b": 2}
+    ref = weave.publish(d)
+
+    d2 = {"c": 3, "d": 4}
+    ref2 = weave.publish(d2)
+
+    d3 = ref.get()
+    assert d3 == {"a": 1, "b": 2}
+
+    d4 = ref2.get()
+    assert d4 == {"c": 3, "d": 4}
+
+    d3["e"] = d4
+    ref5 = weave.publish(d3)
+
+    d5 = ref5.get()
+    assert d5 == {
+        "a": 1,
+        "b": 2,
+        "e": {"c": 3, "d": 4},
+    }
 
 
-def test_multiple_composite_mutation_saving(client):
+def test_mutation_saving_nested(client):
+    class A(weave.Object):
+        b: int
+
+    class B(weave.Object):
+        a: A
+        c: list[int]
+        d: list[list[str]]
+        e: dict[str, int]
+        f: dict[str, dict[str, str]]
+
+    class G(weave.Object):
+        a: A
+        b: B
+
+    g = G(
+        a=A(b=1),
+        b=B(
+            a=A(b=2),
+            c=[3, 4],
+            d=[["x", "y"], ["z"]],
+            e={"a": 5, "b": 6},
+            f={"c": {"d": "e"}},
+        ),
+    )
+    ref = weave.publish(g)
+
+    g2 = ref.get()
+    assert g2.a.b == 1
+    assert g2.b.a.b == 2
+    assert g2.b.c == [3, 4]
+    assert g2.b.d == [["x", "y"], ["z"]]
+    assert g2.b.e == {"a": 5, "b": 6}
+    assert g2.b.f == {"c": {"d": "e"}}
+
+    g2.b.c = [7, 8]
+    g2.b.d = [["p", "q"], ["r", "s"]]
+    g2.b.e = {"c": 9}
+    g2.b.f = {"d": {"e": "f"}}
+    ref2 = weave.publish(g2)
+
+    g3 = ref2.get()
+    print(f"{g3=}")
+    assert g3.a.b == 1
+    assert g3.b.a.b == 2
+    print(f"{g3.b=}")
+    assert g3.b.c == [7, 8]
+    assert g3.b.d == [["p", "q"], ["r", "s"]]
+    assert g3.b.e == {"c": 9}
+    assert g3.b.f == {"d": {"e": "f"}}
+
+    print(f"{g3=}")
     raise

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -1093,8 +1093,6 @@ def test_list_mutation_saving(client):
     ref = weave.publish(lst)
 
     lst2 = ref.get()
-    print(f"{lst2=}")
-    print(f"{lst2.ref=}")
     assert lst2 == [1, 2, 3]
 
     lst2[0] = 100
@@ -1105,6 +1103,11 @@ def test_list_mutation_saving(client):
 
     lst3 = ref2.get()
     assert lst3 == [100, 2, 3, 4, 5, 6]
+
+    # lst2.append(4)
+    # ref2 = weave.publish(lst2)
+    # lst3 = ref2.get()
+
 
 
 def test_dict_mutation_saving(client):

--- a/weave/trace/object_record.py
+++ b/weave/trace/object_record.py
@@ -33,8 +33,8 @@ class ObjectRecord:
                 return False
         return True
 
-    def map_values(self, fn: Callable) -> "ObjectRecord":
-        return ObjectRecord({k: fn(v) for k, v in self.__dict__.items()})
+    def map_values(self, fn: Callable, *args, **kwargs) -> "ObjectRecord":
+        return ObjectRecord({k: fn(v, *args, **kwargs) for k, v in self.__dict__.items()})
 
 
 PydanticBaseModelGeneral = Union[pydantic.BaseModel, pydantic.v1.BaseModel]

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -12,7 +12,15 @@ from weave.trace_server.trace_server_interface import (
 
 
 def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
-    if isinstance(obj, TableRef):
+    from weave.trace.vals import WeaveList, WeaveObject
+
+    print(f"to_json {obj=}")
+
+    if isinstance(obj, WeaveObject):
+        return to_json(obj._val, project_id, server)
+    elif isinstance(obj, WeaveList):
+        return [to_json(v, project_id, server) for v in obj]
+    elif isinstance(obj, TableRef):
         return obj.uri()
     elif isinstance(obj, ObjectRef):
         return obj.uri()

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -12,15 +12,7 @@ from weave.trace_server.trace_server_interface import (
 
 
 def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
-    from weave.trace.vals import WeaveList, WeaveObject
-
-    print(f"to_json {obj=}")
-
-    if isinstance(obj, WeaveObject):
-        return to_json(obj._val, project_id, server)
-    elif isinstance(obj, WeaveList):
-        return [to_json(v, project_id, server) for v in obj]
-    elif isinstance(obj, TableRef):
+    if isinstance(obj, TableRef):
         return obj.uri()
     elif isinstance(obj, ObjectRef):
         return obj.uri()

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -538,7 +538,10 @@ def make_trace_obj(
 
         pass
     else:
-        setattr(box_val, "ref", new_ref)
+        # This used to work but now that we allow assignment on ObjectRefs,
+        # we need another path!
+        if hasattr(box_val, "ref"):
+            setattr(box_val, "ref", new_ref)
     return box_val
 
 

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -87,9 +87,7 @@ def make_mutation(
 
 
 class Traceable:
-    mutated_value: Any = None
     ref: RefWithExtra
-    list_mutations: Optional[list] = None
     mutations: Optional[list[Mutation]] = None
     root: "Traceable"
     server: TraceServerInterface

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -248,7 +248,7 @@ class WeaveTable(Traceable):
     def __init__(
         self,
         table_ref: TableRef,
-        ref: RefWithExtra,
+        ref: Optional[RefWithExtra],
         server: TraceServerInterface,
         filter: _TableRowFilter,
         root: typing.Optional[Traceable],
@@ -406,10 +406,11 @@ class WeaveDict(Traceable, dict):
         return item
 
     def __getitem__(self, key: str) -> Any:
-        if self.ref:
-            new_ref = self.ref.with_key(key)
-        else:
-            new_ref = None
+        # if self.ref:
+        #     new_ref = self.ref.with_key(key)
+        # else:
+        #     new_ref = None
+        new_ref = self.ref.with_key(key)
         # return make_trace_obj(super().__getitem__(key), new_ref, self.server, self.root)
         return make_trace_obj(self._deref(key), new_ref, self.server, self.root)
 
@@ -577,8 +578,8 @@ def make_trace_obj(
     else:
         # This used to work but now that we allow assignment on ObjectRefs,
         # we need another path!
-        if hasattr(box_val, "ref"):
-            setattr(box_val, "ref", new_ref)
+        # if hasattr(box_val, "ref"):
+        setattr(box_val, "ref", new_ref)
     return box_val
 
 

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -125,9 +125,17 @@ def _get_direct_ref(obj: Any) -> Optional[Ref]:
 
 
 def map_to_refs(obj: Any) -> Any:
+    if getattr(obj, "mutations", None):
+        print("This object has mutations, deleting the ref so we can save it")
+        obj.ref = None
+
     ref = _get_direct_ref(obj)
     if ref:
         return ref
+    if isinstance(obj, Ref):
+        # This works but is probably very expensive... what can we do instead?
+        obj = obj.get()
+
     if isinstance(obj, ObjectRecord):
         return obj.map_values(map_to_refs)
     elif isinstance(obj, (pydantic.BaseModel, pydantic.v1.BaseModel)):
@@ -142,7 +150,11 @@ def map_to_refs(obj: Any) -> Any:
         return [map_to_refs(v) for v in obj]
     elif isinstance(obj, dict):
         return {k: map_to_refs(v) for k, v in obj.items()}
-
+    elif isinstance(obj, WeaveObject):
+        # We also have to consider WeaveObject now because you can modify it...
+        # But this change seems wrong because this func was supposed to operate on
+        # "real" objects, not WeaveObjects...
+        return obj.map_values(map_to_refs)
     return obj
 
 

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -127,12 +127,15 @@ def _get_direct_ref(obj: Any) -> Optional[Ref]:
 def map_to_refs(obj: Any) -> Any:
     if getattr(obj, "mutations", None):
         print("This object has mutations, deleting the ref so we can save it")
+        obj._old_ref = obj.ref
         obj.ref = None
 
-    ref = _get_direct_ref(obj)
-    if ref:
-        return ref
-    if isinstance(obj, Ref):
+    # TODO: Need to edit this such that:
+    # 1. When an object has not changed, just return the ref
+    # 2. But if it's part of a change on an outer object, continue???
+    # if ref := _get_direct_ref(obj):
+    #     return ref
+    if isinstance(obj, ObjectRef):
         # This works but is probably very expensive... what can we do instead?
         obj = obj.get()
 

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -133,8 +133,8 @@ def map_to_refs(obj: Any) -> Any:
     # TODO: Need to edit this such that:
     # 1. When an object has not changed, just return the ref
     # 2. But if it's part of a change on an outer object, continue???
-    # if ref := _get_direct_ref(obj):
-    #     return ref
+    if ref := _get_direct_ref(obj):
+        return ref
     if isinstance(obj, ObjectRef):
         # This works but is probably very expensive... what can we do instead?
         obj = obj.get()

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -125,7 +125,8 @@ def _get_direct_ref(obj: Any) -> Optional[Ref]:
 
 
 def map_to_refs(obj: Any) -> Any:
-    if getattr(obj, "mutations", None):
+    print(f"map_to_refs: {obj=}")
+    if getattr(obj, "mutations", None) and (ref := obj.ref) is not None:
         print("This object has mutations, deleting the ref so we can save it")
         obj._old_ref = obj.ref
         obj.ref = None


### PR DESCRIPTION
## Resolves:
- https://wandb.atlassian.net/browse/WB-19588

This PR allows for de-ref'd objects to be mutated and saved.  Supported objects include:
- `WeaveObject`
- `WeaveList`
- `WeaveDict`

It does not include "incremental" mutations where only the mutated parts are updated.  Instead, this will just send the entire latest version of that object across the wire.