### PR TITLE
chore: Implement a more parallel loading scheme for the eval page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/ecpTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/ecpTypes.ts
@@ -5,10 +5,7 @@
  * The `EvaluationComparisonData` fully defines a normalized data structure for the
  * Comparing Evaluations.
  */
-import {
-  TraceCallSchema,
-  TraceObjSchema,
-} from '../wfReactInterface/traceServerClient';
+import {TraceCallSchema} from '../wfReactInterface/traceServerClient';
 
 export type EvaluationComparisonData = {
   // Entity and Project are constant across all calls
@@ -74,7 +71,6 @@ type EvaluationObj = {
   scorerRefs: string[];
   entity: string;
   project: string;
-  _rawEvaluationObject: TraceObjSchema;
 };
 
 /**
@@ -106,7 +102,6 @@ type ModelObj = {
   entity: string;
   project: string;
   properties: {[prop: string]: any};
-  _rawModelObject: TraceObjSchema;
 };
 
 /**

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/EvaluationDefinition.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/EvaluationDefinition.tsx
@@ -1,6 +1,6 @@
 import {Box} from '@material-ui/core';
 import {Circle} from '@mui/icons-material';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import {
   MOON_300,
@@ -8,10 +8,12 @@ import {
   MOON_800,
 } from '../../../../../../../../common/css/color.styles';
 import {hexToRGB} from '../../../../../../../../common/css/utils';
-import {parseRef} from '../../../../../../../../react';
+import {parseRef, WeaveObjectRef} from '../../../../../../../../react';
 import {Icon, IconNames} from '../../../../../../../Icon';
 import {SmallRef} from '../../../../../Browse2/SmallRef';
 import {CallLink, ObjectVersionLink} from '../../../common/Links';
+import {useWFHooks} from '../../../wfReactInterface/context';
+import {ObjectVersionKey} from '../../../wfReactInterface/wfDataModelHooksInterface';
 import {
   BOX_RADIUS,
   CIRCLE_SIZE,
@@ -71,16 +73,41 @@ export const EvaluationModelLink: React.FC<{
   callId: string;
   state: EvaluationComparisonState;
 }> = props => {
+  const {useObjectVersion} = useWFHooks();
   const evaluationCall = props.state.data.evaluationCalls[props.callId];
   const modelObj = props.state.data.models[evaluationCall.modelRef];
+  const objRef = useMemo(
+    () => parseRef(modelObj.ref) as WeaveObjectRef,
+    [modelObj.ref]
+  );
+  const objVersionKey = useMemo(() => {
+    return {
+      scheme: 'weave',
+      entity: objRef.entityName,
+      project: objRef.projectName,
+      weaveKind: objRef.weaveKind,
+      objectId: objRef.artifactName,
+      versionHash: objRef.artifactVersion,
+      path: '',
+      refExtra: objRef.artifactRefExtra,
+    } as ObjectVersionKey;
+  }, [
+    objRef.artifactName,
+    objRef.artifactRefExtra,
+    objRef.artifactVersion,
+    objRef.entityName,
+    objRef.projectName,
+    objRef.weaveKind,
+  ]);
+  const objectVersion = useObjectVersion(objVersionKey);
 
   return (
     <ObjectVersionLink
       entityName={modelObj.entity}
       projectName={modelObj.project}
-      objectName={modelObj._rawModelObject.object_id}
-      version={modelObj._rawModelObject.digest}
-      versionIndex={modelObj._rawModelObject.version_index}
+      objectName={objRef.artifactName}
+      version={objRef.artifactVersion}
+      versionIndex={objectVersion.result?.versionIndex ?? 0}
       color={MOON_800}
       icon={<ModelIcon />}
     />


### PR DESCRIPTION
This PR implements some simple improvements to the loading order and grouping of the eval compare page to squeeze out some low-hanging fruit.

Current Waterfall:
<img width="891" alt="Screenshot 2024-07-18 at 00 44 54" src="https://github.com/user-attachments/assets/b6c0d2d5-377c-4347-be78-5153d818346b">

1. `/calls/stream_query`: for N evaluation calls
2. N Parallel Requests:
   * N x `/obj/read`: for unique Evaluation Objects
3. N Parallel Requests:
   * N x `/obj/read`: for unique Model Objects
4. `/obj/read`: for Baseline dataset table digest
5. `/table/query/`: for table rows data
6. `/calls/stream_query`: for all calls within the N traces

New Waterfall:
<img width="880" alt="Screenshot 2024-07-18 at 00 43 54" src="https://github.com/user-attachments/assets/030cdcce-4ce4-4050-a3f1-08b02f0b638e">

1. `/calls/stream_query`: for N evaluation calls
2. (Non Blocking) `/calls/stream_query`: for all calls within the N traces
3. `/refs/read_batch`: for N unique Evaluation Objects AND N unique Model Objects
4. `/refs/read_batch`: for Baseline dataset table digest
5. `/table/query/`: for table rows data
6. Wait for (2) - often finishes already


Above images are for Jason Case (2 Evals, 1 Model): https://app.wandb.test/jzhao/resume-bot-eval/weave/compare-evaluations?evaluationCallIds=%5B%22fecc2462-10c1-4a7b-a0b9-4e1726e5618d%22%2C%224bc16671-95b6-4044-94d4-b34417b44868%22%5D

Another: Lavanya Case (4 evals, 2 Models): https://app.wandb.test/lavanyashukla/nims_rag_2/weave/compare-evaluations?evaluationCallIds=%5B%223fd22e88-84a6-4f66-ba71-2f789d44aded%22%2C%227ca7836f-e055-42eb-94c5-1625b73af789%22%2C%221024b6c8-6707-4e61-9474-463ad424a067%22%2C%22fad0e96b-e9e3-4a84-8ce0-ad61dce5987e%22%5D

Before:
<img width="690" alt="Screenshot 2024-07-18 at 00 52 35" src="https://github.com/user-attachments/assets/a7c17aeb-39ca-4ea7-a8dc-f9c3f8152b87">

After:
<img width="682" alt="Screenshot 2024-07-18 at 00 55 18" src="https://github.com/user-attachments/assets/a809d052-3ddc-4887-9e48-266f3477a940">



