### PR TITLE
chore: Fix Compare Page "Dimension" Label Overflowing

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleFilterSection/ExampleFilterSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleFilterSection/ExampleFilterSection.tsx
@@ -310,7 +310,10 @@ const DimensionPicker: React.FC<{
   const dimensionMap = props.state.data.scoreMetrics;
 
   return (
-    <FormControl>
+    <FormControl
+      style={{
+        paddingTop: '6px',
+      }}>
       <Autocomplete
         size="small"
         disableClearable


### PR DESCRIPTION
Before
<img width="821" alt="Screenshot 2024-07-18 at 01 07 35" src="https://github.com/user-attachments/assets/7bf16fde-2304-473f-ae14-f80ce12dae03">

After
<img width="827" alt="Screenshot 2024-07-18 at 01 06 58" src="https://github.com/user-attachments/assets/4727c543-d0e2-45f3-a876-abd85c1707e1">
