### PR TITLE
fix: simplify delete error and show in modal

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OverflowMenu.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OverflowMenu.tsx
@@ -154,6 +154,16 @@ export const ConfirmDeleteModal: FC<{
       return;
     }
     setDeleteLoading(true);
+    userEvents.deleteClicked({
+      callIds: calls.map(
+        call => `${call.entity}/${call.project}/${call.callId}`
+      ),
+      numCalls: calls.length,
+      userId: userInfoLoaded?.id ?? '',
+      organizationName: orgName,
+      username: userInfoLoaded?.username ?? '',
+    });
+
     const projectGroups = makeProjectGroups(calls);
     const deletePromises: Array<Promise<void>> = [];
     Object.keys(projectGroups).forEach(projectKey => {
@@ -164,15 +174,6 @@ export const ConfirmDeleteModal: FC<{
     });
     Promise.all(deletePromises)
       .then(() => {
-        userEvents.deleteClicked({
-          callIds: calls.map(
-            call => `${call.entity}/${call.project}/${call.callId}`
-          ),
-          numCalls: calls.length,
-          userId: userInfoLoaded?.id ?? '',
-          organizationName: orgName,
-          entityName: userInfoLoaded?.username ?? '',
-        });
         setDeleteLoading(false);
         setConfirmDelete(false);
         onDeleteCallback?.();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OverflowMenu.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OverflowMenu.tsx
@@ -159,33 +159,38 @@ export const ConfirmDeleteModal: FC<{
     Object.keys(projectGroups).forEach(projectKey => {
       const [entity, project] = projectKey.split('/');
       deletePromises.push(
-        callsDelete(entity, project, projectGroups[projectKey]).catch(() => {
-          const callNames = calls.map(callDisplayName);
-          setError(`Failed to delete call(s) ${callNames.join(', ')}`);
-        })
+        callsDelete(entity, project, projectGroups[projectKey])
       );
     });
-    Promise.all(deletePromises).then(() => {
-      userEvents.deleteClicked({
-        callIds: calls.map(
-          call => `${call.entity}/${call.project}/${call.callId}`
-        ),
-        numCalls: calls.length,
-        userId: userInfoLoaded?.id ?? '',
-        organizationName: orgName,
-        entityName: userInfoLoaded?.username ?? '',
+    Promise.all(deletePromises)
+      .then(() => {
+        userEvents.deleteClicked({
+          callIds: calls.map(
+            call => `${call.entity}/${call.project}/${call.callId}`
+          ),
+          numCalls: calls.length,
+          userId: userInfoLoaded?.id ?? '',
+          organizationName: orgName,
+          entityName: userInfoLoaded?.username ?? '',
+        });
+        setDeleteLoading(false);
+        setConfirmDelete(false);
+        onDeleteCallback?.();
+        closePeek();
+      })
+      .catch(() => {
+        setError(`Error deleting call(s)`);
+        setDeleteLoading(false);
       });
-      setDeleteLoading(false);
-      setConfirmDelete(false);
-      onDeleteCallback?.();
-      closePeek();
-    });
   };
 
   return (
     <Dialog
       open={confirmDelete}
-      onClose={() => setConfirmDelete(false)}
+      onClose={() => {
+        setConfirmDelete(false);
+        setError(null);
+      }}
       maxWidth="xs"
       fullWidth>
       <DialogTitle>Delete {calls.length > 1 ? 'calls' : 'call'}</DialogTitle>
@@ -224,7 +229,10 @@ export const ConfirmDeleteModal: FC<{
         <Button
           variant="ghost"
           disabled={deleteLoading}
-          onClick={() => setConfirmDelete(false)}>
+          onClick={() => {
+            setConfirmDelete(false);
+            setError(null);
+          }}>
           Cancel
         </Button>
       </DialogActions>

--- a/weave-js/src/integrations/analytics/userEvents.ts
+++ b/weave-js/src/integrations/analytics/userEvents.ts
@@ -6,7 +6,7 @@ export const deleteClicked = makeTrackEvent<
     numCalls: number;
     userId: string;
     organizationName: string;
-    entityName: string;
+    username: string;
   },
   {
     _description: `User clicked the delete button`;
@@ -34,9 +34,9 @@ export const deleteClicked = makeTrackEvent<
       description: 'Name of organization';
       exampleValues: ['my-org'];
     };
-    entityName: {
-      description: 'Name of entity';
-      exampleValues: ['my-entity'];
+    username: {
+      description: 'Username of user deleting';
+      exampleValues: ['my-username'];
     };
   }
 >('Weave delete clicked');


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-19880

This PR: 
- simplifies the error message
- only set the error when catching from `Promise.all`
- only close the modal on successful deletion, otherwise display error
