### PR TITLE
feat: store pagination model in URL

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -9,7 +9,11 @@ import {
   Toolbar,
   Typography,
 } from '@mui/material';
-import {GridColumnVisibilityModel, GridSortModel} from '@mui/x-data-grid-pro';
+import {
+  GridColumnVisibilityModel,
+  GridPaginationModel,
+  GridSortModel,
+} from '@mui/x-data-grid-pro';
 import {LicenseInfo} from '@mui/x-license-pro';
 import {useWindowSize} from '@wandb/weave/common/hooks/useWindowSize';
 import {Loading} from '@wandb/weave/components/Loading';
@@ -53,6 +57,10 @@ import {
   WeaveflowPeekContext,
 } from './Browse3/context';
 import {FullPageButton} from './Browse3/FullPageButton';
+import {
+  DEFAULT_PAGE_SIZE,
+  getValidPaginationModel,
+} from './Browse3/grid/pagination';
 import {getValidSortModel} from './Browse3/grid/sort';
 import {BoardPage} from './Browse3/pages/BoardPage';
 import {BoardsPage} from './Browse3/pages/BoardsPage';
@@ -699,6 +707,27 @@ const CallsPageBinding = () => {
     history.push({search: newQuery.toString()});
   };
 
+  const paginationModel = useMemo(
+    () => getValidPaginationModel(query.page, query.pageSize),
+    [query.page, query.pageSize]
+  );
+  const setPaginationModel = (newModel: GridPaginationModel) => {
+    const newQuery = new URLSearchParams(location.search);
+    const {page, pageSize} = newModel;
+    // TODO: If we change page size, should we reset page to 0?
+    if (page === 0) {
+      newQuery.delete('page');
+    } else {
+      newQuery.set('page', page.toString());
+    }
+    if (pageSize === DEFAULT_PAGE_SIZE) {
+      newQuery.delete('pageSize');
+    } else {
+      newQuery.set('pageSize', pageSize.toString());
+    }
+    history.push({search: newQuery.toString()});
+  };
+
   return (
     <CallsPage
       entity={entity}
@@ -709,6 +738,8 @@ const CallsPageBinding = () => {
       setColumnVisibilityModel={setColumnVisibilityModel}
       sortModel={sortModel}
       setSortModel={setSortModel}
+      paginationModel={paginationModel}
+      setPaginationModel={setPaginationModel}
     />
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pagination.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pagination.test.ts
@@ -1,0 +1,39 @@
+import {DEFAULT_PAGE_SIZE, getValidPaginationModel} from './pagination';
+
+describe('getValidPaginationModel', () => {
+  it('parses valid query values', () => {
+    const parsed = getValidPaginationModel('0', '100');
+    expect(parsed).toEqual({
+      page: 0,
+      pageSize: 100,
+    });
+  });
+  it('handles missing page', () => {
+    const parsed = getValidPaginationModel(undefined, '50');
+    expect(parsed).toEqual({
+      page: 0,
+      pageSize: 50,
+    });
+  });
+  it('handles missing pageSize', () => {
+    const parsed = getValidPaginationModel('42', undefined);
+    expect(parsed).toEqual({
+      page: 42,
+      pageSize: DEFAULT_PAGE_SIZE,
+    });
+  });
+  it('handles invalid page', () => {
+    const parsed = getValidPaginationModel('abc', undefined);
+    expect(parsed).toEqual({
+      page: 0,
+      pageSize: DEFAULT_PAGE_SIZE,
+    });
+  });
+  it('handles invalid pageSize', () => {
+    const parsed = getValidPaginationModel('1', '-100');
+    expect(parsed).toEqual({
+      page: 1,
+      pageSize: DEFAULT_PAGE_SIZE,
+    });
+  });
+});

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pagination.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pagination.ts
@@ -1,0 +1,19 @@
+import {GridPaginationModel} from '@mui/x-data-grid-pro';
+
+const MAX_PAGE_SIZE = 100;
+export const DEFAULT_PAGE_SIZE = 100;
+
+export const getValidPaginationModel = (
+  queryPage: string | undefined,
+  queryPageSize: string | undefined
+): GridPaginationModel => {
+  let page = parseInt(queryPage ?? '', 10);
+  if (isNaN(page) || page < 0) {
+    page = 0;
+  }
+  let pageSize = parseInt(queryPageSize ?? '', 10);
+  if (isNaN(pageSize) || pageSize <= 0 || pageSize > MAX_PAGE_SIZE) {
+    pageSize = DEFAULT_PAGE_SIZE;
+  }
+  return {page, pageSize};
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -1,4 +1,8 @@
-import {GridColumnVisibilityModel, GridSortModel} from '@mui/x-data-grid-pro';
+import {
+  GridColumnVisibilityModel,
+  GridPaginationModel,
+  GridSortModel,
+} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
 import React, {FC, useMemo} from 'react';
 
@@ -35,6 +39,9 @@ export const CallsPage: FC<{
 
   sortModel: GridSortModel;
   setSortModel: (newModel: GridSortModel) => void;
+
+  paginationModel: GridPaginationModel;
+  setPaginationModel: (newModel: GridPaginationModel) => void;
 }> = props => {
   const [filter, setFilter] = useControllableState(
     props.initialFilter ?? {},
@@ -83,6 +90,8 @@ export const CallsPage: FC<{
                 setColumnVisibilityModel={props.setColumnVisibilityModel}
                 sortModel={props.sortModel}
                 setSortModel={props.setSortModel}
+                paginationModel={props.paginationModel}
+                setPaginationModel={props.setPaginationModel}
               />
             ),
           },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -45,6 +45,7 @@ import {
   useWeaveflowCurrentRouteContext,
   WeaveHeaderExtrasContext,
 } from '../../context';
+import {DEFAULT_PAGE_SIZE} from '../../grid/pagination';
 import {StyledPaper} from '../../StyledAutocomplete';
 import {SELECTED_FOR_DELETION, StyledDataGrid} from '../../StyledDataGrid';
 import {StyledTextField} from '../../StyledTextField';
@@ -86,6 +87,11 @@ export const DEFAULT_SORT_CALLS: GridSortModel = [
   {field: 'started_at', sort: 'desc'},
 ];
 
+const DEFAULT_PAGINATION_CALLS: GridPaginationModel = {
+  pageSize: DEFAULT_PAGE_SIZE,
+  page: 0,
+};
+
 export const CallsTable: FC<{
   entity: string;
   project: string;
@@ -101,6 +107,9 @@ export const CallsTable: FC<{
 
   sortModel?: GridSortModel;
   setSortModel?: (newModel: GridSortModel) => void;
+
+  paginationModel?: GridPaginationModel;
+  setPaginationModel?: (newModel: GridPaginationModel) => void;
 }> = ({
   entity,
   project,
@@ -112,6 +121,8 @@ export const CallsTable: FC<{
   setColumnVisibilityModel,
   sortModel,
   setSortModel,
+  paginationModel,
+  setPaginationModel,
 }) => {
   const {loading: loadingUserInfo, userInfo} = useViewerInfo();
   const {addExtra, removeExtra} = useContext(WeaveHeaderExtrasContext);
@@ -161,12 +172,8 @@ export const CallsTable: FC<{
   // 3. Sort
   const sortModelResolved = sortModel ?? DEFAULT_SORT_CALLS;
 
-  const defaultPageSize = 100;
   // 4. Pagination
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
-    pageSize: defaultPageSize,
-    page: 0,
-  });
+  const paginationModelResolved = paginationModel ?? DEFAULT_PAGINATION_CALLS;
 
   // 5. Expansion
   const [expandedRefCols, setExpandedRefCols] = useState<Set<string>>(
@@ -209,7 +216,7 @@ export const CallsTable: FC<{
     effectiveFilter,
     filterModel,
     sortModelResolved,
-    paginationModel,
+    paginationModelResolved,
     expandedRefCols
   );
 
@@ -604,6 +611,16 @@ export const CallsTable: FC<{
     [callsLoading, setSortModel, muiColumns]
   );
 
+  const onPaginationModelChange = useCallback(
+    (newModel: GridPaginationModel) => {
+      if (!setPaginationModel || callsLoading) {
+        return;
+      }
+      setPaginationModel(newModel);
+    },
+    [callsLoading, setPaginationModel]
+  );
+
   // CPR (Tim) - (GeneralRefactoring): Pull out different inline-properties and create them above
   return (
     <FilterLayoutTemplate
@@ -748,8 +765,8 @@ export const CallsTable: FC<{
         rowCount={callsTotal}
         paginationMode="server"
         paginationModel={paginationModel}
-        onPaginationModelChange={newModel => setPaginationModel(newModel)}
-        pageSizeOptions={[defaultPageSize]}
+        onPaginationModelChange={onPaginationModelChange}
+        pageSizeOptions={[DEFAULT_PAGE_SIZE]}
         // PAGINATION SECTION END
         rowHeight={38}
         columns={muiColumns}


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-19879

This is the same type of change as https://github.com/wandb/weave/pull/1956 but for the call grid's pagination state. This is another step towards having URLs that a user can bookmark or share.

Since the state in question is just two integers (one of which we don't let users customize today) I just store each of them in their own query parameter rather than storing a single parameter with a serialized JSON object. This makes the URL a little friendlier.