### PR TITLE
chore: Raise on Evaluation Non-Op Models

### DIFF
--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -27,6 +27,16 @@ from weave.trace.op import Op
 console = Console()
 
 
+class EvaluationArgumentError(Exception):
+    pass
+
+
+INVALID_MODEL_ERROR = (
+    "Evaluation.evaluate requires a Model or Op instance as the model argument. "
+    + "If you are using a function, wrap it with `weave.op` to create an Op instance."
+)
+
+
 def async_call(
     func: typing.Union[Callable, Op], *args: Any, **kwargs: Any
 ) -> typing.Coroutine:
@@ -263,6 +273,8 @@ class Evaluation(Object):
 
     @weave.op()
     async def evaluate(self, model: Union[Callable, Model]) -> dict:
+        if not isinstance(Op, Model) and not isinstance(model, Op):
+            raise EvaluationArgumentError(INVALID_MODEL_ERROR)
         eval_rows = []
 
         start_time = time.time()

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -273,7 +273,7 @@ class Evaluation(Object):
 
     @weave.op()
     async def evaluate(self, model: Union[Callable, Model]) -> dict:
-        if not isinstance(Op, Model) and not isinstance(model, Op):
+        if not isinstance(model, Model) and not isinstance(model, Op):
             raise EvaluationArgumentError(INVALID_MODEL_ERROR)
         eval_rows = []
 

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -32,8 +32,8 @@ class EvaluationArgumentError(Exception):
 
 
 INVALID_MODEL_ERROR = (
-    "Evaluation.evaluate requires a Model or Op instance as the model argument. "
-    + "If you are using a function, wrap it with `weave.op` to create an Op instance."
+    "`Evaluation.evaluate` requires a `Model` or `Op` instance as the `model` argument. "
+    + "If you are using a function, wrap it with `weave.op` to create an `Op` instance."
 )
 
 

--- a/weave/tests/test_evaluations.py
+++ b/weave/tests/test_evaluations.py
@@ -4,6 +4,7 @@ import pytest
 
 import weave
 from weave import Evaluation, Model
+from weave.flow.eval import EvaluationArgumentError
 
 from ..trace_server import trace_server_interface as tsi
 
@@ -524,23 +525,25 @@ async def test_eval_supports_non_op_funcs(client):
         scorers=[function_score],
     )
 
-    res = await evaluation.evaluate(function_model)
+    with pytest.raises(EvaluationArgumentError):
+        res = await evaluation.evaluate(function_model)
 
-    assert res["function_score"] == {"correct": {"true_count": 0, "true_fraction": 0.0}}
+    # In the future, if we want to auto-opify, then uncomment the following assertions:
+    # assert res["function_score"] == {"correct": {"true_count": 0, "true_fraction": 0.0}}
 
-    calls = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client._project_id(),
-        )
-    )
-    assert len(calls.calls) == 4
-    shouldBeEvalRef = calls.calls[0].inputs["self"]
-    assert shouldBeEvalRef.startswith("weave:///")
-    gottenEval = weave.ref(shouldBeEvalRef).get()
+    # calls = client.server.calls_query(
+    #     tsi.CallsQueryReq(
+    #         project_id=client._project_id(),
+    #     )
+    # )
+    # assert len(calls.calls) == 4
+    # shouldBeEvalRef = calls.calls[0].inputs["self"]
+    # assert shouldBeEvalRef.startswith("weave:///")
+    # gottenEval = weave.ref(shouldBeEvalRef).get()
 
-    # 1: Assert that the scorer was correctly oped
-    gottenEval.scorers[0].ref.name == "function_score"
-    shouldBeModelRef = calls.calls[0].inputs["model"]
+    # # 1: Assert that the scorer was correctly oped
+    # gottenEval.scorers[0].ref.name == "function_score"
+    # shouldBeModelRef = calls.calls[0].inputs["model"]
 
-    # 2: Assert that the model was correctly oped
-    assert shouldBeModelRef.startswith("weave:///")
+    # # 2: Assert that the model was correctly oped
+    # assert shouldBeModelRef.startswith("weave:///")


### PR DESCRIPTION
At some point in our past we auto-oped the model passed to Evaluation.evaluate. However, probably for good reason, we stopped such a practice. This PR implements a check to verify such cases and inform the user on how to proceed. A test is provided as well. In the case we want to loosen this requirement, the test for that is available too.