### PR TITLE
fix: incorrect use of ?? in call tree

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -443,7 +443,8 @@ export const useCallFlattenedTraceTree = (
     }
 
     if (parentCall) {
-      const siblingCount = childCallLookup[parentCall.callId]?.length - 1 ?? 0;
+      const childrenOfParent = childCallLookup[parentCall.callId];
+      const siblingCount = childrenOfParent ? childrenOfParent.length - 1 : 0;
       if (siblingCount) {
         rows.push({
           id: 'HIDDEN_SIBLING_COUNT',


### PR DESCRIPTION
Fixes this warning seen on startup

```
│[app.wandb] 1:33:58 PM [vite] warning: The "??" operator here will always return the left operand                                                                                             
│[app.wandb] 334|      }                                                                                                                                                                       
│[app.wandb] 335|      if (parentCall) {                                                                                                                                                       
│[app.wandb] 336|        const siblingCount = childCallLookup[parentCall.callId]?.length - 1 ?? 0;                                                                                             
│[app.wandb]    |                                                                            ^                                                                                                 
│[app.wandb] 337|        if (siblingCount) {                                                                                                                                                   
│[app.wandb] 338|          rows.push({                                                                                                                                                         
│[app.wandb]                                                                                                                                                                                   
│[app.wandb]   Plugin: vite:esbuild                                                                                                                                                            
│[app.wandb]   File: /Users/jamie/source/wandb/core/services/weave-python/weave-public/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx               

```