### PR TITLE
chore: Fixes  int/ext conversion logic before pickup in prod

### DIFF
--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -172,7 +172,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         if req.wb_user_id is not None:
-            req.wb_user_id = self._idc.int_to_ext_user_id(req.wb_user_id)
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
         return self._ref_apply(self._internal_trace_server.calls_delete, req)
 
     def calls_query_stats(self, req: tsi.CallsQueryStatsReq) -> tsi.CallsQueryStatsRes:
@@ -195,7 +195,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
     def call_update(self, req: tsi.CallUpdateReq) -> tsi.CallUpdateRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         if req.wb_user_id is not None:
-            req.wb_user_id = self._idc.int_to_ext_user_id(req.wb_user_id)
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
         return self._ref_apply(self._internal_trace_server.call_update, req)
 
     def op_create(self, req: tsi.OpCreateReq) -> tsi.OpCreateRes:

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -41,6 +41,15 @@ B = TypeVar("B")
 
 
 class ExternalTraceServer(tsi.TraceServerInterface):
+    """Used to adapt the internal trace server to the external trace server.
+    This is done by converting the project_id, run_id, and user_id to their
+    internal representations before calling the internal trace server and
+    converting them back to their external representations before returning
+    them to the caller. Additionally, we convert references to their internal
+    representations before calling the internal trace server and convert them
+    back to their external representations before returning them to the caller.
+    """
+
     _internal_trace_server: tsi.TraceServerInterface
     _idc: IdConverter
 


### PR DESCRIPTION
I am working on uptaking the generalized converter in the prod server and my testing highlighted these issues.

Fixes: query_stream and query_stats user conversion

