### PR TITLE
chore: Fix evaluation serialization in notebooks

### DIFF
--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -27,10 +27,6 @@ from weave.trace.op import Op
 console = Console()
 
 
-class EvaluationArgumentError(Exception):
-    pass
-
-
 INVALID_MODEL_ERROR = (
     "`Evaluation.evaluate` requires a `Model` or `Op` instance as the `model` argument. "
     + "If you are using a function, wrap it with `weave.op` to create an `Op` instance."
@@ -274,7 +270,7 @@ class Evaluation(Object):
     @weave.op()
     async def evaluate(self, model: Union[Callable, Model]) -> dict:
         if not isinstance(model, Model) and not isinstance(model, Op):
-            raise EvaluationArgumentError(INVALID_MODEL_ERROR)
+            raise ValueError(INVALID_MODEL_ERROR)
         eval_rows = []
 
         start_time = time.time()

--- a/weave/tests/test_evaluations.py
+++ b/weave/tests/test_evaluations.py
@@ -4,7 +4,6 @@ import pytest
 
 import weave
 from weave import Evaluation, Model
-from weave.flow.eval import EvaluationArgumentError
 
 from ..trace_server import trace_server_interface as tsi
 
@@ -525,7 +524,7 @@ async def test_eval_supports_non_op_funcs(client):
         scorers=[function_score],
     )
 
-    with pytest.raises(EvaluationArgumentError):
+    with pytest.raises(ValueError):
         res = await evaluation.evaluate(function_model)
 
     # In the future, if we want to auto-opify, then uncomment the following assertions:


### PR DESCRIPTION
For some reason op serialization was not happy with the custom exception. Should solve correctly, but for now this works