### PR TITLE
chore: Hides `attributes.weave` from the calls table

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -55,6 +55,8 @@ import {
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {allOperators} from './callsTableQuery';
 
+const HIDDEN_DYNAMIC_COLUMN_PREFIXES = ['summary.usage', 'attributes.weave'];
+
 export const useCallsTableColumns = (
   entity: string,
   project: string,
@@ -181,7 +183,7 @@ function buildCallsTableColumns(
 } {
   // Filters summary.usage. because we add a derived column for tokens and cost
   const filteredDynamicColumnNames = allDynamicColumnNames.filter(
-    c => !c.startsWith('summary.usage.')
+    c => !HIDDEN_DYNAMIC_COLUMN_PREFIXES.some(p => c.startsWith(p + '.'))
   );
 
   const cols: Array<GridColDef<TraceCallSchema>> = [


### PR DESCRIPTION
We recently added system info to the call payload - but it was taking up the most important real-estate!

Before:
<img width="2056" alt="Screenshot 2024-07-19 at 15 13 05" src="https://github.com/user-attachments/assets/9e1fc410-eeb8-4e55-a8eb-e49cc1d242e2">

After:
<img width="2056" alt="Screenshot 2024-07-19 at 15 10 33" src="https://github.com/user-attachments/assets/16e86a7c-ea4b-439f-81cc-1b412f843e39">
