### PR TITLE
fix: catch stopIteration when call doesn't exist in CallRead

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -198,7 +198,7 @@ const useCall = (key: CallKey | null): Loadable<CallSchema | null> => {
       };
     }
     const result =
-      callRes && 'call' in callRes
+      callRes && 'call' in callRes && callRes.call
         ? traceCallToUICallSchema(callRes.call)
         : null;
     if (callRes == null || loadingRef.current) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -198,7 +198,7 @@ const useCall = (key: CallKey | null): Loadable<CallSchema | null> => {
       };
     }
     const result =
-      callRes && 'call' in callRes && callRes.call
+      callRes && 'call' in callRes
         ? traceCallToUICallSchema(callRes.call)
         : null;
     if (callRes == null || loadingRef.current) {

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -202,6 +202,17 @@ def test_trace_server_call_start_and_end(client):
     }
 
 
+def test_call_read_not_found(client):
+    call_id = generate_id()
+    res = client.server.call_read(
+        tsi.CallReadReq(
+            project_id=client._project_id(),
+            id=call_id,
+        )
+    )
+    assert res.call is None
+
+
 def test_graph_call_ordering(client):
     @weave.op()
     def my_op(a: int) -> int:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -729,9 +729,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         ) -> typing.Any:
             conds = []
             parameters = {}
-            refs_by_project_id: dict[
-                str, list[refs_internal.InternalObjectRef]
-            ] = defaultdict(list)
+            refs_by_project_id: dict[str, list[refs_internal.InternalObjectRef]] = (
+                defaultdict(list)
+            )
             for ref in refs:
                 refs_by_project_id[ref.project_id].append(ref)
             for project_id, project_refs in refs_by_project_id.items():

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -309,7 +309,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 limit=1,
             )
         )
-        return tsi.CallReadRes(call=next(res))
+        try:
+            _call = next(res)
+        except StopIteration:
+            _call = None
+        return tsi.CallReadRes(call=_call)
 
     def calls_query(self, req: tsi.CallsQueryReq) -> tsi.CallsQueryRes:
         stream = self.calls_query_stream(req)
@@ -725,9 +729,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         ) -> typing.Any:
             conds = []
             parameters = {}
-            refs_by_project_id: dict[str, list[refs_internal.InternalObjectRef]] = (
-                defaultdict(list)
-            )
+            refs_by_project_id: dict[
+                str, list[refs_internal.InternalObjectRef]
+            ] = defaultdict(list)
             for ref in refs:
                 refs_by_project_id[ref.project_id].append(ref)
             for project_id, project_refs in refs_by_project_id.items():

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -113,6 +113,8 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         original_project_id = req.project_id
         req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         res = self._ref_apply(self._internal_trace_server.call_read, req)
+        if res.call is None:
+            return tsi.CallReadRes(call=None)
         if res.call.project_id != req.project_id:
             raise ValueError("Internal Error - Project Mismatch")
         res.call.project_id = original_project_id

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -114,7 +114,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         res = self._ref_apply(self._internal_trace_server.call_read, req)
         if res.call is None:
-            return tsi.CallReadRes(call=None)
+            return res
         if res.call.project_id != req.project_id:
             raise ValueError("Internal Error - Project Mismatch")
         res.call.project_id = original_project_id

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -235,15 +235,14 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         return tsi.CallEndRes()
 
     def call_read(self, req: tsi.CallReadReq) -> tsi.CallReadRes:
-        return tsi.CallReadRes(
-            call=self.calls_query(
-                tsi.CallsQueryReq(
-                    project_id=req.project_id,
-                    limit=1,
-                    filter=tsi._CallsFilter(call_ids=[req.id]),
-                )
-            ).calls[0]
-        )
+        calls = self.calls_query(
+            tsi.CallsQueryReq(
+                project_id=req.project_id,
+                limit=1,
+                filter=tsi._CallsFilter(call_ids=[req.id]),
+            )
+        ).calls
+        return tsi.CallReadRes(call=calls[0] if calls else None)
 
     def calls_query(self, req: tsi.CallsQueryReq) -> tsi.CallsQueryRes:
         print("REQ", req)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -146,7 +146,7 @@ class CallReadReq(BaseModel):
 
 
 class CallReadRes(BaseModel):
-    call: CallSchema
+    call: typing.Optional[CallSchema]
 
 
 class CallsDeleteReq(BaseModel):


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-19932

This pr: 
- now allows for returning an empty Call in `CallReadRes`
- catch `StopIteration` to prevent returning 500s when the call ID doesn't exist

Test w/o change: 
<img width="755" alt="Screenshot 2024-07-19 at 4 09 31 PM" src="https://github.com/user-attachments/assets/1b90d9a7-0bdf-4299-9480-e4e1af355b17">
