### PR TITLE
chore: callres.call can now be none

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -198,10 +198,10 @@ const useCall = (key: CallKey | null): Loadable<CallSchema | null> => {
       };
     }
     const result =
-      callRes && 'call' in callRes
+      callRes && 'call' in callRes && callRes.call
         ? traceCallToUICallSchema(callRes.call)
         : null;
-    if (loadingRef.current) {
+    if (callRes == null || loadingRef.current) {
       return {
         loading: true,
         result: null,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -201,7 +201,7 @@ const useCall = (key: CallKey | null): Loadable<CallSchema | null> => {
       callRes && 'call' in callRes
         ? traceCallToUICallSchema(callRes.call)
         : null;
-    if (callRes == null || loadingRef.current) {
+    if (loadingRef.current) {
       return {
         loading: true,
         result: null,


### PR DESCRIPTION
depends on: https://github.com/wandb/weave/pull/1991

brings back this beauty:
<img width="1147" alt="Screenshot 2024-07-19 at 4 21 05 PM" src="https://github.com/user-attachments/assets/4dfdb9e1-c27c-4739-9faa-042918e51997">
