### PR TITLE
chore: make attributes hidden but available

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -66,7 +66,10 @@ import {BoardPage} from './Browse3/pages/BoardPage';
 import {BoardsPage} from './Browse3/pages/BoardsPage';
 import {CallPage} from './Browse3/pages/CallPage/CallPage';
 import {CallsPage} from './Browse3/pages/CallsPage/CallsPage';
-import {DEFAULT_SORT_CALLS} from './Browse3/pages/CallsPage/CallsTable';
+import {
+  DEFAULT_COLUMN_VISIBILITY_CALLS,
+  DEFAULT_SORT_CALLS,
+} from './Browse3/pages/CallsPage/CallsTable';
 import {Empty} from './Browse3/pages/common/Empty';
 import {EMPTY_NO_TRACE_SERVER} from './Browse3/pages/common/EmptyContent';
 import {SimplePageLayoutContext} from './Browse3/pages/common/SimplePageLayout';
@@ -684,7 +687,7 @@ const CallsPageBinding = () => {
     try {
       return JSON.parse(query.cols);
     } catch (e) {
-      return {};
+      return DEFAULT_COLUMN_VISIBILITY_CALLS;
     }
   }, [query.cols]);
   const setColumnVisibilityModel = (newModel: GridColumnVisibilityModel) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -83,6 +83,15 @@ const OP_FILTER_GROUP_HEADER = 'Op';
 const MAX_EVAL_COMPARISONS = 5;
 const MAX_BULK_DELETE = 10;
 
+export const DEFAULT_COLUMN_VISIBILITY_CALLS = {
+  'attributes.weave.client_version': false,
+  'attributes.weave.source': false,
+  'attributes.weave.os_name': false,
+  'attributes.weave.os_version': false,
+  'attributes.weave.os_release': false,
+  'attributes.weave.sys_version': false,
+};
+
 export const DEFAULT_SORT_CALLS: GridSortModel = [
   {field: 'started_at', sort: 'desc'},
 ];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -55,7 +55,7 @@ import {
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {allOperators} from './callsTableQuery';
 
-const HIDDEN_DYNAMIC_COLUMN_PREFIXES = ['summary.usage', 'attributes.weave'];
+const HIDDEN_DYNAMIC_COLUMN_PREFIXES = ['summary.usage'];
 
 export const useCallsTableColumns = (
   entity: string,


### PR DESCRIPTION
Alternate approach to https://github.com/wandb/weave/pull/1988 - instead of removing the columns we make them available but hidden by default.

<img width="450" alt="Screenshot 2024-07-19 at 7 27 11 PM" src="https://github.com/user-attachments/assets/18690e15-4022-4484-b97a-8a7cb88f1bdf">
