### PR TITLE
chore: print out op url instead of object when OpRef

### DIFF
--- a/weave/api.py
+++ b/weave/api.py
@@ -1,5 +1,4 @@
-"""These are the top-level functions in the `import weave` namespace.
-"""
+"""These are the top-level functions in the `import weave` namespace."""
 
 import time
 import typing
@@ -212,24 +211,23 @@ def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.Object
 
     ref = client._save_object(obj, save_name, "latest")
 
-    if not isinstance(ref, _weave_client.ObjectRef):
-        return ref
-
-    if isinstance(ref, _weave_client.OpRef):
-        url = urls.op_version_path(
-            ref.entity,
-            ref.project,
-            ref.name,
-            ref.digest,
-        )
-    else:
-        url = urls.object_version_path(
-            ref.entity,
-            ref.project,
-            ref.name,
-            ref.digest,
-        )
-    print(f"{TRACE_OBJECT_EMOJI} Published to {url}")
+    if isinstance(ref, _weave_client.ObjectRef):
+        if isinstance(ref, _weave_client.OpRef):
+            url = urls.op_version_path(
+                ref.entity,
+                ref.project,
+                ref.name,
+                ref.digest,
+            )
+        else:
+            url = urls.object_version_path(
+                ref.entity,
+                ref.project,
+                ref.name,
+                ref.digest,
+            )
+        print(f"{TRACE_OBJECT_EMOJI} Published to {url}")
+    return ref
 
 
 def ref(location: str) -> _weave_client.ObjectRef:
@@ -346,7 +344,6 @@ def serve(
     if _util.is_notebook():
         thread = True
     if thread:
-
         t = threading.Thread(target=run, daemon=True)
         t.start()
         time.sleep(1)

--- a/weave/api.py
+++ b/weave/api.py
@@ -212,16 +212,24 @@ def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.Object
 
     ref = client._save_object(obj, save_name, "latest")
 
-    if isinstance(ref, _weave_client.ObjectRef):
+    if not isinstance(ref, _weave_client.ObjectRef):
+        return ref
+
+    if isinstance(ref, _weave_client.OpRef):
+        url = urls.op_version_path(
+            ref.entity,
+            ref.project,
+            ref.name,
+            ref.digest,
+        )
+    else:
         url = urls.object_version_path(
             ref.entity,
             ref.project,
             ref.name,
             ref.digest,
         )
-        print(f"{TRACE_OBJECT_EMOJI} Published to {url}")
-
-    return ref
+    print(f"{TRACE_OBJECT_EMOJI} Published to {url}")
 
 
 def ref(location: str) -> _weave_client.ObjectRef:

--- a/weave/api.py
+++ b/weave/api.py
@@ -219,6 +219,8 @@ def publish(obj: typing.Any, name: Optional[str] = None) -> _weave_client.Object
                 ref.name,
                 ref.digest,
             )
+        # TODO(gst): once frontend has direct dataset/model links
+        # elif isinstance(obj, _weave_client.Dataset):
         else:
             url = urls.object_version_path(
                 ref.entity,


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-19852

This pr: 
- inspects `objectRef` on publish, if `OpRef`, uses the Op link. 

Before: 
```bash
📦 Published to https://wandb.ai/griffin_wb/project1/weave/objects/func/versions/dEqDuj2UrumkzuLVUyYbE40jWRvwjLJ28v9KbRXYWok
```

This PR:
```bash
📦 Published to https://wandb.ai/griffin_wb/project1/weave/ops/func/versions/dEqDuj2UrumkzuLVUyYbE40jWRvwjLJ28v9KbRXYWok
```