### PR TITLE
fix: ModuleNotFoundError raised by calling weave in CLI

### DIFF
--- a/weave/deploy/gcp/__init__.py
+++ b/weave/deploy/gcp/__init__.py
@@ -8,7 +8,7 @@ import typing
 from pathlib import Path
 
 from weave import __version__, environment
-from weave.artifact_wandb import WeaveWBArtifactURI as WeaveWBArtifactURI
+from weave.legacy.artifact_wandb import WeaveWBArtifactURI as WeaveWBArtifactURI
 from weave.trace.refs import ObjectRef, parse_uri
 
 from ..util import execute, safe_name


### PR DESCRIPTION
## Error
When I calling weave in CLI, below erroro occured.
```
$ weave 
```
```
Traceback (most recent call last):
  File ".../bin/weave", line 5, in <module>
    from weave.cli import cli
  File .../weave/weave/cli.py", line 10, in <module>
    from .deploy import gcp as google
  File ".../weave/weave/deploy/gcp/__init__.py", line 11, in <module>
    from weave.artifact_wandb import WeaveWBArtifactURI as WeaveWBArtifactURI
ModuleNotFoundError: No module named 'weave.artifact_wandb'
```

Changed `weave.artifact_wandb` to `weave.legacy.artifact_wandb`.