### PR TITLE
chore: add a basic test for CLI

### DIFF
--- a/weave/tests/test_cli.py
+++ b/weave/tests/test_cli.py
@@ -1,0 +1,11 @@
+from click.testing import CliRunner
+
+from weave.cli import cli
+from weave.version import VERSION
+
+
+def test_version():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert result.output == f"cli, version {VERSION}\n"


### PR DESCRIPTION
Adds a basic test for the Weave CLI (to catch the issue seen in https://github.com/wandb/weave/pull/2001)