### PR TITLE
chore: Add table update methods

### DIFF
--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -93,16 +93,16 @@ def test_table_update(client):
         assert row.val["val"] == data[i]["val"]
 
     table_create_res = client.server.table_update(
-        tsi.TableUpdateReq(
-            project_id=client._project_id(),
-            base_digest=table_create_res.digest,
-            insert_rows=[
-                (1, {"val": 4}),
-            ],
-            pop_digests=[table_query_res.rows[0].digest],
-            append_rows=[
-                {"val": 5},
-            ],
+        tsi.TableUpdateReq.model_validate(
+            dict(
+                project_id=client._project_id(),
+                base_digest=table_create_res.digest,
+                updates=[
+                    {"insert": {"index": 1, "row": {"val": 4}}},
+                    {"pop": {"index": 0}},
+                    {"append": {"row": {"val": 5}}},
+                ],
+            )
         )
     )
     final_data = [*data]

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -95,7 +95,7 @@ def test_table_update(client):
     table_create_res = client.server.table_update(
         tsi.TableUpdateReq(
             project_id=client._project_id(),
-            initial_digest=table_create_res.digest,
+            base_digest=table_create_res.digest,
             insert_rows=[
                 (1, {"val": 4}),
             ],

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -635,67 +635,58 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         if len(row_digest_result_query.result_rows) == 0:
             raise NotFoundError(f"Table {req.project_id}:{req.base_digest} not found")
 
-        row_digests: list[typing.Optional[str]] = row_digest_result_query.result_rows[
-            0
-        ][2]
-        insert_rows = []
+        final_row_digests: list[str] = row_digest_result_query.result_rows[0][2]
+        new_rows_needed_to_insert = []
+        known_digests = set(final_row_digests)
 
-        def add_insert_row(row_data: typing.Any) -> str:
+        def add_new_row_needed_to_insert(row_data: typing.Any) -> str:
             if not isinstance(row_data, dict):
-                raise ValueError(
-                    f"""Validation Error: Encountered a non-dictionary row when creating a table. Please ensure that all rows are dictionaries. Violating row:\n{row_data}."""
-                )
+                raise ValueError("All rows must be dictionaries")
             row_json = json.dumps(row_data)
             row_digest = str_digest(row_json)
-            insert_rows.append(
-                (
-                    req.project_id,
-                    row_digest,
-                    extract_refs_from_values(row_data),
-                    row_json,
+            if row_digest not in known_digests:
+                new_rows_needed_to_insert.append(
+                    (
+                        req.project_id,
+                        row_digest,
+                        extract_refs_from_values(row_data),
+                        row_json,
+                    )
                 )
-            )
+                known_digests.add(row_digest)
             return row_digest
 
-        # First, go through and replace popped digests with None
-        # Note: we do this first because we want the indexes referenced
-        # by the insert_rows to be correct, but not have the pop delete
-        # an insert. This allows for swapping a position
-        if req.pop_digests:
-            pop_digest_set = set(req.pop_digests)
-            for i, row_digest in enumerate(row_digests):
-                if row_digest in pop_digest_set:
-                    row_digests[i] = None
+        for update in req.updates:
+            if isinstance(update, tsi.TableAppendSpec):
+                new_digest = add_new_row_needed_to_insert(update.row)
+                final_row_digests.append(new_digest)
+            elif isinstance(update, tsi.TablePopSpec):
+                if update.index >= len(final_row_digests) or update.index < 0:
+                    raise ValueError("Index out of range")
+                final_row_digests.pop(update.index)
+            elif isinstance(update, tsi.TableInsertSpec):
+                if update.index > len(final_row_digests) or update.index < 0:
+                    raise ValueError("Index out of range")
+                new_digest = add_new_row_needed_to_insert(update.row)
+                final_row_digests.insert(update.index, new_digest)
+            else:
+                raise ValueError("Unrecognized update", update)
 
-        # Next, insert new rows
-        if req.insert_rows:
-            for ndx, row_data in req.insert_rows:
-                row_digest = add_insert_row(row_data)
-                row_digests.insert(ndx, row_digest)
-
-        # Append any rows
-        if req.append_rows:
-            for row_data in req.append_rows:
-                row_digest = add_insert_row(row_data)
-                row_digests.append(row_digest)
-
-        # Remove any None values
-        row_digests_final: list[str] = [r for r in row_digests if r is not None]
-
-        self._insert(
-            "table_rows",
-            data=insert_rows,
-            column_names=["project_id", "digest", "refs", "val_dump"],
-        )
+        if new_rows_needed_to_insert:
+            self._insert(
+                "table_rows",
+                data=new_rows_needed_to_insert,
+                column_names=["project_id", "digest", "refs", "val_dump"],
+            )
 
         table_hasher = hashlib.sha256()
-        for row_digest in row_digests_final:
+        for row_digest in final_row_digests:
             table_hasher.update(row_digest.encode())
         digest = table_hasher.hexdigest()
 
         self._insert(
             "tables",
-            data=[(req.project_id, digest, row_digests_final)],
+            data=[(req.project_id, digest, final_row_digests)],
             column_names=["project_id", "digest", "row_digests"],
         )
         return tsi.TableCreateRes(digest=digest)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -658,17 +658,20 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
         for update in req.updates:
             if isinstance(update, tsi.TableAppendSpec):
-                new_digest = add_new_row_needed_to_insert(update.row)
+                new_digest = add_new_row_needed_to_insert(update.append.row)
                 final_row_digests.append(new_digest)
             elif isinstance(update, tsi.TablePopSpec):
-                if update.index >= len(final_row_digests) or update.index < 0:
+                if update.pop.index >= len(final_row_digests) or update.pop.index < 0:
                     raise ValueError("Index out of range")
-                final_row_digests.pop(update.index)
+                final_row_digests.pop(update.pop.index)
             elif isinstance(update, tsi.TableInsertSpec):
-                if update.index > len(final_row_digests) or update.index < 0:
+                if (
+                    update.insert.index > len(final_row_digests)
+                    or update.insert.index < 0
+                ):
                     raise ValueError("Index out of range")
-                new_digest = add_new_row_needed_to_insert(update.row)
-                final_row_digests.insert(update.index, new_digest)
+                new_digest = add_new_row_needed_to_insert(update.insert.row)
+                final_row_digests.insert(update.insert.index, new_digest)
             else:
                 raise ValueError("Unrecognized update", update)
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -611,6 +611,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         )
         return tsi.TableCreateRes(digest=digest)
 
+    def table_update(self, req: tsi.TableUpdateReq) -> tsi.TableUpdateRes:
+        raise NotImplementedError()
+
     def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
         conds = []
         parameters = {}

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -628,14 +628,12 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             query,
             parameters={
                 "project_id": req.project_id,
-                "digest": req.initial_digest,
+                "digest": req.base_digest,
             },
         )
 
         if len(row_digest_result_query.result_rows) == 0:
-            raise NotFoundError(
-                f"Table {req.project_id}:{req.initial_digest} not found"
-            )
+            raise NotFoundError(f"Table {req.project_id}:{req.base_digest} not found")
 
         row_digests: list[typing.Optional[str]] = row_digest_result_query.result_rows[
             0

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -259,6 +259,10 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         req.table.project_id = self._idc.ext_to_int_project_id(req.table.project_id)
         return self._ref_apply(self._internal_trace_server.table_create, req)
 
+    def table_update(self, req: tsi.TableUpdateReq) -> tsi.TableUpdateRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.table_update, req)
+
     def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.table_query, req)

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -363,6 +363,11 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/table/create", req, tsi.TableCreateReq, tsi.TableCreateRes
         )
 
+    def table_update(self, req: tsi.TableUpdateReq) -> tsi.TableUpdateRes:
+        return self._generic_request(
+            "/table/update", req, tsi.TableCreateReq, tsi.TableCreateRes
+        )
+
     def table_query(
         self, req: t.Union[tsi.TableQueryReq, t.Dict[str, t.Any]]
     ) -> tsi.TableQueryRes:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -680,17 +680,20 @@ class SqliteTraceServer(tsi.TraceServerInterface):
 
         for update in req.updates:
             if isinstance(update, tsi.TableAppendSpec):
-                new_digest = add_new_row_needed_to_insert(update.row)
+                new_digest = add_new_row_needed_to_insert(update.append.row)
                 final_row_digests.append(new_digest)
             elif isinstance(update, tsi.TablePopSpec):
-                if update.index >= len(final_row_digests) or update.index < 0:
+                if update.pop.index >= len(final_row_digests) or update.pop.index < 0:
                     raise ValueError("Index out of range")
-                final_row_digests.pop(update.index)
+                final_row_digests.pop(update.pop.index)
             elif isinstance(update, tsi.TableInsertSpec):
-                if update.index > len(final_row_digests) or update.index < 0:
+                if (
+                    update.insert.index > len(final_row_digests)
+                    or update.insert.index < 0
+                ):
                     raise ValueError("Index out of range")
-                new_digest = add_new_row_needed_to_insert(update.row)
-                final_row_digests.insert(update.index, new_digest)
+                new_digest = add_new_row_needed_to_insert(update.insert.row)
+                final_row_digests.insert(update.insert.index, new_digest)
             else:
                 raise ValueError("Unrecognized update", update)
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -647,6 +647,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
 
         return tsi.TableCreateRes(digest=digest)
 
+    def table_update(self, req: tsi.TableUpdateReq) -> tsi.TableUpdateRes:
+        raise NotImplementedError()
+
     def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
         conds = []
         if req.filter:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -292,14 +292,87 @@ class TableCreateReq(BaseModel):
     table: TableSchemaForInsert
 
 
+"""
+The `TableUpdateSpec` pattern is as follows, where `OPERATION` is globally unique. This
+follows a similar pattern as our `Query` definitions.
+
+```
+class Table[OPERATION]SpecPayload(BaseModel):
+    ... # Payload for the operation
+
+
+class Table[OPERATION]Spec(BaseModel):
+    [OPERATION]: Table[OPERATION]SpecInner
+```
+
+Fundamentally, this allows us to 
+easily distinguish different operation types over the wire, and is quite readable. 
+Consider the payload:
+
+```
+{
+    updates: [
+        {append: {row: ROW_DATA}},
+        {pop: {index: POP_INDEX}},
+        {insert: {index: INSERT_INDEX, row: ROW_DATA}},
+    ]
+}
+```
+
+Consider that if we did not have this nesting, we would have:
+{
+    updates: [
+        {row: ROW_DATA},
+        {index: POP_INDEX},
+        {index: INSERT_INDEX, row: ROW_DATA},
+    ]
+}
+
+Which would require parsing the keys to make a heuristic "guess" as to what operation each entry is. 
+This is unacceptably fragile. An alternative is to include a "update_type" literal. This would certainly work,
+but stylistically, I prefer the former as it requires fewer JSON characters and is nicer for Pydantic to parse.
+{
+    updates: [
+        {update_type: 'append', row: ROW_DATA},
+        {update_type: 'pop', index: POP_INDEX},
+        {update_type: 'insert', index: INSERT_INDEX, row: ROW_DATA},
+    ]
+}
+"""
+
+
+class TableAppendSpecPayload(BaseModel):
+    row: dict[str, typing.Any]
+
+
+class TableAppendSpec(BaseModel):
+    append: TableAppendSpecPayload
+
+
+class TablePopSpecPayload(BaseModel):
+    index: int
+
+
+class TablePopSpec(BaseModel):
+    pop: TablePopSpecPayload
+
+
+class TableInsertSpecPayload(BaseModel):
+    index: int
+    row: dict[str, typing.Any]
+
+
+class TableInsertSpec(BaseModel):
+    insert: TableInsertSpecPayload
+
+
+TableUpdateSpec = typing.Union[TableAppendSpec, TablePopSpec, TableInsertSpec]
+
+
 class TableUpdateReq(BaseModel):
     project_id: str
-    initial_digest: str
-    # insertions performed before popping so that it is easier for
-    # caller to know the index of insertion
-    insert_rows: typing.Optional[list[tuple[int, dict[str, typing.Any]]]] = None
-    pop_digests: typing.Optional[list[str]] = None
-    append_rows: typing.Optional[list[dict[str, typing.Any]]] = None
+    base_digest: str
+    updates: list[TableUpdateSpec]
 
 
 class TableUpdateRes(BaseModel):
@@ -313,6 +386,7 @@ class TableRowSchema(BaseModel):
 
 class TableCreateRes(BaseModel):
     digest: str
+    # TODO: Add Row Digests
 
 
 class _TableRowFilter(BaseModel):

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -120,7 +120,7 @@ class ObjSchemaForInsert(BaseModel):
 
 class TableSchemaForInsert(BaseModel):
     project_id: str
-    rows: list[typing.Any]
+    rows: list[dict[str, typing.Any]]
 
 
 class CallStartReq(BaseModel):
@@ -290,6 +290,20 @@ class ObjQueryRes(BaseModel):
 
 class TableCreateReq(BaseModel):
     table: TableSchemaForInsert
+
+
+class TableUpdateReq(BaseModel):
+    project_id: str
+    initial_digest: str
+    # insertions performed before popping so that it is easier for
+    # caller to know the index of insertion
+    insert_rows: typing.Optional[list[tuple[int, dict[str, typing.Any]]]] = None
+    pop_digests: typing.Optional[list[str]] = None
+    append_rows: typing.Optional[list[dict[str, typing.Any]]] = None
+
+
+class TableUpdateRes(BaseModel):
+    digest: str
 
 
 class TableRowSchema(BaseModel):
@@ -476,6 +490,10 @@ class TraceServerInterface:
 
     @abc.abstractmethod
     def table_create(self, req: TableCreateReq) -> TableCreateRes:
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def table_update(self, req: TableUpdateReq) -> TableUpdateRes:
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -305,8 +305,8 @@ class Table[OPERATION]Spec(BaseModel):
     [OPERATION]: Table[OPERATION]SpecInner
 ```
 
-Fundamentally, this allows us to 
-easily distinguish different operation types over the wire, and is quite readable. 
+Fundamentally, this allows us to easily distinguish different operation types
+over the wire, and is quite readable.
 Consider the payload:
 
 ```
@@ -328,9 +328,11 @@ Consider that if we did not have this nesting, we would have:
     ]
 }
 
-Which would require parsing the keys to make a heuristic "guess" as to what operation each entry is. 
-This is unacceptably fragile. An alternative is to include a "update_type" literal. This would certainly work,
-but stylistically, I prefer the former as it requires fewer JSON characters and is nicer for Pydantic to parse.
+Which would require parsing the keys to make a heuristic "guess" as to what
+operation each entry is. This is unacceptably fragile. An alternative is to
+include a "update_type" literal. This would certainly work, but stylistically, I
+prefer the former as it requires fewer JSON characters and is nicer for Pydantic
+to parse.
 {
     updates: [
         {update_type: 'append', row: ROW_DATA},

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -388,7 +388,6 @@ class TableRowSchema(BaseModel):
 
 class TableCreateRes(BaseModel):
     digest: str
-    # TODO: Add Row Digests
 
 
 class _TableRowFilter(BaseModel):


### PR DESCRIPTION
This PR introduces a new method / endpoint to our universal interface that allows users to update Table rows via the API: `table_update(self, req: TableUpdateReq) -> TableUpdateRes`.

I was originally motivated for performance / bug reasons (see discussion below), but this is actually an important API for some other features on the horizon, namely:
1. Python SDK Dataset Mutations
2. UI Client Dataset Mutations (think "Add to Dataset")

Ok, now onto the original motivating factor:

Evaluations with large datasets / model predictions fail when getting to the summary step. This is because the input to summary is some multiple of the dataset size, often blowing the limit we have set for our servers. As a practical workaround, we can represent the summary input as a table (https://github.com/wandb/weave/pull/2000). However, we are currently limited to X MB Tables (as dictated by the service network boundary). While we could just notch that up, it is not a good solution. After landing this PR, and the service layer PR: https://github.com/wandb/core/pull/22869, we can implement a routine on the client for very large tables that will chunk table building into a series of updates, allowing us to build massive tables. This will not only fix the Evaluation issue, but also more generally support much more massive datasets. 