### PR TITLE
fix: Allow > 32MB datasets

### DIFF
--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -461,12 +461,26 @@ def network_proxy_client(client):
     """
     app = FastAPI()
 
+    records = []
+
     @app.post("/table/create")
     def table_create(req: tsi.TableCreateReq) -> tsi.TableCreateRes:
+        records.append(
+            (
+                "table_create",
+                req,
+            )
+        )
         return client.server.table_create(req)
 
     @app.post("/table/update")
     def table_update(req: tsi.TableUpdateReq) -> tsi.TableUpdateRes:
+        records.append(
+            (
+                "table_update",
+                req,
+            )
+        )
         return client.server.table_update(req)
 
     with TestClient(app) as c:
@@ -481,6 +495,6 @@ def network_proxy_client(client):
         remote_client = remote_http_trace_server.RemoteHTTPTraceServer(
             trace_server_url=""
         )
-        yield (client, remote_client)
+        yield (client, remote_client, records)
 
         weave.trace_server.requests.post = orig_post

--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -449,6 +449,16 @@ def client(request) -> Generator[weave_client.WeaveClient, None, None]:
 
 @pytest.fixture
 def network_proxy_client(client):
+    """
+    This fixture is used to test the `RemoteHTTPTraceServer` class. There is
+    almost no logic in this class, other than a little batching, so we typically
+    skip it for simplicity. However, we can use this fixture to test such logic.
+    It initializes a mini FastAPI app that proxies requests from the
+    `RemoteHTTPTraceServer` to the underlying `client.server` object.
+
+    We probably will want to flesh this out more in the future, but this is a
+    starting point.
+    """
     app = FastAPI()
 
     @app.post("/table/create")

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -1119,3 +1119,13 @@ def test_weave_server(client):
     url = weave.serve(ref, thread=True)
     response = requests.post(url + "/predict", json={"input": "x"})
     assert response.json() == {"result": "input is: x"}
+
+
+def row_gen(num_rows: int, approx_row_bytes: int = 1024):
+    for i in range(num_rows):
+        yield {"a": i, "b": "x" * approx_row_bytes}
+
+
+def test_table_partitioning(client):
+    dataset = weave.Dataset(rows=list(row_gen(10)))
+    # cl

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -1149,8 +1149,8 @@ def test_table_partitioning(network_proxy_client):
     assert len(records) == 1
 
     remote_client.remote_request_bytes_limit = (
-        1.5 * 1024
-    )  # Small enough to ensure each row is a separate request
+        4 * 1024
+    )  # Small enough to get multiple updates
     res = remote_client.table_create(
         tsi.TableCreateReq(
             table=tsi.TableSchemaForInsert(
@@ -1163,5 +1163,5 @@ def test_table_partitioning(network_proxy_client):
     assert len(records) == (
         1  # The first create call,
         + 1  # the second  create
-        + NUM_ROWS  # updates
+        + NUM_ROWS / 2  # updates - 2 per batch
     )

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -369,7 +369,6 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         with the rows.
         """
         estimated_bytes = len(req.model_dump_json(by_alias=True).encode("utf-8"))
-        print("START CREATE", estimated_bytes)
         if estimated_bytes > self.remote_request_bytes_limit:
             initialization_req = tsi.TableCreateReq(
                 table=tsi.TableSchemaForInsert(
@@ -391,7 +390,6 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
 
             return tsi.TableCreateRes(digest=update_res.digest)
         else:
-            print("EXECUTING CREATE", estimated_bytes)
             return self._generic_request(
                 "/table/create", req, tsi.TableCreateReq, tsi.TableCreateRes
             )
@@ -402,7 +400,6 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         updates.
         """
         estimated_bytes = len(req.model_dump_json(by_alias=True).encode("utf-8"))
-        print("START UPDATE", estimated_bytes)
         if estimated_bytes > self.remote_request_bytes_limit and len(req.updates) > 1:
             split_ndx = len(req.updates) // 2
             first_half_req = tsi.TableUpdateReq(
@@ -419,7 +416,6 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             second_half_res = self.table_update(second_half_req)
             return tsi.TableUpdateRes(digest=second_half_res.digest)
         else:
-            print("EXECUTE UPDATE", estimated_bytes)
             return self._generic_request(
                 "/table/update", req, tsi.TableCreateReq, tsi.TableCreateRes
             )

--- a/weave/trace_server/remote_http_trace_server.py
+++ b/weave/trace_server/remote_http_trace_server.py
@@ -368,6 +368,10 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         a single request. We can create an empty table first, then update the table
         with the rows.
         """
+        if isinstance(req, dict):
+            req = tsi.TableCreateReq.model_validate(req)
+        req = t.cast(tsi.TableCreateReq, req)
+
         estimated_bytes = len(req.model_dump_json(by_alias=True).encode("utf-8"))
         if estimated_bytes > self.remote_request_bytes_limit:
             initialization_req = tsi.TableCreateReq(
@@ -399,6 +403,10 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         due to the property that table updates can be decomposed into a series of
         updates.
         """
+        if isinstance(req, dict):
+            req = tsi.TableUpdateReq.model_validate(req)
+        req = t.cast(tsi.TableUpdateReq, req)
+
         estimated_bytes = len(req.model_dump_json(by_alias=True).encode("utf-8"))
         if estimated_bytes > self.remote_request_bytes_limit and len(req.updates) > 1:
             split_ndx = len(req.updates) // 2


### PR DESCRIPTION
In our server layer, we have a number of endpoints which we would expect to have large request or response payloads. In most cases we have solved that with streaming, batching, or pagination. However, with `table/create` it is still all-or-nothing. This means we have a practical limit (the network configured limit or the memory limit of the container) on the size of tables (which is the underlying data structure for Datasets). This PR augments the writer flow such that we create a binary partition of the dataset rows when they exceed some configurable limit, breaking the creation into a create + log_2(N) updates. This is possible thanks to the new Update api and the fact that a updates can be serialized!
