### PR TITLE
fix: slightly better auth error

### DIFF
--- a/weave/legacy/wandb_api.py
+++ b/weave/legacy/wandb_api.py
@@ -243,7 +243,7 @@ class WandbApiAsync:
                     name
                 }
             }
-        }        
+        }
         """
     )
 
@@ -408,7 +408,7 @@ class WandbApi:
                     name
                 }
             }
-        }        
+        }
         """
     )
 
@@ -417,7 +417,10 @@ class WandbApi:
             result = self.query(self.VIEWER_DEFAULT_ENTITY_QUERY)
         except gql.transport.exceptions.TransportQueryError as e:
             return None
-        return result.get("viewer", {}).get("defaultEntity", {}).get("name", None)
+        try:
+            return result.get("viewer", {}).get("defaultEntity", {}).get("name", None)
+        except AttributeError:
+            return None
 
     def username(self) -> typing.Optional[str]:
         try:

--- a/weave/weave_init.py
+++ b/weave/weave_init.py
@@ -33,9 +33,8 @@ def get_entity_project_from_project_name(project_name: str) -> tuple[str, str]:
     fields = project_name.split("/")
     if len(fields) == 1:
         api = wandb_api.get_wandb_api_sync()
-        try:
-            entity_name = api.default_entity_name()
-        except AttributeError:
+        entity_name = api.default_entity_name()
+        if entity_name is None:
             raise errors.WeaveWandbAuthenticationException(
                 'weave init requires wandb. Run "wandb login"'
             )


### PR DESCRIPTION
This makes `default_entity_name` in `WandbApi` have the same logic as the version of it in `WandbApiAsync`, where a `gql.transport.exceptions.TransportQueryError` will result in None being returned rather than an `AttributeError` being raised.

You will still get a `WeaveWandbAuthenticationException` stack trace which isn't the prettiest, but it will at least not also log the `AttributeError` stack trace.

I encountered this while manually putting an incorrect value in `.netrc` as part of other debugging.