### PR TITLE
chore: expose sortBy to callsIter

### DIFF
--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -228,6 +228,23 @@ def test_graph_call_ordering(client):
     assert [call.inputs["a"] for call in calls] == list(range(10))
 
 
+def test_graph_call_ordering_order_by(client):
+    @weave.op()
+    def my_op(a: int) -> int:
+        return a + 1
+
+    for i in range(10):
+        my_op(i)
+
+    sort_by = tsi._SortBy(field="started_at", direction="desc")
+    calls = list(client.calls(sort_by=[sort_by]))
+    assert [call.inputs["a"] for call in calls] == list(range(9, -1, -1))
+
+    sort_by = tsi._SortBy(field="output.a", direction="asc")
+    calls = list(client.calls(sort_by=[sort_by]))
+    assert [call.inputs["a"] for call in calls] == list(range(10))
+
+
 class OpCallSummary(BaseModel):
     op: typing.Callable
     num_calls: int = 0

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -233,16 +233,18 @@ def test_graph_call_ordering_order_by(client):
     def my_op(a: int) -> int:
         return a + 1
 
-    for i in range(10):
+    for i in range(1, 6):
         my_op(i)
 
     sort_by = tsi._SortBy(field="started_at", direction="desc")
     calls = list(client.calls(sort_by=[sort_by]))
-    assert [call.inputs["a"] for call in calls] == list(range(9, -1, -1))
+    assert [call.inputs["a"] for call in calls] == [5, 4, 3, 2, 1]
 
-    sort_by = tsi._SortBy(field="output.a", direction="asc")
+    my_op(0)
+
+    sort_by = {"field": "output.a", "direction": "asc"}
     calls = list(client.calls(sort_by=[sort_by]))
-    assert [call.inputs["a"] for call in calls] == list(range(10))
+    assert [call.inputs["a"] for call in calls] == [0, 1, 2, 3, 4, 5]
 
 
 class OpCallSummary(BaseModel):

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -39,7 +39,6 @@ from weave.trace.refs import (
 from weave.trace.serialize import from_json, isinstance_namedtuple, to_json
 from weave.trace.vals import WeaveObject, WeaveTable, make_trace_obj
 from weave.trace_server.trace_server_interface import (
-    _SortBy,
     CallEndReq,
     CallSchema,
     CallsDeleteReq,
@@ -60,6 +59,7 @@ from weave.trace_server.trace_server_interface import (
     TraceServerInterface,
     _CallsFilter,
     _ObjectVersionFilter,
+    _SortBy,
 )
 
 if typing.TYPE_CHECKING:
@@ -226,14 +226,14 @@ class Call:
 class CallsIter:
     server: TraceServerInterface
     filter: _CallsFilter
-    sort_by: _SortBy
+    sort_by: list[_SortBy]
 
     def __init__(
         self,
         server: TraceServerInterface,
         project_id: str,
         filter: _CallsFilter,
-        sort_by: _SortBy,
+        sort_by: list[_SortBy],
     ) -> None:
         self.server = server
         self.project_id = project_id
@@ -464,12 +464,14 @@ class WeaveClient:
 
     @trace_sentry.global_trace_sentry.watch()
     def calls(
-        self, filter: Optional[_CallsFilter] = None, sort_by: Optional[_SortBy] = None
+        self,
+        filter: Optional[_CallsFilter] = None,
+        sort_by: Optional[list[_SortBy]] = None,
     ) -> CallsIter:
         if filter is None:
             filter = _CallsFilter()
         if sort_by is None:
-            sort_by = _SortBy(field="started_at", direction="desc")
+            sort_by = [_SortBy(field="started_at", direction="asc")]
 
         return CallsIter(self.server, self._project_id(), filter, sort_by)
 

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -202,6 +202,7 @@ class Call:
             client.server,
             self.project_id,
             _CallsFilter(parent_ids=[self.id]),
+            [_SortBy(field="started_at", direction="asc")],
         )
 
     def delete(self) -> bool:

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -226,13 +226,14 @@ class Call:
 class CallsIter:
     server: TraceServerInterface
     filter: _CallsFilter
+    sort_by: _SortBy
 
     def __init__(
         self,
         server: TraceServerInterface,
         project_id: str,
         filter: _CallsFilter,
-        sort_by: Optional[_SortBy] = None,
+        sort_by: _SortBy,
     ) -> None:
         self.server = server
         self.project_id = project_id
@@ -462,11 +463,15 @@ class WeaveClient:
     ################ Query API ################
 
     @trace_sentry.global_trace_sentry.watch()
-    def calls(self, filter: Optional[_CallsFilter] = None) -> CallsIter:
+    def calls(
+        self, filter: Optional[_CallsFilter] = None, sort_by: Optional[_SortBy] = None
+    ) -> CallsIter:
         if filter is None:
             filter = _CallsFilter()
+        if sort_by is None:
+            sort_by = _SortBy(field="started_at", direction="desc")
 
-        return CallsIter(self.server, self._project_id(), filter)
+        return CallsIter(self.server, self._project_id(), filter, sort_by)
 
     @trace_sentry.global_trace_sentry.watch()
     def call(self, call_id: str) -> WeaveObject:

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -39,6 +39,7 @@ from weave.trace.refs import (
 from weave.trace.serialize import from_json, isinstance_namedtuple, to_json
 from weave.trace.vals import WeaveObject, WeaveTable, make_trace_obj
 from weave.trace_server.trace_server_interface import (
+    _SortBy,
     CallEndReq,
     CallSchema,
     CallsDeleteReq,
@@ -227,11 +228,16 @@ class CallsIter:
     filter: _CallsFilter
 
     def __init__(
-        self, server: TraceServerInterface, project_id: str, filter: _CallsFilter
+        self,
+        server: TraceServerInterface,
+        project_id: str,
+        filter: _CallsFilter,
+        sort_by: Optional[_SortBy] = None,
     ) -> None:
         self.server = server
         self.project_id = project_id
         self.filter = filter
+        self.sort_by = sort_by
         self._page_size = 10
 
     # seems like this caching should be on the server, but it's here for now...
@@ -243,6 +249,7 @@ class CallsIter:
             CallsQueryReq(
                 project_id=self.project_id,
                 filter=self.filter,
+                sort_by=self.sort_by,
                 offset=index * self._page_size,
                 limit=self._page_size,
             )


### PR DESCRIPTION
allows:

```python
api = weave.init('project')
sort_by = {"field": "started_at", "direction": "desc"}
latest_calls = api.calls(sort_by=[sort_by])
```