### PR TITLE
feat(ui): Add isInteractive prop for Tags and Pills

### DIFF
--- a/weave-js/src/components/Tag/Pill.tsx
+++ b/weave-js/src/components/Tag/Pill.tsx
@@ -3,24 +3,32 @@ import {twMerge} from 'tailwind-merge';
 
 import {Icon, IconName} from '../Icon';
 import {Tailwind} from '../Tailwind';
-import {getTagColorClass, TagColorName} from './utils';
+import {useTagClasses} from './Tag';
+import {TagColorName} from './utils';
 
 export type PillProps = {
   label: string;
   icon?: IconName;
   color?: TagColorName;
   className?: string;
+  isInteractive?: boolean;
 };
-export const Pill: FC<PillProps> = ({label, icon, color, className}) => {
+export const Pill: FC<PillProps> = ({
+  label,
+  icon,
+  color,
+  className,
+  isInteractive,
+}) => {
+  const classes = useTagClasses({color, isInteractive});
   return (
     <Tailwind>
       <div
         key={`pill-${label}`}
         className={twMerge(
-          'night-aware',
-          'min-h-22 flex max-h-22 w-fit items-center rounded-2xl text-[14px]',
+          classes,
+          'rounded-2xl',
           icon ? 'pl-4 pr-7' : 'px-7',
-          getTagColorClass(color),
           className
         )}>
         {icon && <Icon className="mr-4 h-14 w-14" name={icon} />}
@@ -35,17 +43,17 @@ export const Pill: FC<PillProps> = ({label, icon, color, className}) => {
 export type IconOnlyPillProps = {
   icon: IconName;
   color?: TagColorName;
+  isInteractive?: boolean;
 };
-export const IconOnlyPill: FC<IconOnlyPillProps> = ({icon, color}) => {
+export const IconOnlyPill: FC<IconOnlyPillProps> = ({
+  icon,
+  color,
+  isInteractive,
+}) => {
+  const classes = useTagClasses({color, isInteractive});
   return (
     <Tailwind>
-      <div
-        key={`pill-${icon}`}
-        className={twMerge(
-          'night-aware',
-          'min-h-22 flex max-h-22 w-fit items-center rounded-2xl',
-          getTagColorClass(color)
-        )}>
+      <div key={`pill-${icon}`} className={twMerge(classes, 'rounded-2xl')}>
         <Icon className="m-4 h-14 w-14" name={icon} />
       </div>
     </Tailwind>

--- a/weave-js/src/components/Tag/Tag.tsx
+++ b/weave-js/src/components/Tag/Tag.tsx
@@ -81,7 +81,7 @@ export const Tag: FC<TagProps> = ({
   return nakedTag;
 };
 
-export type RemovableTagProps = TagProps & {
+export type RemovableTagProps = Omit<TagProps, 'isInteractive'> & {
   removeAction: ReactElement<typeof RemoveAction>;
 };
 export const RemovableTag: FC<RemovableTagProps> = ({

--- a/weave-js/src/components/Tag/Tag.tsx
+++ b/weave-js/src/components/Tag/Tag.tsx
@@ -19,7 +19,13 @@ export const DEFAULT_TAG_ICON = 'tag';
 /**
  * A Tag not given a specific color would have its color change every render cycle. This calculates a default color as a stable value, and only adds it to the class list when color isn't defined
  */
-export function useTagClasses({color}: {color?: TagColorName}) {
+export function useTagClasses({
+  color,
+  isInteractive,
+}: {
+  color?: TagColorName;
+  isInteractive?: boolean;
+}) {
   const defaultColorRef = React.useRef(color ?? getRandomTagColor());
   const tagColor = color ?? defaultColorRef.current;
 
@@ -29,9 +35,9 @@ export function useTagClasses({color}: {color?: TagColorName}) {
         'night-aware',
         'min-h-22 flex max-h-22 w-fit items-center rounded-[3px] text-[14px]',
         getTagColorClass(tagColor),
-        getTagHoverClass(tagColor)
+        isInteractive ? getTagHoverClass(tagColor) : ''
       ),
-    [tagColor]
+    [isInteractive, tagColor]
   );
 }
 
@@ -43,6 +49,7 @@ export type TagProps = {
   // Wrapping the Tag in Tailwind can be a problem if the Tailwind wrapper is supplied higher up
   // and there is a need to position the Tag as a direct child for something like flexbox
   Wrapper?: React.ComponentType<any> | null;
+  isInteractive?: boolean;
 };
 
 export const Tag: FC<TagProps> = ({
@@ -51,8 +58,9 @@ export const Tag: FC<TagProps> = ({
   showIcon = false,
   iconName,
   Wrapper = Tailwind,
+  isInteractive = false,
 }) => {
-  const classes = useTagClasses({color});
+  const classes = useTagClasses({color, isInteractive});
 
   const nakedTag = (
     <div
@@ -86,7 +94,7 @@ export const RemovableTag: FC<RemovableTagProps> = ({
 }) => {
   const labelRef = useRef<HTMLParagraphElement>(null);
   const isTooltipEnabled = isTagLabelTruncated(labelRef);
-  const classes = useTagClasses({color});
+  const classes = useTagClasses({color, isInteractive: true});
 
   const nakedTag = (
     <TagTooltip value={label} disabled={!isTooltipEnabled}>


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-19989

Currently our Tags all have hover state styles (darker on hover). Meanwhile Pills never have hover styles.

I got feedback from design that Tags and Pills should both have hover states, but only if the element is interactive (e.g. is removable or triggers a tooltip). I added an `isInteractive` prop to `Tag` and `Pill` components so that hover styles are only applied if the element is explicitly marked as interactive.

Testing: in storybook

- RemovableTag always has hover styles
- Tag has hover styles only if `isInteractive`
- Pill has hover styles only if `isInteractive`


https://github.com/user-attachments/assets/4735489b-b367-47f2-a5de-5eaba1e19d9f

