### PR TITLE
chore: Fix Core CI relating to summary keys

### DIFF
--- a/weave/legacy/ops_domain/wb_util.py
+++ b/weave/legacy/ops_domain/wb_util.py
@@ -45,12 +45,20 @@ def _filesystem_runfiles_from_run_path(run_path: RunPath, file_path: str):
     runfiles = WandbRunFiles(name=uri.name, uri=uri)
     return runfiles.path_info(file_path)
 
+def key_is_wandb_private(key: str) -> bool:
+    # For a very long time, this was just `key == "_wandb"`, however
+    # it seems that we are now returning fields like `_wandb.runtime`.
+    # This seems like a bug in gorilla, since it is not happening in
+    # local-integration-tests, which makes me think RunsV2 is doing
+    # something different. Anyway, this is a quick fix to make the
+    # tests pass.
+    return key == "_wandb" or key.startswith("_wandb.")
 
 def process_run_dict_obj(run_dict, run_path: typing.Optional[RunPath] = None):
     return {
         k: _process_run_dict_item(v, run_path)
         for k, v in run_dict.items()
-        if k != "_wandb"
+        if not key_is_wandb_private(k)
     }
 
 
@@ -203,7 +211,7 @@ def process_run_dict_type(run_dict):
         {
             k: _process_run_dict_item_type(v)
             for k, v in run_dict.items()
-            if k != "_wandb"
+            if not key_is_wandb_private(k)
         }
     )
 


### PR DESCRIPTION
It seems that in the last 24 hours, we started getting a failing integration test (example: https://app.circleci.com/pipelines/github/wandb/core/144110/workflows/f2b58f88-78bd-40a4-b565-9968904b302e/jobs/3671133/tests) constantly in core. Looking at the details, it appears that the run summary endpoint is returning a flattened `_wandb` subkey payload, resulting in keys like `_wandb.runtime`. In the integration tests we test a related feature that checks summary keys, and we are now failing due to this new key being in the list. However, it is not happening with local-integration-tests, so that makes me think it might have to do with some RunsV2 stuff that doesn't run in local? Honestly, i don't quite know, but this should fix the issue to unblock CI.