### PR TITLE
fix: netrc authentication for windows

### DIFF
--- a/weave/environment.py
+++ b/weave/environment.py
@@ -224,7 +224,15 @@ def _wandb_api_key_via_env() -> typing.Optional[str]:
 
 
 def _wandb_api_key_via_netrc() -> typing.Optional[str]:
-    netrc_path = os.path.expanduser("~/.netrc")
+    for filepath in ("~/.netrc", "~/_netrc"):
+        api_key = _wandb_api_key_via_netrc_file(filepath)
+        if api_key:
+            return api_key
+    return None
+
+
+def _wandb_api_key_via_netrc_file(filepath: str) -> typing.Optional[str]:
+    netrc_path = os.path.expanduser(filepath)
     if not os.path.exists(netrc_path):
         return None
     nrc = netrc.netrc(netrc_path)
@@ -234,7 +242,7 @@ def _wandb_api_key_via_netrc() -> typing.Optional[str]:
         user, account, api_key = res
     if api_key and is_public():
         raise errors.WeaveConfigurationError(
-            "~/.netrc should not be set in public mode."
+            f"{filepath} should not be set in public mode."
         )
     return api_key
 


### PR DESCRIPTION
To simulate what a Windows user might see, I moved my `~/.netrc` file to `~/_netrc`.
The resulting output was unexpected, outputting a "Please login" prompt but then continuing as if the user was authenticated. The resulting `WeaveClient` would throw a `401 Unauthorized` error on subsequent actions.
```
Please login to Weights & Biases (https://wandb.ai/) to continue:
wandb: Currently logged in as: jamie-rasmussen. Use `wandb login --relogin` to force relogin
Logged in as Weights & Biases user: jamie-rasmussen.
View Weave data at https://wandb.ai/jamie-rasmussen/2024-07-29_authtest/weave
Out[2]: <weave.weave_client.WeaveClient at 0x16afa5d90>
```