### PR TITLE
fix(ui): Center dialog, add z-index

### DIFF
--- a/weave-js/src/components/Dialog/Dialog.tsx
+++ b/weave-js/src/components/Dialog/Dialog.tsx
@@ -32,7 +32,8 @@ const overlayClassName = classNames(
   'night-aware',
   'bg-oblivion/[0.24] dark:bg-oblivion/[0.48]',
   'fixed bottom-0 left-0 right-0 top-0',
-  'grid place-items-center overflow-y-auto'
+  'grid place-items-center overflow-y-auto',
+  'z-[1001]'
 );
 export const Overlay = React.forwardRef(
   ({className, children, ...props}: RadixDialog.DialogOverlayProps, ref) => (
@@ -51,11 +52,12 @@ export const Overlay = React.forwardRef(
  */
 const contentClassName = classNames(
   'night-aware',
-  'absolute left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]', // centers modal on screen
+  'fixed left-[50%] top-[50%] translate-x-[-50%] translate-y-[-50%]', // centers modal on screen
   'rounded border py-24 px-32',
   'shadow-lg shadow-oblivion/[0.16] dark:shadow-oblivion/[0.48]',
   'border-moon-250 bg-white text-moon-850',
-  'dark:border-moon-750 dark:bg-moon-900 dark:text-moon-150'
+  'dark:border-moon-750 dark:bg-moon-900 dark:text-moon-150',
+  'z-[1001]'
 );
 export const Content = React.forwardRef<
   HTMLDivElement,


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-20140

Noticed the "delete run" experience is really broken in reports


https://github.com/user-attachments/assets/562dac41-991e-454d-a2e6-4336cf2f5388

Looks like we [recently updated that modal](https://github.com/wandb/core/pull/22777) from semantic to the radix one, which is great! Unfortunately I guess a lot of reports page elements have weird z-indices. The semantic modal had `z-index: 1001` applied but our radix one doesn't set z-index at all.

<img width="428" alt="Screenshot 2024-07-29 at 1 57 17 PM" src="https://github.com/user-attachments/assets/60c8330a-17e0-4638-80f3-dc5c2a20351e">

Honestly I'm not sure of the best way to handle this, but it seems like the safest option is to use that same z-index on our radix dialogs so when devs convert semantic ones to the radix one, we won't be hit with unexpected styling issues like this in the future.