### PR TITLE
feat: store pinned column state in URL

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -12,6 +12,7 @@ import {
 import {
   GridColumnVisibilityModel,
   GridPaginationModel,
+  GridPinnedColumns,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
 import {LicenseInfo} from '@mui/x-license-pro';
@@ -61,13 +62,16 @@ import {
   DEFAULT_PAGE_SIZE,
   getValidPaginationModel,
 } from './Browse3/grid/pagination';
+import {getValidPinModel, removeAlwaysLeft} from './Browse3/grid/pin';
 import {getValidSortModel} from './Browse3/grid/sort';
 import {BoardPage} from './Browse3/pages/BoardPage';
 import {BoardsPage} from './Browse3/pages/BoardsPage';
 import {CallPage} from './Browse3/pages/CallPage/CallPage';
 import {CallsPage} from './Browse3/pages/CallsPage/CallsPage';
 import {
+  ALWAYS_PIN_LEFT_CALLS,
   DEFAULT_COLUMN_VISIBILITY_CALLS,
+  DEFAULT_PIN_CALLS,
   DEFAULT_SORT_CALLS,
 } from './Browse3/pages/CallsPage/CallsTable';
 import {Empty} from './Browse3/pages/common/Empty';
@@ -696,6 +700,19 @@ const CallsPageBinding = () => {
     history.push({search: newQuery.toString()});
   };
 
+  const pinModel = useMemo(
+    () => getValidPinModel(query.pin, DEFAULT_PIN_CALLS, ALWAYS_PIN_LEFT_CALLS),
+    [query.pin]
+  );
+  const setPinModel = (newModel: GridPinnedColumns) => {
+    const newQuery = new URLSearchParams(location.search);
+    newQuery.set(
+      'pin',
+      JSON.stringify(removeAlwaysLeft(newModel, ALWAYS_PIN_LEFT_CALLS))
+    );
+    history.push({search: newQuery.toString()});
+  };
+
   const sortModel = useMemo(
     () => getValidSortModel(query.sort, DEFAULT_SORT_CALLS),
     [query.sort]
@@ -739,6 +756,8 @@ const CallsPageBinding = () => {
       onFilterUpdate={onFilterUpdate}
       columnVisibilityModel={columnVisibilityModel}
       setColumnVisibilityModel={setColumnVisibilityModel}
+      pinModel={pinModel}
+      setPinModel={setPinModel}
       sortModel={sortModel}
       setSortModel={setSortModel}
       paginationModel={paginationModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pin.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pin.test.ts
@@ -1,0 +1,77 @@
+import {getValidPinModel, removeAlwaysLeft} from './pin';
+
+describe('removeAlwaysLeft', () => {
+  it('removes an alwaysLeft item from left', () => {
+    const result = removeAlwaysLeft({left: ['checkbox', 'foo']}, ['checkbox']);
+    expect(result).toEqual({
+      left: ['foo'],
+    });
+  });
+  it('removes multiple alwaysLeft items from left', () => {
+    const result = removeAlwaysLeft({left: ['checkbox', 'foo', 'bar']}, [
+      'bar',
+      'checkbox',
+    ]);
+    expect(result).toEqual({
+      left: ['foo'],
+    });
+  });
+  it('does not change when cols are not in left', () => {
+    const result = removeAlwaysLeft({left: ['checkbox', 'foo']}, ['bar']);
+    expect(result).toEqual({
+      left: ['checkbox', 'foo'],
+    });
+  });
+  it('does not change when no left', () => {
+    const result = removeAlwaysLeft({right: ['checkbox', 'foo']}, ['checkbox']);
+    expect(result).toEqual({
+      right: ['checkbox', 'foo'],
+    });
+  });
+});
+
+describe('getValidPinModel', () => {
+  it('parses a valid pin model', () => {
+    const parsed = getValidPinModel(
+      '{"left": ["CustomCheckbox", "op_name", "feedback"]}'
+    );
+    expect(parsed).toEqual({
+      left: ['CustomCheckbox', 'op_name', 'feedback'],
+    });
+  });
+  it('includes alwaysLeft items when left is specified', () => {
+    const parsed = getValidPinModel('{"left": ["foo"]}', null, ['checkbox']);
+    expect(parsed).toEqual({
+      left: ['checkbox', 'foo'],
+    });
+  });
+  it('includes alwaysLeft items when left is not specified', () => {
+    const parsed = getValidPinModel('{}', null, ['checkbox']);
+    expect(parsed).toEqual({
+      left: ['checkbox'],
+    });
+  });
+  it('moves alwaysLeft items to front', () => {
+    const parsed = getValidPinModel('{"left": ["foo", "checkbox"]}', null, [
+      'checkbox',
+    ]);
+    expect(parsed).toEqual({
+      left: ['checkbox', 'foo'],
+    });
+  });
+
+  it('returns {} on non-object with no explicit default', () => {
+    const parsed = getValidPinModel('[]');
+    expect(parsed).toEqual({});
+  });
+  it('returns {} on invalid pin value with no explicit default', () => {
+    const parsed = getValidPinModel('{"lef": ["foo"]}');
+    expect(parsed).toEqual({});
+  });
+  it('returns default on non-object', () => {
+    const parsed = getValidPinModel('[]', {left: ['checkbox']});
+    expect(parsed).toEqual({
+      left: ['checkbox'],
+    });
+  });
+});

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pin.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pin.ts
@@ -1,0 +1,63 @@
+import {GridPinnedColumns} from '@mui/x-data-grid-pro';
+import _ from 'lodash';
+
+const isValidPinValue = (value: any): boolean => {
+  return _.isArray(value) && value.every(v => _.isString(v));
+};
+
+// Columns that are always pinned left don't need to be present in serialized state.
+export const removeAlwaysLeft = (
+  pinModel: GridPinnedColumns,
+  alwaysLeft: string[]
+): GridPinnedColumns => {
+  if (!pinModel.left) {
+    return pinModel;
+  }
+  const {left} = pinModel;
+  return {
+    ...pinModel,
+    left: left.filter(col => !alwaysLeft.includes(col)),
+  };
+};
+
+// Ensure specified columns are always pinned left.
+const ensureAlwaysLeft = (
+  pinModel: GridPinnedColumns,
+  alwaysLeft: string[]
+): GridPinnedColumns => {
+  let left = pinModel.left ?? [];
+  left = left.filter(col => !alwaysLeft.includes(col));
+  left = alwaysLeft.concat(left);
+  return {
+    ...pinModel,
+    left,
+  };
+};
+
+export const getValidPinModel = (
+  jsonString: string,
+  def: GridPinnedColumns | null = null,
+  alwaysLeft?: string[]
+): GridPinnedColumns => {
+  def = def ?? {};
+  try {
+    const parsed = JSON.parse(jsonString);
+    if (_.isPlainObject(parsed)) {
+      const keys = Object.keys(parsed);
+      if (
+        keys.every(
+          key => ['left', 'right'].includes(key) && isValidPinValue(parsed[key])
+        )
+      ) {
+        const pinModel = parsed as GridPinnedColumns;
+        if (alwaysLeft) {
+          return ensureAlwaysLeft(pinModel, alwaysLeft);
+        }
+        return pinModel;
+      }
+    }
+  } catch (e) {
+    // Ignore
+  }
+  return def;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -1,6 +1,7 @@
 import {
   GridColumnVisibilityModel,
   GridPaginationModel,
+  GridPinnedColumns,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
 import _ from 'lodash';
@@ -36,6 +37,9 @@ export const CallsPage: FC<{
 
   columnVisibilityModel: GridColumnVisibilityModel;
   setColumnVisibilityModel: (newModel: GridColumnVisibilityModel) => void;
+
+  pinModel: GridPinnedColumns;
+  setPinModel: (newModel: GridPinnedColumns) => void;
 
   sortModel: GridSortModel;
   setSortModel: (newModel: GridSortModel) => void;
@@ -88,6 +92,8 @@ export const CallsPage: FC<{
                 onFilterUpdate={setFilter}
                 columnVisibilityModel={props.columnVisibilityModel}
                 setColumnVisibilityModel={props.setColumnVisibilityModel}
+                pinModel={props.pinModel}
+                setPinModel={props.setPinModel}
                 sortModel={props.sortModel}
                 setSortModel={props.setSortModel}
                 paginationModel={props.paginationModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -92,6 +92,12 @@ export const DEFAULT_COLUMN_VISIBILITY_CALLS = {
   'attributes.weave.sys_version': false,
 };
 
+export const ALWAYS_PIN_LEFT_CALLS = ['CustomCheckbox'];
+
+export const DEFAULT_PIN_CALLS: GridPinnedColumns = {
+  left: ['CustomCheckbox', 'op_name', 'feedback'],
+};
+
 export const DEFAULT_SORT_CALLS: GridSortModel = [
   {field: 'started_at', sort: 'desc'},
 ];
@@ -114,6 +120,9 @@ export const CallsTable: FC<{
   columnVisibilityModel?: GridColumnVisibilityModel;
   setColumnVisibilityModel?: (newModel: GridColumnVisibilityModel) => void;
 
+  pinModel?: GridPinnedColumns;
+  setPinModel?: (newModel: GridPinnedColumns) => void;
+
   sortModel?: GridSortModel;
   setSortModel?: (newModel: GridSortModel) => void;
 
@@ -128,6 +137,8 @@ export const CallsTable: FC<{
   hideControls,
   columnVisibilityModel,
   setColumnVisibilityModel,
+  pinModel,
+  setPinModel,
   sortModel,
   setSortModel,
   paginationModel,
@@ -330,10 +341,7 @@ export const CallsTable: FC<{
   );
 
   // DataGrid Model Management
-  const [pinnedColumnsModel, setPinnedColumnsModel] =
-    useState<GridPinnedColumns>({
-      left: ['CustomCheckbox', 'op_name', 'feedback'],
-    });
+  const pinModelResolved = pinModel ?? DEFAULT_PIN_CALLS;
 
   // END OF CPR FACTORED CODE
 
@@ -558,6 +566,16 @@ export const CallsTable: FC<{
       }
     : undefined;
 
+  const onPinnedColumnsChange = useCallback(
+    (newModel: GridPinnedColumns) => {
+      if (!setPinModel || callsLoading) {
+        return;
+      }
+      setPinModel(newModel);
+    },
+    [callsLoading, setPinModel]
+  );
+
   const onSortModelChange = useCallback(
     (newModel: GridSortModel) => {
       if (!setSortModel || callsLoading) {
@@ -748,8 +766,8 @@ export const CallsTable: FC<{
             };
           });
         }}
-        pinnedColumns={pinnedColumnsModel}
-        onPinnedColumnsChange={newModel => setPinnedColumnsModel(newModel)}
+        pinnedColumns={pinModelResolved}
+        onPinnedColumnsChange={onPinnedColumnsChange}
         sx={{
           borderRadius: 0,
         }}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -440,7 +440,6 @@ function buildCallsTableColumns(
     align: 'center',
     sortable: false,
     resizable: false,
-    disableColumnMenu: true,
     renderCell: cellParams => {
       const userId = cellParams.row.wb_user_id;
       if (userId == null) {


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-20138

Same kind of change as in https://github.com/wandb/weave/pull/1976 and https://github.com/wandb/weave/pull/1956

The Material UI grid allows you to pin columns to the left or right. This state was previously just kept in the component but is now stored in the URL. This is another step towards having URLs that a user can bookmark or share.