### PR TITLE
fix: langchain integration regex bug

### DIFF
--- a/weave/integrations/langchain/langchain.py
+++ b/weave/integrations/langchain/langchain.py
@@ -17,7 +17,7 @@ This LangChain integration patching differs from other integrations in how traci
 
 3. Respecting User Settings:
    The patcher respects any existing WEAVE_TRACE_LANGCHAIN environment variable set by the user:
-   - If not set, it's set to "true" and global patchin is enabled.
+   - If not set, it's set to "true" and global patching is enabled.
    - If already set, its value is preserved
 
 4. Context Manager:
@@ -60,7 +60,7 @@ if not import_failed:
     def make_valid_run_name(name: str) -> str:
         name = name.replace("<", "_").replace(">", "")
 
-        valid_run_name = re.sub(r"[^a-zA-Z0-9 .-_]", "_", name)
+        valid_run_name = re.sub(r"[^a-zA-Z0-9 .\\-_]", "_", name)
         return valid_run_name
 
     def _run_to_dict(run: Run, as_input: bool = False) -> dict:


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-20199

Because the `-` in the regular expression was not escaped it matched any characters between `.` (46) and `_` (95) in the ascii codes, including `:` (58). The `^` inverts the match, meaning those characters were not substituted. (We're also lacking proper validation of the op name at other layers, which will be addressed separately.)