### PR TITLE
fix: object viewer autoexpand

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -1,7 +1,13 @@
 import Box from '@mui/material/Box';
 import {GridRowId, useGridApiRef} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
-import React, {useCallback, useContext, useMemo, useState} from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import styled from 'styled-components';
 
 import {isWeaveObjectRef, parseRef} from '../../../../../../react';
@@ -86,9 +92,7 @@ const ObjectViewerSectionNonEmpty = ({
   isExpanded,
 }: ObjectViewerSectionProps) => {
   const apiRef = useGridApiRef();
-  const [mode, setMode] = useState(
-    isSimpleData(data) || isExpanded ? 'expanded' : 'collapsed'
-  );
+  const [mode, setMode] = useState('collapsed');
   const [expandedIds, setExpandedIds] = useState<GridRowId[]>([]);
 
   const body = useMemo(() => {
@@ -152,6 +156,18 @@ const ObjectViewerSectionNonEmpty = ({
     setMode('expanded');
     setExpandedIds(getGroupIds());
   };
+
+  // On first render and when data changes, recompute expansion state
+  useEffect(() => {
+    const isSimple = isSimpleData(data);
+    const newMode = isSimple || isExpanded ? 'expanded' : 'collapsed';
+    if (newMode === 'expanded') {
+      onClickExpanded();
+    } else {
+      onClickCollapsed();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, isExpanded]);
 
   return (
     <>


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-20207

When we have the peek drawer open, the ObjectViewer for the inputs/outputs may stay mounted but with a changing `data` prop. When the data being rendered changes we need to recompute the default expansion mode, clear out the state for manually expanded nodes, etc.