### PR TITLE
fix: Evaluations are robust to empty / null key entries

### DIFF
--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -44,6 +44,10 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     if not data:
         return {}
     data = [x for x in data if x is not None]
+
+    if not data:
+        return None
+
     val = data[0]
 
     if isinstance(val, bool):
@@ -56,7 +60,11 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
     elif isinstance(val, dict):
         result = {}
         for k in val:
-            if (summary := auto_summarize([x[k] for x in data])) is not None:
+            if (
+                summary := auto_summarize(
+                    [x.get(k) for x in data if isinstance(x, dict)]
+                )
+            ) is not None:
                 if k in summary:
                     result.update(summary)
                 else:

--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -59,7 +59,8 @@ def auto_summarize(data: list) -> Optional[dict[str, Any]]:
         return {"mean": np.mean(data).item()}
     elif isinstance(val, dict):
         result = {}
-        for k in val:
+        all_keys = set().union(*[x.keys() for x in data if isinstance(x, dict)])
+        for k in all_keys:
             if (
                 summary := auto_summarize(
                     [x.get(k) for x in data if isinstance(x, dict)]

--- a/weave/tests/test_evaluations.py
+++ b/weave/tests/test_evaluations.py
@@ -595,10 +595,10 @@ async def test_eval_is_robust_to_missing_values(client):
     resp = [
         None,
         {"a": 1, "b": {"c": 2}, "always_none": None},
-        {"a": 1, "b": {"c": None}, "always_none": None},
-        {"a": 1, "b": {}, "always_none": None},
-        {"a": 1, "b": None, "always_none": None},
-        {"a": 1, "always_none": None},
+        {"a": 2, "b": {"c": None}, "always_none": None},
+        {"a": 3, "b": {}, "always_none": None},
+        {"a": 4, "b": None, "always_none": None},
+        {"a": 5, "always_none": None},
         {"a": None, "always_none": None},
         {"always_none": None},
         {},
@@ -613,14 +613,13 @@ async def test_eval_is_robust_to_missing_values(client):
 
     evaluation = weave.Evaluation(
         name="fruit_eval",
-        dataset=[
-            {"model_res": 0, "scorer_res": 0},
-            {"model_res": 1, "scorer_res": 1},
-            {"model_res": 2, "scorer_res": 2},
-            {"model_res": 3, "scorer_res": 3},
-        ],
+        dataset=[{"model_res": i, "scorer_res": i} for i in range(len(resp))],
         scorers=[function_score],
     )
 
     res = await evaluation.evaluate(model_func)
-    assert res != None
+    assert res == {
+        "model_output": {"a": {"mean": 3.0}, "b": {"c": {"mean": 2.0}}},
+        "function_score": {"a": {"mean": 3.0}, "b": {"c": {"mean": 2.0}}},
+        "model_latency": {"mean": pytest.approx(0, abs=1)},
+    }


### PR DESCRIPTION
This can happen when the model or scorer is non deterministic (ie. uses LLM to generate JSON) or when there are conditional keys in the output. A user recently had all "Nones" for an "error" key.