### PR TITLE
style(ui): Update TextField styles

### DIFF
--- a/weave-js/src/components/Form/TextField.tsx
+++ b/weave-js/src/components/Form/TextField.tsx
@@ -57,6 +57,7 @@ export const TextField = ({
   dataTest,
 }: TextFieldProps) => {
   const textFieldSize = size ?? 'medium';
+  const leftPaddingForIcon = textFieldSize === 'medium' ? 'pl-34' : 'pl-36';
 
   const handleChange = onChange
     ? (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -78,34 +79,37 @@ export const TextField = ({
     <Tailwind style={{width: '100%'}}>
       <div
         className={classNames(
-          'relative',
-          textFieldSize === 'medium' ? 'h-32' : 'h-40'
+          'relative rounded-sm',
+          textFieldSize === 'medium' ? 'h-32' : 'h-40',
+          'outline outline-1 outline-moon-250',
+          {
+            'hover:outline-2 [&:hover:not(:focus-within)]:outline-[#83E4EB]':
+              !errorState,
+            'focus-within:outline-2 focus-within:outline-teal-400': !errorState,
+            'outline-2 outline-red-450': errorState,
+            'pointer-events-none opacity-50': disabled,
+          }
         )}>
-        <div
-          className={classNames(
-            'absolute bottom-0 top-0 flex w-full items-center rounded-sm',
-            'outline outline-1 outline-moon-250',
-            disabled
-              ? 'opacity-50'
-              : 'hover:outline hover:outline-2 hover:outline-teal-500/40 focus:outline-2',
-            errorState
-              ? 'outline outline-2 outline-red-450 hover:outline-red-450 focus:outline-red-450'
-              : 'outline outline-1 outline-moon-250 hover:outline-teal-500/40 focus:outline-teal-500/40'
-          )}>
-          {prefix && <div className="text-gray-800 pl-8 pr-1">{prefix}</div>}
+        <div className="absolute bottom-0 top-0 flex w-full items-center rounded-sm">
+          {prefix && (
+            <div
+              className={classNames(
+                'text-gray-800 pr-1',
+                icon ? leftPaddingForIcon : 'pl-8'
+              )}>
+              {prefix}
+            </div>
+          )}
           <input
             className={classNames(
-              'h-full w-full flex-1',
+              'h-full w-full flex-1 rounded-sm pr-8',
               'appearance-none border-none',
               'focus:outline-none',
-              'placeholder-moon-500 dark:placeholder-moon-600',
-              icon
-                ? textFieldSize === 'medium'
-                  ? 'pl-34'
-                  : 'pl-36'
-                : prefix
-                ? null
-                : 'pl-8'
+              'placeholder-moon-500',
+              {
+                [leftPaddingForIcon]: icon && !prefix,
+                'pl-8': !icon && !prefix,
+              }
             )}
             placeholder={placeholder}
             value={value}
@@ -131,7 +135,7 @@ export const TextField = ({
               'absolute left-8',
               textFieldSize === 'medium'
                 ? 'top-8 h-18 w-18'
-                : 'top-10  h-20 w-20',
+                : 'top-10 h-20 w-20',
               value ? 'text-moon-800' : 'text-moon-500'
             )}
           />


### PR DESCRIPTION
There are a few issues with our TextFields component so I wanted to clean it up a bit.

- Hover outline was wrong shade. Before/after:

  https://github.com/user-attachments/assets/0b457df6-a215-461a-a582-3db13869a4c9

- Focus outline was not showing up

  https://github.com/user-attachments/assets/9703fbe7-c7b9-4f3d-9ad8-182f8592ad39

- Icon did not have correct opacity in disabled state

  https://github.com/user-attachments/assets/e7724396-c835-4548-b264-db8b1e8f52e6

- Icon was not triggering hover outline

  https://github.com/user-attachments/assets/7b134da6-7f58-41fd-a5b3-5de82e6a61fb

- Icon and prefix elements clash if both are present

  https://github.com/user-attachments/assets/e7108b4b-ee36-4130-b9b0-d67ef9a26d1d

- Extra polish: input should have right padding so extra long texts don't bump right against the border

  https://github.com/user-attachments/assets/08fe776b-835a-424a-9d4e-2fa2d0fa29d3


NOTE: TextField looks totally broken in dark mode on storybook, but is actually fine in the real app. This is because TextField is not actually `night-aware` and is not compatible with the `ThemeGallery` helper component in storybook. I'd love to fix this by adding actual night-aware dark styles, but the [figma](https://www.figma.com/design/01KWBdMZg5QM9SRS1pQq0z/Design-System----Robot-Styles?node-id=92-1442&t=p91zHZkEPF5g19Rd-0) does not contain dark mode inputs. I started a conversation with [design team](https://weightsandbiases.slack.com/archives/C01QMPF38PQ/p1722533099299349) to see what we want to do from here. If it ends up not being a priority, I will likely open a separate PR to remove `ThemeGallery` from `TextField` in storybook.


Additional testing: verified TextField looks OK in app (both light+dark modes)

https://github.com/user-attachments/assets/a8dfacff-c8a3-4fbc-b4fa-9e2f56787787
