### PR TITLE
chore: fix CI by pinning yanked types-pkg-resources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,8 @@ repos:
     rev: "v1.10.0"
     hooks:
       - id: mypy
-        additional_dependencies: [types-all, wandb>=0.15.5]
+        additional_dependencies:
+          [types-pkg-resources==0.1.3, types-all, wandb>=0.15.5]
         # You have to exclude in 3 places. 1) here. 2) mypi.ini exclude, 3) follow_imports = skip for each module in mypy.ini
         exclude: (.*pyi$)|(weave/legacy)|(weave/tests)
   # Turn pyright back off, duplicative of mypy


### PR DESCRIPTION
Our mypy step in pre-commit depends on types-all.  types-all depends on types-pkg-resources. All of the versions of types-pkg-resources were yanked: https://pypi.org/project/types-pkg-resources/#history

This is a temporary hack to unblock us while we wait for types-all to be updated.