### PR TITLE
chore: add no-op optional column spec to call query

### DIFF
--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -191,6 +191,10 @@ class CallsQueryReq(BaseModel):
     sort_by: typing.Optional[typing.List[_SortBy]] = None
     query: typing.Optional[Query] = None
 
+    # TODO: type this with call schema columns, following the same rules as
+    # _SortBy and thus GetFieldOperator.get_field_ (without direction)
+    columns: typing.Optional[typing.List[str]] = None
+
 
 class CallsQueryRes(BaseModel):
     calls: typing.List[CallSchema]


### PR DESCRIPTION
Typing prep for upcoming prs. 

This will allow: 
- call_stream_query to filter out non-requested columns when exporting
- eventually will be passed on to `calls_query_stream` in `clickhouse_trace_server_batched` to only fetch requested columns from the db 

^^^ performance testing TODO on the query perf impact (speculation: there should be a tradeoff where most small queries get marginally slower, while larger queries might even get faster because we arent reading as much data into the db reader? All queries will have smaller payloads over the wire.)