### PR TITLE
fix: isEmpty and isNotEmpty filter

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -12,6 +12,9 @@ import {Query} from '../wfReactInterface/traceServerClientInterface/query';
 import {CallFilter} from '../wfReactInterface/wfDataModelHooksInterface';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 
+// These operators do not require a value for the filter to be complete.
+const NO_VALUE_OPERATORS = ['(any): isEmpty', '(any): isNotEmpty'];
+
 /**
  * This Hook is responsible for bridging the gap between the CallsTable
  * component and the underlying data hooks. In particular, it takes a high level
@@ -51,9 +54,12 @@ export const useCallsForQuery = (
   );
 
   const filterByRaw = useMemo(() => {
-    const setItems = gridFilter.items.filter(item => item.value !== undefined);
+    const completeItems = gridFilter.items.filter(
+      item =>
+        item.value !== undefined || NO_VALUE_OPERATORS.includes(item.operator)
+    );
 
-    const convertedItems = setItems
+    const convertedItems = completeItems
       .map(operationConverter)
       .filter(item => item !== null) as Array<Query['$expr']>;
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -6,14 +6,14 @@ import {
 import {useMemo} from 'react';
 
 import {useDeepMemo} from '../../../../../../hookUtils';
-import {operationConverter} from '../common/tabularListViews/operators';
+import {
+  isValuelessOperator,
+  operationConverter,
+} from '../common/tabularListViews/operators';
 import {useWFHooks} from '../wfReactInterface/context';
 import {Query} from '../wfReactInterface/traceServerClientInterface/query';
 import {CallFilter} from '../wfReactInterface/wfDataModelHooksInterface';
 import {WFHighLevelCallFilter} from './callsTableFilter';
-
-// These operators do not require a value for the filter to be complete.
-const NO_VALUE_OPERATORS = ['(any): isEmpty', '(any): isNotEmpty'];
 
 /**
  * This Hook is responsible for bridging the gap between the CallsTable
@@ -55,8 +55,7 @@ export const useCallsForQuery = (
 
   const filterByRaw = useMemo(() => {
     const completeItems = gridFilter.items.filter(
-      item =>
-        item.value !== undefined || NO_VALUE_OPERATORS.includes(item.operator)
+      item => item.value !== undefined || isValuelessOperator(item.operator)
     );
 
     const convertedItems = completeItems

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -55,6 +55,13 @@ export const allOperators = Object.entries(allGeneralPurposeOperators).flatMap(
       };
     })
 );
+
+const VALUELESS_OPERATORS = new Set(['(any): isEmpty', '(any): isNotEmpty']);
+
+export const isValuelessOperator = (operator: string) => {
+  return VALUELESS_OPERATORS.has(operator);
+};
+
 export const operationConverter = (
   item: GridFilterItem
 ): null | Query['$expr'] => {


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-20281

Our filter conversion was excluding filters with no value, but it is expected for filters using the `isEmpty` and `isNotEmpty` operator to not have a value.