### PR TITLE
fix(weave): Fix kwargs init issue for WeaveList and WeaveDict

### DIFF
--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -325,7 +325,7 @@ class WeaveList(Traceable, list):
         self.server = server
 
         self.ref = ref
-        self.root = root or self
+        self.root = root if root is not None else self
         self.parent = parent
         super().__init__(*args)
 
@@ -390,7 +390,7 @@ class WeaveDict(Traceable, dict):
         self.server = server
 
         self.ref = ref
-        self.root = root or self
+        self.root = root if root is not None else self
         self.parent = parent
         super().__init__(*args, **kwargs)
 

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -98,7 +98,12 @@ class Traceable:
         """Recursively mark this object and its ancestors as dirty and removes their refs."""
         self._is_dirty = True
         self.ref = None
-        if self.parent not in (self, None) and hasattr(self.parent, "_mark_dirty"):
+        if (
+            # Written this way to satisfy mypy
+            self.parent is not self
+            and self.parent is not None
+            and hasattr(self.parent, "_mark_dirty")
+        ):
             self.parent._mark_dirty()
 
     def add_mutation(

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -317,15 +317,17 @@ class WeaveList(Traceable, list):
     def __init__(
         self,
         *args: Any,
-        **kwargs: Any,
-    ):
-        self.ref: RefWithExtra = kwargs.pop("ref")
-        self.server: TraceServerInterface = kwargs.pop("server")
-        root: Optional[Traceable] = kwargs.pop("root", None)
-        if root is None:
-            root = self
-        self.root = root
-        super().__init__(*args, **kwargs)
+        server: TraceServerInterface,
+        ref: Optional[RefWithExtra] = None,
+        root: Optional[Traceable] = None,
+        parent: Optional[Traceable] = None,
+    ) -> None:
+        self.server = server
+
+        self.ref = ref
+        self.root = root or self
+        self.parent = parent
+        super().__init__(*args)
 
     def __getitem__(self, i: Union[SupportsIndex, slice]) -> Any:
         if isinstance(i, slice):
@@ -379,14 +381,17 @@ class WeaveDict(Traceable, dict):
     def __init__(
         self,
         *args: Any,
+        server: TraceServerInterface,
+        ref: Optional[RefWithExtra] = None,
+        root: Optional[Traceable] = None,
+        parent: Optional[Traceable] = None,
         **kwargs: Any,
-    ):
-        self.ref: Optional[RefWithExtra] = kwargs.pop("ref")
-        self.server: TraceServerInterface = kwargs.pop("server")
-        root: Optional[Traceable] = kwargs.pop("root", None)
-        if root is None:
-            root = self
-        self.root = root
+    ) -> None:
+        self.server = server
+
+        self.ref = ref
+        self.root = root or self
+        self.parent = parent
         super().__init__(*args, **kwargs)
 
     def __getitem__(self, key: str) -> Any:

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -98,7 +98,7 @@ class Traceable:
         """Recursively mark this object and its ancestors as dirty and removes their refs."""
         self._is_dirty = True
         self.ref = None
-        if self.parent is not self and self.parent is not None:
+        if self.parent not in (self, None) and hasattr(self.parent, "_mark_dirty"):
             self.parent._mark_dirty()
 
     def add_mutation(


### PR DESCRIPTION
Resolves:
- https://wandb.atlassian.net/browse/WB-20297

This PR resolves an issue in `WeaveList` where the `parent` attribute, intended for `Traceable`, was passed into `List` which accepts no kwargs.

The PR resolves this by changing clearly separating Traceable config from the regular list args.  We also do this for dict for consistency.
