### PR TITLE
chore(weave): Remove extraneous save

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -155,7 +155,6 @@ def _create_call(func: Op, *args: Any, **kwargs: Any) -> "Call":
     # If/When we do memoization, this would be a good spot
 
     parent_call = call_context.get_current_call()
-    client._save_nested_objects(inputs_with_defaults)
     attributes = call_attributes.get()
 
     return client.create_call(


### PR DESCRIPTION
This PR removes (what seems to be) an extraneous save during calling.

The inputs are saved inside `client.create_call` already:
https://github.com/wandb/weave/blame/andrew/remove-extraneous-save/weave/weave_client.py#L518