### PR TITLE
fix: Don't submit note form if Enter event pressed as part of IME

### DIFF
--- a/weave-js/src/components/Form/TextField.tsx
+++ b/weave-js/src/components/Form/TextField.tsx
@@ -22,7 +22,7 @@ type TextFieldProps = {
   placeholder?: string;
   value?: string;
   onChange?: (value: string) => void;
-  onKeyDown?: (key: string) => void;
+  onKeyDown?: (key: string, e: React.KeyboardEvent<HTMLInputElement>) => void;
   onBlur?: (value: string) => void;
   autoFocus?: boolean;
   disabled?: boolean;
@@ -66,7 +66,7 @@ export const TextField = ({
     : undefined;
   const handleKeyDown = onKeyDown
     ? (e: React.KeyboardEvent<HTMLInputElement>) => {
-        onKeyDown(e.key);
+        onKeyDown(e.key, e);
       }
     : undefined;
   const handleBlur = onBlur

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/Notes.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/Notes.tsx
@@ -39,8 +39,8 @@ export const Notes = ({
       }
     : undefined;
   const onKeyDown = onNoteAdded
-    ? (key: string) => {
-        if (key === 'Enter') {
+    ? (key: string, e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (key === 'Enter' && !e.nativeEvent.isComposing) {
           onNoteAdded();
         }
       }


### PR DESCRIPTION
Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1723216451475369?thread_ts=1723207818.976219&cid=C03BSTEBD7F
Internal Jira: https://wandb.atlassian.net/browse/WB-20311

Fix for IME - the Enter key is used for hiragana to kanji input on a Japanese language keyboard, we were prematurely submitting feedback notes when the user pressed Enter.