### PR TITLE
chore: Remove private underscores from interface classes

### DIFF
--- a/docs/docs/reference/python-sdk/weave/trace_server/weave.trace_server.trace_server_interface.md
+++ b/docs/docs/reference/python-sdk/weave/trace_server/weave.trace_server.trace_server_interface.md
@@ -271,15 +271,15 @@ class CallsDeleteRes(BaseModel):
 ```python
 class CallsQueryReq(BaseModel):
     project_id: str
-    filter: typing.Optional[_CallsFilter] = None
+    filter: typing.Optional[CallsFilter] = None
     limit: typing.Optional[int] = None
     offset: typing.Optional[int] = None
     # Sort by multiple fields
-    sort_by: typing.Optional[typing.List[_SortBy]] = None
+    sort_by: typing.Optional[typing.List[SortBy]] = None
     query: typing.Optional[Query] = None
 
     # TODO: type this with call schema columns, following the same rules as
-    # _SortBy and thus GetFieldOperator.get_field_ (without direction)
+    # SortBy and thus GetFieldOperator.get_field_ (without direction)
     columns: typing.Optional[typing.List[str]] = None
 
 ```
@@ -299,7 +299,7 @@ class CallsQueryRes(BaseModel):
 ```python
 class CallsQueryStatsReq(BaseModel):
     project_id: str
-    filter: typing.Optional[_CallsFilter] = None
+    filter: typing.Optional[CallsFilter] = None
     query: typing.Optional[Query] = None
 
 ```
@@ -473,8 +473,8 @@ class FeedbackQueryReq(BaseModel):
     query: typing.Optional[Query] = None
     # TODO: I think I would prefer to call this order_by to match SQL, but this is what calls API uses
     # TODO: Might be nice to have shortcut for single field and implied ASC direction
-    # TODO: I think _SortBy shouldn't have leading underscore
-    sort_by: typing.Optional[typing.List[_SortBy]] = None
+    # TODO: I think SortBy shouldn't have leading underscore
+    sort_by: typing.Optional[typing.List[SortBy]] = None
     limit: typing.Optional[int] = Field(default=None, examples=[10])
     offset: typing.Optional[int] = Field(default=None, examples=[0])
 
@@ -553,7 +553,7 @@ class ObjCreateRes(BaseModel):
 ```python
 class ObjQueryReq(BaseModel):
     project_id: str
-    filter: typing.Optional[_ObjectVersionFilter] = None
+    filter: typing.Optional[ObjectVersionFilter] = None
 
 ```
             
@@ -639,7 +639,7 @@ class OpCreateRes(BaseModel):
 ```python
 class OpQueryReq(BaseModel):
     project_id: str
-    filter: typing.Optional[_OpVersionFilter] = None
+    filter: typing.Optional[OpVersionFilter] = None
 
 ```
             
@@ -802,7 +802,7 @@ class TablePopSpecPayload(BaseModel):
 class TableQueryReq(BaseModel):
     project_id: str
     digest: str
-    filter: typing.Optional[_TableRowFilter] = None
+    filter: typing.Optional[TableRowFilter] = None
     limit: typing.Optional[int] = None
     offset: typing.Optional[int] = None
 

--- a/docs/docs/reference/python-sdk/weave/weave.weave_client.md
+++ b/docs/docs/reference/python-sdk/weave/weave.weave_client.md
@@ -66,7 +66,7 @@ call(call_id: str) → WeaveObject
 ### <kbd>method</kbd> `calls`
 
 ```python
-calls(filter: Optional[_CallsFilter] = None) → CallsIter
+calls(filter: Optional[CallsFilter] = None) → CallsIter
 ```
 
 
@@ -321,7 +321,7 @@ set_display_name(name: Optional[str]) → None
 __init__(
     server: TraceServerInterface,
     project_id: str,
-    filter: _CallsFilter
+    filter: CallsFilter
 ) → None
 ```
 

--- a/docs/docs/reference/python-sdk/weave/weave.weave_client.md
+++ b/docs/docs/reference/python-sdk/weave/weave.weave_client.md
@@ -54,7 +54,7 @@ __init__(
 ### <kbd>method</kbd> `call`
 
 ```python
-call(call_id: str) → WeaveObject
+call(call_id: str, include_costs: Optional[bool] = False) → WeaveObject
 ```
 
 
@@ -66,7 +66,10 @@ call(call_id: str) → WeaveObject
 ### <kbd>method</kbd> `calls`
 
 ```python
-calls(filter: Optional[CallsFilter] = None) → CallsIter
+calls(
+    filter: Optional[CallsFilter] = None,
+    include_costs: Optional[bool] = False
+) → CallsIter
 ```
 
 
@@ -321,7 +324,8 @@ set_display_name(name: Optional[str]) → None
 __init__(
     server: TraceServerInterface,
     project_id: str,
-    filter: CallsFilter
+    filter: CallsFilter,
+    include_costs: bool = False
 ) → None
 ```
 

--- a/docs/docs/reference/service-api/calls-query-calls-query-post.api.mdx
+++ b/docs/docs/reference/service-api/calls-query-calls-query-post.api.mdx
@@ -29,17 +29,9 @@ import TabItem from "@theme/TabItem";
   as={"h1"}
   className={"openapi__heading"}
   children={"Calls Query"}
->
-</Heading>
+></Heading>
 
-<MethodEndpoint
-  method={"post"}
-  path={"/calls/query"}
->
-  
-</MethodEndpoint>
-
-
+<MethodEndpoint method={"post"} path={"/calls/query"}></MethodEndpoint>
 
 Calls Query
 
@@ -48,519 +40,387 @@ Calls Query
   as={"h2"}
   className={"openapi-tabs__heading"}
   children={"Request"}
->
-</Heading>
+></Heading>
 
-<MimeTabs
-  className={"openapi-tabs__mime"}
->
-  <TabItem
-    label={"application/json"}
-    value={"application/json-schema"}
-  >
+<MimeTabs className={"openapi-tabs__mime"}>
+  <TabItem label={"application/json"} value={"application/json-schema"}>
     <details
       style={{}}
       className={"openapi-markdown__details mime"}
       data-collapsed={false}
       open={true}
     >
-      <summary
-        style={{}}
-        className={"openapi-markdown__details-summary-mime"}
-      >
-        <h3
-          className={"openapi-markdown__details-summary-header-body"}
-        >
+      <summary style={{}} className={"openapi-markdown__details-summary-mime"}>
+        <h3 className={"openapi-markdown__details-summary-header-body"}>
           Body
-        </h3><strong
-          className={"openapi-schema__required"}
-        >
-          required
-        </strong>
-      </summary><div
-        style={{"textAlign":"left","marginLeft":"1rem"}}
-      >
-        
-      </div><ul
-        style={{"marginLeft":"1rem"}}
-      >
+        </h3>
+        <strong className={"openapi-schema__required"}>required</strong>
+      </summary>
+      <div style={{ textAlign: "left", marginLeft: "1rem" }}></div>
+      <ul style={{ marginLeft: "1rem" }}>
         <SchemaItem
           collapsible={false}
           name={"project_id"}
           required={true}
           schemaName={"Project Id (string)"}
           qualifierMessage={undefined}
-          schema={{"type":"string","title":"Project Id"}}
-        >
-          
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                filter
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"_CallsFilter"}
-                  value={"0-item-properties"}
-                >
-                  <SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          op_names
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+          schema={{ type: "string", title: "Project Id" }}
+        ></SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>filter</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"CallsFilter"} value={"0-item-properties"}>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>op_names</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
                             </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          input_refs
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          output_refs
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          parent_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          trace_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          call_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          trace_roots_only
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
                             <div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>input_refs</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>output_refs</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>parent_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>trace_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>call_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>trace_roots_only</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
                               boolean
-                              
-                              
                             </div>
                           </TabItem>
                         </SchemaTabs>
                       </div>
                     </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          wb_user_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>wb_user_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
                               string
-                              
-                              
-                            </div><li>
+                            </div>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -569,55 +429,45 @@ Calls Query
                         </SchemaTabs>
                       </div>
                     </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          wb_run_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>wb_run_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
                               string
-                              
-                              
-                            </div><li>
+                            </div>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -631,155 +481,95 @@ Calls Query
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                limit
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
-                  <div
-                    style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                  >
-                    
-                    
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>limit</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
+                  <div style={{ marginTop: ".5rem", marginBottom: ".5rem" }}>
                     integer
-                    
-                    
                   </div>
                 </TabItem>
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                offset
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
-                  <div
-                    style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                  >
-                    
-                    
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>offset</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
+                  <div style={{ marginTop: ".5rem", marginBottom: ".5rem" }}>
                     integer
-                    
-                    
                   </div>
                 </TabItem>
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                sort_by
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>sort_by</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
                   <li>
                     <div
-                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                      style={{
+                        fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
+                        marginLeft: "-.5rem",
+                        paddingBottom: ".5rem",
+                      }}
                     >
                       Array [
                     </div>
-                  </li><SchemaItem
+                  </li>
+                  <SchemaItem
                     collapsible={false}
                     name={"field"}
                     required={true}
                     schemaName={"Field (string)"}
                     qualifierMessage={undefined}
-                    schema={{"type":"string","title":"Field"}}
-                  >
-                    
-                  </SchemaItem><SchemaItem
+                    schema={{ type: "string", title: "Field" }}
+                  ></SchemaItem>
+                  <SchemaItem
                     collapsible={false}
                     name={"direction"}
                     required={true}
                     schemaName={"Direction (string)"}
                     qualifierMessage={"**Possible values:** [`asc`, `desc`]"}
-                    schema={{"type":"string","enum":["asc","desc"],"title":"Direction"}}
-                  >
-                    
-                  </SchemaItem><li>
+                    schema={{
+                      type: "string",
+                      enum: ["asc", "desc"],
+                      title: "Direction",
+                    }}
+                  ></SchemaItem>
+                  <li>
                     <div
-                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                      style={{
+                        fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
+                        marginLeft: "-.5rem",
+                      }}
                     >
                       ]
                     </div>
@@ -788,101 +578,64 @@ Calls Query
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                query
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"Query"}
-                  value={"0-item-properties"}
-                >
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>query</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"Query"} value={"0-item-properties"}>
                   <SchemaItem
                     collapsible={false}
                     name={"$expr"}
                     required={true}
                     schemaName={"object"}
                     qualifierMessage={undefined}
-                    schema={{"title":"$Expr","type":"object"}}
-                  >
-                    
-                  </SchemaItem>
+                    schema={{ title: "$Expr", type: "object" }}
+                  ></SchemaItem>
                 </TabItem>
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                columns
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>columns</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
                   <li>
                     <div
-                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                      style={{
+                        fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
+                        marginLeft: "-.5rem",
+                        paddingBottom: ".5rem",
+                      }}
                     >
                       Array [
                     </div>
-                  </li><div
-                    style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                  >
-                    
-                    
+                  </li>
+                  <div style={{ marginTop: ".5rem", marginBottom: ".5rem" }}>
                     string
-                    
-                    
-                  </div><li>
+                  </div>
+                  <li>
                     <div
-                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                      style={{
+                        fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
+                        marginLeft: "-.5rem",
+                      }}
                     >
                       ]
                     </div>
@@ -895,38 +648,17 @@ Calls Query
       </ul>
     </details>
   </TabItem>
-</MimeTabs><div>
+</MimeTabs>
+<div>
   <div>
-    <ApiTabs
-      label={undefined}
-      id={undefined}
-    >
-      <TabItem
-        label={"200"}
-        value={"200"}
-      >
+    <ApiTabs label={undefined} id={undefined}>
+      <TabItem label={"200"} value={"200"}>
+        <div>Successful Response</div>
         <div>
-          
-          
-          Successful Response
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -937,85 +669,71 @@ Calls Query
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      <SchemaItem
-                        collapsible={true}
-                        className={"schemaItem"}
-                      >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
+                      <SchemaItem collapsible={true} className={"schemaItem"}>
                         <details
                           style={{}}
                           className={"openapi-markdown__details"}
                         >
-                          <summary
-                            style={{}}
-                          >
-                            <span
-                              className={"openapi-schema__container"}
-                            >
-                              <strong
-                                className={"openapi-schema__property"}
-                              >
+                          <summary style={{}}>
+                            <span className={"openapi-schema__container"}>
+                              <strong className={"openapi-schema__property"}>
                                 calls
-                              </strong><span
-                                className={"openapi-schema__name"}
-                              >
-                                 object[]
-                              </span><span
+                              </strong>
+                              <span className={"openapi-schema__name"}>
+                                object[]
+                              </span>
+                              <span
                                 className={"openapi-schema__divider"}
-                              >
-                                
-                              </span><span
-                                className={"openapi-schema__required"}
-                              >
+                              ></span>
+                              <span className={"openapi-schema__required"}>
                                 required
                               </span>
                             </span>
-                          </summary><div
-                            style={{"marginLeft":"1rem"}}
-                          >
+                          </summary>
+                          <div style={{ marginLeft: "1rem" }}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><SchemaItem
+                            </li>
+                            <SchemaItem
                               collapsible={false}
                               name={"id"}
                               required={true}
                               schemaName={"Id (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Id"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Id" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"project_id"}
                               required={true}
                               schemaName={"Project Id (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Project Id"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Project Id" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"op_name"}
                               required={true}
                               schemaName={"Op Name (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Op Name"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Op Name" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1023,53 +741,42 @@ Calls Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    display_name
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
-                                  >
-                                     object
-                                  </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                <summary style={{}}>
+                                  <strong>display_name</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"trace_id"}
                               required={true}
                               schemaName={"Trace Id (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Trace Id"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Trace Id" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1077,71 +784,62 @@ Calls Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    parent_id
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
-                                  >
-                                     object
-                                  </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                <summary style={{}}>
+                                  <strong>parent_id</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"started_at"}
                               required={true}
                               schemaName={"date-time"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","format":"date-time","title":"Started At"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{
+                                type: "string",
+                                format: "date-time",
+                                title: "Started At",
+                              }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"attributes"}
                               required={true}
                               schemaName={"object"}
                               qualifierMessage={undefined}
-                              schema={{"type":"object","title":"Attributes"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "object", title: "Attributes" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"inputs"}
                               required={true}
                               schemaName={"object"}
                               qualifierMessage={undefined}
-                              schema={{"type":"object","title":"Inputs"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "object", title: "Inputs" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1149,44 +847,34 @@ Calls Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    ended_at
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
-                                  >
-                                     object
-                                  </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                <summary style={{}}>
+                                  <strong>ended_at</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1194,62 +882,50 @@ Calls Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    exception
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
-                                  >
-                                     object
-                                  </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                <summary style={{}}>
+                                  <strong>exception</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"output"}
                               required={false}
                               schemaName={"object"}
                               qualifierMessage={undefined}
-                              schema={{"title":"Output","type":"object"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ title: "Output", type: "object" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"summary"}
                               required={false}
                               schemaName={"object"}
                               qualifierMessage={undefined}
-                              schema={{"title":"Summary","type":"object"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ title: "Summary", type: "object" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1257,44 +933,34 @@ Calls Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    wb_user_id
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
-                                  >
-                                     object
-                                  </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                <summary style={{}}>
+                                  <strong>wb_user_id</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1302,44 +968,34 @@ Calls Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    wb_run_id
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
-                                  >
-                                     object
-                                  </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                <summary style={{}}>
+                                  <strong>wb_run_id</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1347,46 +1003,40 @@ Calls Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    deleted_at
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
-                                  >
-                                     object
-                                  </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                <summary style={{}}>
+                                  <strong>deleted_at</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><li>
+                            </SchemaItem>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -1396,47 +1046,30 @@ Calls Query
                       </SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"calls\": [\n    {\n      \"id\": \"string\",\n      \"project_id\": \"string\",\n      \"op_name\": \"string\",\n      \"display_name\": \"string\",\n      \"trace_id\": \"string\",\n      \"parent_id\": \"string\",\n      \"started_at\": \"2024-08-08T03:46:19.657Z\",\n      \"attributes\": {},\n      \"inputs\": {},\n      \"ended_at\": \"2024-08-08T03:46:19.657Z\",\n      \"exception\": \"string\",\n      \"output\": {},\n      \"summary\": {},\n      \"wb_user_id\": \"string\",\n      \"wb_run_id\": \"string\",\n      \"deleted_at\": \"2024-08-08T03:46:19.657Z\"\n    }\n  ]\n}"}
+                    responseExample={
+                      '{\n  "calls": [\n    {\n      "id": "string",\n      "project_id": "string",\n      "op_name": "string",\n      "display_name": "string",\n      "trace_id": "string",\n      "parent_id": "string",\n      "started_at": "2024-08-08T03:46:19.657Z",\n      "attributes": {},\n      "inputs": {},\n      "ended_at": "2024-08-08T03:46:19.657Z",\n      "exception": "string",\n      "output": {},\n      "summary": {},\n      "wb_user_id": "string",\n      "wb_run_id": "string",\n      "deleted_at": "2024-08-08T03:46:19.657Z"\n    }\n  ]\n}'
+                    }
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
           </MimeTabs>
         </div>
-      </TabItem><TabItem
-        label={"422"}
-        value={"422"}
-      >
+      </TabItem>
+      <TabItem label={"422"} value={"422"}>
+        <div>Validation Error</div>
         <div>
-          
-          
-          Validation Error
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -1447,50 +1080,41 @@ Calls Query
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      <SchemaItem
-                        collapsible={true}
-                        className={"schemaItem"}
-                      >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
+                      <SchemaItem collapsible={true} className={"schemaItem"}>
                         <details
                           style={{}}
                           className={"openapi-markdown__details"}
                         >
-                          <summary
-                            style={{}}
-                          >
-                            <span
-                              className={"openapi-schema__container"}
-                            >
-                              <strong
-                                className={"openapi-schema__property"}
-                              >
+                          <summary style={{}}>
+                            <span className={"openapi-schema__container"}>
+                              <strong className={"openapi-schema__property"}>
                                 detail
-                              </strong><span
-                                className={"openapi-schema__name"}
-                              >
-                                 object[]
+                              </strong>
+                              <span className={"openapi-schema__name"}>
+                                object[]
                               </span>
                             </span>
-                          </summary><div
-                            style={{"marginLeft":"1rem"}}
-                          >
+                          </summary>
+                          <div style={{ marginLeft: "1rem" }}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><SchemaItem
+                            </li>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1498,103 +1122,109 @@ Calls Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <span
-                                    className={"openapi-schema__container"}
-                                  >
+                                <summary style={{}}>
+                                  <span className={"openapi-schema__container"}>
                                     <strong
                                       className={"openapi-schema__property"}
                                     >
                                       loc
-                                    </strong><span
-                                      className={"openapi-schema__name"}
-                                    >
-                                       object[]
-                                    </span><span
+                                    </strong>
+                                    <span className={"openapi-schema__name"}>
+                                      object[]
+                                    </span>
+                                    <span
                                       className={"openapi-schema__divider"}
-                                    >
-                                      
-                                    </span><span
+                                    ></span>
+                                    <span
                                       className={"openapi-schema__required"}
                                     >
                                       required
                                     </span>
                                   </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}>
                                   <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                        paddingBottom: ".5rem",
+                                      }}
                                     >
                                       Array [
                                     </div>
-                                  </li><div>
-                                    <span
-                                      className={"badge badge--info"}
-                                    >
+                                  </li>
+                                  <div>
+                                    <span className={"badge badge--info"}>
                                       anyOf
-                                    </span><SchemaTabs>
+                                    </span>
+                                    <SchemaTabs>
                                       <TabItem
                                         label={"MOD1"}
                                         value={"0-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           string
-                                          
-                                          
                                         </div>
-                                      </TabItem><TabItem
+                                      </TabItem>
+                                      <TabItem
                                         label={"MOD2"}
                                         value={"1-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           integer
-                                          
-                                          
                                         </div>
                                       </TabItem>
                                     </SchemaTabs>
-                                  </div><li>
+                                  </div>
+                                  <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                      }}
                                     >
                                       ]
                                     </div>
                                   </li>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"msg"}
                               required={true}
                               schemaName={"Message (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Message"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Message" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"type"}
                               required={true}
                               schemaName={"Error Type (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Error Type"}}
-                            >
-                              
-                            </SchemaItem><li>
+                              schema={{ type: "string", title: "Error Type" }}
+                            ></SchemaItem>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -1604,16 +1234,17 @@ Calls Query
                       </SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        0\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\"\n    }\n  ]\n}"}
+                    responseExample={
+                      '{\n  "detail": [\n    {\n      "loc": [\n        "string",\n        0\n      ],\n      "msg": "string",\n      "type": "string"\n    }\n  ]\n}'
+                    }
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
@@ -1623,4 +1254,3 @@ Calls Query
     </ApiTabs>
   </div>
 </div>
-      

--- a/docs/docs/reference/service-api/calls-query-stats-calls-query-stats-post.api.mdx
+++ b/docs/docs/reference/service-api/calls-query-stats-calls-query-stats-post.api.mdx
@@ -29,17 +29,9 @@ import TabItem from "@theme/TabItem";
   as={"h1"}
   className={"openapi__heading"}
   children={"Calls Query Stats"}
->
-</Heading>
+></Heading>
 
-<MethodEndpoint
-  method={"post"}
-  path={"/calls/query_stats"}
->
-  
-</MethodEndpoint>
-
-
+<MethodEndpoint method={"post"} path={"/calls/query_stats"}></MethodEndpoint>
 
 Calls Query Stats
 
@@ -48,519 +40,387 @@ Calls Query Stats
   as={"h2"}
   className={"openapi-tabs__heading"}
   children={"Request"}
->
-</Heading>
+></Heading>
 
-<MimeTabs
-  className={"openapi-tabs__mime"}
->
-  <TabItem
-    label={"application/json"}
-    value={"application/json-schema"}
-  >
+<MimeTabs className={"openapi-tabs__mime"}>
+  <TabItem label={"application/json"} value={"application/json-schema"}>
     <details
       style={{}}
       className={"openapi-markdown__details mime"}
       data-collapsed={false}
       open={true}
     >
-      <summary
-        style={{}}
-        className={"openapi-markdown__details-summary-mime"}
-      >
-        <h3
-          className={"openapi-markdown__details-summary-header-body"}
-        >
+      <summary style={{}} className={"openapi-markdown__details-summary-mime"}>
+        <h3 className={"openapi-markdown__details-summary-header-body"}>
           Body
-        </h3><strong
-          className={"openapi-schema__required"}
-        >
-          required
-        </strong>
-      </summary><div
-        style={{"textAlign":"left","marginLeft":"1rem"}}
-      >
-        
-      </div><ul
-        style={{"marginLeft":"1rem"}}
-      >
+        </h3>
+        <strong className={"openapi-schema__required"}>required</strong>
+      </summary>
+      <div style={{ textAlign: "left", marginLeft: "1rem" }}></div>
+      <ul style={{ marginLeft: "1rem" }}>
         <SchemaItem
           collapsible={false}
           name={"project_id"}
           required={true}
           schemaName={"Project Id (string)"}
           qualifierMessage={undefined}
-          schema={{"type":"string","title":"Project Id"}}
-        >
-          
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                filter
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"_CallsFilter"}
-                  value={"0-item-properties"}
-                >
-                  <SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          op_names
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+          schema={{ type: "string", title: "Project Id" }}
+        ></SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>filter</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"CallsFilter"} value={"0-item-properties"}>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>op_names</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
                             </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          input_refs
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          output_refs
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          parent_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          trace_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          call_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          trace_roots_only
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
                             <div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>input_refs</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>output_refs</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>parent_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>trace_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>call_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>trace_roots_only</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
                               boolean
-                              
-                              
                             </div>
                           </TabItem>
                         </SchemaTabs>
                       </div>
                     </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          wb_user_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>wb_user_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
                               string
-                              
-                              
-                            </div><li>
+                            </div>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -569,55 +429,45 @@ Calls Query Stats
                         </SchemaTabs>
                       </div>
                     </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          wb_run_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>wb_run_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
                               string
-                              
-                              
-                            </div><li>
+                            </div>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -631,48 +481,26 @@ Calls Query Stats
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                query
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"Query"}
-                  value={"0-item-properties"}
-                >
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>query</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"Query"} value={"0-item-properties"}>
                   <SchemaItem
                     collapsible={false}
                     name={"$expr"}
                     required={true}
                     schemaName={"object"}
                     qualifierMessage={undefined}
-                    schema={{"title":"$Expr","type":"object"}}
-                  >
-                    
-                  </SchemaItem>
+                    schema={{ title: "$Expr", type: "object" }}
+                  ></SchemaItem>
                 </TabItem>
               </SchemaTabs>
             </div>
@@ -681,38 +509,17 @@ Calls Query Stats
       </ul>
     </details>
   </TabItem>
-</MimeTabs><div>
+</MimeTabs>
+<div>
   <div>
-    <ApiTabs
-      label={undefined}
-      id={undefined}
-    >
-      <TabItem
-        label={"200"}
-        value={"200"}
-      >
+    <ApiTabs label={undefined} id={undefined}>
+      <TabItem label={"200"} value={"200"}>
+        <div>Successful Response</div>
         <div>
-          
-          
-          Successful Response
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -723,69 +530,44 @@ Calls Query Stats
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
                       <SchemaItem
                         collapsible={false}
                         name={"count"}
                         required={true}
                         schemaName={"Count (integer)"}
                         qualifierMessage={undefined}
-                        schema={{"type":"integer","title":"Count"}}
-                      >
-                        
-                      </SchemaItem>
+                        schema={{ type: "integer", title: "Count" }}
+                      ></SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"count\": 0\n}"}
+                    responseExample={'{\n  "count": 0\n}'}
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
           </MimeTabs>
         </div>
-      </TabItem><TabItem
-        label={"422"}
-        value={"422"}
-      >
+      </TabItem>
+      <TabItem label={"422"} value={"422"}>
+        <div>Validation Error</div>
         <div>
-          
-          
-          Validation Error
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -796,50 +578,41 @@ Calls Query Stats
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      <SchemaItem
-                        collapsible={true}
-                        className={"schemaItem"}
-                      >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
+                      <SchemaItem collapsible={true} className={"schemaItem"}>
                         <details
                           style={{}}
                           className={"openapi-markdown__details"}
                         >
-                          <summary
-                            style={{}}
-                          >
-                            <span
-                              className={"openapi-schema__container"}
-                            >
-                              <strong
-                                className={"openapi-schema__property"}
-                              >
+                          <summary style={{}}>
+                            <span className={"openapi-schema__container"}>
+                              <strong className={"openapi-schema__property"}>
                                 detail
-                              </strong><span
-                                className={"openapi-schema__name"}
-                              >
-                                 object[]
+                              </strong>
+                              <span className={"openapi-schema__name"}>
+                                object[]
                               </span>
                             </span>
-                          </summary><div
-                            style={{"marginLeft":"1rem"}}
-                          >
+                          </summary>
+                          <div style={{ marginLeft: "1rem" }}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><SchemaItem
+                            </li>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -847,103 +620,109 @@ Calls Query Stats
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <span
-                                    className={"openapi-schema__container"}
-                                  >
+                                <summary style={{}}>
+                                  <span className={"openapi-schema__container"}>
                                     <strong
                                       className={"openapi-schema__property"}
                                     >
                                       loc
-                                    </strong><span
-                                      className={"openapi-schema__name"}
-                                    >
-                                       object[]
-                                    </span><span
+                                    </strong>
+                                    <span className={"openapi-schema__name"}>
+                                      object[]
+                                    </span>
+                                    <span
                                       className={"openapi-schema__divider"}
-                                    >
-                                      
-                                    </span><span
+                                    ></span>
+                                    <span
                                       className={"openapi-schema__required"}
                                     >
                                       required
                                     </span>
                                   </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}>
                                   <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                        paddingBottom: ".5rem",
+                                      }}
                                     >
                                       Array [
                                     </div>
-                                  </li><div>
-                                    <span
-                                      className={"badge badge--info"}
-                                    >
+                                  </li>
+                                  <div>
+                                    <span className={"badge badge--info"}>
                                       anyOf
-                                    </span><SchemaTabs>
+                                    </span>
+                                    <SchemaTabs>
                                       <TabItem
                                         label={"MOD1"}
                                         value={"0-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           string
-                                          
-                                          
                                         </div>
-                                      </TabItem><TabItem
+                                      </TabItem>
+                                      <TabItem
                                         label={"MOD2"}
                                         value={"1-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           integer
-                                          
-                                          
                                         </div>
                                       </TabItem>
                                     </SchemaTabs>
-                                  </div><li>
+                                  </div>
+                                  <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                      }}
                                     >
                                       ]
                                     </div>
                                   </li>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"msg"}
                               required={true}
                               schemaName={"Message (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Message"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Message" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"type"}
                               required={true}
                               schemaName={"Error Type (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Error Type"}}
-                            >
-                              
-                            </SchemaItem><li>
+                              schema={{ type: "string", title: "Error Type" }}
+                            ></SchemaItem>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -953,16 +732,17 @@ Calls Query Stats
                       </SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        0\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\"\n    }\n  ]\n}"}
+                    responseExample={
+                      '{\n  "detail": [\n    {\n      "loc": [\n        "string",\n        0\n      ],\n      "msg": "string",\n      "type": "string"\n    }\n  ]\n}'
+                    }
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
@@ -972,4 +752,3 @@ Calls Query Stats
     </ApiTabs>
   </div>
 </div>
-      

--- a/docs/docs/reference/service-api/calls-query-stream-calls-stream-query-post.api.mdx
+++ b/docs/docs/reference/service-api/calls-query-stream-calls-stream-query-post.api.mdx
@@ -29,17 +29,9 @@ import TabItem from "@theme/TabItem";
   as={"h1"}
   className={"openapi__heading"}
   children={"Calls Query Stream"}
->
-</Heading>
+></Heading>
 
-<MethodEndpoint
-  method={"post"}
-  path={"/calls/stream_query"}
->
-  
-</MethodEndpoint>
-
-
+<MethodEndpoint method={"post"} path={"/calls/stream_query"}></MethodEndpoint>
 
 Calls Query Stream
 
@@ -48,543 +40,416 @@ Calls Query Stream
   as={"h2"}
   className={"openapi-tabs__heading"}
   children={"Request"}
->
-</Heading>
+></Heading>
 
 <details
-  style={{"marginBottom":"1rem"}}
+  style={{ marginBottom: "1rem" }}
   className={"openapi-markdown__details"}
   data-collapsed={false}
   open={true}
 >
-  <summary
-    style={{}}
-  >
-    <h3
-      className={"openapi-markdown__details-summary-header-params"}
-    >
+  <summary style={{}}>
+    <h3 className={"openapi-markdown__details-summary-header-params"}>
       Header Parameters
     </h3>
-  </summary><div>
+  </summary>
+  <div>
     <ul>
       <ParamsItem
         className={"paramsItem"}
-        param={{"name":"accept","in":"header","required":false,"schema":{"type":"string","default":"application/jsonl","title":"Accept"}}}
-      >
-        
-      </ParamsItem>
+        param={{
+          name: "accept",
+          in: "header",
+          required: false,
+          schema: {
+            type: "string",
+            default: "application/jsonl",
+            title: "Accept",
+          },
+        }}
+      ></ParamsItem>
     </ul>
   </div>
-</details><MimeTabs
-  className={"openapi-tabs__mime"}
->
-  <TabItem
-    label={"application/json"}
-    value={"application/json-schema"}
-  >
+</details>
+<MimeTabs className={"openapi-tabs__mime"}>
+  <TabItem label={"application/json"} value={"application/json-schema"}>
     <details
       style={{}}
       className={"openapi-markdown__details mime"}
       data-collapsed={false}
       open={true}
     >
-      <summary
-        style={{}}
-        className={"openapi-markdown__details-summary-mime"}
-      >
-        <h3
-          className={"openapi-markdown__details-summary-header-body"}
-        >
+      <summary style={{}} className={"openapi-markdown__details-summary-mime"}>
+        <h3 className={"openapi-markdown__details-summary-header-body"}>
           Body
-        </h3><strong
-          className={"openapi-schema__required"}
-        >
-          required
-        </strong>
-      </summary><div
-        style={{"textAlign":"left","marginLeft":"1rem"}}
-      >
-        
-      </div><ul
-        style={{"marginLeft":"1rem"}}
-      >
+        </h3>
+        <strong className={"openapi-schema__required"}>required</strong>
+      </summary>
+      <div style={{ textAlign: "left", marginLeft: "1rem" }}></div>
+      <ul style={{ marginLeft: "1rem" }}>
         <SchemaItem
           collapsible={false}
           name={"project_id"}
           required={true}
           schemaName={"Project Id (string)"}
           qualifierMessage={undefined}
-          schema={{"type":"string","title":"Project Id"}}
-        >
-          
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                filter
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"_CallsFilter"}
-                  value={"0-item-properties"}
-                >
-                  <SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          op_names
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+          schema={{ type: "string", title: "Project Id" }}
+        ></SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>filter</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"CallsFilter"} value={"0-item-properties"}>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>op_names</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
                             </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          input_refs
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          output_refs
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          parent_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          trace_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          call_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          trace_roots_only
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
                             <div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>input_refs</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>output_refs</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>parent_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>trace_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>call_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>trace_roots_only</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
                               boolean
-                              
-                              
                             </div>
                           </TabItem>
                         </SchemaTabs>
                       </div>
                     </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          wb_user_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>wb_user_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
                               string
-                              
-                              
-                            </div><li>
+                            </div>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -593,55 +458,45 @@ Calls Query Stream
                         </SchemaTabs>
                       </div>
                     </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          wb_run_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>wb_run_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
                               string
-                              
-                              
-                            </div><li>
+                            </div>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -655,155 +510,95 @@ Calls Query Stream
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                limit
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
-                  <div
-                    style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                  >
-                    
-                    
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>limit</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
+                  <div style={{ marginTop: ".5rem", marginBottom: ".5rem" }}>
                     integer
-                    
-                    
                   </div>
                 </TabItem>
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                offset
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
-                  <div
-                    style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                  >
-                    
-                    
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>offset</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
+                  <div style={{ marginTop: ".5rem", marginBottom: ".5rem" }}>
                     integer
-                    
-                    
                   </div>
                 </TabItem>
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                sort_by
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>sort_by</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
                   <li>
                     <div
-                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                      style={{
+                        fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
+                        marginLeft: "-.5rem",
+                        paddingBottom: ".5rem",
+                      }}
                     >
                       Array [
                     </div>
-                  </li><SchemaItem
+                  </li>
+                  <SchemaItem
                     collapsible={false}
                     name={"field"}
                     required={true}
                     schemaName={"Field (string)"}
                     qualifierMessage={undefined}
-                    schema={{"type":"string","title":"Field"}}
-                  >
-                    
-                  </SchemaItem><SchemaItem
+                    schema={{ type: "string", title: "Field" }}
+                  ></SchemaItem>
+                  <SchemaItem
                     collapsible={false}
                     name={"direction"}
                     required={true}
                     schemaName={"Direction (string)"}
                     qualifierMessage={"**Possible values:** [`asc`, `desc`]"}
-                    schema={{"type":"string","enum":["asc","desc"],"title":"Direction"}}
-                  >
-                    
-                  </SchemaItem><li>
+                    schema={{
+                      type: "string",
+                      enum: ["asc", "desc"],
+                      title: "Direction",
+                    }}
+                  ></SchemaItem>
+                  <li>
                     <div
-                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                      style={{
+                        fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
+                        marginLeft: "-.5rem",
+                      }}
                     >
                       ]
                     </div>
@@ -812,101 +607,64 @@ Calls Query Stream
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                query
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"Query"}
-                  value={"0-item-properties"}
-                >
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>query</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"Query"} value={"0-item-properties"}>
                   <SchemaItem
                     collapsible={false}
                     name={"$expr"}
                     required={true}
                     schemaName={"object"}
                     qualifierMessage={undefined}
-                    schema={{"title":"$Expr","type":"object"}}
-                  >
-                    
-                  </SchemaItem>
+                    schema={{ title: "$Expr", type: "object" }}
+                  ></SchemaItem>
                 </TabItem>
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                columns
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>columns</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
                   <li>
                     <div
-                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                      style={{
+                        fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
+                        marginLeft: "-.5rem",
+                        paddingBottom: ".5rem",
+                      }}
                     >
                       Array [
                     </div>
-                  </li><div
-                    style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                  >
-                    
-                    
+                  </li>
+                  <div style={{ marginTop: ".5rem", marginBottom: ".5rem" }}>
                     string
-                    
-                    
-                  </div><li>
+                  </div>
+                  <li>
                     <div
-                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                      style={{
+                        fontSize: "var(--ifm-code-font-size)",
+                        opacity: "0.6",
+                        marginLeft: "-.5rem",
+                      }}
                     >
                       ]
                     </div>
@@ -919,38 +677,17 @@ Calls Query Stream
       </ul>
     </details>
   </TabItem>
-</MimeTabs><div>
+</MimeTabs>
+<div>
   <div>
-    <ApiTabs
-      label={undefined}
-      id={undefined}
-    >
-      <TabItem
-        label={"200"}
-        value={"200"}
-      >
+    <ApiTabs label={undefined} id={undefined}>
+      <TabItem label={"200"} value={"200"}>
+        <div>Successful Response</div>
         <div>
-          
-          
-          Successful Response
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -961,50 +698,26 @@ Calls Query Stream
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      any
-                    </ul>
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>any</ul>
                   </details>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
           </MimeTabs>
         </div>
-      </TabItem><TabItem
-        label={"422"}
-        value={"422"}
-      >
+      </TabItem>
+      <TabItem label={"422"} value={"422"}>
+        <div>Validation Error</div>
         <div>
-          
-          
-          Validation Error
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -1015,50 +728,41 @@ Calls Query Stream
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      <SchemaItem
-                        collapsible={true}
-                        className={"schemaItem"}
-                      >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
+                      <SchemaItem collapsible={true} className={"schemaItem"}>
                         <details
                           style={{}}
                           className={"openapi-markdown__details"}
                         >
-                          <summary
-                            style={{}}
-                          >
-                            <span
-                              className={"openapi-schema__container"}
-                            >
-                              <strong
-                                className={"openapi-schema__property"}
-                              >
+                          <summary style={{}}>
+                            <span className={"openapi-schema__container"}>
+                              <strong className={"openapi-schema__property"}>
                                 detail
-                              </strong><span
-                                className={"openapi-schema__name"}
-                              >
-                                 object[]
+                              </strong>
+                              <span className={"openapi-schema__name"}>
+                                object[]
                               </span>
                             </span>
-                          </summary><div
-                            style={{"marginLeft":"1rem"}}
-                          >
+                          </summary>
+                          <div style={{ marginLeft: "1rem" }}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><SchemaItem
+                            </li>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -1066,103 +770,109 @@ Calls Query Stream
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <span
-                                    className={"openapi-schema__container"}
-                                  >
+                                <summary style={{}}>
+                                  <span className={"openapi-schema__container"}>
                                     <strong
                                       className={"openapi-schema__property"}
                                     >
                                       loc
-                                    </strong><span
-                                      className={"openapi-schema__name"}
-                                    >
-                                       object[]
-                                    </span><span
+                                    </strong>
+                                    <span className={"openapi-schema__name"}>
+                                      object[]
+                                    </span>
+                                    <span
                                       className={"openapi-schema__divider"}
-                                    >
-                                      
-                                    </span><span
+                                    ></span>
+                                    <span
                                       className={"openapi-schema__required"}
                                     >
                                       required
                                     </span>
                                   </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}>
                                   <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                        paddingBottom: ".5rem",
+                                      }}
                                     >
                                       Array [
                                     </div>
-                                  </li><div>
-                                    <span
-                                      className={"badge badge--info"}
-                                    >
+                                  </li>
+                                  <div>
+                                    <span className={"badge badge--info"}>
                                       anyOf
-                                    </span><SchemaTabs>
+                                    </span>
+                                    <SchemaTabs>
                                       <TabItem
                                         label={"MOD1"}
                                         value={"0-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           string
-                                          
-                                          
                                         </div>
-                                      </TabItem><TabItem
+                                      </TabItem>
+                                      <TabItem
                                         label={"MOD2"}
                                         value={"1-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           integer
-                                          
-                                          
                                         </div>
                                       </TabItem>
                                     </SchemaTabs>
-                                  </div><li>
+                                  </div>
+                                  <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                      }}
                                     >
                                       ]
                                     </div>
                                   </li>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"msg"}
                               required={true}
                               schemaName={"Message (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Message"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Message" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"type"}
                               required={true}
                               schemaName={"Error Type (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Error Type"}}
-                            >
-                              
-                            </SchemaItem><li>
+                              schema={{ type: "string", title: "Error Type" }}
+                            ></SchemaItem>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -1172,16 +882,17 @@ Calls Query Stream
                       </SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        0\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\"\n    }\n  ]\n}"}
+                    responseExample={
+                      '{\n  "detail": [\n    {\n      "loc": [\n        "string",\n        0\n      ],\n      "msg": "string",\n      "type": "string"\n    }\n  ]\n}'
+                    }
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
@@ -1191,4 +902,3 @@ Calls Query Stream
     </ApiTabs>
   </div>
 </div>
-      

--- a/docs/docs/reference/service-api/objs-query-objs-query-post.api.mdx
+++ b/docs/docs/reference/service-api/objs-query-objs-query-post.api.mdx
@@ -29,17 +29,9 @@ import TabItem from "@theme/TabItem";
   as={"h1"}
   className={"openapi__heading"}
   children={"Objs Query"}
->
-</Heading>
+></Heading>
 
-<MethodEndpoint
-  method={"post"}
-  path={"/objs/query"}
->
-  
-</MethodEndpoint>
-
-
+<MethodEndpoint method={"post"} path={"/objs/query"}></MethodEndpoint>
 
 Objs Query
 
@@ -48,282 +40,182 @@ Objs Query
   as={"h2"}
   className={"openapi-tabs__heading"}
   children={"Request"}
->
-</Heading>
+></Heading>
 
-<MimeTabs
-  className={"openapi-tabs__mime"}
->
-  <TabItem
-    label={"application/json"}
-    value={"application/json-schema"}
-  >
+<MimeTabs className={"openapi-tabs__mime"}>
+  <TabItem label={"application/json"} value={"application/json-schema"}>
     <details
       style={{}}
       className={"openapi-markdown__details mime"}
       data-collapsed={false}
       open={true}
     >
-      <summary
-        style={{}}
-        className={"openapi-markdown__details-summary-mime"}
-      >
-        <h3
-          className={"openapi-markdown__details-summary-header-body"}
-        >
+      <summary style={{}} className={"openapi-markdown__details-summary-mime"}>
+        <h3 className={"openapi-markdown__details-summary-header-body"}>
           Body
-        </h3><strong
-          className={"openapi-schema__required"}
-        >
-          required
-        </strong>
-      </summary><div
-        style={{"textAlign":"left","marginLeft":"1rem"}}
-      >
-        
-      </div><ul
-        style={{"marginLeft":"1rem"}}
-      >
+        </h3>
+        <strong className={"openapi-schema__required"}>required</strong>
+      </summary>
+      <div style={{ textAlign: "left", marginLeft: "1rem" }}></div>
+      <ul style={{ marginLeft: "1rem" }}>
         <SchemaItem
           collapsible={false}
           name={"project_id"}
           required={true}
           schemaName={"Project Id (string)"}
           qualifierMessage={undefined}
-          schema={{"type":"string","title":"Project Id"}}
-        >
-          
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                filter
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
+          schema={{ type: "string", title: "Project Id" }}
+        ></SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>filter</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
                 <TabItem
-                  label={"_ObjectVersionFilter"}
+                  label={"ObjectVersionFilter"}
                   value={"0-item-properties"}
                 >
-                  <SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          base_object_classes
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>base_object_classes</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
                             </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          object_ids
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
-                            <li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
-                              >
-                                Array [
-                              </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                            >
-                              
-                              
-                              string
-                              
-                              
-                            </div><li>
-                              <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
-                              >
-                                ]
-                              </div>
-                            </li>
-                          </TabItem>
-                        </SchemaTabs>
-                      </div>
-                    </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          is_op
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
                             <div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>object_ids</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
+                              >
+                                Array [
+                              </div>
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
+                              string
+                            </div>
+                            <li>
+                              <div
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
+                              >
+                                ]
+                              </div>
+                            </li>
+                          </TabItem>
+                        </SchemaTabs>
+                      </div>
+                    </details>
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>is_op</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
+                            >
                               boolean
-                              
-                              
                             </div>
                           </TabItem>
                         </SchemaTabs>
                       </div>
                     </details>
-                  </SchemaItem><SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          latest_only
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+                  </SchemaItem>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>latest_only</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
                               boolean
-                              
-                              
                             </div>
                           </TabItem>
                         </SchemaTabs>
@@ -338,38 +230,17 @@ Objs Query
       </ul>
     </details>
   </TabItem>
-</MimeTabs><div>
+</MimeTabs>
+<div>
   <div>
-    <ApiTabs
-      label={undefined}
-      id={undefined}
-    >
-      <TabItem
-        label={"200"}
-        value={"200"}
-      >
+    <ApiTabs label={undefined} id={undefined}>
+      <TabItem label={"200"} value={"200"}>
+        <div>Successful Response</div>
         <div>
-          
-          
-          Successful Response
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -380,85 +251,75 @@ Objs Query
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      <SchemaItem
-                        collapsible={true}
-                        className={"schemaItem"}
-                      >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
+                      <SchemaItem collapsible={true} className={"schemaItem"}>
                         <details
                           style={{}}
                           className={"openapi-markdown__details"}
                         >
-                          <summary
-                            style={{}}
-                          >
-                            <span
-                              className={"openapi-schema__container"}
-                            >
-                              <strong
-                                className={"openapi-schema__property"}
-                              >
+                          <summary style={{}}>
+                            <span className={"openapi-schema__container"}>
+                              <strong className={"openapi-schema__property"}>
                                 objs
-                              </strong><span
-                                className={"openapi-schema__name"}
-                              >
-                                 object[]
-                              </span><span
+                              </strong>
+                              <span className={"openapi-schema__name"}>
+                                object[]
+                              </span>
+                              <span
                                 className={"openapi-schema__divider"}
-                              >
-                                
-                              </span><span
-                                className={"openapi-schema__required"}
-                              >
+                              ></span>
+                              <span className={"openapi-schema__required"}>
                                 required
                               </span>
                             </span>
-                          </summary><div
-                            style={{"marginLeft":"1rem"}}
-                          >
+                          </summary>
+                          <div style={{ marginLeft: "1rem" }}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><SchemaItem
+                            </li>
+                            <SchemaItem
                               collapsible={false}
                               name={"project_id"}
                               required={true}
                               schemaName={"Project Id (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Project Id"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Project Id" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"object_id"}
                               required={true}
                               schemaName={"Object Id (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Object Id"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Object Id" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"created_at"}
                               required={true}
                               schemaName={"date-time"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","format":"date-time","title":"Created At"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{
+                                type: "string",
+                                format: "date-time",
+                                title: "Created At",
+                              }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -466,80 +327,69 @@ Objs Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    deleted_at
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
-                                  >
-                                     object
-                                  </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                <summary style={{}}>
+                                  <strong>deleted_at</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"digest"}
                               required={true}
                               schemaName={"Digest (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Digest"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Digest" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"version_index"}
                               required={true}
                               schemaName={"Version Index (integer)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"integer","title":"Version Index"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{
+                                type: "integer",
+                                title: "Version Index",
+                              }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"is_latest"}
                               required={true}
                               schemaName={"Is Latest (integer)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"integer","title":"Is Latest"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "integer", title: "Is Latest" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"kind"}
                               required={true}
                               schemaName={"Kind (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Kind"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Kind" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -547,59 +397,56 @@ Objs Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <strong>
-                                    base_object_class
-                                  </strong><span
-                                    style={{"opacity":"0.6"}}
+                                <summary style={{}}>
+                                  <strong>base_object_class</strong>
+                                  <span style={{ opacity: "0.6" }}>object</span>
+                                  <strong
+                                    style={{
+                                      fontSize: "var(--ifm-code-font-size)",
+                                      color: "var(--openapi-required)",
+                                    }}
                                   >
-                                     object
-                                  </span><strong
-                                    style={{"fontSize":"var(--ifm-code-font-size)","color":"var(--openapi-required)"}}
-                                  >
-                                     required
+                                    required
                                   </strong>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
-                                  
-                                </div><div>
-                                  <span
-                                    className={"badge badge--info"}
-                                  >
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}></div>
+                                <div>
+                                  <span className={"badge badge--info"}>
                                     anyOf
-                                  </span><SchemaTabs>
+                                  </span>
+                                  <SchemaTabs>
                                     <TabItem
                                       label={"MOD1"}
                                       value={"0-item-properties"}
                                     >
                                       <div
-                                        style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                        style={{
+                                          marginTop: ".5rem",
+                                          marginBottom: ".5rem",
+                                        }}
                                       >
-                                        
-                                        
                                         string
-                                        
-                                        
                                       </div>
                                     </TabItem>
                                   </SchemaTabs>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"val"}
                               required={true}
                               schemaName={"Val"}
                               qualifierMessage={undefined}
-                              schema={{"title":"Val"}}
-                            >
-                              
-                            </SchemaItem><li>
+                              schema={{ title: "Val" }}
+                            ></SchemaItem>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -609,47 +456,30 @@ Objs Query
                       </SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"objs\": [\n    {\n      \"project_id\": \"string\",\n      \"object_id\": \"string\",\n      \"created_at\": \"2024-08-08T03:46:19.722Z\",\n      \"deleted_at\": \"2024-08-08T03:46:19.722Z\",\n      \"digest\": \"string\",\n      \"version_index\": 0,\n      \"is_latest\": 0,\n      \"kind\": \"string\",\n      \"base_object_class\": \"string\"\n    }\n  ]\n}"}
+                    responseExample={
+                      '{\n  "objs": [\n    {\n      "project_id": "string",\n      "object_id": "string",\n      "created_at": "2024-08-08T03:46:19.722Z",\n      "deleted_at": "2024-08-08T03:46:19.722Z",\n      "digest": "string",\n      "version_index": 0,\n      "is_latest": 0,\n      "kind": "string",\n      "base_object_class": "string"\n    }\n  ]\n}'
+                    }
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
           </MimeTabs>
         </div>
-      </TabItem><TabItem
-        label={"422"}
-        value={"422"}
-      >
+      </TabItem>
+      <TabItem label={"422"} value={"422"}>
+        <div>Validation Error</div>
         <div>
-          
-          
-          Validation Error
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -660,50 +490,41 @@ Objs Query
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      <SchemaItem
-                        collapsible={true}
-                        className={"schemaItem"}
-                      >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
+                      <SchemaItem collapsible={true} className={"schemaItem"}>
                         <details
                           style={{}}
                           className={"openapi-markdown__details"}
                         >
-                          <summary
-                            style={{}}
-                          >
-                            <span
-                              className={"openapi-schema__container"}
-                            >
-                              <strong
-                                className={"openapi-schema__property"}
-                              >
+                          <summary style={{}}>
+                            <span className={"openapi-schema__container"}>
+                              <strong className={"openapi-schema__property"}>
                                 detail
-                              </strong><span
-                                className={"openapi-schema__name"}
-                              >
-                                 object[]
+                              </strong>
+                              <span className={"openapi-schema__name"}>
+                                object[]
                               </span>
                             </span>
-                          </summary><div
-                            style={{"marginLeft":"1rem"}}
-                          >
+                          </summary>
+                          <div style={{ marginLeft: "1rem" }}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><SchemaItem
+                            </li>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -711,103 +532,109 @@ Objs Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <span
-                                    className={"openapi-schema__container"}
-                                  >
+                                <summary style={{}}>
+                                  <span className={"openapi-schema__container"}>
                                     <strong
                                       className={"openapi-schema__property"}
                                     >
                                       loc
-                                    </strong><span
-                                      className={"openapi-schema__name"}
-                                    >
-                                       object[]
-                                    </span><span
+                                    </strong>
+                                    <span className={"openapi-schema__name"}>
+                                      object[]
+                                    </span>
+                                    <span
                                       className={"openapi-schema__divider"}
-                                    >
-                                      
-                                    </span><span
+                                    ></span>
+                                    <span
                                       className={"openapi-schema__required"}
                                     >
                                       required
                                     </span>
                                   </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}>
                                   <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                        paddingBottom: ".5rem",
+                                      }}
                                     >
                                       Array [
                                     </div>
-                                  </li><div>
-                                    <span
-                                      className={"badge badge--info"}
-                                    >
+                                  </li>
+                                  <div>
+                                    <span className={"badge badge--info"}>
                                       anyOf
-                                    </span><SchemaTabs>
+                                    </span>
+                                    <SchemaTabs>
                                       <TabItem
                                         label={"MOD1"}
                                         value={"0-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           string
-                                          
-                                          
                                         </div>
-                                      </TabItem><TabItem
+                                      </TabItem>
+                                      <TabItem
                                         label={"MOD2"}
                                         value={"1-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           integer
-                                          
-                                          
                                         </div>
                                       </TabItem>
                                     </SchemaTabs>
-                                  </div><li>
+                                  </div>
+                                  <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                      }}
                                     >
                                       ]
                                     </div>
                                   </li>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"msg"}
                               required={true}
                               schemaName={"Message (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Message"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Message" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"type"}
                               required={true}
                               schemaName={"Error Type (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Error Type"}}
-                            >
-                              
-                            </SchemaItem><li>
+                              schema={{ type: "string", title: "Error Type" }}
+                            ></SchemaItem>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -817,16 +644,17 @@ Objs Query
                       </SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        0\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\"\n    }\n  ]\n}"}
+                    responseExample={
+                      '{\n  "detail": [\n    {\n      "loc": [\n        "string",\n        0\n      ],\n      "msg": "string",\n      "type": "string"\n    }\n  ]\n}'
+                    }
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
@@ -836,4 +664,3 @@ Objs Query
     </ApiTabs>
   </div>
 </div>
-      

--- a/docs/docs/reference/service-api/table-query-table-query-post.api.mdx
+++ b/docs/docs/reference/service-api/table-query-table-query-post.api.mdx
@@ -29,17 +29,9 @@ import TabItem from "@theme/TabItem";
   as={"h1"}
   className={"openapi__heading"}
   children={"Table Query"}
->
-</Heading>
+></Heading>
 
-<MethodEndpoint
-  method={"post"}
-  path={"/table/query"}
->
-  
-</MethodEndpoint>
-
-
+<MethodEndpoint method={"post"} path={"/table/query"}></MethodEndpoint>
 
 Table Query
 
@@ -48,141 +40,89 @@ Table Query
   as={"h2"}
   className={"openapi-tabs__heading"}
   children={"Request"}
->
-</Heading>
+></Heading>
 
-<MimeTabs
-  className={"openapi-tabs__mime"}
->
-  <TabItem
-    label={"application/json"}
-    value={"application/json-schema"}
-  >
+<MimeTabs className={"openapi-tabs__mime"}>
+  <TabItem label={"application/json"} value={"application/json-schema"}>
     <details
       style={{}}
       className={"openapi-markdown__details mime"}
       data-collapsed={false}
       open={true}
     >
-      <summary
-        style={{}}
-        className={"openapi-markdown__details-summary-mime"}
-      >
-        <h3
-          className={"openapi-markdown__details-summary-header-body"}
-        >
+      <summary style={{}} className={"openapi-markdown__details-summary-mime"}>
+        <h3 className={"openapi-markdown__details-summary-header-body"}>
           Body
-        </h3><strong
-          className={"openapi-schema__required"}
-        >
-          required
-        </strong>
-      </summary><div
-        style={{"textAlign":"left","marginLeft":"1rem"}}
-      >
-        
-      </div><ul
-        style={{"marginLeft":"1rem"}}
-      >
+        </h3>
+        <strong className={"openapi-schema__required"}>required</strong>
+      </summary>
+      <div style={{ textAlign: "left", marginLeft: "1rem" }}></div>
+      <ul style={{ marginLeft: "1rem" }}>
         <SchemaItem
           collapsible={false}
           name={"project_id"}
           required={true}
           schemaName={"Project Id (string)"}
           qualifierMessage={undefined}
-          schema={{"type":"string","title":"Project Id"}}
-        >
-          
-        </SchemaItem><SchemaItem
+          schema={{ type: "string", title: "Project Id" }}
+        ></SchemaItem>
+        <SchemaItem
           collapsible={false}
           name={"digest"}
           required={true}
           schemaName={"Digest (string)"}
           qualifierMessage={undefined}
-          schema={{"type":"string","title":"Digest"}}
-        >
-          
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                filter
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"_TableRowFilter"}
-                  value={"0-item-properties"}
-                >
-                  <SchemaItem
-                    collapsible={true}
-                    className={"schemaItem"}
-                  >
-                    <details
-                      style={{}}
-                      className={"openapi-markdown__details"}
-                    >
-                      <summary
-                        style={{}}
-                      >
-                        <strong>
-                          row_digests
-                        </strong><span
-                          style={{"opacity":"0.6"}}
-                        >
-                           object
-                        </span>
-                      </summary><div
-                        style={{"marginLeft":"1rem"}}
-                      >
-                        
-                      </div><div>
-                        <span
-                          className={"badge badge--info"}
-                        >
-                          anyOf
-                        </span><SchemaTabs>
-                          <TabItem
-                            label={"MOD1"}
-                            value={"0-item-properties"}
-                          >
+          schema={{ type: "string", title: "Digest" }}
+        ></SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>filter</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"TableRowFilter"} value={"0-item-properties"}>
+                  <SchemaItem collapsible={true} className={"schemaItem"}>
+                    <details style={{}} className={"openapi-markdown__details"}>
+                      <summary style={{}}>
+                        <strong>row_digests</strong>
+                        <span style={{ opacity: "0.6" }}>object</span>
+                      </summary>
+                      <div style={{ marginLeft: "1rem" }}></div>
+                      <div>
+                        <span className={"badge badge--info"}>anyOf</span>
+                        <SchemaTabs>
+                          <TabItem label={"MOD1"} value={"0-item-properties"}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><div
-                              style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                            </li>
+                            <div
+                              style={{
+                                marginTop: ".5rem",
+                                marginBottom: ".5rem",
+                              }}
                             >
-                              
-                              
                               string
-                              
-                              
-                            </div><li>
+                            </div>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -196,91 +136,39 @@ Table Query
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                limit
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
-                  <div
-                    style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                  >
-                    
-                    
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>limit</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
+                  <div style={{ marginTop: ".5rem", marginBottom: ".5rem" }}>
                     integer
-                    
-                    
                   </div>
                 </TabItem>
               </SchemaTabs>
             </div>
           </details>
-        </SchemaItem><SchemaItem
-          collapsible={true}
-          className={"schemaItem"}
-        >
-          <details
-            style={{}}
-            className={"openapi-markdown__details"}
-          >
-            <summary
-              style={{}}
-            >
-              <strong>
-                offset
-              </strong><span
-                style={{"opacity":"0.6"}}
-              >
-                 object
-              </span>
-            </summary><div
-              style={{"marginLeft":"1rem"}}
-            >
-              
-            </div><div>
-              <span
-                className={"badge badge--info"}
-              >
-                anyOf
-              </span><SchemaTabs>
-                <TabItem
-                  label={"MOD1"}
-                  value={"0-item-properties"}
-                >
-                  <div
-                    style={{"marginTop":".5rem","marginBottom":".5rem"}}
-                  >
-                    
-                    
+        </SchemaItem>
+        <SchemaItem collapsible={true} className={"schemaItem"}>
+          <details style={{}} className={"openapi-markdown__details"}>
+            <summary style={{}}>
+              <strong>offset</strong>
+              <span style={{ opacity: "0.6" }}>object</span>
+            </summary>
+            <div style={{ marginLeft: "1rem" }}></div>
+            <div>
+              <span className={"badge badge--info"}>anyOf</span>
+              <SchemaTabs>
+                <TabItem label={"MOD1"} value={"0-item-properties"}>
+                  <div style={{ marginTop: ".5rem", marginBottom: ".5rem" }}>
                     integer
-                    
-                    
                   </div>
                 </TabItem>
               </SchemaTabs>
@@ -290,38 +178,17 @@ Table Query
       </ul>
     </details>
   </TabItem>
-</MimeTabs><div>
+</MimeTabs>
+<div>
   <div>
-    <ApiTabs
-      label={undefined}
-      id={undefined}
-    >
-      <TabItem
-        label={"200"}
-        value={"200"}
-      >
+    <ApiTabs label={undefined} id={undefined}>
+      <TabItem label={"200"} value={"200"}>
+        <div>Successful Response</div>
         <div>
-          
-          
-          Successful Response
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -332,78 +199,69 @@ Table Query
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      <SchemaItem
-                        collapsible={true}
-                        className={"schemaItem"}
-                      >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
+                      <SchemaItem collapsible={true} className={"schemaItem"}>
                         <details
                           style={{}}
                           className={"openapi-markdown__details"}
                         >
-                          <summary
-                            style={{}}
-                          >
-                            <span
-                              className={"openapi-schema__container"}
-                            >
-                              <strong
-                                className={"openapi-schema__property"}
-                              >
+                          <summary style={{}}>
+                            <span className={"openapi-schema__container"}>
+                              <strong className={"openapi-schema__property"}>
                                 rows
-                              </strong><span
-                                className={"openapi-schema__name"}
-                              >
-                                 object[]
-                              </span><span
+                              </strong>
+                              <span className={"openapi-schema__name"}>
+                                object[]
+                              </span>
+                              <span
                                 className={"openapi-schema__divider"}
-                              >
-                                
-                              </span><span
-                                className={"openapi-schema__required"}
-                              >
+                              ></span>
+                              <span className={"openapi-schema__required"}>
                                 required
                               </span>
                             </span>
-                          </summary><div
-                            style={{"marginLeft":"1rem"}}
-                          >
+                          </summary>
+                          <div style={{ marginLeft: "1rem" }}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><SchemaItem
+                            </li>
+                            <SchemaItem
                               collapsible={false}
                               name={"digest"}
                               required={true}
                               schemaName={"Digest (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Digest"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Digest" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"val"}
                               required={true}
                               schemaName={"Val"}
                               qualifierMessage={undefined}
-                              schema={{"title":"Val"}}
-                            >
-                              
-                            </SchemaItem><li>
+                              schema={{ title: "Val" }}
+                            ></SchemaItem>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -413,47 +271,30 @@ Table Query
                       </SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"rows\": [\n    {\n      \"digest\": \"string\"\n    }\n  ]\n}"}
+                    responseExample={
+                      '{\n  "rows": [\n    {\n      "digest": "string"\n    }\n  ]\n}'
+                    }
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
           </MimeTabs>
         </div>
-      </TabItem><TabItem
-        label={"422"}
-        value={"422"}
-      >
+      </TabItem>
+      <TabItem label={"422"} value={"422"}>
+        <div>Validation Error</div>
         <div>
-          
-          
-          Validation Error
-          
-          
-        </div><div>
-          <MimeTabs
-            className={"openapi-tabs__mime"}
-            schemaType={"response"}
-          >
-            <TabItem
-              label={"application/json"}
-              value={"application/json"}
-            >
-              <SchemaTabs
-                className={"openapi-tabs__schema"}
-              >
-                <TabItem
-                  label={"Schema"}
-                  value={"Schema"}
-                >
+          <MimeTabs className={"openapi-tabs__mime"} schemaType={"response"}>
+            <TabItem label={"application/json"} value={"application/json"}>
+              <SchemaTabs className={"openapi-tabs__schema"}>
+                <TabItem label={"Schema"} value={"Schema"}>
                   <details
                     style={{}}
                     className={"openapi-markdown__details response"}
@@ -464,50 +305,41 @@ Table Query
                       style={{}}
                       className={"openapi-markdown__details-summary-response"}
                     >
-                      <strong>
-                        Schema
-                      </strong>
-                    </summary><div
-                      style={{"textAlign":"left","marginLeft":"1rem"}}
-                    >
-                      
-                    </div><ul
-                      style={{"marginLeft":"1rem"}}
-                    >
-                      <SchemaItem
-                        collapsible={true}
-                        className={"schemaItem"}
-                      >
+                      <strong>Schema</strong>
+                    </summary>
+                    <div
+                      style={{ textAlign: "left", marginLeft: "1rem" }}
+                    ></div>
+                    <ul style={{ marginLeft: "1rem" }}>
+                      <SchemaItem collapsible={true} className={"schemaItem"}>
                         <details
                           style={{}}
                           className={"openapi-markdown__details"}
                         >
-                          <summary
-                            style={{}}
-                          >
-                            <span
-                              className={"openapi-schema__container"}
-                            >
-                              <strong
-                                className={"openapi-schema__property"}
-                              >
+                          <summary style={{}}>
+                            <span className={"openapi-schema__container"}>
+                              <strong className={"openapi-schema__property"}>
                                 detail
-                              </strong><span
-                                className={"openapi-schema__name"}
-                              >
-                                 object[]
+                              </strong>
+                              <span className={"openapi-schema__name"}>
+                                object[]
                               </span>
                             </span>
-                          </summary><div
-                            style={{"marginLeft":"1rem"}}
-                          >
+                          </summary>
+                          <div style={{ marginLeft: "1rem" }}>
                             <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                  paddingBottom: ".5rem",
+                                }}
                               >
                                 Array [
                               </div>
-                            </li><SchemaItem
+                            </li>
+                            <SchemaItem
                               collapsible={true}
                               className={"schemaItem"}
                             >
@@ -515,103 +347,109 @@ Table Query
                                 style={{}}
                                 className={"openapi-markdown__details"}
                               >
-                                <summary
-                                  style={{}}
-                                >
-                                  <span
-                                    className={"openapi-schema__container"}
-                                  >
+                                <summary style={{}}>
+                                  <span className={"openapi-schema__container"}>
                                     <strong
                                       className={"openapi-schema__property"}
                                     >
                                       loc
-                                    </strong><span
-                                      className={"openapi-schema__name"}
-                                    >
-                                       object[]
-                                    </span><span
+                                    </strong>
+                                    <span className={"openapi-schema__name"}>
+                                      object[]
+                                    </span>
+                                    <span
                                       className={"openapi-schema__divider"}
-                                    >
-                                      
-                                    </span><span
+                                    ></span>
+                                    <span
                                       className={"openapi-schema__required"}
                                     >
                                       required
                                     </span>
                                   </span>
-                                </summary><div
-                                  style={{"marginLeft":"1rem"}}
-                                >
+                                </summary>
+                                <div style={{ marginLeft: "1rem" }}>
                                   <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem","paddingBottom":".5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                        paddingBottom: ".5rem",
+                                      }}
                                     >
                                       Array [
                                     </div>
-                                  </li><div>
-                                    <span
-                                      className={"badge badge--info"}
-                                    >
+                                  </li>
+                                  <div>
+                                    <span className={"badge badge--info"}>
                                       anyOf
-                                    </span><SchemaTabs>
+                                    </span>
+                                    <SchemaTabs>
                                       <TabItem
                                         label={"MOD1"}
                                         value={"0-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           string
-                                          
-                                          
                                         </div>
-                                      </TabItem><TabItem
+                                      </TabItem>
+                                      <TabItem
                                         label={"MOD2"}
                                         value={"1-item-properties"}
                                       >
                                         <div
-                                          style={{"marginTop":".5rem","marginBottom":".5rem"}}
+                                          style={{
+                                            marginTop: ".5rem",
+                                            marginBottom: ".5rem",
+                                          }}
                                         >
-                                          
-                                          
                                           integer
-                                          
-                                          
                                         </div>
                                       </TabItem>
                                     </SchemaTabs>
-                                  </div><li>
+                                  </div>
+                                  <li>
                                     <div
-                                      style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                      style={{
+                                        fontSize: "var(--ifm-code-font-size)",
+                                        opacity: "0.6",
+                                        marginLeft: "-.5rem",
+                                      }}
                                     >
                                       ]
                                     </div>
                                   </li>
                                 </div>
                               </details>
-                            </SchemaItem><SchemaItem
+                            </SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"msg"}
                               required={true}
                               schemaName={"Message (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Message"}}
-                            >
-                              
-                            </SchemaItem><SchemaItem
+                              schema={{ type: "string", title: "Message" }}
+                            ></SchemaItem>
+                            <SchemaItem
                               collapsible={false}
                               name={"type"}
                               required={true}
                               schemaName={"Error Type (string)"}
                               qualifierMessage={undefined}
-                              schema={{"type":"string","title":"Error Type"}}
-                            >
-                              
-                            </SchemaItem><li>
+                              schema={{ type: "string", title: "Error Type" }}
+                            ></SchemaItem>
+                            <li>
                               <div
-                                style={{"fontSize":"var(--ifm-code-font-size)","opacity":"0.6","marginLeft":"-.5rem"}}
+                                style={{
+                                  fontSize: "var(--ifm-code-font-size)",
+                                  opacity: "0.6",
+                                  marginLeft: "-.5rem",
+                                }}
                               >
                                 ]
                               </div>
@@ -621,16 +459,17 @@ Table Query
                       </SchemaItem>
                     </ul>
                   </details>
-                </TabItem><TabItem
+                </TabItem>
+                <TabItem
                   label={"Example (from schema)"}
                   value={"Example (from schema)"}
                 >
                   <ResponseSamples
-                    responseExample={"{\n  \"detail\": [\n    {\n      \"loc\": [\n        \"string\",\n        0\n      ],\n      \"msg\": \"string\",\n      \"type\": \"string\"\n    }\n  ]\n}"}
+                    responseExample={
+                      '{\n  "detail": [\n    {\n      "loc": [\n        "string",\n        0\n      ],\n      "msg": "string",\n      "type": "string"\n    }\n  ]\n}'
+                    }
                     language={"json"}
-                  >
-                    
-                  </ResponseSamples>
+                  ></ResponseSamples>
                 </TabItem>
               </SchemaTabs>
             </TabItem>
@@ -640,4 +479,3 @@ Table Query
     </ApiTabs>
   </div>
 </div>
-      

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -383,7 +383,7 @@ def test_trace_call_query_filter_op_version_refs(client):
         res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi._CallsFilter(op_names=op_version_refs),
+                filter=tsi.CallsFilter(op_names=op_version_refs),
             )
         )
         print(f"TEST CASE [{i}]", op_version_refs, exp_count)
@@ -459,7 +459,7 @@ def test_trace_call_query_filter_input_object_version_refs(client):
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi._CallsFilter(input_refs=input_object_version_refs),
+                filter=tsi.CallsFilter(input_refs=input_object_version_refs),
             )
         )
 
@@ -513,7 +513,7 @@ def test_trace_call_query_filter_output_object_version_refs(client):
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi._CallsFilter(output_refs=output_object_version_refs),
+                filter=tsi.CallsFilter(output_refs=output_object_version_refs),
             )
         )
 
@@ -549,7 +549,7 @@ def test_trace_call_query_filter_parent_ids(client):
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi._CallsFilter(parent_ids=parent_ids),
+                filter=tsi.CallsFilter(parent_ids=parent_ids),
             )
         )
 
@@ -576,7 +576,7 @@ def test_trace_call_query_filter_trace_ids(client):
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi._CallsFilter(trace_ids=trace_ids),
+                filter=tsi.CallsFilter(trace_ids=trace_ids),
             )
         )
 
@@ -603,7 +603,7 @@ def test_trace_call_query_filter_call_ids(client):
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi._CallsFilter(call_ids=call_ids),
+                filter=tsi.CallsFilter(call_ids=call_ids),
             )
         )
 
@@ -624,7 +624,7 @@ def test_trace_call_query_filter_trace_roots_only(client):
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi._CallsFilter(trace_roots_only=trace_roots_only),
+                filter=tsi.CallsFilter(trace_roots_only=trace_roots_only),
             )
         )
 
@@ -650,7 +650,7 @@ def test_trace_call_query_filter_wb_run_ids(client, user_by_api_key_in_env):
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi._CallsFilter(wb_run_ids=wb_run_ids),
+                filter=tsi.CallsFilter(wb_run_ids=wb_run_ids),
             )
         )
 
@@ -711,13 +711,13 @@ def test_trace_call_sort(client):
         basic_op({"prim": i, "list": [i], "dict": {"inner": i}}, i / 10)
 
     for first, last, sort_by in [
-        (2, 0, [tsi._SortBy(field="started_at", direction="desc")]),
-        (2, 0, [tsi._SortBy(field="inputs.in_val.prim", direction="desc")]),
-        (2, 0, [tsi._SortBy(field="inputs.in_val.list.0", direction="desc")]),
-        (2, 0, [tsi._SortBy(field="inputs.in_val.dict.inner", direction="desc")]),
-        (2, 0, [tsi._SortBy(field="output.prim", direction="desc")]),
-        (2, 0, [tsi._SortBy(field="output.list.0", direction="desc")]),
-        (2, 0, [tsi._SortBy(field="output.dict.inner", direction="desc")]),
+        (2, 0, [tsi.SortBy(field="started_at", direction="desc")]),
+        (2, 0, [tsi.SortBy(field="inputs.in_val.prim", direction="desc")]),
+        (2, 0, [tsi.SortBy(field="inputs.in_val.list.0", direction="desc")]),
+        (2, 0, [tsi.SortBy(field="inputs.in_val.dict.inner", direction="desc")]),
+        (2, 0, [tsi.SortBy(field="output.prim", direction="desc")]),
+        (2, 0, [tsi.SortBy(field="output.list.0", direction="desc")]),
+        (2, 0, [tsi.SortBy(field="output.dict.inner", direction="desc")]),
     ]:
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
@@ -767,7 +767,7 @@ def test_trace_call_sort_with_mixed_types(client):
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
-                sort_by=[tsi._SortBy(field="inputs.in_val.prim", direction=direction)],
+                sort_by=[tsi.SortBy(field="inputs.in_val.prim", direction=direction)],
             )
         )
 
@@ -1237,7 +1237,7 @@ def test_root_type(client):
     inner_res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
-            filter=tsi._ObjectVersionFilter(
+            filter=tsi.ObjectVersionFilter(
                 base_object_classes=["BaseTypeA"],
             ),
         )
@@ -1257,7 +1257,7 @@ def test_attributes_on_ops(client):
     res = get_client_trace_server(client).calls_query(
         tsi.CallsQueryReq(
             project_id=get_client_project_id(client),
-            filter=tsi._CallsFilter(op_names=[ref_str(op_with_attrs)]),
+            filter=tsi.CallsFilter(op_names=[ref_str(op_with_attrs)]),
         )
     )
 
@@ -1303,7 +1303,7 @@ def test_dataclass_support(client):
     res = get_client_trace_server(client).calls_query(
         tsi.CallsQueryReq(
             project_id=get_client_project_id(client),
-            filter=tsi._CallsFilter(op_names=[ref_str(dataclass_maker)]),
+            filter=tsi.CallsFilter(op_names=[ref_str(dataclass_maker)]),
         )
     )
 
@@ -1403,7 +1403,7 @@ def test_tuple_support(client):
     res = get_client_trace_server(client).calls_query(
         tsi.CallsQueryReq(
             project_id=get_client_project_id(client),
-            filter=tsi._CallsFilter(op_names=[ref_str(tuple_maker)]),
+            filter=tsi.CallsFilter(op_names=[ref_str(tuple_maker)]),
         )
     )
 
@@ -1428,7 +1428,7 @@ def test_namedtuple_support(client):
     res = get_client_trace_server(client).calls_query(
         tsi.CallsQueryReq(
             project_id=get_client_project_id(client),
-            filter=tsi._CallsFilter(op_names=[ref_str(tuple_maker)]),
+            filter=tsi.CallsFilter(op_names=[ref_str(tuple_maker)]),
         )
     )
 
@@ -1466,7 +1466,7 @@ def test_named_reuse(client):
     res = get_client_trace_server(client).objs_query(
         tsi.ObjQueryReq(
             project_id=get_client_project_id(client),
-            filter=tsi._ObjectVersionFilter(
+            filter=tsi.ObjectVersionFilter(
                 is_op=False, latest_only=True, base_object_classes=["Dataset"]
             ),
         )
@@ -2184,10 +2184,10 @@ def test_sort_and_filter_through_refs(client):
     )
 
     for first, last, sort_by in [
-        (0, 21, [tsi._SortBy(field="inputs.val.a.b.c.d", direction="asc")]),
-        (21, 0, [tsi._SortBy(field="inputs.val.a.b.c.d", direction="desc")]),
-        (0, 21, [tsi._SortBy(field="output.a.b.c.d", direction="asc")]),
-        (21, 0, [tsi._SortBy(field="output.a.b.c.d", direction="desc")]),
+        (0, 21, [tsi.SortBy(field="inputs.val.a.b.c.d", direction="asc")]),
+        (21, 0, [tsi.SortBy(field="inputs.val.a.b.c.d", direction="desc")]),
+        (0, 21, [tsi.SortBy(field="output.a.b.c.d", direction="asc")]),
+        (21, 0, [tsi.SortBy(field="output.a.b.c.d", direction="desc")]),
     ]:
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
@@ -2241,7 +2241,7 @@ def test_sort_and_filter_through_refs(client):
             tsi.CallsQueryReq.model_validate(
                 dict(
                     project_id=get_client_project_id(client),
-                    sort_by=[tsi._SortBy(field="inputs.val.a.b.c.d", direction="asc")],
+                    sort_by=[tsi.SortBy(field="inputs.val.a.b.c.d", direction="asc")],
                     query={"$expr": query},
                 )
             )
@@ -2372,7 +2372,7 @@ def test_model_save(client):
     inner_res = get_client_trace_server(client).objs_query(
         tsi.ObjQueryReq(
             project_id=get_client_project_id(client),
-            filter=tsi._ObjectVersionFilter(
+            filter=tsi.ObjectVersionFilter(
                 is_op=False, latest_only=True, base_object_classes=["Model"]
             ),
         )

--- a/weave/tests/test_evaluations.py
+++ b/weave/tests/test_evaluations.py
@@ -136,7 +136,7 @@ async def test_basic_evaluation(client):
     objs = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
-            filter=tsi._ObjectVersionFilter(base_object_classes=["Model"]),
+            filter=tsi.ObjectVersionFilter(base_object_classes=["Model"]),
         )
     )
     assert len(objs.objs) == 1

--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -289,7 +289,7 @@ def test_calls_query(client):
     call0 = client.create_call("x", {"a": 5, "b": 10})
     call1 = client.create_call("x", {"a": 6, "b": 11})
     call2 = client.create_call("y", {"a": 5, "b": 10})
-    result = list(client.calls(weave_client._CallsFilter(op_names=[call1.op_name])))
+    result = list(client.calls(weave_client.CallsFilter(op_names=[call1.op_name])))
     assert len(result) == 2
     assert result[0] == weave_client.Call(
         op_name="weave:///shawn/test-project/op/x:tzUhDyzVm5bqQsuqh5RT4axEXSosyLIYZn9zbRyenaw",
@@ -340,16 +340,16 @@ def test_calls_delete(client):
 
     assert len(list(client.calls())) == 4
 
-    result = list(client.calls(weave_client._CallsFilter(op_names=[call0.op_name])))
+    result = list(client.calls(weave_client.CallsFilter(op_names=[call0.op_name])))
     assert len(result) == 3
 
     # should deleted call0_child1, _call0_child2, call1, but not call0
     client.delete_call(call0_child1)
 
-    result = list(client.calls(weave_client._CallsFilter(op_names=[call0.op_name])))
+    result = list(client.calls(weave_client.CallsFilter(op_names=[call0.op_name])))
     assert len(result) == 1
 
-    result = list(client.calls(weave_client._CallsFilter(op_names=[call1.op_name])))
+    result = list(client.calls(weave_client.CallsFilter(op_names=[call1.op_name])))
     assert len(result) == 0
 
     # no-op if already deleted
@@ -1228,13 +1228,13 @@ def test_summary_tokens_cost(client):
 
     callsWithCost = list(
         client.calls(
-            weave_client._CallsFilter(op_names=[call.op_name]),
+            weave_client.CallsFilter(op_names=[call.op_name]),
             include_costs=True,
         )
     )
     callsNoCost = list(
         client.calls(
-            weave_client._CallsFilter(op_names=[call.op_name]),
+            weave_client.CallsFilter(op_names=[call.op_name]),
             include_costs=False,
         )
     )

--- a/weave/trace/tests/test_op_argument_forms.py
+++ b/weave/trace/tests/test_op_argument_forms.py
@@ -420,7 +420,7 @@ def test_general_arg_variations(client, fn, arg_variations):
         res = client.server.calls_query(
             tsi.CallsQueryReq(
                 project_id=client._project_id(),
-                filter=tsi._CallsFilter(op_names=[wrapped_fn.ref.uri()]),
+                filter=tsi.CallsFilter(op_names=[wrapped_fn.ref.uri()]),
             )
         )
 

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -26,8 +26,8 @@ from weave.trace.serialize import from_json
 from weave.trace_server.trace_server_interface import (
     ObjReadReq,
     TableQueryReq,
-    TraceServerInterface,
     TableRowFilter,
+    TraceServerInterface,
 )
 
 

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -27,7 +27,7 @@ from weave.trace_server.trace_server_interface import (
     ObjReadReq,
     TableQueryReq,
     TraceServerInterface,
-    _TableRowFilter,
+    TableRowFilter,
 )
 
 
@@ -229,14 +229,14 @@ class WeaveObject(Traceable):
 
 
 class WeaveTable(Traceable):
-    filter: _TableRowFilter
+    filter: TableRowFilter
 
     def __init__(
         self,
         table_ref: Optional[TableRef],
         ref: Optional[RefWithExtra],
         server: TraceServerInterface,
-        filter: _TableRowFilter,
+        filter: TableRowFilter,
         root: Optional[Traceable],
         parent: Optional[Traceable] = None,
     ) -> None:
@@ -504,7 +504,7 @@ def make_trace_obj(
             table_ref=val_ref,
             ref=new_ref,
             server=server,
-            filter=_TableRowFilter(),
+            filter=TableRowFilter(),
             root=root,
             parent=parent,
         )
@@ -513,7 +513,7 @@ def make_trace_obj(
             table_ref=val,
             ref=new_ref,
             server=server,
-            filter=_TableRowFilter(),
+            filter=TableRowFilter(),
             root=root,
             parent=parent,
         )
@@ -539,7 +539,7 @@ def make_trace_obj(
                     table_ref=val,
                     ref=new_ref,
                     server=server,
-                    filter=_TableRowFilter(),
+                    filter=TableRowFilter(),
                     root=root,
                     parent=parent,
                 )

--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -180,7 +180,7 @@ class Condition(BaseModel):
 
 
 class HardCodedFilter(BaseModel):
-    filter: tsi._CallsFilter
+    filter: tsi.CallsFilter
 
     def is_useful(self) -> bool:
         """Returns True if the filter is useful - i.e. it has any non-null fields
@@ -659,7 +659,7 @@ def process_query_to_conditions(
 
 
 def process_calls_filter_to_conditions(
-    filter: tsi._CallsFilter,
+    filter: tsi.CallsFilter,
     param_builder: ParamBuilder,
     table_alias: str,
 ) -> list[str]:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -204,7 +204,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         res = self.calls_query_stream(
             tsi.CallsQueryReq(
                 project_id=req.project_id,
-                filter=tsi._CallsFilter(
+                filter=tsi.CallsFilter(
                     call_ids=[req.id],
                 ),
                 limit=1,
@@ -310,7 +310,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             self.calls_query_stream(
                 tsi.CallsQueryReq(
                     project_id=req.project_id,
-                    filter=tsi._CallsFilter(
+                    filter=tsi.CallsFilter(
                         call_ids=req.call_ids,
                     ),
                 )
@@ -322,7 +322,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             self.calls_query_stream(
                 tsi.CallsQueryReq(
                     project_id=req.project_id,
-                    filter=tsi._CallsFilter(
+                    filter=tsi.CallsFilter(
                         trace_ids=[p.trace_id for p in parents],
                     ),
                 )

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -222,7 +222,7 @@ class Select:
     _project_id: typing.Optional[str]
     _fields: typing.Optional[list[str]]
     _query: typing.Optional[tsi.Query]
-    _order_by: typing.Optional[typing.List[tsi._SortBy]]
+    _order_by: typing.Optional[typing.List[tsi.SortBy]]
     _limit: typing.Optional[int]
     _offset: typing.Optional[int]
     _group_by: typing.Optional[list[str]]
@@ -261,7 +261,7 @@ class Select:
         self._query = query
         return self
 
-    def order_by(self, order_by: typing.Optional[typing.List[tsi._SortBy]]) -> "Select":
+    def order_by(self, order_by: typing.Optional[typing.List[tsi.SortBy]]) -> "Select":
         if order_by:
             for o in order_by:
                 assert o.direction in (

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -239,7 +239,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             tsi.CallsQueryReq(
                 project_id=req.project_id,
                 limit=1,
-                filter=tsi._CallsFilter(call_ids=[req.id]),
+                filter=tsi.CallsFilter(call_ids=[req.id]),
             )
         ).calls
         return tsi.CallReadRes(call=calls[0] if calls else None)

--- a/weave/trace_server/tests/test_calls_query_builder.py
+++ b/weave/trace_server/tests/test_calls_query_builder.py
@@ -72,7 +72,7 @@ def test_query_heavy_column_simple_filter() -> None:
     cq.add_field("inputs")
     cq.set_hardcoded_filter(
         HardCodedFilter(
-            filter=tsi._CallsFilter(
+            filter=tsi.CallsFilter(
                 op_names=["a", "b"],
             )
         )
@@ -113,7 +113,7 @@ def test_query_heavy_column_simple_filter_with_order() -> None:
     cq.add_order("started_at", "desc")
     cq.set_hardcoded_filter(
         HardCodedFilter(
-            filter=tsi._CallsFilter(
+            filter=tsi.CallsFilter(
                 op_names=["a", "b"],
             )
         )
@@ -156,7 +156,7 @@ def test_query_heavy_column_simple_filter_with_order_and_limit() -> None:
     cq.set_limit(10)
     cq.set_hardcoded_filter(
         HardCodedFilter(
-            filter=tsi._CallsFilter(
+            filter=tsi.CallsFilter(
                 op_names=["a", "b"],
             )
         )
@@ -203,7 +203,7 @@ def test_query_heavy_column_simple_filter_with_order_and_limit_and_mixed_query_c
     cq.set_limit(10)
     cq.set_hardcoded_filter(
         HardCodedFilter(
-            filter=tsi._CallsFilter(
+            filter=tsi.CallsFilter(
                 op_names=["a", "b"],
             )
         )
@@ -287,7 +287,7 @@ def test_query_light_column_with_costs() -> None:
     cq.add_field("started_at")
     cq.set_hardcoded_filter(
         HardCodedFilter(
-            filter=tsi._CallsFilter(
+            filter=tsi.CallsFilter(
                 op_names=["a", "b"],
             )
         )

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -222,7 +222,7 @@ class CallsDeleteRes(BaseModel):
     pass
 
 
-class _CallsFilter(BaseModel):
+class CallsFilter(BaseModel):
     op_names: typing.Optional[typing.List[str]] = None
     input_refs: typing.Optional[typing.List[str]] = None
     output_refs: typing.Optional[typing.List[str]] = None
@@ -234,7 +234,7 @@ class _CallsFilter(BaseModel):
     wb_run_ids: typing.Optional[typing.List[str]] = None
 
 
-class _SortBy(BaseModel):
+class SortBy(BaseModel):
     # Field should be a key of `CallSchema`. For dictionary fields
     # (`attributes`, `inputs`, `outputs`, `summary`), the field can be
     # dot-separated.
@@ -245,7 +245,7 @@ class _SortBy(BaseModel):
 
 class CallsQueryReq(BaseModel):
     project_id: str
-    filter: typing.Optional[_CallsFilter] = None
+    filter: typing.Optional[CallsFilter] = None
     limit: typing.Optional[int] = None
     offset: typing.Optional[int] = None
     # Sort by multiple fields
@@ -264,7 +264,7 @@ class CallsQueryRes(BaseModel):
 
 class CallsQueryStatsReq(BaseModel):
     project_id: str
-    filter: typing.Optional[_CallsFilter] = None
+    filter: typing.Optional[CallsFilter] = None
     query: typing.Optional[Query] = None
 
 
@@ -306,7 +306,7 @@ class OpReadRes(BaseModel):
     op_obj: ObjSchema
 
 
-class _OpVersionFilter(BaseModel):
+class OpVersionFilter(BaseModel):
     op_names: typing.Optional[typing.List[str]] = None
     latest_only: typing.Optional[bool] = None
 
@@ -338,7 +338,7 @@ class ObjReadRes(BaseModel):
     obj: ObjSchema
 
 
-class _ObjectVersionFilter(BaseModel):
+class ObjectVersionFilter(BaseModel):
     base_object_classes: typing.Optional[typing.List[str]] = None
     object_ids: typing.Optional[typing.List[str]] = None
     is_op: typing.Optional[bool] = None
@@ -456,7 +456,7 @@ class TableCreateRes(BaseModel):
     digest: str
 
 
-class _TableRowFilter(BaseModel):
+class TableRowFilter(BaseModel):
     row_digests: typing.Optional[typing.List[str]] = None
 
 
@@ -674,3 +674,11 @@ class TraceServerInterface:
 CallsDeleteReqForInsert = CallsDeleteReq
 CallUpdateReqForInsert = CallUpdateReq
 FeedbackCreateReqForInsert = FeedbackCreateReq
+
+# Legacy Names (i think these might be used in a few growth examples, so keeping
+# around until we clean those up of them)
+_CallsFilter = CallsFilter
+_SortBy = SortBy
+_OpVersionFilter = OpVersionFilter
+_ObjectVersionFilter = ObjectVersionFilter
+_TableRowFilter = TableRowFilter

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -249,12 +249,12 @@ class CallsQueryReq(BaseModel):
     limit: typing.Optional[int] = None
     offset: typing.Optional[int] = None
     # Sort by multiple fields
-    sort_by: typing.Optional[typing.List[_SortBy]] = None
+    sort_by: typing.Optional[typing.List[SortBy]] = None
     query: typing.Optional[Query] = None
     include_costs: typing.Optional[bool] = False
 
     # TODO: type this with call schema columns, following the same rules as
-    # _SortBy and thus GetFieldOperator.get_field_ (without direction)
+    # SortBy and thus GetFieldOperator.get_field_ (without direction)
     columns: typing.Optional[typing.List[str]] = None
 
 
@@ -313,7 +313,7 @@ class OpVersionFilter(BaseModel):
 
 class OpQueryReq(BaseModel):
     project_id: str
-    filter: typing.Optional[_OpVersionFilter] = None
+    filter: typing.Optional[OpVersionFilter] = None
 
 
 class OpQueryRes(BaseModel):
@@ -347,7 +347,7 @@ class ObjectVersionFilter(BaseModel):
 
 class ObjQueryReq(BaseModel):
     project_id: str
-    filter: typing.Optional[_ObjectVersionFilter] = None
+    filter: typing.Optional[ObjectVersionFilter] = None
 
 
 class ObjQueryRes(BaseModel):
@@ -463,7 +463,7 @@ class TableRowFilter(BaseModel):
 class TableQueryReq(BaseModel):
     project_id: str
     digest: str
-    filter: typing.Optional[_TableRowFilter] = None
+    filter: typing.Optional[TableRowFilter] = None
     limit: typing.Optional[int] = None
     offset: typing.Optional[int] = None
 
@@ -527,8 +527,7 @@ class FeedbackQueryReq(BaseModel):
     query: typing.Optional[Query] = None
     # TODO: I think I would prefer to call this order_by to match SQL, but this is what calls API uses
     # TODO: Might be nice to have shortcut for single field and implied ASC direction
-    # TODO: I think _SortBy shouldn't have leading underscore
-    sort_by: typing.Optional[typing.List[_SortBy]] = None
+    sort_by: typing.Optional[typing.List[SortBy]] = None
     limit: typing.Optional[int] = Field(default=None, examples=[10])
     offset: typing.Optional[int] = Field(default=None, examples=[0])
 

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -44,11 +44,13 @@ from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallSchema,
     CallsDeleteReq,
+    CallsFilter,
     CallsQueryReq,
     CallStartReq,
     CallUpdateReq,
     EndedCallSchemaForInsert,
     ObjCreateReq,
+    ObjectVersionFilter,
     ObjQueryReq,
     ObjReadReq,
     ObjSchema,
@@ -59,8 +61,6 @@ from weave.trace_server.trace_server_interface import (
     TableCreateReq,
     TableSchemaForInsert,
     TraceServerInterface,
-    CallsFilter,
-    ObjectVersionFilter,
 )
 
 if typing.TYPE_CHECKING:


### PR DESCRIPTION
These underscores were leftover from an error of experimentation and should be public now

Effects:
```
_CallsFilter 
_SortBy 
_OpVersionFilter 
_ObjectVersionFilter
_TableRowFilter
```