### PR TITLE
feat: new filter UI

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -39,6 +39,7 @@
     "@mui/lab": "^5.0.0-alpha.147",
     "@mui/material": "^5.14.12",
     "@mui/x-data-grid-pro": "^6.16.0",
+    "@mui/x-date-pickers": "^6.16.0",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/material';
 import {
   GridColumnVisibilityModel,
+  GridFilterModel,
   GridPaginationModel,
   GridPinnedColumns,
   GridSortModel,
@@ -58,6 +59,7 @@ import {
   WeaveflowPeekContext,
 } from './Browse3/context';
 import {FullPageButton} from './Browse3/FullPageButton';
+import {getValidFilterModel} from './Browse3/grid/filters';
 import {
   DEFAULT_PAGE_SIZE,
   getValidPaginationModel,
@@ -71,6 +73,7 @@ import {CallsPage} from './Browse3/pages/CallsPage/CallsPage';
 import {
   ALWAYS_PIN_LEFT_CALLS,
   DEFAULT_COLUMN_VISIBILITY_CALLS,
+  DEFAULT_FILTER_CALLS,
   DEFAULT_PIN_CALLS,
   DEFAULT_SORT_CALLS,
 } from './Browse3/pages/CallsPage/CallsTable';
@@ -653,7 +656,7 @@ const CallPageBinding = () => {
 const CallsPageBinding = () => {
   const {entity, project, tab} = useParams<Browse3TabParams>();
   const query = useURLSearchParamsDict();
-  const filters = useMemo(() => {
+  const initialFilter = useMemo(() => {
     if (tab === 'evaluations') {
       return {
         frozen: true,
@@ -713,6 +716,20 @@ const CallsPageBinding = () => {
     history.push({search: newQuery.toString()});
   };
 
+  const filterModel = useMemo(
+    () => getValidFilterModel(query.filters, DEFAULT_FILTER_CALLS),
+    [query.filters]
+  );
+  const setFilterModel = (newModel: GridFilterModel) => {
+    const newQuery = new URLSearchParams(location.search);
+    if (newModel.items.length === 0) {
+      newQuery.delete('filters');
+    } else {
+      newQuery.set('filters', JSON.stringify(newModel));
+    }
+    history.push({search: newQuery.toString()});
+  };
+
   const sortModel = useMemo(
     () => getValidSortModel(query.sort, DEFAULT_SORT_CALLS),
     [query.sort]
@@ -752,12 +769,14 @@ const CallsPageBinding = () => {
     <CallsPage
       entity={entity}
       project={project}
-      initialFilter={filters}
+      initialFilter={initialFilter}
       onFilterUpdate={onFilterUpdate}
       columnVisibilityModel={columnVisibilityModel}
       setColumnVisibilityModel={setColumnVisibilityModel}
       pinModel={pinModel}
       setPinModel={setPinModel}
+      filterModel={filterModel}
+      setFilterModel={setFilterModel}
       sortModel={sortModel}
       setSortModel={setSortModel}
       paginationModel={paginationModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDateTimePicker.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDateTimePicker.tsx
@@ -1,0 +1,28 @@
+import {styled} from '@mui/material/styles';
+import {DateTimePicker, DateTimePickerProps} from '@mui/x-date-pickers';
+import * as Colors from '@wandb/weave/common/css/color.styles';
+import {hexToRGB} from '@wandb/weave/common/css/utils';
+import moment from 'moment';
+import React from 'react';
+
+const COLOR_BORDER_OVER = hexToRGB(Colors.TEAL_500, 0.4);
+const COLOR_BG_SELECTED_TEXT = Colors.MOON_100;
+
+export const StyledDateTimePicker = styled(
+  (props: DateTimePickerProps<moment.Moment>) => <DateTimePicker {...props} />
+)(() => ({
+  '& .MuiOutlinedInput-root': {
+    fontFamily: 'Source Sans Pro',
+    padding: 4,
+    '&:hover fieldset': {
+      borderColor: COLOR_BORDER_OVER,
+      borderWidth: 2,
+    },
+    '&.Mui-focused fieldset': {
+      borderColor: COLOR_BORDER_OVER,
+    },
+    '& ::selection': {
+      backgroundColor: COLOR_BG_SELECTED_TEXT,
+    },
+  },
+}));

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/CellFilterWrapper.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/CellFilterWrapper.tsx
@@ -1,0 +1,35 @@
+/**
+ * Wrap a cell with an Option+Click handler that adds a filter
+ * with the corresponding field, operation, and value.
+ */
+
+import React from 'react';
+
+type CellFilterWrapperProps = {
+  children: React.ReactNode;
+  onAddFilter?: (key: string, operation: string | null, value: any) => void;
+  field: string;
+  operation: string | null;
+  value: any;
+};
+
+export const CellFilterWrapper = ({
+  children,
+  onAddFilter,
+  field,
+  operation,
+  value,
+}: CellFilterWrapperProps) => {
+  const onClickCapture = onAddFilter
+    ? (e: React.MouseEvent) => {
+        // event.altKey - pressed Option key on Macs
+        if (e.altKey) {
+          e.stopPropagation();
+          e.preventDefault();
+          onAddFilter(field, operation, value);
+        }
+      }
+    : undefined;
+
+  return <div onClickCapture={onClickCapture}>{children}</div>;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -10,18 +10,18 @@ import {Button} from '../../../../Button';
 import {DraggableGrow, DraggableHandle} from '../../../../DraggablePopups';
 import {IconFilterAlt} from '../../../../Icon';
 import {Tailwind} from '../../../../Tailwind';
-import {isValuelessOperator} from '../pages/common/tabularListViews/operators';
 import {ColumnInfo} from '../types';
-import {FilterRow} from './FilterRow';
-import {FilterTagItem} from './FilterTagItem';
-import {GroupedOption, SelectFieldOption} from './SelectField';
 import {
   FIELD_DESCRIPTIONS,
   FilterId,
   getOperatorOptions,
+  isValuelessOperator,
   UNFILTERABLE_FIELDS,
   upsertFilter,
-} from './types';
+} from './common';
+import {FilterRow} from './FilterRow';
+import {FilterTagItem} from './FilterTagItem';
+import {GroupedOption, SelectFieldOption} from './SelectField';
 import {VariableChildrenDisplay} from './VariableChildrenDisplayer';
 
 type FilterBarProps = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -1,0 +1,316 @@
+/**
+ * This bar above a grid displays currently set filters for quick editing.
+ */
+
+import {Popover} from '@mui/material';
+import {GridFilterItem, GridFilterModel} from '@mui/x-data-grid-pro';
+import React, {useCallback, useRef} from 'react';
+
+import {Button} from '../../../../Button';
+import {DraggableGrow, DraggableHandle} from '../../../../DraggablePopups';
+import {IconFilterAlt} from '../../../../Icon';
+import {Tailwind} from '../../../../Tailwind';
+import {isValuelessOperator} from '../pages/common/tabularListViews/operators';
+import {ColumnInfo} from '../types';
+import {FilterRow} from './FilterRow';
+import {FilterTagItem} from './FilterTagItem';
+import {GroupedOption, SelectFieldOption} from './SelectField';
+import {
+  FIELD_DESCRIPTIONS,
+  FilterId,
+  getOperatorOptions,
+  UNFILTERABLE_FIELDS,
+  upsertFilter,
+} from './types';
+import {VariableChildrenDisplay} from './VariableChildrenDisplayer';
+
+type FilterBarProps = {
+  filterModel: GridFilterModel;
+  setFilterModel: (newModel: GridFilterModel) => void;
+  columnInfo: ColumnInfo;
+  selectedCalls: string[];
+  clearSelectedCalls: () => void;
+
+  width: number;
+  height: number;
+};
+
+const isFilterIncomplete = (filter: GridFilterItem): boolean => {
+  return (
+    filter.field === undefined ||
+    (filter.value === undefined && !isValuelessOperator(filter.operator))
+  );
+};
+
+export const FilterBar = ({
+  filterModel,
+  setFilterModel,
+  columnInfo,
+  selectedCalls,
+  clearSelectedCalls,
+  width,
+}: FilterBarProps) => {
+  const refBar = useRef<HTMLDivElement>(null);
+  const refLabel = useRef<HTMLDivElement>(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const onClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(anchorEl ? null : refBar.current);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popper' : undefined;
+
+  // TODO: Make not calls specific by using colGroupingModel
+  const {cols} = columnInfo;
+  const options: SelectFieldOption[] = [
+    {
+      label: 'Metadata',
+      options: [],
+    },
+    {
+      label: 'inputs',
+      options: [],
+    },
+    {
+      label: 'output',
+      options: [],
+    },
+    {
+      label: 'attributes',
+      options: [],
+    },
+  ];
+  for (const col of cols) {
+    if (UNFILTERABLE_FIELDS.includes(col.field)) {
+      continue;
+    }
+    if (col.field.startsWith('inputs.')) {
+      (options[1] as GroupedOption).options.push({
+        value: col.field,
+        label: (col.headerName ?? col.field).substring('inputs.'.length),
+      });
+    } else if (col.field === 'output') {
+      (options[2] as GroupedOption).options.push({
+        value: col.field,
+        label: col.headerName ?? col.field,
+      });
+    } else if (col.field.startsWith('output.')) {
+      (options[2] as GroupedOption).options.push({
+        value: col.field,
+        label: (col.headerName ?? col.field).substring('output.'.length),
+      });
+    } else if (col.field.startsWith('attributes.')) {
+      (options[3] as GroupedOption).options.push({
+        value: col.field,
+        label: (col.headerName ?? col.field).substring('attributes.'.length),
+        description: FIELD_DESCRIPTIONS[col.field],
+      });
+    } else {
+      (options[0] as GroupedOption).options.push({
+        value: col.field,
+        label: col.headerName ?? col.field,
+        description: FIELD_DESCRIPTIONS[col.field],
+      });
+    }
+  }
+  (options[0] as GroupedOption).options.unshift({
+    value: 'id',
+    label: 'Call ID',
+  });
+
+  const onRemoveAll = () => {
+    setFilterModel({items: []});
+    setAnchorEl(null);
+  };
+
+  const onAddFilter = useCallback(
+    (field: string) => {
+      const defaultOperator = getOperatorOptions(field)[0].value;
+      const newModel = {
+        ...filterModel,
+        items: [
+          ...filterModel.items,
+          {
+            id: filterModel.items.length,
+            field,
+            operator: defaultOperator,
+          },
+        ],
+      };
+      setFilterModel(newModel);
+    },
+    [filterModel, setFilterModel]
+  );
+
+  const onUpdateFilter = useCallback(
+    (item: GridFilterItem) => {
+      const oldItems = filterModel.items;
+      const index = oldItems.findIndex(f => f.id === item.id);
+
+      if (index === -1) {
+        const newModel2 = {...filterModel, items: [item]};
+        setFilterModel(newModel2);
+        return;
+      }
+
+      const newItems = [
+        ...oldItems.slice(0, index),
+        item,
+        ...oldItems.slice(index + 1),
+      ];
+      const newModel = {...filterModel, items: newItems};
+      setFilterModel(newModel);
+    },
+    [filterModel, setFilterModel]
+  );
+
+  const onRemoveFilter = useCallback(
+    (filterId: FilterId) => {
+      const items = filterModel.items.filter(f => f.id !== filterId);
+      const newModel = {...filterModel, items};
+      setFilterModel(newModel);
+    },
+    [filterModel, setFilterModel]
+  );
+
+  const onSetSelected = useCallback(() => {
+    const newFilter =
+      selectedCalls.length === 1
+        ? {
+            id: filterModel.items.length,
+            field: 'id',
+            operator: '(string): equals',
+            value: selectedCalls[0],
+          }
+        : {
+            id: filterModel.items.length,
+            field: 'id',
+            operator: '(string): in',
+            value: selectedCalls,
+          };
+    const newModel = upsertFilter(
+      filterModel,
+      newFilter,
+      f => f.field === 'id'
+    );
+    setFilterModel(newModel);
+    clearSelectedCalls();
+    setAnchorEl(null);
+  }, [filterModel, setFilterModel, selectedCalls, clearSelectedCalls]);
+
+  const outlineW = 2 * 2;
+  const paddingW = 8 * 2;
+  const iconW = 20;
+  const gapW = 4 * 2; // Between icon and label and label and tags.
+  const labelW = refLabel.current?.offsetWidth ?? 0;
+  const availableWidth = width - outlineW - paddingW - iconW - labelW - gapW;
+
+  const completeItems = filterModel.items.filter(f => !isFilterIncomplete(f));
+
+  return (
+    <>
+      <div
+        ref={refBar}
+        className="flex cursor-pointer items-center gap-4 rounded px-8 py-4 outline outline-moon-250 hover:outline-2 hover:outline-teal-500/40"
+        onClick={onClick}>
+        <div>
+          <IconFilterAlt />
+        </div>
+        <div ref={refLabel} className="select-none">
+          Filter
+        </div>
+        <VariableChildrenDisplay width={availableWidth} gap={8}>
+          {completeItems.map(f => (
+            <FilterTagItem
+              key={f.id}
+              item={f}
+              onRemoveFilter={onRemoveFilter}
+            />
+          ))}
+        </VariableChildrenDisplay>
+      </div>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        slotProps={{
+          paper: {
+            sx: {
+              marginTop: '8px',
+              overflow: 'visible',
+            },
+          },
+        }}
+        onClose={() => setAnchorEl(null)}
+        TransitionComponent={DraggableGrow}>
+        <Tailwind>
+          <div className="p-12">
+            <DraggableHandle>
+              <div className="handle flex items-center pb-12">
+                <div className="flex-auto font-semibold">Filters</div>
+                {selectedCalls.length > 0 && (
+                  <Button size="small" variant="quiet" onClick={onSetSelected}>
+                    {`Selected rows (${selectedCalls.length})`}
+                  </Button>
+                )}
+              </div>
+            </DraggableHandle>
+            <div className="grid grid-cols-[auto_auto_auto_30px] gap-4">
+              {filterModel.items.map(item => (
+                <FilterRow
+                  key={item.id}
+                  item={item}
+                  options={options}
+                  onAddFilter={onAddFilter}
+                  onUpdateFilter={onUpdateFilter}
+                  onRemoveFilter={onRemoveFilter}
+                />
+              ))}
+            </div>
+            {filterModel.items.length === 0 && (
+              <FilterRow
+                item={{
+                  id: undefined,
+                  field: '',
+                  operator: '',
+                  value: undefined,
+                }}
+                options={options}
+                onAddFilter={onAddFilter}
+                onUpdateFilter={onUpdateFilter}
+                onRemoveFilter={onRemoveFilter}
+              />
+            )}
+            <div className="mt-8 flex items-center">
+              <Button
+                size="small"
+                variant="quiet"
+                icon="add-new"
+                disabled={filterModel.items.length === 0}
+                onClick={() => onAddFilter('')}>
+                Add filter
+              </Button>
+              <div className="flex-auto" />
+              <Button
+                size="small"
+                variant="quiet"
+                icon="delete"
+                disabled={filterModel.items.length === 0}
+                onClick={onRemoveAll}>
+                Remove all
+              </Button>
+            </div>
+          </div>
+        </Tailwind>
+      </Popover>
+    </>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
@@ -1,0 +1,39 @@
+/**
+ * This gets size information and passes it down.
+ */
+
+import {GridFilterModel} from '@mui/x-data-grid-pro';
+import {LocalizationProvider} from '@mui/x-date-pickers';
+import {AdapterMoment} from '@mui/x-date-pickers/AdapterMoment';
+import React from 'react';
+import {AutoSizer} from 'react-virtualized';
+
+import {ColumnInfo} from '../types';
+import {FilterBar} from './FilterBar';
+
+type FilterPanelProps = {
+  filterModel: GridFilterModel;
+  setFilterModel: (newModel: GridFilterModel) => void;
+  columnInfo: ColumnInfo;
+  selectedCalls: string[];
+  clearSelectedCalls: () => void;
+};
+
+export const FilterPanel = (props: FilterPanelProps) => {
+  return (
+    <div className="min-w-90 flex-auto self-stretch overflow-hidden">
+      <LocalizationProvider dateAdapter={AdapterMoment}>
+        <AutoSizer
+          className="ml-2 flex items-center"
+          style={{
+            width: '100%',
+            height: '100%',
+          }}>
+          {({width, height}) => (
+            <FilterBar {...props} width={width} height={height} />
+          )}
+        </AutoSizer>
+      </LocalizationProvider>
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -1,0 +1,96 @@
+/**
+ * Each filter in the filter popup is shown as one row.
+ */
+
+import {GridFilterItem} from '@mui/x-data-grid-pro';
+import React, {useMemo} from 'react';
+
+import {Button} from '../../../../Button';
+import {SelectField, SelectFieldOption} from './SelectField';
+import {SelectOperator} from './SelectOperator';
+import {SelectValue} from './SelectValue';
+import {FilterId, getFieldType, getOperatorOptions, isWeaveRef} from './types';
+
+type FilterRowProps = {
+  item: GridFilterItem;
+  options: SelectFieldOption[];
+  onAddFilter: (field: string) => void;
+  onUpdateFilter: (item: GridFilterItem) => void;
+  onRemoveFilter: (id: FilterId) => void;
+};
+
+export const FilterRow = ({
+  item,
+  options,
+  onAddFilter,
+  onUpdateFilter,
+  onRemoveFilter,
+}: FilterRowProps) => {
+  const onSelectField = (field: string) => {
+    if (item.id == null) {
+      onAddFilter(field);
+    } else {
+      // TODO: May need to get new operator or value?
+      onUpdateFilter({...item, field});
+    }
+  };
+
+  const operatorOptions = useMemo(
+    () => getOperatorOptions(item.field),
+    [item.field]
+  );
+
+  const onSelectOperator = (operator: string) => {
+    onUpdateFilter({...item, operator});
+  };
+
+  const onSetValue = (value: string) => {
+    onUpdateFilter({...item, value});
+  };
+
+  const isOperatorDisabled =
+    isWeaveRef(item.value) || ['id', 'user'].includes(getFieldType(item.field));
+
+  return (
+    <>
+      <div className="min-w-[250px]">
+        <SelectField
+          options={options}
+          value={item.field}
+          onSelectField={onSelectField}
+        />
+      </div>
+      <div className="w-[140px]">
+        {item.field && (
+          <SelectOperator
+            options={operatorOptions}
+            value={item.operator}
+            onSelectOperator={onSelectOperator}
+            isDisabled={isOperatorDisabled}
+          />
+        )}
+      </div>
+      <div className="flex items-center">
+        {item.field && (
+          <SelectValue
+            field={item.field}
+            operator={item.operator}
+            value={item.value}
+            onSetValue={onSetValue}
+          />
+        )}
+      </div>
+      <div className="flex items-center justify-center">
+        {item.id != null && (
+          <Button
+            size="small"
+            variant="quiet"
+            icon="delete"
+            tooltip="Remove this filter"
+            onClick={() => onRemoveFilter(item.id)}
+          />
+        )}
+      </div>
+    </>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -6,10 +6,10 @@ import {GridFilterItem} from '@mui/x-data-grid-pro';
 import React, {useMemo} from 'react';
 
 import {Button} from '../../../../Button';
+import {FilterId, getFieldType, getOperatorOptions, isWeaveRef} from './common';
 import {SelectField, SelectFieldOption} from './SelectField';
 import {SelectOperator} from './SelectOperator';
 import {SelectValue} from './SelectValue';
-import {FilterId, getFieldType, getOperatorOptions, isWeaveRef} from './types';
 
 type FilterRowProps = {
   item: GridFilterItem;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTag.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTag.tsx
@@ -1,0 +1,24 @@
+import React, {ReactElement} from 'react';
+import {twMerge} from 'tailwind-merge';
+
+import {RemoveAction, useTagClasses} from '../../../../Tag';
+
+export type FilterTagProps = {
+  label: React.ReactNode;
+  removeAction: ReactElement<typeof RemoveAction>;
+};
+
+export const FilterTag = ({label, removeAction}: FilterTagProps) => {
+  const classes = useTagClasses({color: 'moon', isInteractive: true});
+  return (
+    <div key={`tag-${label}`} className={twMerge(classes, 'pl-6 pr-4')}>
+      <div
+        className={twMerge(
+          'flex items-center overflow-hidden text-ellipsis whitespace-nowrap '
+        )}>
+        {label}
+      </div>
+      {removeAction}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -10,9 +10,6 @@ import {parseRef} from '../../../../../react';
 import {Timestamp} from '../../../../Timestamp';
 import {UserLink} from '../../../../UserLink';
 import {SmallRef} from '../../Browse2/SmallRef';
-import {isValuelessOperator} from '../pages/common/tabularListViews/operators';
-import {FilterTag} from './FilterTag';
-import {IdList} from './IdList';
 import {
   FilterId,
   getFieldLabel,
@@ -20,8 +17,11 @@ import {
   getOperatorLabel,
   getOperatorValueType,
   getStringList,
+  isValuelessOperator,
   isWeaveRef,
-} from './types';
+} from './common';
+import {FilterTag} from './FilterTag';
+import {IdList} from './IdList';
 
 type FilterTagItemProps = {
   item: GridFilterItem;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -1,0 +1,77 @@
+/**
+ * FilterTagItem shows one filter. It can be removed by clicking the 'x' button.
+ */
+
+import {GridFilterItem} from '@mui/x-data-grid-pro';
+import {RemoveAction} from '@wandb/weave/components/Tag';
+import React from 'react';
+
+import {parseRef} from '../../../../../react';
+import {Timestamp} from '../../../../Timestamp';
+import {UserLink} from '../../../../UserLink';
+import {SmallRef} from '../../Browse2/SmallRef';
+import {isValuelessOperator} from '../pages/common/tabularListViews/operators';
+import {FilterTag} from './FilterTag';
+import {IdList} from './IdList';
+import {
+  FilterId,
+  getFieldLabel,
+  getFieldType,
+  getOperatorLabel,
+  getOperatorValueType,
+  getStringList,
+  isWeaveRef,
+} from './types';
+
+type FilterTagItemProps = {
+  item: GridFilterItem;
+  onRemoveFilter: (id: FilterId) => void;
+};
+
+const quoteValue = (valueType: string, value: string): string => {
+  if ('string' === valueType) {
+    return `"${value}"`;
+  }
+  return value;
+};
+
+export const FilterTagItem = ({item, onRemoveFilter}: FilterTagItemProps) => {
+  const field = getFieldLabel(item.field);
+
+  const operator = getOperatorLabel(item.operator);
+  let value: React.ReactNode = '';
+  const fieldType = getFieldType(item.field);
+  if (fieldType === 'id') {
+    value = <IdList ids={getStringList(item.value)} type="Call" />;
+  } else if (fieldType === 'user') {
+    value = <UserLink userId={item.value} hasPopover={false} />;
+  } else if (isWeaveRef(item.value)) {
+    value = <SmallRef objRef={parseRef(item.value)} />;
+  } else if (!isValuelessOperator(item.operator)) {
+    const valueType = getOperatorValueType(item.operator);
+    if (valueType === 'date') {
+      value = <Timestamp value={item.value} />;
+    } else {
+      value = ' ' + quoteValue(valueType, item.value);
+    }
+  }
+  const label = `${field} ${operator}`;
+  return (
+    <FilterTag
+      label={
+        <>
+          {label}
+          <div className="ml-4">{value}</div>
+        </>
+      }
+      removeAction={
+        <RemoveAction
+          onClick={(e: any) => {
+            e.stopPropagation();
+            onRemoveFilter(item.id);
+          }}
+        />
+      }
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/IdList.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/IdList.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import {Id} from '../pages/common/Id';
+
+type IdListProps = {
+  ids: string[];
+  type: string;
+};
+
+export const IdList = ({ids, type}: IdListProps) => {
+  return (
+    <div className="flex items-center">
+      {ids.map((id: string) => (
+        <Id key={id} id={id} type={type} />
+      ))}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectField.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectField.tsx
@@ -1,0 +1,97 @@
+/**
+ * Select the grid column that a filter applies to.
+ */
+import {Select} from '@wandb/weave/components/Form/Select';
+import _ from 'lodash';
+import React from 'react';
+import {components, OptionProps, SingleValueProps} from 'react-select';
+
+import {Tooltip} from '../../../../Tooltip';
+import {getFieldLabel} from './types';
+
+type FieldOption = {
+  readonly value: string;
+  readonly label: string;
+  readonly description?: string;
+};
+
+export type GroupedOption = {
+  readonly label: string;
+  readonly options: FieldOption[];
+  readonly description?: string;
+};
+
+export type SelectFieldOption = FieldOption | GroupedOption;
+
+type SelectFieldProps = {
+  options: SelectFieldOption[];
+  value: string;
+  onSelectField: (name: string) => void;
+};
+
+const Option = (props: OptionProps<FieldOption, false, GroupedOption>) => {
+  const {description} = props.data;
+  const opt = <components.Option {...props} />;
+  if (!description) {
+    return opt;
+  }
+  return <Tooltip trigger={<span>{opt}</span>} content={description} />;
+};
+
+const OptionLabel = (props: SelectFieldOption) => {
+  const {label} = props;
+  return <span className="whitespace-nowrap">{label}</span>;
+};
+
+// What is shown in the input field when a value is selected.
+// For groups like input and output we want that prefix,
+// while for fields like Called we want the pretty name not the internal field.
+const SingleValue = ({
+  children,
+  ...props
+}: SingleValueProps<FieldOption, false, GroupedOption>) => {
+  const label = getFieldLabel(props.data.value);
+  return <components.SingleValue {...props}>{label}</components.SingleValue>;
+};
+
+export const SelectField = ({
+  options,
+  value,
+  onSelectField,
+}: SelectFieldProps) => {
+  const internalOptions = _.cloneDeep(options);
+  const allOptions: FieldOption[] = internalOptions.flatMap(
+    (groupOption: SelectFieldOption) => (groupOption as GroupedOption).options
+  );
+  let isDisabled = false;
+  let selectedOption = allOptions.find(o => o.value === value);
+
+  // Handle the case of a filter that we let the user create but not edit.
+  if (value && !selectedOption) {
+    isDisabled = true;
+    selectedOption = {
+      value,
+      label: getFieldLabel(value),
+    };
+    internalOptions.push(selectedOption);
+  }
+
+  const onReactSelectChange = (option: FieldOption | null) => {
+    if (option) {
+      onSelectField(option.value);
+    }
+  };
+
+  return (
+    <Select<FieldOption, false, GroupedOption>
+      options={internalOptions}
+      placeholder="Select column"
+      value={selectedOption}
+      onChange={onReactSelectChange}
+      components={{Option, SingleValue}}
+      formatOptionLabel={OptionLabel}
+      isDisabled={isDisabled}
+      autoFocus
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectField.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectField.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import {components, OptionProps, SingleValueProps} from 'react-select';
 
 import {Tooltip} from '../../../../Tooltip';
-import {getFieldLabel} from './types';
+import {getFieldLabel} from './common';
 
 type FieldOption = {
   readonly value: string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectOperator.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectOperator.tsx
@@ -1,0 +1,51 @@
+/**
+ * Select an operator for a filter.
+ */
+import {Select} from '@wandb/weave/components/Form/Select';
+import React from 'react';
+
+import {Tooltip} from '../../../../Tooltip';
+import {SelectOperatorOption} from './types';
+
+type SelectOperatorProps = {
+  options: SelectOperatorOption[];
+  value: string;
+  onSelectOperator: (value: string) => void;
+  isDisabled?: boolean;
+};
+
+const OptionLabel = (props: SelectOperatorOption) => {
+  const {value, label} = props;
+  return (
+    <Tooltip
+      trigger={<span className="whitespace-nowrap">{label}</span>}
+      content={value}
+    />
+  );
+};
+
+export const SelectOperator = ({
+  options,
+  value,
+  onSelectOperator,
+  isDisabled,
+}: SelectOperatorProps) => {
+  const selectedOption = options.find(o => o.value === value) ?? options[0];
+
+  const onReactSelectChange = (option: SelectOperatorOption | null) => {
+    if (option) {
+      onSelectOperator(option.value);
+    }
+  };
+
+  return (
+    <Select<SelectOperatorOption>
+      options={options}
+      value={selectedOption}
+      placeholder="Select operator"
+      onChange={onReactSelectChange}
+      formatOptionLabel={OptionLabel}
+      isDisabled={isDisabled}
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectOperator.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectOperator.tsx
@@ -5,7 +5,7 @@ import {Select} from '@wandb/weave/components/Form/Select';
 import React from 'react';
 
 import {Tooltip} from '../../../../Tooltip';
-import {SelectOperatorOption} from './types';
+import {SelectOperatorOption} from './common';
 
 type SelectOperatorProps = {
   options: SelectOperatorOption[];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
@@ -8,11 +8,15 @@ import React from 'react';
 import {parseRef} from '../../../../../react';
 import {UserLink} from '../../../../UserLink';
 import {SmallRef} from '../../Browse2/SmallRef';
-import {isValuelessOperator} from '../pages/common/tabularListViews/operators';
 import {StyledDateTimePicker} from '../StyledDateTimePicker';
+import {
+  getFieldType,
+  getStringList,
+  isValuelessOperator,
+  isWeaveRef,
+} from './common';
 import {IdList} from './IdList';
 import {TextValue} from './TextValue';
-import {getFieldType, getStringList, isWeaveRef} from './types';
 import {ValueInputBoolean} from './ValueInputBoolean';
 
 type SelectValueProps = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
@@ -1,0 +1,65 @@
+/**
+ * Select the value for a filter. Depends on the operator.
+ */
+
+import moment from 'moment';
+import React from 'react';
+
+import {parseRef} from '../../../../../react';
+import {UserLink} from '../../../../UserLink';
+import {SmallRef} from '../../Browse2/SmallRef';
+import {isValuelessOperator} from '../pages/common/tabularListViews/operators';
+import {StyledDateTimePicker} from '../StyledDateTimePicker';
+import {IdList} from './IdList';
+import {TextValue} from './TextValue';
+import {getFieldType, getStringList, isWeaveRef} from './types';
+import {ValueInputBoolean} from './ValueInputBoolean';
+
+type SelectValueProps = {
+  field: string;
+  operator: string;
+  value: any;
+  onSetValue: (value: string) => void;
+};
+
+export const SelectValue = ({
+  field,
+  operator,
+  value,
+  onSetValue,
+}: SelectValueProps) => {
+  if (isValuelessOperator(operator)) {
+    return null;
+  }
+  if (isWeaveRef(value)) {
+    // We don't allow editing ref values in the filter popup
+    // but we show them.
+    return <SmallRef objRef={parseRef(value)} />;
+  }
+
+  const fieldType = getFieldType(field);
+
+  if (fieldType === 'id' && operator.endsWith('in')) {
+    return <IdList ids={getStringList(value)} type="Call" />;
+  }
+  if (fieldType === 'user') {
+    return <UserLink userId={value} includeName={true} hasPopover={false} />;
+  }
+  if (fieldType === 'datetime') {
+    const dateTimeValue = value ? moment(value) : null;
+    return (
+      <StyledDateTimePicker
+        value={dateTimeValue}
+        onChange={(newValue: moment.Moment | null) =>
+          onSetValue(newValue ? newValue.toISOString() : '')
+        }
+      />
+    );
+  }
+
+  if (operator.startsWith('(bool): ')) {
+    return <ValueInputBoolean value={value} onSetValue={onSetValue} />;
+  }
+
+  return <TextValue value={value} onSetValue={onSetValue} />;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/TextValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/TextValue.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import {TextField} from '../../../../Form/TextField';
+
+type TextValueProps = {
+  value: string;
+  onSetValue: (value: string) => void;
+};
+
+export const TextValue = ({value, onSetValue}: TextValueProps) => {
+  // TODO: Need to debounce the value change.
+  return (
+    <div className="min-w-[200px]">
+      <TextField value={value} onChange={onSetValue} />
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/ValueInputBoolean.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/ValueInputBoolean.tsx
@@ -1,0 +1,50 @@
+import classNames from 'classnames';
+import React from 'react';
+
+import * as Colors from '../../../../../common/css/color.styles';
+import {Icon} from '../../../../Icon';
+
+type ValueInputBooleanProps = {
+  value: string | boolean | undefined;
+  onSetValue: (value: string) => void;
+};
+
+export const ValueInputBoolean = ({
+  value,
+  onSetValue,
+}: ValueInputBooleanProps) => {
+  const isTrue = value === 'true' || value === true;
+  const isFalse = value === 'false' || value === false;
+  const classNamesBtn = classNames(
+    'night-aware cursor-pointer',
+    "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
+    'disabled:pointer-events-none disabled:opacity-35',
+    'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
+    'gap-6 px-6 py-3 text-sm leading-[18px]',
+    '[&_svg]:h-16 [&_svg]:w-16',
+    'bg-oblivion/[0.05] dark:bg-moonbeam/[0.05]',
+    'text-moon-800 dark:text-moon-200',
+    'hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400'
+  );
+  const classNamesTrue = classNames(classNamesBtn, {
+    'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400':
+      isTrue,
+  });
+  const classNamesFalse = classNames(classNamesBtn, {
+    'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400':
+      isFalse,
+  });
+
+  // TODO: Maybe clicking on the current value should deselect?
+
+  return (
+    <div className="flex items-center gap-4">
+      <div className={classNamesTrue} onClick={() => onSetValue('true')}>
+        <Icon color={Colors.GREEN_600} name="checkmark" /> True
+      </div>
+      <div className={classNamesFalse} onClick={() => onSetValue('false')}>
+        <Icon color={Colors.RED_600} name="close" /> False
+      </div>
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/ValueInputBoolean.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/ValueInputBoolean.tsx
@@ -9,28 +9,29 @@ type ValueInputBooleanProps = {
   onSetValue: (value: string) => void;
 };
 
+const CLASS_NAMES_BUTTON = classNames(
+  'night-aware cursor-pointer',
+  "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
+  'disabled:pointer-events-none disabled:opacity-35',
+  'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
+  'gap-6 px-6 py-3 text-sm leading-[18px]',
+  '[&_svg]:h-16 [&_svg]:w-16',
+  'bg-oblivion/[0.05] dark:bg-moonbeam/[0.05]',
+  'text-moon-800 dark:text-moon-200',
+  'hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400'
+);
+
 export const ValueInputBoolean = ({
   value,
   onSetValue,
 }: ValueInputBooleanProps) => {
   const isTrue = value === 'true' || value === true;
   const isFalse = value === 'false' || value === false;
-  const classNamesBtn = classNames(
-    'night-aware cursor-pointer',
-    "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
-    'disabled:pointer-events-none disabled:opacity-35',
-    'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
-    'gap-6 px-6 py-3 text-sm leading-[18px]',
-    '[&_svg]:h-16 [&_svg]:w-16',
-    'bg-oblivion/[0.05] dark:bg-moonbeam/[0.05]',
-    'text-moon-800 dark:text-moon-200',
-    'hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400'
-  );
-  const classNamesTrue = classNames(classNamesBtn, {
+  const classNamesTrue = classNames(CLASS_NAMES_BUTTON, {
     'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400':
       isTrue,
   });
-  const classNamesFalse = classNames(classNamesBtn, {
+  const classNamesFalse = classNames(CLASS_NAMES_BUTTON, {
     'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400':
       isFalse,
   });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/VariableChildrenDisplayer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/VariableChildrenDisplayer.tsx
@@ -1,0 +1,226 @@
+/**
+ * This component intelligently determines how many children it can show
+ * based on the available width.
+ */
+
+import _ from 'lodash';
+import React, {isValidElement, ReactChild, useEffect, useState} from 'react';
+import ReactDOM from 'react-dom';
+
+import {useDeepMemo} from '../../../../../hookUtils';
+
+type VariableChildrenDisplayProps = {
+  children: ReactChild[];
+  width: number;
+  gap?: number;
+};
+
+// Given an array of numbers and nulls, return the index of the largest number.
+// Ties are broken by returning the larger index.
+// -1 is returned if there are no numbers in the array.
+const indexOfLargest = (numbers: Array<number | null>): number => {
+  if (numbers.length === 0) {
+    return -1;
+  }
+
+  let largestIndex: number | null = null;
+  let largestValue: number | null = null;
+
+  for (let i = 0; i < numbers.length; i++) {
+    const currentValue = numbers[i];
+
+    if (
+      currentValue !== null &&
+      (largestValue === null || currentValue >= largestValue)
+    ) {
+      largestValue = currentValue;
+      largestIndex = i;
+    }
+  }
+
+  return largestIndex ?? -1;
+};
+
+// Compute the sum of width values in an array, ignoring nulls, and
+// adding gaps.
+const sumSize = (sizes: Array<number | null>, gapWidth: number) => {
+  const included = sizes.filter(size => size !== null) as number[];
+  const gapSum = Math.max(0, gapWidth * (included.length - 1));
+  return _.sum(included) + gapSum;
+};
+
+const measureWidths = (nodes: ReactChild[]): Promise<number[]> => {
+  // Create a container to render the nodes
+  const container = document.createElement('div');
+  container.id = 'measureWidthsContainer';
+  container.classList.add('tw-style');
+  container.style.position = 'absolute';
+  container.style.top = '0';
+  container.style.left = '0';
+  container.style.visibility = 'hidden';
+  container.style.height = 'auto';
+  container.style.width = 'auto';
+  container.style.whiteSpace = 'nowrap';
+
+  document.body.appendChild(container);
+
+  const widthPromises: Array<Promise<number>> = nodes.map(node => {
+    return new Promise(resolve => {
+      const wrapper = document.createElement('div');
+
+      // Append the wrapper to the container
+      container.appendChild(wrapper);
+
+      // Render the node and measure its width
+      if (React.isValidElement(node)) {
+        ReactDOM.render(node, wrapper, () => {
+          const width = wrapper.offsetWidth;
+          resolve(width);
+
+          // Clean up after measuring
+          ReactDOM.unmountComponentAtNode(wrapper);
+          container.removeChild(wrapper);
+        });
+      } else {
+        wrapper.textContent = node.toString();
+        const width = wrapper.offsetWidth;
+        resolve(width);
+        container.removeChild(wrapper);
+      }
+    });
+  });
+
+  // Clean up the container once all measurements are done
+  return Promise.all(widthPromises).then(widths => {
+    document.body.removeChild(container);
+    return widths;
+  });
+};
+
+// Compare two ReactNode's for equality.
+const isEqualNode = (
+  node1: React.ReactNode,
+  node2: React.ReactNode
+): boolean => {
+  if (!isValidElement(node1) || !isValidElement(node2)) {
+    return node1 === node2;
+  }
+
+  if (node1.type !== node2.type) {
+    return false;
+  }
+
+  const props1 = {...node1.props, children: undefined};
+  const props2 = {...node2.props, children: undefined};
+
+  if (JSON.stringify(props1) !== JSON.stringify(props2)) {
+    return false;
+  }
+
+  const children1 = React.Children.toArray(node1.props.children);
+  const children2 = React.Children.toArray(node2.props.children);
+
+  if (children1.length !== children2.length) {
+    return false;
+  }
+
+  for (let i = 0; i < children1.length; i++) {
+    if (!isEqualNode(children1[i], children2[i])) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const isEqualNodeArray = (
+  nodes1: React.ReactNode[],
+  nodes2: React.ReactNode[] | undefined
+) => {
+  if (nodes2 === undefined) {
+    return false;
+  }
+  if (nodes1.length !== nodes2.length) {
+    return false;
+  }
+  for (let i = 0; i < nodes1.length; i++) {
+    if (!isEqualNode(nodes1[i], nodes2[i])) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const calculateDisplayedItems = (
+  availableWidth: number,
+  childWidths: number[],
+  gap: number,
+  extraSize: number
+) => {
+  const result: Array<number | null> = _.clone(childWidths);
+  let used = sumSize(childWidths, gap);
+  if (used < availableWidth) {
+    // Best case, we can show all children.
+    return result;
+  }
+
+  // Not enough room to display everything.
+  // Repeatedly remove the largest child until we fit.
+  availableWidth -= extraSize;
+  while (used > availableWidth) {
+    const largestIndex = indexOfLargest(result);
+    if (largestIndex === -1) {
+      return _.fill(Array(result.length), null);
+    }
+    result[largestIndex] = null;
+    used = sumSize(result, gap);
+  }
+  return result;
+};
+
+// This is to account for the space needed by the "N more" indicator.
+// TODO: This value should be calculated.
+const EXTRA_SIZE = 50;
+
+export const VariableChildrenDisplay = ({
+  children,
+  width,
+  gap = 0,
+}: VariableChildrenDisplayProps) => {
+  const [childWidths, setChildWidths] = useState<number[]>([]);
+  const memoedChildren = useDeepMemo(children, isEqualNodeArray);
+
+  useEffect(() => {
+    measureWidths(memoedChildren).then(setChildWidths);
+  }, [memoedChildren]);
+
+  const displayedItems = calculateDisplayedItems(
+    width,
+    childWidths,
+    gap,
+    EXTRA_SIZE
+  );
+  const numChildren = memoedChildren.length;
+  const numShown = displayedItems.filter(item => item !== null).length;
+  const numHidden = numChildren - numShown;
+
+  return (
+    <div
+      className="flex items-center overflow-hidden"
+      style={{
+        gap,
+      }}>
+      {memoedChildren.map((child, index) => {
+        if (displayedItems[index] === null) {
+          return null;
+        }
+        return <div key={index}>{child}</div>;
+      })}
+      {numChildren && numChildren === numHidden ? (
+        <span>({numChildren})</span>
+      ) : numHidden > 0 ? (
+        <div className="whitespace-nowrap">{numHidden} more</div>
+      ) : null}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -1,3 +1,7 @@
+/**
+ * Shared type definitions and utility methods for filtering UI.
+ */
+
 import {
   GridColDef,
   GridColumnGroupingModel,
@@ -113,6 +117,12 @@ const operatorLabels: Record<string, string> = allOperators.reduce(
   },
   {} as Record<string, string>
 );
+
+const VALUELESS_OPERATORS = new Set(['(any): isEmpty', '(any): isNotEmpty']);
+
+export const isValuelessOperator = (operator: string) => {
+  return VALUELESS_OPERATORS.has(operator);
+};
 
 export type SelectOperatorOption = {
   value: string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/types.ts
@@ -1,0 +1,250 @@
+import {
+  GridColDef,
+  GridColumnGroupingModel,
+  GridFilterItem,
+  GridFilterModel,
+} from '@mui/x-data-grid-pro';
+import _ from 'lodash';
+
+import {TraceCallSchema} from '../pages/wfReactInterface/traceServerClientTypes';
+
+export type FilterId = number | string | undefined;
+
+// These are columns we won't allow the user to filter on.
+// For most of these it would be great if we could enable filtering in the future.
+export const UNFILTERABLE_FIELDS = [
+  'op_name',
+  'feedback',
+  'summary.weave.status',
+  'summary.weave.tokens',
+  'summary.weave.cost',
+  'summary.weave.latency',
+  'wb_user_id', // Option+Click works
+];
+
+export type ColumnInfo = {
+  cols: Array<GridColDef<TraceCallSchema>>;
+  colGroupingModel: GridColumnGroupingModel;
+};
+
+export const FIELD_LABELS: Record<string, string> = {
+  id: 'Call ID',
+  started_at: 'Called',
+  wb_user_id: 'User',
+};
+
+export const getFieldLabel = (field: string): string => {
+  return FIELD_LABELS[field] ?? field;
+};
+
+export const FIELD_TYPE: Record<string, string> = {
+  id: 'id',
+  'summary.weave.status': 'status',
+  wb_user_id: 'user',
+  started_at: 'datetime',
+};
+
+export const getFieldType = (field: string): string => {
+  return FIELD_TYPE[field] ?? 'text';
+};
+
+const allOperators = [
+  {
+    value: '(string): contains',
+    label: 'contains',
+  },
+  {
+    value: '(string): equals',
+    label: 'equals',
+  },
+  {
+    value: '(string): in',
+    label: 'in',
+  },
+  {
+    value: '(number): =',
+    label: '=',
+  },
+  {
+    value: '(number): !=',
+    label: '≠',
+  },
+  {
+    value: '(number): <',
+    label: '<',
+  },
+  {
+    value: '(number): <=',
+    label: '≤',
+  },
+  {
+    value: '(number): >',
+    label: '>',
+  },
+  {
+    value: '(number): >=',
+    label: '≥',
+  },
+  {
+    value: '(bool): is',
+    label: 'is',
+  },
+  {
+    value: '(date): after',
+    label: 'after',
+  },
+  {
+    value: '(date): before',
+    label: 'before',
+  },
+  {
+    value: '(any): isEmpty',
+    label: 'is empty',
+  },
+  {
+    value: '(any): isNotEmpty',
+    label: 'is not empty',
+  },
+];
+const operatorLabels: Record<string, string> = allOperators.reduce(
+  (acc, operator) => {
+    acc[operator.value] = operator.label;
+    return acc;
+  },
+  {} as Record<string, string>
+);
+
+export type SelectOperatorOption = {
+  value: string;
+  label: string;
+};
+
+export const getOperatorLabel = (operatorValue: string): string => {
+  const label = operatorLabels[operatorValue];
+  if (label) {
+    return label;
+  }
+  const parts = operatorValue.split(':');
+  if (parts.length > 1) {
+    return parts[1].trim();
+  }
+  return operatorValue;
+};
+
+export const getOperatorValueType = (operatorValue: string): string => {
+  const parts = operatorValue.split(':');
+  if (parts.length > 1) {
+    return parts[0].substring(1, parts[0].length - 1);
+  }
+
+  return 'any';
+};
+
+export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
+  const fieldType = getFieldType(field);
+  if ('id' === fieldType) {
+    return [
+      {
+        value: '(string): equals',
+        label: 'equals',
+      },
+      {
+        value: '(string): in',
+        label: 'in',
+      },
+    ];
+  }
+  if ('datetime' === fieldType) {
+    return [
+      {
+        value: '(date): after',
+        label: 'after',
+      },
+      {
+        value: '(date): before',
+        label: 'before',
+      },
+    ];
+  }
+  if ('status' === fieldType) {
+    return [
+      {
+        value: 'is',
+        label: 'is',
+      },
+      {
+        value: 'is not',
+        label: 'is not',
+      },
+    ];
+  }
+  if ('user' === fieldType) {
+    return [
+      {
+        value: '(string): equals',
+        label: 'equals',
+      },
+    ];
+  }
+  return allOperators;
+};
+
+export const getDefaultOperatorForValue = (value: any) => {
+  if (typeof value === 'number') {
+    return '(number): =';
+  }
+  if (typeof value === 'boolean') {
+    return '(bool): is';
+  }
+  return '(string): equals';
+};
+
+export const FIELD_DESCRIPTIONS: Record<string, string> = {
+  started_at: 'The time the op was invoked',
+  'attributes.weave.client_version': 'The version of the Weave library used',
+  'attributes.weave.source': 'Which Weave client was used',
+  'attributes.weave.os_name': 'Operating system name',
+  'attributes.weave.os_version': 'Detailed operating system version',
+  'attributes.weave.os_release': 'Brief operating system version',
+  'attributes.weave.sys_version': 'Python version used',
+};
+
+export const isWeaveRef = (value: any): boolean => {
+  return typeof value === 'string' && value.startsWith('weave:///');
+};
+
+export const getStringList = (value: any): string[] => {
+  if (_.isString(value)) {
+    return value.split(',').map(id => id.trim());
+  }
+  if (_.isArray(value) && value.every(_.isString)) {
+    return value;
+  }
+  throw new Error('Invalid value');
+};
+
+type ReplacementTest = (item: GridFilterItem) => boolean;
+
+export const upsertFilter = (
+  model: GridFilterModel,
+  item: GridFilterItem,
+  replacementTest: ReplacementTest
+): GridFilterModel => {
+  const items: GridFilterItem[] = [];
+  let found = false;
+  for (const i of model.items) {
+    if (replacementTest(i)) {
+      items.push(item);
+      found = true;
+    } else {
+      items.push(i);
+    }
+  }
+  if (!found) {
+    items.push(item);
+  }
+  return {
+    ...model,
+    items,
+  };
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/filters.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/filters.test.ts
@@ -1,0 +1,19 @@
+import {getValidFilterModel} from './filters';
+
+describe('getValidFilterModel', () => {
+  it('parses valid query values', () => {
+    const parsed = getValidFilterModel(
+      '{"items":[{"field":"summary.weave.status","operator":"contains","id":71521}],"logicOperator":"and"}'
+    );
+    expect(parsed).toEqual({
+      items: [
+        {
+          field: 'summary.weave.status',
+          operator: 'contains',
+          id: 71521,
+        },
+      ],
+      logicOperator: 'and',
+    });
+  });
+});

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/filters.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/filters.ts
@@ -1,0 +1,43 @@
+import {
+  GridFilterItem,
+  GridFilterModel,
+  GridLogicOperator,
+} from '@mui/x-data-grid-pro';
+import _ from 'lodash';
+
+const isValidFilterItem = (obj: any): obj is GridFilterItem => {
+  if (!_.isPlainObject(obj)) {
+    return false;
+  }
+  if (
+    'field' in obj &&
+    _.isString(obj.field) &&
+    'operator' in obj &&
+    _.isString(obj.operator)
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const getValidFilterModel = <T extends GridFilterModel | null>(
+  jsonString: string,
+  def: T = null as T
+): T => {
+  try {
+    const parsed = JSON.parse(jsonString);
+    if (
+      'items' in parsed &&
+      _.isArray(parsed.items) &&
+      parsed.items.every(isValidFilterItem)
+    ) {
+      return {
+        items: parsed.items,
+        logicOperator: GridLogicOperator.And,
+      } as T;
+    }
+  } catch (e) {
+    // Ignore
+  }
+  return def;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -1,5 +1,6 @@
 import {
   GridColumnVisibilityModel,
+  GridFilterModel,
   GridPaginationModel,
   GridPinnedColumns,
   GridSortModel,
@@ -36,6 +37,9 @@ export const CallsPage: FC<{
 
   pinModel: GridPinnedColumns;
   setPinModel: (newModel: GridPinnedColumns) => void;
+
+  filterModel: GridFilterModel;
+  setFilterModel: (newModel: GridFilterModel) => void;
 
   sortModel: GridSortModel;
   setSortModel: (newModel: GridSortModel) => void;
@@ -90,6 +94,8 @@ export const CallsPage: FC<{
                 setColumnVisibilityModel={props.setColumnVisibilityModel}
                 pinModel={props.pinModel}
                 setPinModel={props.setPinModel}
+                filterModel={props.filterModel}
+                setFilterModel={props.setFilterModel}
                 sortModel={props.sortModel}
                 setSortModel={props.setSortModel}
                 paginationModel={props.paginationModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -43,8 +43,8 @@ import {
   useWeaveflowCurrentRouteContext,
   WeaveHeaderExtrasContext,
 } from '../../context';
+import {getDefaultOperatorForValue} from '../../filters/common';
 import {FilterPanel} from '../../filters/FilterPanel';
-import {getDefaultOperatorForValue} from '../../filters/types';
 import {DEFAULT_PAGE_SIZE} from '../../grid/pagination';
 import {StyledPaper} from '../../StyledAutocomplete';
 import {StyledDataGrid} from '../../StyledDataGrid';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -17,6 +17,7 @@ import {Box, Typography} from '@mui/material';
 import {
   GridColumnVisibilityModel,
   GridFilterModel,
+  GridLogicOperator,
   GridPaginationModel,
   GridPinnedColumns,
   GridRowSelectionModel,
@@ -37,10 +38,13 @@ import {useHistory} from 'react-router-dom';
 
 import {useViewerInfo} from '../../../../../../common/hooks/useViewerInfo';
 import {A, TargetBlank} from '../../../../../../common/util/links';
+import {Tailwind} from '../../../../../Tailwind';
 import {
   useWeaveflowCurrentRouteContext,
   WeaveHeaderExtrasContext,
 } from '../../context';
+import {FilterPanel} from '../../filters/FilterPanel';
+import {getDefaultOperatorForValue} from '../../filters/types';
 import {DEFAULT_PAGE_SIZE} from '../../grid/pagination';
 import {StyledPaper} from '../../StyledAutocomplete';
 import {StyledDataGrid} from '../../StyledDataGrid';
@@ -102,6 +106,10 @@ export const DEFAULT_PIN_CALLS: GridPinnedColumns = {
 export const DEFAULT_SORT_CALLS: GridSortModel = [
   {field: 'started_at', sort: 'desc'},
 ];
+export const DEFAULT_FILTER_CALLS: GridFilterModel = {
+  items: [],
+  logicOperator: GridLogicOperator.And,
+};
 
 const DEFAULT_PAGINATION_CALLS: GridPaginationModel = {
   pageSize: DEFAULT_PAGE_SIZE,
@@ -124,6 +132,9 @@ export const CallsTable: FC<{
   pinModel?: GridPinnedColumns;
   setPinModel?: (newModel: GridPinnedColumns) => void;
 
+  filterModel?: GridFilterModel;
+  setFilterModel?: (newModel: GridFilterModel) => void;
+
   sortModel?: GridSortModel;
   setSortModel?: (newModel: GridSortModel) => void;
 
@@ -140,6 +151,8 @@ export const CallsTable: FC<{
   setColumnVisibilityModel,
   pinModel,
   setPinModel,
+  filterModel,
+  setFilterModel,
   sortModel,
   setSortModel,
   paginationModel,
@@ -176,7 +189,7 @@ export const CallsTable: FC<{
   );
 
   // 2. Filter (Unstructured Filter)
-  const [filterModel, setFilterModel] = useState<GridFilterModel>({items: []});
+  const filterModelResolved = filterModel ?? DEFAULT_FILTER_CALLS;
 
   // 3. Sort
   const sortModelResolved = sortModel ?? DEFAULT_SORT_CALLS;
@@ -223,7 +236,7 @@ export const CallsTable: FC<{
     entity,
     project,
     effectiveFilter,
-    filterModel,
+    filterModelResolved,
     sortModelResolved,
     paginationModelResolved,
     expandedRefCols
@@ -260,6 +273,26 @@ export const CallsTable: FC<{
     [callsResult]
   );
 
+  const onAddFilter =
+    filterModel && setFilterModel
+      ? (field: string, operator: string | null, value: any) => {
+          const op = operator ? operator : getDefaultOperatorForValue(value);
+          const newModel = {
+            ...filterModel,
+            items: [
+              ...filterModel.items,
+              {
+                id: filterModel.items.length,
+                field,
+                operator: op,
+                value,
+              },
+            ],
+          };
+          setFilterModel(newModel);
+        }
+      : undefined;
+
   // Column Management: Build the columns needed for the table
   const {columns, setUserDefinedColumnWidths} = useCallsTableColumns(
     entity,
@@ -269,7 +302,8 @@ export const CallsTable: FC<{
     expandedRefCols,
     onCollapse,
     onExpand,
-    columnIsRefExpanded
+    columnIsRefExpanded,
+    onAddFilter
   );
 
   // Now, there are 4 primary controls:
@@ -366,8 +400,10 @@ export const CallsTable: FC<{
   // CPR (Tim) - (GeneralRefactoring): Co-locate this closer to the effective filter stuff
   const clearFilters = useCallback(() => {
     setFilter({});
-    setFilterModel({items: []});
-  }, [setFilter]);
+    if (setFilterModel) {
+      setFilterModel({items: []});
+    }
+  }, [setFilter, setFilterModel]);
 
   // CPR (Tim) - (GeneralRefactoring): Remove this, and add a slot for empty content that can be calculated
   // in the parent component
@@ -379,6 +415,9 @@ export const CallsTable: FC<{
 
   // Selection Management
   const [selectedCalls, setSelectedCalls] = useState<string[]>([]);
+  const clearSelectedCalls = useCallback(() => {
+    setSelectedCalls([]);
+  }, [setSelectedCalls]);
   const muiColumns = useMemo(() => {
     const cols = [
       {
@@ -527,7 +566,7 @@ export const CallsTable: FC<{
             entity,
             project,
             filter: effectiveFilter,
-            gridFilter: filterModel,
+            gridFilter: filterModel ?? DEFAULT_FILTER_CALLS,
             gridSort: sortModel,
           }}
           rightmostButton={isReadonly}
@@ -653,52 +692,64 @@ export const CallsTable: FC<{
       filterListSx={{
         pb: 1,
         display: hideControls ? 'none' : 'flex',
+        alignItems: 'center',
       }}
       filterListItems={
-        <>
-          <ListItem sx={{minWidth: '190px'}}>
-            <FormControl fullWidth>
-              <Autocomplete
-                PaperComponent={paperProps => <StyledPaper {...paperProps} />}
-                size="small"
-                // Temp disable multiple for simplicity - may want to re-enable
-                // multiple
-                limitTags={1}
-                disabled={Object.keys(frozenFilter ?? {}).includes(
-                  'opVersions'
-                )}
-                value={selectedOpVersionOption}
-                onChange={(event, newValue) => {
-                  if (newValue === ALL_TRACES_OR_CALLS_REF_KEY) {
-                    setFilter({
-                      ...filter,
-                      opVersionRefs: [],
-                    });
-                  } else {
-                    setFilter({
-                      ...filter,
-                      opVersionRefs: newValue ? [newValue] : [],
-                    });
+        <Tailwind style={{display: 'contents'}}>
+          <div style={{flex: '0 0 auto'}}>
+            <ListItem sx={{minWidth: 190, width: 320}}>
+              <FormControl fullWidth>
+                <Autocomplete
+                  PaperComponent={paperProps => <StyledPaper {...paperProps} />}
+                  size="small"
+                  // Temp disable multiple for simplicity - may want to re-enable
+                  // multiple
+                  limitTags={1}
+                  disabled={Object.keys(frozenFilter ?? {}).includes(
+                    'opVersions'
+                  )}
+                  value={selectedOpVersionOption}
+                  onChange={(event, newValue) => {
+                    if (newValue === ALL_TRACES_OR_CALLS_REF_KEY) {
+                      setFilter({
+                        ...filter,
+                        opVersionRefs: [],
+                      });
+                    } else {
+                      setFilter({
+                        ...filter,
+                        opVersionRefs: newValue ? [newValue] : [],
+                      });
+                    }
+                  }}
+                  renderInput={renderParams => (
+                    <StyledTextField
+                      {...renderParams}
+                      label={OP_FILTER_GROUP_HEADER}
+                      sx={{maxWidth: '350px'}}
+                    />
+                  )}
+                  getOptionLabel={option => {
+                    return opVersionOptions[option]?.title ?? 'loading...';
+                  }}
+                  disableClearable={
+                    selectedOpVersionOption === ALL_TRACES_OR_CALLS_REF_KEY
                   }
-                }}
-                renderInput={renderParams => (
-                  <StyledTextField
-                    {...renderParams}
-                    label={OP_FILTER_GROUP_HEADER}
-                    sx={{maxWidth: '350px'}}
-                  />
-                )}
-                getOptionLabel={option => {
-                  return opVersionOptions[option]?.title ?? 'loading...';
-                }}
-                disableClearable={
-                  selectedOpVersionOption === ALL_TRACES_OR_CALLS_REF_KEY
-                }
-                groupBy={option => opVersionOptions[option]?.group}
-                options={Object.keys(opVersionOptions)}
-              />
-            </FormControl>
-          </ListItem>
+                  groupBy={option => opVersionOptions[option]?.group}
+                  options={Object.keys(opVersionOptions)}
+                />
+              </FormControl>
+            </ListItem>
+          </div>
+          {filterModel && setFilterModel && (
+            <FilterPanel
+              filterModel={filterModel}
+              columnInfo={columns}
+              setFilterModel={setFilterModel}
+              selectedCalls={selectedCalls}
+              clearSelectedCalls={clearSelectedCalls}
+            />
+          )}
           {selectedInputObjectVersion && (
             <Chip
               label={`Input: ${objectVersionNiceString(
@@ -736,9 +787,8 @@ export const CallsTable: FC<{
               }}
             />
           )}
-          <div style={{flex: '1 1 auto'}} />
           {columnVisibilityModel && setColumnVisibilityModel && (
-            <div>
+            <div style={{flex: '0 0 auto'}}>
               <ManageColumnsButton
                 columnInfo={columns}
                 columnVisibilityModel={columnVisibilityModel}
@@ -746,14 +796,14 @@ export const CallsTable: FC<{
               />
             </div>
           )}
-        </>
+        </Tailwind>
       }>
       <StyledDataGrid
         // Start Column Menu
         // ColumnMenu is needed to support pinning and column visibility
         disableColumnMenu={false}
         // ColumnFilter is definitely useful
-        disableColumnFilter={false}
+        disableColumnFilter={true}
         disableMultipleColumnsFiltering={false}
         // ColumnPinning seems to be required in DataGridPro, else it crashes.
         // However, in this case it is also useful.
@@ -781,11 +831,6 @@ export const CallsTable: FC<{
         sortModel={sortModel}
         onSortModelChange={onSortModelChange}
         // SORT SECTION END
-        // FILTER SECTION START
-        filterMode="server"
-        filterModel={filterModel}
-        onFilterModelChange={newModel => setFilterModel(newModel)}
-        // FILTER SECTION END
         // PAGINATION SECTION START
         pagination
         rowCount={callsTotal}
@@ -827,7 +872,7 @@ export const CallsTable: FC<{
                 return <Empty {...EMPTY_PROPS_EVALUATIONS} />;
               } else if (
                 effectiveFilter.traceRootsOnly &&
-                filterModel.items.length === 0
+                filterModelResolved.items.length === 0
               ) {
                 return <Empty {...EMPTY_PROPS_TRACES} />;
               }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -17,6 +17,7 @@ import {isWeaveObjectRef, parseRef} from '../../../../../../react';
 import {makeRefCall} from '../../../../../../util/refs';
 import {Timestamp} from '../../../../../Timestamp';
 import {Reactions} from '../../feedback/Reactions';
+import {CellFilterWrapper} from '../../filters/CellFilterWrapper';
 import {
   getTokensAndCostFromUsage,
   getUsageFromCellParams,
@@ -52,7 +53,8 @@ export const useCallsTableColumns = (
   expandedRefCols: Set<string>,
   onCollapse: (col: string) => void,
   onExpand: (col: string) => void,
-  columnIsRefExpanded: (col: string) => boolean
+  columnIsRefExpanded: (col: string) => boolean,
+  onAddFilter?: (field: string, operator: string | null, value: any) => void
 ) => {
   const [userDefinedColumnWidths, setUserDefinedColumnWidths] = useState<
     Record<string, number>
@@ -126,7 +128,8 @@ export const useCallsTableColumns = (
         columnsWithRefs,
         onExpand,
         columnIsRefExpanded,
-        userDefinedColumnWidths
+        userDefinedColumnWidths,
+        onAddFilter
       ),
     [
       entity,
@@ -141,6 +144,7 @@ export const useCallsTableColumns = (
       onExpand,
       columnIsRefExpanded,
       userDefinedColumnWidths,
+      onAddFilter,
     ]
   );
 
@@ -163,7 +167,8 @@ function buildCallsTableColumns(
   columnsWithRefs: Set<string>,
   onExpand: (col: string) => void,
   columnIsRefExpanded: (col: string) => boolean,
-  userDefinedColumnWidths: Record<string, number>
+  userDefinedColumnWidths: Record<string, number>,
+  onAddFilter?: (field: string, operator: string | null, value: any) => void
 ): {
   cols: Array<GridColDef<TraceCallSchema>>;
   colGroupingModel: GridColumnGroupingModel;
@@ -178,9 +183,6 @@ function buildCallsTableColumns(
       field: 'op_name',
       headerName: 'Trace',
       minWidth: 100,
-      // This filter should be controlled by the custom filter
-      // in the header
-      filterable: false,
       width: 250,
       hideable: false,
       valueGetter: rowParams => {
@@ -265,13 +267,8 @@ function buildCallsTableColumns(
       headerName: 'Status',
       headerAlign: 'center',
       sortable: false,
-      disableColumnMenu: true,
+      // disableColumnMenu: true,
       resizable: false,
-      // Again, the underlying value is not obvious to the user,
-      // so the default free-form filter is likely more confusing than helpful.
-      filterable: false,
-      // type: 'singleSelect',
-      // valueOptions: ['SUCCESS', 'ERROR', 'PENDING'],
       width: 59,
       valueGetter: cellParams => {
         return traceCallStatusCode(cellParams.row);
@@ -295,8 +292,9 @@ function buildCallsTableColumns(
     onExpand,
     // TODO (Tim) - (BackendExpansion): This can be removed once we support backend expansion!
     key => !columnIsRefExpanded(key) && !columnsWithRefs.has(key),
-    // TODO (Tim) - (BackendExpansion): This can be removed once we support backend expansion!
-    key => !columnIsRefExpanded(key) && !columnsWithRefs.has(key)
+    (key, operator, value) => {
+      onAddFilter?.(key, operator, value);
+    }
   );
   cols.push(...newCols);
 
@@ -305,9 +303,6 @@ function buildCallsTableColumns(
     headerName: 'User',
     headerAlign: 'center',
     width: 50,
-    // Might be confusing to enable as-is, because the user sees name /
-    // email but the underlying data is userId.
-    filterable: false,
     align: 'center',
     sortable: false,
     resizable: false,
@@ -316,7 +311,15 @@ function buildCallsTableColumns(
       if (userId == null) {
         return null;
       }
-      return <UserLink userId={userId} />;
+      return (
+        <CellFilterWrapper
+          onAddFilter={onAddFilter}
+          field="wb_user_id"
+          operation="(string): equals"
+          value={userId}>
+          <UserLink userId={userId} />
+        </CellFilterWrapper>
+      );
     },
   });
 
@@ -331,11 +334,20 @@ function buildCallsTableColumns(
     minWidth: 100,
     maxWidth: 100,
     renderCell: cellParams => {
+      // TODO: A better filter might be to be on the same day?
+      const date = convertISOToDate(cellParams.row.started_at);
+      const filterDate = new Date(date);
+      filterDate.setSeconds(0, 0);
+      const filterValue = filterDate.toISOString();
+      const value = date.getTime() / 1000;
       return (
-        <Timestamp
-          value={convertISOToDate(cellParams.row.started_at).getTime() / 1000}
-          format="relative"
-        />
+        <CellFilterWrapper
+          onAddFilter={onAddFilter}
+          field="started_at"
+          operation="(date): after"
+          value={filterValue}>
+          <Timestamp value={value} format="relative" />
+        </CellFilterWrapper>
       );
     },
   };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -25,7 +25,6 @@ import {
 import {CallLink} from '../common/Links';
 import {StatusChip} from '../common/StatusChip';
 import {buildDynamicColumns} from '../common/tabularListViews/columnBuilder';
-import {allOperators} from '../common/tabularListViews/operators';
 import {isRef} from '../common/util';
 import {TraceCallSchema} from '../wfReactInterface/traceServerClientTypes';
 import {
@@ -326,8 +325,6 @@ function buildCallsTableColumns(
   const startedAtCol: GridColDef<TraceCallSchema> = {
     field: 'started_at',
     headerName: 'Called',
-    // Should have custom timestamp filter here.
-    filterOperators: allOperators.filter(o => o.value.startsWith('(date)')),
     sortable: true,
     sortingOrder: ['desc', 'asc'],
     width: 100,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -6,10 +6,8 @@ import {
 import {useMemo} from 'react';
 
 import {useDeepMemo} from '../../../../../../hookUtils';
-import {
-  isValuelessOperator,
-  operationConverter,
-} from '../common/tabularListViews/operators';
+import {isValuelessOperator} from '../../filters/common';
+import {operationConverter} from '../common/tabularListViews/operators';
 import {useWFHooks} from '../wfReactInterface/context';
 import {Query} from '../wfReactInterface/traceServerClientInterface/query';
 import {CallFilter} from '../wfReactInterface/wfDataModelHooksInterface';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimpleFilterableDataTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimpleFilterableDataTable.tsx
@@ -253,6 +253,7 @@ export const FilterLayoutTemplate: React.FC<{
           sx={{
             flex: '0 0 auto',
             width: '100%',
+            maxWidth: '100%',
             transition: 'width 0.1s ease-in-out',
             display: 'flex',
             flexDirection: 'row',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 
 import {Tooltip} from '../../../../../Tooltip';
 
-export const CALL_STATUS = ['SUCCESS', 'DESCENDANT_ERROR', 'ERROR'];
+export const CALL_STATUS = ['SUCCESS', 'DESCENDANT_ERROR', 'ERROR', 'UNSET'];
 export type CallStatusType = (typeof CALL_STATUS)[number];
 
 type StatusChipProps = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
@@ -15,6 +15,7 @@ import {CollapseHeader} from '../../../../Browse2/CollapseGroupHeader';
 import {ExpandHeader} from '../../../../Browse2/ExpandHeader';
 import {NotApplicable} from '../../../../Browse2/NotApplicable';
 import {SmallRef} from '../../../../Browse2/SmallRef';
+import {CellFilterWrapper} from '../../../filters/CellFilterWrapper';
 import {
   OBJECT_ATTR_EDGE_NAME,
   WEAVE_PRIVATE_PREFIX,
@@ -187,8 +188,8 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
   columnCanBeExpanded?: (col: string) => boolean,
   onCollapse?: (col: string) => void,
   onExpand?: (col: string) => void,
-  columnIsFilterable?: (col: string) => boolean,
-  columnIsSortable?: (col: string) => boolean
+  columnIsSortable?: (col: string) => boolean,
+  onAddFilter?: (field: string, operator: string | null, value: any) => void
 ) => {
   const cols: Array<GridColDef<T>> = [];
 
@@ -245,7 +246,6 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
       flex: 1,
       minWidth: 150,
       field: key,
-      filterable: columnIsFilterable && columnIsFilterable(key),
       sortable: columnIsSortable && columnIsSortable(key),
       filterOperators: allOperators,
       headerName: key,
@@ -273,19 +273,33 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
       renderCell: cellParams => {
         const val = valueForKey(cellParams.row, key);
         if (val === undefined) {
-          return <NotApplicable />;
+          return (
+            <CellFilterWrapper
+              onAddFilter={onAddFilter}
+              field={key}
+              operation={'(any): isEmpty'}
+              value={undefined}>
+              <NotApplicable />
+            </CellFilterWrapper>
+          );
         }
         return (
           <ErrorBoundary>
-            {/* In the future, we may want to move this isExpandedRefWithValueAsTableRef condition
+            <CellFilterWrapper
+              onAddFilter={onAddFilter}
+              field={key}
+              operation={null}
+              value={val}>
+              {/* In the future, we may want to move this isExpandedRefWithValueAsTableRef condition
             into `CellValue`. However, at the moment, `ExpandedRefWithValueAsTableRef` is a
             Table-specific data structure and we might not want to leak that into the
             rest of the system*/}
-            {isExpandedRefWithValueAsTableRef(val) ? (
-              <SmallRef objRef={parseRef(val[EXPANDED_REF_REF_KEY])} />
-            ) : (
-              <CellValue value={val} />
-            )}
+              {isExpandedRefWithValueAsTableRef(val) ? (
+                <SmallRef objRef={parseRef(val[EXPANDED_REF_REF_KEY])} />
+              ) : (
+                <CellValue value={val} />
+              )}
+            </CellFilterWrapper>
           </ErrorBoundary>
         );
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
@@ -31,7 +31,6 @@ import {
 } from '../../wfReactInterface/tsDataModelHooksCallRefExpansion';
 import {isRef} from '../util';
 import {buildTree} from './buildTree';
-import {allOperators} from './operators';
 
 /**
  * This function is responsible for taking the raw data and flattening it
@@ -247,7 +246,6 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
       minWidth: 150,
       field: key,
       sortable: columnIsSortable && columnIsSortable(key),
-      filterOperators: allOperators,
       headerName: key,
       renderHeader: () => {
         return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -6,6 +6,7 @@ import {
   GridFilterItem,
   GridFilterOperator,
 } from '@mui/x-data-grid';
+import _ from 'lodash';
 
 import {Query} from '../../wfReactInterface/traceServerClientInterface/query';
 
@@ -88,6 +89,14 @@ export const operationConverter = (
     return {
       $eq: [{$getField: item.field}, {$literal: item.value}],
     };
+  } else if (item.operator === '(string): in') {
+    const values = _.isArray(item.value)
+      ? item.value
+      : item.value.split(',').map((v: string) => v.trim());
+    const clauses = values.map((v: string) => ({
+      $eq: [{$getField: item.field}, {$literal: v}],
+    }));
+    return {$or: clauses};
   } else if (item.operator === '(number): =') {
     if (item.value === '') {
       return null;
@@ -171,7 +180,7 @@ export const operationConverter = (
       return null;
     }
     return {
-      $eq: [{$getField: item.field}, {$literal: item.value}],
+      $eq: [{$getField: item.field}, {$literal: `${item.value}`}],
     };
   } else if (item.operator === '(date): after') {
     if (item.value === '') {
@@ -194,6 +203,6 @@ export const operationConverter = (
       ],
     };
   } else {
-    throw new Error('Unsupported operator');
+    throw new Error(`Unsupported operator: ${item.operator}`);
   }
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -1,68 +1,9 @@
-import {
-  getGridBooleanOperators,
-  getGridDateOperators,
-  getGridNumericOperators,
-  getGridStringOperators,
-  GridFilterItem,
-  GridFilterOperator,
-} from '@mui/x-data-grid';
+import {GridFilterItem} from '@mui/x-data-grid';
 import _ from 'lodash';
 
 import {Query} from '../../wfReactInterface/traceServerClientInterface/query';
 
-const operatorListAsMap = (operators: GridFilterOperator[]) => {
-  return operators.reduce((acc, operator) => {
-    acc[operator.value] = operator;
-    return acc;
-  }, {} as Record<string, GridFilterOperator>);
-};
-const stringOperators = operatorListAsMap(getGridStringOperators());
-const numberOperators = operatorListAsMap(getGridNumericOperators());
-const booleanOperators = operatorListAsMap(getGridBooleanOperators());
-const dateTimeOperators = operatorListAsMap(getGridDateOperators(true));
-const allGeneralPurposeOperators = {
-  string: {
-    contains: stringOperators.contains,
-    equals: stringOperators.equals,
-  },
-  number: {
-    '=': numberOperators['='],
-    '!=': numberOperators['!='],
-    '>': numberOperators['>'],
-    '>=': numberOperators['>='],
-    '<': numberOperators['<'],
-    '<=': numberOperators['<='],
-  },
-  bool: {
-    is: booleanOperators.is,
-  },
-  date: {
-    after: dateTimeOperators.after,
-    before: dateTimeOperators.before,
-  },
-  any: {
-    isEmpty: stringOperators.isEmpty,
-    isNotEmpty: stringOperators.isEmpty,
-  },
-};
-
-export const allOperators = Object.entries(allGeneralPurposeOperators).flatMap(
-  ([type, operators]) =>
-    Object.entries(operators).map(([label, operator]) => {
-      return {
-        ...operator,
-        value: `(${type}): ${label}`,
-        label: `(${type}): ${label}`,
-      };
-    })
-);
-
-const VALUELESS_OPERATORS = new Set(['(any): isEmpty', '(any): isNotEmpty']);
-
-export const isValuelessOperator = (operator: string) => {
-  return VALUELESS_OPERATORS.has(operator);
-};
-
+// Convert one Material GridFilterItem to our Mongo-like query format.
 export const operationConverter = (
   item: GridFilterItem
 ): null | Query['$expr'] => {

--- a/weave-js/src/components/UserLink.tsx
+++ b/weave-js/src/components/UserLink.tsx
@@ -97,8 +97,9 @@ type UserContentProps = {
   user: UserInfo;
   mode: 'tooltip' | 'popover';
   onClose?: () => void;
+  hasPopover?: boolean;
 };
-const UserContent = ({user, mode, onClose}: UserContentProps) => {
+const UserContent = ({user, mode, onClose, hasPopover}: UserContentProps) => {
   const isPopover = mode === 'popover';
   const imgSize = isPopover ? 100 : 50;
   const username = isPopover ? (
@@ -138,7 +139,9 @@ const UserContent = ({user, mode, onClose}: UserContentProps) => {
           <div>{email}</div>
         </Grid>
       </UserContentBody>
-      {!isPopover && <TooltipHint>Click to open card</TooltipHint>}
+      {hasPopover && !isPopover && (
+        <TooltipHint>Click to open card</TooltipHint>
+      )}
     </>
   );
 };
@@ -147,13 +150,22 @@ type UserInnerProps = {
   user: UserInfo;
   includeName?: boolean;
   placement?: TooltipProps['placement'];
+  hasPopover?: boolean;
 };
-const UserInner = ({user, includeName, placement}: UserInnerProps) => {
+const UserInner = ({
+  user,
+  includeName,
+  placement,
+  hasPopover,
+}: UserInnerProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const onClick = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(anchorEl ? null : ref.current);
-  };
+  const showPopover = hasPopover ?? true;
+  const onClick = showPopover
+    ? (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(anchorEl ? null : ref.current);
+      }
+    : undefined;
   const onClose = () => setAnchorEl(null);
 
   const open = Boolean(anchorEl);
@@ -162,7 +174,7 @@ const UserInner = ({user, includeName, placement}: UserInnerProps) => {
   const title = open ? (
     '' // Suppress tooltip when popper is open.
   ) : (
-    <UserContent user={user} mode="tooltip" />
+    <UserContent user={user} mode="tooltip" hasPopover={hasPopover} />
   );
 
   // Unfortunate but necessary to get appear on top of peek drawer.
@@ -218,6 +230,7 @@ type UserLinkProps = {
   userId: string | null;
   includeName?: boolean; // Default is to show avatar image only.
   placement?: TooltipProps['placement'];
+  hasPopover?: boolean; // Can you click to open more a popup
 };
 
 const fetchUser = (userId: string) => {
@@ -266,7 +279,12 @@ export const useUsers = (userIds: string[]) => {
   return users;
 };
 
-export const UserLink = ({userId, includeName, placement}: UserLinkProps) => {
+export const UserLink = ({
+  userId,
+  includeName,
+  placement,
+  hasPopover,
+}: UserLinkProps) => {
   const users = useUsers(userId ? [userId] : []);
   if (userId == null) {
     return <NotApplicable />;
@@ -279,6 +297,11 @@ export const UserLink = ({userId, includeName, placement}: UserLinkProps) => {
   }
   const user = users[0];
   return (
-    <UserInner user={user} placement={placement} includeName={includeName} />
+    <UserInner
+      user={user}
+      placement={placement}
+      includeName={includeName}
+      hasPopover={hasPopover}
+    />
   );
 };

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -1387,6 +1387,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.23.9":
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.0.tgz#3af9a91c1b739c569d5d80cc917280919c544ecb"
+  integrity sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.22.15":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -1991,6 +1998,21 @@
   dependencies:
     "@floating-ui/utils" "^0.1.3"
 
+"@floating-ui/core@^1.6.0":
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.5.tgz#102335cac0d22035b04d70ca5ff092d2d1a26f2b"
+  integrity sha512-8GrTWmoFhm5BsMZOTHeGD2/0FLKLQQHvO/ZmQga4tKempYRLz8aqJGqXVuQgisnMObq2YZ2SgkwctN1LOOxcqA==
+  dependencies:
+    "@floating-ui/utils" "^0.2.5"
+
+"@floating-ui/dom@^1.0.0":
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.8.tgz#45e20532b6d8a061b356a4fb336022cf2609754d"
+  integrity sha512-kx62rP19VZ767Q653wsP1XZCGIirkE09E0QUGNYTM/ttbbQHqcGPdSfWFxUyyNLc/W6aoJRBajOSXhP6GXjC0Q==
+  dependencies:
+    "@floating-ui/core" "^1.6.0"
+    "@floating-ui/utils" "^0.2.5"
+
 "@floating-ui/dom@^1.0.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.1.tgz#88b70defd002fe851f17b4a25efb2d3c04d7a8d7"
@@ -2035,6 +2057,13 @@
   dependencies:
     "@floating-ui/dom" "^1.5.1"
 
+"@floating-ui/react-dom@^2.0.8":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.1.1.tgz#cca58b6b04fc92b4c39288252e285e0422291fb0"
+  integrity sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==
+  dependencies:
+    "@floating-ui/dom" "^1.0.0"
+
 "@floating-ui/react@^0.24.5":
   version "0.24.7"
   resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.24.7.tgz#af4e85cc1ff4c8695810e6d3e83fc17956e4ce2c"
@@ -2053,6 +2082,11 @@
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.6.tgz#22958c042e10b67463997bd6ea7115fe28cbcaf9"
   integrity sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==
+
+"@floating-ui/utils@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.5.tgz#105c37d9d9620ce69b7f692a20c821bf1ad2cbf9"
+  integrity sha512-sTcG+QZ6fdEUObICavU+aB3Mp8HY4n14wYHdxK4fXjPmv3PXZZeY5RaguJmGyeH/CJQhX3fqKUtS4qc1LoHwhQ==
 
 "@graphql-codegen/add@^5.0.0":
   version "5.0.0"
@@ -2811,6 +2845,19 @@
     clsx "^2.0.0"
     prop-types "^15.8.1"
 
+"@mui/base@^5.0.0-beta.22":
+  version "5.0.0-beta.40"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.40.tgz#1f8a782f1fbf3f84a961e954c8176b187de3dae2"
+  integrity sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@floating-ui/react-dom" "^2.0.8"
+    "@mui/types" "^7.2.14"
+    "@mui/utils" "^5.15.14"
+    "@popperjs/core" "^2.11.8"
+    clsx "^2.1.0"
+    prop-types "^15.8.1"
+
 "@mui/core-downloads-tracker@^5.14.18":
   version "5.14.18"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.18.tgz#f8b187dc89756fa5c0b7d15aea537a6f73f0c2d8"
@@ -2887,6 +2934,11 @@
     csstype "^3.1.2"
     prop-types "^15.8.1"
 
+"@mui/types@^7.2.14", "@mui/types@^7.2.15":
+  version "7.2.15"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.15.tgz#dadd232fe9a70be0d526630675dff3b110f30b53"
+  integrity sha512-nbo7yPhtKJkdf9kcVOF8JZHPZTmqXjJ/tI0bdWgHg5tp9AnIN4Y7f7wm9T+0SyGYJk76+GYZ8Q5XaTYAsUHN0Q==
+
 "@mui/types@^7.2.9":
   version "7.2.9"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.9.tgz#730ee83a37af292a5973962f78ce5c95f31213a7"
@@ -2901,6 +2953,18 @@
     "@types/prop-types" "^15.7.10"
     prop-types "^15.8.1"
     react-is "^18.2.0"
+
+"@mui/utils@^5.15.14":
+  version "5.16.6"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.16.6.tgz#905875bbc58d3dcc24531c3314a6807aba22a711"
+  integrity sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/types" "^7.2.15"
+    "@types/prop-types" "^15.7.12"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^18.3.1"
 
 "@mui/x-data-grid-pro@^6.16.0":
   version "6.18.1"
@@ -2926,6 +2990,19 @@
     clsx "^2.0.0"
     prop-types "^15.8.1"
     reselect "^4.1.8"
+
+"@mui/x-date-pickers@^6.16.0":
+  version "6.20.2"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-6.20.2.tgz#b1b1e4862daafb750496cc77a1645caeac28a739"
+  integrity sha512-x1jLg8R+WhvkmUETRfX2wC+xJreMii78EXKLl6r3G+ggcAZlPyt0myID1Amf6hvJb9CtR7CgUo8BwR+1Vx9Ggw==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+    "@mui/base" "^5.0.0-beta.22"
+    "@mui/utils" "^5.14.16"
+    "@types/react-transition-group" "^4.4.8"
+    clsx "^2.0.0"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.5"
 
 "@mui/x-license-pro@6.10.2":
   version "6.10.2"
@@ -4338,6 +4415,11 @@
   version "15.7.10"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.10.tgz#892afc9332c4d62a5ea7e897fe48ed2085bbb08a"
   integrity sha512-mxSnDQxPqsZxmeShFH+uwQ4kO4gcJcGahjjMFeLbKE95IAZiiZyiEepGZjtXJ7hN/yfu0bu9xN2ajcU0JcxX6A==
+
+"@types/prop-types@^15.7.12":
+  version "15.7.12"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.12.tgz#12bb1e2be27293c1406acb6af1c3f3a1481d98c6"
+  integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
 
 "@types/query-string@^6.3.0":
   version "6.3.0"
@@ -5910,6 +5992,11 @@ clsx@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.0.0.tgz#12658f3fd98fafe62075595a5c30e43d18f3d00b"
   integrity sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==
+
+clsx@^2.1.0, clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 co@^4.6.0:
   version "4.6.0"
@@ -11935,6 +12022,11 @@ react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
Internal weave: https://wandb.atlassian.net/browse/WB-19861

Adds a new UI for filtering calls and managing of filter state in URL.

In the header, there is a button that opens up the filter editing popup. When there are filters, we will dynamically determine what to show based on the available width:

No filters:
<img width="100" alt="Screenshot 2024-08-12 at 10 47 44 AM" src="https://github.com/user-attachments/assets/605f34f7-5767-429f-be94-15ce2f45d819">

There are filters but none can be shown in the available space:
<img width="113" alt="Screenshot 2024-08-12 at 10 47 59 AM" src="https://github.com/user-attachments/assets/e5034290-96da-492a-9e2c-995e7f4f9f24">

All filters fit in the available space
<img width="329" alt="Screenshot 2024-08-12 at 10 50 10 AM" src="https://github.com/user-attachments/assets/928a1c15-ba77-43f3-9593-7f97e9634f6e">

Too many filters to show in the available space, but some fit
<img width="726" alt="Screenshot 2024-08-12 at 10 48 43 AM" src="https://github.com/user-attachments/assets/72d179a7-605f-4ac9-b340-48898c1fe24f">

If there's room to show a filter tag, user can one-click remove it with the 'x' button on the tag.

Clicking on the button opens up a dialog:

<img width="735" alt="Screenshot 2024-08-12 at 10 55 40 AM" src="https://github.com/user-attachments/assets/e4a57bbc-3b6a-422d-b4f9-8769d07c6af2">

Each row corresponds to one filter. The 'x' button can be used to remove a filter, or you can remove all of them at once.
The available operators depend on the selected field, and the type of value input depends on the operator

Column selection:
<img width="326" alt="Screenshot 2024-08-12 at 10 55 18 AM" src="https://github.com/user-attachments/assets/1349a998-ba1d-4b3c-af18-b42b3dccc4bb">

Operator selection:
<img width="156" alt="Screenshot 2024-08-12 at 10 55 12 AM" src="https://github.com/user-attachments/assets/f172fc29-e033-4d66-8d04-b291ac6823fa">


