### PR TITLE
fix(weave): Defer ref zero-ing until save time

### DIFF
--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -90,7 +90,6 @@ class Traceable:
     def _mark_dirty(self) -> None:
         """Recursively mark this object and its ancestors as dirty and removes their refs."""
         self._is_dirty = True
-        self.ref = None
         if (
             # Written this way to satisfy mypy
             self.parent is not self


### PR DESCRIPTION
Resolves:
- https://wandb.atlassian.net/browse/WB-20376

This PR defers ref zeroing until save time (instead of immediately on mutations), which has a few effects:
1. It allows anything dependent on the parent ref (like an `OpRef`) to be de-ref'd even after the object is mutated
2. It now means that looking at the `ref` alone is not sufficient to tell if it's fresh or stale.  You must also look at `_is_dirty`.  In future, a helper method to check "freshness" of a ref may be useful.

Ref-zeroing already happens here:
- https://github.com/wandb/weave/blame/andrew/zero-ref/weave/weave_client.py#L765