### PR TITLE
chore: Refactor FileContent to ArrayBuffer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -202,7 +202,7 @@ export type TraceFileContentReadReq = {
 };
 
 export type TraceFileContentReadRes = {
-  content: string;
+  content: ArrayBuffer;
 };
 
 export enum ContentType {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
@@ -260,9 +260,10 @@ export class DirectTraceServerClient {
   public fileContent(
     req: TraceFileContentReadReq
   ): Promise<TraceFileContentReadRes> {
-    const res = this.makeRequest<TraceFileContentReadReq, string>(
+    const res = this.makeRequest<TraceFileContentReadReq, ArrayBuffer>(
       '/files/content',
       req,
+      false,
       true
     );
     return new Promise((resolve, reject) => {
@@ -280,6 +281,7 @@ export class DirectTraceServerClient {
     endpoint: string,
     req: QT,
     returnText?: boolean,
+    returnArrayBuffer?: boolean,
     contentType?: ContentType
   ): Promise<ST> => {
     const url = `${this.baseUrl}${endpoint}`;
@@ -322,6 +324,8 @@ export class DirectTraceServerClient {
       .then(response => {
         if (returnText) {
           return response.text();
+        } else if (returnArrayBuffer) {
+          return response.arrayBuffer();
         }
         return response.json();
       })

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
@@ -92,7 +92,7 @@ export class DirectTraceServerClient {
     const res = this.makeRequest<TraceCallsQueryReq, string>(
       '/calls/stream_query',
       req,
-      true
+      'text'
     );
     return new Promise((resolve, reject) => {
       res
@@ -263,8 +263,7 @@ export class DirectTraceServerClient {
     const res = this.makeRequest<TraceFileContentReadReq, ArrayBuffer>(
       '/files/content',
       req,
-      false,
-      true
+      'arrayBuffer'
     );
     return new Promise((resolve, reject) => {
       res
@@ -280,8 +279,7 @@ export class DirectTraceServerClient {
   private makeRequest = async <QT, ST>(
     endpoint: string,
     req: QT,
-    returnText?: boolean,
-    returnArrayBuffer?: boolean,
+    responseReturnType: 'json' | 'text' | 'arrayBuffer' = 'json',
     contentType?: ContentType
   ): Promise<ST> => {
     const url = `${this.baseUrl}${endpoint}`;
@@ -322,12 +320,15 @@ export class DirectTraceServerClient {
       body: reqBody,
     })
       .then(response => {
-        if (returnText) {
+        if (responseReturnType === 'text') {
           return response.text();
-        } else if (returnArrayBuffer) {
+        } else if (responseReturnType === 'arrayBuffer') {
           return response.arrayBuffer();
+        } else if (responseReturnType === 'json') {
+          return response.json();
+        } else {
+          throw new Error('Invalid responseReturnType: ' + responseReturnType);
         }
-        return response.json();
       })
       .then(res => {
         try {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
@@ -327,6 +327,7 @@ export class DirectTraceServerClient {
         } else if (responseReturnType === 'json') {
           return response.json();
         } else {
+          // Should never happen with correct type checking
           throw new Error('Invalid responseReturnType: ' + responseReturnType);
         }
       })

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -744,7 +744,7 @@ const useOpVersions = makeTraceServerEndpointHook<
 const useFileContent = makeTraceServerEndpointHook<
   'fileContent',
   [string, string, string, {skip?: boolean}?],
-  string
+  ArrayBuffer
 >(
   'fileContent',
   (
@@ -1192,12 +1192,27 @@ const useCodeForOpRef = (opVersionRef: string): Loadable<string> => {
     }
     return null;
   }, [opVersionRef, query.result]);
-  const text = useFileContent(
+  const arrayBuffer = useFileContent(
     fileSpec?.entity ?? '',
     fileSpec?.project ?? '',
     fileSpec?.digest ?? '',
     {skip: fileSpec == null}
   );
+  const text = useMemo(() => {
+    if (arrayBuffer.loading) {
+      return {
+        loading: true,
+        result: null,
+      };
+    }
+    return {
+      loading: false,
+      result: new TextDecoder().decode(
+        arrayBuffer.result ?? new ArrayBuffer(0)
+      ),
+    };
+  }, [arrayBuffer.loading, arrayBuffer.result]);
+
   return text;
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -236,7 +236,7 @@ export type WFDataModelHooksInterface = {
     project: string,
     digest: string,
     opts?: {skip?: boolean}
-  ) => Loadable<string>;
+  ) => Loadable<ArrayBuffer>;
   useFeedback: (
     key: FeedbackKey | null,
     sortBy?: traceServerClientTypes.SortBy[]


### PR DESCRIPTION
This PR changes the return type of the FileContent in the Trace Server YS client to ArrayBuffer. 

This should have no impact on users - this is part of Image support, trying to decouple the PR