### PR TITLE
chore: remove dead redirect code

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -18,7 +18,6 @@ import {
 } from '@mui/x-data-grid-pro';
 import {LicenseInfo} from '@mui/x-license-pro';
 import {useWindowSize} from '@wandb/weave/common/hooks/useWindowSize';
-import {Loading} from '@wandb/weave/components/Loading';
 import {EVALUATE_OP_NAME_POST_PYDANTIC} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/heuristics';
 import {opVersionKeyToRefUri} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities';
 import _ from 'lodash';
@@ -45,7 +44,6 @@ import {Button} from '../../Button';
 import {ErrorBoundary} from '../../ErrorBoundary';
 import {Browse2EntityPage} from './Browse2/Browse2EntityPage';
 import {Browse2HomePage} from './Browse2/Browse2HomePage';
-// import {RouteAwareBrowse3ProjectSideNav} from './Browse3/Browse3SideNav';
 import {
   baseContext,
   browse2Context,
@@ -95,7 +93,6 @@ import {TablePage} from './Browse3/pages/TablePage';
 import {TablesPage} from './Browse3/pages/TablesPage';
 import {useURLSearchParamsDict} from './Browse3/pages/util';
 import {
-  useProjectHasTraceServerData,
   useWFHooks,
   WFDataModelAutoProvider,
 } from './Browse3/pages/wfReactInterface/context';
@@ -411,23 +408,8 @@ const MainPeekingLayout: FC = () => {
 const ProjectRedirect: FC = () => {
   const {entity, project} = useParams<Browse3ProjectMountedParams>();
   const {baseRouter} = useWeaveflowRouteContext();
-
-  const projectHasTraceServerData = useProjectHasTraceServerData(
-    entity,
-    project
-  );
-  if (projectHasTraceServerData.loading) {
-    return <Loading centered />;
-  }
-  // TODO: If we have no data, perhaps better to show a quickstart.
-  // const shouldRedirect = projectHasTraceServerData.result;
-  const shouldRedirect = true;
-  if (shouldRedirect) {
-    const url = baseRouter.tracesUIUrl(entity, project);
-    return <Redirect to={url} />;
-  }
-
-  return null;
+  const url = baseRouter.tracesUIUrl(entity, project);
+  return <Redirect to={url} />;
 };
 
 const Browse3ProjectRoot: FC<{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
@@ -10,7 +10,6 @@
 
 import React, {createContext, FC, useContext} from 'react';
 
-import {useHasTraceServerClientContext} from './traceServerClientContext';
 import {tsWFDataModelHooks} from './tsDataModelHooks';
 import {WFDataModelHooksInterface} from './wfDataModelHooksInterface';
 
@@ -35,43 +34,4 @@ export const WFDataModelAutoProvider: FC<{
       {children}
     </WFDataModelHooksContext.Provider>
   );
-};
-
-/**
- * Returns true if the client can connect to trace server and the project has
- * objects or calls.
- */
-export const useProjectHasTraceServerData = (
-  entity: string,
-  project: string
-) => {
-  const hasTraceServer = useHasTraceServerClientContext();
-  const objs = tsWFDataModelHooks.useRootObjectVersions(
-    entity,
-    project,
-    {},
-    1,
-    {
-      skip: !hasTraceServer,
-    }
-  );
-
-  const calls = tsWFDataModelHooks.useCalls(
-    entity,
-    project,
-    {},
-    1,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    {
-      skip: !hasTraceServer,
-    }
-  );
-  const loading = objs.loading || calls.loading;
-  return {
-    loading,
-    result: (objs.result ?? []).length > 0 || (calls.result ?? []).length > 0,
-  };
 };


### PR DESCRIPTION
At the time we were adding the new sidebar (https://github.com/wandb/core/pull/20661/) we also added redirecting of the `/entity/project` page to the traces page when the project has Weave data and no Models data.

Browse3 has similar redirection code, taking you from `/entity/project/weave` to the traces page.

In its current state, the code always redirects you to the traces page. It was doing a query to see if the project has published data and showing a loader, but this is unnecessary if we're going to redirect regardless of the result.

The query is particularly bad because the limit parameter to useRootObjectVersions does not get passed along and used as it should, so it is fetching all of the object information for the project even though we only cared about a non-zero count.