### PR TITLE
chore: accidentally removed help text

### DIFF
--- a/weave-js/src/components/UserLink.tsx
+++ b/weave-js/src/components/UserLink.tsx
@@ -283,7 +283,7 @@ export const UserLink = ({
   userId,
   includeName,
   placement,
-  hasPopover,
+  hasPopover = true,
 }: UserLinkProps) => {
   const users = useUsers(userId ? [userId] : []);
   if (userId == null) {


### PR DESCRIPTION
The user link tooltip preview is supposed to have some help text noting you can click to open a larger card. I accidentally removed this in https://github.com/wandb/weave/pull/2107 

<img width="292" alt="Screenshot 2024-08-14 at 9 09 05 AM" src="https://github.com/user-attachments/assets/9f444e7c-152b-4a7d-bccd-c70e97f5fa66">
