### PR TITLE
fix(weave): Automatically pass self instance when using `call` special func on a `WeaveObject`

### DIFF
--- a/weave/tests/test_op_decorator_behaviour.py
+++ b/weave/tests/test_op_decorator_behaviour.py
@@ -245,3 +245,21 @@ async def test_gotten_object_method_is_callable(client, weave_obj):
     weave_obj2 = ref.get()
     assert weave_obj.method(1) == weave_obj2.method(1) == 2
     assert await weave_obj.amethod(1) == await weave_obj2.amethod(1) == 2
+
+
+@pytest.mark.asyncio
+async def test_gotten_object_method_is_callable_with_call_func(client, weave_obj):
+    ref = weave.publish(weave_obj)
+
+    weave_obj2 = ref.get()
+    res, call = weave_obj.method.call(1)
+    res2, call2 = weave_obj2.method.call(1)
+    assert res == res2
+    assert call.inputs == call2.inputs
+    assert call.output == call2.output
+
+    res3, call3 = await weave_obj.amethod.call(1)
+    res4, call4 = await weave_obj2.amethod.call(1)
+    assert res3 == res4
+    assert call3.inputs == call4.inputs
+    assert call3.output == call4.output

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -2,6 +2,7 @@ import dataclasses
 import inspect
 import operator
 import typing
+from functools import partial
 from typing import Any, Generator, Iterator, Literal, Optional, SupportsIndex, Union
 
 from pydantic import BaseModel
@@ -12,7 +13,7 @@ from weave.table import Table
 from weave.trace import box
 from weave.trace.errors import InternalError
 from weave.trace.object_record import ObjectRecord
-from weave.trace.op import Op, maybe_bind_method
+from weave.trace.op import Op, call, maybe_bind_method
 from weave.trace.refs import (
     DICT_KEY_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
@@ -572,6 +573,7 @@ def make_trace_obj(
             raise MissingSelfInstanceError(
                 f"{val.name} Op requires a bound self instance. Must be called from an instance method."
             )
+        val.call = partial(call, val, parent)
         val = maybe_bind_method(val, parent)
     box_val = box.box(val)
     if isinstance(box_val, pydantic_v1.BaseModel) or isinstance(val, Op):


### PR DESCRIPTION
Resolves:
- https://wandb.atlassian.net/browse/WB-20326

This PR automatically passes `self` into the `call` special func when attached to a `WeaveObject`.  We already do this for [`Object`](https://github.com/wandb/weave/blame/andrew/call-self/weave/flow/obj.py#L83).