### PR TITLE
chore(weave): Inline pydantic and dataclass objects on weave.Object

### DIFF
--- a/weave/integrations/anthropic/anthropic_test.py
+++ b/weave/integrations/anthropic/anthropic_test.py
@@ -1,5 +1,4 @@
 import os
-from typing import Any
 
 import pytest
 from anthropic import Anthropic, AsyncAnthropic
@@ -9,17 +8,6 @@ from weave.trace_server import trace_server_interface as tsi
 
 model = "claude-3-haiku-20240307"
 # model = "claude-3-opus-20240229"
-
-
-def _get_call_output(call: tsi.CallSchema) -> Any:
-    """This is a hack and should not be needed. We should be able to auto-resolve this for the user.
-
-    Keeping this here for now, but it should be removed in the future once we have a better solution.
-    """
-    call_output = call.output
-    if isinstance(call_output, str) and call_output.startswith("weave://"):
-        return weave.ref(call_output).get()
-    return call_output
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
@@ -47,7 +35,7 @@ def test_anthropic(
     assert len(res.calls) == 1
     call = res.calls[0]
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
+    output = call.output
     assert output.id == message.id
     assert output.model == message.model
     assert output.stop_reason == "end_turn"
@@ -94,7 +82,7 @@ def test_anthropic_stream(
     assert len(res.calls) == 1
     call = res.calls[0]
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
+    output = call.output
     assert output.id == message.id
     assert output.model == message.model
     assert output.stop_reason == "end_turn"
@@ -135,7 +123,7 @@ async def test_async_anthropic(
     assert len(res.calls) == 1
     call = res.calls[0]
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
+    output = call.output
     assert output.id == message.id
     assert output.model == message.model
     assert output.stop_reason == "end_turn"
@@ -184,7 +172,7 @@ async def test_async_anthropic_stream(
     assert len(res.calls) == 1
     call = res.calls[0]
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
+    output = call.output
     assert output.id == message.id
     assert output.model == message.model
     assert output.stop_reason == "end_turn"
@@ -244,7 +232,7 @@ def test_tools_calling(
     assert len(res.calls) == 1
     call = res.calls[0]
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
+    output = call.output
     assert output.id == message.id
     assert output.model == message.model
     assert output.stop_reason == "tool_use"

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -243,7 +243,7 @@ def simple_line_call_bootstrap(init_wandb: bool = False) -> OpCallSpec:
     # class Number:
     #     value: int
 
-    class Number(BaseModel):
+    class Number(weave.Object):
         value: int
 
     @weave.op()
@@ -1313,13 +1313,25 @@ def test_dataclass_support(client):
 
     assert len(res.calls) == 1
     assert res.calls[0].inputs == {
-        "a": "weave:///shawn/test-project/object/MyDataclass:qDo5jHFme5xIM1LwgeiXXVxYoGnp4LQ9hulqkX5zunY",
-        "b": "weave:///shawn/test-project/object/MyDataclass:We1slmdrWzi2NYSWObBsLybTTNSP4M9zfQbCMf8rQMc",
+        "a": {
+            "_bases": [],
+            "_class_name": "MyDataclass",
+            "_type": "MyDataclass",
+            "val": 1,
+        },
+        "b": {
+            "_bases": [],
+            "_class_name": "MyDataclass",
+            "_type": "MyDataclass",
+            "val": 2,
+        },
     }
-    assert (
-        res.calls[0].output
-        == "weave:///shawn/test-project/object/MyDataclass:2exnZIHkq8DyHTbJzhL0m5Ew1XrqIBCstZWilQS6Lpo"
-    )
+    assert res.calls[0].output == {
+        "_bases": [],
+        "_class_name": "MyDataclass",
+        "_type": "MyDataclass",
+        "val": 3,
+    }
 
 
 def test_op_retrieval(client):

--- a/weave/tests/test_client_trace.py
+++ b/weave/tests/test_client_trace.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ValidationError
 
 import weave
 from weave import Thread, ThreadPoolExecutor, weave_client
+from weave.trace.object_record import ObjectRecord
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace_server.ids import generate_id
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
@@ -1405,25 +1406,12 @@ def test_dataclass_support(client):
 
     assert len(res.calls) == 1
     assert res.calls[0].inputs == {
-        "a": {
-            "_bases": [],
-            "_class_name": "MyDataclass",
-            "_type": "MyDataclass",
-            "val": 1,
-        },
-        "b": {
-            "_bases": [],
-            "_class_name": "MyDataclass",
-            "_type": "MyDataclass",
-            "val": 2,
-        },
+        "a": ObjectRecord({"val": 1, "_class_name": "MyDataclass", "_bases": []}),
+        "b": ObjectRecord({"val": 2, "_class_name": "MyDataclass", "_bases": []}),
     }
-    assert res.calls[0].output == {
-        "_bases": [],
-        "_class_name": "MyDataclass",
-        "_type": "MyDataclass",
-        "val": 3,
-    }
+    assert res.calls[0].output == ObjectRecord(
+        {"val": 3, "_class_name": "MyDataclass", "_bases": []}
+    )
 
 
 def test_op_retrieval(client):

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -87,6 +87,22 @@ def _load_custom_obj_files(
     return loaded_files
 
 
+def from_json_special(obj: Any) -> Any:
+    if isinstance(obj, list):
+        return [from_json_special(v) for v in obj]
+    elif isinstance(obj, dict):
+        if (val_type := obj.pop("_type", None)) is None:
+            return {k: from_json_special(v) for k, v in obj.items()}
+        elif val_type == "ObjectRecord":
+            return ObjectRecord({k: from_json_special(v) for k, v in obj.items()})
+        else:
+            return ObjectRecord({k: from_json_special(v) for k, v in obj.items()})
+    elif isinstance(obj, str) and obj.startswith("weave://"):
+        return parse_uri(obj)
+
+    return obj
+
+
 def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
     if isinstance(obj, list):
         return [from_json(v, project_id, server) for v in obj]

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -2,7 +2,13 @@ import abc
 import datetime
 import typing
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+)
 from typing_extensions import TypedDict
 
 from .interface.query import Query
@@ -103,7 +109,21 @@ class CallSchema(BaseModel):
     def serialize_typed_dicts(
         self, v: typing.Dict[str, typing.Any]
     ) -> typing.Dict[str, typing.Any]:
-        return dict(v)
+        return v
+
+    @field_validator("output")
+    @classmethod
+    def validate_output(cls, v):
+        from weave.trace.serialize import from_json_special
+
+        return from_json_special(v)
+
+    @field_validator("inputs")
+    @classmethod
+    def validate_inputs(cls, v):
+        from weave.trace.serialize import from_json_special
+
+        return from_json_special(v)
 
 
 # Essentially a partial of StartedCallSchema. Mods:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -7,7 +7,6 @@ from pydantic import (
     ConfigDict,
     Field,
     field_serializer,
-    field_validator,
 )
 from typing_extensions import TypedDict
 
@@ -111,19 +110,20 @@ class CallSchema(BaseModel):
     ) -> typing.Dict[str, typing.Any]:
         return v
 
-    @field_validator("output")
-    @classmethod
-    def validate_output(cls, v):
-        from weave.trace.serialize import from_json_special
+    # TODO: How do I get project, server here?
+    # @field_validator("output")
+    # @classmethod
+    # def validate_output(cls, v):
+    #     from weave.trace.serialize import from_json_special
 
-        return from_json_special(v)
+    #     return from_json_special(v)
 
-    @field_validator("inputs")
-    @classmethod
-    def validate_inputs(cls, v):
-        from weave.trace.serialize import from_json_special
+    # @field_validator("inputs")
+    # @classmethod
+    # def validate_inputs(cls, v):
+    #     from weave.trace.serialize import from_json_special
 
-        return from_json_special(v)
+    #     return from_json_special(v)
 
 
 # Essentially a partial of StartedCallSchema. Mods:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -2,12 +2,7 @@ import abc
 import datetime
 import typing
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    field_serializer,
-)
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 from typing_extensions import TypedDict
 
 from .interface.query import Query
@@ -111,19 +106,19 @@ class CallSchema(BaseModel):
         return v
 
     # TODO: How do I get project, server here?
-    # @field_validator("output")
-    # @classmethod
-    # def validate_output(cls, v):
-    #     from weave.trace.serialize import from_json_special
+    @field_validator("output")
+    @classmethod
+    def validate_output(cls, v):
+        from weave.trace.serialize import from_json_special
 
-    #     return from_json_special(v)
+        return from_json_special(v)
 
-    # @field_validator("inputs")
-    # @classmethod
-    # def validate_inputs(cls, v):
-    #     from weave.trace.serialize import from_json_special
+    @field_validator("inputs")
+    @classmethod
+    def validate_inputs(cls, v):
+        from weave.trace.serialize import from_json_special
 
-    #     return from_json_special(v)
+        return from_json_special(v)
 
 
 # Essentially a partial of StartedCallSchema. Mods:

--- a/weave/trace_server/trace_server_interface_util.py
+++ b/weave/trace_server/trace_server_interface_util.py
@@ -2,6 +2,8 @@ import base64
 import hashlib
 import typing
 
+from weave.trace.refs import Ref
+
 from . import refs_internal
 
 TRACE_REF_SCHEME = "weave"
@@ -71,6 +73,8 @@ def extract_refs_from_values(
             val.startswith(scheme + "://") for scheme in valid_schemes
         ):
             refs.append(val)
+        elif isinstance(val, Ref):
+            refs.append(val.uri())
 
     _visit(vals)
     return refs


### PR DESCRIPTION
## Summary
1. Inlines pydantic and dataclass objects, keeping the `ObjectRecord` shape but skipping `obj_create` (and inlined objects have no refs)
2. Saves _____ time for (benchmark obj) when saving deeply nested objects
3. Avoids cluttering the top-level Object space in the UI (and also from the object query)

## Resolves
1. https://wandb.atlassian.net/browse/WB-20357