### PR TITLE
chore: Fixes smart flattening to only skip custom types

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/browse2Util.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/browse2Util.ts
@@ -7,7 +7,11 @@ export const flattenObjectPreservingWeaveTypes = (obj: {
   [key: string]: any;
 }) => {
   return flattenObject(obj, '', {}, (key, value) => {
-    return typeof value !== 'object' || value == null || value._type == null;
+    return (
+      typeof value !== 'object' ||
+      value == null ||
+      value._type !== 'CustomWeaveType'
+    );
   });
 };
 


### PR DESCRIPTION
this makes sure that something like:

```
class Model(weave.Model):
    inner_settings: dict
```

is properly flattened. As implemented, `inner_settings` will not get flattened. 