### PR TITLE
fix: No longer crash when object or op not found in UI

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -669,6 +669,13 @@ const useOpVersion = (
       };
     }
 
+    if (opVersionRes.obj == null) {
+      return {
+        loading: false,
+        result: null,
+      };
+    }
+
     const returnedResult = convertTraceServerObjectVersionToOpSchema(
       opVersionRes.obj
     );
@@ -808,6 +815,13 @@ const useObjectVersion = (
     if (objectVersionRes == null || loadingRef.current) {
       return {
         loading: true,
+        result: null,
+      };
+    }
+
+    if (objectVersionRes.obj == null) {
+      return {
+        loading: false,
         result: null,
       };
     }


### PR DESCRIPTION
Are you like me and sometimes try to lookup deleted or missing ops or objects? Do you hate page crashes? Me too! 

Before: Yuk!
<img width="2056" alt="Screenshot 2024-08-16 at 14 06 53" src="https://github.com/user-attachments/assets/f3328e13-45f0-487c-b393-86046bf456a8">

After: ...
<img width="2056" alt="Screenshot 2024-08-16 at 14 07 25" src="https://github.com/user-attachments/assets/7e4b2091-2dd0-4912-bc5d-606bcc7942c1">

Paired with https://github.com/wandb/weave/pull/2154, it actually is a nice dismissible error!:
<img width="2056" alt="Screenshot 2024-08-16 at 14 09 12" src="https://github.com/user-attachments/assets/a7778fd8-a0aa-47d2-bee5-a9fa54b6a1b6">


