### PR TITLE
fix: serialization bug when a Ref is put directly into a dict

### DIFF
--- a/weave/tests/test_weave_client.py
+++ b/weave/tests/test_weave_client.py
@@ -1324,3 +1324,13 @@ def test_summary_tokens_cost_sqlite(client):
 
     assert noCostCallSummary is None
     assert withCostCallSummary is None
+
+
+def test_ref_in_dict(client):
+    ref = client._save_object({"a": 5}, "d1")
+
+    # Put a ref directly in a dict.
+    ref2 = client._save_object({"b": ref}, "d2")
+
+    obj = weave.ref(ref2.uri()).get()
+    assert obj["b"] == {"a": 5}

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -102,6 +102,8 @@ def _get_direct_ref(obj: Any) -> Optional[Ref]:
 
 
 def map_to_refs(obj: Any) -> Any:
+    if isinstance(obj, Ref):
+        return obj
     if ref := _get_direct_ref(obj):
         return ref
 
@@ -797,7 +799,7 @@ class WeaveClient:
                 self._save_nested_objects(v)
             ref = self._save_object_basic(obj_rec, name or get_obj_name(obj_rec))
             obj.__dict__["ref"] = ref
-        elif dataclasses.is_dataclass(obj):
+        elif dataclasses.is_dataclass(obj) and not isinstance(obj, Ref):
             obj_rec = dataclass_object_record(obj)
             for v in obj_rec.__dict__.values():
                 self._save_nested_objects(v)


### PR DESCRIPTION
Here's the test case:

```
def test_ref_in_dict(client):
    ref = client._save_object({"a": 5}, "d1")

    # Put a ref directly in a dict.
    ref2 = client._save_object({"b": ref}, "d2")

    obj = weave.ref(ref2.uri()).get()
    assert obj["b"] == {"a": 5}
```

Prior to the fix, we would actually save the Ref object itself as an ObjectRecord. After the fix we correctly save the ref as its uri string.