### PR TITLE
chore: type constraints, class maps, and runtime validation of props

### DIFF
--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -109,65 +109,66 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     /**
      * Runtime validation of props' type constraints
      */
-    const ButtonInner = () => {
-      if (icon) {
-        if (children || startIcon || endIcon) {
-          console.warn(
-            'Button: `startIcon`, `endIcon`, and `children` are ignored when using `icon`.'
-          );
+    const ButtonInternal = () => {
+      const validatedChildren = () => {
+        if (icon) {
+          if (children || startIcon || endIcon) {
+            console.warn(
+              'Button: `startIcon`, `endIcon`, and `children` are ignored when using `icon`.'
+            );
+          }
+          return <Icon name={icon} role="presentation" />;
         }
-        return <Icon name={icon} role="presentation" />;
-      }
 
-      if (!children) {
-        console.error('Button: `children` is required when not using `icon`.');
-        return null;
-      }
+        if (!children) {
+          console.error(
+            'Button: `children` is required when not using `icon`.'
+          );
+          return null;
+        }
+
+        return (
+          <>
+            {startIcon ? <Icon name={startIcon} role="presentation" /> : null}
+            {children}
+            {endIcon ? <Icon name={endIcon} role="presentation" /> : null}
+          </>
+        );
+      };
 
       return (
-        <>
-          {startIcon ? <Icon name={startIcon} role="presentation" /> : null}
-          {children}
-          {endIcon ? <Icon name={endIcon} role="presentation" /> : null}
-        </>
+        <button
+          ref={ref}
+          {...htmlAttributes}
+          type="button"
+          aria-disabled={htmlAttributes.disabled}
+          aria-label={htmlAttributes['aria-label'] || tooltip}
+          className={twMerge(
+            classNames(
+              // Display
+              'inline-flex items-center justify-center',
+              // Font
+              "font-['Source_Sans_Pro'] font-semibold",
+              // Disabled
+              'disabled:pointer-events-none disabled:opacity-35',
+              // Focused
+              'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
+              // Other
+              'night-aware whitespace-nowrap rounded border-none',
+              sizeClasses[size],
+              variantClasses[variant],
+              // Conditional classes
+              {
+                [iconOnlySizeClasses[size]]: Boolean(icon),
+                [activeVariantClasses[variant]]: active,
+              },
+              className
+            )
+          )}>
+          {validatedChildren()}
+        </button>
       );
     };
-
-    const ButtonInternal = () => (
-      <button
-        ref={ref}
-        {...htmlAttributes}
-        type="button"
-        aria-disabled={htmlAttributes.disabled}
-        aria-label={htmlAttributes['aria-label'] || tooltip}
-        className={twMerge(
-          classNames(
-            'night-aware',
-            'inline-flex',
-            'items-center',
-            'justify-center',
-            'whitespace-nowrap',
-            'rounded',
-            'border-none',
-            "font-['Source_Sans_Pro']",
-            'font-semibold',
-            'disabled:pointer-events-none',
-            'disabled:opacity-35',
-            'focus-visible:outline',
-            'focus-visible:outline-[2px]',
-            'focus-visible:outline-teal-500',
-            sizeClasses[size],
-            variantClasses[variant],
-            {
-              [iconOnlySizeClasses[size]]: Boolean(icon),
-              [activeVariantClasses[variant]]: active,
-            },
-            className
-          )
-        )}>
-        <ButtonInner />
-      </button>
-    );
 
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 

--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -4,30 +4,38 @@
  * https://www.figma.com/file/01KWBdMZg5QM9SRS1pQq0z/Design-System----Robot-Styles?type=design&node-id=5956-31813&mode=design&t=Gm4WWGWwgjdfUUTe-0
  */
 
-import {TooltipContentProps} from '@radix-ui/react-tooltip';
+import {type TooltipContentProps} from '@radix-ui/react-tooltip';
 import classNames from 'classnames';
-import React, {ReactElement, useState} from 'react';
+import React, {
+  CSSProperties,
+  forwardRef,
+  type ReactElement,
+  useState,
+} from 'react';
 import {twMerge} from 'tailwind-merge';
 
-import {Icon, IconName} from '../Icon';
+import {Icon, type IconName} from '../Icon';
 import * as Tooltip from '../RadixTooltip';
 import {Tailwind} from '../Tailwind';
-import {ButtonSize, ButtonVariant} from './types';
+import type {ButtonSize, ButtonVariant} from './types';
+
+type IconButtonProps = {
+  icon?: IconName;
+  children?: never;
+  startIcon?: never;
+  endIcon?: never;
+  tooltip: string;
+};
+
+type LabelButtonProps = {
+  icon?: never;
+  children: ReactElement | string;
+  startIcon?: IconName;
+  endIcon?: IconName;
+  tooltip?: string;
+};
 
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  /**
-   * Shorthand alias for `startIcon` since most button icons are startIcons.
-   * If both props are provided, `startIcon` value will be used out of the two.
-   */
-  icon?: IconName;
-  /**
-   * Icon displayed before the children
-   */
-  startIcon?: IconName;
-  /**
-   * Icon displayed after the children
-   */
-  endIcon?: IconName;
   size?: ButtonSize;
   variant?: ButtonVariant;
   children?: ReactElement | string;
@@ -35,114 +43,104 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   tooltip?: string;
   tooltipProps?: TooltipContentProps;
   twWrapperStyles?: React.CSSProperties;
+} & (IconButtonProps | LabelButtonProps);
+
+const sizeMap = {
+  small:
+    'gap-6 px-6 py-3 text-sm leading-[18px] [&_svg]:h-16 [&_svg]:w-16 h-24 w-24 p-0',
+  medium: 'gap-10 px-10 py-4 text-base [&_svg]:h-18 [&_svg]:w-18 h-32 w-32 p-0',
+  large: 'gap-8 px-12 py-8 text-base h-40 w-40 p-0',
 };
 
-export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const variantMap = {
+  primary: 'bg-teal-500 text-white hover:bg-teal-450',
+  secondary:
+    'bg-oblivion/[0.05] dark:bg-moonbeam/[0.05] text-moon-800 dark:text-moon-200 hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400',
+  ghost:
+    'bg-oblivion/[0.05] dark:bg-moonbeam/[0.05] text-moon-800 dark:text-moon-200 hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400',
+  quiet:
+    'text-moon-500 hover:text-moon-800 dark:hover:text-moon-200 hover:bg-oblivion/[0.05] dark:hover:bg-moonbeam/[0.05]',
+  destructive: 'bg-red-500 text-white hover:bg-red-450',
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       size = 'medium',
       variant = 'primary',
       icon,
-      startIcon = icon,
+      startIcon,
       endIcon,
       active,
       children,
       className = '',
       tooltip,
       tooltipProps,
-      twWrapperStyles = {},
+      twWrapperStyles,
       ...htmlAttributes
     },
     ref
   ) => {
-    const hasIcon = startIcon || endIcon;
-    if (!children && !hasIcon) {
-      console.error('Button: requires either children or an icon.');
-    }
-
-    const isSmall = size === 'small';
-    const isMedium = size === 'medium';
-    const isLarge = size === 'large';
-    const isPrimary = variant === 'primary';
-    const isSecondary = variant === 'secondary';
-    const isGhost = variant === 'ghost';
-    const isQuiet = variant === 'quiet';
-    const isDestructive = variant === 'destructive';
-
-    const hasBothIcons = startIcon && endIcon;
-    const hasOnlyOneIcon = hasIcon && !hasBothIcons;
-    const isIconOnly = hasOnlyOneIcon && !children;
-
     /**
      * The Tailwind wrapper is a div, which is a block-element. However, a normal button
      * wouldn't be wrapped and would be inline-block by default. These styles are a
      * necessary workaround to ensure Button is styled correctly despite the wrapper.
      */
-    const wrapperStyles = {
+    const wrapperStyles: CSSProperties = {
       display: 'inline-flex',
       width: className.includes('w-full') ? '100%' : undefined,
       ...twWrapperStyles,
     };
 
-    const button = (
+    /**
+     * Runtime validation of props' type constraints
+     */
+    const ButtonInner = () => {
+      if (icon) {
+        if (children || startIcon || endIcon) {
+          console.warn(
+            'Button: `startIcon`, `endIcon`, and `children` are ignored when using `icon`.'
+          );
+        }
+        return <Icon name={icon} role="presentation" />;
+      }
+
+      if (!children) {
+        console.error('Button: `children` is required when not using `icon`.');
+        return null;
+      }
+
+      return (
+        <>
+          {startIcon ? <Icon name={startIcon} role="presentation" /> : null}
+          {children}
+          {endIcon ? <Icon name={endIcon} role="presentation" /> : null}
+        </>
+      );
+    };
+
+    const ButtonInternal = () => (
       <button
         ref={ref}
+        {...htmlAttributes}
         type="button"
+        aria-disabled={htmlAttributes.disabled}
+        aria-label={htmlAttributes['aria-label'] || tooltip}
         className={twMerge(
-          classNames(
-            'night-aware',
-            "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
-            'disabled:pointer-events-none disabled:opacity-35',
-            'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
-            {
-              // small
-              'gap-6 px-6 py-3 text-sm leading-[18px]': isSmall,
-              '[&_svg]:h-16 [&_svg]:w-16': isSmall,
-              'h-24 w-24 p-0': isSmall && isIconOnly,
-
-              // medium
-              'gap-10 px-10 py-4 text-base': isMedium,
-              '[&_svg]:h-18 [&_svg]:w-18': isMedium,
-              'h-32 w-32 p-0': isMedium && isIconOnly,
-
-              // large
-              'gap-8 px-12 py-8 text-base': isLarge,
-              'h-40 w-40 p-0': isLarge && isIconOnly,
-
-              // primary
-              'bg-teal-500 text-white hover:bg-teal-450': isPrimary,
-              'bg-teal-450': isPrimary && active,
-
-              // secondary & ghost
-              'bg-oblivion/[0.05] dark:bg-moonbeam/[0.05]': isSecondary,
-              'text-moon-800 dark:text-moon-200': isSecondary || isGhost,
-              'hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400':
-                isSecondary || isGhost,
-              'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400':
-                (isSecondary || isGhost) && active,
-
-              // quiet
-              'text-moon-500': isQuiet,
-              'bg-oblivion/[0.05] text-moon-800 dark:bg-moonbeam/[0.05] dark:text-moon-200':
-                isQuiet && active,
-              'hover:text-moon-800 dark:hover:text-moon-200': isQuiet,
-              'hover:bg-oblivion/[0.05] dark:hover:bg-moonbeam/[0.05]': isQuiet,
-
-              // destructive
-              'bg-red-500 text-white hover:bg-red-450': isDestructive,
-              'bg-red-450': isDestructive && active,
-            },
-            className
-          )
-        )}
-        {...htmlAttributes}>
-        {startIcon ? <Icon name={startIcon} /> : null}
-        {children}
-        {endIcon ? <Icon name={endIcon} /> : null}
+          'night-aware',
+          "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
+          'disabled:pointer-events-none disabled:opacity-35',
+          'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
+          sizeMap[size] + (icon && !children ? ' h-24 w-24 p-0' : ''),
+          variantMap[variant] + (active ? ' bg-teal-450' : ''),
+          className
+        )}>
+        <ButtonInner />
       </button>
     );
 
     const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+
     if (tooltip) {
       return (
         <Tailwind style={wrapperStyles}>
@@ -150,7 +148,9 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             <Tooltip.Root open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
               <Tooltip.Trigger asChild>
                 {/* span is needed so tooltip works on disabled buttons */}
-                <span>{button}</span>
+                <span>
+                  <ButtonInternal />
+                </span>
               </Tooltip.Trigger>
               <Tooltip.Portal>
                 <Tooltip.Content {...tooltipProps}>{tooltip}</Tooltip.Content>
@@ -161,6 +161,10 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       );
     }
 
-    return <Tailwind style={wrapperStyles}>{button}</Tailwind>;
+    return (
+      <Tailwind style={wrapperStyles}>
+        <ButtonInternal />
+      </Tailwind>
+    );
   }
 );

--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -127,13 +127,15 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         aria-disabled={htmlAttributes.disabled}
         aria-label={htmlAttributes['aria-label'] || tooltip}
         className={twMerge(
-          'night-aware',
-          "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
-          'disabled:pointer-events-none disabled:opacity-35',
-          'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
-          sizeMap[size] + (icon && !children ? ' h-24 w-24 p-0' : ''),
-          variantMap[variant] + (active ? ' bg-teal-450' : ''),
-          className
+          classNames(
+            'night-aware',
+            "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
+            'disabled:pointer-events-none disabled:opacity-35',
+            'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
+            sizeMap[size] + (icon && !children ? ' h-24 w-24 p-0' : ''),
+            variantMap[variant] + (active ? ' bg-teal-450' : ''),
+            className
+          )
         )}>
         <ButtonInner />
       </button>

--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -20,11 +20,11 @@ import {Tailwind} from '../Tailwind';
 import type {ButtonSize, ButtonVariant} from './types';
 
 type IconButtonProps = {
-  icon?: IconName;
+  icon: IconName;
   children?: never;
   startIcon?: never;
   endIcon?: never;
-  tooltip: string;
+  'aria-label': string;
 };
 
 type LabelButtonProps = {
@@ -32,7 +32,6 @@ type LabelButtonProps = {
   children: ReactElement | string;
   startIcon?: IconName;
   endIcon?: IconName;
-  tooltip?: string;
 };
 
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -45,22 +44,37 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   twWrapperStyles?: React.CSSProperties;
 } & (IconButtonProps | LabelButtonProps);
 
-const sizeMap = {
-  small:
-    'gap-6 px-6 py-3 text-sm leading-[18px] [&_svg]:h-16 [&_svg]:w-16 h-24 w-24 p-0',
-  medium: 'gap-10 px-10 py-4 text-base [&_svg]:h-18 [&_svg]:w-18 h-32 w-32 p-0',
-  large: 'gap-8 px-12 py-8 text-base h-40 w-40 p-0',
+const sizeClasses = {
+  small: 'gap-6 px-6 py-3 text-sm leading-[18px] [&_svg]:h-16 [&_svg]:w-16',
+  medium: 'gap-10 px-10 py-4 text-base [&_svg]:h-18 [&_svg]:w-18',
+  large: 'gap-8 px-12 py-8 text-base [&_svg]:h-20 [&_svg]:w-20',
 };
 
-const variantMap = {
+const iconOnlySizeClasses = {
+  small: 'h-24 w-24 p-0',
+  medium: 'h-32 w-32 p-0',
+  large: 'h-40 w-40 p-0',
+};
+
+const variantClasses = {
   primary: 'bg-teal-500 text-white hover:bg-teal-450',
   secondary:
     'bg-oblivion/[0.05] dark:bg-moonbeam/[0.05] text-moon-800 dark:text-moon-200 hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400',
   ghost:
-    'bg-oblivion/[0.05] dark:bg-moonbeam/[0.05] text-moon-800 dark:text-moon-200 hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400',
-  quiet:
-    'text-moon-500 hover:text-moon-800 dark:hover:text-moon-200 hover:bg-oblivion/[0.05] dark:hover:bg-moonbeam/[0.05]',
+    'text-moon-800 dark:text-moon-200 hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400',
+  quiet: 'text-moon-500 hover:text-moon-800 dark:hover:text-moon-200',
   destructive: 'bg-red-500 text-white hover:bg-red-450',
+};
+
+const activeVariantClasses = {
+  primary: 'bg-teal-450',
+  secondary:
+    'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400',
+  ghost:
+    'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400',
+  quiet:
+    'bg-oblivion/[0.05] text-moon-800 dark:bg-moonbeam/[0.05] dark:text-moon-200',
+  destructive: 'bg-red-450',
 };
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -129,11 +143,25 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         className={twMerge(
           classNames(
             'night-aware',
-            "inline-flex items-center justify-center whitespace-nowrap rounded border-none font-['Source_Sans_Pro'] font-semibold",
-            'disabled:pointer-events-none disabled:opacity-35',
-            'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
-            sizeMap[size] + (icon && !children ? ' h-24 w-24 p-0' : ''),
-            variantMap[variant] + (active ? ' bg-teal-450' : ''),
+            'inline-flex',
+            'items-center',
+            'justify-center',
+            'whitespace-nowrap',
+            'rounded',
+            'border-none',
+            "font-['Source_Sans_Pro']",
+            'font-semibold',
+            'disabled:pointer-events-none',
+            'disabled:opacity-35',
+            'focus-visible:outline',
+            'focus-visible:outline-[2px]',
+            'focus-visible:outline-teal-500',
+            sizeClasses[size],
+            variantClasses[variant],
+            {
+              [iconOnlySizeClasses[size]]: Boolean(icon),
+              [activeVariantClasses[variant]]: active,
+            },
             className
           )
         )}>

--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -86,7 +86,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       endIcon,
       active,
       children,
-      className = '',
+      className,
       tooltip,
       tooltipProps,
       ...htmlAttributes
@@ -124,7 +124,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
          * necessary workaround to ensure Button is styled correctly despite the wrapper.
          */
         style={{display: 'contents'}}>
-        <OptionalTooltip tooltip={Boolean(tooltip)} tooltipProps={tooltipProps}>
+        <OptionalTooltip tooltip={tooltip} tooltipProps={tooltipProps}>
           <button
             ref={ref}
             {...htmlAttributes}
@@ -152,7 +152,7 @@ function OptionalTooltip({
   children,
   tooltip,
   tooltipProps,
-}: PropsWithChildren<{tooltip: boolean; tooltipProps?: TooltipContentProps}>) {
+}: PropsWithChildren<{tooltip?: string; tooltipProps?: TooltipContentProps}>) {
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
 
   if (tooltip) {
@@ -170,5 +170,6 @@ function OptionalTooltip({
       </Tooltip.Provider>
     );
   }
+
   return <>{children}</>;
 }


### PR DESCRIPTION
This PR does the following:
- Replaces variables for each variant with a mapping
- Moves static values outside of function
- Uses JSX element instead of interpolation 
- Adds compile & runtime constraints for props:
  - Icon OR label button
- Sensible defaults for certain a11y attributes
- Prevents external overrides of explicitly added internal html attributes