### PR TITLE
fix: filters with numeric operator should only accept numeric values

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
@@ -12,6 +12,7 @@ import {StyledDateTimePicker} from '../StyledDateTimePicker';
 import {
   getFieldType,
   getStringList,
+  isNumericOperator,
   isValuelessOperator,
   isWeaveRef,
 } from './common';
@@ -65,5 +66,6 @@ export const SelectValue = ({
     return <ValueInputBoolean value={value} onSetValue={onSetValue} />;
   }
 
-  return <TextValue value={value} onSetValue={onSetValue} />;
+  const type = isNumericOperator(operator) ? 'number' : 'text';
+  return <TextValue value={value} onSetValue={onSetValue} type={type} />;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/TextValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/TextValue.tsx
@@ -5,13 +5,14 @@ import {TextField} from '../../../../Form/TextField';
 type TextValueProps = {
   value: string;
   onSetValue: (value: string) => void;
+  type?: string;
 };
 
-export const TextValue = ({value, onSetValue}: TextValueProps) => {
+export const TextValue = ({value, onSetValue, type}: TextValueProps) => {
   // TODO: Need to debounce the value change.
   return (
     <div className="min-w-[200px]">
-      <TextField value={value} onChange={onSetValue} />
+      <TextField type={type} value={value} onChange={onSetValue} />
     </div>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -124,6 +124,10 @@ export const isValuelessOperator = (operator: string) => {
   return VALUELESS_OPERATORS.has(operator);
 };
 
+export const isNumericOperator = (operator: string) => {
+  return operator.startsWith('(number):');
+};
+
 export type SelectOperatorOption = {
   value: string;
   label: string;


### PR DESCRIPTION
If you have selected a numeric operator like "<" the input element for the value should be put into numeric mode.

With this change, if you have a non-numeric operator and value, and then switch the operator to be numeric one, you will get a console warning. (The input will appear empty.) I considered handling clearing the value in this case, but it is actually convenient to have the original value there if you switched operators by mistake or to see what would happen and want to switch the operator back. It should be possible to handle state more intelligently to avoid this warning, but leaving that additional work for the future since the warning doesn't seem to hurt anything.