### PR TITLE
chore: move header buttons in preparation for saved views design

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -552,98 +552,14 @@ export const CallsTable: FC<{
     return Array.from(keysSet);
   }, [tableData]);
 
+  const visibleColumns =
+    tableData.length > 0
+      ? allRowKeys.filter(col => columnVisibilityModel?.[col] !== false)
+      : [];
+
   // Register Export Button
-  useEffect(() => {
-    const visibleColumns =
-      tableData.length > 0
-        ? allRowKeys.filter(col => columnVisibilityModel?.[col] !== false)
-        : [];
-    addExtra('exportButton', {
-      node: (
-        <ExportSelector
-          selectedCalls={selectedCalls}
-          numTotalCalls={callsTotal}
-          disabled={callsTotal === 0}
-          visibleColumns={visibleColumns}
-          callQueryParams={{
-            entity,
-            project,
-            filter: effectiveFilter,
-            gridFilter: filterModel ?? DEFAULT_FILTER_CALLS,
-            gridSort: sortModel,
-          }}
-          rightmostButton={isReadonly}
-        />
-      ),
-      order: 2,
-    });
 
-    return () => removeExtra('exportButton');
-  }, [
-    selectedCalls,
-    callsTotal,
-    tableData,
-    allRowKeys,
-    columnVisibilityModel,
-    entity,
-    project,
-    isReadonly,
-    effectiveFilter,
-    filterModel,
-    sortModel,
-    addExtra,
-    removeExtra,
-  ]);
-
-  // Register Delete Button
   const [deleteConfirmModalOpen, setDeleteConfirmModalOpen] = useState(false);
-  useEffect(() => {
-    if (isReadonly) {
-      return;
-    }
-    addExtra('deleteSelectedCalls', {
-      node: (
-        <BulkDeleteButton
-          onClick={() => setDeleteConfirmModalOpen(true)}
-          disabled={selectedCalls.length === 0}
-        />
-      ),
-      order: 3,
-    });
-
-    return () => removeExtra('deleteSelectedCalls');
-  }, [addExtra, removeExtra, selectedCalls, isEvaluateTable, isReadonly]);
-
-  useEffect(() => {
-    if (isReadonly) {
-      return;
-    }
-    addExtra('deleteSelectedCallsModal', {
-      node: (
-        <ConfirmDeleteModal
-          calls={tableData
-            .filter(row => selectedCalls.includes(row.id))
-            .map(traceCallToUICallSchema)}
-          confirmDelete={deleteConfirmModalOpen}
-          setConfirmDelete={setDeleteConfirmModalOpen}
-          onDeleteCallback={() => {
-            setSelectedCalls([]);
-          }}
-        />
-      ),
-      order: -1,
-    });
-    return () => removeExtra('deleteSelectedCallsModal');
-  }, [
-    addExtra,
-    removeExtra,
-    selectedCalls,
-    deleteConfirmModalOpen,
-    isReadonly,
-    entity,
-    project,
-    tableData,
-  ]);
 
   // Called in reaction to Hide column menu
   const onColumnVisibilityModelChange = setColumnVisibilityModel
@@ -700,7 +616,7 @@ export const CallsTable: FC<{
       filterListItems={
         <Tailwind style={{display: 'contents'}}>
           {!hideOpSelector && (
-            <div style={{flex: '0 0 auto'}}>
+            <div className="flex-none">
               <ListItem sx={{minWidth: 190, width: 320}}>
                 <FormControl fullWidth>
                   <Autocomplete
@@ -794,14 +710,50 @@ export const CallsTable: FC<{
               }}
             />
           )}
-          {columnVisibilityModel && setColumnVisibilityModel && (
-            <div style={{flex: '0 0 auto'}}>
-              <ManageColumnsButton
-                columnInfo={columns}
-                columnVisibilityModel={columnVisibilityModel}
-                setColumnVisibilityModel={setColumnVisibilityModel}
+          {!isReadonly && (
+            <div className="flex-none">
+              <BulkDeleteButton
+                onClick={() => setDeleteConfirmModalOpen(true)}
+                disabled={selectedCalls.length === 0}
+              />
+              <ConfirmDeleteModal
+                calls={tableData
+                  .filter(row => selectedCalls.includes(row.id))
+                  .map(traceCallToUICallSchema)}
+                confirmDelete={deleteConfirmModalOpen}
+                setConfirmDelete={setDeleteConfirmModalOpen}
+                onDeleteCallback={() => {
+                  setSelectedCalls([]);
+                }}
               />
             </div>
+          )}
+          <div className="flex-none">
+            <ExportSelector
+              selectedCalls={selectedCalls}
+              numTotalCalls={callsTotal}
+              disabled={callsTotal === 0}
+              visibleColumns={visibleColumns}
+              callQueryParams={{
+                entity,
+                project,
+                filter: effectiveFilter,
+                gridFilter: filterModel ?? DEFAULT_FILTER_CALLS,
+                gridSort: sortModel,
+              }}
+            />
+          </div>
+          {columnVisibilityModel && setColumnVisibilityModel && (
+            <>
+              <div className="h-24 flex-none border-l-[1px] border-moon-250"></div>
+              <div className="flex-none">
+                <ManageColumnsButton
+                  columnInfo={columns}
+                  columnVisibilityModel={columnVisibilityModel}
+                  setColumnVisibilityModel={setColumnVisibilityModel}
+                />
+              </div>
+            </>
           )}
         </Tailwind>
       }>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -552,10 +552,11 @@ export const CallsTable: FC<{
     return Array.from(keysSet);
   }, [tableData]);
 
-  const visibleColumns =
-    tableData.length > 0
+  const visibleColumns = useMemo(() => {
+    return tableData.length > 0
       ? allRowKeys.filter(col => columnVisibilityModel?.[col] !== false)
       : [];
+  }, [allRowKeys, columnVisibilityModel, tableData]);
 
   // Register Export Button
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -33,7 +33,6 @@ export const ExportSelector = ({
   visibleColumns,
   disabled,
   callQueryParams,
-  rightmostButton = false,
 }: {
   selectedCalls: string[];
   numTotalCalls: number;
@@ -46,7 +45,6 @@ export const ExportSelector = ({
     gridSort?: GridSortModel;
   };
   disabled: boolean;
-  rightmostButton?: boolean;
 }) => {
   const [selectionState, setSelectionState] = useState<SelectionState>('all');
   const [downloadLoading, setDownloadLoading] = useState<ContentType | null>(
@@ -130,7 +128,6 @@ export const ExportSelector = ({
     <>
       <span ref={ref}>
         <Button
-          className={rightmostButton ? 'mr-16' : 'mr-4'}
           icon="export-share-upload"
           variant="ghost"
           onClick={onClick}
@@ -333,7 +330,6 @@ export const BulkDeleteButton: FC<{
         alignItems: 'center',
       }}>
       <Button
-        className="ml-4 mr-16"
         variant="ghost"
         size="medium"
         disabled={disabled}


### PR DESCRIPTION
Internal Figma: https://www.figma.com/design/mufhcDVpsRg9HJrLM61PCN/Weave-(Latest)?node-id=1089-18178&t=U28KGlyGddcrndUf-0
Internal Jira: https://wandb.atlassian.net/browse/WB-20484

We're planning to use the header space for saved view controls. Moving export and delete calls grid controls to "filter bar" area.

Need to check with design on where the Compare button should be.

Before:
<img width="1485" alt="Screenshot 2024-08-21 at 2 31 51 PM" src="https://github.com/user-attachments/assets/e5ed2cec-bf13-4cbf-8097-aa5c2c9dbe7b">

After:
<img width="1484" alt="Screenshot 2024-08-21 at 2 31 39 PM" src="https://github.com/user-attachments/assets/eabfd6fb-df62-4ee2-a027-f738e66a68b8">
