### PR TITLE
fix: don't limit height of single string output

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -298,7 +298,9 @@ export const ObjectViewer = ({
             }
           }
 
-          const colInner = <ValueView data={row} isExpanded={isExpanded} />;
+          const colInner = (
+            <ValueView data={row} isExpanded={isExpanded} maxHeight={300} />
+          );
           if (baseRef) {
             return (
               <WeaveCHTableSourceRefContext.Provider value={baseRef}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -24,9 +24,10 @@ type ValueData = Record<string, any>;
 type ValueViewProps = {
   data: ValueData;
   isExpanded: boolean;
+  maxHeight?: number;
 };
 
-export const ValueView = ({data, isExpanded}: ValueViewProps) => {
+export const ValueView = ({data, isExpanded, maxHeight}: ValueViewProps) => {
   const opDefRef = useMemo(() => parseRefMaybe(data.value ?? ''), [data.value]);
   if (!data.isLeaf) {
     if (data.valueType === 'object' && '_ref' in data.value) {
@@ -59,7 +60,13 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
     if (data.value.startsWith('data:image/')) {
       return <ValueViewImage value={data.value} />;
     }
-    return <ValueViewString value={data.value} isExpanded={isExpanded} />;
+    return (
+      <ValueViewString
+        value={data.value}
+        isExpanded={isExpanded}
+        maxHeight={maxHeight}
+      />
+    );
   }
 
   if (data.valueType === 'number') {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
@@ -15,9 +15,8 @@ import {ValueViewStringFormatMenu} from './ValueViewStringFormatMenu';
 type ValueViewStringProps = {
   value: string;
   isExpanded: boolean;
+  maxHeight?: number;
 };
-
-const MAX_SCROLL_HEIGHT = 300;
 
 const Column = styled.div`
   display: flex;
@@ -51,7 +50,6 @@ Collapsed.displayName = 'S.Collapsed';
 
 const Scrolling = styled.div`
   min-height: 38px;
-  max-height: ${MAX_SCROLL_HEIGHT}px;
   display: flex;
   align-items: center;
   overflow: auto;
@@ -60,7 +58,6 @@ Scrolling.displayName = 'S.Scrolling';
 
 const ScrollingInner = styled.div`
   width: 100%;
-  max-height: ${MAX_SCROLL_HEIGHT}px;
 `;
 ScrollingInner.displayName = 'S.ScrollingInner';
 
@@ -72,7 +69,11 @@ const PreserveWrapping = styled.div`
 `;
 PreserveWrapping.displayName = 'S.PreserveWrapping';
 
-export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
+export const ValueViewString = ({
+  value,
+  isExpanded,
+  maxHeight,
+}: ValueViewStringProps) => {
   const trimmed = value.trim();
   const hasScrolling = trimmed.indexOf('\n') !== -1 || value.length > 100;
   const [hasFull, setHasFull] = useState(false);
@@ -103,10 +104,10 @@ export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
   const scrollingRef = React.createRef<HTMLDivElement>();
 
   useEffect(() => {
-    if (scrollingRef.current) {
-      setHasFull(scrollingRef.current.offsetHeight >= MAX_SCROLL_HEIGHT);
+    if (scrollingRef.current && maxHeight) {
+      setHasFull(scrollingRef.current.offsetHeight >= maxHeight);
     }
-  }, [mode, value, scrollingRef]);
+  }, [mode, value, maxHeight, scrollingRef]);
 
   let toolbar = null;
   if (mode !== 0) {
@@ -188,8 +189,8 @@ export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
     return (
       <Column>
         {toolbar}
-        <Scrolling ref={scrollingRef}>
-          <ScrollingInner>{content}</ScrollingInner>
+        <Scrolling ref={scrollingRef} style={{maxHeight}}>
+          <ScrollingInner style={{maxHeight}}>{content}</ScrollingInner>
         </Scrolling>
       </Column>
     );


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-20481

Our string viewer component for use in the input/output tree grid was explicitly capped to 300px in height as we didn't want a huge row height that would cause users to lose the context. We reused that component for the single output case, but the height limitation isn't useful there.

Before:
![image](https://github.com/user-attachments/assets/a43e3a97-d5e8-4e72-ac1b-8196fce9dbbc)

After:
![image](https://github.com/user-attachments/assets/ab17873a-d37d-4953-b0b0-1f9856473b4d)
