### PR TITLE
feat: guess renderer for string values

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
@@ -72,12 +72,35 @@ const PreserveWrapping = styled.div`
 `;
 PreserveWrapping.displayName = 'S.PreserveWrapping';
 
+// Regular expressions for common Markdown syntax
+// Note this is intentionally limited in scope to reduce false positives.
+const LIKELY_MARKDOWN_PATTERNS: RegExp[] = [
+  /```[\s\S]*```/, // Code block
+  /\[.+\]\(.+\)/, // Links [text](url)
+  /!\[.*\]\(.+\)/, // Images ![alt](url)
+];
+
+const isLikelyMarkdown = (value: string): boolean => {
+  return LIKELY_MARKDOWN_PATTERNS.some(pattern => pattern.test(value));
+};
+
+const getDefaultFormat = (value: string): string => {
+  // TODO: Add JSON detection.
+  if (isLikelyMarkdown(value)) {
+    return 'Markdown';
+  }
+  return 'Text';
+};
+
 export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
   const trimmed = value.trim();
   const hasScrolling = trimmed.indexOf('\n') !== -1 || value.length > 100;
   const [hasFull, setHasFull] = useState(false);
 
-  const [format, setFormat] = useState('Text');
+  const [format, setFormat] = useState(getDefaultFormat(value));
+  useEffect(() => {
+    setFormat(getDefaultFormat(value));
+  }, [value]);
 
   const [mode, setMode] = useState(hasScrolling ? (isExpanded ? 1 : 0) : 0);
 


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-20485

If we have high confidence that a string value is markdown via heuristics we can default the string viewer to the corresponding mode, saving the user a few clicks and making things look nicer by default.