### PR TITLE
fix: if code for op can't be found, show alert instead of crash

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/Browse2OpDefCode.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/Browse2OpDefCode.tsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import {Loading} from '@wandb/weave/components/Loading';
 import React, {FC} from 'react';
 
+import {Alert} from '../../../Alert';
 import {useWFHooks} from '../Browse3/pages/wfReactInterface/context';
 
 export const Browse2OpDefCode: FC<{uri: string; maxRowsInView?: number}> = ({
@@ -21,6 +22,17 @@ export const Browse2OpDefCode: FC<{uri: string; maxRowsInView?: number}> = ({
           width: '100%',
         }}>
         <Loading centered size={25} />
+      </Box>
+    );
+  }
+
+  if (text.result == null) {
+    return (
+      <Box
+        sx={{
+          margin: '10px 16px 0 10px',
+        }}>
+        <Alert severity="warning">No code found for this operation</Alert>
       </Box>
     );
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -1196,6 +1196,9 @@ const useCodeForOpRef = (opVersionRef: string): Loadable<string> => {
       return null;
     }
     const result = query.result[0];
+    if (result == null) {
+      return null;
+    }
     const ref = parseRef(opVersionRef);
     if (isWeaveObjectRef(ref)) {
       return {
@@ -1221,9 +1224,9 @@ const useCodeForOpRef = (opVersionRef: string): Loadable<string> => {
     }
     return {
       loading: false,
-      result: new TextDecoder().decode(
-        arrayBuffer.result ?? new ArrayBuffer(0)
-      ),
+      result: arrayBuffer.result
+        ? new TextDecoder().decode(arrayBuffer.result)
+        : null,
     };
   }, [arrayBuffer.loading, arrayBuffer.result]);
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-20503

Before:
<img width="629" alt="Screenshot 2024-08-22 at 10 00 52 AM" src="https://github.com/user-attachments/assets/8621632e-0d3a-45e2-90ca-32621cc644ca">

After:
<img width="632" alt="Screenshot 2024-08-22 at 10 00 36 AM" src="https://github.com/user-attachments/assets/c337af56-e2f3-434b-a4af-fbb8daa05542">
