### PR TITLE
chore: move evaluation compare button

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -28,7 +28,6 @@ import {Checkbox} from '@wandb/weave/components/Checkbox/Checkbox';
 import React, {
   FC,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -39,10 +38,7 @@ import {useHistory} from 'react-router-dom';
 import {useViewerInfo} from '../../../../../../common/hooks/useViewerInfo';
 import {A, TargetBlank} from '../../../../../../common/util/links';
 import {Tailwind} from '../../../../../Tailwind';
-import {
-  useWeaveflowCurrentRouteContext,
-  WeaveHeaderExtrasContext,
-} from '../../context';
+import {useWeaveflowCurrentRouteContext} from '../../context';
 import {getDefaultOperatorForValue} from '../../filters/common';
 import {FilterPanel} from '../../filters/FilterPanel';
 import {DEFAULT_PAGE_SIZE} from '../../grid/pagination';
@@ -162,7 +158,6 @@ export const CallsTable: FC<{
   setPaginationModel,
 }) => {
   const {loading: loadingUserInfo, userInfo} = useViewerInfo();
-  const {addExtra, removeExtra} = useContext(WeaveHeaderExtrasContext);
 
   const isReadonly =
     loadingUserInfo || !userInfo?.username || !userInfo?.teams.includes(entity);
@@ -508,38 +503,6 @@ export const CallsTable: FC<{
   // Register Compare Evaluations Button
   const history = useHistory();
   const router = useWeaveflowCurrentRouteContext();
-  useEffect(() => {
-    if (!isEvaluateTable) {
-      return;
-    }
-    addExtra('compareEvaluations', {
-      node: (
-        <CompareEvaluationsTableButton
-          onClick={() => {
-            history.push(
-              router.compareEvaluationsUri(entity, project, selectedCalls)
-            );
-          }}
-          disabled={selectedCalls.length === 0}
-        />
-      ),
-      order: 1,
-    });
-
-    return () => removeExtra('compareEvaluations');
-  }, [
-    apiRef,
-    addExtra,
-    removeExtra,
-    isEvaluateTable,
-    selectedCalls.length,
-    selectedCalls,
-    tableData,
-    router,
-    entity,
-    project,
-    history,
-  ]);
 
   // We really want to use columns here, but because visibleColumns
   // is a prop to ExportSelector, it causes infinite reloads.
@@ -709,6 +672,16 @@ export const CallsTable: FC<{
                   parentId: undefined,
                 });
               }}
+            />
+          )}
+          {isEvaluateTable && (
+            <CompareEvaluationsTableButton
+              onClick={() => {
+                history.push(
+                  router.compareEvaluationsUri(entity, project, selectedCalls)
+                );
+              }}
+              disabled={selectedCalls.length === 0}
             />
           )}
           {!isReadonly && (


### PR DESCRIPTION
Follow up to https://github.com/wandb/weave/pull/2191
After consulting with @adamwdraper this is where the Compare button should go in preparation for a top Saved Views header.

Before:
<img width="737" alt="Screenshot 2024-08-22 at 1 26 34 PM" src="https://github.com/user-attachments/assets/e02f1fd5-0c0b-4baa-b7a7-0038df79eac4">

After:
<img width="731" alt="Screenshot 2024-08-22 at 1 26 04 PM" src="https://github.com/user-attachments/assets/e2417cb0-db52-40bb-8624-a1e4adc96d8f">


Note that after this change I think the WeaveHeaderExtrasContext is unused and we should consider removing it.