### PR TITLE
fix: useCall can set stale cache results

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -191,7 +191,7 @@ const useCall = (key: CallKey | null): Loadable<CallSchema | null> => {
   }, [getTsClient, doFetch]);
 
   return useMemo(() => {
-    if (key == null) {
+    if (deepKey == null) {
       return {
         loading: false,
         result: null,
@@ -214,14 +214,14 @@ const useCall = (key: CallKey | null): Loadable<CallSchema | null> => {
       };
     } else {
       if (result) {
-        callCache.set(key, result);
+        callCache.set(deepKey, result);
       }
       return {
         loading: false,
         result,
       };
     }
-  }, [cachedCall, callRes, key]);
+  }, [cachedCall, callRes, deepKey]);
 };
 
 const useCallsNoExpansion = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -238,7 +238,6 @@ const useCallsNoExpansion = (
   offset?: number,
   sortBy?: traceServerTypes.SortBy[],
   query?: Query,
-  columns?: string[],
   opts?: {skip?: boolean; refetchOnDelete?: boolean}
 ): Loadable<CallSchema[]> => {
   const getTsClient = useGetTraceServerClientContext();
@@ -270,7 +269,6 @@ const useCallsNoExpansion = (
       offset,
       sort_by: sortBy,
       query,
-      columns,
     };
     const onSuccess = (res: traceServerTypes.TraceCallsQueryRes) => {
       loadingRef.current = false;
@@ -292,7 +290,6 @@ const useCallsNoExpansion = (
     offset,
     sortBy,
     query,
-    columns,
   ]);
 
   // register doFetch as a callback after deletion
@@ -334,24 +331,22 @@ const useCallsNoExpansion = (
         result: [],
       };
     } else {
-      if (!columns) {
-        allResults.forEach(call => {
-          callCache.set(
-            {
-              entity,
-              project,
-              callId: call.callId,
-            },
-            call
-          );
-        });
-      }
+      allResults.forEach(call => {
+        callCache.set(
+          {
+            entity,
+            project,
+            callId: call.callId,
+          },
+          call
+        );
+      });
       return {
         loading: false,
         result,
       };
     }
-  }, [callRes, entity, project, opts?.skip, columns]);
+  }, [callRes, entity, project, opts?.skip]);
 };
 
 const useCalls = (
@@ -362,7 +357,6 @@ const useCalls = (
   offset?: number,
   sortBy?: traceServerTypes.SortBy[],
   query?: Query,
-  columns?: string[],
   expandedRefColumns?: Set<string>,
   opts?: {skip?: boolean; refetchOnDelete?: boolean}
 ): Loadable<CallSchema[]> => {
@@ -374,7 +368,6 @@ const useCalls = (
     offset,
     sortBy,
     query,
-    columns,
     opts
   );
 
@@ -993,7 +986,6 @@ const useChildCallsForCompare = (
     undefined,
     undefined,
     undefined,
-    undefined,
     {skip: skipParent}
   );
 
@@ -1011,7 +1003,6 @@ const useChildCallsForCompare = (
       parentIds: subParentCallIds,
       opVersionRefs: selectedOpVersionRef ? [selectedOpVersionRef] : [],
     },
-    undefined,
     undefined,
     undefined,
     undefined,


### PR DESCRIPTION
Pernicious little bug that was causing me hassles. Not sure of the best way to fix this, but this does solve the problem...

`useCall` is a hook, so we expect keys to change and have the result change as well. As written in master, while we handle key changes (with deepmemo), we actually return the previous result before calling `doFetch`. We not only return the old result, but we set the cache with the **new** key to the **old result**!

Note: I think this affects all the hooks that use this pattern...