### PR TITLE
fix: code query returns twice, breaking loading state

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -1216,7 +1216,7 @@ const useCodeForOpRef = (opVersionRef: string): Loadable<string> => {
     {skip: fileSpec == null}
   );
   const text = useMemo(() => {
-    if (arrayBuffer.loading) {
+    if (arrayBuffer.loading || query.loading) {
       return {
         loading: true,
         result: null,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -1228,7 +1228,7 @@ const useCodeForOpRef = (opVersionRef: string): Loadable<string> => {
         ? new TextDecoder().decode(arrayBuffer.result)
         : null,
     };
-  }, [arrayBuffer.loading, arrayBuffer.result]);
+  }, [arrayBuffer.loading, arrayBuffer.result, query.loading]);
 
   return text;
 };


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-20522

Query returns while internal query is still loading, so we flash the "code not found" message. 

Prod:
![loading-double-prod](https://github.com/user-attachments/assets/6929fab6-4e26-420b-8215-fa394b22eb3a)

This branch:
![loading-double-branch](https://github.com/user-attachments/assets/e53a3242-d77b-4867-8dde-ce4dcd1df3af)
