### PR TITLE
chore: update data table UI row limit to 10k

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
@@ -31,7 +31,7 @@ import {useWFHooks} from '../wfReactInterface/context';
 import {TableQuery} from '../wfReactInterface/wfDataModelHooksInterface';
 
 // Controls the maximum number of rows to display in the table
-const MAX_ROWS = 1000;
+const MAX_ROWS = 10_000;
 
 // Controls whether to use a table for arrays or not.
 export const USE_TABLE_FOR_ARRAYS = false;


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-20533

To test this, I updated the `wf` script's dataset add functionality and tried with 2k and 20k row datasets. It loads slowly but under 10s for larger and UI works.