### PR TITLE
chore: update LinearProgress styling

### DIFF
--- a/weave-js/src/components/LinearProgress.tsx
+++ b/weave-js/src/components/LinearProgress.tsx
@@ -1,0 +1,25 @@
+/**
+ * Styled linear progress bar.
+ */
+
+import MuiLinearProgress, {
+  LinearProgressProps as MuiLinearProgressProps,
+} from '@mui/material/LinearProgress';
+import React from 'react';
+
+import * as Colors from '../common/css/color.styles';
+
+export const LinearProgress = (props: MuiLinearProgressProps) => {
+  return (
+    <MuiLinearProgress
+      {...props}
+      sx={{
+        backgroundColor: Colors.TEAL_300,
+        '& .MuiLinearProgress-bar': {
+          backgroundColor: Colors.TEAL_400,
+        },
+        height: 3, // Default is 4px
+      }}
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/compareEvaluationsContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/compareEvaluationsContext.tsx
@@ -1,7 +1,8 @@
-import {Box, LinearProgress} from '@material-ui/core';
+import {Box} from '@material-ui/core';
 import React, {useMemo} from 'react';
 
 import {WeaveLoader} from '../../../../../../common/components/WeaveLoader';
+import {LinearProgress} from '../../../../../LinearProgress';
 import {useEvaluationComparisonState} from './ecpState';
 import {EvaluationComparisonState} from './ecpState';
 import {ComparisonDimensionsType} from './ecpState';


### PR DESCRIPTION
Evaluation comparison was using a default styled MUI progress indicator. Add some styling to make it more harmonious with our palette.

Before:
<img width="1415" alt="Screenshot 2024-08-23 at 5 30 34 PM" src="https://github.com/user-attachments/assets/bea6d18b-9a08-4f80-b4c2-bcf5e4a34627">

After:
<img width="1424" alt="Screenshot 2024-08-23 at 5 30 51 PM" src="https://github.com/user-attachments/assets/32d08bfc-a79f-477d-bb9d-c99adf2c2ee1">
