### PR TITLE
chore(weave): Update client func names to be less confusing

### DIFF
--- a/weave/integrations/langchain/langchain.py
+++ b/weave/integrations/langchain/langchain.py
@@ -182,7 +182,7 @@ if not import_failed:
                             # Note: this is implemented as a network call - it would be much nice
                             # to refactor `create_call` such that it could accept a parent_id instead
                             # of an entire Parent object.
-                            parent_run = self.gc.call(wv_current_run.parent_id)
+                            parent_run = self.gc.get_call(wv_current_run.parent_id)
 
             fn_name = make_pythonic_function_name(run.name)
             complete_op_name = f"langchain.{run.run_type.capitalize()}.{fn_name}"

--- a/weave/refs.py
+++ b/weave/refs.py
@@ -35,5 +35,5 @@ class Refs(AbstractRichContainer[str]):
         for ref in self.call_refs():
             parsed = parse_uri(ref)
             assert isinstance(parsed, CallRef)
-            objs.append(client.call(parsed.id))
+            objs.append(client.get_call(parsed.id))
         return objs

--- a/weave/weave_client.py
+++ b/weave/weave_client.py
@@ -5,7 +5,7 @@ import sys
 import typing
 import warnings
 from functools import lru_cache, wraps
-from typing import Any, Dict, Iterator, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Iterator, Optional, Sequence, Union
 
 import pydantic
 from requests import HTTPError
@@ -60,10 +60,10 @@ if typing.TYPE_CHECKING:
 ALLOW_MIXED_PROJECT_REFS = False
 
 
-def deprecated(new_name: str):
-    def deco(func):
+def deprecated(new_name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def deco(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             warnings.warn(
                 f"{func.__name__} is deprecated and will be removed in a future version. Use {new_name} instead.",
                 DeprecationWarning,
@@ -759,7 +759,7 @@ class WeaveClient:
         offset: int = 0,
         limit: int = 100,
     ) -> FeedbackQuery:
-        return self.get_feedback(query, reaction, offset, limit)
+        return self.get_feedback(query, reaction=reaction, offset=offset, limit=limit)
 
     ################ Internal Helpers ################
 


### PR DESCRIPTION
## Summary
1. For clarity, renames:
    1. `call -> get_call`
    2. `calls -> get_calls`
    3. `feedback -> get_feedback`
2. This lines up with other methods like:
    1. `finish_call`
    2. `fail_call`.
3. Deprecates the functions `call`, `calls`, and `feedback`, adding warnings to update to the new name

## Resolves
- https://wandb.atlassian.net/browse/WB-20562

