### PR TITLE
chore(weave): Legacy Refactor pt6

### DIFF
--- a/weave/legacy/arrow/list_.py
+++ b/weave/legacy/arrow/list_.py
@@ -12,7 +12,6 @@ import typing_extensions
 
 from weave import (
     errors,
-    node_ref,
     ref_base,
     ref_util,
     weave_internal,
@@ -27,6 +26,7 @@ from weave.legacy import (
     graph,
     op_def,
     op_def_type,
+    node_ref,
 )
 from weave.legacy.arrow.arrow import (
     ArrowWeaveListType,

--- a/weave/legacy/artifact_wandb.py
+++ b/weave/legacy/artifact_wandb.py
@@ -14,7 +14,6 @@ from wandb.apis.public import api as wb_public
 from wandb.sdk.lib.hashutil import b64_to_hex_id, hex_to_b64_id
 
 from weave import (
-    eager,
     engine_trace,
     errors,
     filesystem,
@@ -24,6 +23,7 @@ from weave import (
 from weave import weave_types as types
 from weave.legacy import (
     artifact_fs,
+    eager,
     file_base,
     file_util,
     memo,

--- a/weave/legacy/compile.py
+++ b/weave/legacy/compile.py
@@ -9,7 +9,6 @@ from weave import (
     engine_trace,
     errors,
     registry_mem,
-    stitch,
     weave_internal,
 )
 from weave import weave_types as types
@@ -28,6 +27,7 @@ from weave.legacy import (
     partial_object,
     propagate_gql_keys,
     serialize,
+    stitch,
     value_or_error,
 )
 from weave.legacy.language_features.tagging import tagged_value_type_helpers

--- a/weave/legacy/compile_domain.py
+++ b/weave/legacy/compile_domain.py
@@ -2,9 +2,9 @@ import typing
 
 import graphql
 
-from weave import errors, registry_mem, stitch
+from weave import errors, registry_mem
 from weave import weave_types as types
-from weave.legacy import gql_op_plugin, gql_to_weave, graph, op_args
+from weave.legacy import gql_op_plugin, gql_to_weave, graph, op_args, stitch
 from weave.legacy.input_provider import InputAndStitchProvider
 
 if typing.TYPE_CHECKING:

--- a/weave/legacy/compile_table.py
+++ b/weave/legacy/compile_table.py
@@ -2,7 +2,8 @@
 
 import typing
 
-from weave import errors, stitch
+from weave import errors
+from weave.legacy import stitch
 
 KeyTree = typing.Dict[str, "KeyTree"]  # type:ignore
 

--- a/weave/legacy/decorator_op.py
+++ b/weave/legacy/decorator_op.py
@@ -4,9 +4,9 @@ from typing import Callable, Optional, TypeVar
 
 from typing_extensions import ParamSpec
 
-from weave import pyfunc_type_util, registry_mem
+from weave import registry_mem
 from weave import weave_types as types
-from weave.legacy import context_state, derive_op, op_args, op_def
+from weave.legacy import context_state, derive_op, op_args, op_def, pyfunc_type_util
 
 if typing.TYPE_CHECKING:
     from weave.legacy.gql_op_plugin import GqlOpPlugin

--- a/weave/legacy/dispatch.py
+++ b/weave/legacy/dispatch.py
@@ -5,9 +5,9 @@ import logging
 import typing
 from dataclasses import dataclass
 
-from weave import errors, pyfunc_type_util, registry_mem, util
+from weave import errors, registry_mem, util
 from weave import weave_types as types
-from weave.legacy import graph, memo, op_args, op_def
+from weave.legacy import graph, memo, op_args, op_def, pyfunc_type_util
 from weave.legacy.language_features.tagging.is_tag_getter import is_tag_getter
 from weave.legacy.language_features.tagging.tagged_value_type import TaggedValueType
 

--- a/weave/legacy/eager.py
+++ b/weave/legacy/eager.py
@@ -2,8 +2,8 @@ import typing
 
 from weave.legacy import context_state, graph
 
-from . import weave_internal
-from . import weave_types as types
+from .. import weave_internal
+from .. import weave_types as types
 
 WeaveIterObjectType = typing.TypeVar("WeaveIterObjectType")
 

--- a/weave/legacy/execute.py
+++ b/weave/legacy/execute.py
@@ -10,7 +10,6 @@ import typing
 from collections.abc import Mapping
 
 from weave import (
-    eager,
     engine_trace,
     environment,
     errors,
@@ -32,6 +31,7 @@ from weave.legacy import (
     compile,
     context,
     context_state,
+    eager,
     forward_graph,
     graph,
     graph_debug,

--- a/weave/legacy/graph_mapper.py
+++ b/weave/legacy/graph_mapper.py
@@ -1,6 +1,6 @@
-from weave import node_ref, ref_base
+from weave import ref_base
 from weave import weave_types as types
-from weave.legacy import graph, mappers
+from weave.legacy import graph, mappers, node_ref
 from weave.legacy import mappers_python_def as mappers_python
 
 

--- a/weave/legacy/input_provider.py
+++ b/weave/legacy/input_provider.py
@@ -2,7 +2,7 @@ import json
 import typing
 from dataclasses import dataclass, field
 
-from .. import stitch
+from . import stitch
 
 
 @dataclass

--- a/weave/legacy/mappers_arrow.py
+++ b/weave/legacy/mappers_arrow.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 
 import pyarrow as pa
 
-from weave import errors, node_ref, ref_base
+from weave import errors, ref_base
 from weave import weave_types as types
 from weave.legacy import (
     arrow_util,
@@ -13,6 +13,7 @@ from weave.legacy import (
     box,
     mappers,
     mappers_weave,
+    node_ref,
     partial_object,
 )
 from weave.legacy import mappers_python_def as mappers_python

--- a/weave/legacy/mappers_publisher.py
+++ b/weave/legacy/mappers_publisher.py
@@ -4,7 +4,7 @@ import typing
 
 from weave import errors, ref_base, storage, weave_internal
 from weave import weave_types as types
-from weave.node_ref import ref_to_node
+from weave.legacy.node_ref import ref_to_node
 
 # from weave.legacy.ops_primitives import weave_api
 from weave.legacy import (

--- a/weave/legacy/node_ref.py
+++ b/weave/legacy/node_ref.py
@@ -3,7 +3,7 @@ import typing
 
 from weave.legacy import graph
 
-from . import ref_base
+from .. import ref_base
 
 # Notes for the future:
 # - I added list.lookup to lookup rows in a list by ID. I think we probably should

--- a/weave/legacy/op_def.py
+++ b/weave/legacy/op_def.py
@@ -9,7 +9,6 @@ from typing import Iterator, Sequence
 from weave import (
     engine_trace,
     errors,
-    pyfunc_type_util,
     weave_internal,
 )
 from weave import weave_types as types
@@ -22,6 +21,7 @@ from weave.legacy import (
     op_args,
     op_def_type,
     op_execute,
+    pyfunc_type_util,
     uris,
 )
 from weave.legacy.language_features.tagging import (

--- a/weave/legacy/pyfunc_type_util.py
+++ b/weave/legacy/pyfunc_type_util.py
@@ -3,8 +3,8 @@ import typing
 
 from weave.legacy import infer_types, op_args
 
-from . import errors
-from . import weave_types as types
+from .. import errors
+from .. import weave_types as types
 
 InputTypeItemType = typing.Union[types.Type, typing.Callable[..., types.Type]]
 InputTypeType = typing.Union[op_args.OpArgs, typing.Mapping[str, InputTypeItemType]]

--- a/weave/legacy/run_streamtable_span.py
+++ b/weave/legacy/run_streamtable_span.py
@@ -2,7 +2,7 @@ import typing
 from typing import Iterable
 
 from weave.legacy import stream_data_interfaces
-from weave.eager import WeaveIter
+from weave.legacy.eager import WeaveIter
 from weave.legacy import artifact_wandb, uris
 from weave.legacy.run import Run
 

--- a/weave/legacy/show.py
+++ b/weave/legacy/show.py
@@ -5,8 +5,8 @@ import urllib
 
 from IPython.display import IFrame, display
 
-from weave.legacy import artifact_fs, context, graph, ops, panel
-from weave import errors, node_ref, ref_base, storage, util
+from weave.legacy import artifact_fs, context, graph, ops, node_ref, panel
+from weave import errors, ref_base, storage, util
 from . import usage_analytics
 from .. import weave_types as types
 from . import weavejs_fixes

--- a/weave/legacy/stitch.py
+++ b/weave/legacy/stitch.py
@@ -25,9 +25,9 @@ import typing
 from weave.legacy import graph, op_def
 from weave.legacy.language_features.tagging import opdef_util
 
-from . import errors, registry_mem
-from . import weave_types as types
-from .legacy import _dict_utils
+from .. import errors, registry_mem
+from .. import weave_types as types
+from . import _dict_utils
 
 
 @dataclasses.dataclass

--- a/weave/serve_fastapi.py
+++ b/weave/serve_fastapi.py
@@ -12,12 +12,12 @@ try:
 except ImportError:
     from typing_extensions import Annotated  # type: ignore
 
-from weave.legacy import cache, op_args
+from weave.legacy import cache, op_args, pyfunc_type_util
 from weave.legacy.wandb_api import WandbApiAsync
 from weave.trace.op import Op
 from weave.trace.refs import ObjectRef
 
-from . import errors, pyfunc_type_util, weave_pydantic
+from . import errors, weave_pydantic
 
 key_cache: cache.LruTimeWindowCache[str, typing.Optional[bool]] = (
     cache.LruTimeWindowCache(datetime.timedelta(minutes=5))

--- a/weave/tests/legacy/test_node_ref.py
+++ b/weave/tests/legacy/test_node_ref.py
@@ -1,7 +1,7 @@
 from weave.legacy import graph
 
 from ... import api as weave
-from ... import node_ref
+from ...legacy import node_ref
 
 
 def test_node_to_ref():

--- a/weave/tests/legacy/test_stitch.py
+++ b/weave/tests/legacy/test_stitch.py
@@ -8,7 +8,8 @@ from weave.legacy import context_state as _context
 from weave.legacy.language_features.tagging import make_tag_getter_op
 from weave.legacy.ops_domain import run_ops
 
-from ... import stitch, weave_internal
+from ... import weave_internal
+from ...legacy import stitch
 from .. import fixture_fakewandb as fwb
 from . import test_wb
 

--- a/weave/tests/legacy/test_wb.py
+++ b/weave/tests/legacy/test_wb.py
@@ -7,9 +7,8 @@ import pytest
 import wandb
 
 from weave import query_api as weave
-from weave import stitch
 from weave import weave_types as types
-from weave.legacy import artifact_fs, artifact_wandb, compile, graph, ops, uris
+from weave.legacy import artifact_fs, artifact_wandb, compile, graph, ops, stitch, uris
 from weave.legacy import ops_arrow as arrow
 from weave.legacy.language_features.tagging.tagged_value_type import TaggedValueType
 from weave.legacy.ops_arrow import ArrowWeaveListType


### PR DESCRIPTION
Split out from: https://github.com/wandb/weave/pull/2182

This slice moves the following to `legacy`:
- `eager`
- `stitch`
- `pyfunc_type_util`
- `node_ref`