### PR TITLE
fix: object with dupe ref not loading in ui

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -142,6 +142,8 @@ export const ObjectViewer = ({
       if (
         isRef(context.value) &&
         refValues[context.value] != null &&
+        // If this is a ref and the parent has been visited, we already resolved
+        // this ref. Example: `a._ref` where `a` is already in resolvedRefPaths
         !resolvedRefPaths.has(context.parent?.toString() ?? '')
       ) {
         dirty = true;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -139,13 +139,10 @@ export const ObjectViewer = ({
     let dirty = true;
     const resolvedRefPaths = new Set<string>();
     const mapper = (context: TraverseContext) => {
-      const parentPathStr = context.path
-        .ancestor(context.path.length() - 1)
-        .toString();
       if (
         isRef(context.value) &&
         refValues[context.value] != null &&
-        !resolvedRefPaths.has(parentPathStr)
+        !resolvedRefPaths.has(context.parent?.toString() ?? '')
       ) {
         dirty = true;
         const res = refValues[context.value];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -137,11 +137,19 @@ export const ObjectViewer = ({
     }
     let resolved = data;
     let dirty = true;
+    const resolvedRefPaths = new Set<string>();
     const mapper = (context: TraverseContext) => {
-      if (isRef(context.value) && refValues[context.value] != null) {
+      const parentPathStr = context.path
+        .ancestor(context.path.length() - 1)
+        .toString();
+      if (
+        isRef(context.value) &&
+        refValues[context.value] != null &&
+        !resolvedRefPaths.has(parentPathStr)
+      ) {
         dirty = true;
         const res = refValues[context.value];
-        delete refValues[context.value];
+        resolvedRefPaths.add(context.path.toString());
         return res;
       }
       return _.clone(context.value);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
@@ -196,6 +196,7 @@ export type TraverseContext = {
   valueType: ValueType;
   isLeaf: boolean;
   depth: number;
+  parent?: ObjectPath;
 };
 
 type CallbackResult = void | boolean | 'skip';
@@ -256,6 +257,7 @@ export const traverse = (
           value,
           valueType: itemValueType,
           isLeaf: isLeafType(itemValueType),
+          parent: context.path,
           path: context.path.plus(i),
           depth: context.depth + 1,
         });
@@ -270,6 +272,7 @@ export const traverse = (
           value,
           valueType: itemValueType,
           isLeaf: isLeafType(itemValueType),
+          parent: context.path,
           path: context.path.plus(key),
           depth: context.depth + 1,
         });


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-18553

This pr slightly changes the way we render refs in the object viewer. During replacement of refs with values, instead of relying on deleting refs once we see them, keep track of if we replaced. Currently we don't handle the case when we might want to replace multiple identical refs, as we have already deleted the ref from our lookup. 

Prod:
<img width="1239" alt="Screenshot 2024-08-27 at 12 41 58 PM" src="https://github.com/user-attachments/assets/7761c248-27b4-4cf8-b249-83806bd6ca79">


This branch:
<img width="1202" alt="Screenshot 2024-08-27 at 12 42 42 PM" src="https://github.com/user-attachments/assets/b0cf40fa-e336-46b1-9b52-5e6d662c9e0a">


