### PR TITLE
chore: don't resolve table refs in call_stream ref expansion

### DIFF
--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -1334,3 +1334,27 @@ def test_ref_in_dict(client):
 
     obj = weave.ref(ref2.uri()).get()
     assert obj["b"] == {"a": 5}
+
+
+def test_calls_stream_table_ref_expansion(client):
+    class ObjWithTable(weave.Object):
+        table: weave_client.Table
+
+    o = ObjWithTable(table=weave_client.Table([{"a": 1}, {"a": 2}, {"a": 3}]))
+    client._save_object(o, "my-obj")
+
+    @weave.op
+    def f(a):
+        return {"a": a, "table": o.table}
+
+    f(1)
+
+    calls = client.server.calls_query_stream(
+        req=tsi.CallsQueryReq(
+            project_id=client._project_id(),
+            expand_columns=["output.table"],
+        )
+    )
+    calls = list(calls)
+    assert len(calls) == 1
+    assert calls[0].output["table"] == o.table.table_ref.uri()

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -397,6 +397,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 if isinstance(parsed_ref, refs_internal.InternalTableRef):
                     refs_to_resolve.pop((i, col))
                     parsed_raw_refs.pop(i)
+                    refs.pop(i)
 
             parsed_refs = typing.cast(ObjRefListType, parsed_raw_refs)
             vals = self._refs_read_batch_within_project(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -354,8 +354,10 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
     def _get_refs_to_resolve(
         self, calls: list[dict[str, typing.Any]], expand_columns: typing.List[str]
-    ) -> typing.Dict[tuple[int, str], str]:
-        refs_to_resolve: typing.Dict[tuple[int, str], str] = {}
+    ) -> typing.Dict[tuple[int, str], refs_internal.InternalObjectRef]:
+        refs_to_resolve: typing.Dict[
+            tuple[int, str], refs_internal.InternalObjectRef
+        ] = {}
         for i, call in enumerate(calls):
             for col in expand_columns:
                 if col in call:
@@ -368,7 +370,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 if not refs_internal.any_will_be_interpreted_as_ref_str(val):
                     continue
 
-                refs_to_resolve[(i, col)] = val
+                ref = refs_internal.parse_internal_uri(val)
+                if isinstance(ref, refs_internal.InternalTableRef):
+                    continue
+
+                refs_to_resolve[(i, col)] = ref
         return refs_to_resolve
 
     def _expand_call_refs(
@@ -390,20 +396,10 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             if not refs_to_resolve:
                 continue
 
-            parsed_raw_refs = [
-                refs_internal.parse_internal_uri(r)
-                for r in list(refs_to_resolve.values())
-            ]
-            # Remove table refs from refs_to_resolve
-            for i, parsed_ref in enumerate(parsed_raw_refs):
-                if isinstance(parsed_ref, refs_internal.InternalTableRef):
-                    refs_to_resolve.pop((i, col))
-                    parsed_raw_refs.pop(i)
-
             vals = self._refs_read_batch_within_project(
-                project_id, typing.cast(ObjRefListType, parsed_raw_refs), ref_cache
+                project_id, list(refs_to_resolve.values()), ref_cache
             )
-            for (i, col), val, ref in zip(refs_to_resolve, vals, parsed_raw_refs):
+            for ((i, col), ref), val in zip(refs_to_resolve.items(), vals):
                 if isinstance(val, dict) and "_ref" not in val:
                     val["_ref"] = ref.uri()
                 set_nested_key(calls[i], col, val)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -392,6 +392,12 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
             refs = list(refs_to_resolve.values())
             parsed_raw_refs = [refs_internal.parse_internal_uri(r) for r in refs]
+            # Remove table refs from refs_to_resolve
+            for i, parsed_ref in enumerate(parsed_raw_refs):
+                if isinstance(parsed_ref, refs_internal.InternalTableRef):
+                    refs_to_resolve.pop((i, col))
+                    parsed_raw_refs.pop(i)
+
             parsed_refs = typing.cast(ObjRefListType, parsed_raw_refs)
             vals = self._refs_read_batch_within_project(
                 project_id, parsed_refs, ref_cache

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -498,6 +498,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             if not any_will_be_interpreted_as_ref_str(val):
                 continue
 
+            if isinstance(parse_internal_uri(val), InternalTableRef):
+                continue
+
             derefed_val = self.refs_read_batch(tsi.RefsReadBatchReq(refs=[val])).vals[0]
             set_nested_key(data, col, derefed_val)
 


### PR DESCRIPTION
[DD trace](https://app.datadoghq.com/apm/services/weave-trace/operations/fastapi.request/resources?query=env%3Aprod%20operation_name%3Afastapi.request%20service%3Aweave-trace&dependencyMap=qson%3A%28data%3A%28telemetrySelection%3Aall_sources%29%2Cversion%3A%210%29&deployments=qson%3A%28data%3A%28hits%3A%28selected%3Aversion_count%29%2Cerrors%3A%28selected%3Aversion_count%29%2Clatency%3A%2195%2CtopN%3A%215%29%2Cversion%3A%210%29&env=prod&errors=qson%3A%28data%3A%28issueSort%3ATOTAL_COUNT%29%2Cversion%3A%210%29&fromUser=false&graphType=flamegraph&groupMapByOperation=null&infrastructure=qson%3A%28data%3A%28viewType%3Apods%29%2Cversion%3A%210%29&isInferred=false&logs=qson%3A%28data%3A%28indexes%3A%5B%5D%29%2Cversion%3A%210%29&panels=qson%3A%28data%3A%28activePanelKey%3Atrace%2Ctrace%3A%28traceID%3A66ce906300000000d5c1655bef1e04e0%2CspanID%3A2225772455963247578%29%29%2Cversion%3A%210%29&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap99.9%29%2CtopN%3A%215%29%2Cversion%3A%211%29&s3BucketDetails=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&shouldShowLegend=true&sort=time&spanID=2225772455963247578&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A95%29%2Cdistribution%3A%28isLogScale%3A%21f%29%2CshowTraceOutliers%3A%21t%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%2ClagMetrics%3A%28selectedMetric%3A%21s%2CselectedGroupBy%3A%21s%29%29%2Cversion%3A%211%29&timeHint=1724813411898&topGraphs=latency%3Alatency%2Chits%3Aversion_count%2Cerrors%3Aversion_count%2CbreakdownAs%3Apercentage&trace=AgAAAZGW5AY6xtj8VQAAAAAAAAAYAAAAAEFaR1c1QXhpQUFCNFZBRjA0c0hFanNIVgAAACQAAAAAMDE5MTk2ZTQtMWM1NC00NGY3LWIxOGYtN2QzZmMwZjZlMGI5&traceID=66ce906300000000d5c1655bef1e04e0&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&view=spans&start=1724209003270&end=1724813803270&paused=false)

`refs_read_batch` doesn't like tableRefs, filter them out, even if explicitly provided in `expand_columns`