### PR TITLE
chore(weave): Add {started,ended,deleted}_at attributes to high level Call object

### DIFF
--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ValidationError
 
 import weave
 from weave import Thread, ThreadPoolExecutor
+from weave.tests.trace.util import DatetimeMatcher
 from weave.trace import weave_client
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace.weave_client import sanitize_object_name
@@ -86,6 +87,9 @@ def test_simple_op(client):
                 "sys_version": sys.version,
             },
         },
+        started_at=DatetimeMatcher(),
+        ended_at=None,
+        deleted_at=None,
     )
 
 

--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -88,7 +88,7 @@ def test_simple_op(client):
             },
         },
         started_at=DatetimeMatcher(),
-        ended_at=None,
+        ended_at=DatetimeMatcher(),
         deleted_at=None,
     )
 

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import datetime
 import json
 import platform
 import re
@@ -45,6 +46,11 @@ class RegexStringMatcher(str):
         if not isinstance(other_string, str):
             return NotImplemented
         return bool(re.match(self.pattern, other_string))
+
+
+class DatetimeMatcher:
+    def __eq__(self, other: datetime.datetime):
+        return isinstance(other, datetime.datetime)
 
 
 def test_table_create(client):
@@ -308,6 +314,9 @@ def test_calls_query(client):
                 "sys_version": sys.version,
             },
         },
+        started_at=DatetimeMatcher(),
+        ended_at=None,
+        deleted_at=None,
     )
     assert result[1] == weave_client.Call(
         op_name="weave:///shawn/test-project/op/x:tzUhDyzVm5bqQsuqh5RT4axEXSosyLIYZn9zbRyenaw",
@@ -326,6 +335,9 @@ def test_calls_query(client):
                 "sys_version": sys.version,
             },
         },
+        started_at=DatetimeMatcher(),
+        ended_at=None,
+        deleted_at=None,
     )
     client.finish_call(call2, None)
     client.finish_call(call1, None)

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -1,9 +1,7 @@
 import asyncio
 import dataclasses
-import datetime
 import json
 import platform
-import re
 import sys
 
 import pydantic
@@ -14,6 +12,7 @@ import weave
 import weave.trace_server.trace_server_interface as tsi
 from weave import Evaluation
 from weave.legacy.weave import op_def
+from weave.tests.trace.util import DatetimeMatcher, RegexStringMatcher
 from weave.trace import refs, weave_client
 from weave.trace.isinstance import weave_isinstance
 from weave.trace.op import Op
@@ -34,23 +33,6 @@ from weave.trace_server.trace_server_interface import (
     TableQueryReq,
     TableSchemaForInsert,
 )
-
-pytestmark = pytest.mark.trace
-
-
-class RegexStringMatcher(str):
-    def __init__(self, pattern):
-        self.pattern = pattern
-
-    def __eq__(self, other_string):
-        if not isinstance(other_string, str):
-            return NotImplemented
-        return bool(re.match(self.pattern, other_string))
-
-
-class DatetimeMatcher:
-    def __eq__(self, other):
-        return isinstance(other, datetime.datetime)
 
 
 def test_table_create(client):

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -49,7 +49,7 @@ class RegexStringMatcher(str):
 
 
 class DatetimeMatcher:
-    def __eq__(self, other: datetime.datetime):
+    def __eq__(self, other):
         return isinstance(other, datetime.datetime)
 
 

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -269,6 +269,9 @@ def test_call_create(client):
                 "sys_version": sys.version,
             },
         },
+        started_at=DatetimeMatcher(),
+        ended_at=DatetimeMatcher(),
+        deleted_at=None,
     )
     assert dataclasses.asdict(result._val) == dataclasses.asdict(expected)
 

--- a/weave/tests/trace/util.py
+++ b/weave/tests/trace/util.py
@@ -1,0 +1,17 @@
+import datetime
+import re
+
+
+class RegexStringMatcher(str):
+    def __init__(self, pattern):
+        self.pattern = pattern
+
+    def __eq__(self, other_string):
+        if not isinstance(other_string, str):
+            return NotImplemented
+        return bool(re.match(self.pattern, other_string))
+
+
+class DatetimeMatcher:
+    def __eq__(self, other):
+        return isinstance(other, datetime.datetime)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -145,6 +145,9 @@ class Call:
     summary: Optional[dict] = None
     display_name: Optional[str] = None
     attributes: Optional[dict] = None
+    started_at: Optional[datetime.datetime] = None
+    ended_at: Optional[datetime.datetime] = None
+    deleted_at: Optional[datetime.datetime] = None
     # These are the live children during logging
     _children: list["Call"] = dataclasses.field(default_factory=list)
 
@@ -294,6 +297,9 @@ def make_client_call(
         summary=dict(server_call.summary) if server_call.summary is not None else None,
         display_name=server_call.display_name,
         attributes=server_call.attributes,
+        started_at=server_call.started_at,
+        ended_at=server_call.ended_at,
+        deleted_at=server_call.deleted_at,
     )
     if call.id is None:
         raise ValueError("Call ID is None")


### PR DESCRIPTION
These seem to be missing, and are required to satisfy the updated tests in: https://github.com/wandb/weave/pull/2260