### PR TITLE
fix: feedback grid overflow

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -24,7 +24,9 @@ export const FeedbackGridInner = ({
       field: 'feedback_type',
       headerName: 'Type',
       renderCell: params => (
-        <FeedbackTypeChip feedbackType={params.row.feedback_type} />
+        <div className="overflow-hidden">
+          <FeedbackTypeChip feedbackType={params.row.feedback_type} />
+        </div>
       ),
     },
     {
@@ -45,6 +47,7 @@ export const FeedbackGridInner = ({
     {
       field: 'created_at',
       headerName: 'Timestamp',
+      minWidth: 120,
       width: 120,
       renderCell: params => (
         <Timestamp value={params.row.created_at} format="relative" />
@@ -59,6 +62,7 @@ export const FeedbackGridInner = ({
     {
       field: 'wb_user_id',
       headerName: 'Creator',
+      minWidth: 150,
       width: 150,
       // Might be confusing to enable as-is, because the user sees name /
       // email but the underlying data is userId.
@@ -100,6 +104,7 @@ export const FeedbackGridInner = ({
   const rows = feedback;
   return (
     <StyledDataGrid
+      autosizeOnMount
       // Start Column Menu
       // ColumnMenu is only needed when we have other actions
       // such as filtering.


### PR DESCRIPTION
Internal Jira: https://wandb.atlassian.net/browse/WB-20602

Autosize to avoid cropping feedback grid type column, and hide overflow rather than having it escape into next column over.

Before:
<img width="838" alt="Screenshot 2024-08-28 at 2 25 37 PM" src="https://github.com/user-attachments/assets/b4ee110a-ee59-4891-b118-da68def0c564">

After:
<img width="837" alt="Screenshot 2024-08-28 at 2 24 48 PM" src="https://github.com/user-attachments/assets/8d442c60-b606-4249-a795-5fd27ff02adb">
