### PR TITLE
chore(weave): CI: Remove extraneous step with linting errors

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,13 +50,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: source /root/venv/bin/activate && pre-commit run --hook-stage=pre-push --all-files
-      - name: Show changes if pre-commit fails
-        if: failure()
-        run: |
-          echo "Files were modified, printing names of changed files"
-          git diff --name-only
-          echo "Failing this step to expand logs in the UI"
-          exit 1
 
   weavejs-lint-compile:
     name: WeaveJS Lint and Compile


### PR DESCRIPTION
We currently expand the wrong thing.  I always have to click the one above it to see the errors!