### PR TITLE
chore(weave): Split out Trace Server bindings

### DIFF
--- a/docs/scripts/generate_python_sdk_docs.py
+++ b/docs/scripts/generate_python_sdk_docs.py
@@ -7,6 +7,8 @@ import re
 import lazydocs
 import pydantic
 
+from weave.trace_server_bindings import remote_http_trace_server
+
 MARKDOWN_HEADER = """"""
 SECTION_SEPARATOR = "---"
 
@@ -265,7 +267,6 @@ def main():
     from weave.trace import feedback, util
     from weave.trace import weave_client as client
     from weave.trace_server import (
-        remote_http_trace_server,
         trace_server_interface,
     )
     from weave.trace_server.interface import query

--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -21,10 +21,10 @@ from weave.legacy.weave.language_features.tagging.tag_store import (
 from weave.trace import weave_init
 from weave.trace_server import (
     clickhouse_trace_server_batched,
-    remote_http_trace_server,
     sqlite_trace_server,
 )
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server_bindings import remote_http_trace_server
 
 from .legacy.weave import logs
 from .tests import fixture_fakewandb

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -2,7 +2,8 @@ import typing
 
 from weave.trace import autopatch, errors, init_message, trace_sentry, weave_client
 from weave.trace.client_context import weave_client as weave_client_context
-from weave.trace_server import remote_http_trace_server, sqlite_trace_server
+from weave.trace_server import sqlite_trace_server
+from weave.trace_server_bindings import remote_http_trace_server
 
 _current_inited_client = None
 

--- a/weave/trace_server/tests/test_remote_http_trace_server.py
+++ b/weave/trace_server/tests/test_remote_http_trace_server.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
-from weave.trace_server.remote_http_trace_server import RemoteHTTPTraceServer
+from weave.trace_server_bindings.remote_http_trace_server import RemoteHTTPTraceServer
 
 
 def generate_start(id) -> tsi.StartedCallSchemaForInsert:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -8,10 +8,9 @@ from pydantic import BaseModel, ValidationError
 
 from weave.legacy.weave.environment import weave_trace_server_url
 from weave.legacy.weave.wandb_interface import project_creator
-
-from . import requests
-from . import trace_server_interface as tsi
-from .async_batch_processor import AsyncBatchProcessor
+from weave.trace_server import requests
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.async_batch_processor import AsyncBatchProcessor
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
1. Splits out `remote_http_trace_server.py` and clarifies its role as a language binding, not part of the server

## Resolves
1. https://wandb.atlassian.net/browse/WB-20422