### PR TITLE
chore(weave): Inline pydantic and dataclass objects

### DIFF
--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -16,6 +16,7 @@ import weave
 from weave import Thread, ThreadPoolExecutor
 from weave.tests.trace.util import DatetimeMatcher
 from weave.trace import weave_client
+from weave.trace.object_record import ObjectRecord
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace.weave_client import sanitize_object_name
 from weave.trace_server import trace_server_interface as tsi
@@ -250,7 +251,7 @@ def simple_line_call_bootstrap(init_wandb: bool = False) -> OpCallSpec:
     # class Number:
     #     value: int
 
-    class Number(BaseModel):
+    class Number(weave.Object):
         value: int
 
     @weave.op()
@@ -427,7 +428,7 @@ def test_trace_call_query_filter_input_object_version_refs(client):
     input_object_version_refs = unique_vals(
         [ref for call in res.calls for ref in extract_refs_from_values(call.inputs)]
     )
-    assert len(input_object_version_refs) > 3
+    assert len(input_object_version_refs) > 3  # > 3
 
     for input_object_version_refs, exp_count in [
         # Test the None case
@@ -1320,13 +1321,25 @@ def test_dataclass_support(client):
 
     assert len(res.calls) == 1
     assert res.calls[0].inputs == {
-        "a": "weave:///shawn/test-project/object/MyDataclass:qDo5jHFme5xIM1LwgeiXXVxYoGnp4LQ9hulqkX5zunY",
-        "b": "weave:///shawn/test-project/object/MyDataclass:We1slmdrWzi2NYSWObBsLybTTNSP4M9zfQbCMf8rQMc",
+        "a": {
+            "_bases": [],
+            "_class_name": "MyDataclass",
+            "_type": "MyDataclass",
+            "val": 1,
+        },
+        "b": {
+            "_bases": [],
+            "_class_name": "MyDataclass",
+            "_type": "MyDataclass",
+            "val": 2,
+        },
     }
-    assert (
-        res.calls[0].output
-        == "weave:///shawn/test-project/object/MyDataclass:2exnZIHkq8DyHTbJzhL0m5Ew1XrqIBCstZWilQS6Lpo"
-    )
+    assert res.calls[0].output == {
+        "_bases": [],
+        "_class_name": "MyDataclass",
+        "_type": "MyDataclass",
+        "val": 3,
+    }
 
 
 def test_op_retrieval(client):
@@ -2759,3 +2772,95 @@ def test_calls_stream_feedback(client):
         "detoned_alias": ":thumbs_up:",
         "emoji": "👍",
     } in call2_payloads
+
+
+def test_inline_dataclass_generates_no_refs_in_function(client):
+    @dataclasses.dataclass
+    class A:
+        b: int
+
+    @weave.op
+    def func(a: A):
+        return A(b=a.b + 1)
+
+    a = A(b=1)
+    func(a)
+
+    res = get_client_trace_server(client).calls_query(
+        tsi.CallsQueryReq(
+            project_id=get_client_project_id(client),
+        )
+    )
+    input_object_version_refs = unique_vals(
+        [ref for call in res.calls for ref in extract_refs_from_values(call.inputs)]
+    )
+    assert len(input_object_version_refs) == 0
+
+    output_object_version_refs = unique_vals(
+        [ref for call in res.calls for ref in extract_refs_from_values(call.output)]
+    )
+    assert len(output_object_version_refs) == 0
+
+
+def test_inline_dataclass_generates_no_refs_in_object(client):
+    @dataclasses.dataclass
+    class A:
+        b: int
+
+    class WeaveObject(weave.Object):
+        a: A
+
+    wo = WeaveObject(a=A(b=1))
+    ref = weave.publish(wo)
+
+    res = get_client_trace_server(client).objs_query(
+        tsi.ObjQueryReq(
+            project_id=get_client_project_id(client),
+        )
+    )
+    assert len(res.objs) == 1  # Just the weave object, and not the dataclass
+
+
+def test_inline_pydantic_basemodel_generates_no_refs_in_function(client):
+    class A(BaseModel):
+        b: int
+
+    @weave.op
+    def func(a: A):
+        return A(b=a.b + 1)
+
+    a = A(b=1)
+    func(a)
+
+    res = get_client_trace_server(client).calls_query(
+        tsi.CallsQueryReq(
+            project_id=get_client_project_id(client),
+        )
+    )
+    input_object_version_refs = unique_vals(
+        [ref for call in res.calls for ref in extract_refs_from_values(call.inputs)]
+    )
+    assert len(input_object_version_refs) == 0
+
+    output_object_version_refs = unique_vals(
+        [ref for call in res.calls for ref in extract_refs_from_values(call.output)]
+    )
+    assert len(output_object_version_refs) == 0
+
+
+def test_inline_pydantic_basemodel_generates_no_refs_in_object(client):
+    class A(BaseModel):
+        b: int
+
+    class WeaveObject(weave.Object):
+        a: A
+
+    wo = WeaveObject(a=A(b=1))
+    ref = weave.publish(wo)
+
+    res = get_client_trace_server(client).objs_query(
+        tsi.ObjQueryReq(
+            project_id=get_client_project_id(client),
+        )
+    )
+    assert len(res.objs) == 1  # Just the weave object, and not the pydantic model

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -827,19 +827,23 @@ class WeaveClient:
             if ref.project == self.project:
                 return
             remove_ref(obj)
+        # Must defer import here to avoid circular import
+        from weave.flow.obj import Object
 
-        if isinstance(obj, (pydantic.BaseModel, pydantic.v1.BaseModel)):
+        if isinstance(obj, Object):
             obj_rec = pydantic_object_record(obj)
             for v in obj_rec.__dict__.values():
                 self._save_nested_objects(v)
             ref = self._save_object_basic(obj_rec, name or get_obj_name(obj_rec))
             obj.__dict__["ref"] = ref
+        elif isinstance(obj, (pydantic.BaseModel, pydantic.v1.BaseModel)):
+            obj_rec = pydantic_object_record(obj)
+            for v in obj_rec.__dict__.values():
+                self._save_nested_objects(v)
         elif dataclasses.is_dataclass(obj) and not isinstance(obj, Ref):
             obj_rec = dataclass_object_record(obj)
             for v in obj_rec.__dict__.values():
                 self._save_nested_objects(v)
-            ref = self._save_object_basic(obj_rec, name or get_obj_name(obj_rec))
-            obj.__dict__["ref"] = ref
         elif isinstance(obj, Table):
             table_ref = self._save_table(obj)
             obj.ref = table_ref


### PR DESCRIPTION
## Summary
1. Inlines pydantic and dataclass objects such that they don't have their own refs, unless explicitly published.
    ```py
    class Something(BaseModel):
        a: str
        b: int
    
    class WeaveObject(weave.Object):
        a: str
        s: Something    
    
    s = Something('a', 2)
    wo = WeaveObject('b', s)
    
    weave.publish(s)   # `s` object gets a ref
    weave.publish(wo)  # `s` object does not get a ref
    ```
  
    This should speed up the write path for deeply nested objects


## Resolves
- https://wandb.atlassian.net/browse/WB-20357