### PR TITLE
chore: Temporarily disable server-side object id validation until new client bakes

### DIFF
--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -26,6 +26,7 @@ from weave.trace_server.trace_server_interface_util import (
     WILDCARD_ARTIFACT_VERSION_AND_PATH,
     extract_refs_from_values,
 )
+from weave.trace_server.validation import SHOULD_ENFORCE_OBJ_ID_CHARSET
 
 pytestmark = pytest.mark.trace
 
@@ -2592,8 +2593,10 @@ def test_object_with_disallowed_keys(client):
             )
         )
     )
-    with pytest.raises(Exception):
-        client.server.obj_create(create_req)
+
+    if SHOULD_ENFORCE_OBJ_ID_CHARSET:
+        with pytest.raises(Exception):
+            client.server.obj_create(create_req)
 
 
 CHAR_LIMIT = 128

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -5,6 +5,12 @@ from weave.trace_server import refs_internal
 
 from . import validation_util
 
+# Ater >95% of users are on weave>=0.51.1, we
+# can set this to true. This will at least ensure
+# that the majority of potentially offending users
+# have client-side protection against this.
+SHOULD_ENFORCE_OBJ_ID_CHARSET = False
+
 
 def project_id_validator(s: str) -> str:
     return validation_util.require_base64(s)
@@ -72,7 +78,8 @@ def _validate_object_name_charset(name: str) -> None:
 
 
 def object_id_validator(s: str) -> str:
-    _validate_object_name_charset(s)
+    if SHOULD_ENFORCE_OBJ_ID_CHARSET:
+       _validate_object_name_charset(s)
     return validation_util.require_max_str_len(s, 128)
 
 

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -79,7 +79,7 @@ def _validate_object_name_charset(name: str) -> None:
 
 def object_id_validator(s: str) -> str:
     if SHOULD_ENFORCE_OBJ_ID_CHARSET:
-       _validate_object_name_charset(s)
+        _validate_object_name_charset(s)
     return validation_util.require_max_str_len(s, 128)
 
 

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -5,10 +5,17 @@ from weave.trace_server import refs_internal
 
 from . import validation_util
 
-# Ater >95% of users are on weave>=0.51.1, we
-# can set this to true. This will at least ensure
-# that the majority of potentially offending users
-# have client-side protection against this.
+# Temporary flag to disable database-side validation of object ids.
+# We want to enable this be default, but we need to wait until >95% of users
+# are on weave>=0.51.1, when we can enforce the charset check on the db
+# side.
+#
+# Actions:
+# 1. (ETA: Sept 30) - Verify that 95% of users are on weave>=0.51.1, or
+#    that 95% of new objects have the valid charset.
+# 2. Remove this flag (thereby setting this to True), and add a check to the
+#    server-side validation code to ensure that the charset is valid.
+# 3. Release and deploy backend.
 SHOULD_ENFORCE_OBJ_ID_CHARSET = False
 
 


### PR DESCRIPTION
Adds new flag:

```
# Ater >95% of users are on weave>=0.51.1, we
# can set this to true. This will at least ensure
# that the majority of potentially offending users
# have client-side protection against this.
SHOULD_ENFORCE_OBJ_ID_CHARSET = False
```