### PR TITLE
chore: better expand ref management in export

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -292,17 +292,18 @@ export const CallsTable: FC<{
       : undefined;
 
   // Column Management: Build the columns needed for the table
-  const {columns, setUserDefinedColumnWidths} = useCallsTableColumns(
-    entity,
-    project,
-    effectiveFilter,
-    tableData,
-    expandedRefCols,
-    onCollapse,
-    onExpand,
-    columnIsRefExpanded,
-    onAddFilter
-  );
+  const {columns, columnsWithRefs, setUserDefinedColumnWidths} =
+    useCallsTableColumns(
+      entity,
+      project,
+      effectiveFilter,
+      tableData,
+      expandedRefCols,
+      onCollapse,
+      onExpand,
+      columnIsRefExpanded,
+      onAddFilter
+    );
 
   // Now, there are 4 primary controls:
   // 1. Op Version
@@ -708,6 +709,7 @@ export const CallsTable: FC<{
               numTotalCalls={callsTotal}
               disabled={callsTotal === 0}
               visibleColumns={visibleColumns}
+              columnsWithRefs={columnsWithRefs}
               callQueryParams={{
                 entity,
                 project,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -93,20 +93,9 @@ export const ExportSelector = ({
     const offset = 0;
     const limit = MAX_EXPORT;
     // TODO(gst): add support for JSONL and JSON column selection
-    const columns = [ContentType.csv, ContentType.tsv].includes(contentType)
-      ? visibleColumns
+    const leafColumns = [ContentType.csv, ContentType.tsv].includes(contentType)
+      ? makeLeafColumns(visibleColumns)
       : undefined;
-    // Filter columns down to only the most nested, for example
-    // ['output', 'output.x', 'output.x.y'] -> ['output.x.y']
-    // sort columns by length, longest to shortest
-    visibleColumns.sort((a, b) => b.length - a.length);
-    const leafColumns: string[] = [];
-    for (const col of visibleColumns) {
-      if (leafColumns.some(leafCol => leafCol.startsWith(col))) {
-        continue;
-      }
-      leafColumns.push(col);
-    }
     const startTime = Date.now();
     download(
       callQueryParams.entity,
@@ -129,7 +118,7 @@ export const ExportSelector = ({
 
       userEvents.exportClicked({
         dataSize: blob.size,
-        numColumns: columns?.length ?? null,
+        numColumns: leafColumns?.length ?? null,
         numRows: numTotalCalls,
         numExpandedColumns: refColumnsToExpand.length,
         // the most nested refColumn to expand
@@ -427,6 +416,21 @@ function initiateDownloadFromBlob(blob: Blob, fileName: string) {
   anchor.click();
   document.body.removeChild(anchor);
   URL.revokeObjectURL(downloadUrl);
+}
+
+function makeLeafColumns(visibleColumns: string[]) {
+  // Filter columns down to only the most nested, for example
+  // ['output', 'output.x', 'output.x.y'] -> ['output.x.y']
+  // sort columns by length, longest to shortest
+  visibleColumns.sort((a, b) => b.length - a.length);
+  const leafColumns: string[] = [];
+  for (const col of visibleColumns) {
+    if (leafColumns.some(leafCol => leafCol.startsWith(col))) {
+      continue;
+    }
+    leafColumns.push(col);
+  }
+  return leafColumns;
 }
 
 function makeCodeText(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -118,7 +118,7 @@ export const ExportSelector = ({
 
       userEvents.exportClicked({
         dataSize: blob.size,
-        numColumns: leafColumns?.length ?? null,
+        numColumns: visibleColumns?.length ?? null,
         numRows: numTotalCalls,
         numExpandedColumns: refColumnsToExpand.length,
         // the most nested refColumn to expand

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -13,14 +13,7 @@ import {Icon, IconName} from '@wandb/weave/components/Icon';
 import {Loading} from '@wandb/weave/components/Loading';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import classNames from 'classnames';
-import React, {
-  Dispatch,
-  FC,
-  SetStateAction,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, {Dispatch, FC, SetStateAction, useRef, useState} from 'react';
 
 import * as userEvents from '../../../../../../integrations/analytics/userEvents';
 import {useWFHooks} from '../wfReactInterface/context';
@@ -30,7 +23,6 @@ import {
   fileExtensions,
 } from '../wfReactInterface/traceServerClientTypes';
 import {CallFilter} from '../wfReactInterface/wfDataModelHooksInterface';
-import {isDynamicCallColumn, stringToPath} from './callsTableColumnsUtil';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {useFilterSortby} from './callsTableQuery';
 
@@ -42,12 +34,14 @@ export const ExportSelector = ({
   selectedCalls,
   numTotalCalls,
   visibleColumns,
+  columnsWithRefs,
   disabled,
   callQueryParams,
 }: {
   selectedCalls: string[];
   numTotalCalls: number;
   visibleColumns: string[];
+  columnsWithRefs: Set<string>;
   callQueryParams: {
     entity: string;
     project: string;
@@ -86,10 +80,7 @@ export const ExportSelector = ({
     callQueryParams.gridSort
   );
 
-  const refColumnsToExpand = useMemo(
-    () => visibleColumns.filter(col => isDynamicCallColumn(stringToPath(col))),
-    [visibleColumns]
-  );
+  const refColumnsToExpand = Array.from(columnsWithRefs);
 
   const onClickDownload = (contentType: ContentType) => {
     if (downloadLoading) {
@@ -116,7 +107,6 @@ export const ExportSelector = ({
       }
       leafColumns.push(col);
     }
-
     const startTime = Date.now();
     download(
       callQueryParams.entity,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -150,9 +150,10 @@ export const useCallsTableColumns = (
   return useMemo(() => {
     return {
       columns,
+      columnsWithRefs,
       setUserDefinedColumnWidths,
     };
-  }, [columns, setUserDefinedColumnWidths]);
+  }, [columns, columnsWithRefs, setUserDefinedColumnWidths]);
 };
 function buildCallsTableColumns(
   entity: string,


### PR DESCRIPTION
Lets use the pre-computed ref columns rather than just guess. This makes everything look cleaner, and should also improve performance on the backend. We will not expand columns that have refs only in rows that aren't present on the screen. In this case they wouldn't be in the header, so I'm not sure its a big issue. 

Also tweak column management to always dump all columns when json/jsonl

Impact: 
- json export now always includes all columns
   * doesn't make wonky columns when column headers include `"."`
- performance improvement for exports with many nested columns, as we avoid having to check for refs in the server
- more accurate [analytics](https://mixpanel.com/s/2ubLxe) on columns