### PR TITLE
fix: render nested objects with the same path

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -144,11 +144,11 @@ export const ObjectViewer = ({
         refValues[context.value] != null &&
         // If this is a ref and the parent has been visited, we already resolved
         // this ref. Example: `a._ref` where `a` is already in resolvedRefPaths
-        !resolvedRefPaths.has(context.parent?.toString() ?? '')
+        !resolvedRefPaths.has(context.value + context.parent?.toString() ?? '')
       ) {
         dirty = true;
         const res = refValues[context.value];
-        resolvedRefPaths.add(context.path.toString());
+        resolvedRefPaths.add(context.value + context.path.toString());
         return res;
       }
       return _.clone(context.value);


### PR DESCRIPTION
Fix regression in [this pr](https://github.com/wandb/weave/pull/2247), where we skip rendering of different refs with the same path. 


Prod: 
<img width="923" alt="Screenshot 2024-08-29 at 11 38 13 AM" src="https://github.com/user-attachments/assets/f06fcfad-9c34-4992-a8c8-e16800cd966f">


Branch:
<img width="842" alt="Screenshot 2024-08-29 at 11 37 50 AM" src="https://github.com/user-attachments/assets/5d3d8257-90b0-4f3c-8aa9-32413fa87084">
