### PR TITLE
fix: display displayName in trace tree

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -334,7 +334,10 @@ export const useCallFlattenedTraceTree = (
   selectedPath: string | null
 ) => {
   const {useCalls} = useWFHooks();
-  const columns = useMemo(() => ['parent_id', 'started_at', 'ended_at'], []);
+  const columns = useMemo(
+    () => ['parent_id', 'started_at', 'ended_at', 'display_name'],
+    []
+  );
   const traceCalls = useCalls(
     call.entity,
     call.project,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
@@ -197,7 +197,7 @@ export const CustomGridTreeDataGroupingCell: FC<
                   whiteSpace: 'nowrap',
                   flex: '1 1 auto',
                 }}>
-                {opNiceName(call.spanName)}
+                {call.displayName ?? opNiceName(call.spanName)}
               </Box>
             </Box>
             {call?.rawSpan?.summary && (


### PR DESCRIPTION
This pr:
- adds display_name to the trace query
- displays the display name preferentially

Prod: 
<img width="682" alt="Screenshot 2024-08-29 at 3 21 57 PM" src="https://github.com/user-attachments/assets/f5912d1b-22ec-433d-a636-04211c76fe20">



This Branch:
<img width="678" alt="Screenshot 2024-08-29 at 3 22 18 PM" src="https://github.com/user-attachments/assets/3b6f04f5-48af-4137-9d1c-df0a83d5917e">

