### PR TITLE
chore: add back summary to treeview query

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -334,7 +334,7 @@ export const useCallFlattenedTraceTree = (
   selectedPath: string | null
 ) => {
   const {useCalls} = useWFHooks();
-  const columns = useMemo(() => ['parent_id', 'started_at', 'ended_at'], []);
+  const columns = useMemo(() => ['parent_id', 'started_at', 'ended_at', 'summary'], []);
   const traceCalls = useCalls(
     call.entity,
     call.project,


### PR DESCRIPTION
Add back query for `summary` to render cost in tree view

Prod:
<img width="589" alt="Screenshot 2024-08-29 at 3 45 34 PM" src="https://github.com/user-attachments/assets/5fdd3e46-8cb4-4b51-b068-a399c4f6fdd0">

Branch:

<img width="443" alt="Screenshot 2024-08-29 at 3 45 22 PM" src="https://github.com/user-attachments/assets/8d133562-a0e9-4667-884f-54dd0773395e">
