### PR TITLE
chore: show object name if set

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -204,13 +204,13 @@ export const ObjectViewer = ({
 
       if (context.depth !== 0) {
         const contextTail = context.path.tail();
-        const isNullDescription =
+        const isNullDescriptionOrName =
           typeof contextTail === 'string' &&
-          contextTail === 'description' &&
+          (contextTail === 'description' || contextTail === 'name') &&
           context.valueType === 'null';
         // For now we'll hide all keys that start with an underscore, is a name field, or is a null description.
         // Eventually we might offer a user toggle to display them.
-        if (context.path.hasHiddenKey() || isNullDescription) {
+        if (context.path.hasHiddenKey() || isNullDescriptionOrName) {
           return 'skip';
         }
         if (isExpandableRef(context.value)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
@@ -93,7 +93,7 @@ export class ObjectPath {
 
   hasHiddenKey(): boolean {
     const t = this.tail();
-    return typeof t === 'string' && (t.startsWith('_') || t === 'name');
+    return typeof t === 'string' && t.startsWith('_');
   }
 
   length(): number {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -189,8 +189,8 @@ const ObjectVersionsTable: React.FC<{
         // solution here in the future. Maybe exclude table refs?
         val = _.omit(val, 'rows');
       }
-      // We don't want to show name (because it is the same as the object id)
-      val = _.omit(val, 'name');
+      // Show name, even though it can be = to object id, consider adding back
+      // val = _.omit(val, 'name');
       return {
         id: objectVersionKeyToRefUri(ov),
         obj: {


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-19884

Handle object `name` exactly the same as `description`, rather than always filtering out `name`. 

Prod: 
![Screenshot 2024-09-03 at 1 40 05 PM](https://github.com/user-attachments/assets/697894a1-442c-4cbd-a942-fd7038f524db)

This branch:
![Screenshot 2024-09-03 at 1 39 46 PM](https://github.com/user-attachments/assets/a41f151b-f258-4c97-9986-e64fe2060163)
