### PR TITLE
fix: don't repeat code we've already seen

### DIFF
--- a/weave/legacy/weave/op_def_type.py
+++ b/weave/legacy/weave/op_def_type.py
@@ -237,6 +237,7 @@ def get_code_deps(
                 dependencies are available for the function body.
             warnings: list[str], any warnings that occurred during the process.
     """
+    print("USING OP DEF TYPE VERSION")
     # Generates repeats.
     warnings: list[str] = []
 

--- a/weave/tests/trace/test_op_versioning.py
+++ b/weave/tests/trace/test_op_versioning.py
@@ -1,6 +1,5 @@
 import shutil
 import typing
-from typing import Union
 
 import numpy as np
 import pytest

--- a/weave/tests/trace/test_op_versioning.py
+++ b/weave/tests/trace/test_op_versioning.py
@@ -536,7 +536,6 @@ class SomeClass:
 
 
 EXPECTED_NO_REPEATS_CODE = """import weave
-from typing import Union
 
 class SomeOtherClass:
     pass
@@ -546,14 +545,18 @@ class SomeClass:
         return SomeOtherClass()
 
 @weave.op()
-def some_d(v: Union[SomeClass, SomeOtherClass]):
+def some_d(v):
+    a = SomeOtherClass()
+    b = SomeClass()
     return SomeClass()
 """
 
 
 def test_op_no_repeats(client):
     @weave.op()
-    def some_d(v: Union[SomeClass, SomeOtherClass]):
+    def some_d(v):
+        a = SomeOtherClass()
+        b = SomeClass()
         return SomeClass()
 
     some_d(SomeClass())

--- a/weave/tests/trace/test_op_versioning.py
+++ b/weave/tests/trace/test_op_versioning.py
@@ -1,6 +1,7 @@
 import shutil
 import typing
 from typing import Union
+
 import numpy as np
 import pytest
 

--- a/weave/tests/trace/test_op_versioning.py
+++ b/weave/tests/trace/test_op_versioning.py
@@ -1,6 +1,6 @@
 import shutil
 import typing
-
+from typing import Union
 import numpy as np
 import pytest
 
@@ -523,3 +523,43 @@ def test_op_basic_execution(client):
 
     op2 = weave.ref(ref.uri()).get()
     assert op2(2) == 3
+
+
+class SomeOtherClass:
+    pass
+
+
+class SomeClass:
+    def some_fn(self):
+        return SomeOtherClass()
+
+
+EXPECTED_NO_REPEATS_CODE = """import weave
+from typing import Union
+
+class SomeOtherClass:
+    pass
+
+class SomeClass:
+    def some_fn(self):
+        return SomeOtherClass()
+
+@weave.op()
+def some_d(v: Union[SomeClass, SomeOtherClass]):
+    return SomeClass()
+"""
+
+
+def test_op_no_repeats(client, strict_op_saving):
+    @weave.op()
+    def some_d(v: Union[SomeClass, SomeOtherClass]):
+        return SomeClass()
+
+    some_d(SomeClass())
+    ref = weave.obj_ref(some_d)
+    assert ref is not None
+
+    saved_code = get_saved_code(client, ref)
+    print(saved_code)
+
+    assert saved_code == EXPECTED_NO_REPEATS_CODE

--- a/weave/tests/trace/test_op_versioning.py
+++ b/weave/tests/trace/test_op_versioning.py
@@ -551,7 +551,7 @@ def some_d(v: Union[SomeClass, SomeOtherClass]):
 """
 
 
-def test_op_no_repeats(client, strict_op_saving):
+def test_op_no_repeats(client):
     @weave.op()
     def some_d(v: Union[SomeClass, SomeOtherClass]):
         return SomeClass()

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -277,7 +277,9 @@ def get_source_or_fallback(fn: typing.Callable) -> str:
         def {func_name}{sig_str}:
             ... # Code-capture unavailable for this op
         """
-    )[1:]  # skip first newline char
+    )[
+        1:
+    ]  # skip first newline char
 
     try:
         return get_source_notebook_safe(fn)
@@ -402,16 +404,25 @@ def _get_code_deps(
                     import_code.append(import_line)
 
         else:
+            print(
+                "NON FN",
+                var_value,
+                getattr(var_value, "__name__", None),
+                getattr(var_value, "__module__", None),
+                fn.__module__,
+            )
             if (
                 hasattr(var_value, "__name__")
                 and hasattr(var_value, "__module__")
                 and var_value.__module__ != fn.__module__
             ):
+                print("HERE", var_value.__module__, fn.__module__)
                 import_line = f"from {var_value.__module__} import {var_value.__name__}"
                 if var_value.__name__ != var_name:
                     import_line += f"as {var_name}"
                 import_code.append(import_line)
             else:
+                print("VAR_VALUE", var_value)
                 try:
                     # This relies on old Weave type mechanism.
                     # TODO: Update to use new Weave trace serialization mechanism.

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -277,9 +277,7 @@ def get_source_or_fallback(fn: typing.Callable) -> str:
         def {func_name}{sig_str}:
             ... # Code-capture unavailable for this op
         """
-    )[
-        1:
-    ]  # skip first newline char
+    )[1:]  # skip first newline char
 
     try:
         return get_source_notebook_safe(fn)

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -407,6 +407,7 @@ def _get_code_deps(
             print(
                 "NON FN",
                 var_value,
+                type(var_value),
                 getattr(var_value, "__name__", None),
                 getattr(var_value, "__module__", None),
                 fn.__module__,

--- a/weave/trace/op_type.py
+++ b/weave/trace/op_type.py
@@ -404,26 +404,16 @@ def _get_code_deps(
                     import_code.append(import_line)
 
         else:
-            print(
-                "NON FN",
-                var_value,
-                type(var_value),
-                getattr(var_value, "__name__", None),
-                getattr(var_value, "__module__", None),
-                fn.__module__,
-            )
             if (
                 hasattr(var_value, "__name__")
                 and hasattr(var_value, "__module__")
                 and var_value.__module__ != fn.__module__
             ):
-                print("HERE", var_value.__module__, fn.__module__)
                 import_line = f"from {var_value.__module__} import {var_value.__name__}"
                 if var_value.__name__ != var_name:
                     import_line += f"as {var_name}"
                 import_code.append(import_line)
             else:
-                print("VAR_VALUE", var_value)
                 try:
                     # This relies on old Weave type mechanism.
                     # TODO: Update to use new Weave trace serialization mechanism.


### PR DESCRIPTION
Code saving fix.

If there were multiple paths to the same symbol we'd repeat it. This could really explode into generating tons of repeated code.

This PR just makes it so we do nothing if we've already seen a symbol. And adds a test.