### PR TITLE
chore: refresh trace tree on rename/delete call

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -355,7 +355,10 @@ export const useCallFlattenedTraceTree = (
     undefined,
     undefined,
     undefined,
-    columns
+    columns,
+    undefined,
+    // Refetch the trace tree on delete or rename
+    {refetchOnDelete: true}
   );
   const traceCallsResult = useMemo(
     () => traceCalls.result ?? [],


### PR DESCRIPTION
Refresh the trace tree when the call in the detail page is renamed (or deleted)