### PR TITLE
chore(weave): add regex highlighting method for panel search

### DIFF
--- a/weave-js/src/common/util/fuzzyMatch.tsx
+++ b/weave-js/src/common/util/fuzzyMatch.tsx
@@ -232,6 +232,28 @@ export function fuzzyMatchHighlight(
   return fuzzyMatchHighlightPieces(fuzzyMatchSplit(str, query), matchStyle);
 }
 
+export function regexMatchHighlight(
+  str: string,
+  regex: RegExp | null,
+  matchStyle: {[key: string]: string} = {fontWeight: 'bold'}
+): React.ReactFragment {
+  if (!regex) {
+    return str;
+  }
+  const pieces = [];
+  while (str) {
+    const match = regex.exec(str);
+    if (!match) {
+      pieces.push(str);
+      break;
+    }
+    pieces.push(str.substring(0, match.index));
+    pieces.push(match[0]);
+    str = str.substring(match.index + match[0].length);
+  }
+  return fuzzyMatchHighlightPieces(pieces, matchStyle);
+}
+
 export function preferExactMatch<T>(
   objs: T[],
   matchStr: string,


### PR DESCRIPTION
Please use conventional commits in your PR title. If you are unsure what conventional commits are or how to use them, please check out [this notion doc](https://www.notion.so/wandbai/17966b997841407b95b7c36414ae0634).

## JIRA Issue(s)

- https://wandb.atlassian.net/browse/WB-17219

## Description

This PR introduces a helper for highlighting regex matches within a string. This is an alternative to the fuzzy match that is currently implemented and will be used for section and panel names when the user searches panels with a regex.

The consumers of this new function are introduced in https://github.com/wandb/core/pull/23675

## Questions

Please answer the following as appropriate, leave blank if no. If you aren't sure, ask someone!

- Testing: how was this PR tested?
- Migrations: are there frontend or backend migrations?
- On-prem: will this change work in private cloud & local?
