### PR TITLE
chore(app): fix possible infinite loop in regex highlighter

### DIFF
--- a/weave-js/src/common/util/fuzzyMatch.tsx
+++ b/weave-js/src/common/util/fuzzyMatch.tsx
@@ -243,7 +243,7 @@ export function regexMatchHighlight(
   const pieces = [];
   while (str) {
     const match = regex.exec(str);
-    if (!match) {
+    if (!match || !match[0]) {
       pieces.push(str);
       break;
     }


### PR DESCRIPTION
Please use conventional commits in your PR title. If you are unsure what conventional commits are or how to use them, please check out [this notion doc](https://www.notion.so/wandbai/17966b997841407b95b7c36414ae0634).

## Description

This PR fixes an infinite loop that can occur if the regex highlighting helper receives a zero-width regex (eg `^`) as input
