### PR TITLE
fix: python code export filter respects selected rows in table

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -444,7 +444,9 @@ function makeCodeText(
 
   const filteredCallIds = callIds ?? filter.callIds;
   if (filteredCallIds && filteredCallIds.length > 0) {
-    codeStr += `   "call_ids": ["${filteredCallIds.join('", "')}"],\n`;
+    codeStr += `   "filter": {"call_ids": ["${filteredCallIds.join(
+      '", "'
+    )}"]},\n`;
     if (expandColumns.length > 0) {
       const expandColumnsStr = JSON.stringify(expandColumns, null, 0);
       codeStr += `   "expand_columns": ${expandColumnsStr},\n`;
@@ -465,7 +467,7 @@ function makeCodeText(
       codeStr += `"user_ids": ["${filter.userIds.join('", "')}"],`;
     }
     if (filter.traceId) {
-      codeStr += `"trace_id": "${filter.traceId}",`;
+      codeStr += `"trace_ids": ["${filter.traceId}"],`;
     }
     if (filter.traceRootsOnly) {
       codeStr += `"trace_roots_only": True,`;


### PR DESCRIPTION
Now, selecting a row will populate the `call_ids` field of the filter, respecting the CallsQueryReq and CallFilter Specs:
<img width="1728" alt="Screenshot 2024-09-05 at 3 08 47 PM" src="https://github.com/user-attachments/assets/9085911a-0e5a-4711-9107-b2a7d7634a90">

CallsQueryReq:
```python
class CallsQueryReq(BaseModel):
    project_id: str
    filter: Optional[CallsFilter] = None
    limit: Optional[int] = None
    offset: Optional[int] = None
    sort_by: Optional[List[SortBy]] = None
    query: Optional[Query] = None
    include_costs: Optional[bool] = Field(
        default=False,
        description="Beta, subject to change. If true, the response will"
        " include any model costs for each call.",
    )
    include_feedback: Optional[bool] = Field(
        default=False,
        description="Beta, subject to change. If true, the response will"
        " include feedback for each call.",
    )
    columns: Optional[List[str]] = None
    expand_columns: Optional[List[str]] = Field(
        default=None,
        examples=[["inputs.self.message", "inputs.model.prompt"]],
        description="Columns to expand, i.e. refs to other objects",
    )

```

CallFilter:
```python
class CallsFilter(BaseModel):
    op_names: Optional[List[str]] = None
    input_refs: Optional[List[str]] = None
    output_refs: Optional[List[str]] = None
    parent_ids: Optional[List[str]] = None
    trace_ids: Optional[List[str]] = None
    call_ids: Optional[List[str]] = None
    trace_roots_only: Optional[bool] = None
    wb_user_ids: Optional[List[str]] = None
    wb_run_ids: Optional[List[str]] = None
```
