### PR TITLE
chore: delete button now accounts for call/evaluation

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -693,7 +693,6 @@ export const CallsTable: FC<{
                   .filter(row => selectedCalls.includes(row.id))
                   .map(traceCallToUICallSchema)}
                 confirmDelete={deleteConfirmModalOpen}
-                deleteTargetType={isEvaluateTable ? 'evaluation' : 'call'}
                 setConfirmDelete={setDeleteConfirmModalOpen}
                 onDeleteCallback={() => {
                   setSelectedCalls([]);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -693,6 +693,7 @@ export const CallsTable: FC<{
                   .filter(row => selectedCalls.includes(row.id))
                   .map(traceCallToUICallSchema)}
                 confirmDelete={deleteConfirmModalOpen}
+                deleteTargetType={isEvaluateTable ? 'evaluation' : 'call'}
                 setConfirmDelete={setDeleteConfirmModalOpen}
                 onDeleteCallback={() => {
                   setSelectedCalls([]);


### PR DESCRIPTION
This pr: 
- Adds parameter to specify text "call" or "evaluation" depending on the call span name
   * also handles the case of both, and both plural
- Removes the button disable when non-critical queries are loading

Prod:
<img width="475" alt="Screenshot 2024-09-06 at 1 21 10 PM" src="https://github.com/user-attachments/assets/fd3ed172-41e6-4db7-9f7c-a295e725bb3e">


This branch:

<img width="1151" alt="Screenshot 2024-09-06 at 1 18 14 PM" src="https://github.com/user-attachments/assets/5a8352c3-e937-4d88-b9fe-3dcdc24b5971">
<img width="462" alt="Screenshot 2024-09-06 at 1 18 22 PM" src="https://github.com/user-attachments/assets/f60d827e-dbc0-4b80-ba3e-5e1d26593c44">
<img width="477" alt="Screenshot 2024-09-06 at 1 18 27 PM" src="https://github.com/user-attachments/assets/8e3a816d-6144-4eb5-99a8-83e97fc577c3">
<img width="481" alt="Screenshot 2024-09-06 at 1 18 33 PM" src="https://github.com/user-attachments/assets/1b404bcf-605d-4f8b-b026-4a84c2f95395">
<img width="473" alt="Screenshot 2024-09-06 at 1 20 27 PM" src="https://github.com/user-attachments/assets/54888019-80b8-45b9-8091-6b958e785c8b">
