### PR TITLE
chore: hide derived fields from trace table

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -355,7 +355,7 @@ function buildCallsTableColumns(
   cols.push(startedAtCol);
 
   cols.push({
-    field: 'summary.weave.tokens',
+    field: 'tokens',
     headerName: 'Tokens',
     width: 100,
     minWidth: 100,
@@ -376,7 +376,7 @@ function buildCallsTableColumns(
   });
 
   cols.push({
-    field: 'summary.weave.cost',
+    field: 'cost',
     headerName: 'Cost',
     width: 100,
     minWidth: 100,
@@ -397,7 +397,7 @@ function buildCallsTableColumns(
   });
 
   cols.push({
-    field: 'summary.weave.latency',
+    field: 'latency',
     headerName: 'Latency',
     width: 100,
     minWidth: 100,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -42,7 +42,7 @@ import {
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {OpVersionIndexText} from './OpVersionIndexText';
 
-const HIDDEN_DYNAMIC_COLUMN_PREFIXES = ['summary.usage'];
+const HIDDEN_DYNAMIC_COLUMN_PREFIXES = ['summary.usage', 'summary.weave'];
 
 export const useCallsTableColumns = (
   entity: string,
@@ -262,7 +262,7 @@ function buildCallsTableColumns(
     //   },
     // },
     {
-      field: 'summary.weave.status',
+      field: 'status',
       headerName: 'Status',
       headerAlign: 'center',
       sortable: false,


### PR DESCRIPTION
The weave summary derived fields should be used to create nice fields in the UI, but only once the SDK has been released. `summary.weave` should always be safe to hide. 

Also change the field names because they now conflict (in a weird and degenerate way) with the derived fields. 


Prod:
<img width="1728" alt="Screenshot 2024-09-10 at 9 14 08 AM" src="https://github.com/user-attachments/assets/4d534a77-9c54-43c4-b261-9a9a3f21ab5b">

Degenerate case (with horizontal scrolling):
<img width="1237" alt="Screenshot 2024-09-10 at 8 40 33 AM" src="https://github.com/user-attachments/assets/d2ffa581-9edf-47bb-b205-2891bdc127e6">

Branch:
<img width="1728" alt="Screenshot 2024-09-10 at 9 14 36 AM" src="https://github.com/user-attachments/assets/5abc6f60-7cc0-41e3-b9bb-2565a183568f">
