### PR TITLE
fix: Fixes backend to correctly filter out results where start even is not yet processed

### DIFF
--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -398,6 +398,15 @@ class CallsQuery(BaseModel):
             )
         )
 
+        # Important: We must always filter out calls that have not been started
+        # This can occur when there is an out of order call part insertion or worse,
+        # when such occurance happens and the client terminates early.
+        self.add_condition(
+            tsi_query.NotOperation.model_validate(
+                {"$not": [{"$eq": [{"$getField": "started_at"}, {"$literal": None}]}]}
+            )
+        )
+
         # If we should not optimize, then just build the base query
         if not should_optimize and not self.include_costs:
             return self._as_sql_base_format(pb, table_alias)

--- a/weave/trace_server/tests/test_call_lifecycle.py
+++ b/weave/trace_server/tests/test_call_lifecycle.py
@@ -1,0 +1,60 @@
+import datetime
+import uuid
+
+from weave.trace import weave_client
+from weave.trace_server import trace_server_interface as tsi
+
+
+def test_call_update_out_of_order(client: weave_client.WeaveClient):
+    # Here, we are going to do an out of order sequence:
+    # 1. Name a call
+    # 2. Finish the call
+    # 3. Start the call
+    # 4. Delete the call
+    #
+    # Only step 3 should actually have the result in the query.
+    
+    call_id = str(uuid.uuid4())
+    project_id = client._project_id()
+
+    
+    def get_calls():
+        res = client.server.calls_query(tsi.CallsQueryReq(
+                project_id=project_id,
+        ))
+        return res.calls
+
+
+    client.server.call_update(tsi.CallUpdateReq(
+            project_id=project_id,
+            call_id=call_id,
+            display_name="test_display_name",
+    ))
+
+    assert len(get_calls()) == 0
+
+    client.server.call_end(tsi.CallEndReq(
+            project_id=project_id,
+            id=call_id,
+            ended_at=datetime.datetime.now(),
+            exception=None,
+            output=None,
+            summary={},
+    ))
+
+    assert len(get_calls()) == 0
+
+    client.server.call_start(tsi.CallStartReq(
+                project_id=project_id,
+            id=call_id,
+            started_at=datetime.datetime.now(),
+    ))
+
+    assert len(get_calls()) == 1
+
+    client.server.call_delete(tsi.CallDeleteReq(
+            project_id=project_id,
+            id=call_id,
+    ))
+
+    assert len(get_calls()) == 0

--- a/weave/trace_server/tests/test_call_lifecycle.py
+++ b/weave/trace_server/tests/test_call_lifecycle.py
@@ -55,6 +55,7 @@ def test_call_update_out_of_order(client: weave_client.WeaveClient):
             start=tsi.StartedCallSchemaForInsert(
                 project_id=project_id,
                 id=call_id,
+                trace_id=call_id,
                 started_at=datetime.datetime.now(),
                 op_name="test_op_name",
                 attributes={},

--- a/weave/trace_server/tests/test_call_lifecycle.py
+++ b/weave/trace_server/tests/test_call_lifecycle.py
@@ -13,48 +13,56 @@ def test_call_update_out_of_order(client: weave_client.WeaveClient):
     # 4. Delete the call
     #
     # Only step 3 should actually have the result in the query.
-    
+
     call_id = str(uuid.uuid4())
     project_id = client._project_id()
 
-    
     def get_calls():
-        res = client.server.calls_query(tsi.CallsQueryReq(
+        res = client.server.calls_query(
+            tsi.CallsQueryReq(
                 project_id=project_id,
-        ))
+            )
+        )
         return res.calls
 
-
-    client.server.call_update(tsi.CallUpdateReq(
+    client.server.call_update(
+        tsi.CallUpdateReq(
             project_id=project_id,
             call_id=call_id,
             display_name="test_display_name",
-    ))
+        )
+    )
 
     assert len(get_calls()) == 0
 
-    client.server.call_end(tsi.CallEndReq(
+    client.server.call_end(
+        tsi.CallEndReq(
             project_id=project_id,
             id=call_id,
             ended_at=datetime.datetime.now(),
             exception=None,
             output=None,
             summary={},
-    ))
+        )
+    )
 
     assert len(get_calls()) == 0
 
-    client.server.call_start(tsi.CallStartReq(
-                project_id=project_id,
+    client.server.call_start(
+        tsi.CallStartReq(
+            project_id=project_id,
             id=call_id,
             started_at=datetime.datetime.now(),
-    ))
+        )
+    )
 
     assert len(get_calls()) == 1
 
-    client.server.call_delete(tsi.CallDeleteReq(
+    client.server.calls_delete(
+        tsi.CallsDeleteReq(
             project_id=project_id,
             id=call_id,
-    ))
+        )
+    )
 
     assert len(get_calls()) == 0

--- a/weave/trace_server/tests/test_call_lifecycle.py
+++ b/weave/trace_server/tests/test_call_lifecycle.py
@@ -37,12 +37,14 @@ def test_call_update_out_of_order(client: weave_client.WeaveClient):
 
     client.server.call_end(
         tsi.CallEndReq(
-            project_id=project_id,
-            id=call_id,
-            ended_at=datetime.datetime.now(),
-            exception=None,
-            output=None,
-            summary={},
+            end=tsi.EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=call_id,
+                ended_at=datetime.datetime.now(),
+                exception=None,
+                output=None,
+                summary={},
+            )
         )
     )
 
@@ -50,9 +52,14 @@ def test_call_update_out_of_order(client: weave_client.WeaveClient):
 
     client.server.call_start(
         tsi.CallStartReq(
-            project_id=project_id,
-            id=call_id,
-            started_at=datetime.datetime.now(),
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=call_id,
+                started_at=datetime.datetime.now(),
+                op_name="test_op_name",
+                attributes={},
+                inputs={},
+            )
         )
     )
 
@@ -61,7 +68,7 @@ def test_call_update_out_of_order(client: weave_client.WeaveClient):
     client.server.calls_delete(
         tsi.CallsDeleteReq(
             project_id=project_id,
-            id=call_id,
+            call_ids=[call_id],
         )
     )
 

--- a/weave/trace_server/tests/test_calls_query_builder.py
+++ b/weave/trace_server/tests/test_calls_query_builder.py
@@ -17,7 +17,15 @@ def test_query_baseline() -> None:
         WHERE project_id = {pb_0:String}
         GROUP BY (project_id,id)
         HAVING (
-            any(calls_merged.deleted_at) IS NULL
+            ((
+                any(calls_merged.deleted_at) IS NULL
+            ))
+            AND
+            ((
+               NOT ((
+                  any(calls_merged.started_at) IS NULL
+               ))
+            ))
         )
         """,
         {"pb_0": "project"},
@@ -38,7 +46,15 @@ def test_query_light_column() -> None:
         WHERE project_id = {pb_0:String}
         GROUP BY (project_id,id)
         HAVING (
-            any(calls_merged.deleted_at) IS NULL
+            ((
+                any(calls_merged.deleted_at) IS NULL
+            ))
+            AND
+            ((
+               NOT ((
+                  any(calls_merged.started_at) IS NULL
+               ))
+            ))
         )
         """,
         {"pb_0": "project"},
@@ -59,7 +75,15 @@ def test_query_heavy_column() -> None:
         WHERE project_id = {pb_0:String}
         GROUP BY (project_id,id)
         HAVING (
-            any(calls_merged.deleted_at) IS NULL
+            ((
+                any(calls_merged.deleted_at) IS NULL
+            ))
+            AND
+            ((
+               NOT ((
+                  any(calls_merged.started_at) IS NULL
+               ))
+            ))
         )
         """,
         {"pb_0": "project"},
@@ -88,9 +112,9 @@ def test_query_heavy_column_simple_filter() -> None:
             GROUP BY (project_id,id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.started_at) IS NULL))))
             AND
-                (any(calls_merged.op_name) IN {pb_0:Array(String)})
-            )
+                (any(calls_merged.op_name) IN {pb_0:Array(String)}))
         )
         SELECT
             calls_merged.id AS id,
@@ -129,9 +153,9 @@ def test_query_heavy_column_simple_filter_with_order() -> None:
             GROUP BY (project_id,id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.started_at) IS NULL))))
             AND
-                (any(calls_merged.op_name) IN {pb_0:Array(String)})
-            )
+                (any(calls_merged.op_name) IN {pb_0:Array(String)}))
         )
         SELECT
             calls_merged.id AS id,
@@ -172,6 +196,8 @@ def test_query_heavy_column_simple_filter_with_order_and_limit() -> None:
             GROUP BY (project_id,id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
+            AND
+                ((NOT ((any(calls_merged.started_at) IS NULL))))
             AND
                 (any(calls_merged.op_name) IN {pb_0:Array(String)})
             )
@@ -239,6 +265,8 @@ def test_query_heavy_column_simple_filter_with_order_and_limit_and_mixed_query_c
             AND
                 ((any(calls_merged.deleted_at) IS NULL))
             AND
+                ((NOT ((any(calls_merged.started_at) IS NULL))))
+            AND
                 (any(calls_merged.op_name) IN {pb_1:Array(String)})
             )
         )
@@ -304,7 +332,8 @@ def test_query_light_column_with_costs() -> None:
                 WHERE project_id = {pb_1:String}
                 GROUP BY (project_id, id)
                 HAVING (((any(calls_merged.deleted_at) IS NULL))
-                        AND (any(calls_merged.op_name) IN {pb_0:Array(String)}))),
+                AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+                AND (any(calls_merged.op_name) IN {pb_0:Array(String)}))),
             all_calls AS (
                 SELECT
                     calls_merged.id AS id,


### PR DESCRIPTION
It is possible under a few conditions that the start event is logged after other events, thereby creating partial call objects. This can occur if the client sends the request out of order (allowed) and in such cases could actually drop the start event. Our DB layer should be robust to this and in such scenarios filter out the partial results.