### PR TITLE
chore(weave): correctly sort cost query

### DIFF
--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -438,9 +438,16 @@ class CallsQuery(BaseModel):
         """
 
         if self.include_costs:
+            # TODO: We should unify the calls query order by fields to be orm sort by fields
+            order_by_fields = [
+                tsi.SortBy(
+                    field=sort_by.field.field, direction=sort_by.direction.lower()
+                )
+                for sort_by in self.order_fields
+            ]
             raw_sql += f""",
             all_calls AS ({outer_query._as_sql_base_format(pb, table_alias, id_subquery_name="filtered_calls")}),
-            {cost_query(pb, "all_calls", self.project_id, [field.field for field in self.select_fields])}
+            {cost_query(pb, "all_calls", self.project_id, [field.field for field in self.select_fields], order_by_fields)}
             """
 
         else:

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -342,6 +342,19 @@ class Select:
         if joined:
             sql += f"\nWHERE {joined}"
 
+        if self._group_by is not None:
+            internal_fields = [
+                _transform_external_field_to_internal_field(
+                    f,
+                    self.all_columns,
+                    self.table.json_cols,
+                    param_builder=param_builder,
+                )[0]
+                for f in self._group_by
+            ]
+            joined_fields = ", ".join(internal_fields)
+            sql += f"\nGROUP BY {joined_fields}"
+
         if self._order_by is not None:
             order_parts = []
             for clause in self._order_by:
@@ -386,18 +399,6 @@ class Select:
         if self._offset is not None:
             param_offset = param_builder.add(self._offset, "offset", "UInt64")
             sql += f"\nOFFSET {param_offset}"
-        if self._group_by is not None:
-            internal_fields = [
-                _transform_external_field_to_internal_field(
-                    f,
-                    self.all_columns,
-                    self.table.json_cols,
-                    param_builder=param_builder,
-                )[0]
-                for f in self._group_by
-            ]
-            joined_fields = ", ".join(internal_fields)
-            sql += f"\nGROUP BY {joined_fields}"
 
         parameters = param_builder.get_params()
         return PreparedSelect(sql=sql, parameters=parameters, fields=fieldnames)

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -278,6 +278,7 @@ def final_call_select_with_cost(
     param_builder: ParamBuilder,
     price_table_alias: str,
     select_fields: list[str],
+    order_fields: list[tsi.SortBy],
 ) -> PreparedSelect:
     # We filter out summary_dump, because we add costs to summary dump in the select statement
     final_select_fields = [field for field in select_fields if field != "summary_dump"]
@@ -370,6 +371,7 @@ def final_call_select_with_cost(
             tsi.Query(**{"$expr": {"$eq": [{"$getField": "rank"}, {"$literal": 1}]}})
         )
         .group_by(final_select_fields)
+        .order_by(order_fields)
     )
 
     final_prepared_query = final_query.prepare(
@@ -387,6 +389,7 @@ def cost_query(
     call_table_alias: str,
     project_id: str,
     select_fields: list[str],
+    order_fields: list[tsi.SortBy],
 ) -> str:
     """
     This function takes something like the following:
@@ -419,7 +422,7 @@ def cost_query(
         ranked_prices AS ({get_ranked_prices(pb, "llm_usage", project_id).sql})
 
         -- Final Select, which just selects the correct fields, and adds a costs object
-        {final_call_select_with_cost(pb, 'ranked_prices', select_fields).sql}
+        {final_call_select_with_cost(pb, 'ranked_prices', select_fields, order_fields).sql}
     """
     return raw_sql
 


### PR DESCRIPTION
## Description

1. we were not sorting in the final cost query
2. the orm had incorrectly ordered some clauses, it is now
- group by
- order by
- limit, offset

instead of 
- order by
- limit, offset
- group by



## Testing

How was this PR tested?
