### PR TITLE
feat: log path to image as Path, auto save image

### DIFF
--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -1,4 +1,5 @@
 import typing
+from pathlib import Path
 from typing import Any
 
 from weave.trace import custom_objs
@@ -30,6 +31,14 @@ def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
 
     if isinstance(obj, (int, float, str, bool)) or obj is None:
         return obj
+
+    if isinstance(obj, Path):
+        # only support image files for now
+        if obj.suffix in [".png", ".jpg", ".jpeg", ".gif", ".tiff"]:
+            # Load the image
+            from PIL import Image
+
+            obj = Image.open(obj)
 
     encoded = custom_objs.encode_custom_obj(obj)
     if encoded is None:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN

This PR:
- inspects `pathlib.Path` type log values, and if they are an image, opens them as `PIL.Image` and saves them. 

## Testing

- adds test
