### PR TITLE
feat: Add a refresh button to the Calls Table

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
@@ -21,7 +21,7 @@ type FilterPanelProps = {
 
 export const FilterPanel = (props: FilterPanelProps) => {
   return (
-    <div className="min-w-90 flex-auto self-stretch overflow-hidden">
+    <div className="min-w-90 flex-auto self-stretch">
       <LocalizationProvider dateAdapter={AdapterMoment}>
         <AutoSizer
           className="ml-2 flex items-center"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -68,6 +68,7 @@ import {
   BulkDeleteButton,
   CompareEvaluationsTableButton,
   ExportSelector,
+  LivePollingButton,
 } from './CallsTableButtons';
 import {useCallsTableColumns} from './callsTableColumns';
 import {WFHighLevelCallFilter} from './callsTableFilter';
@@ -567,6 +568,8 @@ export const CallsTable: FC<{
     [callsLoading, setPaginationModel]
   );
 
+  const [isPolling, setIsPolling] = useState(false);
+
   // CPR (Tim) - (GeneralRefactoring): Pull out different inline-properties and create them above
   return (
     <FilterLayoutTemplate
@@ -721,7 +724,7 @@ export const CallsTable: FC<{
           </div>
           {columnVisibilityModel && setColumnVisibilityModel && (
             <>
-              <div className="h-24 flex-none border-l-[1px] border-moon-250"></div>
+              <ButtonDivider />
               <div className="flex-none">
                 <ManageColumnsButton
                   columnInfo={columns}
@@ -731,6 +734,11 @@ export const CallsTable: FC<{
               </div>
             </>
           )}
+          <ButtonDivider />
+          <LivePollingButton
+            isPolling={isPolling}
+            onClick={() => setIsPolling(!isPolling)}
+          />
         </Tailwind>
       }>
       <StyledDataGrid
@@ -851,6 +859,10 @@ export const CallsTable: FC<{
       />
     </FilterLayoutTemplate>
   );
+};
+
+const ButtonDivider = () => {
+  return <div className="h-24 flex-none border-l-[1px] border-moon-250"></div>;
 };
 
 const useParentIdOptions = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -161,7 +161,6 @@ export const CallsTable: FC<{
   const {loading: loadingUserInfo, userInfo} = useViewerInfo();
   const [isPolling, setIsPolling] = useState(false);
 
-
   const isReadonly =
     loadingUserInfo || !userInfo?.username || !userInfo?.teams.includes(entity);
 
@@ -240,7 +239,8 @@ export const CallsTable: FC<{
     filterModelResolved,
     sortModelResolved,
     paginationModelResolved,
-    expandedRefCols
+    expandedRefCols,
+    isPolling
   );
 
   // Here, we only update our local state once the calls have loaded.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -159,6 +159,8 @@ export const CallsTable: FC<{
   setPaginationModel,
 }) => {
   const {loading: loadingUserInfo, userInfo} = useViewerInfo();
+  const [isPolling, setIsPolling] = useState(false);
+
 
   const isReadonly =
     loadingUserInfo || !userInfo?.username || !userInfo?.teams.includes(entity);
@@ -567,8 +569,6 @@ export const CallsTable: FC<{
     },
     [callsLoading, setPaginationModel]
   );
-
-  const [isPolling, setIsPolling] = useState(false);
 
   // CPR (Tim) - (GeneralRefactoring): Pull out different inline-properties and create them above
   return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -689,7 +689,6 @@ export const CallsTable: FC<{
                 onClick={() => setDeleteConfirmModalOpen(true)}
                 disabled={selectedCalls.length === 0}
               />
-              <ButtonDivider />
               <ConfirmDeleteModal
                 calls={tableData
                   .filter(row => selectedCalls.includes(row.id))
@@ -702,6 +701,8 @@ export const CallsTable: FC<{
               />
             </div>
           )}
+          <ButtonDivider />
+
           <div className="flex-none">
             <ExportSelector
               selectedCalls={selectedCalls}
@@ -734,9 +735,7 @@ export const CallsTable: FC<{
             </>
           )}
           <ButtonDivider />
-          <RefreshButton
-            onClick={() => console.log('refresh')}
-          />
+          <RefreshButton onClick={() => calls.refetch()} />
         </Tailwind>
       }>
       <StyledDataGrid

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -858,9 +858,9 @@ export const CallsTable: FC<{
   );
 };
 
-const ButtonDivider = () => {
-  return <div className="h-24 flex-none border-l-[1px] border-moon-250"></div>;
-};
+const ButtonDivider = () => (
+  <div className="h-24 flex-none border-l-[1px] border-moon-250"></div>
+);
 
 const useParentIdOptions = (
   entity: string,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -68,7 +68,7 @@ import {
   BulkDeleteButton,
   CompareEvaluationsTableButton,
   ExportSelector,
-  LivePollingButton,
+  RefreshButton,
 } from './CallsTableButtons';
 import {useCallsTableColumns} from './callsTableColumns';
 import {WFHighLevelCallFilter} from './callsTableFilter';
@@ -159,7 +159,6 @@ export const CallsTable: FC<{
   setPaginationModel,
 }) => {
   const {loading: loadingUserInfo, userInfo} = useViewerInfo();
-  const [isPolling, setIsPolling] = useState(false);
 
   const isReadonly =
     loadingUserInfo || !userInfo?.username || !userInfo?.teams.includes(entity);
@@ -239,8 +238,7 @@ export const CallsTable: FC<{
     filterModelResolved,
     sortModelResolved,
     paginationModelResolved,
-    expandedRefCols,
-    isPolling
+    expandedRefCols
   );
 
   // Here, we only update our local state once the calls have loaded.
@@ -691,6 +689,7 @@ export const CallsTable: FC<{
                 onClick={() => setDeleteConfirmModalOpen(true)}
                 disabled={selectedCalls.length === 0}
               />
+              <ButtonDivider />
               <ConfirmDeleteModal
                 calls={tableData
                   .filter(row => selectedCalls.includes(row.id))
@@ -735,9 +734,8 @@ export const CallsTable: FC<{
             </>
           )}
           <ButtonDivider />
-          <LivePollingButton
-            isPolling={isPolling}
-            onClick={() => setIsPolling(!isPolling)}
+          <RefreshButton
+            onClick={() => console.log('refresh')}
           />
         </Tailwind>
       }>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -402,11 +402,9 @@ export const BulkDeleteButton: FC<{
   );
 };
 
-export const LivePollingButton: FC<{
-  isPolling: boolean;
+export const RefreshButton: FC<{
   onClick: () => void;
-}> = ({isPolling, onClick}) => {
-  const tooltip = isPolling ? 'Pause live updates' : 'Enable live updates';
+}> = ({onClick}) => {
 
   return (
     <Box
@@ -416,11 +414,12 @@ export const LivePollingButton: FC<{
         alignItems: 'center',
       }}>
       <Button
-        variant={isPolling ? 'primary' : 'ghost'}
+        variant={'ghost'}
         size="medium"
         onClick={onClick}
-        tooltip={tooltip}
-        icon={isPolling ? 'pause' : 'play'}></Button>
+        tooltip="Refresh"
+        icon='randomize-reset-reload'
+      />
     </Box>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -405,7 +405,12 @@ export const BulkDeleteButton: FC<{
 export const LivePollingButton: FC<{
   isPolling: boolean;
   onClick: () => void;
+
 }> = ({isPolling, onClick}) => {
+  const tooltip = isPolling
+  ? 'Pause live updates'
+  : 'Enable live updates'
+
   return (
     <Box
       sx={{
@@ -417,16 +422,8 @@ export const LivePollingButton: FC<{
         variant={isPolling ? 'primary' : 'ghost'}
         size="medium"
         onClick={onClick}
-        tooltip={isPolling ? 'Pause live updates' : 'Enable live updates'}
+        tooltip={tooltip}
         icon={isPolling ? 'pause' : 'play'}>
-        <span
-          style={{
-            width: '40px',
-            display: 'inline-block',
-            textAlign: 'center',
-          }}>
-          {isPolling ? 'Pause' : 'Live'}
-        </span>
       </Button>
     </Box>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -402,6 +402,36 @@ export const BulkDeleteButton: FC<{
   );
 };
 
+export const LivePollingButton: FC<{
+  isPolling: boolean;
+  onClick: () => void;
+}> = ({isPolling, onClick}) => {
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+      }}>
+      <Button
+        variant={isPolling ? 'primary' : 'ghost'}
+        size="medium"
+        onClick={onClick}
+        tooltip={isPolling ? 'Pause live updates' : 'Enable live updates'}
+        icon={isPolling ? 'pause' : 'play'}>
+        <span
+          style={{
+            width: '40px',
+            display: 'inline-block',
+            textAlign: 'center',
+          }}>
+          {isPolling ? 'Pause' : 'Live'}
+        </span>
+      </Button>
+    </Box>
+  );
+};
+
 function initiateDownloadFromBlob(blob: Blob, fileName: string) {
   const downloadUrl = URL.createObjectURL(blob);
   // Create a download link and click it

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -405,7 +405,6 @@ export const BulkDeleteButton: FC<{
 export const RefreshButton: FC<{
   onClick: () => void;
 }> = ({onClick}) => {
-
   return (
     <Box
       sx={{
@@ -418,7 +417,7 @@ export const RefreshButton: FC<{
         size="medium"
         onClick={onClick}
         tooltip="Refresh"
-        icon='randomize-reset-reload'
+        icon="randomize-reset-reload"
       />
     </Box>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -405,11 +405,8 @@ export const BulkDeleteButton: FC<{
 export const LivePollingButton: FC<{
   isPolling: boolean;
   onClick: () => void;
-
 }> = ({isPolling, onClick}) => {
-  const tooltip = isPolling
-  ? 'Pause live updates'
-  : 'Enable live updates'
+  const tooltip = isPolling ? 'Pause live updates' : 'Enable live updates';
 
   return (
     <Box
@@ -423,8 +420,7 @@ export const LivePollingButton: FC<{
         size="medium"
         onClick={onClick}
         tooltip={tooltip}
-        icon={isPolling ? 'pause' : 'play'}>
-      </Button>
+        icon={isPolling ? 'pause' : 'play'}></Button>
     </Box>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -13,8 +13,6 @@ import {Query} from '../wfReactInterface/traceServerClientInterface/query';
 import {CallFilter} from '../wfReactInterface/wfDataModelHooksInterface';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 
-const WEAVE_CALLS_POLL_INTERVAL_MS = 1000;
-
 /**
  * This Hook is responsible for bridging the gap between the CallsTable
  * component and the underlying data hooks. In particular, it takes a high level
@@ -32,8 +30,7 @@ export const useCallsForQuery = (
   gridFilter: GridFilterModel,
   gridSort: GridSortModel,
   gridPage: GridPaginationModel,
-  expandedColumns: Set<string>,
-  enablePolling: boolean
+  expandedColumns: Set<string>
 ) => {
   const {useCalls, useCallsStats} = useWFHooks();
   const offset = gridPage.page * gridPage.pageSize;
@@ -56,13 +53,11 @@ export const useCallsForQuery = (
     expandedColumns,
     {
       refetchOnDelete: true,
-      pollIntervalMs: enablePolling ? WEAVE_CALLS_POLL_INTERVAL_MS : undefined,
     }
   );
 
   const callsStats = useCallsStats(entity, project, lowLevelFilter, filterBy, {
     refetchOnDelete: true,
-    pollIntervalMs: enablePolling ? WEAVE_CALLS_POLL_INTERVAL_MS : undefined,
   });
 
   const callResults = useMemo(() => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -13,16 +13,7 @@ import {Query} from '../wfReactInterface/traceServerClientInterface/query';
 import {CallFilter} from '../wfReactInterface/wfDataModelHooksInterface';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 
-// Expose a window-level param for poll interval
-declare global {
-  interface Window {
-    WEAVE_CALLS_POLL_INTERVAL_MS?: number;
-  }
-}
-
-const getPollIntervalMs = (): number | undefined => {
-  return window.WEAVE_CALLS_POLL_INTERVAL_MS;
-};
+const WEAVE_CALLS_POLL_INTERVAL_MS = 1000;
 
 /**
  * This Hook is responsible for bridging the gap between the CallsTable
@@ -41,7 +32,8 @@ export const useCallsForQuery = (
   gridFilter: GridFilterModel,
   gridSort: GridSortModel,
   gridPage: GridPaginationModel,
-  expandedColumns: Set<string>
+  expandedColumns: Set<string>,
+  enablePolling: boolean
 ) => {
   const {useCalls, useCallsStats} = useWFHooks();
   const offset = gridPage.page * gridPage.pageSize;
@@ -64,13 +56,13 @@ export const useCallsForQuery = (
     expandedColumns,
     {
       refetchOnDelete: true,
-      pollIntervalMs: getPollIntervalMs(),
+      pollIntervalMs: enablePolling ? WEAVE_CALLS_POLL_INTERVAL_MS : undefined,
     }
   );
 
   const callsStats = useCallsStats(entity, project, lowLevelFilter, filterBy, {
     refetchOnDelete: true,
-    pollIntervalMs: getPollIntervalMs(),
+    pollIntervalMs: enablePolling ? WEAVE_CALLS_POLL_INTERVAL_MS : undefined,
   });
 
   const callResults = useMemo(() => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -3,14 +3,17 @@ import {
   GridPaginationModel,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {useDeepMemo} from '../../../../../../hookUtils';
 import {isValuelessOperator} from '../../filters/common';
 import {operationConverter} from '../common/tabularListViews/operators';
 import {useWFHooks} from '../wfReactInterface/context';
 import {Query} from '../wfReactInterface/traceServerClientInterface/query';
-import {CallFilter} from '../wfReactInterface/wfDataModelHooksInterface';
+import {
+  CallFilter,
+  CallSchema,
+} from '../wfReactInterface/wfDataModelHooksInterface';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 
 /**
@@ -31,7 +34,12 @@ export const useCallsForQuery = (
   gridSort: GridSortModel,
   gridPage: GridPaginationModel,
   expandedColumns: Set<string>
-) => {
+): {
+  result: CallSchema[];
+  loading: boolean;
+  total: number;
+  refetch: () => void;
+} => {
   const {useCalls, useCallsStats} = useWFHooks();
   const offset = gridPage.page * gridPage.pageSize;
   const limit = gridPage.pageSize;
@@ -72,13 +80,19 @@ export const useCallsForQuery = (
     }
   }, [callResults.length, callsStats.loading, callsStats.result, offset]);
 
+  const refetch = useCallback(() => {
+    calls.refetch();
+    callsStats.refetch();
+  }, [calls, callsStats]);
+
   return useMemo(() => {
     return {
       loading: calls.loading,
       result: calls.loading ? [] : callResults,
       total,
+      refetch,
     };
-  }, [callResults, calls.loading, total]);
+  }, [callResults, calls.loading, total, refetch]);
 };
 
 export const useFilterSortby = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -174,14 +174,14 @@ export type WFDataModelHooksInterface = {
     columns?: string[],
     expandedRefColumns?: Set<string>,
     opts?: {skip?: boolean; refetchOnDelete?: boolean}
-  ) => Loadable<CallSchema[]>;
+  ) => Loadable<CallSchema[]> & Refetchable;
   useCallsStats: (
     entity: string,
     project: string,
     filter: CallFilter,
     query?: Query,
     opts?: {skip?: boolean; refetchOnDelete?: boolean}
-  ) => Loadable<traceServerClientTypes.TraceCallsQueryStatsRes>;
+  ) => Loadable<traceServerClientTypes.TraceCallsQueryStatsRes> & Refetchable;
   useCallsDeleteFunc: () => (
     entity: string,
     project: string,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -173,15 +173,15 @@ export type WFDataModelHooksInterface = {
     query?: Query,
     columns?: string[],
     expandedRefColumns?: Set<string>,
-    opts?: {skip?: boolean; refetchOnDelete?: boolean; pollIntervalMs?: number}
-  ) => Loadable<CallSchema[]>;
+    opts?: {skip?: boolean; refetchOnDelete?: boolean}
+  ) => Loadable<CallSchema[]> & Refetchable;
   useCallsStats: (
     entity: string,
     project: string,
     filter: CallFilter,
     query?: Query,
-    opts?: {skip?: boolean; refetchOnDelete?: boolean; pollIntervalMs?: number}
-  ) => Loadable<traceServerClientTypes.TraceCallsQueryStatsRes>;
+    opts?: {skip?: boolean; refetchOnDelete?: boolean}
+  ) => Loadable<traceServerClientTypes.TraceCallsQueryStatsRes> & Refetchable;
   useCallsDeleteFunc: () => (
     entity: string,
     project: string,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -174,14 +174,14 @@ export type WFDataModelHooksInterface = {
     columns?: string[],
     expandedRefColumns?: Set<string>,
     opts?: {skip?: boolean; refetchOnDelete?: boolean}
-  ) => Loadable<CallSchema[]> & Refetchable;
+  ) => Loadable<CallSchema[]>;
   useCallsStats: (
     entity: string,
     project: string,
     filter: CallFilter,
     query?: Query,
     opts?: {skip?: boolean; refetchOnDelete?: boolean}
-  ) => Loadable<traceServerClientTypes.TraceCallsQueryStatsRes> & Refetchable;
+  ) => Loadable<traceServerClientTypes.TraceCallsQueryStatsRes>;
   useCallsDeleteFunc: () => (
     entity: string,
     project: string,


### PR DESCRIPTION
In this PR, I add a little refresh button to the calls table. It simply updates the table and is way way better than doing a full page refresh. I was going to implement polling, but:
a) I want to avoid a lot of server pings
b) To really make polling effective, we probably want to add more smarts to:
   1. Quickly determine which ids need refreshing
   2. Refetch those ids in particular

This is a little more advanced than the timebox I gave myself, so stopping with basic refresh for now.

<img width="2056" alt="Screenshot 2024-09-12 at 14 38 12" src="https://github.com/user-attachments/assets/ab2bc601-c52e-458c-8c1f-32cda1819d95">
