### PR TITLE
fix(weave): Remove erroneous self-binding of weave ops on classes

### DIFF
--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -79,6 +79,29 @@ def my_function(name: str):
 print(my_function.call("World"))
 ```
 
+:::note
+If your op is a method on a class, you need to pass the instance as the first argument to the op (see example below).
+:::
+
+
+```python showLineNumbers
+import weave
+
+# Initialize Weave Tracing
+weave.init("intro-example")
+
+class MyClass:
+    # Decorate your method
+    @weave.op
+    def my_method(self, name: str):
+        return f"Hello, {name}!"
+
+instance = MyClass()
+
+# Call your method -- Weave will automatically track inputs and outputs
+instance.my_method.call(instance, "World")
+```
+
 #### Call Display Name
 
 Sometimes you may want to override the display name of a call. You can achieve this in one of two ways:

--- a/weave/flow/obj.py
+++ b/weave/flow/obj.py
@@ -1,4 +1,3 @@
-from functools import partial
 from typing import Any, Optional
 
 from pydantic import (
@@ -9,7 +8,7 @@ from pydantic import (
     model_validator,
 )
 
-from weave.trace.op import ObjectRef, Op, call
+from weave.trace.op import ObjectRef, Op
 from weave.trace.vals import WeaveObject, pydantic_getattribute
 from weave.trace.weave_client import get_ref
 
@@ -70,17 +69,6 @@ class Object(BaseModel):
 
             return new_obj
         return handler(v)
-
-    def model_post_init(self, __context: Any) -> None:
-        super().model_post_init(__context)
-
-        # This binds the call "method" to the Op instance
-        # - before:  obj.method.call(obj, ...)
-        # - after:   obj.method.call(...)
-        for k in dir(self):
-            if not k.startswith("__") and isinstance(getattr(self, k), Op):
-                op = getattr(self, k)
-                op.__dict__["call"] = partial(call, op, self)
 
 
 # Enable ref tracking for Weave.Object

--- a/weave/tests/trace/test_op_call_method.py
+++ b/weave/tests/trace/test_op_call_method.py
@@ -1,7 +1,4 @@
-import pytest
-
 import weave
-from weave.trace.errors import OpCallError
 
 
 def test_op_call_method(client):
@@ -20,21 +17,3 @@ def test_op_call_method(client):
     assert call.inputs == {"a": 1, "b": 2}
     assert call.output == 3
     assert res2 == 3
-
-
-def test_op_call_class_with_method(client):
-    class Thing(weave.Object):
-        x: int
-
-        @weave.op
-        def add(self, y: int) -> int:
-            return self.x + y
-
-    t = Thing(x=1)
-    assert t.add(2) == 3
-
-    res, _ = t.add.call(t, 2)
-    assert res == 3
-
-    with pytest.raises(OpCallError, match="missing a required argument"):
-        t.add.call(2)  # missing self "t"

--- a/weave/tests/trace/test_op_call_method.py
+++ b/weave/tests/trace/test_op_call_method.py
@@ -1,4 +1,7 @@
+import pytest
+
 import weave
+from weave.trace.errors import OpCallError
 
 
 def test_op_call_method(client):
@@ -17,3 +20,21 @@ def test_op_call_method(client):
     assert call.inputs == {"a": 1, "b": 2}
     assert call.output == 3
     assert res2 == 3
+
+
+def test_op_call_class_with_method(client):
+    class Thing(weave.Object):
+        x: int
+
+        @weave.op
+        def add(self, y: int) -> int:
+            return self.x + y
+
+    t = Thing(x=1)
+    assert t.add(2) == 3
+
+    res, _ = t.add.call(t, 2)
+    assert res == 3
+
+    with pytest.raises(OpCallError, match="missing a required argument"):
+        t.add.call(2)  # missing self "t"

--- a/weave/tests/trace/test_op_decorator_behaviour.py
+++ b/weave/tests/trace/test_op_decorator_behaviour.py
@@ -216,7 +216,7 @@ def test_sync_method_calls(client, weave_obj):
         weave_obj.method(x)
 
     for x in range(3):
-        weave_obj.method.call(x)
+        weave_obj.method.call(weave_obj, x)
 
     calls = weave_obj.method.calls()
     calls = list(calls)
@@ -230,7 +230,7 @@ async def test_async_method_calls(client, weave_obj):
         await weave_obj.amethod(x)
 
     for x in range(3):
-        await weave_obj.amethod.call(x)
+        await weave_obj.amethod.call(weave_obj, x)
 
     calls = weave_obj.amethod.calls()
     calls = list(calls)
@@ -252,14 +252,14 @@ async def test_gotten_object_method_is_callable_with_call_func(client, weave_obj
     ref = weave.publish(weave_obj)
 
     weave_obj2 = ref.get()
-    res, call = weave_obj.method.call(1)
-    res2, call2 = weave_obj2.method.call(1)
+    res, call = weave_obj.method.call(weave_obj, 1)
+    res2, call2 = weave_obj2.method.call(weave_obj2, 1)
     assert res == res2
     assert call.inputs == call2.inputs
     assert call.output == call2.output
 
-    res3, call3 = await weave_obj.amethod.call(1)
-    res4, call4 = await weave_obj2.amethod.call(1)
+    res3, call3 = await weave_obj.amethod.call(weave_obj, 1)
+    res4, call4 = await weave_obj2.amethod.call(weave_obj2, 1)
     assert res3 == res4
     assert call3.inputs == call4.inputs
     assert call3.output == call4.output

--- a/weave/tests/trace/test_op_decorator_behaviour.py
+++ b/weave/tests/trace/test_op_decorator_behaviour.py
@@ -125,7 +125,7 @@ def test_sync_method(client, weave_obj, py_obj):
 
 
 def test_sync_method_call(client, weave_obj, py_obj):
-    res, call = weave_obj.method.call(1)
+    res, call = weave_obj.method.call(weave_obj, 1)
     assert isinstance(call, Call)
     assert call.inputs == {
         "self": ObjectRef(
@@ -145,7 +145,7 @@ def test_sync_method_call(client, weave_obj, py_obj):
         weave_obj_method2 = weave_obj_method_ref.get()
 
     with pytest.raises(errors.OpCallError):
-        call2 = py_obj.amethod.call(1)
+        res2, call2 = py_obj.amethod.call(1)
 
 
 @pytest.mark.asyncio
@@ -160,7 +160,7 @@ async def test_async_method(client, weave_obj, py_obj):
 
 @pytest.mark.asyncio
 async def test_async_method_call(client, weave_obj, py_obj):
-    res, call = await weave_obj.amethod.call(1)
+    res, call = await weave_obj.amethod.call(weave_obj, 1)
     assert isinstance(call, Call)
     assert call.inputs == {
         "self": ObjectRef(
@@ -180,7 +180,7 @@ async def test_async_method_call(client, weave_obj, py_obj):
         weave_obj_amethod2 = weave_obj_amethod_ref.get()
 
     with pytest.raises(errors.OpCallError):
-        call2 = await py_obj.amethod.call(1)
+        res2, call2 = await py_obj.amethod.call(1)
 
 
 def test_sync_func_patching_passes_inspection(func):

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -2,7 +2,6 @@ import dataclasses
 import inspect
 import operator
 import typing
-from functools import partial
 from typing import Any, Generator, Iterator, Literal, Optional, SupportsIndex, Union
 
 from pydantic import BaseModel
@@ -12,7 +11,7 @@ from weave.trace import box
 from weave.trace.client_context.weave_client import get_weave_client
 from weave.trace.errors import InternalError
 from weave.trace.object_record import ObjectRecord
-from weave.trace.op import Op, call, maybe_bind_method
+from weave.trace.op import Op, maybe_bind_method
 from weave.trace.refs import (
     DICT_KEY_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
@@ -579,7 +578,9 @@ def make_trace_obj(
             raise MissingSelfInstanceError(
                 f"{val.name} Op requires a bound self instance. Must be called from an instance method."
             )
-        val.call = partial(call, val, parent)
+        # TODO: This binding is correct but not done for consistency with the
+        # not-yet-saved-method-op API which requires explicitly passing self
+        # val.call = partial(call, val, parent)
         val = maybe_bind_method(val, parent)
     box_val = box.box(val)
     if isinstance(box_val, pydantic_v1.BaseModel) or isinstance(val, Op):


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
https://wandb.atlassian.net/browse/WB-20637

This removes auto-self-binding that could sometimes bind to the wrong instance, leading to unexpected results.

## Testing

Unit tests
