### PR TITLE
feat: Make Image serialization background process

### DIFF
--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -177,7 +177,7 @@ class TestOnlyFlushingWeaveClient(weave_client.WeaveClient):
 
             def wrapper(*args, **kwargs):
                 res = attr(*args, **kwargs)
-                self_super.flush()
+                self_super._flush()
                 return res
 
             return wrapper

--- a/weave/trace/async_job_queue.py
+++ b/weave/trace/async_job_queue.py
@@ -1,0 +1,143 @@
+import atexit
+import concurrent.futures
+import logging
+import threading
+from concurrent.futures import Future
+from typing import Any, Callable, TypeVar
+
+T = TypeVar("T")
+
+MAX_WORKER_DEFAULT = 2**3  # 8 workers to not overwhelm the DB
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncJobQueue:
+    """A queue for managing asynchronous job execution.
+
+    This class provides a thread-safe way to submit and execute jobs asynchronously
+    using a ThreadPoolExecutor. It ensures proper shutdown of the executor when the
+    object is deleted or when the program exits. If jobs are submitted after shutdown,
+    the queue will restart automatically.
+
+    Attributes:
+        executor (concurrent.futures.ThreadPoolExecutor): The executor used to run jobs.
+        _lock (threading.Lock): A lock to ensure thread-safe operations.
+        _is_shutdown (bool): A flag indicating whether the queue has been shut down.
+        _active_jobs (set): A set to keep track of active jobs and callbacks.
+        _max_workers (int): The maximum number of worker threads to use.
+
+    Args:
+        max_workers (int): The maximum number of worker threads to use. Defaults to 8.
+    """
+
+    def __init__(self, max_workers: int = MAX_WORKER_DEFAULT) -> None:
+        self._max_workers = max_workers
+        self._lock = threading.Lock()
+        self._is_shutdown = True
+        self._active_jobs: set[Future] = set()
+        self._start()
+
+    def _start(self) -> None:
+        """Initializes or reinitializes the executor."""
+        with self._lock:
+            if not self._is_shutdown:
+                return
+            self._is_shutdown = False
+            self.executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=self._max_workers, thread_name_prefix="AsyncJobQueue"
+            )
+            atexit.register(self.shutdown)
+
+    def submit_job(
+        self, func: Callable[..., T], *args: Any, **kwargs: Any
+    ) -> Future[T]:
+        """Submits a job to be executed asynchronously.
+
+        If the queue has been shut down, it will be restarted automatically.
+
+        Args:
+            func: The function to be executed.
+            *args: Positional arguments to pass to the function.
+            **kwargs: Keyword arguments to pass to the function.
+
+        Returns:
+            A Future representing the execution of the job.
+
+        Example usage:
+
+        ```python
+        def example_job(x):
+            time.sleep(1)  # Simulate some work
+            return x * 2
+
+        queue = AsyncJobQueue(max_workers=4)
+
+        # Submit multiple jobs
+        futures = [queue.submit_job(example_job, i) for i in range(5)]
+
+        # Wait for all jobs to complete and get results
+        results = [future.result() for future in futures]
+        print(results)  # Output: [0, 2, 4, 6, 8]
+
+        # Shutdown the queue when done
+        queue.shutdown()
+        ```
+        """
+        with self._lock:
+            if self._is_shutdown:
+                self._start()
+
+            future = self.executor.submit(func, *args, **kwargs)
+            self._active_jobs.add(future)
+
+        def callback(f: Future[T]) -> None:
+            with self._lock:
+                self._active_jobs.remove(f)
+            exception = f.exception()
+            if exception:
+                logger.error(f"Job failed with exception: {exception}")
+
+        future.add_done_callback(callback)
+        return future
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Shuts down the executor and cleans up resources.
+
+        This method ensures that the executor is shut down only once and in a thread-safe manner.
+
+        Args:
+            wait: If True, wait for all pending jobs to complete before shutting down.
+                  If False, outstanding jobs are cancelled and the executor is shut down immediately.
+        """
+        with self._lock:
+            if self._is_shutdown:
+                return
+            self._is_shutdown = True
+            atexit.unregister(self.shutdown)  # Remove the atexit handler
+
+        self.flush()  # Flush outside the lock
+        self.executor.shutdown(wait=wait)
+
+        with self._lock:
+            self._active_jobs.clear()
+
+    def __del__(self) -> None:
+        """Ensures the executor is shut down when the object is deleted."""
+        self.shutdown(wait=False)
+
+    def flush(self) -> None:
+        """Waits for all currently submitted jobs to complete.
+
+        This method blocks until all active jobs in the queue at the time of calling
+        have finished executing. It prevents new jobs from interfering with the flush operation.
+        """
+        active_jobs = []
+        with self._lock:
+            active_jobs = list(self._active_jobs)
+
+        for future in concurrent.futures.as_completed(active_jobs):
+            try:
+                future.result()
+            except Exception as e:
+                logger.error(f"Job failed during flush: {e}")

--- a/weave/trace/async_job_queue.py
+++ b/weave/trace/async_job_queue.py
@@ -114,7 +114,8 @@ class AsyncJobQueue:
             if self._is_shutdown:
                 return
             self._is_shutdown = True
-            atexit.unregister(self.shutdown)  # Remove the atexit handler
+            if atexit is not None:
+                atexit.unregister(self.shutdown)  # Remove the atexit handler
 
         self.flush()  # Flush outside the lock
         self.executor.shutdown(wait=wait)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1115,7 +1115,7 @@ class WeaveClient:
         self.async_job_queue.flush()
         if self._server_is_flushable:
             # We don't want to do an instance check here because it could
-            # be suseptibale to shutdown race conditions. So we save a boolean
+            # be susceptible to shutdown race conditions. So we save a boolean
             # _server_is_flushable and only call this if we know the server is
             # flushable. The # type: ignore is safe because we check the type
             # first.

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1114,7 +1114,12 @@ class WeaveClient:
         # Used to wait until all currently enqueued jobs are processed
         self.async_job_queue.flush()
         if self._server_is_flushable:
-            self.server.call_processor.wait_until_all_processed()
+            # We don't want to do an instance check here because it could
+            # be suseptibale to shutdown race conditions. So we save a boolean
+            # _server_is_flushable and only call this if we know the server is
+            # flushable. The # type: ignore is safe because we check the type
+            # first.
+            self.server.call_processor.wait_until_all_processed()  # type: ignore
 
     def __del__(self) -> None:
         self._cleanup()
@@ -1125,7 +1130,7 @@ class WeaveClient:
 
     def _cleanup(self) -> None:
         # Safe to call multiple times
-        self._flush() 
+        self._flush()
         self.async_job_queue.shutdown(wait=True)
 
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1,3 +1,4 @@
+import atexit
 import dataclasses
 import datetime
 import platform
@@ -13,6 +14,7 @@ from requests import HTTPError
 from weave import version
 from weave.legacy.weave import ref_base, urls
 from weave.trace import call_context, trace_sentry
+from weave.trace.async_job_queue import AsyncJobQueue
 from weave.trace.client_context import weave_client as weave_client_context
 from weave.trace.exception import exception_to_json_str
 from weave.trace.feedback import FeedbackQuery, RefFeedbackQuery
@@ -58,6 +60,7 @@ from weave.trace_server.trace_server_interface import (
     TableSchemaForInsert,
     TraceServerInterface,
 )
+from weave.trace_server_bindings.remote_http_trace_server import RemoteHTTPTraceServer
 
 # Controls if objects can have refs to projects not the WeaveClient project.
 # If False, object refs with with mismatching projects will be recreated.
@@ -386,6 +389,7 @@ class AttributesDict(dict):
 
 class WeaveClient:
     server: TraceServerInterface
+    async_job_queue: AsyncJobQueue
 
     """
     A client for interacting with the Weave trace server.
@@ -408,7 +412,9 @@ class WeaveClient:
         self.project = project
         self.server = server
         self._anonymous_ops: dict[str, Op] = {}
+        self.async_job_queue = AsyncJobQueue()
         self.ensure_project_exists = ensure_project_exists
+        atexit.register(self._cleanup)
 
         if ensure_project_exists:
             resp = self.server.ensure_project_exists(entity, project)
@@ -591,19 +597,24 @@ class WeaveClient:
 
         current_wb_run_id = safe_current_wb_run_id()
         check_wandb_run_matches(current_wb_run_id, self.entity, self.project)
-        start = StartedCallSchemaForInsert(
-            project_id=self._project_id(),
-            id=call_id,
-            op_name=op_str,
-            display_name=display_name,
+
+        started_at = datetime.datetime.now(tz=datetime.timezone.utc)
+        project_id = self._project_id()
+
+        self.async_job_queue.submit_job(
+            send_start_call,
+            project_id=project_id,
+            call_id=call_id,
+            op_str=op_str,
             trace_id=trace_id,
-            started_at=datetime.datetime.now(tz=datetime.timezone.utc),
+            started_at=started_at,
+            display_name=display_name,
             parent_id=parent_id,
-            inputs=to_json(inputs_with_refs, self._project_id(), self.server),
+            inputs_with_refs=inputs_with_refs,
             attributes=attributes,
-            wb_run_id=current_wb_run_id,
+            current_wb_run_id=current_wb_run_id,
+            server=self.server,
         )
-        self.server.call_start(CallStartReq(start=start))
 
         if use_stack:
             call_context.push_call(call)
@@ -650,17 +661,17 @@ class WeaveClient:
             exception_str = exception_to_json_str(exception)
             call.exception = exception_str
 
-        self.server.call_end(
-            CallEndReq(
-                end=EndedCallSchemaForInsert(
-                    project_id=self._project_id(),
-                    id=call.id,  # type: ignore
-                    ended_at=datetime.datetime.now(tz=datetime.timezone.utc),
-                    output=to_json(output, self._project_id(), self.server),
-                    summary=summary,
-                    exception=exception_str,
-                )
-            )
+        project_id = self._project_id()
+        ended_at = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.async_job_queue.submit_job(
+            send_end_call,
+            project_id=project_id,
+            call_id=call.id,
+            ended_at=ended_at,
+            output=output,
+            summary=summary,
+            exception_str=exception_str,
+            server=self.server,
         )
 
         # Descendent error tracking disabled til we fix UI
@@ -1094,6 +1105,73 @@ class WeaveClient:
 
     def _ref_uri(self, name: str, version: str, path: str) -> str:
         return ObjectRef(self.entity, self.project, name, version).uri()
+
+    def flush(self) -> None:
+        self.async_job_queue.flush()
+        if isinstance(self.server, RemoteHTTPTraceServer):
+            if self.server.should_batch:
+                self.server.call_processor.wait_until_all_processed()
+
+    def __del__(self) -> None:
+        self._cleanup()
+        atexit.unregister(self._cleanup)
+
+    def _cleanup(self) -> None:
+        self.flush()
+        self.async_job_queue.shutdown(wait=True)
+
+
+def send_start_call(
+    project_id: str,
+    call_id: str,
+    op_str: str,
+    trace_id: str,
+    started_at: datetime.datetime,
+    display_name: Optional[str],
+    parent_id: Optional[str],
+    inputs_with_refs: dict[str, Any],
+    attributes: dict[str, Any],
+    current_wb_run_id: Optional[str],
+    server: TraceServerInterface,
+) -> None:
+    inputs_json = to_json(inputs_with_refs, project_id, server)
+    start = StartedCallSchemaForInsert(
+        project_id=project_id,
+        id=call_id,
+        op_name=op_str,
+        display_name=display_name,
+        trace_id=trace_id,
+        started_at=started_at,
+        parent_id=parent_id,
+        inputs=inputs_json,
+        attributes=attributes,
+        wb_run_id=current_wb_run_id,
+    )
+    server.call_start(CallStartReq(start=start))
+
+
+def send_end_call(
+    project_id: str,
+    call_id: str,
+    ended_at: datetime.datetime,
+    output: Any,
+    summary: dict[str, Any],
+    exception_str: Optional[str],
+    server: TraceServerInterface,
+) -> None:
+    output_json = to_json(output, project_id, server)
+    server.call_end(
+        CallEndReq(
+            end=EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=call_id,
+                ended_at=ended_at,
+                output=output_json,
+                summary=summary,
+                exception=exception_str,
+            )
+        )
+    )
 
 
 def safe_current_wb_run_id() -> Optional[str]:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -401,9 +401,14 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         if conditions_part:
             query += f" AND {conditions_part}"
 
-        order_by = (
-            None if not req.sort_by else [(s.field, s.direction) for s in req.sort_by]
-        )
+        # Match the batch server:
+        if req.sort_by is None:
+            order_by = [("started_at", "asc")]
+        elif len(req.sort_by) == 0:
+            order_by = None
+        else:
+            order_by = [(s.field, s.direction) for s in req.sort_by]
+
         if order_by is not None:
             order_parts = []
             for field, direction in order_by:


### PR DESCRIPTION
This PR is a patch to the previously reverted: https://github.com/wandb/weave/pull/2302 ... Essentially i made the exit procedure safer and tested in:
* local ipython
* local python
* colab

This is a good view to see changes on top of the previous pr: https://github.com/wandb/weave/pull/2367/files/1224f719c58b7289ecccc1cfaba8603b56893665..2316cb120567a657eb79ed1e0bc67e9b6d7db1bf

The original implementation had a bug that when running in ipython, explicitly exiting would throw:

```
Exception ignored in: <function WeaveClient.__del__ at 0x141ae9080>
Traceback (most recent call last):
  File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/trace/weave_client.py", line 1116, in __del__
  File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/trace/weave_client.py", line 1120, in _cleanup
  File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/trace/weave_client.py", line 1111, in flush
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

This was because the `__del__` method was running after the other symbol was deleted. This cleans up such cases