### PR TITLE
fix: Remove `Value` prefix from output rendering

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -41,7 +41,7 @@ import {
 import {mapObject, ObjectPath, traverse, TraverseContext} from './traverse';
 import {ValueView} from './ValueView';
 
-type Data = Record<string, any>;
+type Data = Record<string, any> | any[];
 
 type ObjectViewerProps = {
   apiRef: React.MutableRefObject<GridApiPro>;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -244,15 +244,11 @@ export const ObjectViewerSection = ({
   if (numKeys === 1 && '_result' in data) {
     const value = data._result;
     const valueType = getValueType(value);
-    if (
-      valueType === 'object' ||
-      (valueType === 'array' && value.length > 0) ||
-      isWeaveRef(value)
-    ) {
+    if (valueType === 'object' || (valueType === 'array' && value.length > 0)) {
       return (
         <ObjectViewerSectionNonEmptyMemoed
           title={title}
-          data={{Value: value}}
+          data={value}
           noHide={noHide}
           isExpanded={isExpanded}
         />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -35,6 +35,9 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
     if (USE_TABLE_FOR_ARRAYS && data.valueType === 'array') {
       return <DataTableView data={data.value} />;
     }
+    if (data.valueType === 'array' && data.value.length === 0) {
+      return <ValueViewPrimitive>Empty List</ValueViewPrimitive>;
+    }
     return null;
   }
 
@@ -74,8 +77,10 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
   }
 
   if (data.valueType === 'array') {
+    if (data.value.length === 0) {
+      return <ValueViewPrimitive>Empty List</ValueViewPrimitive>;
+    }
     // Compared to toString this keeps the square brackets.
-    // This is particularly helpful for empty lists, for which toString would return an empty string.
     return <div>{JSON.stringify(data.value)}</div>;
   }
 


### PR DESCRIPTION
@adamwdraper notice that we render a "Value" key for lists in the output. This is a bit of legacy code from when our viewer was not generic enough to handle lists. It is now. This PR cleans up this code path effectively removing the dummy "Value" key.

Before (above), After (below)

<img width="2054" alt="Screenshot 2024-09-12 at 16 36 13" src="https://github.com/user-attachments/assets/bb46170e-b589-4538-b1b1-1f22288096db">
