### PR TITLE
Griffin/serialize large json blobs

### DIFF
--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any
+from typing import Any, Optional
 
 from weave.trace import custom_objs
 from weave.trace.object_record import ObjectRecord
@@ -9,9 +9,15 @@ from weave.trace_server.trace_server_interface import (
     FileCreateReq,
     TraceServerInterface,
 )
+from weave.type_serializers.JSONBlob.jsonblob import JSONBlob
 
 
-def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
+def to_json(
+    obj: Any,
+    project_id: str,
+    server: TraceServerInterface,
+    parent_bytes: Optional[int] = None,
+) -> Any:
     if isinstance(obj, TableRef):
         return obj.uri()
     elif isinstance(obj, ObjectRef):
@@ -19,14 +25,26 @@ def to_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
     elif isinstance(obj, ObjectRecord):
         res = {"_type": obj._class_name}
         for k, v in obj.__dict__.items():
-            res[k] = to_json(v, project_id, server)
+            res[k] = to_json(v, project_id, server, parent_bytes)
         return res
     elif isinstance_namedtuple(obj):
-        return {k: to_json(v, project_id, server) for k, v in obj._asdict().items()}
-    elif isinstance(obj, (list, tuple)):
-        return [to_json(v, project_id, server) for v in obj]
+        return {
+            k: to_json(v, project_id, server, parent_bytes)
+            for k, v in obj._asdict().items()
+        }
+
+    if (parent_bytes is None or parent_bytes > 1 * 1024**2) and isinstance(
+        obj, (list, tuple, str)
+    ):
+        parent_bytes = len(str(obj).encode("utf-8"))
+
+    if parent_bytes and parent_bytes > 1 * 1024**2:
+        obj = JSONBlob(obj)
+
+    if isinstance(obj, (list, tuple)):
+        return [to_json(v, project_id, server, parent_bytes) for v in obj]
     elif isinstance(obj, dict):
-        return {k: to_json(v, project_id, server) for k, v in obj.items()}
+        return {k: to_json(v, project_id, server, parent_bytes) for k, v in obj.items()}
 
     if isinstance(obj, (int, float, str, bool)) or obj is None:
         return obj

--- a/weave/type_serializers/JSONBlob/jsonblob.py
+++ b/weave/type_serializers/JSONBlob/jsonblob.py
@@ -6,8 +6,12 @@ from weave.trace.custom_objs import MemTraceFilesArtifact
 
 
 class JSONBlob:
-    def __init__(self, obj: Any) -> None:
+    def __init__(self, obj: Any, size: int) -> None:
         self.obj = obj
+        self.size = size
+
+    def __repr__(self) -> str:
+        return f"JSONBlob <{self.size} bytes>"
 
 
 def save(obj: JSONBlob, artifact: MemTraceFilesArtifact, name: str) -> None:

--- a/weave/type_serializers/JSONBlob/jsonblob.py
+++ b/weave/type_serializers/JSONBlob/jsonblob.py
@@ -1,0 +1,24 @@
+import json
+from typing import Any
+
+from weave.trace import serializer
+from weave.trace.custom_objs import MemTraceFilesArtifact
+
+
+class JSONBlob:
+    def __init__(self, obj: Any) -> None:
+        self.obj = obj
+
+
+def save(obj: JSONBlob, artifact: MemTraceFilesArtifact, name: str) -> None:
+    with artifact.new_file("blob.json", binary=False) as f:
+        json.dump(obj.obj, f)
+
+
+def load(artifact: MemTraceFilesArtifact, name: str) -> JSONBlob:
+    with artifact.path("blob.json") as f:
+        return JSONBlob(json.load(f))
+
+
+def register() -> None:
+    serializer.register_serializer(JSONBlob, save, load)

--- a/weave/type_serializers/__init__.py
+++ b/weave/type_serializers/__init__.py
@@ -1,3 +1,5 @@
 from .Image import image
+from .JSONBlob import jsonblob
 
 image.register()
+jsonblob.register()


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

In the client, before serialization, iterate through keys on the inputs and output objects. Convert very large objects to jsonblobs which when serialized load content as files. 

## Testing

How was this PR tested?
