### PR TITLE
chore: make len(dataset.rows) work

### DIFF
--- a/weave/trace/table.py
+++ b/weave/trace/table.py
@@ -32,6 +32,9 @@ class Table:
         self._validate_rows(value)
         self._rows = value
 
+    def __len__(self) -> int:
+        return len(self.rows)
+
     def __getitem__(self, key: int) -> dict:
         return self.rows[key]
 


### PR DESCRIPTION
## Description

Seemed odd that I could iterate over the rows in a table and access them by index but `__len__` wasn't implemented.

(I also feel like the API for Dataset should do the same thing, but that's worthy of a broader discussion.)

## Testing

How was this PR tested?
