### PR TITLE
fix(ui): Inherit display styles for Buttons with tooltips

### DIFF
--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -150,7 +150,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             <Tooltip.Root open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
               <Tooltip.Trigger asChild>
                 {/* span is needed so tooltip works on disabled buttons */}
-                <span>{button}</span>
+                <span className="[display:inherit]">{button}</span>
               </Tooltip.Trigger>
               <Tooltip.Portal>
                 <Tooltip.Content {...tooltipProps}>{tooltip}</Tooltip.Content>


### PR DESCRIPTION
before: i noticed the info tooltip buttons in the workspaces overflow menu were not vertically centered

<img width="306" alt="Screenshot 2024-09-12 at 3 54 11 PM" src="https://github.com/user-attachments/assets/0a840185-390d-45d9-b8d1-73d26c125741">
<img width="380" alt="Screenshot 2024-09-12 at 3 54 22 PM" src="https://github.com/user-attachments/assets/dd05d2bb-1570-4747-9063-b1b19bd8bf7c">

after: problem is fixed (very subtle but definitely different!)

<img width="300" alt="Screenshot 2024-09-12 at 3 54 28 PM" src="https://github.com/user-attachments/assets/e618af90-a534-43ea-84f8-0797dcfd5c07">
<img width="371" alt="Screenshot 2024-09-12 at 6 49 23 PM" src="https://github.com/user-attachments/assets/3f863d9f-00b7-4888-b940-5ad300547231">

additional testing: spot-checked various other buttons with tooltips and they all still look correct