### PR TITLE
feat: add Evaluation tab

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -14,6 +14,7 @@ import {NotFoundPanel} from '../../NotFoundPanel';
 import {isEvaluateOp} from '../common/heuristics';
 import {CenteredAnimatedLoader} from '../common/Loader';
 import {SimplePageLayoutWithHeader} from '../common/SimplePageLayout';
+import {CompareEvaluationsPageContent} from '../CompareEvaluationsPage/CompareEvaluationsPage';
 import {TabUseCall} from '../TabUseCall';
 import {useURLSearchParamsDict} from '../util';
 import {useWFHooks} from '../wfReactInterface/context';
@@ -49,6 +50,20 @@ const useCallTabs = (call: CallSchema) => {
   const {entity, project, callId} = call;
   const weaveRef = makeRefCall(entity, project, callId);
   return [
+    ...(isEvaluateOp(call.spanName)
+      ? [
+          {
+            label: 'Evaluation',
+            content: (
+              <CompareEvaluationsPageContent
+                entity={call.entity}
+                project={call.project}
+                evaluationCallIds={[call.callId]}
+              />
+            ),
+          },
+        ]
+      : []),
     {
       label: 'Call',
       content: <CallDetails call={call} />,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -42,6 +42,30 @@ type CompareEvaluationsPageProps = {
 export const CompareEvaluationsPage: React.FC<
   CompareEvaluationsPageProps
 > = props => {
+  return (
+    <SimplePageLayout
+      title="Compare Evaluations"
+      hideTabsIfSingle
+      tabs={[
+        {
+          label: 'All',
+          content: (
+            <CompareEvaluationsPageContent
+              entity={props.entity}
+              project={props.project}
+              evaluationCallIds={props.evaluationCallIds}
+            />
+          ),
+        },
+      ]}
+      headerExtra={<HeaderExtra {...props} />}
+    />
+  );
+};
+
+export const CompareEvaluationsPageContent: React.FC<
+  CompareEvaluationsPageProps
+> = props => {
   const [baselineEvaluationCallId, setBaselineEvaluationCallId] =
     React.useState(
       props.evaluationCallIds.length > 0 ? props.evaluationCallIds[0] : null
@@ -77,35 +101,21 @@ export const CompareEvaluationsPage: React.FC<
   }
 
   return (
-    <SimplePageLayout
-      title="Compare Evaluations"
-      hideTabsIfSingle
-      tabs={[
-        {
-          label: 'All',
-          content: (
-            <CompareEvaluationsProvider
-              entity={props.entity}
-              project={props.project}
-              evaluationCallIds={props.evaluationCallIds}
-              baselineEvaluationCallId={baselineEvaluationCallId ?? undefined}
-              comparisonDimensions={comparisonDimensions ?? undefined}
-              setBaselineEvaluationCallId={setBaselineEvaluationCallId}
-              setComparisonDimensions={
-                setComparisonDimensionsAndClearInputDigest
-              }
-              selectedInputDigest={selectedInputDigest ?? undefined}
-              setSelectedInputDigest={setSelectedInputDigest}>
-              <CustomWeaveTypeProjectContext.Provider
-                value={{entity: props.entity, project: props.project}}>
-                <CompareEvaluationsPageInner />
-              </CustomWeaveTypeProjectContext.Provider>
-            </CompareEvaluationsProvider>
-          ),
-        },
-      ]}
-      headerExtra={<HeaderExtra {...props} />}
-    />
+    <CompareEvaluationsProvider
+      entity={props.entity}
+      project={props.project}
+      evaluationCallIds={props.evaluationCallIds}
+      baselineEvaluationCallId={baselineEvaluationCallId ?? undefined}
+      comparisonDimensions={comparisonDimensions ?? undefined}
+      setBaselineEvaluationCallId={setBaselineEvaluationCallId}
+      setComparisonDimensions={setComparisonDimensionsAndClearInputDigest}
+      selectedInputDigest={selectedInputDigest ?? undefined}
+      setSelectedInputDigest={setSelectedInputDigest}>
+      <CustomWeaveTypeProjectContext.Provider
+        value={{entity: props.entity, project: props.project}}>
+        <CompareEvaluationsPageInner />
+      </CustomWeaveTypeProjectContext.Provider>
+    </CompareEvaluationsProvider>
   );
 };
 


### PR DESCRIPTION
## Description

Reuses the evaluation comparison page as default tab when viewing an evaluation call.
![image](https://github.com/user-attachments/assets/402c1159-bd1c-42e5-b9af-5f2bc48cdf53)

## Testing

How was this PR tested?
