### PR TITLE
chore(app): Update Button tooltip type

### DIFF
--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -32,7 +32,7 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: ButtonVariant;
   children?: ReactElement | string;
   active?: boolean;
-  tooltip?: string;
+  tooltip?: ReactElement | string;
   tooltipProps?: TooltipContentProps;
   twWrapperStyles?: React.CSSProperties;
 };


### PR DESCRIPTION
## Description

Button `tooltip` prop is typed as a plain `string`, even though it's perfectly capable of handling rich, composable contents. This change simply updates the prop type to allow this.

Use case: I have an info button tooltip where I want to apply semibold styling to a specific word and also display an icon

<img width="509" alt="Screenshot 2024-09-16 at 10 09 57 AM" src="https://github.com/user-attachments/assets/0dcb0f70-e8e6-4dcf-b897-6e81f25160fb">


## Testing

How was this PR tested?
