### PR TITLE
fix: Simplify the exit procedures to reduce flush errors

### DIFF
--- a/weave/trace/async_job_queue.py
+++ b/weave/trace/async_job_queue.py
@@ -88,21 +88,10 @@ class AsyncJobQueue:
         future.add_done_callback(callback)
         return future
 
-    def _shutdown(self, wait: bool = True) -> None:
-        """Shuts down the executor and cleans up resources.
-
-        This method ensures that the executor is shut down only once and in a thread-safe manner.
-
-        Args:
-            wait: If True, wait for all pending jobs to complete before shutting down.
-                  If False, outstanding jobs are cancelled and the executor is shut down immediately.
-        """
-        self.executor.shutdown(wait=wait)
-
     def _at_exit_handler(self) -> None:
         """Ensures the executor is shut down when the program exits."""
         try:
-            self._shutdown(wait=True)
+            self.executor.shutdown(wait=True)
         except Exception as e:
             logger.error(f"Error shutting down executor: {e}")
 

--- a/weave/trace/async_job_queue.py
+++ b/weave/trace/async_job_queue.py
@@ -23,7 +23,6 @@ class AsyncJobQueue:
     Attributes:
         executor (concurrent.futures.ThreadPoolExecutor): The executor used to run jobs.
         _lock (threading.Lock): A lock to ensure thread-safe operations.
-        _is_shutdown (bool): A flag indicating whether the queue has been shut down.
         _active_jobs (set): A set to keep track of active jobs and callbacks.
         _max_workers (int): The maximum number of worker threads to use.
 
@@ -34,20 +33,11 @@ class AsyncJobQueue:
     def __init__(self, max_workers: int = MAX_WORKER_DEFAULT) -> None:
         self._max_workers = max_workers
         self._lock = threading.Lock()
-        self._is_shutdown = True
         self._active_jobs: set[Future] = set()
-        self._start()
-
-    def _start(self) -> None:
-        """Initializes or reinitializes the executor."""
-        with self._lock:
-            if not self._is_shutdown:
-                return
-            self._is_shutdown = False
-            self.executor = concurrent.futures.ThreadPoolExecutor(
-                max_workers=self._max_workers, thread_name_prefix="AsyncJobQueue"
-            )
-            atexit.register(self.shutdown)
+        self.executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=self._max_workers, thread_name_prefix="AsyncJobQueue"
+        )
+        atexit.register(self._at_exit_handler)
 
     def submit_job(
         self, func: Callable[..., T], *args: Any, **kwargs: Any
@@ -85,9 +75,6 @@ class AsyncJobQueue:
         ```
         """
         with self._lock:
-            if self._is_shutdown:
-                self._start()
-
             future = self.executor.submit(func, *args, **kwargs)
             self._active_jobs.add(future)
 
@@ -101,7 +88,7 @@ class AsyncJobQueue:
         future.add_done_callback(callback)
         return future
 
-    def shutdown(self, wait: bool = True) -> None:
+    def _shutdown(self, wait: bool = True) -> None:
         """Shuts down the executor and cleans up resources.
 
         This method ensures that the executor is shut down only once and in a thread-safe manner.
@@ -110,15 +97,14 @@ class AsyncJobQueue:
             wait: If True, wait for all pending jobs to complete before shutting down.
                   If False, outstanding jobs are cancelled and the executor is shut down immediately.
         """
-        with self._lock:
-            # Lock and flag avoids race conditions with multiple shutdowns
-            if self._is_shutdown:
-                return
-            self._is_shutdown = True
-            if atexit is not None:
-                atexit.unregister(self.shutdown)  # Remove the atexit handler
+        self.executor.shutdown(wait=wait)
 
-            self.executor.shutdown(wait=wait)
+    def _at_exit_handler(self) -> None:
+        """Ensures the executor is shut down when the program exits."""
+        try:
+            self._shutdown(wait=True)
+        except Exception as e:
+            logger.error(f"Error shutting down executor: {e}")
 
     def flush(self) -> None:
         """Waits for all currently submitted jobs to complete.

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1,4 +1,3 @@
-import atexit
 import dataclasses
 import datetime
 import platform
@@ -427,7 +426,6 @@ class WeaveClient:
         self._anonymous_ops: dict[str, Op] = {}
         self.async_job_queue = AsyncJobQueue()
         self.ensure_project_exists = ensure_project_exists
-        atexit.register(self._cleanup)
 
         if ensure_project_exists:
             resp = self.server.ensure_project_exists(entity, project)
@@ -1177,18 +1175,6 @@ class WeaveClient:
             # flushable. The # type: ignore is safe because we check the type
             # first.
             self.server.call_processor.wait_until_all_processed()  # type: ignore
-
-    def __del__(self) -> None:
-        self._cleanup()
-        # Because "__del__" is called when the interpreter exits, we need to
-        # make sure that atexit is available.
-        if atexit is not None:
-            atexit.unregister(self._cleanup)
-
-    def _cleanup(self) -> None:
-        # Safe to call multiple times
-        self._flush()
-        self.async_job_queue.shutdown(wait=True)
 
 
 def send_start_call(


### PR DESCRIPTION
Currently, our system has a few async mechanics to handle writing data to Weave in a non-blocking way. As currently implemented, I used both `atexit` handlers AND `__del__` overrides. This system was admittedly over-engineered and overkill. As a result, in some scenarios, we were running into error at exit time for some machines. 

This PR does the following:
1. Remove all the `__del__` handling. Upon reflection, this is not needed and makes everything more complicated. Remove a bunch of code relating to this
2. Refactor the code to just use `atexit`

The net effect of this PR is that:
1. The only classes that register exit functions are those that explicitly construct the threads (much much cleaner). This is in contrast to my prior approach which was trying to also execute cleanup at `__del__` moments. However, this is overkill.
2. As a result of the above, the complete flush events will not occur until program exit (meaning if all references to a client are deleted - invoking a GC), we will retain exit handlers to their underlying threads.
