### PR TITLE
fix: dynamic height for eval page (particularly in drawer view)

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -8,6 +8,7 @@ import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
 import React, {FC, useCallback, useContext, useMemo, useState} from 'react';
 import {useHistory} from 'react-router-dom';
+import {AutoSizer} from 'react-virtualized';
 
 import {Button} from '../../../../../Button';
 import {
@@ -113,7 +114,9 @@ export const CompareEvaluationsPageContent: React.FC<
       setSelectedInputDigest={setSelectedInputDigest}>
       <CustomWeaveTypeProjectContext.Provider
         value={{entity: props.entity, project: props.project}}>
-        <CompareEvaluationsPageInner />
+        <AutoSizer style={{height: '100%', width: '100%'}}>
+          {({height, width}) => <CompareEvaluationsPageInner height={height} />}
+        </AutoSizer>
       </CustomWeaveTypeProjectContext.Provider>
     </CompareEvaluationsProvider>
   );
@@ -165,7 +168,9 @@ const ReturnToEvaluationsButton: FC<{entity: string; project: string}> = ({
   );
 };
 
-const CompareEvaluationsPageInner: React.FC = props => {
+const CompareEvaluationsPageInner: React.FC<{
+  height: number;
+}> = props => {
   const {state} = useCompareEvaluationsState();
   const showExampleFilter =
     Object.keys(state.data.evaluationCalls).length === 2;
@@ -173,7 +178,7 @@ const CompareEvaluationsPageInner: React.FC = props => {
   return (
     <Box
       sx={{
-        height: '100%',
+        height: props.height,
         width: '100%',
         overflow: 'auto',
       }}>
@@ -192,7 +197,7 @@ const CompareEvaluationsPageInner: React.FC = props => {
         {showExamples ? (
           <>
             {showExampleFilter && <ExampleFilterSection state={state} />}
-            <ResultExplorer state={state} />
+            <ResultExplorer state={state} height={props.height} />
           </>
         ) : (
           <VerticalBox
@@ -222,9 +227,10 @@ const CompareEvaluationsPageInner: React.FC = props => {
   );
 };
 
-const ResultExplorer: React.FC<{state: EvaluationComparisonState}> = ({
-  state,
-}) => {
+const ResultExplorer: React.FC<{
+  state: EvaluationComparisonState;
+  height: number;
+}> = ({state, height}) => {
   return (
     <VerticalBox
       sx={{
@@ -250,7 +256,7 @@ const ResultExplorer: React.FC<{state: EvaluationComparisonState}> = ({
       </HorizontalBox>
       <Box
         sx={{
-          height: 'calc(100vh - 114px)',
+          height,
           overflow: 'auto',
         }}>
         <ExampleCompareSection state={state} />


### PR DESCRIPTION
Now that the eval view is not full-screen, we need to measure the available hight for the example view to work correctly. Notice how the left browser (new) has full height of the pager when scrolled to the bottom

![Screenshot 2024-09-16 at 14 09 31](https://github.com/user-attachments/assets/0a9edfee-caa5-4391-8f96-b2041bab1962)


