### PR TITLE
chore: overflow trace name gracefully

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -303,11 +303,23 @@ export const CallLink: React.FC<{
             display: 'flex',
             alignItems: 'center',
             gap: '4px',
-            justifyContent: 'space-between',
+            // allow flex items to shrink below their minimum content size
+            minWidth: 0,
           }}>
           {props.icon}
-          {opName}
-          <Id id={props.callId} type="Call" />
+          <span
+            style={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              flexGrow: 1,
+              flexShrink: 1,
+            }}>
+            {opName}
+          </span>
+          <span style={{flexShrink: 0}}>
+            <Id id={props.callId} type="Call" />
+          </span>
         </Link>
       </LinkTruncater>
     </LinkWrapper>


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-20956](https://wandb.atlassian.net/browse/WB-20956)

Simple clipping of the text

Prod: 
<img width="384" alt="Screenshot 2024-09-16 at 6 58 44 PM" src="https://github.com/user-attachments/assets/cf0ebecb-7bf6-4ab5-91a6-f60f4d04657a">

This branch:

<img width="400" alt="Screenshot 2024-09-16 at 7 07 20 PM" src="https://github.com/user-attachments/assets/981d5d31-9b07-4f8b-98fb-91b126963d9b">

## Testing

How was this PR tested?


[WB-20956]: https://wandb.atlassian.net/browse/WB-20956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ