### PR TITLE
chore: guess cell format for timestamps

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
@@ -5,6 +5,10 @@ import styled from 'styled-components';
 import {parseRef} from '../../../../react';
 import {isWeaveRef} from '../Browse3/filters/common';
 import {ValueViewNumber} from '../Browse3/pages/CallPage/ValueViewNumber';
+import {
+  isProbablyTimestamp,
+  ValueViewNumberTimestamp,
+} from '../Browse3/pages/CallPage/ValueViewNumberTimestamp';
 import {ValueViewPrimitive} from '../Browse3/pages/CallPage/ValueViewPrimitive';
 import {isCustomWeaveTypePayload} from '../Browse3/typeViews/customWeaveType.types';
 import {CustomWeaveTypeDispatcher} from '../Browse3/typeViews/CustomWeaveTypeDispatcher';
@@ -56,6 +60,9 @@ export const CellValue = ({value, isExpanded = false}: CellValueProps) => {
     return <CellValueString value={value} />;
   }
   if (typeof value === 'number') {
+    if (isProbablyTimestamp(value)) {
+      return <ValueViewNumberTimestamp value={value} />;
+    }
     return (
       <Box
         sx={{


### PR DESCRIPTION
## Description

In cell values, if a number looks like a timestamp, give it the timestamp treatment.

Before:
<img width="190" alt="Screenshot 2024-09-16 at 11 35 09 PM" src="https://github.com/user-attachments/assets/677dec35-693b-416e-ad80-81ea626fbfa6">

After:
<img width="338" alt="Screenshot 2024-09-16 at 11 33 53 PM" src="https://github.com/user-attachments/assets/c6e3d18d-742a-4e24-8ae8-36c45d5797f5">


## Testing

How was this PR tested?
