### PR TITLE
feat: Improve serialization & deserialization of custom objects using in mem cache

### DIFF
--- a/weave/conftest.py
+++ b/weave/conftest.py
@@ -196,7 +196,7 @@ def make_server_recorder(server: tsi.TraceServerInterface):  # type: ignore
     For example, you can do something like the followng to assert that various
     read operations do not happen!
 
-    ```pyth
+    ```python
     access_log = client.server.attribute_access_log
     assert "table_query" not in access_log
     assert "obj_read" not in access_log

--- a/weave/tests/trace/test_custom_weave_type_serialization_cache.py
+++ b/weave/tests/trace/test_custom_weave_type_serialization_cache.py
@@ -1,0 +1,128 @@
+import gc
+
+import pytest
+
+from weave.trace.custom_weave_type_serialization_cache import (
+    CustomWeaveTypeSerializationCache,
+)
+
+
+class CustomWeaveType:
+    def __init__(self, value):
+        self.value = value
+
+    def __eq__(self, other):
+        return isinstance(other, CustomWeaveType) and self.value == other.value
+
+
+@pytest.fixture
+def cache():
+    return CustomWeaveTypeSerializationCache()
+
+
+def test_store_and_retrieve(cache):
+    obj = CustomWeaveType(1)
+    serialized_dict = {"value": 1}
+    cache.store(obj, serialized_dict)
+
+    assert cache.get_serialized_dict(obj) == serialized_dict
+    assert cache.get_deserialized_obj(serialized_dict) == obj
+
+
+def test_store_multiple_objects(cache):
+    obj1 = CustomWeaveType(1)
+    obj2 = CustomWeaveType(2)
+    serialized_dict1 = {"value": 1}
+    serialized_dict2 = {"value": 2}
+
+    cache.store(obj1, serialized_dict1)
+    cache.store(obj2, serialized_dict2)
+
+    assert cache.get_serialized_dict(obj1) == serialized_dict1
+    assert cache.get_serialized_dict(obj2) == serialized_dict2
+    assert cache.get_deserialized_obj(serialized_dict1) == obj1
+    assert cache.get_deserialized_obj(serialized_dict2) == obj2
+
+
+def test_reset(cache):
+    obj = CustomWeaveType(1)
+    serialized_dict = {"value": 1}
+    cache.store(obj, serialized_dict)
+
+    cache.reset()
+
+    assert cache.get_serialized_dict(obj) is None
+    assert cache.get_deserialized_obj(serialized_dict) is None
+
+
+def test_weak_reference_behavior(cache):
+    obj = CustomWeaveType(1)
+    serialized_dict = {"value": 1}
+    cache.store(obj, serialized_dict)
+
+    del obj
+    gc.collect()
+
+    assert cache.get_deserialized_obj(serialized_dict) is None
+
+
+def test_non_existent_object(cache):
+    obj = CustomWeaveType(1)
+    serialized_dict = {"value": 1}
+
+    assert cache.get_serialized_dict(obj) is None
+    assert cache.get_deserialized_obj(serialized_dict) is None
+
+
+def test_update_existing_object(cache):
+    obj = CustomWeaveType(1)
+    serialized_dict1 = {"value": 1}
+    serialized_dict2 = {"value": "one"}
+
+    cache.store(obj, serialized_dict1)
+    cache.store(obj, serialized_dict2)
+
+    assert cache.get_serialized_dict(obj) == serialized_dict2
+    assert cache.get_deserialized_obj(serialized_dict2) == obj
+    assert cache.get_deserialized_obj(serialized_dict1) is None
+
+
+def test_unhashable_object(cache):
+    class UnhashableObject:
+        def __hash__(self):
+            raise TypeError("unhashable type")
+
+    obj = UnhashableObject()
+    serialized_dict = {"type": "unhashable"}
+
+    cache.store(obj, serialized_dict)
+
+    assert cache.get_serialized_dict(obj) == serialized_dict
+    assert cache.get_deserialized_obj(serialized_dict) == obj
+
+
+def test_exception_handling(cache):
+    obj = CustomWeaveType(1)
+    bad_dict = {"key": object()}  # object() is not JSON serializable
+
+    # This should not raise an exception
+    cache.store(obj, bad_dict)
+
+    assert cache.get_serialized_dict(obj) == bad_dict
+
+    # We are unable lookup unserializable objects
+    assert cache.get_deserialized_obj(bad_dict) is None
+
+
+def test_multiple_objects_same_serialization(cache):
+    obj1 = CustomWeaveType(1)
+    obj2 = CustomWeaveType(1)
+    serialized_dict = {"value": 1}
+
+    cache.store(obj1, serialized_dict)
+    cache.store(obj2, serialized_dict)
+
+    assert cache.get_serialized_dict(obj1) == serialized_dict
+    assert cache.get_serialized_dict(obj2) == serialized_dict
+    # The last stored object should be returned
+    assert cache.get_deserialized_obj(serialized_dict) == obj2

--- a/weave/tests/trace/test_evaluations.py
+++ b/weave/tests/trace/test_evaluations.py
@@ -709,6 +709,7 @@ async def test_eval_with_complex_types(client):
     # These assertions ensure that we aren't making those extra requests.
     # There is no reason to query the table, objects, or files
     # as everything is in memory
+    client._flush()
     access_log = client.server.attribute_access_log
     assert "table_query" not in access_log
     assert "obj_read" not in access_log
@@ -728,6 +729,7 @@ async def test_eval_with_complex_types(client):
     assert isinstance(row["obj"], str)  #  MyObj
     assert isinstance(row["text"], str)
 
+    client._flush()
     access_log = client.server.attribute_access_log
     assert "table_query" in access_log
     assert "obj_read" in access_log

--- a/weave/tests/trace/test_serialize.py
+++ b/weave/tests/trace/test_serialize.py
@@ -9,5 +9,60 @@ def test_serialize_caching(client):
     serialized_img = serialize._to_json_custom_weave_type(
         img, client._project_id(), client.server
     )
+    client._flush()
     access_log = client.server.attribute_access_log
-    assert "files_create" not in access_log
+    methods_1 = [log for log in access_log if not log.startswith("_")]
+    assert methods_1 == [
+        "ensure_project_exists",  # default initialization
+        "file_create",  # creates the deserialize op code
+        "obj_create",  # creates the deserialize op object
+        "file_create",  # creates the image file
+    ]
+
+    # Serialize again
+    serialized_img = serialize._to_json_custom_weave_type(
+        img, client._project_id(), client.server
+    )
+    client._flush()
+    access_log = client.server.attribute_access_log
+    methods_2 = [log for log in access_log if not log.startswith("_")]
+    # No new methods should be called!
+    assert methods_2 == methods_1
+
+    # Make sure we can deserialize
+    deserialize_img = serialize._from_json_custom_weave_type(
+        serialized_img, client._project_id(), client.server
+    )
+    assert isinstance(deserialize_img, Image.Image)
+    assert deserialize_img.tobytes() == img.tobytes()
+
+    # Again, no new methods should be called!
+    client._flush()
+    access_log = client.server.attribute_access_log
+    methods_3 = [log for log in access_log if not log.startswith("_")]
+    assert methods_3 == methods_2
+
+    # Reset the cache
+    serialize._custom_weave_type_cache.reset()
+
+    # Deserialize should trigger new methods
+    deserialize_img = serialize._from_json_custom_weave_type(
+        serialized_img, client._project_id(), client.server
+    )
+    client._flush()
+    access_log = client.server.attribute_access_log
+    methods_4 = [log for log in access_log if not log.startswith("_")]
+    assert methods_4 == methods_3 + [
+        "file_content_read",  # load the deserializer
+        "obj_read",  # load the image dict
+        "file_content_read",  # load the image bytes
+    ]
+
+    # Reserialize should not trigger any new methods
+    serialized_img = serialize._to_json_custom_weave_type(
+        deserialize_img, client._project_id(), client.server
+    )
+    client._flush()
+    access_log = client.server.attribute_access_log
+    methods_5 = [log for log in access_log if not log.startswith("_")]
+    assert methods_5 == methods_4

--- a/weave/tests/trace/test_serialize.py
+++ b/weave/tests/trace/test_serialize.py
@@ -5,6 +5,7 @@ from weave.trace import serialize
 
 
 def test_serialize_caching(client):
+    serialize._custom_weave_type_cache_map[client._project_id()].reset()
     img = Image.new("RGB", (100, 100))
     serialized_img = serialize._to_json_custom_weave_type(
         img, client._project_id(), client.server

--- a/weave/tests/trace/test_serialize.py
+++ b/weave/tests/trace/test_serialize.py
@@ -43,7 +43,7 @@ def test_serialize_caching(client):
     assert methods_3 == methods_2
 
     # Reset the cache
-    serialize._custom_weave_type_cache.reset()
+    serialize._custom_weave_type_cache_map[client._project_id()].reset()
 
     # Deserialize should trigger new methods
     deserialize_img = serialize._from_json_custom_weave_type(

--- a/weave/tests/trace/test_serialize.py
+++ b/weave/tests/trace/test_serialize.py
@@ -1,28 +1,50 @@
-from PIL import Image
+import json
 
-import weave
-from weave.trace import serialize
+from weave.trace import serialize, serializer
+from weave.trace.custom_objs import MemTraceFilesArtifact
+
+
+class MyCustomClass:
+    def __init__(self, value):
+        self.value = value
+
+
+def save(obj: MyCustomClass, artifact: MemTraceFilesArtifact, name: str) -> None:
+    with artifact.new_file("obj.json", binary=True) as f:
+        f.write(json.dumps({"value": obj.value}).encode("utf-8"))
+
+
+def load(artifact: MemTraceFilesArtifact, name: str) -> MyCustomClass:
+    with open(artifact.path("obj.json"), "r") as f:
+        return MyCustomClass(json.load(f)["value"])
+
+
+serializer.register_serializer(MyCustomClass, save, load)
 
 
 def test_serialize_caching(client):
-    serialize._custom_weave_type_cache_map[client._project_id()].reset()
-    img = Image.new("RGB", (100, 100))
-    serialized_img = serialize._to_json_custom_weave_type(
-        img, client._project_id(), client.server
+    # Technically, we could use PIL images in this test, but I like
+    # the purity of not having external dependencies in our tests.
+    # Furthermore, when running with other tests, it is possible
+    # that they will have already serialized this object, and
+    # so our tests should be resilient to that.
+    obj = MyCustomClass(1)
+    serialized_obj = serialize._to_json_custom_weave_type(
+        obj, client._project_id(), client.server
     )
     client._flush()
     access_log = client.server.attribute_access_log
     methods_1 = [log for log in access_log if not log.startswith("_")]
     assert methods_1 == [
         "ensure_project_exists",  # default initialization
-        "file_create",  # creates the deserialize op code
-        "obj_create",  # creates the deserialize op object
-        "file_create",  # creates the image file
+        "file_create",  # creates the serialized op code
+        "obj_create",  # creates the serialized op object
+        "file_create",  # creates the custom object file
     ]
 
     # Serialize again
-    serialized_img = serialize._to_json_custom_weave_type(
-        img, client._project_id(), client.server
+    serialized_obj = serialize._to_json_custom_weave_type(
+        obj, client._project_id(), client.server
     )
     client._flush()
     access_log = client.server.attribute_access_log
@@ -31,11 +53,11 @@ def test_serialize_caching(client):
     assert methods_2 == methods_1
 
     # Make sure we can deserialize
-    deserialize_img = serialize._from_json_custom_weave_type(
-        serialized_img, client._project_id(), client.server
+    deserialize_obj = serialize._from_json_custom_weave_type(
+        serialized_obj, client._project_id(), client.server
     )
-    assert isinstance(deserialize_img, Image.Image)
-    assert deserialize_img.tobytes() == img.tobytes()
+    assert isinstance(deserialize_obj, MyCustomClass)
+    assert deserialize_obj.value == obj.value
 
     # Again, no new methods should be called!
     client._flush()
@@ -47,8 +69,8 @@ def test_serialize_caching(client):
     serialize._custom_weave_type_cache_map[client._project_id()].reset()
 
     # Deserialize should trigger new methods
-    deserialize_img = serialize._from_json_custom_weave_type(
-        serialized_img, client._project_id(), client.server
+    deserialize_obj = serialize._from_json_custom_weave_type(
+        serialized_obj, client._project_id(), client.server
     )
     client._flush()
     access_log = client.server.attribute_access_log
@@ -60,8 +82,8 @@ def test_serialize_caching(client):
     ]
 
     # Reserialize should not trigger any new methods
-    serialized_img = serialize._to_json_custom_weave_type(
-        deserialize_img, client._project_id(), client.server
+    serialized_obj = serialize._to_json_custom_weave_type(
+        deserialize_obj, client._project_id(), client.server
     )
     client._flush()
     access_log = client.server.attribute_access_log

--- a/weave/tests/trace/test_serialize.py
+++ b/weave/tests/trace/test_serialize.py
@@ -1,0 +1,13 @@
+from PIL import Image
+
+import weave
+from weave.trace import serialize
+
+
+def test_serialize_caching(client):
+    img = Image.new("RGB", (100, 100))
+    serialized_img = serialize._to_json_custom_weave_type(
+        img, client._project_id(), client.server
+    )
+    access_log = client.server.attribute_access_log
+    assert "files_create" not in access_log

--- a/weave/tests/trace/test_weak_key_dict.py
+++ b/weave/tests/trace/test_weak_key_dict.py
@@ -1,6 +1,11 @@
-import pytest
 import gc
-from weave.trace.data_structures.weak_unhashable_key_dictionary import WeakKeyDictionarySupportingNonHashableKeys
+
+import pytest
+
+from weave.trace.data_structures.weak_unhashable_key_dictionary import (
+    WeakKeyDictionarySupportingNonHashableKeys,
+)
+
 
 class UnhashableObject:
     def __init__(self, value):
@@ -8,24 +13,28 @@ class UnhashableObject:
 
     def __eq__(self, other):
         return isinstance(other, UnhashableObject) and self.value == other.value
-    
+
     def __hash__(self):
         raise NotImplementedError("Unhashable object")
+
 
 @pytest.fixture
 def weak_dict():
     return WeakKeyDictionarySupportingNonHashableKeys()
+
 
 def test_set_and_get(weak_dict):
     key = UnhashableObject(1)
     weak_dict[key] = "value"
     assert weak_dict[key] == "value"
 
+
 def test_delete_item(weak_dict):
     key = UnhashableObject(1)
     weak_dict[key] = "value"
     del weak_dict[key]
     assert key not in weak_dict
+
 
 def test_len(weak_dict):
     objs = [UnhashableObject(i) for i in range(3)]
@@ -37,6 +46,7 @@ def test_len(weak_dict):
     gc.collect()
     assert len(weak_dict) == 0
 
+
 def test_iter(weak_dict):
     keys = [UnhashableObject(i) for i in range(3)]
     for key in keys:
@@ -46,6 +56,7 @@ def test_iter(weak_dict):
     del keys
     gc.collect()
     assert len(weak_dict) == 0
+
 
 def test_keys(weak_dict):
     keys = [UnhashableObject(i) for i in range(3)]
@@ -57,6 +68,7 @@ def test_keys(weak_dict):
     gc.collect()
     assert len(list(weak_dict.keys())) == 0
 
+
 def test_values(weak_dict):
     objs = [UnhashableObject(i) for i in range(3)]
     for obj in objs:
@@ -67,6 +79,7 @@ def test_values(weak_dict):
     gc.collect()
     assert len(weak_dict.values()) == 0
 
+
 def test_items(weak_dict):
     objs = [UnhashableObject(i) for i in range(3)]
     for obj in objs:
@@ -74,7 +87,9 @@ def test_items(weak_dict):
     items = list(weak_dict.items())
     assert len(items) == 3
     assert all(isinstance(k, UnhashableObject) and isinstance(v, str) for k, v in items)
-    assert set((k.value, v) for k, v in items) == set((i, f"value{i}") for i in range(3))
+    assert set((k.value, v) for k, v in items) == set(
+        (i, f"value{i}") for i in range(3)
+    )
     del obj
     del objs
     gc.collect()
@@ -83,16 +98,18 @@ def test_items(weak_dict):
     gc.collect()
     assert len(list(weak_dict.items())) == 0
 
+
 def test_weak_reference_behavior():
     weak_dict = WeakKeyDictionarySupportingNonHashableKeys()
     key = UnhashableObject(1)
     weak_dict[key] = "value"
-    
+
     assert len(weak_dict) == 1
     del key
     # Force garbage collection
     gc.collect()
     assert len(weak_dict) == 0
+
 
 def test_get_method(weak_dict):
     key = UnhashableObject(1)
@@ -105,6 +122,7 @@ def test_get_method(weak_dict):
     gc.collect()
     assert len(weak_dict) == 0
 
+
 def test_clear_method(weak_dict):
     objs = [UnhashableObject(i) for i in range(3)]
     for obj in objs:
@@ -115,6 +133,7 @@ def test_clear_method(weak_dict):
     del objs
     gc.collect()
     assert len(weak_dict) == 0
+
 
 def test_multiple_values_same_id():
     weak_dict = WeakKeyDictionarySupportingNonHashableKeys()
@@ -138,9 +157,9 @@ def test_unhashable_key_error_handling():
     weak_dict = WeakKeyDictionarySupportingNonHashableKeys()
     key = UnhashableObject(1)
     weak_dict[key] = "value"
-    
+
     with pytest.raises(KeyError):
         _ = weak_dict[UnhashableObject(2)]
-    
+
     with pytest.raises(KeyError):
         del weak_dict[UnhashableObject(2)]

--- a/weave/tests/trace/test_weak_key_dict.py
+++ b/weave/tests/trace/test_weak_key_dict.py
@@ -1,0 +1,146 @@
+import pytest
+import gc
+from weave.trace.data_structures.weak_unhashable_key_dictionary import WeakKeyDictionarySupportingNonHashableKeys
+
+class UnhashableObject:
+    def __init__(self, value):
+        self.value = value
+
+    def __eq__(self, other):
+        return isinstance(other, UnhashableObject) and self.value == other.value
+    
+    def __hash__(self):
+        raise NotImplementedError("Unhashable object")
+
+@pytest.fixture
+def weak_dict():
+    return WeakKeyDictionarySupportingNonHashableKeys()
+
+def test_set_and_get(weak_dict):
+    key = UnhashableObject(1)
+    weak_dict[key] = "value"
+    assert weak_dict[key] == "value"
+
+def test_delete_item(weak_dict):
+    key = UnhashableObject(1)
+    weak_dict[key] = "value"
+    del weak_dict[key]
+    assert key not in weak_dict
+
+def test_len(weak_dict):
+    objs = [UnhashableObject(i) for i in range(3)]
+    for obj in objs:
+        weak_dict[obj] = f"value{obj.value}"
+    assert len(weak_dict) == 3
+    del obj
+    del objs
+    gc.collect()
+    assert len(weak_dict) == 0
+
+def test_iter(weak_dict):
+    keys = [UnhashableObject(i) for i in range(3)]
+    for key in keys:
+        weak_dict[key] = f"value{key.value}"
+    assert set(key.value for key in weak_dict) == set(range(3))
+    del key
+    del keys
+    gc.collect()
+    assert len(weak_dict) == 0
+
+def test_keys(weak_dict):
+    keys = [UnhashableObject(i) for i in range(3)]
+    for key in keys:
+        weak_dict[key] = f"value{key.value}"
+    assert set(key.value for key in weak_dict.keys()) == set(range(3))
+    del key
+    del keys
+    gc.collect()
+    assert len(list(weak_dict.keys())) == 0
+
+def test_values(weak_dict):
+    objs = [UnhashableObject(i) for i in range(3)]
+    for obj in objs:
+        weak_dict[obj] = f"value{obj.value}"
+    assert set(weak_dict.values()) == set(f"value{i}" for i in range(3))
+    del obj
+    del objs
+    gc.collect()
+    assert len(weak_dict.values()) == 0
+
+def test_items(weak_dict):
+    objs = [UnhashableObject(i) for i in range(3)]
+    for obj in objs:
+        weak_dict[obj] = f"value{obj.value}"
+    items = list(weak_dict.items())
+    assert len(items) == 3
+    assert all(isinstance(k, UnhashableObject) and isinstance(v, str) for k, v in items)
+    assert set((k.value, v) for k, v in items) == set((i, f"value{i}") for i in range(3))
+    del obj
+    del objs
+    gc.collect()
+    assert len(list(weak_dict.items())) == 3
+    del items
+    gc.collect()
+    assert len(list(weak_dict.items())) == 0
+
+def test_weak_reference_behavior():
+    weak_dict = WeakKeyDictionarySupportingNonHashableKeys()
+    key = UnhashableObject(1)
+    weak_dict[key] = "value"
+    
+    assert len(weak_dict) == 1
+    del key
+    # Force garbage collection
+    gc.collect()
+    assert len(weak_dict) == 0
+
+def test_get_method(weak_dict):
+    key = UnhashableObject(1)
+    assert weak_dict.get(key) is None
+    assert weak_dict.get(key, "default") == "default"
+    weak_dict[key] = "value"
+    assert weak_dict.get(key) == "value"
+    assert weak_dict.get(key, "default") == "value"
+    del key
+    gc.collect()
+    assert len(weak_dict) == 0
+
+def test_clear_method(weak_dict):
+    objs = [UnhashableObject(i) for i in range(3)]
+    for obj in objs:
+        weak_dict[obj] = f"value{obj.value}"
+    assert len(weak_dict) == 3
+    weak_dict.clear()
+    assert len(weak_dict) == 0
+    del objs
+    gc.collect()
+    assert len(weak_dict) == 0
+
+def test_multiple_values_same_id():
+    weak_dict = WeakKeyDictionarySupportingNonHashableKeys()
+    key1 = UnhashableObject(1)
+    key2 = UnhashableObject(1)
+    weak_dict[key1] = "value1"
+    weak_dict[key2] = "value2"
+    assert weak_dict[key1] == "value1"
+    assert weak_dict[key2] == "value2"
+    assert len(weak_dict) == 2
+    del key1
+    gc.collect()
+    assert len(weak_dict) == 1
+    assert weak_dict[key2] == "value2"
+    del key2
+    gc.collect()
+    assert len(weak_dict) == 0
+
+
+def test_unhashable_key_error_handling():
+    weak_dict = WeakKeyDictionarySupportingNonHashableKeys()
+    key = UnhashableObject(1)
+    weak_dict[key] = "value"
+    
+    with pytest.raises(KeyError):
+        _ = weak_dict[UnhashableObject(2)]
+    
+    with pytest.raises(KeyError):
+        del weak_dict[UnhashableObject(2)]

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -2,7 +2,7 @@ import contextlib
 import io
 import os
 import tempfile
-from typing import Any, Dict, Generator, Iterator, Mapping, Optional, Union
+from typing import Any, Generator, Iterator, Mapping, Optional, TypedDict, Union
 
 from weave.legacy.weave import artifact_fs
 from weave.trace import op_type  # noqa: F401, Must import this to register op save/load
@@ -131,8 +131,19 @@ def encode_custom_obj(obj: Any) -> Optional[dict]:
     }
 
 
+class CustomWeaveTypeWeaveTypeDict(TypedDict):
+    type: str
+
+
+class CustomWeaveTypeDict(TypedDict):
+    _type: str  # "CustomWeaveType"
+    weave_type: CustomWeaveTypeWeaveTypeDict
+    files: dict[str, str]
+    load_op: Optional[str]
+
+
 def decode_custom_obj(
-    weave_type: Dict,
+    weave_type: CustomWeaveTypeWeaveTypeDict,
     encoded_path_contents: Mapping[str, Union[str, bytes]],
     load_instance_op_uri: Optional[str],
 ) -> Any:

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -2,7 +2,7 @@ import contextlib
 import io
 import os
 import tempfile
-from typing import Any, Generator, Iterator, Mapping, Optional, TypedDict, Union
+from typing import Any, Generator, Iterator, Mapping, Optional, Union
 
 from weave.legacy.weave import artifact_fs
 from weave.trace import op_type  # noqa: F401, Must import this to register op save/load
@@ -131,19 +131,8 @@ def encode_custom_obj(obj: Any) -> Optional[dict]:
     }
 
 
-class CustomWeaveTypeWeaveTypeDict(TypedDict):
-    type: str
-
-
-class CustomWeaveTypeDict(TypedDict):
-    _type: str  # "CustomWeaveType"
-    weave_type: CustomWeaveTypeWeaveTypeDict
-    files: dict[str, str]
-    load_op: Optional[str]
-
-
 def decode_custom_obj(
-    weave_type: CustomWeaveTypeWeaveTypeDict,
+    weave_type: dict,
     encoded_path_contents: Mapping[str, Union[str, bytes]],
     load_instance_op_uri: Optional[str],
 ) -> Any:

--- a/weave/trace/custom_weave_type_serialization_cache.py
+++ b/weave/trace/custom_weave_type_serialization_cache.py
@@ -1,0 +1,70 @@
+import json
+import weakref
+from typing import Any, Optional
+
+from weave.trace.data_structures.weak_unhashable_key_dictionary import (
+    WeakKeyDictionarySupportingNonHashableKeys,
+)
+
+
+class CustomWeaveTypeSerializationCache:
+    """Cache for custom weave type serialization.
+
+    Specifically, a dev can:
+    - store a serialization tuple of (deserialized object, serialized dict)
+    - retrieve the serialized dict for a deserialized object
+    - retrieve the deserialized object for a serialized dict
+
+    """
+
+    def __init__(self) -> None:
+        self._obj_to_dict: WeakKeyDictionarySupportingNonHashableKeys[Any, dict] = (
+            WeakKeyDictionarySupportingNonHashableKeys()
+        )
+        self._dict_to_obj: weakref.WeakValueDictionary[str, Any] = (
+            weakref.WeakValueDictionary()
+        )
+
+    def reset(self) -> None:
+        self._obj_to_dict.clear()
+        self._dict_to_obj.clear()
+
+    def store(self, obj: Any, serialized_dict: dict) -> None:
+        try:
+            self._store(obj, serialized_dict)
+        except Exception:
+            # Consider logging the exception here
+            pass
+
+    def _store(self, obj: Any, serialized_dict: dict) -> None:
+        self._obj_to_dict[obj] = serialized_dict
+        dict_key = self._get_dict_key(serialized_dict)
+        if dict_key is not None:
+            self._dict_to_obj[dict_key] = obj
+
+    def get_serialized_dict(self, obj: Any) -> Optional[dict]:
+        try:
+            return self._get_serialized_dict(obj)
+        except Exception:
+            # Consider logging the exception here
+            return None
+
+    def _get_serialized_dict(self, obj: Any) -> Optional[dict]:
+        return self._obj_to_dict.get(obj)
+
+    def get_deserialized_obj(self, serialized_dict: dict) -> Optional[Any]:
+        try:
+            return self._get_deserialized_obj(serialized_dict)
+        except Exception:
+            # Consider logging the exception here
+            return None
+
+    def _get_deserialized_obj(self, serialized_dict: dict) -> Optional[Any]:
+        dict_key = self._get_dict_key(serialized_dict)
+        return None if dict_key is None else self._dict_to_obj.get(dict_key)
+
+    def _get_dict_key(self, d: dict) -> Optional[str]:
+        try:
+            return json.dumps(d, sort_keys=True)
+        except Exception:
+            return None

--- a/weave/trace/custom_weave_type_serialization_cache.py
+++ b/weave/trace/custom_weave_type_serialization_cache.py
@@ -8,16 +8,20 @@ from weave.trace.data_structures.weak_unhashable_key_dictionary import (
 
 
 class CustomWeaveTypeSerializationCache:
-    """Cache for custom weave type serialization.
+    """A cache for custom Weave type serialization and deserialization.
 
-    Specifically, a dev can:
-    - store a serialization tuple of (deserialized object, serialized dict)
-    - retrieve the serialized dict for a deserialized object
-    - retrieve the deserialized object for a serialized dict
+    This class provides a bidirectional cache for storing and retrieving
+    serialized and deserialized representations of custom Weave types.
+    It uses weak references to prevent memory leaks and supports
+    non-hashable objects as keys.
 
+    Attributes:
+        _obj_to_dict (WeakKeyDictionarySupportingNonHashableKeys): Maps deserialized objects to their serialized dicts.
+        _dict_to_obj (weakref.WeakValueDictionary): Maps serialized dict keys to deserialized objects.
     """
 
     def __init__(self) -> None:
+        """Initialize an empty CustomWeaveTypeSerializationCache."""
         self._obj_to_dict: WeakKeyDictionarySupportingNonHashableKeys[Any, dict] = (
             WeakKeyDictionarySupportingNonHashableKeys()
         )
@@ -26,45 +30,108 @@ class CustomWeaveTypeSerializationCache:
         )
 
     def reset(self) -> None:
+        """Clear all entries from the cache."""
         self._obj_to_dict.clear()
         self._dict_to_obj.clear()
 
     def store(self, obj: Any, serialized_dict: dict) -> None:
+        """Store a serialization pair in the cache.
+
+        Args:
+            obj: The deserialized object.
+            serialized_dict: The serialized representation of the object.
+
+        Note:
+            This method silently fails if an exception occurs during storage.
+        """
         try:
             self._store(obj, serialized_dict)
         except Exception:
-            # Consider logging the exception here
+            # TODO: Consider logging the exception here
             pass
 
     def _store(self, obj: Any, serialized_dict: dict) -> None:
+        """Internal method to store a serialization pair.
+
+        Args:
+            obj: The deserialized object.
+            serialized_dict: The serialized representation of the object.
+        """
         self._obj_to_dict[obj] = serialized_dict
         dict_key = self._get_dict_key(serialized_dict)
         if dict_key is not None:
             self._dict_to_obj[dict_key] = obj
 
     def get_serialized_dict(self, obj: Any) -> Optional[dict]:
+        """Retrieve the serialized dict for a given object.
+
+        Args:
+            obj: The deserialized object to look up.
+
+        Returns:
+            The serialized dict if found, None otherwise.
+
+        Note:
+            This method returns None if an exception occurs during retrieval.
+        """
         try:
             return self._get_serialized_dict(obj)
         except Exception:
-            # Consider logging the exception here
+            # TODO: Consider logging the exception here
             return None
 
     def _get_serialized_dict(self, obj: Any) -> Optional[dict]:
+        """Internal method to retrieve the serialized dict for an object.
+
+        Args:
+            obj: The deserialized object to look up.
+
+        Returns:
+            The serialized dict if found, None otherwise.
+        """
         return self._obj_to_dict.get(obj)
 
     def get_deserialized_obj(self, serialized_dict: dict) -> Optional[Any]:
+        """Retrieve the deserialized object for a given serialized dict.
+
+        Args:
+            serialized_dict: The serialized dict to look up.
+
+        Returns:
+            The deserialized object if found, None otherwise.
+
+        Note:
+            This method returns None if an exception occurs during retrieval.
+        """
         try:
             return self._get_deserialized_obj(serialized_dict)
         except Exception:
-            # Consider logging the exception here
+            # TODO: Consider logging the exception here
             return None
 
     def _get_deserialized_obj(self, serialized_dict: dict) -> Optional[Any]:
+        """Internal method to retrieve the deserialized object for a serialized dict.
+
+        Args:
+            serialized_dict: The serialized dict to look up.
+
+        Returns:
+            The deserialized object if found, None otherwise.
+        """
         dict_key = self._get_dict_key(serialized_dict)
         return None if dict_key is None else self._dict_to_obj.get(dict_key)
 
     def _get_dict_key(self, d: dict) -> Optional[str]:
+        """Generate a string key for a serialized dict.
+
+        Args:
+            d: The serialized dict.
+
+        Returns:
+            A string key if successful, None if serialization fails.
+        """
         try:
             return json.dumps(d, sort_keys=True)
         except Exception:
+            # TODO: Consider logging the exception here
             return None

--- a/weave/trace/custom_weave_type_serialization_cache.py
+++ b/weave/trace/custom_weave_type_serialization_cache.py
@@ -57,6 +57,14 @@ class CustomWeaveTypeSerializationCache:
             obj: The deserialized object.
             serialized_dict: The serialized representation of the object.
         """
+        # Remove the old serialized dict if it exists
+        old_dict = self._obj_to_dict.get(obj)
+        if old_dict is not None:
+            old_dict_key = self._get_dict_key(old_dict)
+            if old_dict_key is not None:
+                self._dict_to_obj.pop(old_dict_key, None)
+
+        # Store the new serialized dict
         self._obj_to_dict[obj] = serialized_dict
         dict_key = self._get_dict_key(serialized_dict)
         if dict_key is not None:

--- a/weave/trace/data_structures/weak_unhashable_key_dictionary.py
+++ b/weave/trace/data_structures/weak_unhashable_key_dictionary.py
@@ -37,16 +37,14 @@ class WeakKeyDictionarySupportingNonHashableKeys(Generic[K, V]):
     """
 
     def __init__(self) -> None:
-        """
-        Initialize an empty WeakKeyDictionarySupportingNonHashableKeys.
-        """
+        """Initialize an empty WeakKeyDictionarySupportingNonHashableKeys."""
         self._id_to_data: dict[int, V] = {}
-        self._id_to_key: dict[int, K] = {}
+        self._id_to_key: weakref.WeakValueDictionary[int, K] = (
+            weakref.WeakValueDictionary()
+        )
 
     def clear(self) -> None:
-        """
-        Remove all items from the dictionary.
-        """
+        """Remove all items from the dictionary."""
         self._id_to_data.clear()
         self._id_to_key.clear()
 
@@ -97,6 +95,8 @@ class WeakKeyDictionarySupportingNonHashableKeys(Generic[K, V]):
         if item_id in self._id_to_data:
             del self._id_to_data[item_id]
             del self._id_to_key[item_id]
+        else:
+            raise KeyError(key)
 
     def __setitem__(self, key: K, value: V) -> None:
         """
@@ -125,6 +125,7 @@ class WeakKeyDictionarySupportingNonHashableKeys(Generic[K, V]):
         Args:
             item_id (int): The id of the item to remove.
         """
+        print("removing item", item_id)
         self._id_to_data.pop(item_id, None)
         self._id_to_key.pop(item_id, None)
 
@@ -144,14 +145,18 @@ class WeakKeyDictionarySupportingNonHashableKeys(Generic[K, V]):
         Returns:
             int: The number of items in the dictionary.
         """
+        print("len", len(self._id_to_data))
+        print("len key", len(self._id_to_key))
+        print("len data values", self._id_to_data.values())
+        print("len key values", self._id_to_key.values())
         return len(self._id_to_data)
 
-    def keys(self) -> ValuesView[K]:
+    def keys(self) -> Iterator[K]:
         """
         Return a view of the dictionary's keys.
 
         Returns:
-            ValuesView[K]: A view object providing a view on the dictionary's keys.
+            Iterator[K]: A view object providing a view on the dictionary's keys.
         """
         return self._id_to_key.values()
 

--- a/weave/trace/data_structures/weak_unhashable_key_dictionary.py
+++ b/weave/trace/data_structures/weak_unhashable_key_dictionary.py
@@ -1,0 +1,174 @@
+import weakref
+from typing import Any, Generic, Iterator, Tuple, TypeVar, Union, ValuesView
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class WeakKeyDictionarySupportingNonHashableKeys(Generic[K, V]):
+    """
+    A dictionary-like data structure that supports weak references to keys,
+    including non-hashable objects.
+
+    This class is similar to `weakref.WeakKeyDictionary`, but it can handle
+    keys that are not hashable. It uses the object's id as a proxy for hashing,
+    allowing it to store and retrieve items based on object identity rather than
+    hash value.
+
+    The keys are held using weak references, which means that when there are no
+    other references to a key object, it will be garbage collected, and its
+    corresponding entry will be automatically removed from this dictionary.
+
+    This implementation uses the `weakref.finalize` method to ensure that entries
+    are removed from the internal maps when a key object is garbage collected.
+    This approach effectively prevents issues related to id reuse, as the entry
+    for a specific id is guaranteed to be removed before that id could potentially
+    be reused for a new object.
+
+    Type Parameters:
+    K: The type of the keys (can be any object, including non-hashable ones)
+    V: The type of the values
+
+    Note: While this implementation mitigates the risk of id collisions due to
+    garbage collection and id reuse, it's important to remember that object ids
+    in Python are not guaranteed to be unique over the lifetime of a program.
+    However, for most practical purposes, this implementation provides a robust
+    solution for weak key dictionaries supporting non-hashable keys.
+    """
+
+    def __init__(self) -> None:
+        """
+        Initialize an empty WeakKeyDictionarySupportingNonHashableKeys.
+        """
+        self._id_to_data: dict[int, V] = {}
+        self._id_to_key: dict[int, K] = {}
+
+    def clear(self) -> None:
+        """
+        Remove all items from the dictionary.
+        """
+        self._id_to_data.clear()
+        self._id_to_key.clear()
+
+    def get(self, key: K, default: Any = None) -> Union[V, Any]:
+        """
+        Return the value for key if key is in the dictionary, else default.
+
+        Args:
+            key (K): The key to look up.
+            default (Any, optional): The value to return if the key is not found.
+                Defaults to None.
+
+        Returns:
+            Union[V, Any]: The value associated with the key, or the default value.
+        """
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+    def __getitem__(self, key: K) -> V:
+        """
+        Return the value associated with the given key.
+
+        Args:
+            key (K): The key to look up.
+
+        Returns:
+            V: The value associated with the key.
+
+        Raises:
+            KeyError: If the key is not found in the dictionary.
+        """
+        item_id = id(key)
+        return self._id_to_data[item_id]
+
+    def __delitem__(self, key: K) -> None:
+        """
+        Remove the item with the given key from the dictionary.
+
+        Args:
+            key (K): The key of the item to remove.
+
+        Raises:
+            KeyError: If the key is not found in the dictionary.
+        """
+        item_id = id(key)
+        if item_id in self._id_to_data:
+            del self._id_to_data[item_id]
+            del self._id_to_key[item_id]
+
+    def __setitem__(self, key: K, value: V) -> None:
+        """
+        Set the value for the given key in the dictionary.
+
+        This method also sets up a weak reference to the key object,
+        so that the item will be automatically removed when the key
+        object is garbage collected.
+
+        Args:
+            key (K): The key to set.
+            value (V): The value to associate with the key.
+        """
+        item_id = id(key)
+        self._id_to_data[item_id] = value
+        self._id_to_key[item_id] = key
+        weakref.finalize(key, self._remove_item, item_id)
+
+    def _remove_item(self, item_id: int) -> None:
+        """
+        Remove an item from the dictionary based on its id.
+
+        This method is called by the weak reference callback when a key
+        object is garbage collected.
+
+        Args:
+            item_id (int): The id of the item to remove.
+        """
+        self._id_to_data.pop(item_id, None)
+        self._id_to_key.pop(item_id, None)
+
+    def __iter__(self) -> Iterator[K]:
+        """
+        Return an iterator over the keys in the dictionary.
+
+        Returns:
+            Iterator[K]: An iterator yielding the dictionary's keys.
+        """
+        return iter(self._id_to_key.values())
+
+    def __len__(self) -> int:
+        """
+        Return the number of items in the dictionary.
+
+        Returns:
+            int: The number of items in the dictionary.
+        """
+        return len(self._id_to_data)
+
+    def keys(self) -> ValuesView[K]:
+        """
+        Return a view of the dictionary's keys.
+
+        Returns:
+            ValuesView[K]: A view object providing a view on the dictionary's keys.
+        """
+        return self._id_to_key.values()
+
+    def values(self) -> ValuesView[V]:
+        """
+        Return a view of the dictionary's values.
+
+        Returns:
+            ValuesView[V]: A view object providing a view on the dictionary's values.
+        """
+        return self._id_to_data.values()
+
+    def items(self) -> Iterator[Tuple[K, V]]:
+        """
+        Return an iterator over the dictionary's items (key-value pairs).
+
+        Returns:
+            Iterator[Tuple[K, V]]: An iterator yielding (key, value) pairs.
+        """
+        return ((self._id_to_key[id], value) for id, value in self._id_to_data.items())

--- a/weave/trace/data_structures/weak_unhashable_key_dictionary.py
+++ b/weave/trace/data_structures/weak_unhashable_key_dictionary.py
@@ -125,7 +125,6 @@ class WeakKeyDictionarySupportingNonHashableKeys(Generic[K, V]):
         Args:
             item_id (int): The id of the item to remove.
         """
-        print("removing item", item_id)
         self._id_to_data.pop(item_id, None)
         self._id_to_key.pop(item_id, None)
 
@@ -145,10 +144,6 @@ class WeakKeyDictionarySupportingNonHashableKeys(Generic[K, V]):
         Returns:
             int: The number of items in the dictionary.
         """
-        print("len", len(self._id_to_data))
-        print("len key", len(self._id_to_key))
-        print("len data values", self._id_to_data.values())
-        print("len key values", self._id_to_key.values())
         return len(self._id_to_data)
 
     def keys(self) -> Iterator[K]:

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -107,7 +107,8 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
 # Importantly we can actually cache the results of both directions so that we
 # don't have to do the work more than once.
 
-# Initialize the global cache
+# Initialize the global cache - consider making this a context var or even part of the WeaveClient
+# so that testing can be better isolated
 _custom_weave_type_cache_map: DefaultDict[str, CustomWeaveTypeSerializationCache] = (
     defaultdict(CustomWeaveTypeSerializationCache)
 )

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -566,10 +566,13 @@ def make_trace_obj(
             val.ref = new_ref
         return val
     if hasattr(val, "ref") and isinstance(val.ref, RefWithExtra):
-        # The Traceable check above does not currently work for Ops, where we
-        # directly attach a ref, or to our Boxed classes. We should use Traceable
-        # for all of these, but for now we need to check for the ref attribute.
-        return val
+        if isinstance(val, Op):
+            new_ref = new_ref or val.ref
+        else:
+            # The Traceable check above does not currently work for Ops, where we
+            # directly attach a ref, or to our Boxed classes. We should use Traceable
+            # for all of these, but for now we need to check for the ref attribute.
+            return val
     # Derefence val and create the appropriate wrapper object
     extra: tuple[str, ...] = ()
     if isinstance(val, ObjectRef):

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -566,13 +566,10 @@ def make_trace_obj(
             val.ref = new_ref
         return val
     if hasattr(val, "ref") and isinstance(val.ref, RefWithExtra):
-        if isinstance(val, Op):
-            new_ref = new_ref or val.ref
-        else:
-            # The Traceable check above does not currently work for Ops, where we
-            # directly attach a ref, or to our Boxed classes. We should use Traceable
-            # for all of these, but for now we need to check for the ref attribute.
-            return val
+        # The Traceable check above does not currently work for Ops, where we
+        # directly attach a ref, or to our Boxed classes. We should use Traceable
+        # for all of these, but for now we need to check for the ref attribute.
+        return val
     # Derefence val and create the appropriate wrapper object
     extra: tuple[str, ...] = ()
     if isinstance(val, ObjectRef):


### PR DESCRIPTION
Currently our serialization procedures (to/from json) also handle custom objects. This means: possible file I/O AND network transmission.

Horribly, we don't cache any of this, so every time the same Image is passed through the call stack it gets re-serialzied every time! This means that our evaluations with Images likely serialize and de-serialize the same image multiple times. With this change, we create an in-memory cache of such serialization and deserialization results. Everything uses WeakRefs so we don't have an ever-expanding memory footprint.

Attention Reviewers:
1. The entry-point for the change is refactoring the serialize.py to/from json methods to have sub-methods for custom weave objects. These sub methods are literally the same code as before, with a little code at the top and bottom for cache lookups / storage.
2. Most of the logic resides in the 2 new classes `CustomWeaveTypeSerializationCache` and `WeakKeyDictionarySupportingNonHashableKeys` which have ample comments and unit tests.
3. The entire end to end system is also tested to ensure we have minimal network calls.