### PR TITLE
chore(weave): Use base and pod url for frontend apollo queries

### DIFF
--- a/weave-js/src/apollo.ts
+++ b/weave-js/src/apollo.ts
@@ -30,6 +30,14 @@ const authMiddleware = new ApolloLink((operation, forward) => {
 export const makeGorillaApolloClient = (
   gorillaApolloEndpoint: string = `${window.WEAVE_CONFIG.WANDB_BASE_URL}/graphql`
 ) => {
+  if (
+    window.WEAVE_CONFIG.WANDB_POD_BASE_URL != '' &&
+    window.WEAVE_CONFIG.WANDB_POD_BASE_URL !=
+      window.WEAVE_CONFIG.WANDB_BASE_URL &&
+    gorillaApolloEndpoint.includes(window.WEAVE_CONFIG.WANDB_BASE_URL)
+  ) {
+    gorillaApolloEndpoint = `${window.WEAVE_CONFIG.WANDB_POD_BASE_URL}/graphql`;
+  }
   return new ApolloClient({
     link: ApolloLink.from([
       authMiddleware,

--- a/weave-js/src/apollo.ts
+++ b/weave-js/src/apollo.ts
@@ -31,8 +31,8 @@ export const makeGorillaApolloClient = (
   gorillaApolloEndpoint: string = `${window.WEAVE_CONFIG.WANDB_BASE_URL}/graphql`
 ) => {
   if (
-    window.WEAVE_CONFIG.WANDB_POD_BASE_URL != '' &&
-    window.WEAVE_CONFIG.WANDB_POD_BASE_URL !=
+    window.WEAVE_CONFIG.WANDB_POD_BASE_URL !== '' &&
+    window.WEAVE_CONFIG.WANDB_POD_BASE_URL !==
       window.WEAVE_CONFIG.WANDB_BASE_URL &&
     gorillaApolloEndpoint.includes(window.WEAVE_CONFIG.WANDB_BASE_URL)
   ) {

--- a/weave-js/src/apollo.ts
+++ b/weave-js/src/apollo.ts
@@ -30,19 +30,17 @@ const authMiddleware = new ApolloLink((operation, forward) => {
 export const makeGorillaApolloClient = (
   gorillaApolloEndpoint: string = `${window.WEAVE_CONFIG.WANDB_BASE_URL}/graphql`
 ) => {
+  let endpoint = gorillaApolloEndpoint;
   if (
     window.WEAVE_CONFIG.WANDB_POD_BASE_URL !== '' &&
     window.WEAVE_CONFIG.WANDB_POD_BASE_URL !==
       window.WEAVE_CONFIG.WANDB_BASE_URL &&
     gorillaApolloEndpoint.includes(window.WEAVE_CONFIG.WANDB_BASE_URL)
   ) {
-    gorillaApolloEndpoint = `${window.WEAVE_CONFIG.WANDB_POD_BASE_URL}/graphql`;
+    endpoint = `${window.WEAVE_CONFIG.WANDB_POD_BASE_URL}/graphql`;
   }
   return new ApolloClient({
-    link: ApolloLink.from([
-      authMiddleware,
-      makeHttpLink(gorillaApolloEndpoint),
-    ]),
+    link: ApolloLink.from([authMiddleware, makeHttpLink(endpoint)]),
     cache: new InMemoryCache(),
   });
 };

--- a/weave-js/src/apollo.ts
+++ b/weave-js/src/apollo.ts
@@ -34,8 +34,7 @@ export const makeGorillaApolloClient = (
   if (
     window.WEAVE_CONFIG.WANDB_POD_BASE_URL !== '' &&
     window.WEAVE_CONFIG.WANDB_POD_BASE_URL !==
-      window.WEAVE_CONFIG.WANDB_BASE_URL &&
-    gorillaApolloEndpoint.includes(window.WEAVE_CONFIG.WANDB_BASE_URL)
+      window.WEAVE_CONFIG.WANDB_BASE_URL
   ) {
     endpoint = `${window.WEAVE_CONFIG.WANDB_POD_BASE_URL}/graphql`;
   }

--- a/weave-js/src/config.ts
+++ b/weave-js/src/config.ts
@@ -9,6 +9,7 @@ declare global {
       WANDB_BASE_URL: string;
       DD_ENV: string;
       ENV_IS_CI: boolean;
+      WANDB_POD_BASE_URL: string;
     };
   }
 }
@@ -22,6 +23,7 @@ if (!window.WEAVE_CONFIG) {
     WEAVE_BACKEND_HOST: '/__weave',
     TRACE_BACKEND_BASE_URL: '',
     WANDB_BASE_URL: 'https://api.wandb.ai',
+    WANDB_POD_BASE_URL: '',
     DD_ENV: '',
     ENV_IS_CI: false,
   };

--- a/weave-js/src/config.ts
+++ b/weave-js/src/config.ts
@@ -41,6 +41,7 @@ interface Config {
   backendWeaveExecutionUrl(shadow?: boolean): string;
   backendWeaveViewerUrl(): string;
   backendWeaveOpsUrl(): string;
+  WANDB_POD_BASE_URL: string;
 }
 
 const WEAVE_BACKEND_HOST = window.WEAVE_CONFIG.WEAVE_BACKEND_HOST;
@@ -92,6 +93,7 @@ const DEFAULT_CONFIG: Config = {
   WANDB_BASE_URL: window.WEAVE_CONFIG.WANDB_BASE_URL,
   ENV_IS_CI: window.WEAVE_CONFIG.ENV_IS_CI,
   TRACE_BACKEND_BASE_URL: window.WEAVE_CONFIG.TRACE_BACKEND_BASE_URL,
+  WANDB_POD_BASE_URL: window.WEAVE_CONFIG.WANDB_POD_BASE_URL,
 } as const;
 
 let config = {...DEFAULT_CONFIG};

--- a/weave/weave_server.py
+++ b/weave/weave_server.py
@@ -438,6 +438,7 @@ def frontend_env():
         "WANDB_BASE_URL": environment.wandb_frontend_base_url(),
         "DD_ENV": environment.dd_env(),
         "ENV_IS_CI": environment.env_is_ci(),
+        "WANDB_POD_BASE_URL": environment.wandb_base_url(),
     }
 
 


### PR DESCRIPTION
## Description

In the case where we have a pod to pod base url, use that for apollo queries rather than specified urls
instead of qa-aws.wandb
use wandb-app:8080

I believe the original change for makeGorillaApolloClient was because the frontend url might have a different hostname compared to the backend. This should still be in line with that. If the pod url is set and different from the frontend url, we should use it, as it will go directly to the pod. Rather than make network request outside the cluster

## Testing

How was this PR tested?
