### PR TITLE
fix: dont crash when changing eval peek

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -68,10 +68,7 @@ export const CompareEvaluationsPageContent: React.FC<
   CompareEvaluationsPageProps
 > = props => {
   const [baselineEvaluationCallId, setBaselineEvaluationCallId] =
-    React.useState(
-      props.evaluationCallIds.length > 0 ? props.evaluationCallIds[0] : null
-    );
-
+    React.useState<string | null>(null);
   const [comparisonDimensions, setComparisonDimensions] =
     React.useState<ComparisonDimensionsType | null>(null);
 
@@ -96,6 +93,12 @@ export const CompareEvaluationsPageContent: React.FC<
     },
     [comparisonDimensions]
   );
+
+  React.useEffect(() => {
+    if (props.evaluationCallIds.length > 0) {
+      setBaselineEvaluationCallId(props.evaluationCallIds[0]);
+    }
+  }, [props.evaluationCallIds]);
 
   if (props.evaluationCallIds.length === 0) {
     return <div>No evaluations to compare</div>;


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-20976](https://wandb.atlassian.net/browse/WB-20976)

This component was designed to just be passed in the id, now we listen to changing props even if mounted.

Prod:
![eval-state-prod](https://github.com/user-attachments/assets/34879fd3-7ab0-4e83-8a38-5314b34e2b21)

Branch:
![eval-state](https://github.com/user-attachments/assets/353abdfc-e54c-4972-9837-14f62c224a26)


[WB-20976]: https://wandb.atlassian.net/browse/WB-20976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ