### PR TITLE
chore: Refactor & Comment Saving Methods

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -983,6 +983,16 @@ class WeaveClient:
         return res.results
 
     ################# Object Saving ##################
+    # `_save_object` is the top level entry point for saving data to the weave server.
+    # `_save_nested_objects` is a recursive method to dispatch saving of nested objects.
+    #  it is called by `_save_object` above, as well as `create_call` and `finish_call`
+    #  since we don't save the entire dictionary, but rather want to save any nested objects
+    # `_save_object_basic` is the lowest level object saving logic which:
+    #  - serializes the object to json
+    #  - calls the server to save the object
+    #  - creates an ObjectRef and attaches it to the object
+    # `_save_op` and `_save_table` are the sister functions to `_save_object_basic`
+    #  but for Ops and Tables respectively.
 
     @trace_sentry.global_trace_sentry.watch()
     def _save_object(self, val: Any, name: str, branch: str = "latest") -> ObjectRef:

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1272,7 +1272,7 @@ class WeaveClient:
             self.server.call_processor.wait_until_all_processed()  # type: ignore
 
 
-def send_start_call(  #
+def send_start_call(
     project_id: str,
     call_id: str,
     op_str: str,

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -98,6 +98,20 @@ def remove_ref(obj: Any) -> None:
             obj.ref = None
 
 
+def set_ref(obj: Any, ref: Optional[Ref]) -> None:
+    try:
+        obj.ref = ref
+    except:
+        try:
+            setattr(obj, "ref", ref)
+        except:
+            try:
+                obj.__dict__["ref"] = ref
+            except:
+                pass
+    raise ValueError(f"Failed to set ref on object of type {type(obj)}")
+
+
 def _get_direct_ref(obj: Any) -> Optional[Ref]:
     if isinstance(obj, WeaveTable):
         # TODO: this path is odd. We want to use table_ref when serializing
@@ -1157,7 +1171,12 @@ class WeaveClient:
             ref = ObjectRef(self.entity, self.project, name, response.digest)
 
         # Attach the ref to the object
-        val.__dict__["ref"] = ref
+        try:
+            set_ref(val, ref)
+        except:
+            # Don't worry if we can't set the ref.
+            # This can happen for primitive types that don't have __dict__
+            pass
 
         return ref
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1080,6 +1080,11 @@ class WeaveClient:
             for v in obj_rec.__dict__.values():
                 self._save_nested_objects(v)
             ref = self._save_object_basic(obj_rec, name or get_obj_name(obj_rec))
+            # Personally, i think we should be passing `obj` into _save_object_basic,
+            # and letting `to_json` handle converting the pydantic object into a jsonable object
+            # but that might have unintended consequences. As a result, we break the
+            # typical pattern and explicitly set the ref here.
+            set_ref(obj, ref)
 
         # Case 2: Op:
         # Here we save the op itself.

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -108,8 +108,7 @@ def set_ref(obj: Any, ref: Optional[Ref]) -> None:
             try:
                 obj.__dict__["ref"] = ref
             except:
-                pass
-    raise ValueError(f"Failed to set ref on object of type {type(obj)}")
+                raise ValueError(f"Failed to set ref on object of type {type(obj)}")
 
 
 def _get_direct_ref(obj: Any) -> Optional[Ref]:
@@ -1137,6 +1136,7 @@ class WeaveClient:
             val.ref = None
 
         is_opdef = isinstance(val, Op)
+        orig_val = val
         val = map_to_refs(val)
         if isinstance(val, ObjectRef):
             return val
@@ -1172,7 +1172,7 @@ class WeaveClient:
 
         # Attach the ref to the object
         try:
-            set_ref(val, ref)
+            set_ref(orig_val, ref)
         except:
             # Don't worry if we can't set the ref.
             # This can happen for primitive types that don't have __dict__

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1067,8 +1067,6 @@ class WeaveClient:
             for v in obj_rec.__dict__.values():
                 self._save_nested_objects(v)
             ref = self._save_object_basic(obj_rec, name or get_obj_name(obj_rec))
-            # Should this go in `_save_object_basic`?
-            obj.__dict__["ref"] = ref
 
         # Case 2: Op:
         # Here we save the op itself.
@@ -1078,14 +1076,11 @@ class WeaveClient:
 
         # Case 3: Table
         elif isinstance(obj, Table):
-            table_ref = self._save_table(obj)
-            obj.ref = table_ref
+            self._save_table(obj)
 
         # Case 4: WeaveTable
         elif isinstance(obj, WeaveTable):
-            table_ref = self._save_table(obj)
-            obj.ref = table_ref
-            obj.table_ref = table_ref
+            self._save_table(obj)
 
         # Special case: Custom recursive handling for WeaveObject with rows
         # TODO: Kinda hacky way to dispatching Dataset with rows: Table
@@ -1198,12 +1193,18 @@ class WeaveClient:
         # the WeaveTable knows that it needs to fetch the rows from the server.
         if len(response.row_digests) == len(table.rows):
             row_digests = response.row_digests
-        return TableRef(
+        table_ref = TableRef(
             entity=self.entity,
             project=self.project,
             digest=response.digest,
             row_digests=row_digests,
         )
+        table.ref = table_ref
+
+        if isinstance(table, WeaveTable):
+            table.table_ref = table_ref
+
+        return table_ref
 
     ################ Internal Helpers ################
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -99,6 +99,12 @@ def remove_ref(obj: Any) -> None:
 
 
 def set_ref(obj: Any, ref: Optional[Ref]) -> None:
+    """Try to set the ref on "any" object.
+
+    We use increasingly complex methods to try to set the ref
+    to support different kinds of objects. This will still
+    fail for python primitives, but those can't be traced anyway.
+    """
     try:
         obj.ref = ref
     except:
@@ -1057,6 +1063,9 @@ class WeaveClient:
         3. Otherwise, traverse all values within `obj` recursively, applying the above logic to each value.
         Important notes to developers: This method does not return anything - it _mutates_ the
         values that it traverses (specifically, it attaches `ref` values to them)
+
+        Important: This method calls low level save methods directly - causing network events. Until
+        these are backgrounded, they should not be invoked from inside a critical path.
         """
         # Base case: if the object is already refed
         #  - if the ref is to a different project, remove it


### PR DESCRIPTION
The dataflow for saving objects has been notoriously complex and undocumented. This PR changes that by:
1. Co-locating common functions
2. Commenting profusely
3. Re-arranging some switch statements to be grouped more logically.

There should be no logical changes as a result of this PR