### PR TITLE
feat: Add pagination and sorting to object APIs

### DIFF
--- a/weave/tests/trace/test_objs_query.py
+++ b/weave/tests/trace/test_objs_query.py
@@ -83,38 +83,38 @@ def test_objs_query_filter_limit_offset_sort_by_created_at(client: WeaveClient):
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(latest_only=True),
             limit=3,
             offset=5,
-            latest_only=True,
             sort_by=[tsi.SortBy(field="created_at", direction="desc")],
         )
     )
     assert len(res.objs) == 3
     assert all([obj.is_latest for obj in res.objs])
     assert res.objs[0].val["j"] == 9
-    assert res.objs[0].val["i"] == 9
+    assert res.objs[0].val["i"] == 4
     assert res.objs[1].val["j"] == 9
-    assert res.objs[1].val["i"] == 8
+    assert res.objs[1].val["i"] == 3
     assert res.objs[2].val["j"] == 9
-    assert res.objs[2].val["i"] == 7
+    assert res.objs[2].val["i"] == 2
 
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(latest_only=True),
             limit=3,
             offset=5,
-            latest_only=True,
             sort_by=[tsi.SortBy(field="created_at", direction="asc")],
         )
     )
     assert len(res.objs) == 3
     assert all([obj.is_latest for obj in res.objs])
     assert res.objs[0].val["j"] == 9
-    assert res.objs[0].val["i"] == 0
+    assert res.objs[0].val["i"] == 5
     assert res.objs[1].val["j"] == 9
-    assert res.objs[1].val["i"] == 1
+    assert res.objs[1].val["i"] == 6
     assert res.objs[2].val["j"] == 9
-    assert res.objs[2].val["i"] == 2
+    assert res.objs[2].val["i"] == 7
 
 
 def test_objs_query_filter_limit_offset_sort_by_object_id(client: WeaveClient):
@@ -123,35 +123,35 @@ def test_objs_query_filter_limit_offset_sort_by_object_id(client: WeaveClient):
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(latest_only=True),
             limit=3,
             offset=5,
-            latest_only=True,
             sort_by=[tsi.SortBy(field="object_id", direction="desc")],
         )
     )
     assert len(res.objs) == 3
     assert all([obj.is_latest for obj in res.objs])
     assert res.objs[0].val["j"] == 9
-    assert res.objs[0].val["i"] == 9
+    assert res.objs[0].val["i"] == 4
     assert res.objs[1].val["j"] == 9
-    assert res.objs[1].val["i"] == 8
+    assert res.objs[1].val["i"] == 3
     assert res.objs[2].val["j"] == 9
-    assert res.objs[2].val["i"] == 7
+    assert res.objs[2].val["i"] == 2
 
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(latest_only=True),
             limit=3,
             offset=5,
-            latest_only=True,
             sort_by=[tsi.SortBy(field="object_id", direction="asc")],
         )
     )
     assert len(res.objs) == 3
     assert all([obj.is_latest for obj in res.objs])
     assert res.objs[0].val["j"] == 9
-    assert res.objs[0].val["i"] == 0
+    assert res.objs[0].val["i"] == 5
     assert res.objs[1].val["j"] == 9
-    assert res.objs[1].val["i"] == 1
+    assert res.objs[1].val["i"] == 6
     assert res.objs[2].val["j"] == 9
-    assert res.objs[2].val["i"] == 2
+    assert res.objs[2].val["i"] == 7

--- a/weave/tests/trace/test_objs_query.py
+++ b/weave/tests/trace/test_objs_query.py
@@ -77,7 +77,7 @@ def test_objs_query_filter_latest_only(client: WeaveClient):
     assert all([obj.val["j"] == 9 for obj in res.objs])
 
 
-def test_objs_query_filter_limit_offset_sort_by_desc(client: WeaveClient):
+def test_objs_query_filter_limit_offset_sort_by_created_at(client: WeaveClient):
     generate_objects(client, 10, 10)
     client._flush()
     res = client.server.objs_query(
@@ -86,7 +86,7 @@ def test_objs_query_filter_limit_offset_sort_by_desc(client: WeaveClient):
             limit=3,
             offset=5,
             latest_only=True,
-            sort_by=[tsi.SortBy(key="created_at", direction="desc")],
+            sort_by=[tsi.SortBy(field="created_at", direction="desc")],
         )
     )
     assert len(res.objs) == 3
@@ -98,8 +98,26 @@ def test_objs_query_filter_limit_offset_sort_by_desc(client: WeaveClient):
     assert res.objs[2].val["j"] == 9
     assert res.objs[2].val["i"] == 7
 
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            limit=3,
+            offset=5,
+            latest_only=True,
+            sort_by=[tsi.SortBy(field="created_at", direction="asc")],
+        )
+    )
+    assert len(res.objs) == 3
+    assert all([obj.is_latest for obj in res.objs])
+    assert res.objs[0].val["j"] == 9
+    assert res.objs[0].val["i"] == 0
+    assert res.objs[1].val["j"] == 9
+    assert res.objs[1].val["i"] == 1
+    assert res.objs[2].val["j"] == 9
+    assert res.objs[2].val["i"] == 2
 
-def test_objs_query_filter_limit_offset_sort_by_asc(client: WeaveClient):
+
+def test_objs_query_filter_limit_offset_sort_by_object_id(client: WeaveClient):
     generate_objects(client, 10, 10)
     client._flush()
     res = client.server.objs_query(
@@ -108,7 +126,7 @@ def test_objs_query_filter_limit_offset_sort_by_asc(client: WeaveClient):
             limit=3,
             offset=5,
             latest_only=True,
-            sort_by=[tsi.SortBy(key="created_at", direction="asc")],
+            sort_by=[tsi.SortBy(field="object_id", direction="desc")],
         )
     )
     assert len(res.objs) == 3
@@ -119,3 +137,21 @@ def test_objs_query_filter_limit_offset_sort_by_asc(client: WeaveClient):
     assert res.objs[1].val["i"] == 8
     assert res.objs[2].val["j"] == 9
     assert res.objs[2].val["i"] == 7
+
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            limit=3,
+            offset=5,
+            latest_only=True,
+            sort_by=[tsi.SortBy(field="object_id", direction="asc")],
+        )
+    )
+    assert len(res.objs) == 3
+    assert all([obj.is_latest for obj in res.objs])
+    assert res.objs[0].val["j"] == 9
+    assert res.objs[0].val["i"] == 0
+    assert res.objs[1].val["j"] == 9
+    assert res.objs[1].val["i"] == 1
+    assert res.objs[2].val["j"] == 9
+    assert res.objs[2].val["i"] == 2

--- a/weave/tests/trace/test_objs_query.py
+++ b/weave/tests/trace/test_objs_query.py
@@ -11,7 +11,7 @@ def generate_objects(weave_client: WeaveClient, obj_count: int, version_count: i
 
 def test_objs_query_all(client: WeaveClient):
     generate_objects(client, 10, 10)
-    client._flush()
+
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
@@ -22,20 +22,7 @@ def test_objs_query_all(client: WeaveClient):
 
 def test_objs_query_filter_object_ids(client: WeaveClient):
     generate_objects(client, 10, 10)
-    client._flush()
-    res = client.server.objs_query(
-        tsi.ObjQueryReq(
-            project_id=client._project_id(),
-            filter=tsi.ObjectVersionFilter(object_ids=["obj_0", "obj_1"]),
-        )
-    )
-    assert len(res.objs) == 20
-    assert all([obj.object_id in ["obj_0", "obj_1"] for obj in res.objs])
 
-
-def test_objs_query_filter_object_ids(client: WeaveClient):
-    generate_objects(client, 10, 10)
-    client._flush()
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
@@ -48,7 +35,7 @@ def test_objs_query_filter_object_ids(client: WeaveClient):
 
 def test_objs_query_filter_is_op(client: WeaveClient):
     generate_objects(client, 10, 10)
-    client._flush()
+
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(), filter=tsi.ObjectVersionFilter(is_op=True)
@@ -65,7 +52,7 @@ def test_objs_query_filter_is_op(client: WeaveClient):
 
 def test_objs_query_filter_latest_only(client: WeaveClient):
     generate_objects(client, 10, 10)
-    client._flush()
+
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
@@ -79,7 +66,7 @@ def test_objs_query_filter_latest_only(client: WeaveClient):
 
 def test_objs_query_filter_limit_offset_sort_by_created_at(client: WeaveClient):
     generate_objects(client, 10, 10)
-    client._flush()
+
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),
@@ -119,7 +106,7 @@ def test_objs_query_filter_limit_offset_sort_by_created_at(client: WeaveClient):
 
 def test_objs_query_filter_limit_offset_sort_by_object_id(client: WeaveClient):
     generate_objects(client, 10, 10)
-    client._flush()
+
     res = client.server.objs_query(
         tsi.ObjQueryReq(
             project_id=client._project_id(),

--- a/weave/tests/trace/test_objs_query.py
+++ b/weave/tests/trace/test_objs_query.py
@@ -1,0 +1,121 @@
+import weave
+from weave.trace.weave_client import WeaveClient
+from weave.trace_server import trace_server_interface as tsi
+
+
+def generate_objects(weave_client: WeaveClient, obj_count: int, version_count: int):
+    for i in range(obj_count):
+        for j in range(version_count):
+            weave.publish({"i": i, "j": j}, name=f"obj_{i}")
+
+
+def test_objs_query_all(client: WeaveClient):
+    generate_objects(client, 10, 10)
+    client._flush()
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+        )
+    )
+    assert len(res.objs) == 100
+
+
+def test_objs_query_filter_object_ids(client: WeaveClient):
+    generate_objects(client, 10, 10)
+    client._flush()
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(object_ids=["obj_0", "obj_1"]),
+        )
+    )
+    assert len(res.objs) == 20
+    assert all([obj.object_id in ["obj_0", "obj_1"] for obj in res.objs])
+
+
+def test_objs_query_filter_object_ids(client: WeaveClient):
+    generate_objects(client, 10, 10)
+    client._flush()
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(object_ids=["obj_0", "obj_1"]),
+        )
+    )
+    assert len(res.objs) == 20
+    assert all([obj.object_id in ["obj_0", "obj_1"] for obj in res.objs])
+
+
+def test_objs_query_filter_is_op(client: WeaveClient):
+    generate_objects(client, 10, 10)
+    client._flush()
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(), filter=tsi.ObjectVersionFilter(is_op=True)
+        )
+    )
+    assert len(res.objs) == 0
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(), filter=tsi.ObjectVersionFilter(is_op=False)
+        )
+    )
+    assert len(res.objs) == 100
+
+
+def test_objs_query_filter_latest_only(client: WeaveClient):
+    generate_objects(client, 10, 10)
+    client._flush()
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(latest_only=True),
+        )
+    )
+    assert len(res.objs) == 10
+    assert all([obj.is_latest for obj in res.objs])
+    assert all([obj.val["j"] == 9 for obj in res.objs])
+
+
+def test_objs_query_filter_limit_offset_sort_by_desc(client: WeaveClient):
+    generate_objects(client, 10, 10)
+    client._flush()
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            limit=3,
+            offset=5,
+            latest_only=True,
+            sort_by=[tsi.SortBy(key="created_at", direction="desc")],
+        )
+    )
+    assert len(res.objs) == 3
+    assert all([obj.is_latest for obj in res.objs])
+    assert res.objs[0].val["j"] == 9
+    assert res.objs[0].val["i"] == 9
+    assert res.objs[1].val["j"] == 9
+    assert res.objs[1].val["i"] == 8
+    assert res.objs[2].val["j"] == 9
+    assert res.objs[2].val["i"] == 7
+
+
+def test_objs_query_filter_limit_offset_sort_by_asc(client: WeaveClient):
+    generate_objects(client, 10, 10)
+    client._flush()
+    res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            limit=3,
+            offset=5,
+            latest_only=True,
+            sort_by=[tsi.SortBy(key="created_at", direction="asc")],
+        )
+    )
+    assert len(res.objs) == 3
+    assert all([obj.is_latest for obj in res.objs])
+    assert res.objs[0].val["j"] == 9
+    assert res.objs[0].val["i"] == 9
+    assert res.objs[1].val["j"] == 9
+    assert res.objs[1].val["i"] == 8
+    assert res.objs[2].val["j"] == 9
+    assert res.objs[2].val["i"] == 7

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -631,6 +631,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             is_latest=is_latest,
             limit=req.limit,
             offset=req.offset,
+            sort_by=req.sort_by,
         )
 
         return tsi.ObjQueryRes(objs=[_ch_obj_to_obj_schema(obj) for obj in objs])
@@ -1393,6 +1394,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         is_latest: bool = False,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        sort_by: Optional[list[tsi.SortBy]] = None,
     ) -> list[SelectableCHObjSchema]:
         """
         Main query for fetching objects.
@@ -1425,6 +1427,19 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             limit_part = f"LIMIT {int(limit)}"
         if offset is not None:
             offset_part = f" OFFSET {int(offset)}"
+
+        sort_part = ""
+        if sort_by:
+            valid_sort_fields = {"object_id", "created_at"}
+            sort_clauses = []
+            for sort in sort_by:
+                if sort.field in valid_sort_fields and sort.direction in {
+                    "asc",
+                    "desc",
+                }:
+                    sort_clauses.append(f"{sort.field} {sort.direction.upper()}")
+            if sort_clauses:
+                sort_part = f"ORDER BY {', '.join(sort_clauses)}"
 
         if parameters is None:
             parameters = {}
@@ -1479,6 +1494,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     {conditions_part}
             )
             WHERE {is_latest_part}
+            {sort_part}
             {limit_part}
             {offset_part}
         """

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -629,6 +629,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             object_id_conditions=object_id_conditions,
             parameters=parameters,
             is_latest=is_latest,
+            limit=req.limit,
+            offset=req.offset,
         )
 
         return tsi.ObjQueryRes(objs=[_ch_obj_to_obj_schema(obj) for obj in objs])
@@ -1390,6 +1392,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         parameters: Optional[Dict[str, Any]] = None,
         is_latest: bool = False,
         limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> list[SelectableCHObjSchema]:
         """
         Main query for fetching objects.
@@ -1417,8 +1420,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         is_latest_part = "is_latest = 1" if is_latest else "1 = 1"
 
         limit_part = ""
-        if limit != None:
-            limit_part = f"LIMIT {limit}"
+        offset_part = ""
+        if limit is not None:
+            limit_part = f"LIMIT {int(limit)}"
+        if offset is not None:
+            offset_part = f" OFFSET {int(offset)}"
 
         if parameters is None:
             parameters = {}
@@ -1474,6 +1480,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             )
             WHERE {is_latest_part}
             {limit_part}
+            {offset_part}
         """
         query_result = self._query_stream(
             select_query,

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -617,6 +617,11 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         # TODO: version index isn't right here, what if we delete stuff?
         with self.lock:
             cursor.execute("BEGIN TRANSACTION")
+            # Mark all existing objects with such id as not latest
+            cursor.execute(
+                """UPDATE objects SET is_latest = 0 WHERE project_id = ? AND object_id = ?""",
+                (req_obj.project_id, req_obj.object_id),
+            )
             # first get version count
             cursor.execute(
                 """SELECT COUNT(*) FROM objects WHERE project_id = ? AND object_id = ?""",

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -377,6 +377,9 @@ class ObjectVersionFilter(BaseModel):
 class ObjQueryReq(BaseModel):
     project_id: str
     filter: Optional[ObjectVersionFilter] = None
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+    sort_by: Optional[List[SortBy]] = None
 
 
 class ObjQueryRes(BaseModel):

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -368,18 +368,52 @@ class ObjReadRes(BaseModel):
 
 
 class ObjectVersionFilter(BaseModel):
-    base_object_classes: Optional[List[str]] = None
-    object_ids: Optional[List[str]] = None
-    is_op: Optional[bool] = None
-    latest_only: Optional[bool] = None
+    base_object_classes: Optional[List[str]] = Field(
+        default=None,
+        description="Filter objects by their base classes",
+        examples=[["Model"], ["Dataset"]],
+    )
+    object_ids: Optional[List[str]] = Field(
+        default=None,
+        description="Filter objects by their IDs",
+        examples=["my_favorite_model", "my_favorite_dataset"],
+    )
+    is_op: Optional[bool] = Field(
+        default=None,
+        description="Filter objects based on whether they are weave.ops or not. `True` will only return ops, `False` will return non-ops, and `None` will return all objects",
+        examples=[True, False, None],
+    )
+    latest_only: Optional[bool] = Field(
+        default=None,
+        description="If True, return only the latest version of each object. `False` and `None` will return all versions",
+        examples=[True, False],
+    )
 
 
 class ObjQueryReq(BaseModel):
-    project_id: str
-    filter: Optional[ObjectVersionFilter] = None
-    limit: Optional[int] = None
-    offset: Optional[int] = None
-    sort_by: Optional[List[SortBy]] = None
+    project_id: str = Field(
+        description="The ID of the project to query", examples=["user/project"]
+    )
+    filter: Optional[ObjectVersionFilter] = Field(
+        default=None,
+        description="Filter criteria for the query. See `ObjectVersionFilter`",
+        examples=[
+            ObjectVersionFilter(object_ids=["my_favorite_model"], latest_only=True)
+        ],
+    )
+    limit: Optional[int] = Field(
+        default=None, description="Maximum number of results to return", examples=[100]
+    )
+    offset: Optional[int] = Field(
+        default=None,
+        description="Number of results to skip before returning",
+        examples=[0],
+    )
+    sort_by: Optional[List[SortBy]] = Field(
+        default=None,
+        description="Sorting criteria for the query results. Currently only supports 'object_id' and 'created_at'.",
+        examples=[[SortBy(field="created_at", direction="desc")]],
+    )
 
 
 class ObjQueryRes(BaseModel):


### PR DESCRIPTION
This PR:
1. Adds a bunch of object query tests
2. Adds limit/offset/sort so we can paginate more effectively on the server