### PR TITLE
chore(weave): auto detect right-to-left text in tables

### DIFF
--- a/weave-js/src/components/Panel2/PanelString.tsx
+++ b/weave-js/src/components/Panel2/PanelString.tsx
@@ -14,6 +14,9 @@ import * as S from './PanelString.styles';
 import {TooltipTrigger} from './Tooltip';
 import {WeaveFormatContext} from './WeaveFormatContext';
 
+const rtlChars =
+  /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/;
+
 const inputType = {
   type: 'union' as const,
   members: [
@@ -52,6 +55,25 @@ function isURL(text: string): boolean {
     return false;
   }
 }
+
+/**
+ * Determines if a given text contains any right-to-left (RTL) script characters.
+ *
+ * RTL script characters are defined as any character within the Unicode ranges:
+ * - U+0590 to U+05FF
+ * - U+0600 to U+06FF
+ * - U+0750 to U+077F
+ * - U+08A0 to U+08FF
+ * - U+FB50 to U+FDFF
+ * - U+FE70 to U+FEFF
+ * Matching arabic, hebrew, and other related scripts.
+ *
+ * @param text - The text to be checked for RTL characters.
+ * @returns `true` if the text contains RTL characters, otherwise `false`.
+ */
+const isRTL = (text: string): boolean => {
+  return rtlChars.test(text);
+};
 
 const defaultConfig = (): PanelStringConfigState => {
   return {
@@ -224,16 +246,21 @@ export const PanelString: React.FC<PanelStringProps> = props => {
         console.error(e);
       }
     }
+    // Check if the first 100 characters contain any characters from an RTL script
+    // and set the text direction accordingly.
+    const textStyle: React.CSSProperties = isRTL(fullStr.slice(0, 100))
+      ? {direction: 'rtl', textAlign: 'right'}
+      : {};
     let contentPlaintext;
     if (parsed) {
       contentPlaintext = (
-        <S.PreformattedJSONString>
+        <S.PreformattedJSONString style={textStyle}>
           {JSON.stringify(parsed, null, 2)}
         </S.PreformattedJSONString>
       );
     } else {
       contentPlaintext = (
-        <S.PreformattedProportionalString>
+        <S.PreformattedProportionalString style={textStyle}>
           {fullStr}
         </S.PreformattedProportionalString>
       );


### PR DESCRIPTION
## JIRA Issue(s)

- https://wandb.atlassian.net/browse/WB-20787

## Description

This PR updates the plain text display for table cells to format arabic/hebrew text right-to-left (RTL). A regex specifying unicode ranges for arabic, hebrew, and related scripts is tested against the text. If matches are found, RTL formatting is applied. Specifically, we set `direction: rtl` and `text-align: right` on the div containing the text.

Before:

![Screenshot 2024-09-19 at 4 51 17 PM](https://github.com/user-attachments/assets/8f5bd896-9e65-411e-9203-e2c47815ca99)


After:

![Screenshot 2024-09-19 at 4 50 25 PM](https://github.com/user-attachments/assets/51cce0fb-237a-4913-8385-49a7fc0e0683)

## Questions

This PR adds a regex check for these character ranges for all table cells rendering plain text. The code already parses the text to detect if its a url and applies special formatting in this case, so this pr does not worsen the asymptotic complexity of the related code.