### PR TITLE
chore: indicate empty dictionary better

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -29,6 +29,9 @@ type ValueViewProps = {
 export const ValueView = ({data, isExpanded}: ValueViewProps) => {
   const opDefRef = useMemo(() => parseRefMaybe(data.value ?? ''), [data.value]);
   if (!data.isLeaf) {
+    if (data.valueType === 'object' && Object.keys(data.value).length === 0) {
+      return <ValueViewPrimitive>Empty object</ValueViewPrimitive>;
+    }
     if (data.valueType === 'object' && '_ref' in data.value) {
       return <SmallRef objRef={parseRef(data.value._ref)} />;
     }


### PR DESCRIPTION
## Description

Makes empty objects less confusing in inputs

Before:
<img width="495" alt="Screenshot 2024-09-19 at 2 50 10 PM" src="https://github.com/user-attachments/assets/704ac1a2-9f84-47a9-a457-e06f0ad42346">

After:
<img width="492" alt="Screenshot 2024-09-19 at 2 59 10 PM" src="https://github.com/user-attachments/assets/6fd13902-8a62-4ff6-9431-db7443b7230a">


## Testing

How was this PR tested?
