### PR TITLE
fix: Ref expansion crashing page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -167,16 +167,11 @@ export const ObjectViewer = ({
         refValues[context.value] != null &&
         // If this is a ref and the parent has been visited, we already resolved
         // this ref. Example: `a._ref` where `a` is already in resolvedRefPaths
-        !resolvedRefPaths.has(
-          context.value + context.parent?.toString() ?? ''
-        ) &&
-        // Don't traverse into the _ref key (this is a special key that is added
-        // to the resolved value to indicate the original ref URI)
-        context.path.tail() !== RESOVLED_REF_KEY
+        !resolvedRefPaths.has(context.parent?.toString() ?? '')
       ) {
         dirty = true;
         const res = refValues[context.value];
-        resolvedRefPaths.add(context.value + context.path.toString());
+        resolvedRefPaths.add(context.path.toString());
         return res;
       }
       return _.clone(context.value);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -64,6 +64,8 @@ const getRefs = (data: Data): string[] => {
 
 type RefValues = Record<string, any>; // ref URI to value
 
+const RESOVLED_REF_KEY = '_ref';
+
 // This is a general purpose object viewer that can be used to view any object.
 export const ObjectViewer = ({
   apiRef,
@@ -144,13 +146,13 @@ export const ObjectViewer = ({
         if (typeof val === 'object' && val !== null) {
           val = {
             ...v,
-            _ref: r,
+            [RESOVLED_REF_KEY]: r,
           };
         } else {
           // This makes it so that runs pointing to primitives can still be expanded in the table.
           val = {
             '': v,
-            _ref: r,
+            [RESOVLED_REF_KEY]: r,
           };
         }
       }
@@ -165,7 +167,12 @@ export const ObjectViewer = ({
         refValues[context.value] != null &&
         // If this is a ref and the parent has been visited, we already resolved
         // this ref. Example: `a._ref` where `a` is already in resolvedRefPaths
-        !resolvedRefPaths.has(context.value + context.parent?.toString() ?? '')
+        !resolvedRefPaths.has(
+          context.value + context.parent?.toString() ?? ''
+        ) &&
+        // Don't traverse into the _ref key (this is a special key that is added
+        // to the resolved value to indicate the original ref URI)
+        context.path.tail() !== RESOVLED_REF_KEY
       ) {
         dirty = true;
         const res = refValues[context.value];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -30,7 +30,13 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
   const opDefRef = useMemo(() => parseRefMaybe(data.value ?? ''), [data.value]);
   if (!data.isLeaf) {
     if (data.valueType === 'object' && '_ref' in data.value) {
-      return <SmallRef objRef={parseRef(data.value._ref)} />;
+      const innerRef = data.value._ref;
+      const ref = parseRefMaybe(innerRef);
+      if (ref != null) {
+        return <SmallRef objRef={ref} />;
+      } else {
+        console.error('Expected ref, found', innerRef, typeof innerRef);
+      }
     }
     if (USE_TABLE_FOR_ARRAYS && data.valueType === 'array') {
       return <DataTableView data={data.value} />;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/traverse.ts
@@ -304,7 +304,7 @@ export const mapObject = (
   data: any,
   transform: (context: TraverseContext) => any
 ) => {
-  const result = {};
+  const result = getValueType(data) === 'array' ? [] : {};
   traverse(data, context => {
     if (context.depth === 0) {
       return;


### PR DESCRIPTION
https://github.com/wandb/weave/commit/da7422ea593f2f6dc7126113082676cc7a1c94a5 introduced some modified logic to the expansion code. As a result, we were double expanding, breaking the expansion views.

See bug and fix here: https://app.wandb.test/a-sh0ts/evalgen_test_117112/weave/calls/0192101d-ad57-79b0-8458-9d3f3bb3293f