### PR TITLE
fix(artifacts): fix date returned by opArtifactCreatedAt in weave-js

### DIFF
--- a/weave-js/src/core/ops/domain/artifact.ts
+++ b/weave-js/src/core/ops/domain/artifact.ts
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 import * as Urls from '../../_external/util/urls';
 import {list, maybe, typedDict} from '../../model/helpers';
 import {docType} from '../../util/docs';

--- a/weave-js/src/core/ops/domain/artifact.ts
+++ b/weave-js/src/core/ops/domain/artifact.ts
@@ -87,7 +87,7 @@ export const opArtifactCreatedAt = makeArtifactOp({
   argDescriptions: {artifact: artifactArgDescription},
   returnValueDescription: `The creation date of the ${docType('artifact')}`,
   returnType: inputTypes => 'date',
-  resolver: ({artifact}) => moment(artifact.createdAt + 'Z').toDate(),
+  resolver: ({artifact}) => artifact.createdAt,
 });
 
 export const opArtifactProject = makeArtifactOp({


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-20951](https://wandb.atlassian.net/browse/WB-20951)
- Fixes #NNNN

Updated opArtifactCreatedAt to be similar to opArtifactVersionCreatedAt. 

https://github.com/wandb/weave/blob/bb9c605b25066f34e918cc7971795274516fb3d5/weave-js/src/core/ops/domain/artifactVersion.ts#L150-L164

## Testing

invoker_fe_prod.ini with w0 enabled


[WB-20951]: https://wandb.atlassian.net/browse/WB-20951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ