### PR TITLE
fix: dont only include trace roots when filtering all ops

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -181,17 +181,18 @@ export const CallsTable: FC<{
     initialFilter ?? {},
     onFilterUpdate
   );
-  // Calculate the effective filter
-  const effectiveFilter = useMemo(
-    () => getEffectiveFilter(filter, frozenFilter),
-    [filter, frozenFilter]
-  );
 
   // 2. Filter (Unstructured Filter)
   const filterModelResolved = filterModel ?? DEFAULT_FILTER_CALLS;
 
   // 3. Sort
   const sortModelResolved = sortModel ?? DEFAULT_SORT_CALLS;
+
+  // 3.5 Calculate the effective filter
+  const effectiveFilter = useMemo(
+    () => getEffectiveFilter(filter, frozenFilter, filterModelResolved),
+    [filter, frozenFilter, filterModelResolved]
+  );
 
   // 4. Pagination
   const paginationModelResolved = paginationModel ?? DEFAULT_PAGINATION_CALLS;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableFilter.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableFilter.ts
@@ -1,3 +1,4 @@
+import {GridFilterModel} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
 import {useMemo} from 'react';
 
@@ -38,7 +39,8 @@ export type WFHighLevelCallFilter = {
  */
 export const getEffectiveFilter = (
   activeFilter: WFHighLevelCallFilter,
-  frozenFilter?: WFHighLevelCallFilter
+  frozenFilter?: WFHighLevelCallFilter,
+  gridFilterModel?: GridFilterModel
 ) => {
   const effectiveFilter = {
     ...activeFilter,
@@ -46,8 +48,10 @@ export const getEffectiveFilter = (
   };
 
   // TraceRootsOnly is now only a calculated field
-  effectiveFilter.traceRootsOnly =
-    filterShouldUseTraceRootsOnly(effectiveFilter);
+  effectiveFilter.traceRootsOnly = filterShouldUseTraceRootsOnly(
+    effectiveFilter,
+    gridFilterModel
+  );
 
   validateFilterUICompatibility(effectiveFilter);
   return effectiveFilter;
@@ -78,7 +82,8 @@ const validateFilterUICompatibility = (filter: WFHighLevelCallFilter) => {
  * other fields.
  */
 export const filterShouldUseTraceRootsOnly = (
-  filter: WFHighLevelCallFilter
+  filter: WFHighLevelCallFilter,
+  gridFilterModel?: GridFilterModel
 ) => {
   const opVersionRefsSet = (filter.opVersionRefs?.length ?? 0) > 0;
   const inputObjectVersionRefsSet =
@@ -86,11 +91,13 @@ export const filterShouldUseTraceRootsOnly = (
   const outputObjectVersionRefsSet =
     (filter.outputObjectVersionRefs?.length ?? 0) > 0;
   const parentIdSet = filter.parentId != null;
+  const gridFilterModelSet = (gridFilterModel?.items.length ?? 0) > 0;
   return (
     !opVersionRefsSet &&
     !inputObjectVersionRefsSet &&
     !outputObjectVersionRefsSet &&
-    !parentIdSet
+    !parentIdSet &&
+    !gridFilterModelSet
   );
 };
 export const useInputObjectVersionOptions = (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes 

Removes the `trace_roots_only` flag when we have a gridfilter set, like "col = 1"

## Testing

How was this PR tested?
