### PR TITLE
fix: Fix rendering of singular ref outputs

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -129,7 +129,7 @@ export const CallDetails: FC<{
           }}>
           <CustomWeaveTypeProjectContext.Provider
             value={{entity: call.entity, project: call.project}}>
-            <ObjectViewerSection title="Inputs" data={inputs} />
+            <ObjectViewerSection title="Inputs" data={inputs} isExpanded />
           </CustomWeaveTypeProjectContext.Provider>
         </Box>
         <Box
@@ -147,7 +147,7 @@ export const CallDetails: FC<{
           ) : (
             <CustomWeaveTypeProjectContext.Provider
               value={{entity: call.entity, project: call.project}}>
-              <ObjectViewerSection title="Output" data={output} />
+              <ObjectViewerSection title="Output" data={output} isExpanded />
             </CustomWeaveTypeProjectContext.Provider>
           )}
         </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -160,19 +160,15 @@ export const ObjectViewer = ({
     }
     let resolved = data;
     let dirty = true;
-    const resolvedRefPaths = new Set<string>();
     const mapper = (context: TraverseContext) => {
       if (
         isWeaveRef(context.value) &&
         refValues[context.value] != null &&
-        // If this is a ref and the parent has been visited, we already resolved
-        // this ref. Example: `a._ref` where `a` is already in resolvedRefPaths
-        !resolvedRefPaths.has(context.parent?.toString() ?? '')
+        // Don't expand _ref keys
+        context.path.tail() !== RESOVLED_REF_KEY
       ) {
         dirty = true;
-        const res = refValues[context.value];
-        resolvedRefPaths.add(context.path.toString());
-        return res;
+        return refValues[context.value];
       }
       return _.clone(context.value);
     };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -242,7 +242,12 @@ export const ObjectViewerSection = ({
     );
   }
   if (numKeys === 1 && '_result' in data) {
-    const value = data._result;
+    let value = data._result;
+    if (isWeaveRef(value)) {
+      // Little hack to make sure that we render refs
+      // inside the expansion table view
+      value = {' ': value};
+    }
     const valueType = getValueType(value);
     if (valueType === 'object' || (valueType === 'array' && value.length > 0)) {
       return (


### PR DESCRIPTION
This PR does a few things:
1. Auto-expand the first layer of inputs and outputs
2. Make sure that single-ref outputs are viewed in the object viewer
3. Fix the object viewer to support expanding direct child refs
Good example: https://app.wandb.test/adrian2/support-model-eval/weave/calls/01919101-4953-79e3-b797-68e9e506abf9
