### PR TITLE
fix: chat view not showing when it should

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallChat.tsx
@@ -127,7 +127,11 @@ export const isMessage = (message: any): boolean => {
   if (!('content' in message) && !('tool_calls' in message)) {
     return false;
   }
-  if ('content' in message && !isMessageContent(message.content)) {
+  if (
+    'content' in message &&
+    message.content !== null &&
+    !isMessageContent(message.content)
+  ) {
     return false;
   }
   if ('tool_calls' in message && !isToolCalls(message.tool_calls)) {


### PR DESCRIPTION
## Description

Internal Slack: 
https://weightsandbiases.slack.com/archives/C05DURZNT41/p1727118627553499

When a message contains `tool_calls` then `content` might also exist but be null.

## Testing

How was this PR tested?
