### PR TITLE
chore: upgrade Material grid to v7.18.0

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -37,7 +37,7 @@
     "@monaco-editor/react": "^4.3.1",
     "@mui/icons-material": "^5.14.12",
     "@mui/material": "^6.0.2",
-    "@mui/x-data-grid-pro": "^6.16.0",
+    "@mui/x-data-grid-pro": "^7.18.0",
     "@mui/x-date-pickers": "^6.16.0",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2.tsx
@@ -8,7 +8,7 @@ import {
   Toolbar,
   Typography,
 } from '@mui/material';
-import {LicenseInfo} from '@mui/x-license-pro';
+import {LicenseInfo} from '@mui/x-license';
 import React, {FC} from 'react';
 import {
   BrowserRouter as Router,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -14,10 +14,10 @@ import {
   GridColumnVisibilityModel,
   GridFilterModel,
   GridPaginationModel,
-  GridPinnedColumns,
+  GridPinnedColumnFields,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
-import {LicenseInfo} from '@mui/x-license-pro';
+import {LicenseInfo} from '@mui/x-license';
 import {makeGorillaApolloClient} from '@wandb/weave/apollo';
 import {EVALUATE_OP_NAME_POST_PYDANTIC} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/heuristics';
 import {opVersionKeyToRefUri} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities';
@@ -727,7 +727,7 @@ const CallsPageBinding = () => {
     () => getValidPinModel(query.pin, DEFAULT_PIN_CALLS, ALWAYS_PIN_LEFT_CALLS),
     [query.pin]
   );
-  const setPinModel = (newModel: GridPinnedColumns) => {
+  const setPinModel = (newModel: GridPinnedColumnFields) => {
     const newQuery = new URLSearchParams(location.search);
     newQuery.set(
       'pin',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
@@ -46,12 +46,7 @@ export const StyledDataGrid = styled(
 
   fontFamily: 'Source Sans Pro',
 
-  '& .MuiDataGrid-columnHeaders': {
-    backgroundColor: MOON_50,
-    color: MOON_500,
-  },
-
-  '& .MuiDataGrid-pinnedColumnHeaders': {
+  '& .MuiDataGrid-columnHeader': {
     backgroundColor: MOON_50,
     color: MOON_500,
   },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -23,6 +23,7 @@ export const FeedbackGridInner = ({
     {
       field: 'feedback_type',
       headerName: 'Type',
+      display: 'flex',
       renderCell: params => (
         <div className="overflow-hidden">
           <FeedbackTypeChip feedbackType={params.row.feedback_type} />
@@ -57,6 +58,7 @@ export const FeedbackGridInner = ({
       field: 'id',
       headerName: 'ID',
       width: 50,
+      display: 'flex',
       renderCell: params => <CopyableId id={params.row.id} type="Feedback" />,
     },
     {
@@ -88,6 +90,7 @@ export const FeedbackGridInner = ({
       sortable: false,
       resizable: false,
       disableColumnMenu: true,
+      display: 'flex',
       renderCell: params => {
         const projectId = params.row.project_id;
         const feedbackId = params.row.id;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pin.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pin.ts
@@ -1,4 +1,4 @@
-import {GridPinnedColumns} from '@mui/x-data-grid-pro';
+import {GridPinnedColumnFields} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
 
 const isValidPinValue = (value: any): boolean => {
@@ -7,9 +7,9 @@ const isValidPinValue = (value: any): boolean => {
 
 // Columns that are always pinned left don't need to be present in serialized state.
 export const removeAlwaysLeft = (
-  pinModel: GridPinnedColumns,
+  pinModel: GridPinnedColumnFields,
   alwaysLeft: string[]
-): GridPinnedColumns => {
+): GridPinnedColumnFields => {
   if (!pinModel.left) {
     return pinModel;
   }
@@ -22,9 +22,9 @@ export const removeAlwaysLeft = (
 
 // Ensure specified columns are always pinned left.
 const ensureAlwaysLeft = (
-  pinModel: GridPinnedColumns,
+  pinModel: GridPinnedColumnFields,
   alwaysLeft: string[]
-): GridPinnedColumns => {
+): GridPinnedColumnFields => {
   let left = pinModel.left ?? [];
   left = left.filter(col => !alwaysLeft.includes(col));
   left = alwaysLeft.concat(left);
@@ -36,9 +36,9 @@ const ensureAlwaysLeft = (
 
 export const getValidPinModel = (
   jsonString: string,
-  def: GridPinnedColumns | null = null,
+  def: GridPinnedColumnFields | null = null,
   alwaysLeft?: string[]
-): GridPinnedColumns => {
+): GridPinnedColumnFields => {
   def = def ?? {};
   try {
     const parsed = JSON.parse(jsonString);
@@ -49,7 +49,7 @@ export const getValidPinModel = (
           key => ['left', 'right'].includes(key) && isValidPinValue(parsed[key])
         )
       ) {
-        const pinModel = parsed as GridPinnedColumns;
+        const pinModel = parsed as GridPinnedColumnFields;
         if (alwaysLeft) {
           return ensureAlwaysLeft(pinModel, alwaysLeft);
         }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -51,6 +51,7 @@ export const CallTraceView: FC<{
       headerName: 'Call Tree',
       headerAlign: 'center',
       flex: 1,
+      display: 'flex',
       renderCell: params => (
         <CustomGridTreeDataGroupingCell
           {...params}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
@@ -335,7 +335,6 @@ export const DataTableView: FC<{
           keepBorders={false}
           apiRef={apiRef}
           density="compact"
-          experimentalFeatures={{columnGrouping: true}}
           rows={gridRows}
           columns={columnSpec}
           loading={props.loading}
@@ -367,7 +366,7 @@ export const typeToDataGridColumnSpec = (
         innerKey
       );
       if (valTypeCols.length === 0) {
-        let colType = 'string';
+        let colType: GridColDef['type'] = 'string';
         let editable = false;
         if (isAssignableTo(valueType, maybe('boolean'))) {
           editable = true;
@@ -383,7 +382,7 @@ export const typeToDataGridColumnSpec = (
           return [
             {
               maxWidth,
-              type: 'string',
+              type: 'string' as const,
               editable: false,
               field: innerKey,
               headerName: innerKey,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -294,6 +294,7 @@ export const ObjectViewer = ({
         field: 'value',
         headerName: 'Value',
         flex: 1,
+        display: 'flex',
         sortable: false,
         renderCell: ({row}) => {
           if (row.isCode) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -2,7 +2,7 @@ import {
   GridColumnVisibilityModel,
   GridFilterModel,
   GridPaginationModel,
-  GridPinnedColumns,
+  GridPinnedColumnFields,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
 import React, {FC, useMemo} from 'react';
@@ -35,8 +35,8 @@ export const CallsPage: FC<{
   columnVisibilityModel: GridColumnVisibilityModel;
   setColumnVisibilityModel: (newModel: GridColumnVisibilityModel) => void;
 
-  pinModel: GridPinnedColumns;
-  setPinModel: (newModel: GridPinnedColumns) => void;
+  pinModel: GridPinnedColumnFields;
+  setPinModel: (newModel: GridPinnedColumnFields) => void;
 
   filterModel: GridFilterModel;
   setFilterModel: (newModel: GridFilterModel) => void;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -19,7 +19,7 @@ import {
   GridFilterModel,
   GridLogicOperator,
   GridPaginationModel,
-  GridPinnedColumns,
+  GridPinnedColumnFields,
   GridRowSelectionModel,
   GridSortModel,
   useGridApiRef,
@@ -96,7 +96,7 @@ export const DEFAULT_COLUMN_VISIBILITY_CALLS = {
 
 export const ALWAYS_PIN_LEFT_CALLS = ['CustomCheckbox'];
 
-export const DEFAULT_PIN_CALLS: GridPinnedColumns = {
+export const DEFAULT_PIN_CALLS: GridPinnedColumnFields = {
   left: ['CustomCheckbox', 'op_name'],
 };
 
@@ -128,8 +128,8 @@ export const CallsTable: FC<{
   columnVisibilityModel?: GridColumnVisibilityModel;
   setColumnVisibilityModel?: (newModel: GridColumnVisibilityModel) => void;
 
-  pinModel?: GridPinnedColumns;
-  setPinModel?: (newModel: GridPinnedColumns) => void;
+  pinModel?: GridPinnedColumnFields;
+  setPinModel?: (newModel: GridPinnedColumnFields) => void;
 
   filterModel?: GridFilterModel;
   setFilterModel?: (newModel: GridFilterModel) => void;
@@ -532,7 +532,7 @@ export const CallsTable: FC<{
     : undefined;
 
   const onPinnedColumnsChange = useCallback(
-    (newModel: GridPinnedColumns) => {
+    (newModel: GridPinnedColumnFields) => {
       if (!setPinModel || callsLoading) {
         return;
       }
@@ -781,7 +781,6 @@ export const CallsTable: FC<{
         // PAGINATION SECTION END
         rowHeight={38}
         columns={muiColumns}
-        experimentalFeatures={{columnGrouping: true}}
         disableRowSelectionOnClick
         rowSelectionModel={rowSelectionModel}
         // columnGroupingModel={groupingModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import {Box, Typography} from '@mui/material';
 import {
+  GridColDef,
   GridColumnVisibilityModel,
   GridFilterModel,
   GridLogicOperator,
@@ -418,7 +419,7 @@ export const CallsTable: FC<{
     setSelectedCalls([]);
   }, [setSelectedCalls]);
   const muiColumns = useMemo(() => {
-    const cols = [
+    const cols: GridColDef[] = [
       {
         minWidth: 30,
         width: 38,
@@ -427,6 +428,7 @@ export const CallsTable: FC<{
         disableColumnMenu: true,
         resizable: false,
         disableExport: true,
+        display: 'flex',
         renderHeader: (params: any) => {
           return (
             <Checkbox

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -184,8 +184,8 @@ function buildCallsTableColumns(
       minWidth: 100,
       width: 250,
       hideable: false,
-      valueGetter: rowParams => {
-        const op_name = rowParams.row.op_name;
+      valueGetter: (unused, row) => {
+        const op_name = row.op_name;
         if (!isWeaveRef(op_name)) {
           return op_name;
         }
@@ -237,7 +237,7 @@ function buildCallsTableColumns(
           {
             field: 'derived.op_version',
             headerName: 'Op Version',
-            type: 'number',
+            type: 'number' as const,
             align: 'right' as const,
             disableColumnMenu: true,
             sortable: false,
@@ -269,8 +269,8 @@ function buildCallsTableColumns(
       // disableColumnMenu: true,
       resizable: false,
       width: 59,
-      valueGetter: cellParams => {
-        return traceCallStatusCode(cellParams.row);
+      valueGetter: (unused, row) => {
+        return traceCallStatusCode(row);
       },
       renderCell: cellParams => {
         return (
@@ -363,8 +363,8 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
-    valueGetter: cellParams => {
-      const usage = getUsageFromCellParams(cellParams.row);
+    valueGetter: (unused, row) => {
+      const usage = getUsageFromCellParams(row);
       const {tokensNum} = getTokensAndCostFromUsage(usage);
       return tokensNum;
     },
@@ -384,8 +384,8 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
-    valueGetter: cellParams => {
-      const usage = getUsageFromCellParams(cellParams.row);
+    valueGetter: (unused, row) => {
+      const usage = getUsageFromCellParams(row);
       const {costNum} = getTokensAndCostFromUsage(usage);
       return costNum;
     },
@@ -405,13 +405,13 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
-    valueGetter: cellParams => {
-      if (traceCallStatusCode(cellParams.row) === 'UNSET') {
+    valueGetter: (unused, row) => {
+      if (traceCallStatusCode(row) === 'UNSET') {
         // Call is still in progress, latency will be 0.
         // Displaying nothing seems preferable to being misleading.
         return null;
       }
-      return traceCallLatencyS(cellParams.row);
+      return traceCallLatencyS(row);
     },
     renderCell: cellParams => {
       if (traceCallStatusCode(cellParams.row) === 'UNSET') {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -184,7 +184,8 @@ function buildCallsTableColumns(
       minWidth: 100,
       width: 250,
       hideable: false,
-      valueGetter: (unused, row) => {
+      display: 'flex',
+      valueGetter: (unused: any, row: any) => {
         const op_name = row.op_name;
         if (!isWeaveRef(op_name)) {
           return op_name;
@@ -269,7 +270,8 @@ function buildCallsTableColumns(
       // disableColumnMenu: true,
       resizable: false,
       width: 59,
-      valueGetter: (unused, row) => {
+      display: 'flex',
+      valueGetter: (unused: any, row: any) => {
         return traceCallStatusCode(row);
       },
       renderCell: cellParams => {
@@ -309,6 +311,7 @@ function buildCallsTableColumns(
     align: 'center',
     sortable: false,
     resizable: false,
+    display: 'flex',
     renderCell: cellParams => {
       const userId = cellParams.row.wb_user_id;
       if (userId == null) {
@@ -363,7 +366,7 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
-    valueGetter: (unused, row) => {
+    valueGetter: (unused: any, row: any) => {
       const usage = getUsageFromCellParams(row);
       const {tokensNum} = getTokensAndCostFromUsage(usage);
       return tokensNum;
@@ -384,7 +387,7 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
-    valueGetter: (unused, row) => {
+    valueGetter: (unused: any, row: any) => {
       const usage = getUsageFromCellParams(row);
       const {costNum} = getTokensAndCostFromUsage(usage);
       return costNum;
@@ -405,7 +408,7 @@ function buildCallsTableColumns(
     // Should probably have a custom filter here.
     filterable: false,
     sortable: false,
-    valueGetter: (unused, row) => {
+    valueGetter: (unused: any, row: any) => {
       if (traceCallStatusCode(row) === 'UNSET') {
         // Call is still in progress, latency will be 0.
         // Displaying nothing seems preferable to being misleading.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -274,8 +274,8 @@ const ObjectVersionsTable: React.FC<{
     cols.push(
       basicField('baseObjectClass', 'Category', {
         width: 100,
-        valueGetter: cellParams => {
-          return cellParams.row.obj.baseObjectClass;
+        valueGetter: (unused, row) => {
+          return row.obj.baseObjectClass;
         },
         renderCell: cellParams => {
           const category = cellParams.value;
@@ -290,8 +290,8 @@ const ObjectVersionsTable: React.FC<{
     cols.push(
       basicField('createdAtMs', 'Created', {
         width: 100,
-        valueGetter: cellParams => {
-          return cellParams.row.obj.createdAtMs;
+        valueGetter: (unused, row) => {
+          return row.obj.createdAtMs;
         },
         renderCell: cellParams => {
           const createdAtMs = cellParams.value;
@@ -371,7 +371,6 @@ const ObjectVersionsTable: React.FC<{
       columnHeaderHeight={40}
       rowHeight={38}
       columns={columns}
-      experimentalFeatures={{columnGrouping: true}}
       disableRowSelectionOnClick
       rowSelectionModel={rowSelectionModel}
       columnGroupingModel={columnGroupingModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -274,7 +274,8 @@ const ObjectVersionsTable: React.FC<{
     cols.push(
       basicField('baseObjectClass', 'Category', {
         width: 100,
-        valueGetter: (unused, row) => {
+        display: 'flex',
+        valueGetter: (unused: any, row: any) => {
           return row.obj.baseObjectClass;
         },
         renderCell: cellParams => {
@@ -290,7 +291,7 @@ const ObjectVersionsTable: React.FC<{
     cols.push(
       basicField('createdAtMs', 'Created', {
         width: 100,
-        valueGetter: (unused, row) => {
+        valueGetter: (unused: any, row: any) => {
           return row.obj.createdAtMs;
         },
         renderCell: cellParams => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -223,7 +223,6 @@ export const FilterableOpVersionsTable: React.FC<{
       columnHeaderHeight={40}
       rowHeight={38}
       columns={columns}
-      experimentalFeatures={{columnGrouping: true}}
       disableRowSelectionOnClick
       rowSelectionModel={rowSelectionModel}
       columnGroupingModel={columnGroupingModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
@@ -262,6 +262,7 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
       field: key,
       sortable: columnIsSortable && columnIsSortable(key),
       headerName: key,
+      display: 'flex',
       renderHeader: () => {
         return (
           <div
@@ -272,7 +273,7 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
           </div>
         );
       },
-      valueGetter: (unused, row) => {
+      valueGetter: (unused: any, row: any) => {
         const val = valueForKey(row, key);
         if (Array.isArray(val) || typeof val === 'object') {
           try {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
@@ -272,8 +272,8 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
           </div>
         );
       },
-      valueGetter: cellParams => {
-        const val = valueForKey(cellParams.row, key);
+      valueGetter: (unused, row) => {
+        const val = valueForKey(row, key);
         if (Array.isArray(val) || typeof val === 'object') {
           try {
             return JSON.stringify(val);

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -1380,7 +1380,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.22.6", "@babel/runtime@^7.23.2":
+"@babel/runtime@^7.23.2":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
   integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
@@ -1394,7 +1394,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.25.0":
+"@babel/runtime@^7.25.0", "@babel/runtime@^7.25.6":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.6.tgz#9afc3289f7184d8d7f98b099884c26317b9264d2"
   integrity sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==
@@ -2949,7 +2949,7 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.16.tgz#66710c691b51cd4fca95322100cd74ec230cfe30"
   integrity sha512-qI8TV3M7ShITEEc8Ih15A2vLzZGLhD+/UPNwck/hcls2gwg7dyRjNGXcQYHKLB5Q7PuTRfrTkAoPa2VV1s67Ag==
 
-"@mui/utils@^5.13.7", "@mui/utils@^5.14.16":
+"@mui/utils@^5.14.16":
   version "5.14.18"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.14.18.tgz#d2a46df9b06230423ba6b6317748b27185a56ac3"
   integrity sha512-HZDRsJtEZ7WMSnrHV9uwScGze4wM/Y+u6pDVo+grUjt5yXzn+wI8QX/JwTHh9YSw/WpnUL80mJJjgCnWj2VrzQ==
@@ -2959,7 +2959,7 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/utils@^5.15.14":
+"@mui/utils@^5.15.14", "@mui/utils@^5.16.6":
   version "5.16.6"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.16.6.tgz#905875bbc58d3dcc24531c3314a6807aba22a711"
   integrity sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==
@@ -2983,30 +2983,32 @@
     prop-types "^15.8.1"
     react-is "^18.3.1"
 
-"@mui/x-data-grid-pro@^6.16.0":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid-pro/-/x-data-grid-pro-6.18.1.tgz#24ac7bb281729ce84f52f8048d222c572c3ff434"
-  integrity sha512-UP5SE3fwWHgGZ9l4+4TPkbAw5gE4jzGo3raU47+0OOTrqhYbnu9msGLIRX5oV7SzEeEkLd4HeMlv8ns2lBkVjg==
+"@mui/x-data-grid-pro@^7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid-pro/-/x-data-grid-pro-7.18.0.tgz#2099c00d837f04cf681674ecbac4e4c294925164"
+  integrity sha512-g6Ot1s69bfjBRlp6/vwjZgn4CPwX90zt7nx1d28srFD14koet+r/45vg69Bjn7+/REThZMO7g4kcOW2nFkeS8w==
   dependencies:
-    "@babel/runtime" "^7.23.2"
-    "@mui/utils" "^5.14.16"
-    "@mui/x-data-grid" "6.18.1"
-    "@mui/x-license-pro" "6.10.2"
-    "@types/format-util" "^1.0.3"
-    clsx "^2.0.0"
+    "@babel/runtime" "^7.25.6"
+    "@mui/utils" "^5.16.6"
+    "@mui/x-data-grid" "7.18.0"
+    "@mui/x-internals" "7.18.0"
+    "@mui/x-license" "7.18.0"
+    "@types/format-util" "^1.0.4"
+    clsx "^2.1.1"
     prop-types "^15.8.1"
-    reselect "^4.1.8"
+    reselect "^5.1.1"
 
-"@mui/x-data-grid@6.18.1":
-  version "6.18.1"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-6.18.1.tgz#0b34d7aebd5d8319524f78c9078dcc57becf06f0"
-  integrity sha512-ibsrWwzM2lRRWB1xs/eop63kaxlXH/qar1S1rQx3fycJiYvK6fsM72jsScBNRlRZQQwRVSGI0ZPBsOZ+/tg7Qw==
+"@mui/x-data-grid@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-7.18.0.tgz#9be96110e0334eb347b09eef68f1d61d3720bb13"
+  integrity sha512-41UjJbRxWk+Yk/lfvaO55Pwo5p+F5s3rOTiHLl53ikCT5GuJ5OCCvik0Bi3c6DzTuUBdrEucae2618rydc2DGw==
   dependencies:
-    "@babel/runtime" "^7.23.2"
-    "@mui/utils" "^5.14.16"
-    clsx "^2.0.0"
+    "@babel/runtime" "^7.25.6"
+    "@mui/utils" "^5.16.6"
+    "@mui/x-internals" "7.18.0"
+    clsx "^2.1.1"
     prop-types "^15.8.1"
-    reselect "^4.1.8"
+    reselect "^5.1.1"
 
 "@mui/x-date-pickers@^6.16.0":
   version "6.20.2"
@@ -3021,13 +3023,21 @@
     prop-types "^15.8.1"
     react-transition-group "^4.4.5"
 
-"@mui/x-license-pro@6.10.2":
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/@mui/x-license-pro/-/x-license-pro-6.10.2.tgz#68b069214efb085f7f8c34b73d450743857e0aea"
-  integrity sha512-Baw3shilU+eHgU+QYKNPFUKvfS5rSyNJ98pQx02E0gKA22hWp/XAt88K1qUfUMPlkPpvg/uci6gviQSSLZkuKw==
+"@mui/x-internals@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.18.0.tgz#f079968d4f7ea93e63be9faf6ba8558d6f12923b"
+  integrity sha512-lzCHOWIR0cAIY1bGrWSprYerahbnH5C31ql/2OWCEjcngL2NAV1M6oKI2Vp4HheqzJ822c60UyWyapvyjSzY/A==
   dependencies:
-    "@babel/runtime" "^7.22.6"
-    "@mui/utils" "^5.13.7"
+    "@babel/runtime" "^7.25.6"
+    "@mui/utils" "^5.16.6"
+
+"@mui/x-license@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-license/-/x-license-7.18.0.tgz#0f4d8feadc44a309926b03445874d31a70a2b015"
+  integrity sha512-/UJp4NSQ5iURLQ7Si0oyGhiOqb3rg/HO4LcIxmKICO7Xn9VcupoX9+uDko+UwbCrybkpkC/3lyJEmD+4pbLqbA==
+  dependencies:
+    "@babel/runtime" "^7.25.6"
+    "@mui/utils" "^5.16.6"
 
 "@ndhoule/after@^1.0.0":
   version "1.0.0"
@@ -4232,7 +4242,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.1.tgz#aa22750962f3bf0e79d753d3cc067f010c95f194"
   integrity sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==
 
-"@types/format-util@^1.0.3":
+"@types/format-util@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/format-util/-/format-util-1.0.4.tgz#c4e3b556735149fdf047898a5b9c04650491509b"
   integrity sha512-xrCYOdHh5zA3LUrn6CvspYwlzSWxPso11Lx32WnAG6KvLCRecKZ/Rh21PLXUkzUFsQmrGcx/traJAFjR6dVS5Q==
@@ -12731,10 +12741,10 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
-reselect@^4.1.8:
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
-  integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
+reselect@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
+  integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
 
 resize-observer-polyfill@^1.5.0:
   version "1.5.1"


### PR DESCRIPTION
## Description

Several internal and external customers have been affected by this issue where one or more cells in the objectviewer get into a resizing loop with scrollbars appearing and disappearing.
https://wandb.atlassian.net/browse/WB-21047

From what I could determine, it appears to be a bug in Material UI data grid when you use auto with getRowHeight rather than our code. While digging into that I discovered that the grid code has changed a lot between v6 and v7. On a hunch, I tried upgrading to 7 to see if it resolves the issue and I think so. This PR fixes the other things necessary to upgrade the library.

https://mui.com/x/migration/migration-data-grid-v6/#start-using-the-new-release
https://mui.com/x/migration/migration-data-grid-v6/#removed-props
https://mui.com/x/migration/migration-data-grid-v6/#update-the-license-package
https://mui.com/x/migration/migration-data-grid-v6/#columns
https://mui.com/x/migration/migration-data-grid-v6/#css-classes-and-styling

## Testing

How was this PR tested?
