### PR TITLE
chore: remove feedback from pinned cols

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -97,7 +97,7 @@ export const DEFAULT_COLUMN_VISIBILITY_CALLS = {
 export const ALWAYS_PIN_LEFT_CALLS = ['CustomCheckbox'];
 
 export const DEFAULT_PIN_CALLS: GridPinnedColumns = {
-  left: ['CustomCheckbox', 'op_name', 'feedback'],
+  left: ['CustomCheckbox', 'op_name'],
 };
 
 export const DEFAULT_SORT_CALLS: GridSortModel = [


### PR DESCRIPTION
## Description

Remove feedback from the list of default pinned left columns.

Internal Notion: https://www.notion.so/wandbai/Traces-table-d0abd588c49e4a77a213db27af717b4f?pvs=4#10ae2f5c7ef38086bcd8c3cecc19b0ba

## Testing

How was this PR tested?
