### PR TITLE
chore: reorder nav bar, traces to top

### DIFF
--- a/weave-js/src/components/FancyPage/useProjectSidebar.ts
+++ b/weave-js/src/components/FancyPage/useProjectSidebar.ts
@@ -123,11 +123,17 @@ export const useProjectSidebar = (
           },
           {
             type: 'button' as const,
+            name: 'Traces',
+            slug: 'weave/traces',
+            isShown: showWeaveSidebarItems || isShowAll,
+            iconName: IconNames.LayoutTabs,
+          },
+          {
+            type: 'button' as const,
             name: 'Evals',
             slug: 'weave/evaluations',
             isShown: showWeaveSidebarItems || isShowAll,
             iconName: IconNames.BaselineAlt,
-            // path: baseRouter.callsUIUrl(entity, project, evaluationsFilter),
           },
           {
             type: 'button' as const,
@@ -147,16 +153,6 @@ export const useProjectSidebar = (
             type: 'divider' as const,
             key: 'dividerWithinWeave',
             isShown: isWeaveOnly,
-          },
-          {
-            type: 'button' as const,
-            name: 'Traces',
-            slug: 'weave/traces',
-            isShown: showWeaveSidebarItems || isShowAll,
-            iconName: IconNames.LayoutTabs,
-            // path: baseRouter.callsUIUrl(entity, project, {
-            //   traceRootsOnly: true,
-            // }),
           },
           {
             type: 'button' as const,


### PR DESCRIPTION
## Description

Just moving Traces button to top of nav and removing commented out code.

Internal Notion: https://www.notion.so/wandbai/Nav-bar-f9ddbab018824a59b30b0d0ff17d7de6?pvs=4#10ae2f5c7ef380a2b5fcd98e93dceed7

Before:
<img width="62" alt="Screenshot 2024-09-24 at 2 43 20 PM" src="https://github.com/user-attachments/assets/7f598965-2fcb-493a-80a8-cf207da78ba9">

After:
<img width="61" alt="Screenshot 2024-09-24 at 2 42 32 PM" src="https://github.com/user-attachments/assets/29f71195-3765-4db3-a888-bebf1ffcf50b">



## Testing

How was this PR tested?
