### PR TITLE
chore: remove semibold styling from table headers

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CollapseGroupHeader.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CollapseGroupHeader.tsx
@@ -16,7 +16,6 @@ type CollapseGroupHeaderProps = {
 export const Header = styled.div`
   display: flex;
   align-items: center;
-  font-weight: 600;
 `;
 Header.displayName = 'S.Header';
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/ExpandHeader.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/ExpandHeader.tsx
@@ -17,7 +17,6 @@ type ExpandHeaderProps = {
 export const Header = styled.div`
   display: flex;
   align-items: center;
-  font-weight: 600;
 `;
 Header.displayName = 'S.Header';
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDataGrid.tsx
@@ -52,7 +52,7 @@ export const StyledDataGrid = styled(
   },
 
   '& .MuiDataGrid-columnHeaderTitle': {
-    fontWeight: 600,
+    fontWeight: 400,
   },
 
   '& .MuiDataGrid-columnHeader:focus, .MuiDataGrid-cell:focus': {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
@@ -264,14 +264,7 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
       headerName: key,
       display: 'flex',
       renderHeader: () => {
-        return (
-          <div
-            style={{
-              fontWeight: 600,
-            }}>
-            {key.split('.').slice(-1)[0]}
-          </div>
-        );
+        return <div>{key.split('.').slice(-1)[0]}</div>;
       },
       valueGetter: (unused: any, row: any) => {
         const val = valueForKey(row, key);


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Traces-table-d0abd588c49e4a77a213db27af717b4f?pvs=4#10ae2f5c7ef380499df8df28dabbf12f

Before:
<img width="670" alt="Screenshot 2024-09-24 at 3 16 40 PM" src="https://github.com/user-attachments/assets/0e26647e-0c90-4083-b302-90c803f298a4">

After:
<img width="672" alt="Screenshot 2024-09-24 at 3 16 31 PM" src="https://github.com/user-attachments/assets/cdc12bef-fb87-4e20-8ece-f23a6cab3ee9">



## Testing

How was this PR tested?
