### PR TITLE
chore: Fix image zoom in docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -238,8 +238,8 @@ const config: Config = {
       ],
     },
     imageZoom: {
-      // CSS selector to apply the plugin to, defaults to '.markdown img'
-      selector: '.markdown img',
+      // CSS selector to apply the plugin to
+      selector: 'img.zoomable',
       // Optional medium-zoom options
       // see: https://www.npmjs.com/package/medium-zoom#options
       options: {},

--- a/docs/src/components/DesktopImage/index.tsx
+++ b/docs/src/components/DesktopImage/index.tsx
@@ -46,7 +46,7 @@ export const DesktopWindow = ({ images, alt }) => {
               <img 
                 src={src} 
                 alt={`${alt} ${index + 1}`}
-                className={styles['carousel-image']}
+                className={styles['carousel-image'] + " zoomable"}
               />
             </div>
           ))}


### PR DESCRIPTION
We were zooming on everything! Even buttons and such. This scopes the zoom to just the images in the special viewer