### PR TITLE
chore: use smaller checkbox in call grid

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -422,7 +422,7 @@ export const CallsTable: FC<{
     const cols: GridColDef[] = [
       {
         minWidth: 30,
-        width: 38,
+        width: 34,
         field: 'CustomCheckbox',
         sortable: false,
         disableColumnMenu: true,
@@ -432,6 +432,7 @@ export const CallsTable: FC<{
         renderHeader: (params: any) => {
           return (
             <Checkbox
+              size="small"
               checked={
                 selectedCalls.length === 0
                   ? false
@@ -481,6 +482,7 @@ export const CallsTable: FC<{
               {/* To accommodate disabled elements, add a simple wrapper element, such as a span. */}
               <span>
                 <Checkbox
+                  size="small"
                   disabled={disabled}
                   checked={isSelected}
                   onCheckedChange={() => {


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Traces-table-d0abd588c49e4a77a213db27af717b4f?pvs=4#10ae2f5c7ef38061b3fbc12015136df4

Before:
<img width="300" alt="Screenshot 2024-09-24 at 11 11 25 PM" src="https://github.com/user-attachments/assets/12f2d3e0-6f43-4362-b8bc-c5027f4ff34e">

After:
<img width="295" alt="Screenshot 2024-09-24 at 11 11 19 PM" src="https://github.com/user-attachments/assets/0366aa20-c6f6-4608-a868-1452745fdd86">


## Testing

How was this PR tested?
