### PR TITLE
chore: make trace links teal colored

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -12,6 +12,7 @@ import {Tooltip} from '@wandb/weave/components/Tooltip';
 import {UserLink} from '@wandb/weave/components/UserLink';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
+import {TEAL_600} from '../../../../../../common/css/color.styles';
 import {monthRoundedTime} from '../../../../../../common/util/time';
 import {isWeaveObjectRef, parseRef} from '../../../../../../react';
 import {makeRefCall} from '../../../../../../util/refs';
@@ -205,6 +206,7 @@ function buildCallsTableColumns(
             callId={rowParams.row.id}
             fullWidth={true}
             preservePath={preservePath}
+            color={TEAL_600}
           />
         );
       },


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Traces-table-d0abd588c49e4a77a213db27af717b4f?pvs=4#10ae2f5c7ef380678bf4df103783509a

Before:
<img width="295" alt="Screenshot 2024-09-24 at 11 24 41 PM" src="https://github.com/user-attachments/assets/ec0215d4-cb80-464f-be5a-0d6294db3815">

After:
<img width="303" alt="Screenshot 2024-09-24 at 11 24 32 PM" src="https://github.com/user-attachments/assets/5bdd282a-acf9-4bec-a545-00ee0004fb23">

## Testing

How was this PR tested?
