### PR TITLE
fix: version index on obj/read bug

### DIFF
--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -1402,3 +1402,20 @@ def test_calls_stream_table_ref_expansion(client):
     calls = list(calls)
     assert len(calls) == 1
     assert calls[0].output["table"] == o.table.table_ref.uri()
+
+
+def test_object_version_read(client):
+    refs = []
+    for i in range(10):
+        refs.append(weave.publish({"a": i}))
+
+    # print(refs[6])
+    obj_res = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=client._project_id(),
+            object_id=refs[6].name,
+            digest=refs[6].digest,
+        )
+    )
+    assert obj_res.obj.val == {"a": 6}
+    assert obj_res.obj.version_index == 6

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -1409,12 +1409,33 @@ def test_object_version_read(client):
     for i in range(10):
         refs.append(weave.publish({"a": i}))
 
-    obj_res = client.server.obj_read(
-        tsi.ObjReadReq(
+    # read all objects, check the version
+    objs = client.server.objs_query(
+        tsi.ObjQueryReq(
             project_id=client._project_id(),
-            object_id=refs[6].name,
-            digest=refs[6].digest,
+            object_id=refs[0].name,
         )
-    )
-    assert obj_res.obj.val == {"a": 6}
-    assert obj_res.obj.version_index == 6
+    ).objs
+    assert len(objs) == 10
+    assert objs[0].version_index == 0
+    assert objs[1].version_index == 1
+    assert objs[2].version_index == 2
+    assert objs[3].version_index == 3
+    assert objs[4].version_index == 4
+    assert objs[5].version_index == 5
+    assert objs[6].version_index == 6
+    assert objs[7].version_index == 7
+    assert objs[8].version_index == 8
+    assert objs[9].version_index == 9
+
+    # read each object one at a time, check the version
+    for i in range(10):
+        obj_res = client.server.obj_read(
+            tsi.ObjReadReq(
+                project_id=client._project_id(),
+                object_id=refs[i].name,
+                digest=refs[i].digest,
+            )
+        )
+        assert obj_res.obj.val == {"a": i}
+        assert obj_res.obj.version_index == i

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -1409,7 +1409,6 @@ def test_object_version_read(client):
     for i in range(10):
         refs.append(weave.publish({"a": i}))
 
-    # print(refs[6])
     obj_res = client.server.obj_read(
         tsi.ObjReadReq(
             project_id=client._project_id(),

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1452,10 +1452,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             conditions = ["1 = 1"]
         if not object_id_conditions:
             object_id_conditions = ["1 = 1"]
+        if is_latest:
+            conditions.append("is_latest = 1")
 
         conditions_part = combine_conditions(conditions, "AND")
         object_id_conditions_part = combine_conditions(object_id_conditions, "AND")
-        is_latest_part = "is_latest = 1" if is_latest else "1 = 1"
 
         limit_part = ""
         offset_part = ""
@@ -1537,10 +1538,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     WHERE project_id = {{project_id: String}} AND
                         {object_id_conditions_part}
                 )
-                WHERE rn = 1 AND
-                    {conditions_part}
+                WHERE rn = 1
             )
-            WHERE {is_latest_part}
+            WHERE {conditions_part}
             {sort_part}
             {limit_part}
             {offset_part}

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -542,20 +542,18 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         parameters = {}
         conds: list[str] = ["is_op = 1"]
         object_id_conditions: list[str] = []
-        is_latest = False
         if req.filter:
             if req.filter.op_names:
                 object_id_conditions.append("object_id IN {op_names: Array(String)}")
                 parameters["op_names"] = req.filter.op_names
             if req.filter.latest_only:
-                is_latest = True
+                conds.append("is_latest = 1")
 
         ch_objs = self._select_objs_query(
             req.project_id,
             conditions=conds,
             object_id_conditions=object_id_conditions,
             parameters=parameters,
-            is_latest=is_latest,
         )
         objs = [_ch_obj_to_obj_schema(call) for call in ch_objs]
         return tsi.OpQueryRes(op_objs=objs)
@@ -586,8 +584,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         conds: list[str] = []
         object_id_conditions = ["object_id = {object_id: String}"]
         parameters: Dict[str, Union[str, int]] = {"object_id": req.object_id}
-        is_latest = req.digest == "latest"
-        if not is_latest:
+        if req.digest == "latest":
+            conds.append("is_latest = 1")
+        else:
             (is_version, version_index) = _digest_is_version_like(req.digest)
             if is_version:
                 conds.append("version_index = {version_index: UInt64}")
@@ -600,7 +599,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             conditions=conds,
             object_id_conditions=object_id_conditions,
             parameters=parameters,
-            is_latest=is_latest,
         )
         if len(objs) == 0:
             raise NotFoundError(f"Obj {req.object_id}:{req.digest} not found")
@@ -611,7 +609,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         conds: list[str] = []
         object_id_conditions: list[str] = []
         parameters = {}
-        is_latest = False
         if req.filter:
             if req.filter.is_op is not None:
                 if req.filter.is_op:
@@ -622,7 +619,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 object_id_conditions.append("object_id IN {object_ids: Array(String)}")
                 parameters["object_ids"] = req.filter.object_ids
             if req.filter.latest_only:
-                is_latest = True
+                conds.append("is_latest = 1")
             if req.filter.base_object_classes:
                 conds.append(
                     "base_object_class IN {base_object_classes: Array(String)}"
@@ -634,7 +631,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             conditions=conds,
             object_id_conditions=object_id_conditions,
             parameters=parameters,
-            is_latest=is_latest,
             metadata_only=req.metadata_only,
             limit=req.limit,
             offset=req.offset,
@@ -1422,7 +1418,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         conditions: Optional[list[str]] = None,
         object_id_conditions: Optional[list[str]] = None,
         parameters: Optional[Dict[str, Any]] = None,
-        is_latest: bool = False,
         metadata_only: Optional[bool] = False,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
@@ -1440,9 +1435,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         parameters:
             parameters to be passed to the query. Must include all parameters for both
             conditions and object_id_conditions.
-        is_latest:
-            if is_latest is True, then we add the condition "is_latest = 1" to the outer
-            query, and only return the most recent version of each object.
         metadata_only:
             if metadata_only is True, then we exclude the val_dump field in the select query.
             generally, "queries" should not include the val_dump, but "reads" should, as
@@ -1452,8 +1444,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             conditions = ["1 = 1"]
         if not object_id_conditions:
             object_id_conditions = ["1 = 1"]
-        if is_latest:
-            conditions.append("is_latest = 1")
 
         conditions_part = combine_conditions(conditions, "AND")
         object_id_conditions_part = combine_conditions(object_id_conditions, "AND")


### PR DESCRIPTION
Digest filtering must occur outside of both count and dedupe subqueries. 

When specifying the digest, we can't use that to filter out the other objects with the same ID but different digests in the middle level subquery. When reading to a specific digest, we don't care about any other objects, which is why correctness checks pass for the existing query. **However**, we calculate the version index in this step (not obvious from looking at the query) so we actually need to grab ALL the objects even if we specify just a single one. 

This reduces the performance impact of the[ original pr](https://github.com/wandb/weave/pull/2412), but isn't bugged. 