### PR TITLE
test: add test for string version object read

### DIFF
--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -23,6 +23,7 @@ from weave.tests.trace.util import (
 )
 from weave.trace import weave_client
 from weave.trace.object_record import ObjectRecord
+from weave.trace.util import client_is_sqlite
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace.weave_client import sanitize_object_name
 from weave.trace_server import trace_server_interface as tsi
@@ -789,10 +790,6 @@ def test_trace_call_sort_with_mixed_types(client):
 
         for i, call in enumerate(inner_res.calls):
             assert call.inputs["in_val"].get("prim") == seq[i]
-
-
-def client_is_sqlite(client):
-    return isinstance(client.server._internal_trace_server, SqliteTraceServer)
 
 
 def test_trace_call_filter(client):

--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -20,10 +20,10 @@ from weave.tests.trace.util import (
     DatetimeMatcher,
     FuzzyDateTimeMatcher,
     MaybeStringMatcher,
+    client_is_sqlite,
 )
 from weave.trace import weave_client
 from weave.trace.object_record import ObjectRecord
-from weave.trace.util import client_is_sqlite
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace.weave_client import sanitize_object_name
 from weave.trace_server import trace_server_interface as tsi

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -12,7 +12,12 @@ import weave
 import weave.trace_server.trace_server_interface as tsi
 from weave import Evaluation
 from weave.legacy.weave import op_def
-from weave.tests.trace.util import AnyIntMatcher, DatetimeMatcher, RegexStringMatcher
+from weave.tests.trace.util import (
+    AnyIntMatcher,
+    DatetimeMatcher,
+    RegexStringMatcher,
+    client_is_sqlite,
+)
 from weave.trace import refs, weave_client
 from weave.trace.isinstance import weave_isinstance
 from weave.trace.op import Op, is_op
@@ -24,7 +29,6 @@ from weave.trace.refs import (
 )
 from weave.trace.serializer import get_serializer_for_obj, register_serializer
 from weave.trace.tests.testutil import ObjectRefStrMatcher
-from weave.trace.util import client_is_sqlite
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 from weave.trace_server.trace_server_interface import (
     FileContentReadReq,

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -1439,3 +1439,25 @@ def test_object_version_read(client):
         )
         assert obj_res.obj.val == {"a": i}
         assert obj_res.obj.version_index == i
+
+    # now grab the latest version of the object
+    obj_res = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=client._project_id(),
+            object_id=refs[0].name,
+            digest="latest",
+        )
+    )
+    assert obj_res.obj.val == {"a": 9}
+    assert obj_res.obj.version_index == 9
+
+    # now grab version 5
+    obj_res = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=client._project_id(),
+            object_id=refs[0].name,
+            digest="v5",
+        )
+    )
+    assert obj_res.obj.val == {"a": 5}
+    assert obj_res.obj.version_index == 5

--- a/weave/tests/trace/test_weave_client.py
+++ b/weave/tests/trace/test_weave_client.py
@@ -24,6 +24,7 @@ from weave.trace.refs import (
 )
 from weave.trace.serializer import get_serializer_for_obj, register_serializer
 from weave.trace.tests.testutil import ObjectRefStrMatcher
+from weave.trace.util import client_is_sqlite
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 from weave.trace_server.trace_server_interface import (
     FileContentReadReq,
@@ -1405,6 +1406,9 @@ def test_calls_stream_table_ref_expansion(client):
 
 
 def test_object_version_read(client):
+    if client_is_sqlite(client):
+        return
+
     refs = []
     for i in range(10):
         refs.append(weave.publish({"a": i}))

--- a/weave/tests/trace/util.py
+++ b/weave/tests/trace/util.py
@@ -1,6 +1,12 @@
 import datetime
 import re
 
+from weave.trace_server.sqlite_trace_server import SqliteTraceServer
+
+
+def client_is_sqlite(client):
+    return isinstance(client.server._internal_trace_server, SqliteTraceServer)
+
 
 class AnyIntMatcher:
     """Matches any integer."""


### PR DESCRIPTION
Adds test for fetching an object with a specific version, like: `obj = weave.ref("weave:///griffin/proj/object/obj:v2")`

This does not work in sqlite....