### PR TITLE
chore: update empty feedback styling

### DIFF
--- a/weave-js/src/common/util/links.tsx
+++ b/weave-js/src/common/util/links.tsx
@@ -102,11 +102,14 @@ export const TargetBlank: FCWithRef<
     ) {
       passthroughProps.href = getConfig().urlPrefixed(passthroughProps.href);
     }
+    // Tailwind default styling overrides styled components, need to specify here too.
+    const className = 'font-semibold text-teal-600 hover:text-teal-500';
     return (
       // eslint-disable-next-line wandb/no-a-tags
       <A
         target="_blank"
         rel="noopener noreferrer"
+        className={className}
         {...passthroughProps}
         ref={ref}>
         {children}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGrid.tsx
@@ -3,9 +3,11 @@ import _ from 'lodash';
 import React, {useEffect} from 'react';
 
 import {useViewerInfo} from '../../../../../common/hooks/useViewerInfo';
+import {TargetBlank} from '../../../../../common/util/links';
 import {Alert} from '../../../../Alert';
 import {Loading} from '../../../../Loading';
 import {Tailwind} from '../../../../Tailwind';
+import {Empty} from '../pages/common/Empty';
 import {useWFHooks} from '../pages/wfReactInterface/context';
 import {useGetTraceServerClientContext} from '../pages/wfReactInterface/traceServerClientContext';
 import {FeedbackGridInner} from './FeedbackGridInner';
@@ -60,11 +62,22 @@ export const FeedbackGrid = ({
   }
 
   if (!query.result || !query.result.length) {
-    const obj = objectType ?? 'object';
     return (
-      <div className="m-16 flex flex-col gap-8">
-        <Alert>No feedback added to this {obj}.</Alert>
-      </div>
+      <Empty
+        size="small"
+        icon="add-reaction"
+        heading="No feedback yet"
+        description="You can provide feedback directly within the Weave UI or through the API."
+        moreInformation={
+          <>
+            Learn how to{' '}
+            <TargetBlank href="http://wandb.me/weave_feedback">
+              add feedback
+            </TargetBlank>
+            .
+          </>
+        }
+      />
     );
   }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Empty.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Empty.tsx
@@ -9,11 +9,14 @@ import * as Colors from '../../../../../../common/css/color.styles';
 import {hexToRGB} from '../../../../../../common/css/utils';
 import {Icon, IconName} from '../../../../../Icon';
 
+type EmptySize = 'small' | 'medium';
+
 export type EmptyProps = {
   icon: IconName;
   heading: string;
   description: string;
   moreInformation: React.ReactNode;
+  size?: EmptySize;
 };
 
 const Container = styled.div`
@@ -32,10 +35,10 @@ const Content = styled.div`
 `;
 Content.displayName = 'S.Content';
 
-const Circle = styled.div`
+const Circle = styled.div<{size: EmptySize}>`
   border-radius: 50%;
-  width: 80px;
-  height: 80px;
+  width: ${props => (props.size === 'small' ? '60px' : '80px')};
+  height: ${props => (props.size === 'small' ? '60px' : '80px')};
   background-color: ${hexToRGB(Colors.TEAL_300, 0.48)};
   display: flex;
   align-items: center;
@@ -44,16 +47,16 @@ const Circle = styled.div`
 `;
 Circle.displayName = 'S.Circle';
 
-const CircleIcon = styled(Icon)`
-  width: 33px;
-  height: 33px;
+const CircleIcon = styled(Icon)<{size: EmptySize}>`
+  width: ${props => (props.size === 'small' ? '25px' : '33px')};
+  height: ${props => (props.size === 'small' ? '25px' : '33px')};
   color: ${Colors.TEAL_600};
 `;
 CircleIcon.displayName = 'S.CircleIcon';
 
-const Heading = styled.div`
+const Heading = styled.div<{size: EmptySize}>`
   font-family: Source Sans Pro;
-  font-size: 24px;
+  font-size: ${props => (props.size === 'small' ? '20px' : '24px')};
   font-weight: 600;
   line-height: 32px;
   text-align: left;
@@ -62,9 +65,9 @@ const Heading = styled.div`
 `;
 Heading.displayName = 'S.Heading';
 
-const Description = styled.div`
+const Description = styled.div<{size: EmptySize}>`
   font-family: Source Sans Pro;
-  font-size: 18px;
+  font-size: ${props => (props.size === 'small' ? '14px' : '18px')};
   font-weight: 400;
   line-height: 25.2px;
   text-align: center;
@@ -73,9 +76,9 @@ const Description = styled.div`
 `;
 Description.displayName = 'S.Description';
 
-const MoreInformation = styled.div`
+const MoreInformation = styled.div<{size: EmptySize}>`
   font-family: Source Sans Pro;
-  font-size: 16px;
+  font-size: ${props => (props.size === 'small' ? '14px' : '16px')};
   font-weight: 400;
   line-height: 22.4px;
   text-align: center;
@@ -88,16 +91,17 @@ export const Empty = ({
   heading,
   description,
   moreInformation,
+  size = 'medium',
 }: EmptyProps) => {
   return (
     <Container>
       <Content>
-        <Circle>
-          <CircleIcon name={icon} />
+        <Circle size={size}>
+          <CircleIcon size={size} name={icon} />
         </Circle>
-        <Heading>{heading}</Heading>
-        <Description>{description}</Description>
-        <MoreInformation>{moreInformation}</MoreInformation>
+        <Heading size={size}>{heading}</Heading>
+        <Description size={size}>{description}</Description>
+        <MoreInformation size={size}>{moreInformation}</MoreInformation>
       </Content>
     </Container>
   );


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Empty-state-for-Feedback-tab-10ae2f5c7ef380f9af66d14cabd23a19?pvs=4

Before:
<img width="669" alt="Screenshot 2024-09-25 at 3 46 10 PM" src="https://github.com/user-attachments/assets/d3622630-257a-4275-b2e3-43abfe7a15e9">

After:
<img width="673" alt="Screenshot 2024-09-25 at 3 46 52 PM" src="https://github.com/user-attachments/assets/636d2dda-7915-4f25-b736-a19cedaa07bb">

## Testing

How was this PR tested?
