### PR TITLE
fix(weave): align tables column header cell text based on panel type

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable.styles.ts
+++ b/weave-js/src/components/Panel2/PanelTable.styles.ts
@@ -32,7 +32,6 @@ export const ColumnName = styled.div`
     color: ${globals.primary};
   }
   overflow: hidden;
-  text-align: left;
 `;
 ColumnName.displayName = 'S.ColumnName';
 

--- a/weave-js/src/components/Panel2/PanelTable.styles.ts
+++ b/weave-js/src/components/Panel2/PanelTable.styles.ts
@@ -98,18 +98,23 @@ FilterIcon.displayName = 'S.FilterIcon';
 
 export const ColumnAction = styled.div<{isHovered?: boolean}>`
   cursor: pointer;
+  height: 100%;
+  background-color: transparent;
+`;
+ColumnAction.displayName = 'S.ColumnAction';
+
+export const ColumnActionContainer = styled.div<{isHovered?: boolean}>`
+  display: flex;
   padding: 5px 0px 0px 0px;
+  font-size: 20px;
   flex: 0 0 auto;
   height: 100%;
-  background: white;
-  font-size: 20px;
 
   :hover {
     background-color: ${hexToRGB(OBLIVION, 0.04)};
   }
-  background-color: transparent;
 `;
-ColumnAction.displayName = 'S.ColumnAction';
+ColumnActionContainer.displayName = 'S.ColumnActionContainer';
 
 export const TableAction = styled.div<{
   highlight?: boolean;

--- a/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
@@ -496,6 +496,19 @@ export const ColumnHeader: React.FC<{
     };
   }, [cellFrame, weave, propsSelectFunction, inputArrayNode]);
 
+  const columnNameStyle =
+    columnFormat?.textAlign === 'right'
+      ? {marginLeft: `-${colControlsWidth}px`}
+      : {marginRight: `-${colControlsWidth}px`};
+
+  // When there is a right justified column, reverse the order of the indicators
+  // and set z-index to 1 otherwise click events on the Ellipses icon is blocked
+  // by the click event on the column name due to DOM ordering and negative margins.
+  const columnActionContainerStyle =
+    columnFormat?.textAlign === 'right'
+      ? {zIndex: 1, flexDirection: 'row-reverse'}
+      : {flexDirection: 'row'};
+
   return (
     <S.ColumnHeader
       data-test="column-header"
@@ -543,12 +556,7 @@ export const ColumnHeader: React.FC<{
           }}
           trigger={
             <S.ColumnName
-              style={{
-                marginRight:
-                  columnFormat?.textAlign === 'center'
-                    ? `-${colControlsWidth}px`
-                    : 'inherit',
-              }}
+              style={columnNameStyle}
               onClick={() => setColumnSettingsOpen(!columnSettingsOpen)}>
               {propsColumnName !== '' ? (
                 <S.ColumnNameText>{propsColumnName}</S.ColumnNameText>
@@ -657,10 +665,7 @@ export const ColumnHeader: React.FC<{
           {({anchorRef, setOpen, open}) => (
             <S.ColumnActionContainer
               className="column-controls"
-              style={{
-                flexDirection:
-                  columnFormat?.textAlign === 'right' ? 'row-reverse' : 'row',
-              }}>
+              style={columnActionContainerStyle}>
               <S.ColumnAction>
                 {isPinned && (
                   <PinnedIndicator unpin={() => setColumnPinState(false)} />

--- a/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
@@ -499,7 +499,11 @@ export const ColumnHeader: React.FC<{
   return (
     <S.ColumnHeader
       data-test="column-header"
-      style={{textAlign: columnFormat?.textAlign ?? 'center'}}>
+      style={{
+        textAlign: columnFormat?.textAlign ?? 'center',
+        flexDirection:
+          columnFormat?.textAlign === 'right' ? 'row-reverse' : 'row',
+      }}>
       {simpleTable ? (
         workingColumnName !== '' ? (
           <S.ColumnNameText>{workingColumnName}</S.ColumnNameText>
@@ -540,7 +544,10 @@ export const ColumnHeader: React.FC<{
           trigger={
             <S.ColumnName
               style={{
-                marginRight: `-${colControlsWidth}px`,
+                marginRight:
+                  columnFormat?.textAlign === 'center'
+                    ? `-${colControlsWidth}px`
+                    : 'inherit',
               }}
               onClick={() => setColumnSettingsOpen(!columnSettingsOpen)}>
               {propsColumnName !== '' ? (
@@ -648,36 +655,47 @@ export const ColumnHeader: React.FC<{
       {!simpleTable && (
         <WBPopupMenuTrigger options={columnMenuItems}>
           {({anchorRef, setOpen, open}) => (
-            <S.ColumnAction className="column-controls">
-              {isPinned && (
-                <PinnedIndicator unpin={() => setColumnPinState(false)} />
-              )}
-              {isGroupCol && (
-                <S.ControlIcon
-                  name="group-runs"
-                  onClick={e => {
-                    recordEvent('REMOVE_COLUMN_GROUPING');
-                    doUngroup();
-                  }}
+            <S.ColumnActionContainer
+              className="column-controls"
+              style={{
+                flexDirection:
+                  columnFormat?.textAlign === 'right' ? 'row-reverse' : 'row',
+              }}>
+              <S.ColumnAction>
+                {isPinned && (
+                  <PinnedIndicator unpin={() => setColumnPinState(false)} />
+                )}
+                {isGroupCol && (
+                  <S.ControlIcon
+                    name="group-runs"
+                    onClick={e => {
+                      recordEvent('REMOVE_COLUMN_GROUPING');
+                      doUngroup();
+                    }}
+                  />
+                )}
+              </S.ColumnAction>
+              <S.ColumnAction>
+                {colIsSorted && (
+                  <SortStateToggle
+                    {...{
+                      tableState,
+                      colId,
+                      updateTableState,
+                    }}
+                  />
+                )}
+              </S.ColumnAction>
+              <S.ColumnAction>
+                <S.EllipsisIcon
+                  ref={anchorRef}
+                  data-test="column-options"
+                  name="overflow"
+                  className="column-actions-trigger"
+                  onClick={() => setOpen(o => !o)}
                 />
-              )}
-              {colIsSorted && (
-                <SortStateToggle
-                  {...{
-                    tableState,
-                    colId,
-                    updateTableState,
-                  }}
-                />
-              )}
-              <S.EllipsisIcon
-                ref={anchorRef}
-                data-test="column-options"
-                name="overflow"
-                className="column-actions-trigger"
-                onClick={() => setOpen(o => !o)}
-              />
-            </S.ColumnAction>
+              </S.ColumnAction>
+            </S.ColumnActionContainer>
           )}
         </WBPopupMenuTrigger>
       )}

--- a/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
@@ -17,7 +17,7 @@ import {
   voidNode,
 } from '@wandb/weave/core';
 import {TableState} from '@wandb/weave/index';
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import {Popup} from 'semantic-ui-react';
 
 import {useWeaveContext} from '../../../context';
@@ -31,6 +31,7 @@ import {PanelComp2} from '../PanelComp';
 import {PanelContextProvider, usePanelContext} from '../PanelContext';
 import {makeEventRecorder} from '../panellib/libanalytics';
 import * as S from '../PanelTable.styles';
+import {WeaveFormatContext} from '../WeaveFormatContext';
 import * as Table from './tableState';
 import {stripTag} from './util';
 
@@ -152,6 +153,7 @@ export const ColumnHeader: React.FC<{
 }) => {
   const weave = useWeaveContext();
   const {stack} = usePanelContext();
+  const {columnFormat} = useContext(WeaveFormatContext);
 
   const [columnSettingsOpen, setColumnSettingsOpen] = useState(false);
 
@@ -495,7 +497,9 @@ export const ColumnHeader: React.FC<{
   }, [cellFrame, weave, propsSelectFunction, inputArrayNode]);
 
   return (
-    <S.ColumnHeader data-test="column-header">
+    <S.ColumnHeader
+      data-test="column-header"
+      style={{textAlign: columnFormat?.textAlign ?? 'center'}}>
       {simpleTable ? (
         workingColumnName !== '' ? (
           <S.ColumnNameText>{workingColumnName}</S.ColumnNameText>

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -542,28 +542,33 @@ const PanelTableInner: React.FC<
 
   const headerRendererForColumn = useCallback(
     (colId: string, {headerIndex}: any) => {
+      const columnDef = columnDefinitions[colId];
+      const colType = columnDef.selectFn.type;
+
       return (
-        <ColumnHeader
-          isGroupCol={columnDefinitions[colId].isGrouped}
-          tableState={tableState}
-          inputArrayNode={input}
-          rowsNode={rowsNode}
-          columnName={tableState.columnNames[colId]}
-          selectFunction={tableState.columnSelectFunctions[colId]}
-          colId={colId}
-          panelId={tableState.columns[colId].panelId}
-          config={tableState.columns[colId].panelConfig}
-          panelContext={props.context}
-          updatePanelContext={updateContext}
-          updateTableState={updateTableState}
-          isPinned={config.pinnedColumns?.includes(colId)}
-          setColumnPinState={(pinned: boolean) => {
-            setColumnPinState(colId, pinned);
-          }}
-          simpleTable={props.config.simpleTable}
-          countColumnId={countColumnId}
-          setCountColumnId={setCountColumnId}
-        />
+        <WeaveFormatContext.Provider value={getColumnCellFormats(colType)}>
+          <ColumnHeader
+            isGroupCol={columnDefinitions[colId].isGrouped}
+            tableState={tableState}
+            inputArrayNode={input}
+            rowsNode={rowsNode}
+            columnName={tableState.columnNames[colId]}
+            selectFunction={tableState.columnSelectFunctions[colId]}
+            colId={colId}
+            panelId={tableState.columns[colId].panelId}
+            config={tableState.columns[colId].panelConfig}
+            panelContext={props.context}
+            updatePanelContext={updateContext}
+            updateTableState={updateTableState}
+            isPinned={config.pinnedColumns?.includes(colId)}
+            setColumnPinState={(pinned: boolean) => {
+              setColumnPinState(colId, pinned);
+            }}
+            simpleTable={props.config.simpleTable}
+            countColumnId={countColumnId}
+            setCountColumnId={setCountColumnId}
+          />
+        </WeaveFormatContext.Provider>
       );
     },
     [

--- a/weave-js/src/components/Panel2/PanelTable/util.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.ts
@@ -29,7 +29,7 @@ import {WeaveFormatContextType} from '../WeaveFormatContext';
 import * as Table from './tableState';
 import {useTableStateWithRefinedExpressions} from './tableStateReact';
 
-// Formatting for PanelNumbers and PanelStrings inside Tables
+// Formatting for PanelNumber and PanelString headers and values inside Tables
 export const getColumnCellFormats = (colType: Type): WeaveFormatContextType => {
   const t = nullableTaggableStrip(colType);
   const numberFormat =
@@ -42,9 +42,14 @@ export const getColumnCellFormats = (colType: Type): WeaveFormatContextType => {
         }
       : {};
   const stringFormat = {spacing: t === 'string'};
+  const columnFormat = {
+    textAlign: t === 'number' ? ('right' as const) : ('center' as const),
+  };
+
   return {
     numberFormat,
     stringFormat,
+    columnFormat,
   };
 };
 

--- a/weave-js/src/components/Panel2/WeaveFormatContext.tsx
+++ b/weave-js/src/components/Panel2/WeaveFormatContext.tsx
@@ -11,9 +11,14 @@ type PanelStringFormat = {
   spacing?: boolean;
 };
 
+type PanelColumnFormat = {
+  textAlign?: React.CSSProperties['textAlign'];
+};
+
 export type WeaveFormatContextType = {
   numberFormat: PanelNumberFormat;
   stringFormat: PanelStringFormat;
+  columnFormat: PanelColumnFormat;
 };
 
 export const WeaveFormatContext = React.createContext<WeaveFormatContextType>({
@@ -25,5 +30,8 @@ export const WeaveFormatContext = React.createContext<WeaveFormatContextType>({
   },
   stringFormat: {
     spacing: false,
+  },
+  columnFormat: {
+    textAlign: 'center',
   },
 });


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

**Internal JIRA:** [WB-17238](https://wandb.atlassian.net/browse/WB-17238)

The JIRA reports a difficulty in difficulty in reading Tables because column header cells are left justified while numerical value cells are right justified.

This PR fixes that by **using the same text alignment for the column header cell as the value cell**. This solution differs from the proposed solution on the JIRA (center all header cells and cells) because typically numerical columns are right justified for visual clarity. It's easier to interpret the magnitude of cells when numerical values have the same level of precision. Non-numerical column header cells are defaulted to `center` text alignment.

Previous PR that introduced the issue: https://github.com/wandb/weave/pull/875

### Implementation Details
I leveraged the new `WeaveFormatContext` from the PR mentioned above to add a `columnFormat` field to specifies the column headers' `textAlign` value.

### Screenshots

Before:
![image](https://github.com/user-attachments/assets/f4d368b9-0368-4726-b66e-67fdf98d19c6)


After:
![image](https://github.com/user-attachments/assets/21580629-b586-4187-a6a6-eb87b4ebb6de)

**One thing to note,** on hover-over, the `EllipsisIcon` to trigger the Popup will overlap the column name text due to its negative margin.
![image](https://github.com/user-attachments/assets/d537f9c1-8c48-4152-b229-cd58100c5d02)

I thought this behavior is acceptable because it currently happens when the column widths are resized smaller than the column header text.

edit(10/02): See update below

## Testing

How was this PR tested?
Visually with my [pytorch-intro project](https://wandb.ai/dominic-phan-weights-and-biases/pytorch-intro?nw=nwuserdominicphan). 

[WB-17238]: https://wandb.atlassian.net/browse/WB-17238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Update to handle overlapping indicators

I took a display approach that [material-ui data grid uses](https://mui.com/x/react-data-grid/) to place the **indicators on the opposite side in reverse** for numerical columns. This mitigates the ellipses stacking on the right justified column name.

Here's the column header on hoverover:
![image](https://github.com/user-attachments/assets/920dae4c-24d6-4326-a3eb-234a237e0f99)

When pinned on hoverover:
![image](https://github.com/user-attachments/assets/b1b0ba3b-da4e-4ce7-a663-568564a8378e)

Pinned, sorted on hoverover:
![image](https://github.com/user-attachments/assets/778b5422-acd6-4300-b82a-5183665e14aa)

Without hoverover:
![image](https://github.com/user-attachments/assets/d94d52c5-cea6-412f-91f3-a6b1eb38c957)
