### PR TITLE
fix: Stop printing errors with OpenAI Stream + error handling

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -457,6 +457,8 @@ def op(*args: Any, **kwargs: Any) -> Union[Callable[[Any], Op], Op]:
                     if not wrapper._tracing_enabled:  # type: ignore
                         return await func(*args, **kwargs)
                     try:
+                        # This try/except allows us to fail gracefully and
+                        # still let the user code continue to execute
                         call = _create_call(wrapper, *args, **kwargs)  # type: ignore
                     except Exception as e:
                         log_once(
@@ -479,6 +481,8 @@ def op(*args: Any, **kwargs: Any) -> Union[Callable[[Any], Op], Op]:
                     if not wrapper._tracing_enabled:  # type: ignore
                         return func(*args, **kwargs)
                     try:
+                        # This try/except allows us to fail gracefully and
+                        # still let the user code continue to execute
                         call = _create_call(wrapper, *args, **kwargs)  # type: ignore
                     except Exception as e:
                         log_once(

--- a/weave/trace/op_extensions/accumulator.py
+++ b/weave/trace/op_extensions/accumulator.py
@@ -1,5 +1,6 @@
 import atexit
 import logging
+import traceback
 import weakref
 from typing import (
     Any,
@@ -54,9 +55,10 @@ class _IteratorWrapper(Generic[V]):
             try:
                 self._on_close()  # type: ignore
             except Exception as e:
+                full_exception = traceback.format_exc()
                 log_once(
                     logger.error,
-                    f"Error finishing call - some logs may not be captured: {e}",
+                    f"Error finishing call - some logs may not be captured: {full_exception}",
                 )
                 if get_raise_on_captured_errors():
                     raise
@@ -67,9 +69,10 @@ class _IteratorWrapper(Generic[V]):
             try:
                 self._on_error(e)
             except Exception as e:
+                full_exception = traceback.format_exc()
                 log_once(
                     logger.error,
-                    f"Error finishing call with exception - some logs may not be captured: {e}",
+                    f"Error finishing call with exception - some logs may not be captured: {full_exception}",
                 )
                 if get_raise_on_captured_errors():
                     raise
@@ -91,8 +94,15 @@ class _IteratorWrapper(Generic[V]):
                 # the yielded value
                 self._on_yield(value)
             except Exception as e:
+                # We actually use StopIteration to signal the end of the iterator
+                # in some cases (like when we don't want to surface the last chunk
+                # with usage info from openai integration).
+                if isinstance(e, (StopAsyncIteration, StopIteration)):
+                    raise
+                full_exception = traceback.format_exc()
                 log_once(
-                    logger.error, f"Error capturing yielded value for call output: {e}"
+                    logger.error,
+                    f"Error capturing yielded value for call output: {full_exception}",
                 )
                 if get_raise_on_captured_errors():
                     raise
@@ -120,9 +130,15 @@ class _IteratorWrapper(Generic[V]):
                 # break the user process if we trip up on processing
                 # the yielded value
             except Exception as e:
+                # We actually use StopIteration to signal the end of the iterator
+                # in some cases (like when we don't want to surface the last chunk
+                # with usage info from openai integration).
+                if isinstance(e, (StopAsyncIteration, StopIteration)):
+                    raise
+                full_exception = traceback.format_exc()
                 log_once(
                     logger.error,
-                    f"Error capturing async yielded value for call output: {e}",
+                    f"Error capturing async yielded value for call output: {full_exception}",
                 )
                 if get_raise_on_captured_errors():
                     raise


### PR DESCRIPTION
While debugging a different issue with @vanpelt, I noticed something alarming: We were printing an error while iterating through stream data.

This lead to an investigation and this PR. This PR:

1. Critically: we re-raise in our iterator! `if isinstance(e, (StopAsyncIteration, StopIteration)):`. In current release, we actually capture this error, but very critically, the `on_yield` contract is to raise an exception when it is finished with the accumulation! This was causing breakages as noted below
2. Adds one more try/except to the entry-point of an op to ensure we handle that gracefully.
3. Improves some logging text

Note: When doing async, the data is still logged, but non async crashes!!

Further note: this specific case was not caught in tests since we auto raise in tests to be more careful, but this case is a bit inverted as the bug occurs when we don't raise!


Above = Fixed
Below = Current Release

![Screenshot 2024-09-25 at 17 41 09](https://github.com/user-attachments/assets/0b8d9444-6d20-4d88-832f-8780a4593720)
