### PR TITLE
chore: reduce header height and font size

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -397,11 +397,7 @@ const MainPeekingLayout: FC = () => {
               <SimplePageLayoutContext.Provider
                 value={{
                   headerSuffix: (
-                    <Box
-                      sx={{
-                        height: '41px',
-                        flex: '0 0 auto',
-                      }}>
+                    <Box sx={{flex: '0 0 auto'}}>
                       <FullPageButton
                         query={query}
                         generalBase={generalBase}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -191,10 +191,7 @@ const CallPageInnerVertical: FC<{
   return (
     <SimplePageLayoutWithHeader
       headerExtra={
-        <Box
-          sx={{
-            height: '41px',
-          }}>
+        <Box>
           <Button
             icon="layout-tabs"
             tooltip={`${showTraceTree ? 'Hide' : 'Show'} trace tree`}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -67,7 +67,7 @@ export const SimplePageLayout: FC<{
           zIndex: 1,
           backgroundColor: 'white',
           pb: 0,
-          height: 55, // manual to match sidebar
+          height: 44,
 
           display: 'flex',
           flexDirection: 'row',
@@ -77,11 +77,11 @@ export const SimplePageLayout: FC<{
         }}>
         <Box
           sx={{
-            height: 55, // manual to match sidebar
-            flex: '0 0 55px',
+            height: 44,
+            flex: '0 0 44px',
             display: 'flex',
             flexDirection: 'row',
-            alignItems: 'flex-end',
+            alignItems: 'center',
             gap: 1,
             pl: 2,
             pr: 2,
@@ -89,7 +89,6 @@ export const SimplePageLayout: FC<{
           {simplePageLayoutContextValue.headerPrefix}
           <Box
             sx={{
-              pb: 2,
               fontWeight: 600,
               fontSize: '1.25rem',
               flex: '1 1 auto',
@@ -198,11 +197,11 @@ export const SimplePageLayoutWithHeader: FC<{
       }}>
       <Box
         sx={{
-          height: 55, // manual to match sidebar
-          flex: '0 0 55px',
+          height: 44,
+          flex: '0 0 44px',
           display: 'flex',
           flexDirection: 'row',
-          alignItems: 'flex-end',
+          alignItems: 'center',
           pl: 2,
           pr: 2,
           // merge line
@@ -217,9 +216,8 @@ export const SimplePageLayoutWithHeader: FC<{
         {simplePageLayoutContextValue.headerPrefix}
         <Box
           sx={{
-            pb: 2,
             fontWeight: 600,
-            fontSize: '1.5rem',
+            fontSize: '1.25rem',
             flex: '1 1 auto',
             overflow: 'hidden',
             textOverflow: 'ellipsis',


### PR DESCRIPTION
## Description

Internal notion: https://www.notion.so/wandbai/Update-drawer-headers-10ae2f5c7ef380b78ec7de4d47dc105b?pvs=4#10ae2f5c7ef3805cb76bc52b3780f6d5

Before:
<img width="615" alt="Screenshot 2024-09-26 at 9 30 27 AM" src="https://github.com/user-attachments/assets/ee55bcfd-29d9-4e07-8f78-1bb668309f52">

After:
<img width="618" alt="Screenshot 2024-09-26 at 9 30 15 AM" src="https://github.com/user-attachments/assets/b12cbb4a-7ba9-4dc2-b6c7-8621890f7be2">



## Testing

How was this PR tested?
