### PR TITLE
refactor: rename file to match component name

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CollapseHeader.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CollapseHeader.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import {Button} from '../../../Button';
 import {Tooltip} from '../../../Tooltip';
 
-type CollapseGroupHeaderProps = {
+type CollapseHeaderProps = {
   headerName: string;
   field: string;
   onCollapse: (col: string) => void;
@@ -23,7 +23,7 @@ export const CollapseHeader = ({
   headerName,
   field,
   onCollapse,
-}: CollapseGroupHeaderProps) => {
+}: CollapseHeaderProps) => {
   const onClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     onCollapse(field);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
@@ -11,7 +11,7 @@ import {isWeaveObjectRef, parseRef} from '../../../../../../../react';
 import {ErrorBoundary} from '../../../../../../ErrorBoundary';
 import {flattenObjectPreservingWeaveTypes} from '../../../../Browse2/browse2Util';
 import {CellValue} from '../../../../Browse2/CellValue';
-import {CollapseHeader} from '../../../../Browse2/CollapseGroupHeader';
+import {CollapseHeader} from '../../../../Browse2/CollapseHeader';
 import {ExpandHeader} from '../../../../Browse2/ExpandHeader';
 import {NotApplicable} from '../../../../Browse2/NotApplicable';
 import {SmallRef} from '../../../../Browse2/SmallRef';


### PR DESCRIPTION
## Description

Component was renamed from `CollapseGroupHeader` to `CollapseHeader` in https://github.com/wandb/weave/pull/1692, update props and filename to match.

## Testing

How was this PR tested?
