### PR TITLE
chore: add icon to object header instead of chip

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -3,7 +3,10 @@ import {useObjectViewEvent} from '@wandb/weave/integrations/analytics/useViewEve
 import React, {useMemo} from 'react';
 
 import {maybePluralizeWord} from '../../../../../core/util/string';
+import {Icon, IconName} from '../../../../Icon';
 import {LoadingDots} from '../../../../LoadingDots';
+import {Tailwind} from '../../../../Tailwind';
+import {Tooltip} from '../../../../Tooltip';
 import {NotFoundPanel} from '../NotFoundPanel';
 import {CustomWeaveTypeProjectContext} from '../typeViews/CustomWeaveTypeDispatcher';
 import {WeaveCHTableSourceRefContext} from './CallPage/DataTableView';
@@ -22,7 +25,6 @@ import {
   SimpleKeyValueTable,
   SimplePageLayoutWithHeader,
 } from './common/SimplePageLayout';
-import {TypeVersionCategoryChip} from './common/TypeVersionCategoryChip';
 import {TabUseDataset} from './TabUseDataset';
 import {TabUseModel} from './TabUseModel';
 import {TabUseObject} from './TabUseObject';
@@ -33,8 +35,33 @@ import {
 } from './wfReactInterface/utilities';
 import {
   CallSchema,
+  KnownBaseObjectClassType,
   ObjectVersionSchema,
 } from './wfReactInterface/wfDataModelHooksInterface';
+
+type ObjectIconProps = {
+  baseObjectClass: KnownBaseObjectClassType;
+};
+const OBJECT_ICONS: Record<KnownBaseObjectClassType, IconName> = {
+  Model: 'model',
+  Dataset: 'table',
+};
+const ObjectIcon = ({baseObjectClass}: ObjectIconProps) => {
+  if (baseObjectClass in OBJECT_ICONS) {
+    const iconName = OBJECT_ICONS[baseObjectClass];
+    return (
+      <Tooltip
+        trigger={
+          <div className="flex h-22 w-22 items-center justify-center rounded-full bg-moon-300/[0.48] text-moon-600">
+            <Icon width={14} height={14} name={iconName} />
+          </div>
+        }
+        content={baseObjectClass}
+      />
+    );
+  }
+  return null;
+};
 
 export const ObjectVersionPage: React.FC<{
   entity: string;
@@ -126,7 +153,16 @@ const ObjectVersionPageInner: React.FC<{
 
   return (
     <SimplePageLayoutWithHeader
-      title={objectVersionText(objectName, objectVersionIndex)}
+      title={
+        <Tailwind>
+          <div className="flex items-center gap-8">
+            {baseObjectClass && (
+              <ObjectIcon baseObjectClass={baseObjectClass} />
+            )}
+            {objectVersionText(objectName, objectVersionIndex)}
+          </div>
+        </Tailwind>
+      }
       headerContent={
         <SimpleKeyValueTable
           data={{
@@ -154,15 +190,6 @@ const ObjectVersionPageInner: React.FC<{
               </>
             ),
             Version: <>{objectVersionIndex}</>,
-            ...(baseObjectClass
-              ? {
-                  Category: (
-                    <TypeVersionCategoryChip
-                      baseObjectClass={baseObjectClass}
-                    />
-                  ),
-                }
-              : {}),
             ...(refExtra
               ? {
                   Subpath: refExtra,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -158,7 +158,7 @@ export const SimplePageLayout: FC<{
 };
 
 export const SimplePageLayoutWithHeader: FC<{
-  title?: string;
+  title?: ReactNode;
   tabs: Array<{
     label: string;
     content: ReactNode;


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Update-drawer-headers-10ae2f5c7ef380b78ec7de4d47dc105b?pvs=4#10ae2f5c7ef380a78bb5d5b2739906ab

This only updates object header, not call header.

Before:
<img width="285" alt="Screenshot 2024-09-26 at 11 13 51 AM" src="https://github.com/user-attachments/assets/a203f24d-a057-462e-9df5-fec7af9c1a61">

After:
<img width="275" alt="Screenshot 2024-09-26 at 11 13 41 AM" src="https://github.com/user-attachments/assets/f7fa09d9-eccf-41db-83da-6906cb50a236">



## Testing

How was this PR tested?
