### PR TITLE
chore: add version_count to object schema for fe calculations

### DIFF
--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -150,4 +150,5 @@ class SelectableCHObjSchema(BaseModel):
     base_object_class: typing.Optional[str]
     digest: str
     version_index: int
+    version_count: typing.Optional[int]
     is_latest: int

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -179,7 +179,12 @@ class ObjSchema(BaseModel):
     created_at: datetime.datetime
     deleted_at: Optional[datetime.datetime] = None
     digest: str
-    version_index: int
+    version_index: int = Field(
+        description="The version number for this object version."
+    )
+    version_count: Optional[int] = Field(
+        default=None, description="The count of total versions of the object."
+    )
     is_latest: int
     kind: str
     base_object_class: Optional[str]


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr is the backend to enable a much more efficient query path for objects. In a few places we have to query for all objects just to display the name because of the version_count (like on the first peek page of the objects/ops table), this would fix that. Also, on the Objects/Versions page we show `99+` because it's expensive to get all the versions, this would allow up to be exact. 

TODO:
- fix tests


## Testing

How was this PR tested?
