### PR TITLE
chore(weave): add width to autocomplete

### DIFF
--- a/weave-js/src/components/Form/AutoComplete.tsx
+++ b/weave-js/src/components/Form/AutoComplete.tsx
@@ -59,7 +59,7 @@ const getStyles = (props: AdditionalProps) => {
                 opacity: 1,
               },
               '& .MuiInputBase-input': {
-                padding: '0px', // Adjust padding as needed
+                padding: '0px',
                 minHeight: `${HEIGHTS[size]} !important`,
               },
             },

--- a/weave-js/src/components/Form/AutoComplete.tsx
+++ b/weave-js/src/components/Form/AutoComplete.tsx
@@ -153,7 +153,6 @@ type AdditionalProps = {
 export const AutoComplete = <Option,>(
   props: AutocompleteProps<Option, boolean, boolean, boolean> & AdditionalProps
 ) => {
-  console.log(props);
   return (
     <ThemeProvider theme={getStyles(props)}>
       <Autocomplete ref={props.inputRef} {...props} />

--- a/weave-js/src/components/Form/AutoComplete.tsx
+++ b/weave-js/src/components/Form/AutoComplete.tsx
@@ -147,7 +147,7 @@ type AdditionalProps = {
   maxWidth?: number;
   minWidth?: number;
   hasInputValue?: boolean;
-  inputRef?: React.MutableRefObject<HTMLDivElement | null>;
+  autocompleteRef?: React.MutableRefObject<HTMLDivElement | null>;
 };
 
 export const AutoComplete = <Option,>(
@@ -155,7 +155,7 @@ export const AutoComplete = <Option,>(
 ) => {
   return (
     <ThemeProvider theme={getStyles(props)}>
-      <Autocomplete ref={props.inputRef} {...props} />
+      <Autocomplete ref={props.autocompleteRef} {...props} />
     </ThemeProvider>
   );
 };

--- a/weave-js/src/components/Form/AutoComplete.tsx
+++ b/weave-js/src/components/Form/AutoComplete.tsx
@@ -40,9 +40,9 @@ const getStyles = (props: AdditionalProps) => {
               paddingBottom: '0px !important',
               fontSize: FONT_SIZES[size],
               fontFamily: 'Source Sans Pro',
-              minWidth: '100px',
               color: MOON_800,
               maxWidth: props.maxWidth ? `${props.maxWidth}px` : '100%',
+              minWidth: props.minWidth ? `${props.minWidth}px` : '100px',
               '& fieldset': {
                 borderColor: MOON_250,
               },
@@ -145,15 +145,18 @@ type AdditionalProps = {
   size?: SelectSize;
   isDarkMode?: boolean;
   maxWidth?: number;
+  minWidth?: number;
   hasInputValue?: boolean;
+  inputRef?: React.MutableRefObject<HTMLDivElement | null>;
 };
 
 export const AutoComplete = <Option,>(
   props: AutocompleteProps<Option, boolean, boolean, boolean> & AdditionalProps
 ) => {
+  console.log(props);
   return (
     <ThemeProvider theme={getStyles(props)}>
-      <Autocomplete {...props} />
+      <Autocomplete ref={props.inputRef} {...props} />
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

Adds minWidth param and ref to the autocomplete component so we can measure the full width of the text input for use in https://github.com/wandb/core/pull/24247.

## Testing

How was this PR tested?
