### PR TITLE
chore: objects query conditionally use metadataOnly

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -130,7 +130,9 @@ export const FilterableObjectVersionsTable: React.FC<{
         ? [effectiveFilter.objectName]
         : undefined,
       latestOnly: effectivelyLatestOnly,
-    }
+    },
+    undefined,
+    effectivelyLatestOnly // metadata only when getting latest
   );
 
   if (filteredObjectVersions.loading) {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

First cut at this was too conservative, we also want to restrict the query to metadata only when the `objectId` is set. This query is used twice, once to get the list of objects and another time once we have drilled down. We want `metadataOnly` the first time, and then values the second. 

For a monster project: 

Prod:
<img width="578" alt="Screenshot 2024-09-26 at 3 28 10 PM" src="https://github.com/user-attachments/assets/354dedad-6fd7-4db9-91dd-cf698bb2d03b">

This branch:
<img width="578" alt="Screenshot 2024-09-26 at 3 27 29 PM" src="https://github.com/user-attachments/assets/5a2801e7-38a0-45af-b588-03ecd8eabfa9">

While maintaining the correct functionality:
<img width="1676" alt="Screenshot 2024-09-26 at 3 30 06 PM" src="https://github.com/user-attachments/assets/66635835-56b0-47b3-8ef9-aba5c9b0e94e">
<img width="1676" alt="Screenshot 2024-09-26 at 3 30 01 PM" src="https://github.com/user-attachments/assets/def85494-d2ac-4a6d-a567-9061bb2d210b">


