### PR TITLE
chore: trace tree styling

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -204,17 +204,21 @@ const CallPageInnerVertical: FC<{
       isSidebarOpen={showTraceTree}
       headerContent={<CallOverview call={currentCall} />}
       leftSidebar={
-        loading ? (
-          <Loading centered />
-        ) : (
-          <CallTraceView
-            call={call}
-            selectedCall={currentCall}
-            rows={rows}
-            forcedExpandKeys={expandKeys}
-            path={path}
-          />
-        )
+        <Tailwind style={{display: 'contents'}}>
+          <div className="h-full bg-moon-50">
+            {loading ? (
+              <Loading centered />
+            ) : (
+              <CallTraceView
+                call={call}
+                selectedCall={currentCall}
+                rows={rows}
+                forcedExpandKeys={expandKeys}
+                path={path}
+              />
+            )}
+          </div>
+        </Tailwind>
       }
       tabs={callTabs}
     />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -183,8 +183,14 @@ export const CallTraceView: FC<{
           outline: 'none',
         },
       },
+      '& .MuiDataGrid-topContainer': {
+        display: 'none',
+      },
       '& .MuiDataGrid-columnHeaders': {
         borderBottom: 'none',
+      },
+      '& .MuiDataGrid-filler': {
+        display: 'none',
       },
       [callClass]: {
         backgroundColor: '#a9edf252',


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Trace-drawer-specific-items-43c3106f7d2848758d02f89cee2b3540?pvs=4#10ae2f5c7ef3804a99d3e2d32d1ecb12

Things improved:
* background color 
* hide border artifacts at top and bottom
* Divider now positioned with absolute positioning, allowing us to extend left and main panels underneath border

Before:
<img width="438" alt="Screenshot 2024-09-26 at 5 23 02 PM" src="https://github.com/user-attachments/assets/69b6cf5f-5bf6-456d-861a-e22faf6967f2">

After:
<img width="416" alt="Screenshot 2024-09-26 at 5 22 21 PM" src="https://github.com/user-attachments/assets/807e5bb2-8bca-4146-9619-bed3c4227df1">


## Testing

How was this PR tested?
