### PR TITLE
fix: select columns for child call table preview

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -71,7 +71,13 @@ export const CallSchemaLink = ({call}: {call: CallSchema}) => {
   );
 };
 
-const SHOWN_COLS = ['op_name', 'status', 'inputs.*', 'output', 'output.*'];
+const ALLOWED_COLUMN_PATTERNS = [
+  'op_name',
+  'status',
+  'inputs.*',
+  'output',
+  'output.*',
+];
 
 export const CallDetails: FC<{
   call: CallSchema;
@@ -178,7 +184,7 @@ export const CallDetails: FC<{
               }}
               entity={call.entity}
               project={call.project}
-              shownCols={SHOWN_COLS}
+              allowedColumnPatterns={ALLOWED_COLUMN_PATTERNS}
             />
           );
           if (isPeeking) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -71,6 +71,8 @@ export const CallSchemaLink = ({call}: {call: CallSchema}) => {
   );
 };
 
+const SHOWN_COLS = ['op_name', 'status', 'inputs.*', 'output', 'output.*'];
+
 export const CallDetails: FC<{
   call: CallSchema;
 }> = ({call}) => {
@@ -176,6 +178,7 @@ export const CallDetails: FC<{
               }}
               entity={call.entity}
               project={call.project}
+              shownCols={SHOWN_COLS}
             />
           );
           if (isPeeking) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -143,6 +143,9 @@ export const CallsTable: FC<{
 
   paginationModel?: GridPaginationModel;
   setPaginationModel?: (newModel: GridPaginationModel) => void;
+
+  // Can include glob for prefix match, e.g. "inputs.*"
+  shownCols?: string[];
 }> = ({
   entity,
   project,
@@ -161,6 +164,7 @@ export const CallsTable: FC<{
   setSortModel,
   paginationModel,
   setPaginationModel,
+  shownCols,
 }) => {
   const {loading: loadingUserInfo, userInfo} = useViewerInfo();
 
@@ -367,6 +371,7 @@ export const CallsTable: FC<{
     onCollapse,
     onExpand,
     columnIsRefExpanded,
+    shownCols,
     onAddFilter
   );
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -145,7 +145,7 @@ export const CallsTable: FC<{
   setPaginationModel?: (newModel: GridPaginationModel) => void;
 
   // Can include glob for prefix match, e.g. "inputs.*"
-  shownCols?: string[];
+  allowedColumnPatterns?: string[];
 }> = ({
   entity,
   project,
@@ -164,7 +164,7 @@ export const CallsTable: FC<{
   setSortModel,
   paginationModel,
   setPaginationModel,
-  shownCols,
+  allowedColumnPatterns,
 }) => {
   const {loading: loadingUserInfo, userInfo} = useViewerInfo();
 
@@ -371,7 +371,7 @@ export const CallsTable: FC<{
     onCollapse,
     onExpand,
     columnIsRefExpanded,
-    shownCols,
+    allowedColumnPatterns,
     onAddFilter
   );
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -54,7 +54,7 @@ export const useCallsTableColumns = (
   onCollapse: (col: string) => void,
   onExpand: (col: string) => void,
   columnIsRefExpanded: (col: string) => boolean,
-  shownCols?: string[],
+  allowedColumnPatterns?: string[],
   onAddFilter?: OnAddFilter
 ) => {
   const [userDefinedColumnWidths, setUserDefinedColumnWidths] = useState<
@@ -130,7 +130,7 @@ export const useCallsTableColumns = (
         onExpand,
         columnIsRefExpanded,
         userDefinedColumnWidths,
-        shownCols,
+        allowedColumnPatterns,
         onAddFilter
       ),
     [
@@ -146,7 +146,7 @@ export const useCallsTableColumns = (
       onExpand,
       columnIsRefExpanded,
       userDefinedColumnWidths,
-      shownCols,
+      allowedColumnPatterns,
       onAddFilter,
     ]
   );
@@ -171,7 +171,7 @@ function buildCallsTableColumns(
   onExpand: (col: string) => void,
   columnIsRefExpanded: (col: string) => boolean,
   userDefinedColumnWidths: Record<string, number>,
-  shownCols?: string[],
+  allowedColumnPatterns?: string[],
   onAddFilter?: OnAddFilter
 ): {
   cols: Array<GridColDef<TraceCallSchema>>;
@@ -457,8 +457,8 @@ function buildCallsTableColumns(
   // TODO: It would be better to build up the cols rather than throwing away
   //       some at the end, but making simpler change for now.
   let orderedCols = cols;
-  if (shownCols !== undefined) {
-    orderedCols = shownCols.flatMap(shownCol => {
+  if (allowedColumnPatterns !== undefined) {
+    orderedCols = allowedColumnPatterns.flatMap(shownCol => {
       if (shownCol.includes('*')) {
         const regex = new RegExp('^' + shownCol.replace('*', '.*') + '$');
         return cols.filter(col => regex.test(col.field));

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -54,6 +54,7 @@ export const useCallsTableColumns = (
   onCollapse: (col: string) => void,
   onExpand: (col: string) => void,
   columnIsRefExpanded: (col: string) => boolean,
+  shownCols?: string[],
   onAddFilter?: OnAddFilter
 ) => {
   const [userDefinedColumnWidths, setUserDefinedColumnWidths] = useState<
@@ -129,6 +130,7 @@ export const useCallsTableColumns = (
         onExpand,
         columnIsRefExpanded,
         userDefinedColumnWidths,
+        shownCols,
         onAddFilter
       ),
     [
@@ -144,6 +146,7 @@ export const useCallsTableColumns = (
       onExpand,
       columnIsRefExpanded,
       userDefinedColumnWidths,
+      shownCols,
       onAddFilter,
     ]
   );
@@ -168,15 +171,29 @@ function buildCallsTableColumns(
   onExpand: (col: string) => void,
   columnIsRefExpanded: (col: string) => boolean,
   userDefinedColumnWidths: Record<string, number>,
+  shownCols?: string[],
   onAddFilter?: OnAddFilter
 ): {
   cols: Array<GridColDef<TraceCallSchema>>;
   colGroupingModel: GridColumnGroupingModel;
 } {
   // Filters summary.usage. because we add a derived column for tokens and cost
-  const filteredDynamicColumnNames = allDynamicColumnNames.filter(
-    c => !HIDDEN_DYNAMIC_COLUMN_PREFIXES.some(p => c.startsWith(p + '.'))
-  );
+  // Sort attributes after inputs and outputs.
+  const filteredDynamicColumnNames = allDynamicColumnNames
+    .filter(
+      c => !HIDDEN_DYNAMIC_COLUMN_PREFIXES.some(p => c.startsWith(p + '.'))
+    )
+    .sort((a, b) => {
+      const prefixes = ['inputs.', 'output.', 'attributes.'];
+      const aPrefix =
+        a === 'output' ? 'output.' : prefixes.find(p => a.startsWith(p)) ?? '';
+      const bPrefix =
+        b === 'output' ? 'output.' : prefixes.find(p => b.startsWith(p)) ?? '';
+      if (aPrefix !== bPrefix) {
+        return prefixes.indexOf(aPrefix) - prefixes.indexOf(bPrefix);
+      }
+      return a.localeCompare(b);
+    });
 
   const cols: Array<GridColDef<TraceCallSchema>> = [
     {
@@ -437,7 +454,21 @@ function buildCallsTableColumns(
     }
   });
 
-  return {cols, colGroupingModel: groupingModel};
+  // TODO: It would be better to build up the cols rather than throwing away
+  //       some at the end, but making simpler change for now.
+  let orderedCols = cols;
+  if (shownCols !== undefined) {
+    orderedCols = shownCols.flatMap(shownCol => {
+      if (shownCol.includes('*')) {
+        const regex = new RegExp('^' + shownCol.replace('*', '.*') + '$');
+        return cols.filter(col => regex.test(col.field));
+      } else {
+        return cols.filter(col => col.field === shownCol);
+      }
+    });
+  }
+
+  return {cols: orderedCols, colGroupingModel: groupingModel};
 }
 /**
  * This function maintains an ever-growing list of dynamic column names. It is used to


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-21218

Also sorts attributes after inputs and output in the column management modal.

Before:
<img width="1000" alt="Screenshot 2024-09-27 at 9 57 37 AM" src="https://github.com/user-attachments/assets/1b78e502-3cda-4de1-9263-fdcb1f076d67">

After:
<img width="1000" alt="Screenshot 2024-09-27 at 9 57 17 AM" src="https://github.com/user-attachments/assets/63b24421-bdfe-4bac-9f76-dec89ea64aac">



## Testing

How was this PR tested?
