### PR TITLE
chore: update string popup styling

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -75,7 +75,6 @@ const Toolbar = styled.div`
   display: flex;
   align-items: center;
   padding: 4px 0;
-  border-bottom: 1px solid ${Colors.MOON_150};
 `;
 Toolbar.displayName = 'S.Toolbar';
 
@@ -166,17 +165,6 @@ const CellValueStringWithPopup = ({value}: CellValueStringProps) => {
               <Toolbar>
                 <Button
                   size="small"
-                  variant="ghost"
-                  icon="copy"
-                  tooltip="Copy to clipboard"
-                  onClick={e => {
-                    e.stopPropagation();
-                    copy();
-                  }}
-                />
-                <Spacer />
-                <Button
-                  size="small"
                   variant="quiet"
                   active={format === 'Text'}
                   icon="text-language"
@@ -190,7 +178,7 @@ const CellValueStringWithPopup = ({value}: CellValueStringProps) => {
                   size="small"
                   variant="quiet"
                   active={format === 'Markdown'}
-                  icon="document"
+                  icon="markdown"
                   tooltip="Markdown mode"
                   onClick={e => {
                     e.stopPropagation();
@@ -201,7 +189,7 @@ const CellValueStringWithPopup = ({value}: CellValueStringProps) => {
                   size="small"
                   variant="quiet"
                   active={format === 'Code'}
-                  icon="job-program-code"
+                  icon="code-alt"
                   tooltip="Code mode"
                   onClick={e => {
                     e.stopPropagation();
@@ -209,6 +197,16 @@ const CellValueStringWithPopup = ({value}: CellValueStringProps) => {
                   }}
                 />
                 <Spacer />
+                <Button
+                  size="small"
+                  variant="ghost"
+                  icon="copy"
+                  tooltip="Copy to clipboard"
+                  onClick={e => {
+                    e.stopPropagation();
+                    copy();
+                  }}
+                />
                 <Button
                   size="small"
                   variant="ghost"


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Popovers-style-10ae2f5c7ef380f48cc0c438a8212732?pvs=4

Some changes like grab handle still to come.

Before:
<img width="629" alt="Screenshot 2024-09-27 at 12 51 40 PM" src="https://github.com/user-attachments/assets/e9e202f8-6604-478e-b9ad-ec5447e7d5af">

After:
<img width="635" alt="Screenshot 2024-09-27 at 12 51 28 PM" src="https://github.com/user-attachments/assets/9e016acb-f27c-439c-974f-9657b4745fe0">



## Testing

How was this PR tested?
