### PR TITLE
chore: update call details header styling

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -15,15 +15,14 @@ export const Overview = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 3px 0;
 `;
 Overview.displayName = 'S.Overview';
 
 export const CallName = styled.div`
   font-family: Source Sans Pro;
-  font-size: 24px;
+  font-size: 16px;
   font-weight: 600;
-  line-height: 32px;
+  line-height: 20px;
   letter-spacing: 0px;
   text-align: left;
 `;
@@ -50,6 +49,7 @@ export const CallOverview: React.FC<{
   return (
     <>
       <Overview>
+        <StatusChip value={statusCode} iconOnly />
         <CallName>
           <EditableCallName
             call={call}
@@ -57,7 +57,6 @@ export const CallOverview: React.FC<{
           />
         </CallName>
         <CopyableId id={call.callId} type="Call" />
-        <StatusChip value={statusCode} iconOnly />
         <Spacer />
         <Reactions weaveRef={refCall} forceVisible={true} />
         <OverflowBin>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
@@ -49,6 +49,7 @@ export const EditableCallName: React.FC<{
   return (
     <EditableField
       ref={editableFieldRef}
+      className="m-0"
       value={currNameToDisplay}
       onFinish={saveName}
       placeholder={defaultDisplayName}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -250,20 +250,23 @@ export const SimplePageLayoutWithHeader: FC<{
                   flex: '0 0 auto',
                   width: '100%',
                   overflow: 'auto',
-                  borderBottom: '1px solid #e0e0e0',
-                  p: 1,
+                  pt: 1,
+                  px: 2,
                   alignContent: 'center',
                 }}>
                 {props.headerContent}
               </Box>
               {(!props.hideTabsIfSingle || tabs.length > 1) && (
                 <Tabs.Root
-                  style={{margin: '12px 8px 0 8px'}}
+                  style={{margin: '12px 16px 0 16px'}}
                   value={tabs[tabValue].label}
                   onValueChange={handleTabChange}>
                   <Tabs.List>
                     {tabs.map(tab => (
-                      <Tabs.Trigger key={tab.label} value={tab.label}>
+                      <Tabs.Trigger
+                        key={tab.label}
+                        value={tab.label}
+                        className="h-[30px] text-sm">
                         {tab.label}
                       </Tabs.Trigger>
                     ))}


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Trace-drawer-specific-items-43c3106f7d2848758d02f89cee2b3540?pvs=4#10ae2f5c7ef380c19132fe89cc3ed3ea

Reduce height and font sizes, remove border, move status to front.

Before:
<img width="785" alt="Screenshot 2024-09-27 at 1 27 58 PM" src="https://github.com/user-attachments/assets/5cb1bfbd-40ba-4369-9826-e663656d4fb4">

After:
<img width="782" alt="Screenshot 2024-09-27 at 1 27 40 PM" src="https://github.com/user-attachments/assets/5864f54a-125e-4287-8842-11dba034fc49">


## Testing

How was this PR tested?
