### PR TITLE
fix: some unfilterable cols showing up in filters

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -22,10 +22,10 @@ export type FilterId = number | string | undefined;
 export const UNFILTERABLE_FIELDS = [
   'op_name',
   'feedback',
-  'summary.weave.status',
-  'summary.weave.tokens',
-  'summary.weave.cost',
-  'summary.weave.latency',
+  'status',
+  'tokens',
+  'cost',
+  'latency',
   'wb_user_id', // Option+Click works
 ];
 


### PR DESCRIPTION
## Description

Some field IDs changed in https://github.com/wandb/weave/pull/2339 but the filters UI was still referring to the previous values, causing them to not get filtered out as they should be.

## Testing

How was this PR tested?
