### PR TITLE
feat: optionally include feedback in calls export

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -3,6 +3,7 @@ import {GridFilterModel, GridSortModel} from '@mui/x-data-grid-pro';
 import {useOrgName} from '@wandb/weave/common/hooks/useOrganization';
 import {useViewerUserInfo2} from '@wandb/weave/common/hooks/useViewerUserInfo';
 import {Radio} from '@wandb/weave/components';
+import {Switch} from '@wandb/weave/components';
 import {Button} from '@wandb/weave/components/Button';
 import {CodeEditor} from '@wandb/weave/components/CodeEditor';
 import {
@@ -61,6 +62,7 @@ export const ExportSelector = ({
     entityName: userInfoLoaded?.username ?? '',
     skip: viewerLoading,
   });
+  const [includeFeedback, setIncludeFeedback] = useState(false);
 
   // Popover management
   const ref = useRef<HTMLDivElement>(null);
@@ -105,7 +107,8 @@ export const ExportSelector = ({
       sortBy,
       filterBy,
       leafColumns,
-      refColumnsToExpand
+      refColumnsToExpand,
+      includeFeedback
     ).then(blob => {
       const fileExtension = fileExtensions[contentType];
       const date = new Date().toISOString().split('T')[0];
@@ -141,7 +144,8 @@ export const ExportSelector = ({
     lowLevelFilter,
     filterBy,
     refColumnsToExpand,
-    sortBy
+    sortBy,
+    includeFeedback
   );
   const curlText = makeCurlText(
     callQueryParams.entity,
@@ -150,7 +154,8 @@ export const ExportSelector = ({
     lowLevelFilter,
     filterBy,
     refColumnsToExpand,
-    sortBy
+    sortBy,
+    includeFeedback
   );
 
   return (
@@ -205,6 +210,28 @@ export const ExportSelector = ({
                 />
               )}
             </DraggableHandle>
+            <div
+              className={classNames(
+                'flex items-center py-2',
+                disabled ? 'opacity-40' : ''
+              )}>
+              <Switch.Root
+                id="include-feedback"
+                size="small"
+                checked={includeFeedback}
+                onCheckedChange={setIncludeFeedback}
+                disabled={disabled}>
+                <Switch.Thumb size="small" checked={includeFeedback} />
+              </Switch.Root>
+              <label
+                htmlFor="include-feedback"
+                className={classNames(
+                  'ml-6',
+                  disabled ? '' : 'cursor-pointer'
+                )}>
+                Include feedback
+              </label>
+            </div>
             <DownloadGrid
               pythonText={pythonText}
               curlText={curlText}
@@ -457,7 +484,8 @@ function makeCodeText(
   filter: CallFilter,
   query: Query | undefined,
   expandColumns: string[],
-  sortBy: Array<{field: string; direction: 'asc' | 'desc'}>
+  sortBy: Array<{field: string; direction: 'asc' | 'desc'}>,
+  includeFeedback: boolean
 ) {
   let codeStr = `import weave\nassert weave.__version__ >= "0.50.14", "Please upgrade weave!" \n\nclient = weave.init("${entity}/${project}")`;
   codeStr += `\ncalls = client.server.calls_query_stream({\n`;
@@ -471,6 +499,9 @@ function makeCodeText(
     if (expandColumns.length > 0) {
       const expandColumnsStr = JSON.stringify(expandColumns, null, 0);
       codeStr += `   "expand_columns": ${expandColumnsStr},\n`;
+    }
+    if (includeFeedback) {
+      codeStr += `   "include_feedback": true,\n`;
     }
     // specifying call_ids ignores other filters, return early
     codeStr += `})`;
@@ -510,6 +541,9 @@ function makeCodeText(
   if (sortBy.length > 0) {
     codeStr += `   "sort_by": ${JSON.stringify(sortBy, null, 0)},\n`;
   }
+  if (includeFeedback) {
+    codeStr += `   "include_feedback": True,\n`;
+  }
 
   codeStr += `})`;
 
@@ -523,7 +557,8 @@ function makeCurlText(
   filter: CallFilter,
   query: Query | undefined,
   expandColumns: string[],
-  sortBy: Array<{field: string; direction: 'asc' | 'desc'}>
+  sortBy: Array<{field: string; direction: 'asc' | 'desc'}>,
+  includeFeedback: boolean
 ) {
   const baseUrl = (window as any).CONFIG.TRACE_BACKEND_BASE_URL;
   const filterStr = JSON.stringify(
@@ -562,7 +597,8 @@ curl '${baseUrl}/calls/stream_query' \\
   }
   baseCurl += `    "limit":${MAX_EXPORT},
     "offset":0,
-    "sort_by":${JSON.stringify(sortBy, null, 0)}
+    "sort_by":${JSON.stringify(sortBy, null, 0)},
+    "include_feedback": ${includeFeedback}
   }'`;
 
   return baseCurl;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -92,7 +92,15 @@ export const ExportSelector = ({
     // TODO(gst): allow specifying offset
     const offset = 0;
     const limit = MAX_EXPORT;
-    // TODO(gst): add support for JSONL and JSON column selection
+
+    // Explicitly add feedback column for CSV/TSV exports
+    if (
+      [ContentType.csv, ContentType.tsv].includes(contentType) &&
+      includeFeedback
+    ) {
+      visibleColumns.push('summary.weave.feedback');
+    }
+
     const leafColumns = [ContentType.csv, ContentType.tsv].includes(contentType)
       ? makeLeafColumns(visibleColumns)
       : undefined;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -60,6 +60,7 @@ export type TraceCallsQueryReq = {
   query?: Query;
   columns?: string[];
   expand_columns?: string[];
+  include_feedback?: boolean;
 };
 
 export type TraceCallsQueryRes = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -554,7 +554,8 @@ const useCallsExport = () => {
       sortBy?: traceServerTypes.SortBy[],
       query?: Query,
       columns?: string[],
-      expandedRefCols?: string[]
+      expandedRefCols?: string[],
+      includeFeedback?: boolean
     ) => {
       const req: traceServerTypes.TraceCallsQueryReq = {
         project_id: projectIdFromParts({entity, project}),
@@ -575,6 +576,7 @@ const useCallsExport = () => {
         query,
         columns: columns ?? undefined,
         expand_columns: expandedRefCols ?? undefined,
+        include_feedback: includeFeedback ?? false,
       };
       return getTsClient().callsStreamDownload(req, contentType);
     },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -203,7 +203,8 @@ export type WFDataModelHooksInterface = {
     sortBy?: traceServerClientTypes.SortBy[],
     query?: Query,
     columns?: string[],
-    expandedRefCols?: string[]
+    expandedRefCols?: string[],
+    includeFeedback?: boolean
   ) => Promise<Blob>;
   useOpVersion: (key: OpVersionKey | null) => Loadable<OpVersionSchema | null>;
   useOpVersions: (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-21009](https://wandb.atlassian.net/browse/WB-21009)

Adds the option to include feedback made on traces during trace export. 

This branch:

<img width="576" alt="Screenshot 2024-09-27 at 11 52 17 AM" src="https://github.com/user-attachments/assets/89c7b173-9aca-4372-a847-90adce51df3c">




[WB-21009]: https://wandb.atlassian.net/browse/WB-21009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ