### PR TITLE
chore(weave): Cleanup mistral integration tests

### DIFF
--- a/weave/integrations/mistral/v0/mistral_test.py
+++ b/weave/integrations/mistral/v0/mistral_test.py
@@ -1,6 +1,8 @@
 import os
 
 import pytest
+from mistralai.async_client import MistralAsyncClient
+from mistralai.client import MistralClient
 
 import weave
 
@@ -10,8 +12,6 @@ import weave
     filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
 )
 def test_mistral_quickstart(client: weave.trace.weave_client.WeaveClient) -> None:
-    from mistralai.client import MistralClient
-
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
     api_key = os.environ.get("MISTRAL_API_KEY", "DUMMY_API_KEY")
     model = "mistral-large-latest"
@@ -68,8 +68,6 @@ def test_mistral_quickstart(client: weave.trace.weave_client.WeaveClient) -> Non
 async def test_mistral_quickstart_async(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    from mistralai.async_client import MistralAsyncClient
-
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
     api_key = os.environ.get("MISTRAL_API_KEY", "DUMMY_API_KEY")
     model = "mistral-large-latest"
@@ -121,8 +119,6 @@ Ultimately, the best French cheese is a matter of personal taste. I would recomm
 def test_mistral_quickstart_with_stream(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    from mistralai.client import MistralClient
-
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
     api_key = os.environ.get("MISTRAL_API_KEY", "DUMMY_API_KEY")
     model = "mistral-large-latest"
@@ -182,8 +178,6 @@ def test_mistral_quickstart_with_stream(
 async def test_mistral_quickstart_with_stream_async(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    from mistralai.async_client import MistralAsyncClient
-
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
     api_key = os.environ.get("MISTRAL_API_KEY", "DUMMY_API_KEY")
     model = "mistral-large-latest"

--- a/weave/integrations/mistral/v1/mistral_test.py
+++ b/weave/integrations/mistral/v1/mistral_test.py
@@ -54,21 +54,19 @@ Each of these cheeses has its unique characteristics, so the "best" one depends 
 
     assert call.exception is None and call.ended_at is not None
     output = call.output
-    assert output["choices"][0]["message"]["content"] == exp
-    assert output["choices"][0]["finish_reason"] == "stop"
-    assert output["id"] == chat_response.id
-    assert output["model"] == chat_response.model
-    assert output["object"] == chat_response.object
-    assert output["created"] == chat_response.created
+    assert output.choices[0].message.content == exp
+    assert output.choices[0].finish_reason == "stop"
+    assert output.id == chat_response.id
+    assert output.model == chat_response.model
+    assert output.object == chat_response.object
+    assert output.created == chat_response.created
     summary = call.summary
     assert summary is not None
-    model_usage = summary["usage"][output["model"]]
+    model_usage = summary["usage"][output.model]
     assert model_usage["requests"] == 1
-    assert (
-        output["usage"]["completion_tokens"] == model_usage["completion_tokens"] == 406
-    )
-    assert output["usage"]["prompt_tokens"] == model_usage["prompt_tokens"] == 10
-    assert output["usage"]["total_tokens"] == model_usage["total_tokens"] == 416
+    assert output.usage.completion_tokens == model_usage["completion_tokens"] == 406
+    assert output.usage.prompt_tokens == model_usage["prompt_tokens"] == 10
+    assert output.usage.total_tokens == model_usage["total_tokens"] == 416
 
 
 @pytest.mark.skip_clickhouse_client
@@ -114,21 +112,19 @@ Each of these cheeses offers a unique taste and texture, so the "best" one is a 
 
     assert call.exception is None and call.ended_at is not None
     output = call.output
-    assert output["choices"][0]["message"]["content"] == exp
-    assert output["choices"][0]["finish_reason"] == "stop"
-    assert output["id"] == chat_response.id
-    assert output["model"] == chat_response.model
-    assert output["object"] == chat_response.object
-    assert output["created"] == chat_response.created
+    assert output.choices[0].message.content == exp
+    assert output.choices[0].finish_reason == "stop"
+    assert output.id == chat_response.id
+    assert output.model == chat_response.model
+    assert output.object == chat_response.object
+    assert output.created == chat_response.created
     summary = call.summary
     assert summary is not None
-    model_usage = summary["usage"][output["model"]]
+    model_usage = summary["usage"][output.model]
     assert model_usage["requests"] == 1
-    assert (
-        output["usage"]["completion_tokens"] == model_usage["completion_tokens"] == 363
-    )
-    assert output["usage"]["prompt_tokens"] == model_usage["prompt_tokens"] == 10
-    assert output["usage"]["total_tokens"] == model_usage["total_tokens"] == 373
+    assert output.usage.completion_tokens == model_usage["completion_tokens"] == 363
+    assert output.usage.prompt_tokens == model_usage["prompt_tokens"] == 10
+    assert output.usage.total_tokens == model_usage["total_tokens"] == 373
 
 
 @pytest.mark.skip_clickhouse_client
@@ -175,21 +171,19 @@ Each of these cheeses offers a unique taste and texture, so the "best" one depen
 
     assert call.exception is None and call.ended_at is not None
     output = call.output
-    assert output["choices"][0]["message"]["content"] == exp
-    assert output["choices"][0]["finish_reason"] == "stop"
-    assert output["id"] == chunk.data.id
-    assert output["model"] == chunk.data.model
-    assert output["object"] == chunk.data.object
-    assert output["created"] == chunk.data.created
+    assert output.choices[0].message.content == exp
+    assert output.choices[0].finish_reason == "stop"
+    assert output.id == chunk.data.id
+    assert output.model == chunk.data.model
+    assert output.object == chunk.data.object
+    assert output.created == chunk.data.created
     summary = call.summary
     assert summary is not None
-    model_usage = summary["usage"][output["model"]]
+    model_usage = summary["usage"][output.model]
     assert model_usage["requests"] == 1
-    assert (
-        output["usage"]["completion_tokens"] == model_usage["completion_tokens"] == 350
-    )
-    assert output["usage"]["prompt_tokens"] == model_usage["prompt_tokens"] == 10
-    assert output["usage"]["total_tokens"] == model_usage["total_tokens"] == 360
+    assert output.usage.completion_tokens == model_usage["completion_tokens"] == 350
+    assert output.usage.prompt_tokens == model_usage["prompt_tokens"] == 10
+    assert output.usage.total_tokens == model_usage["total_tokens"] == 360
 
 
 @pytest.mark.skip_clickhouse_client
@@ -245,18 +239,16 @@ Each of these cheeses has its unique characteristics, so the "best" one depends 
 
     assert call.exception is None and call.ended_at is not None
     output = call.output
-    assert output["choices"][0]["message"]["content"] == exp
-    assert output["choices"][0]["finish_reason"] == "stop"
-    assert output["id"] == chunk.data.id
-    assert output["model"] == chunk.data.model
-    assert output["object"] == chunk.data.object
-    assert output["created"] == chunk.data.created
+    assert output.choices[0].message.content == exp
+    assert output.choices[0].finish_reason == "stop"
+    assert output.id == chunk.data.id
+    assert output.model == chunk.data.model
+    assert output.object == chunk.data.object
+    assert output.created == chunk.data.created
     summary = call.summary
     assert summary is not None
-    model_usage = summary["usage"][output["model"]]
+    model_usage = summary["usage"][output.model]
     assert model_usage["requests"] == 1
-    assert (
-        output["usage"]["completion_tokens"] == model_usage["completion_tokens"] == 459
-    )
-    assert output["usage"]["prompt_tokens"] == model_usage["prompt_tokens"] == 10
-    assert output["usage"]["total_tokens"] == model_usage["total_tokens"] == 469
+    assert output.usage.completion_tokens == model_usage["completion_tokens"] == 459
+    assert output.usage.prompt_tokens == model_usage["prompt_tokens"] == 10
+    assert output.usage.total_tokens == model_usage["total_tokens"] == 469

--- a/weave/integrations/mistral/v1/mistral_test.py
+++ b/weave/integrations/mistral/v1/mistral_test.py
@@ -1,21 +1,9 @@
 import os
-from typing import Any
 
 import pytest
+from mistralai import Mistral
 
 import weave
-from weave.trace_server import trace_server_interface as tsi
-
-
-def _get_call_output(call: tsi.CallSchema) -> Any:
-    """This is a hack and should not be needed. We should be able to auto-resolve this for the user.
-
-    Keeping this here for now, but it should be removed in the future once we have a better solution.
-    """
-    call_output = call.output
-    if isinstance(call_output, str) and call_output.startswith("weave://"):
-        return weave.ref(call_output).get()
-    return call_output
 
 
 @pytest.mark.skip_clickhouse_client
@@ -24,7 +12,6 @@ def _get_call_output(call: tsi.CallSchema) -> Any:
 )
 def test_mistral_quickstart(client: weave.trace.weave_client.WeaveClient) -> None:
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
-    from mistralai import Mistral  # type: ignore
 
     api_key = os.environ.get("MISTRAL_API_KEY", "DUMMY_API_KEY")
     model = "mistral-large-latest"
@@ -61,12 +48,12 @@ def test_mistral_quickstart(client: weave.trace.weave_client.WeaveClient) -> Non
 
 Each of these cheeses has its unique characteristics, so the "best" one depends on your preferences. It's always fun to try several and decide which you like the most!"""
     assert all_content == exp
-    res = client.server.calls_query(tsi.CallsQueryReq(project_id=client._project_id()))
-    assert len(res.calls) == 1
-    call = res.calls[0]
+    calls = list(client.calls())
+    assert len(calls) == 1
+    call = calls[0]
+
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
-    print(f"{output['choices'][0]=}")
+    output = call.output
     assert output["choices"][0]["message"]["content"] == exp
     assert output["choices"][0]["finish_reason"] == "stop"
     assert output["id"] == chat_response.id
@@ -92,8 +79,6 @@ Each of these cheeses has its unique characteristics, so the "best" one depends 
 async def test_mistral_quickstart_async(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    from mistralai import Mistral  # type: ignore
-
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
     api_key = os.environ.get("MISTRAL_API_KEY", "DUMMY_API_KEY")
     model = "mistral-large-latest"
@@ -123,11 +108,12 @@ async def test_mistral_quickstart_async(
 Each of these cheeses offers a unique taste and texture, so the "best" one is a matter of personal preference."""
 
     assert all_content == exp
-    res = client.server.calls_query(tsi.CallsQueryReq(project_id=client._project_id()))
-    assert len(res.calls) == 1
-    call = res.calls[0]
+    calls = list(client.calls())
+    assert len(calls) == 1
+    call = calls[0]
+
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
+    output = call.output
     assert output["choices"][0]["message"]["content"] == exp
     assert output["choices"][0]["finish_reason"] == "stop"
     assert output["id"] == chat_response.id
@@ -152,8 +138,6 @@ Each of these cheeses offers a unique taste and texture, so the "best" one is a 
 def test_mistral_quickstart_with_stream(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    from mistralai import Mistral  # type: ignore
-
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
     api_key = os.environ.get("MISTRAL_API_KEY", "DUMMY_API_KEY")
     model = "mistral-large-latest"
@@ -185,12 +169,12 @@ def test_mistral_quickstart_with_stream(
 
 Each of these cheeses offers a unique taste and texture, so the "best" one depends on your personal preference. It's always fun to try a variety to see which you like best!"""
     assert all_content == exp
-    res = client.server.calls_query(tsi.CallsQueryReq(project_id=client._project_id()))
-    assert len(res.calls) == 1
-    call = res.calls[0]
+    calls = list(client.calls())
+    assert len(calls) == 1
+    call = calls[0]
+
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
-    print(f"{output=}")
+    output = call.output
     assert output["choices"][0]["message"]["content"] == exp
     assert output["choices"][0]["finish_reason"] == "stop"
     assert output["id"] == chunk.data.id
@@ -216,8 +200,6 @@ Each of these cheeses offers a unique taste and texture, so the "best" one depen
 async def test_mistral_quickstart_with_stream_async(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    from mistralai import Mistral  # type: ignore
-
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
     api_key = os.environ.get("MISTRAL_API_KEY", "DUMMY_API_KEY")
     model = "mistral-large-latest"
@@ -257,11 +239,12 @@ async def test_mistral_quickstart_with_stream_async(
 
 Each of these cheeses has its unique characteristics, so the "best" one depends on your preferences. It's always fun to try several types to discover your favorite!"""
     assert all_content == exp
-    res = client.server.calls_query(tsi.CallsQueryReq(project_id=client._project_id()))
-    assert len(res.calls) == 1
-    call = res.calls[0]
+    calls = list(client.calls())
+    assert len(calls) == 1
+    call = calls[0]
+
     assert call.exception is None and call.ended_at is not None
-    output = _get_call_output(call)
+    output = call.output
     assert output["choices"][0]["message"]["content"] == exp
     assert output["choices"][0]["finish_reason"] == "stop"
     assert output["id"] == chunk.data.id


### PR DESCRIPTION
Cleans up imports and removes the use of lower level `tsi` in tests