### PR TITLE
chore(dev): static fingerprint for error with useNodeValue

### DIFF
--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react';
 import {
   callOpVeryUnsafe,
   Client,
@@ -354,8 +355,9 @@ export const useNodeValue = <T extends Type>(
       const message =
         'Node execution failed (useNodeValue): ' + errorToText(error);
       // console.error(message);
-
-      throw new UseNodeValueServerExecutionError(message);
+      const err = new UseNodeValueServerExecutionError(message);
+      Sentry.captureException(err, {fingerprint: ['useNodeValue']});
+      throw err;
     }
     if (isConstNode(node)) {
       if (isFunction(node.type)) {


### PR DESCRIPTION
## Description

This PR adds explicit sentry handling for a throw that is generatic about 25% of the "new issues" being reported in the user-interface sentry project today. The exception is now captured explicitly and given a static fingerprint so it does not register as new in sentry due to differences in the stack trace.
