### PR TITLE
chore(app): Silencing browser warnings from props falling through to the DOM

### DIFF
--- a/weave-js/src/components/Form/AutoComplete.tsx
+++ b/weave-js/src/components/Form/AutoComplete.tsx
@@ -160,7 +160,7 @@ export const AutoComplete = <Option,>(
     maxWidth,
     minWidth,
     size,
-    ...safeProps // we're just destructuring the other values out since they're recognized by the autocomplete component
+    ...safeProps // we're just destructuring the other values out since they're unrecognized by the autocomplete component
   } = props;
   return (
     <ThemeProvider theme={getStyles(props)}>


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-21198

The props falling through to the autocomplete component are causing console warnings.