### PR TITLE
fix: `include_feedback` breaks when > 10 results AND no expand fields listed

### DIFF
--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -2685,20 +2685,6 @@ def test_calls_stream_column_expansion_dynamic_batch_size(client, batch_size):
     for i in range(batch_size):
         assert calls[i].output == i
 
-    res = client.server.calls_query_stream(
-        tsi.CallsQueryReq(
-            project_id=client._project_id(),
-            columns=["output"],
-            expand_columns=[
-                "output.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z"
-            ],
-        )
-    )
-    calls = list(res)
-    assert len(calls) == batch_size
-    for i in range(batch_size):
-        assert calls[i].output == i
-
 
 class Custom(weave.Object):
     val: dict

--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -277,9 +277,7 @@ def simple_line_call_bootstrap(init_wandb: bool = False) -> OpCallSpec:
     @weave.op()
     def multiplier(
         a: Number, b
-    ) -> (
-        int
-    ):  # intentionally deviant in returning plain int - so that we have a different type
+    ) -> int:  # intentionally deviant in returning plain int - so that we have a different type
         return a.value * b
 
     @weave.op()

--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -2793,16 +2793,18 @@ def test_objects_and_keys_with_special_characters(client):
 
 
 def test_calls_stream_feedback(client):
+    BATCH_SIZE = 10
+    num_calls = BATCH_SIZE + 1
+
     @weave.op
     def test_call(x):
         return "ello chap"
 
-    test_call(1)
-    test_call(2)
-    test_call(3)
+    for i in range(num_calls):
+        test_call(i)
 
     calls = list(test_call.calls())
-    assert len(calls) == 3
+    assert len(calls) == num_calls
 
     # add feedback to the first call
     calls[0].feedback.add("note", {"note": "this is a note on call1"})
@@ -2821,7 +2823,7 @@ def test_calls_stream_feedback(client):
     )
     calls = list(res)
 
-    assert len(calls) == 3
+    assert len(calls) == num_calls
     assert len(calls[0].summary["weave"]["feedback"]) == 4
     assert len(calls[1].summary["weave"]["feedback"]) == 1
     assert not calls[2].summary.get("weave", {}).get("feedback")

--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -2664,6 +2664,41 @@ def test_calls_stream_column_expansion(client):
     assert call_result.output == nested_ref.uri()
 
 
+def test_calls_stream_column_expansion_dynamic_batch_size(client):
+    @weave.op
+    def test_op(x):
+        return x
+
+    for i in range(1000):
+        test_op(i)
+
+    res = client.server.calls_query_stream(
+        tsi.CallsQueryReq(
+            project_id=client._project_id(),
+            columns=["output"],
+            expand_columns=["output"],
+        )
+    )
+    calls = list(res)
+    assert len(calls) == 1000
+    for i in range(1000):
+        assert calls[i].output == i
+
+    res = client.server.calls_query_stream(
+        tsi.CallsQueryReq(
+            project_id=client._project_id(),
+            columns=["output"],
+            expand_columns=[
+                "output.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z"
+            ],
+        )
+    )
+    calls = list(res)
+    assert len(calls) == 1000
+    for i in range(1000):
+        assert calls[i].output == i
+
+
 class Custom(weave.Object):
     val: dict
 

--- a/weave/tests/trace/test_client_trace.py
+++ b/weave/tests/trace/test_client_trace.py
@@ -2664,7 +2664,10 @@ def test_calls_stream_column_expansion(client):
     assert call_result.output == nested_ref.uri()
 
 
-@pytest.mark.parametrize("batch_size", [1, 11, 101, 120])
+# Batch size is dynamically increased from 10 to MAX_CALLS_STREAM_BATCH_SIZE (500)
+# in clickhouse_trace_server_batched.py, this test verifies that the dynamic
+# increase works as expected
+@pytest.mark.parametrize("batch_size", [1, 10, 100, 110])
 def test_calls_stream_column_expansion_dynamic_batch_size(client, batch_size):
     @weave.op
     def test_op(x):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -106,7 +106,7 @@ MAX_FLUSH_AGE = 15
 FILE_CHUNK_SIZE = 100000
 
 MAX_DELETE_CALLS_COUNT = 100
-MAX_CALL_STREAM_BATCH_SIZE = 500
+MAX_CALLS_STREAM_BATCH_SIZE = 500
 
 
 class NotFoundError(Exception):
@@ -350,7 +350,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         yield tsi.CallSchema.model_validate(call)
 
                     # *** Dynamic increase from 10 to 500 ***
-                    batch_size = min(MAX_CALL_STREAM_BATCH_SIZE, batch_size * 10)
+                    batch_size = min(MAX_CALLS_STREAM_BATCH_SIZE, batch_size * 10)
                     batch = []
 
             hydrated_batch = self._hydrate_calls(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -348,8 +348,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     for call in hydrated_batch:
                         yield tsi.CallSchema.model_validate(call)
 
-                    # *** Dynamic increase from 10 to 1000 ***
-                    batch_size = min(1000, batch_size * 10)
+                    # *** Dynamic increase from 10 to 500 ***
+                    batch_size = min(500, batch_size * 10)
                     batch = []
 
             hydrated_batch = self._hydrate_calls(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -106,6 +106,7 @@ MAX_FLUSH_AGE = 15
 FILE_CHUNK_SIZE = 100000
 
 MAX_DELETE_CALLS_COUNT = 100
+MAX_CALL_STREAM_BATCH_SIZE = 500
 
 
 class NotFoundError(Exception):
@@ -349,7 +350,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         yield tsi.CallSchema.model_validate(call)
 
                     # *** Dynamic increase from 10 to 500 ***
-                    batch_size = min(500, batch_size * 10)
+                    batch_size = min(MAX_CALL_STREAM_BATCH_SIZE, batch_size * 10)
                     batch = []
 
             hydrated_batch = self._hydrate_calls(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -354,6 +354,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         depths = Counter(col.count(".") for col in expand_columns)
                         # take the max number of columns at any depth
                         max_count_at_ref_depth = max(depths.values())
+                        if max_count_at_ref_depth == 0:
+                            max_count_at_ref_depth = 1
                         # divide max refs that we can resolve 1000 refs at any depth
                         max_size = 1000 // max_count_at_ref_depth
                         # double batch size up to what refs_read_batch can handle

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -329,7 +329,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             expand_columns = req.expand_columns or []
             ref_cache = LRUCache(max_size=1000)
 
-            batch_size = 100
+            batch_size = 10
             batch = []
             for row in raw_res:
                 call_dict = _ch_call_dict_to_call_schema_dict(
@@ -349,7 +349,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                         yield tsi.CallSchema.model_validate(call)
 
                     # *** Dynamic increase from 100 to 1000 ***
-                    batch_size = min(1000, batch_size * 2)
+                    batch_size = min(1000, batch_size * 10)
                     batch = []
 
             hydrated_batch = self._hydrate_calls(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -28,7 +28,7 @@ import hashlib
 import json
 import logging
 import threading
-from collections import Counter, defaultdict
+from collections import defaultdict
 from contextlib import contextmanager
 from typing import (
     Any,
@@ -348,7 +348,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     for call in hydrated_batch:
                         yield tsi.CallSchema.model_validate(call)
 
-                    # *** Dynamic increase from 100 to 1000 ***
+                    # *** Dynamic increase from 10 to 1000 ***
                     batch_size = min(1000, batch_size * 10)
                     batch = []
 


### PR DESCRIPTION
Simplify dynamic batch size calculation in calls stream to be `10` then `100` then a max of `500` 