### PR TITLE
chore(weave): Add conditional ci

### DIFF
--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -2,6 +2,11 @@ name: Check which tests to run
 
 on:
   workflow_call:
+    outputs:
+      weave_query_tests:
+        value: ${{ jobs.check.outputs.weave_query_tests}}
+      core_integration_tests:
+        value: ${{ jobs.check.outputs.core_integration_tests }}
 
 env:
   WEAVE_QUERY_PATHS: 'weave_query/'

--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -1,5 +1,8 @@
 name: Check which tests to run
 
+on:
+  workflow_call:
+
 env:
   WEAVE_QUERY_PATHS: 'weave_query/'
   CORE_INTEGRATION_PATHS: 'weave-js/ weave_query/'

--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -1,0 +1,46 @@
+name: Check which tests to run
+
+env:
+  WEAVE_QUERY_PATHS: 'weave_query/'
+  CORE_INTEGRATION_PATHS: 'weave-js/ weave_query/'
+  # Everything else is implicitly trace server
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      weave_query_tests: ${{ steps.weave_query.outputs.run_tests }}
+      core_integration_tests: ${{ steps.core_integration.outputs.run_tests }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.head_ref }}
+      - run: git fetch origin ${{ github.base_ref }}
+      - run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha=$(git rev-parse origin/${{ github.base_ref }})
+            head_sha=$(git rev-parse HEAD)
+            changed_files=$(git diff --name-only $base_sha $head_sha)
+          else
+            changed_files=$(git diff --name-only HEAD^)
+          fi
+      - id: weave_query
+        run: |
+          for path in ${{ env.WEAVE_QUERY_PATHS }}; do
+            if echo "$changed_files" | grep -q "$path"; then
+              echo "run_tests=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+          echo "run_tests=false" >> $GITHUB_OUTPUT
+      - id: core_integration
+        run: |
+          for path in ${{ env.CORE_INTEGRATION_PATHS }}; do
+            if echo "$changed_files" | grep -q "$path"; then
+              echo "run_tests=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+          echo "run_tests=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -4,12 +4,15 @@ on:
   workflow_call:
     outputs:
       weave_query_tests:
-        value: ${{ jobs.check.outputs.weave_query_tests}}
+        value: ${{ jobs.check.outputs.weave_query_tests }}
       core_integration_tests:
         value: ${{ jobs.check.outputs.core_integration_tests }}
+      weave_js_tests:
+        value: ${{ jobs.check.outputs.weave_js_tests }}
 
 env:
   WEAVE_QUERY_PATHS: 'weave_query/'
+  WEAVE_JS_PATHS: 'weave-js/'
   CORE_INTEGRATION_PATHS: 'weave-js/ weave_query/'
   # Everything else is implicitly trace server
 
@@ -19,6 +22,7 @@ jobs:
     outputs:
       weave_query_tests: ${{ steps.weave_query.outputs.run_tests }}
       core_integration_tests: ${{ steps.core_integration.outputs.run_tests }}
+      weave_js_tests: ${{ steps.weave_js.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -52,6 +56,12 @@ jobs:
             fi
           done
           echo "run_tests=false" >> $GITHUB_OUTPUT
-      - run: |
-          echo "Weave Query Tests: ${{ steps.weave_query.outputs.run_tests }}"
-          echo "Core Integration Tests: ${{ steps.core_integration.outputs.run_tests }}"
+      - id: weave_js
+        run: |
+          for path in ${{ env.WEAVE_JS_PATHS }}; do
+            if echo "$changed_files" | grep -q "$path"; then
+              echo "run_tests=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+          echo "run_tests=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       weave_query_tests: ${{ steps.weave_query.outputs.run_tests }}
       weave_js_tests: ${{ steps.weave_js.outputs.run_tests }}
-      trace_server_tests: ${{ steps.core_integration.outputs.run_tests }}
+      trace_server_tests: ${{ steps.trace_server.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -47,3 +47,6 @@ jobs:
             fi
           done
           echo "run_tests=false" >> $GITHUB_OUTPUT
+      - run: |
+          echo "Weave Query Tests: ${{ steps.weave_query.outputs.run_tests }}"
+          echo "Core Integration Tests: ${{ steps.core_integration.outputs.run_tests }}"

--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -7,22 +7,22 @@ on:
         value: ${{ jobs.check.outputs.weave_query_tests }}
       weave_js_tests:
         value: ${{ jobs.check.outputs.weave_js_tests }}
-      core_integration_tests:
-        value: ${{ jobs.check.outputs.core_integration_tests }}
+      trace_server_tests:
+        value: ${{ jobs.check.outputs.trace_server_tests }}
 
 env:
   WEAVE_QUERY_PATHS: 'weave_query/'
   WEAVE_JS_PATHS: 'weave-js/'
-  CORE_INTEGRATION_PATHS: 'weave-js/ weave_query/'
-  # Everything else is implicitly trace server
+  TRACE_SERVER_PATHS: 'weave/trace_server/'
+  # Everything else is implicitly trace SDK
 
 jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
       weave_query_tests: ${{ steps.weave_query.outputs.run_tests }}
-      core_integration_tests: ${{ steps.core_integration.outputs.run_tests }}
       weave_js_tests: ${{ steps.weave_js.outputs.run_tests }}
+      trace_server_tests: ${{ steps.core_integration.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -59,8 +59,8 @@ jobs:
             fi
           done
           echo "run_tests=false" >> $GITHUB_OUTPUT
-      - id: core_integration
-        name: Core Integration Checks
+      - id: trace_server
+        name: Weave Trace Server Checks
         run: |
           for path in ${{ env.CORE_INTEGRATION_PATHS }}; do
             if echo "$changed_files" | grep -q "$path"; then

--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -5,10 +5,10 @@ on:
     outputs:
       weave_query_tests:
         value: ${{ jobs.check.outputs.weave_query_tests }}
-      core_integration_tests:
-        value: ${{ jobs.check.outputs.core_integration_tests }}
       weave_js_tests:
         value: ${{ jobs.check.outputs.weave_js_tests }}
+      core_integration_tests:
+        value: ${{ jobs.check.outputs.core_integration_tests }}
 
 env:
   WEAVE_QUERY_PATHS: 'weave_query/'
@@ -29,8 +29,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ github.head_ref }}
-      - run: git fetch origin ${{ github.base_ref }}
-      - run: |
+      - name: Git setup
+        run: |
+          git fetch origin ${{ github.base_ref }}
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base_sha=$(git rev-parse origin/${{ github.base_ref }})
             head_sha=$(git rev-parse HEAD)
@@ -39,6 +40,7 @@ jobs:
             changed_files=$(git diff --name-only HEAD^)
           fi
       - id: weave_query
+        name: Weave Query Checks
         run: |
           for path in ${{ env.WEAVE_QUERY_PATHS }}; do
             if echo "$changed_files" | grep -q "$path"; then
@@ -47,18 +49,20 @@ jobs:
             fi
           done
           echo "run_tests=false" >> $GITHUB_OUTPUT
-      - id: core_integration
+      - id: weave_js
+        name: Weave JS Checks
         run: |
-          for path in ${{ env.CORE_INTEGRATION_PATHS }}; do
+          for path in ${{ env.WEAVE_JS_PATHS }}; do
             if echo "$changed_files" | grep -q "$path"; then
               echo "run_tests=true" >> $GITHUB_OUTPUT
               exit 0
             fi
           done
           echo "run_tests=false" >> $GITHUB_OUTPUT
-      - id: weave_js
+      - id: core_integration
+        name: Core Integration Checks
         run: |
-          for path in ${{ env.WEAVE_JS_PATHS }}; do
+          for path in ${{ env.CORE_INTEGRATION_PATHS }}; do
             if echo "$changed_files" | grep -q "$path"; then
               echo "run_tests=true" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -31,4 +31,4 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.outputs.core_integration_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -25,4 +25,4 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ github.event.inputs.run_core_integration_tests }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": "${{ github.event.inputs.run_core_integration_tests }}""}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -25,4 +25,4 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": "${{ github.event.inputs.run_core_integration_tests }}""}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": "${{ github.event.inputs.run_core_integration_tests }}"}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -25,9 +25,7 @@ jobs:
       - name: Print payload
         run: |
           echo "Sending payload:"
-          echo "Weave Query Tests: ${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}"
-          echo "Core Integration Tests: ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}"
-          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'
+          echo "Output payload: ${{ needs }}"
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -22,4 +22,4 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_weave_query_tests": ${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}}, "run_weave_js_tests": ${{ needs.check-which-tests-to-run.outputs.weave_js_tests }}}, "run_trace_server_tests": ${{ needs.check-which-tests-to-run.outputs.trace_server_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -16,6 +16,8 @@ on:
         default: true
 
 jobs:
+  check-which-tests-to-run:
+    uses: ./.github/workflows/check-which-tests-to-run.yaml
   notify-wandb-core:
     needs: check-which-tests-to-run
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - '**'
+  workflow_dispatch:
 
 jobs:
   check-which-tests-to-run:
@@ -21,9 +22,4 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: |
-            {
-              "ref_name": "${{ github.ref_name }}",
-              "sha": "${{ github.sha }}",
-              "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}
-            }
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -17,17 +17,17 @@ on:
 
 jobs:
   notify-wandb-core:
+    needs: check-which-tests-to-run
     runs-on: ubuntu-latest
     steps:
       - name: Print payload
         run: |
           echo "Sending payload:"
-          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ github.event.inputs.run_core_integration_tests || false }}}'
-
+          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ github.event.inputs.run_core_integration_tests || false }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -18,8 +18,6 @@ on:
 jobs:
   check-which-tests-to-run:
     uses: ./.github/workflows/check-which-tests-to-run.yaml
-    with:
-      job: check
   notify-wandb-core:
     needs: check-which-tests-to-run
     runs-on: ubuntu-latest
@@ -27,11 +25,11 @@ jobs:
       - name: Print payload
         run: |
           echo "Sending payload:"
-          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'
+          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -25,11 +25,11 @@ jobs:
       - name: Print payload
         run: |
           echo "Sending payload:"
-          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'
+          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -22,13 +22,10 @@ jobs:
     needs: check-which-tests-to-run
     runs-on: ubuntu-latest
     steps:
-      - name: Print payload
-        run: |
-          echo "${{ toJSON(needs) }}"
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.outputs.core_integration_tests }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -24,13 +24,7 @@ jobs:
     steps:
       - name: Print payload
         run: |
-          echo "Sending payload:"
-          echo '{'
-          echo '  "needs": '${{ toJson(needs) }}','
-          echo '  "check-which-tests-to-run": '${{ toJson(needs.check-which-tests-to-run) }}','
-          echo '  "outputs": '${{ toJson(needs.check-which-tests-to-run.outputs) }}','
-          echo '  "weave_query_tests": "'${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}'"'
-          echo '}'
+          echo "${{ toJSON(needs) }}"
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -26,6 +26,9 @@ jobs:
         run: |
           echo "Sending payload:"
           echo "Output payload: ${{ needs }}"
+          echo "Output payload: ${{ needs.check-which-tests-to-run }}"
+          echo "Output payload: ${{ needs.check-which-tests-to-run.outputs }}"
+          echo "Output payload: ${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}"
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -18,6 +18,8 @@ on:
 jobs:
   check-which-tests-to-run:
     uses: ./.github/workflows/check-which-tests-to-run.yaml
+    with:
+      job: check
   notify-wandb-core:
     needs: check-which-tests-to-run
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -7,13 +7,6 @@ on:
   push:
     branches:
       - '**'
-  workflow_dispatch:
-    inputs:
-      run_core_integration_tests:
-        description: 'Run core integration tests'
-        required: true
-        type: boolean
-        default: true
 
 jobs:
   check-which-tests-to-run:
@@ -28,4 +21,9 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'
+          client-payload: |
+            {
+              "ref_name": "${{ github.ref_name }}",
+              "sha": "${{ github.sha }}",
+              "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}
+            }

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -22,4 +22,4 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_weave_query_tests": ${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}}, "run_weave_js_tests": ${{ needs.check-which-tests-to-run.outputs.weave_js_tests }}}, "run_trace_server_tests": ${{ needs.check-which-tests-to-run.outputs.trace_server_tests }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_weave_js_tests": ${{ needs.check-which-tests-to-run.outputs.weave_js_tests }}, "run_weave_query_tests": ${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}, "run_trace_server_tests": ${{ needs.check-which-tests-to-run.outputs.trace_server_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -25,4 +25,4 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": "${{ github.event.inputs.run_core_integration_tests }}"}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ github.event.inputs.run_core_integration_tests || false }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -25,11 +25,11 @@ jobs:
       - name: Print payload
         run: |
           echo "Sending payload:"
-          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'
+          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -19,6 +19,11 @@ jobs:
   notify-wandb-core:
     runs-on: ubuntu-latest
     steps:
+      - name: Print payload
+        run: |
+          echo "Sending payload:"
+          echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ github.event.inputs.run_core_integration_tests || false }}}'
+
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -25,10 +25,12 @@ jobs:
       - name: Print payload
         run: |
           echo "Sending payload:"
-          echo "Output payload: ${{ needs }}"
-          echo "Output payload: ${{ needs.check-which-tests-to-run }}"
-          echo "Output payload: ${{ needs.check-which-tests-to-run.outputs }}"
-          echo "Output payload: ${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}"
+          echo '{'
+          echo '  "needs": '${{ toJson(needs) }}','
+          echo '  "check-which-tests-to-run": '${{ toJson(needs.check-which-tests-to-run) }}','
+          echo '  "outputs": '${{ toJson(needs.check-which-tests-to-run.outputs) }}','
+          echo '  "weave_query_tests": "'${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}'"'
+          echo '}'
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -6,8 +6,14 @@ name: Notify wandb/core
 on:
   push:
     branches:
-      - "**"
+      - '**'
   workflow_dispatch:
+    inputs:
+      run_core_integration_tests:
+        description: 'Run core integration tests'
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   notify-wandb-core:
@@ -19,4 +25,4 @@ jobs:
           token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
           repository: wandb/core
           event-type: weave-package-updated
-          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ github.event.inputs.run_core_integration_tests }}}'

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -25,6 +25,8 @@ jobs:
       - name: Print payload
         run: |
           echo "Sending payload:"
+          echo "Weave Query Tests: ${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}"
+          echo "Core Integration Tests: ${{ needs.check-which-tests-to-run.outputs.core_integration_tests }}"
           echo '{"ref_name": "${{ github.ref_name }}", "sha": "${{ github.sha }}", "run_core_integration_tests": ${{ needs.check-which-tests-to-run.outputs.check.core_integration_tests }}}'
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         job_num: [0, 1]
     # runs-on: ubuntu-latest
-    container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test-python-query-service:${{ github.sha }}
+    container: ${{ needs.build-container-query-service.outputs.build_needed == 'true' && 'us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test-python-query-service:${{ github.sha }}' || 'ubuntu:latest' }}
     services:
       wandbservice:
         image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
     env:
       REGISTRY: us-east4-docker.pkg.dev/weave-support-367421/weave-images
     needs: check-which-tests-to-run
-    if: needs.check-which-tests-to-run.outputs.core_integration_tests
+    if: needs.check-which-tests-to-run.outputs.weave_query_tests
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,7 +51,7 @@ jobs:
     # runs-on: [self-hosted, gke-runner]
     runs-on: ubuntu-latest
     needs: check-which-tests-to-run
-    if: needs.check-which-tests-to-run.outputs.core_integration_tests
+    if: needs.check-which-tests-to-run.outputs.weave_query_tests
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
     env:
       REGISTRY: us-east4-docker.pkg.dev/weave-support-367421/weave-images
     needs: check-which-tests-to-run
-    if: needs.check-which-tests-to-run.outputs.weave_query_tests
+    if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
     steps:
       - uses: actions/checkout@v3
         with:
@@ -51,7 +51,7 @@ jobs:
     # runs-on: [self-hosted, gke-runner]
     runs-on: ubuntu-latest
     needs: check-which-tests-to-run
-    if: needs.check-which-tests-to-run.outputs.weave_query_tests
+    if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
     strategy:
       fail-fast: false
       matrix:
@@ -101,7 +101,7 @@ jobs:
     needs:
       - test-query-service
       - check-which-tests-to-run
-    if: needs.check-which-tests-to-run.outputs.weave_query_tests
+    if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
 
     runs-on: ubuntu-latest
 
@@ -116,7 +116,7 @@ jobs:
     name: WeaveJS Lint and Compile
     runs-on: ubuntu-latest
     needs: check-which-tests-to-run
-    if: needs.check-which-tests-to-run.outputs.weave_js_tests
+    if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests
     # runs-on: [self-hosted, gke-runner]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,10 @@ jobs:
   build-container-query-service-dummy:
     name: "SKIPPED: Build Legacy (Query Service) test container"
     if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_query_tests
+    runs-on: ubuntu-latest
     steps:
+      - run: |
+          echo "Skipping build-container-query-service-dummy"
 
   build-container-query-service-matrix-check: # This job does nothing and is only used for the branch protection
     if: always()
@@ -119,7 +122,10 @@ jobs:
   test-query-service-dummy:
     name: "SKIPPED: Legacy (Query Service) Python unit tests"
     if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_query_tests
+    runs-on: ubuntu-latest
     steps:
+      - run: |
+          echo "Skipping build-container-query-service-dummy"
 
   test-query-service-matrix-check: # This job does nothing and is only used for the branch protection
     if: always()
@@ -163,7 +169,10 @@ jobs:
   weavejs-lint-compile-dummy:
     name: "SKIPPED: WeaveJS Lint and Compile"
     if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_js_tests
+    runs-on: ubuntu-latest
     steps:
+      - run: |
+          echo "Skipping build-container-query-service-dummy"
 
   weavejs-lint-compile-matrix-check: # This job does nothing and is only used for the branch protection
     if: always()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,24 @@ jobs:
       - name: Build legacy (query sevice) unit test image
         run: python3 weave/docker/docker_build.py build_deps weave-test-python-query-service builder . weave_query/Dockerfile.ci.test
 
+  build-container-query-service-dummy:
+    name: "SKIPPED: Build Legacy (Query Service) test container"
+    if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_query_tests
+    steps:
+
+  build-container-query-service-matrix-check: # This job does nothing and is only used for the branch protection
+    needs:
+      - check-which-tests-to-run
+      - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests) && 'build-container-query-service' || 'build-container-query-service-dummy' }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Passes if all test-query-service jobs succeeded
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}  
+
   test-query-service:
     name: Legacy (Query Service) Python unit tests
     timeout-minutes: 15 # do not raise! running longer than this indicates an issue with the tests. fix there.
@@ -97,11 +115,15 @@ jobs:
           --durations=5 \
           .
 
+  test-query-service-dummy:
+    name: "SKIPPED: Legacy (Query Service) Python unit tests"
+    if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_query_tests
+    steps:
+
   test-query-service-matrix-check: # This job does nothing and is only used for the branch protection
     needs:
-      - test-query-service
       - check-which-tests-to-run
-    if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
+      - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests) && 'test-query-service' || 'test-query-service-dummy' }}
 
     runs-on: ubuntu-latest
 
@@ -135,6 +157,26 @@ jobs:
           yarn tslint
           yarn prettier
           yarn run tsc
+
+  weavejs-lint-compile-dummy:
+    name: "SKIPPED: WeaveJS Lint and Compile"
+    if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_js_tests
+    steps:
+
+  weavejs-lint-compile-matrix-check: # This job does nothing and is only used for the branch protection
+    if: always()
+
+    needs:
+      - check-which-tests-to-run
+      - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests) && 'weavejs-lint-compile' || 'weavejs-lint-compile-dummy' }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Passes if all weavejs-lint-compile jobs succeeded
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
 
   # ==== Trace Jobs ====
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,169 +24,154 @@ jobs:
     env:
       REGISTRY: us-east4-docker.pkg.dev/weave-support-367421/weave-images
     needs: check-which-tests-to-run
-    if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
+
+    # if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
+      - name: Check if build is needed
+        id: build_check
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" || "${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}" == "true" ]]; then
+            echo "Build is needed"
+            echo "build_needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "Build is not needed"
+            echo "build_needed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Login to Docker Hub
+        if: steps.build_check.outputs.build_needed == 'true'
         uses: docker/login-action@v2
         with:
           registry: us-east4-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.gcp_sa_key }}
 
-      # this script is hardcoded to build for linux/amd64
       - name: Prune docker cache
+        if: steps.build_check.outputs.build_needed == 'true'
         run: docker system prune -f
-      - name: Build legacy (query sevice) unit test image
+
+      - name: Build legacy (query service) unit test image
+        if: steps.build_check.outputs.build_needed == 'true'
         run: python3 weave/docker/docker_build.py build_deps weave-test-python-query-service builder . weave_query/Dockerfile.ci.test
 
-  build-container-query-service-dummy:
-    name: 'SKIPPED: Build Legacy (Query Service) test container'
-    if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_query_tests
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "Skipping build-container-query-service-dummy"
+  # test-query-service:
+  #   name: Legacy (Query Service) Python unit tests
+  #   timeout-minutes: 15 # do not raise! running longer than this indicates an issue with the tests. fix there.
+  #   needs:
+  #     - check-which-tests-to-run
+  #     - build-container-query-service
+  #   # runs-on: [self-hosted, gke-runner]
+  #   runs-on: ubuntu-latest
+  #   if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       job_num: [0, 1]
+  #   # runs-on: ubuntu-latest
+  #   container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test-python-query-service:${{ github.sha }}
+  #   services:
+  #     wandbservice:
+  #       image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
+  #       credentials:
+  #         username: _json_key
+  #         password: ${{ secrets.gcp_wb_sa_key }}
+  #       env:
+  #         CI: 1
+  #         WANDB_ENABLE_TEST_CONTAINER: true
+  #       ports:
+  #         - '8080:8080'
+  #         - '8083:8083'
+  #         - '9015:9015'
+  #       options: --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" --health-interval=5s --health-timeout=3s
+  #   steps:
+  #     # - uses: datadog/agent-github-action@v1.3
+  #     #   with:
+  #     #     api_key: ${{ secrets.DD_API_KEY }}
+  #     - uses: actions/checkout@v2
+  #     - name: Verify wandb server is running
+  #       run: curl -s http://wandbservice:8080/healthz
+  #     - name: Run Legacy (Query Service) Python Unit Tests
+  #       env:
+  #         DD_SERVICE: weave-python
+  #         DD_ENV: ci
+  #         WEAVE_SENTRY_ENV: ci
+  #         CI: 1
+  #         WB_SERVER_HOST: http://wandbservice
+  #         WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
+  #       run: |
+  #         source /root/venv/bin/activate && \
+  #         cd weave_query && \
+  #         pytest \
+  #         --job-num=${{ matrix.job_num }} \
+  #         --timeout=90 \
+  #         --ddtrace \
+  #         --durations=5 \
+  #         .
 
-  build-container-query-service-matrix-check: # This job does nothing and is only used for the branch protection
-    if: always()
-    needs:
-      - check-which-tests-to-run
-      - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests) && 'build-container-query-service' || 'build-container-query-service-dummy' }}
+  # test-query-service-matrix-check: # This job does nothing and is only used for the branch protection
+  #   if: always()
 
-    runs-on: ubuntu-latest
+  #   needs:
+  #     - test-query-service
 
-    steps:
-      - name: Passes if all test-query-service jobs succeeded
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
+  #   runs-on: ubuntu-latest
 
-  test-query-service:
-    name: Legacy (Query Service) Python unit tests
-    timeout-minutes: 15 # do not raise! running longer than this indicates an issue with the tests. fix there.
-    needs:
-      - check-which-tests-to-run
-      - build-container-query-service
-    # runs-on: [self-hosted, gke-runner]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
-    strategy:
-      fail-fast: false
-      matrix:
-        job_num: [0, 1]
-    # runs-on: ubuntu-latest
-    container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test-python-query-service:${{ github.sha }}
-    services:
-      wandbservice:
-        image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
-        credentials:
-          username: _json_key
-          password: ${{ secrets.gcp_wb_sa_key }}
-        env:
-          CI: 1
-          WANDB_ENABLE_TEST_CONTAINER: true
-        ports:
-          - '8080:8080'
-          - '8083:8083'
-          - '9015:9015'
-        options: --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" --health-interval=5s --health-timeout=3s
-    steps:
-      # - uses: datadog/agent-github-action@v1.3
-      #   with:
-      #     api_key: ${{ secrets.DD_API_KEY }}
-      - uses: actions/checkout@v2
-      - name: Verify wandb server is running
-        run: curl -s http://wandbservice:8080/healthz
-      - name: Run Legacy (Query Service) Python Unit Tests
-        env:
-          DD_SERVICE: weave-python
-          DD_ENV: ci
-          WEAVE_SENTRY_ENV: ci
-          CI: 1
-          WB_SERVER_HOST: http://wandbservice
-          WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
-        run: |
-          source /root/venv/bin/activate && \
-          cd weave_query && \
-          pytest \
-          --job-num=${{ matrix.job_num }} \
-          --timeout=90 \
-          --ddtrace \
-          --durations=5 \
-          .
+  #   steps:
+  #     - name: Passes if all test-query-service jobs succeeded
+  #       uses: re-actors/alls-green@release/v1
+  #       with:
+  #         jobs: ${{ toJSON(needs) }}
 
-  test-query-service-dummy:
-    name: 'SKIPPED: Legacy (Query Service) Python unit tests'
-    if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_query_tests
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "Skipping build-container-query-service-dummy"
+  # # ==== Weave UI Jobs ====
+  # weavejs-lint-compile:
+  #   name: WeaveJS Lint and Compile
+  #   runs-on: ubuntu-latest
+  #   needs: check-which-tests-to-run
+  #   if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests
+  #   # runs-on: [self-hosted, gke-runner]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         fetch-depth: 0
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #     - uses: actions/setup-node@v1
+  #       with:
+  #         node-version: '18.x'
+  #     - run: |
+  #         set -e
+  #         cd weave-js
+  #         yarn install --frozen-lockfile
+  #         yarn generate
+  #         yarn eslint --max-warnings=0
+  #         yarn tslint
+  #         yarn prettier
+  #         yarn run tsc
 
-  test-query-service-matrix-check: # This job does nothing and is only used for the branch protection
-    if: always()
-    needs:
-      - check-which-tests-to-run
-      - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests) && 'test-query-service' || 'test-query-service-dummy' }}
+  # weavejs-lint-compile-dummy:
+  #   name: 'SKIPPED: WeaveJS Lint and Compile'
+  #   if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_js_tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: |
+  #         echo "Skipping build-container-query-service-dummy"
 
-    runs-on: ubuntu-latest
+  # weavejs-lint-compile-matrix-check: # This job does nothing and is only used for the branch protection
+  #   if: always()
+  #   needs:
+  #     - check-which-tests-to-run
+  #     - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests) && 'weavejs-lint-compile' || 'weavejs-lint-compile-dummy' }}
 
-    steps:
-      - name: Passes if all test-query-service jobs succeeded
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
+  #   runs-on: ubuntu-latest
 
-  # ==== Weave UI Jobs ====
-  weavejs-lint-compile:
-    name: WeaveJS Lint and Compile
-    runs-on: ubuntu-latest
-    needs: check-which-tests-to-run
-    if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests
-    # runs-on: [self-hosted, gke-runner]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '18.x'
-      - run: |
-          set -e
-          cd weave-js
-          yarn install --frozen-lockfile
-          yarn generate
-          yarn eslint --max-warnings=0
-          yarn tslint
-          yarn prettier
-          yarn run tsc
-
-  weavejs-lint-compile-dummy:
-    name: 'SKIPPED: WeaveJS Lint and Compile'
-    if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_js_tests
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "Skipping build-container-query-service-dummy"
-
-  weavejs-lint-compile-matrix-check: # This job does nothing and is only used for the branch protection
-    if: always()
-    needs:
-      - check-which-tests-to-run
-      - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests) && 'weavejs-lint-compile' || 'weavejs-lint-compile-dummy' }}
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Passes if all weavejs-lint-compile jobs succeeded
-        uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
+  #   steps:
+  #     - name: Passes if all weavejs-lint-compile jobs succeeded
+  #       uses: re-actors/alls-green@release/v1
+  #       with:
+  #         jobs: ${{ toJSON(needs) }}
 
   # ==== Trace Jobs ====
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,7 +44,7 @@ jobs:
         run: python3 weave/docker/docker_build.py build_deps weave-test-python-query-service builder . weave_query/Dockerfile.ci.test
 
   build-container-query-service-dummy:
-    name: "SKIPPED: Build Legacy (Query Service) test container"
+    name: 'SKIPPED: Build Legacy (Query Service) test container'
     if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_query_tests
     runs-on: ubuntu-latest
     steps:
@@ -63,16 +63,16 @@ jobs:
       - name: Passes if all test-query-service jobs succeeded
         uses: re-actors/alls-green@release/v1
         with:
-          jobs: ${{ toJSON(needs) }}  
+          jobs: ${{ toJSON(needs) }}
 
   test-query-service:
     name: Legacy (Query Service) Python unit tests
     timeout-minutes: 15 # do not raise! running longer than this indicates an issue with the tests. fix there.
     needs:
+      - check-which-tests-to-run
       - build-container-query-service
     # runs-on: [self-hosted, gke-runner]
     runs-on: ubuntu-latest
-    needs: check-which-tests-to-run
     if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
     strategy:
       fail-fast: false
@@ -120,7 +120,7 @@ jobs:
           .
 
   test-query-service-dummy:
-    name: "SKIPPED: Legacy (Query Service) Python unit tests"
+    name: 'SKIPPED: Legacy (Query Service) Python unit tests'
     if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_query_tests
     runs-on: ubuntu-latest
     steps:
@@ -167,7 +167,7 @@ jobs:
           yarn run tsc
 
   weavejs-lint-compile-dummy:
-    name: "SKIPPED: WeaveJS Lint and Compile"
+    name: 'SKIPPED: WeaveJS Lint and Compile'
     if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_js_tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,120 +58,119 @@ jobs:
         if: steps.build_check.outputs.build_needed == 'true'
         run: python3 weave/docker/docker_build.py build_deps weave-test-python-query-service builder . weave_query/Dockerfile.ci.test
 
-  # test-query-service:
-  #   name: Legacy (Query Service) Python unit tests
-  #   timeout-minutes: 15 # do not raise! running longer than this indicates an issue with the tests. fix there.
-  #   needs:
-  #     - check-which-tests-to-run
-  #     - build-container-query-service
-  #   # runs-on: [self-hosted, gke-runner]
-  #   runs-on: ubuntu-latest
-  #   if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       job_num: [0, 1]
-  #   # runs-on: ubuntu-latest
-  #   container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test-python-query-service:${{ github.sha }}
-  #   services:
-  #     wandbservice:
-  #       image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
-  #       credentials:
-  #         username: _json_key
-  #         password: ${{ secrets.gcp_wb_sa_key }}
-  #       env:
-  #         CI: 1
-  #         WANDB_ENABLE_TEST_CONTAINER: true
-  #       ports:
-  #         - '8080:8080'
-  #         - '8083:8083'
-  #         - '9015:9015'
-  #       options: --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" --health-interval=5s --health-timeout=3s
-  #   steps:
-  #     # - uses: datadog/agent-github-action@v1.3
-  #     #   with:
-  #     #     api_key: ${{ secrets.DD_API_KEY }}
-  #     - uses: actions/checkout@v2
-  #     - name: Verify wandb server is running
-  #       run: curl -s http://wandbservice:8080/healthz
-  #     - name: Run Legacy (Query Service) Python Unit Tests
-  #       env:
-  #         DD_SERVICE: weave-python
-  #         DD_ENV: ci
-  #         WEAVE_SENTRY_ENV: ci
-  #         CI: 1
-  #         WB_SERVER_HOST: http://wandbservice
-  #         WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
-  #       run: |
-  #         source /root/venv/bin/activate && \
-  #         cd weave_query && \
-  #         pytest \
-  #         --job-num=${{ matrix.job_num }} \
-  #         --timeout=90 \
-  #         --ddtrace \
-  #         --durations=5 \
-  #         .
+  test-query-service:
+    name: Legacy (Query Service) Python unit tests
+    timeout-minutes: 15 # do not raise! running longer than this indicates an issue with the tests. fix there.
+    needs:
+      - check-which-tests-to-run
+      - build-container-query-service
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        job_num: [0, 1]
+    # runs-on: ubuntu-latest
+    container: us-east4-docker.pkg.dev/weave-support-367421/weave-images/weave-test-python-query-service:${{ github.sha }}
+    services:
+      wandbservice:
+        image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
+        credentials:
+          username: _json_key
+          password: ${{ secrets.gcp_wb_sa_key }}
+        env:
+          CI: 1
+          WANDB_ENABLE_TEST_CONTAINER: true
+        ports:
+          - '8080:8080'
+          - '8083:8083'
+          - '9015:9015'
+        options: --health-cmd "curl --fail http://localhost:8080/healthz || exit 1" --health-interval=5s --health-timeout=3s
+    outputs:
+      tests_should_run: ${{ steps.test_check.outputs.tests_should_run }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check if tests should run
+        id: test_check
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" || "${{ needs.check-which-tests-to-run.outputs.weave_query_tests }}" == "true" ]]; then
+            echo "Tests should run"
+            echo "tests_should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tests should not run"
+            echo "tests_should_run=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Verify wandb server is running
+        if: steps.test_check.outputs.tests_should_run == 'true'
+        run: curl -s http://wandbservice:8080/healthz
+      - name: Run Legacy (Query Service) Python Unit Tests
+        if: steps.test_check.outputs.tests_should_run == 'true'
+        env:
+          DD_SERVICE: weave-python
+          DD_ENV: ci
+          WEAVE_SENTRY_ENV: ci
+          CI: 1
+          WB_SERVER_HOST: http://wandbservice
+          WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
+        run: |
+          source /root/venv/bin/activate && \
+          cd weave_query && \
+          pytest \
+          --job-num=${{ matrix.job_num }} \
+          --timeout=90 \
+          --ddtrace \
+          --durations=5 \
+          .
 
-  # test-query-service-matrix-check: # This job does nothing and is only used for the branch protection
-  #   if: always()
+  test-query-service-matrix-check: # This job does nothing and is only used for the branch protection
+    if: always()
 
-  #   needs:
-  #     - test-query-service
+    needs:
+      - test-query-service
 
-  #   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Passes if all test-query-service jobs succeeded
-  #       uses: re-actors/alls-green@release/v1
-  #       with:
-  #         jobs: ${{ toJSON(needs) }}
+    steps:
+      - name: Passes if all test-query-service jobs succeeded
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
 
-  # # ==== Weave UI Jobs ====
-  # weavejs-lint-compile:
-  #   name: WeaveJS Lint and Compile
-  #   runs-on: ubuntu-latest
-  #   needs: check-which-tests-to-run
-  #   if: github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests
-  #   # runs-on: [self-hosted, gke-runner]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #       with:
-  #         fetch-depth: 0
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: '18.x'
-  #     - run: |
-  #         set -e
-  #         cd weave-js
-  #         yarn install --frozen-lockfile
-  #         yarn generate
-  #         yarn eslint --max-warnings=0
-  #         yarn tslint
-  #         yarn prettier
-  #         yarn run tsc
-
-  # weavejs-lint-compile-dummy:
-  #   name: 'SKIPPED: WeaveJS Lint and Compile'
-  #   if: github.ref != 'refs/heads/master' && !needs.check-which-tests-to-run.outputs.weave_js_tests
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - run: |
-  #         echo "Skipping build-container-query-service-dummy"
-
-  # weavejs-lint-compile-matrix-check: # This job does nothing and is only used for the branch protection
-  #   if: always()
-  #   needs:
-  #     - check-which-tests-to-run
-  #     - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests) && 'weavejs-lint-compile' || 'weavejs-lint-compile-dummy' }}
-
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Passes if all weavejs-lint-compile jobs succeeded
-  #       uses: re-actors/alls-green@release/v1
-  #       with:
-  #         jobs: ${{ toJSON(needs) }}
+  # ==== Weave UI Jobs ====
+  weavejs-lint-compile:
+    name: WeaveJS Lint and Compile
+    runs-on: ubuntu-latest
+    needs:
+      - check-which-tests-to-run
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if lint and compile should run
+        id: check_run
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/master" || "${{ needs.check-which-tests-to-run.outputs.weave_js_tests }}" == "true" ]]; then
+            echo "Lint and compile should run"
+            echo "should_lint_and_compile=true" >> $GITHUB_OUTPUT
+          else
+            echo "Lint and compile should not run"
+            echo "should_lint_and_compile=false" >> $GITHUB_OUTPUT
+          fi
+      - uses: actions/setup-node@v1
+        if: steps.check_run.outputs.should_lint_and_compile == 'true'
+        with:
+          node-version: '18.x'
+      - name: Run WeaveJS Lint and Compile
+        if: steps.check_run.outputs.should_lint_and_compile == 'true'
+        run: |
+          set -e
+          cd weave-js
+          yarn install --frozen-lockfile
+          yarn generate
+          yarn eslint --max-warnings=0
+          yarn tslint
+          yarn prettier
+          yarn run tsc
 
   # ==== Trace Jobs ====
   lint:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -49,6 +49,7 @@ jobs:
     steps:
 
   build-container-query-service-matrix-check: # This job does nothing and is only used for the branch protection
+    if: always()
     needs:
       - check-which-tests-to-run
       - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests) && 'build-container-query-service' || 'build-container-query-service-dummy' }}
@@ -121,6 +122,7 @@ jobs:
     steps:
 
   test-query-service-matrix-check: # This job does nothing and is only used for the branch protection
+    if: always()
     needs:
       - check-which-tests-to-run
       - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_query_tests) && 'test-query-service' || 'test-query-service-dummy' }}
@@ -165,7 +167,6 @@ jobs:
 
   weavejs-lint-compile-matrix-check: # This job does nothing and is only used for the branch protection
     if: always()
-
     needs:
       - check-which-tests-to-run
       - ${{ (github.ref == 'refs/heads/master' || needs.check-which-tests-to-run.outputs.weave_js_tests) && 'weavejs-lint-compile' || 'weavejs-lint-compile-dummy' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,9 @@ on:
   push:
 
 jobs:
+  check-which-tests-to-run:
+    uses: ./.github/workflows/check-which-tests-to-run.yaml
+
   # ==== Query Service Jobs ====
   build-container-query-service:
     name: Build Legacy (Query Service) test container
@@ -20,6 +23,8 @@ jobs:
     # runs-on: ubuntu-latest
     env:
       REGISTRY: us-east4-docker.pkg.dev/weave-support-367421/weave-images
+    needs: check-which-tests-to-run
+    if: needs.check-which-tests-to-run.outputs.core_integration_tests
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,6 +50,8 @@ jobs:
       - build-container-query-service
     # runs-on: [self-hosted, gke-runner]
     runs-on: ubuntu-latest
+    needs: check-which-tests-to-run
+    if: needs.check-which-tests-to-run.outputs.core_integration_tests
     strategy:
       fail-fast: false
       matrix:
@@ -91,10 +98,10 @@ jobs:
           .
 
   test-query-service-matrix-check: # This job does nothing and is only used for the branch protection
-    if: always()
-
     needs:
       - test-query-service
+      - check-which-tests-to-run
+    if: needs.check-which-tests-to-run.outputs.weave_query_tests
 
     runs-on: ubuntu-latest
 
@@ -108,6 +115,8 @@ jobs:
   weavejs-lint-compile:
     name: WeaveJS Lint and Compile
     runs-on: ubuntu-latest
+    needs: check-which-tests-to-run
+    if: needs.check-which-tests-to-run.outputs.weave_js_tests
     # runs-on: [self-hosted, gke-runner]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
1. Conditionally runs tests based on which dirs have changed.
2. Updates the notify job payload to also include a signal for whether or not core integration tests should be run.  Core is always notified and the commit is always added, but tests are conditionally run based on the payload


This PR cannot be fully tested e2e until both sides are merged into master because `repository_dispatch` only applies on the master branch (of core), but I have tested the individual pieces and it seems to work

Companion to: https://github.com/wandb/core/pull/24362