### PR TITLE
fix: tool call text overflow

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ToolCalls.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ToolCalls.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import Prism from 'prismjs';
+import React, {useEffect, useRef} from 'react';
 
 import {Alert} from '../../../../../Alert';
 import {ToolCall} from './types';
@@ -8,6 +9,13 @@ type OneToolCallProps = {
 };
 
 const OneToolCall = ({toolCall}: OneToolCallProps) => {
+  const ref = useRef<HTMLElement>(null);
+  useEffect(() => {
+    if (ref.current) {
+      Prism.highlightElement(ref.current!);
+    }
+  });
+
   const {function: toolCallFunction} = toolCall;
   const {name, arguments: args} = toolCallFunction;
   let parsedArgs: any = null;
@@ -21,9 +29,14 @@ const OneToolCall = ({toolCall}: OneToolCallProps) => {
     // The model does not always generate valid JSON
     return <Alert severity="error">Invalid JSON: {args}</Alert>;
   }
+
   return (
-    <code className="whitespace-pre text-xs">
-      {name}({parsedArgs})
+    <code className="whitespace-pre-wrap font-['Inconsolata'] text-sm">
+      {name}(
+      <span ref={ref} className="language-json">
+        {parsedArgs}
+      </span>
+      )
     </code>
   );
 };


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1727885436333269

Wrap text and add syntax highlighting, use standard code font.

Before:
<img width="511" alt="Screenshot 2024-10-02 at 11 46 56 AM" src="https://github.com/user-attachments/assets/56d52cca-3f9c-4dde-8363-0c8bcb10cd71">

After:
<img width="486" alt="Screenshot 2024-10-02 at 12 04 06 PM" src="https://github.com/user-attachments/assets/b2d8f4ce-e3e0-48b3-9c68-018114f6757f">



## Testing

How was this PR tested?
