### PR TITLE
fix(registries): handle loading state for 2 queries separately in PanelHistogramInner 🍒 

### DIFF
--- a/weave-js/src/components/Panel2/PanelStringHistogram.tsx
+++ b/weave-js/src/components/Panel2/PanelStringHistogram.tsx
@@ -169,7 +169,12 @@ const PanelStringHistogramInner: React.FC<
   const isColorable = colorNode.nodeType !== 'void';
   const nodeValueQuery = CGReact.useNodeValue(props.input);
   const data = useMemo(() => {
-    if (nodeValueQuery.loading || (isColorable && colorNodeValue.loading)) {
+    const shouldEject = [
+      nodeValueQuery.loading,
+      isColorable && colorNodeValue.loading,
+      nodeValueQuery.result == null,
+    ].some(Boolean);
+    if (shouldEject) {
       return [];
     }
     if (!isColorable) {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Cherry picking https://github.com/wandb/weave/pull/2540

## Testing

How was this PR tested?
