### PR TITLE
fix: ref alignment in grid cell

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
@@ -581,6 +581,7 @@ export const typeToDataGridColumnSpec = (
             maxWidth,
             minWidth,
             flex: 1,
+            display: 'flex',
             type: colType,
             editable: editable && !disableEdits,
             field: innerKey,


### PR DESCRIPTION
## Description

Missed necessary colspec adjustment in https://github.com/wandb/weave/pull/2455

Before:
<img width="333" alt="Screenshot 2024-10-03 at 5 34 18 PM" src="https://github.com/user-attachments/assets/c9bf2332-ce79-4403-9ab7-9d1fa2767555">

After:
<img width="320" alt="Screenshot 2024-10-03 at 5 35 00 PM" src="https://github.com/user-attachments/assets/3adb7167-3bf2-4a81-93e1-16adbe855282">


## Testing

How was this PR tested?
