### PR TITLE
chore: make op and obj links teal in grid first col

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -18,6 +18,7 @@ import {
 import _ from 'lodash';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import {TEAL_600} from '../../../../../common/css/color.styles';
 import {ErrorPanel} from '../../../../ErrorPanel';
 import {Loading} from '../../../../Loading';
 import {LoadingDots} from '../../../../LoadingDots';
@@ -223,6 +224,7 @@ const ObjectVersionsTable: React.FC<{
               version={obj.versionHash}
               versionIndex={obj.versionIndex}
               fullWidth={true}
+              color={TEAL_600}
             />
           );
         },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -6,6 +6,7 @@ import {
 } from '@mui/x-data-grid-pro';
 import React, {useEffect, useMemo, useState} from 'react';
 
+import {TEAL_600} from '../../../../../common/css/color.styles';
 import {ErrorPanel} from '../../../../ErrorPanel';
 import {Loading} from '../../../../Loading';
 import {LoadingDots} from '../../../../LoadingDots';
@@ -121,6 +122,7 @@ export const FilterableOpVersionsTable: React.FC<{
             version={obj.versionHash}
             versionIndex={obj.versionIndex}
             fullWidth={true}
+            color={TEAL_600}
           />
         );
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -226,6 +226,7 @@ export const OpVersionLink: React.FC<{
   versionIndex: number;
   variant?: LinkVariant;
   fullWidth?: boolean;
+  color?: string;
 }> = props => {
   const history = useHistory();
   const {peekingRouter} = useWeaveflowRouteContext();
@@ -243,7 +244,10 @@ export const OpVersionLink: React.FC<{
     history.push(to);
   };
   return (
-    <LinkWrapper onClick={onClick} fullWidth={props.fullWidth}>
+    <LinkWrapper
+      onClick={onClick}
+      fullWidth={props.fullWidth}
+      color={props.color}>
       <LinkTruncater fullWidth={props.fullWidth}>
         <Link $variant={props.variant} to={to}>
           {text}


### PR DESCRIPTION
## Description

Internal Notion: https://www.notion.so/wandbai/Traces-table-d0abd588c49e4a77a213db27af717b4f?pvs=4#10ae2f5c7ef380678bf4df103783509a

Makes Op and Obj links in their respective grids teal. This makes them consistent with Calls grid.

Before:
<img width="230" alt="Screenshot 2024-10-04 at 9 53 03 PM" src="https://github.com/user-attachments/assets/514c5f15-48c5-4ea5-b8d4-98bf6868f28b">
<img width="152" alt="Screenshot 2024-10-04 at 9 52 59 PM" src="https://github.com/user-attachments/assets/9503cdff-8f73-41be-a29e-45d9ab7178dd">

After:
<img width="185" alt="Screenshot 2024-10-04 at 9 52 45 PM" src="https://github.com/user-attachments/assets/f773516e-52ea-47dc-a5a1-3485738c93fa">
<img width="294" alt="Screenshot 2024-10-04 at 9 52 37 PM" src="https://github.com/user-attachments/assets/801d35ff-b3b3-4301-8f8d-7b4e96d1da8c">


## Testing

How was this PR tested?
