### PR TITLE
fix: broken obj grid links

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -211,7 +211,9 @@ const ObjectVersionsTable: React.FC<{
   const {cols: columns, groups: columnGroupingModel} = useMemo(() => {
     let groups: GridColumnGroupingModel = [];
     const cols: GridColDef[] = [
-      basicField('object', 'Object', {
+      // This field name chosen to reduce possibility of conflict
+      // with the dynamic fields added below.
+      basicField('weave__object_version_link', 'Object', {
         hideable: false,
         renderCell: cellParams => {
           // Icon to indicate navigation to the object version


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-21208

https://github.com/wandb/weave/pull/2076 added display of object properties as columns in the grid when viewing all versions. Unfortunately, it is possible that a property name conflicts with the field IDs that are used for the non-dynamic columns, and this was happening for the first column, "object" in this case.

There's certainly a more robust fix possible here, did a quick one in the interests of time.

In the before image, note how the first column is getting overwritten by the "object" column definition from the sixth column due to the field ID conflict. This also generates a bunch of developer console errors.

Before:
<img width="1444" alt="Screenshot 2024-10-04 at 10 12 29 PM" src="https://github.com/user-attachments/assets/5e5e7dce-e2b6-48dd-be84-9dc4e93b60f5">

After:
<img width="1438" alt="Screenshot 2024-10-04 at 10 12 47 PM" src="https://github.com/user-attachments/assets/5b0955ea-3b2f-4aed-bc8d-d34c5d45dc41">



## Testing

How was this PR tested?
