### PR TITLE
chore(ui): Adjust weave0 timestamp resolver and documentation for parity

### DIFF
--- a/weave-js/src/core/ops/primitives/number.test.ts
+++ b/weave-js/src/core/ops/primitives/number.test.ts
@@ -7,7 +7,7 @@ import {
   taggedValue,
 } from '../../model';
 import {testClient} from '../../testUtil';
-import {opNumberFloor} from './number';
+import {opNumberFloor, opNumberToTimestamp} from './number';
 
 describe('number ops', () => {
   describe('floor', () => {
@@ -86,6 +86,44 @@ describe('number ops', () => {
         ]),
       });
       expect(await client.query(expr)).toEqual([1, null, 2]);
+    });
+  });
+
+  describe('timestamp', () => {
+    it('handles a unix timestamp in miliseconds', async () => {
+      const client = await testClient();
+      const expr = opNumberToTimestamp({val: constNumber(1729000000000)});
+      expect(await client.query(expr)).toEqual(1729000000000);
+    });
+
+    it('handles a unix timestamp in microseconds by converting to ms', async () => {
+      const client = await testClient();
+      const expr = opNumberToTimestamp({
+        val: constNumber(1729000000000 * 1000 * 1000),
+      });
+      expect(await client.query(expr)).toEqual(1729000000000);
+    });
+
+    it('handles a unix timestamp in nanoseconds by converting to ms', async () => {
+      const client = await testClient();
+      const expr = opNumberToTimestamp({
+        val: constNumber(1729000000000 * 1000 * 1000 * 1000),
+      });
+      expect(await client.query(expr)).toEqual(1729000000000);
+    });
+
+    it('handles negative numbers', async () => {
+      const client = await testClient();
+      const expr = opNumberToTimestamp({
+        val: constNumber(-1 * 1729000000000 * 1000 * 1000 * 1000),
+      });
+      expect(await client.query(expr)).toEqual(-1729000000000);
+    });
+
+    it('handles a unix timestamp in seconds by doing nothing', async () => {
+      const client = await testClient();
+      const expr = opNumberToTimestamp({val: constNumber(1729000000)});
+      expect(await client.query(expr)).toEqual(1729000000);
     });
   });
 });

--- a/weave_query/weave_query/ops_primitives/number.py
+++ b/weave_query/weave_query/ops_primitives/number.py
@@ -215,6 +215,9 @@ class Number(object):
         output_type=types.Timestamp(),
     )
     def to_timestamp(val):
+        """
+        Converts a number representing unix time in milliseconds to a timestamp.
+        """
         return weave_timestamp.ms_to_python_datetime(
             weave_timestamp.unitless_int_to_inferred_ms(val)
         )

--- a/weave_query/weave_query/ops_primitives/number.py
+++ b/weave_query/weave_query/ops_primitives/number.py
@@ -215,9 +215,6 @@ class Number(object):
         output_type=types.Timestamp(),
     )
     def to_timestamp(val):
-        """
-        Converts a number representing unix time in milliseconds to a timestamp.
-        """
         return weave_timestamp.ms_to_python_datetime(
             weave_timestamp.unitless_int_to_inferred_ms(val)
         )


### PR DESCRIPTION
## Description
[Internal Jira [WB-19303]](https://wandb.atlassian.net/browse/WB-19303)

This PR adds a docstring stating the expected time unit for the to_timestamp op.


[WB-19303]: https://wandb.atlassian.net/browse/WB-19303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ