### PR TITLE
feat: add finish handler for ops

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -82,6 +82,8 @@ def print_call_link(call: "Call") -> None:
 
 FinishCallbackType = Callable[[Any, Optional[BaseException]], None]
 OnOutputHandlerType = Callable[[Any, FinishCallbackType, Dict], Any]
+# Call, original function output, exception if occurred
+OnFinishHandlerType = Callable[["Call", Any, Optional[BaseException]], None]
 
 
 def value_is_sentinel(param: Any) -> bool:
@@ -149,6 +151,9 @@ class Op(Protocol):
     _set_on_output_handler: Callable[[OnOutputHandlerType], None]
     _on_output_handler: Optional[OnOutputHandlerType]
 
+    _set_on_finish_handler: Callable[[OnFinishHandlerType], None]
+    _on_finish_handler: Optional[OnFinishHandlerType]
+
     __call__: Callable[..., Any]
     __self__: Any
 
@@ -166,6 +171,12 @@ def _set_on_output_handler(func: Op, on_output: OnOutputHandlerType) -> None:
     if func._on_output_handler is not None:
         raise ValueError("Cannot set on_output_handler multiple times")
     func._on_output_handler = on_output
+
+
+def _set_on_finish_handler(func: Op, on_finish: OnFinishHandlerType) -> None:
+    if func._on_finish_handler is not None:
+        raise ValueError("Cannot set on_finish_handler multiple times")
+    func._on_finish_handler = on_finish
 
 
 def _is_unbound_method(func: Callable) -> bool:
@@ -232,6 +243,7 @@ def _execute_call(
             output,
             exception,
             postprocess_output=__op.postprocess_output,
+            op=__op,
         )
         if not call_context.get_current_call():
             print_call_link(call)
@@ -496,6 +508,9 @@ def op(
 
             wrapper._set_on_output_handler = partial(_set_on_output_handler, wrapper)  # type: ignore
             wrapper._on_output_handler = None  # type: ignore
+
+            wrapper._set_on_finish_handler = partial(_set_on_finish_handler, wrapper)  # type: ignore
+            wrapper._on_finish_handler = None  # type: ignore
 
             wrapper._tracing_enabled = True  # type: ignore
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -242,7 +242,6 @@ def _execute_call(
             call,
             output,
             exception,
-            postprocess_output=__op.postprocess_output,
             op=__op,
         )
         if not call_context.get_current_call():

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -712,13 +712,12 @@ class WeaveClient:
         output: Any = None,
         exception: Optional[BaseException] = None,
         *,
-        postprocess_output: Optional[Callable[..., Any]] = None,
         op: Optional[Op] = None,
     ) -> None:
         original_output = output
 
-        if postprocess_output:
-            postprocessed_output = postprocess_output(original_output)
+        if op is not None and op.postprocess_output:
+            postprocessed_output = op.postprocess_output(original_output)
         else:
             postprocessed_output = original_output
         self._save_nested_objects(postprocessed_output)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -748,6 +748,19 @@ class WeaveClient:
             if isinstance(usage, dict) and isinstance(model, str):
                 summary["usage"] = {}
                 summary["usage"][model] = {"requests": 1, **usage}
+
+        # JR Oct 24 - This descendants stats code has been commented out since
+        # it entered the code base. A screenshot of the non-ideal UI that the
+        # comment refers to is available in the description of that PR:
+        # https://github.com/wandb/weave/pull/1414
+        # These should probably be added under the "weave" key in the summary.
+        # ---
+        # Descendent error tracking disabled til we fix UI
+        # Add this call's summary after logging the call, so that only
+        # descendents are included in what we log
+        # summary.setdefault("descendants", {}).setdefault(
+        #     call.op_name, {"successes": 0, "errors": 0}
+        # )["successes"] += 1
         call.summary = summary
 
         # Exception Handling


### PR DESCRIPTION
## Description

Adds the ability to set a "finish" handler on an Op. The intended use is as an extension point for integrations. For example, I intend to use this functionality in the Gemini integration to copy information about token usage from the Gemini call response object (whose structure only the Gemini integration should have to know anything about) into our standard token usage format in the call's summary dictionary.

## Testing

How was this PR tested?
