### PR TITLE
fix(weave_query): Handle paths with colons when escaping artifact path

### DIFF
--- a/weave_query/tests/test_wb.py
+++ b/weave_query/tests/test_wb.py
@@ -1776,16 +1776,66 @@ def test_is_valid_version_string():
     for v in ["v01", "v0009"]:
         assert not artifact_wandb.is_valid_version_index(v)
 
+class TestEscapeArtifactPath:
+    wandb_prefix = "wandb-client-artifact://"
+    artifact_name = "12347187287418787843872388177814"
+    file_path = "table #3.table.json"
+    file_path_with_colon = "(batch: 1) table #3.table.json"
+    version = "latest"
+    # version_with_colon = "latest:v0"
 
-def test_artifact_path_character_escaping():
-    name = 12347187287418787843872388177814
-    path = "table #3.table.json"
-    result = wb_util.escape_artifact_path(
-        f"wandb-client-artifact://{name}:latest/{path}"
-    )
-    uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
+    def test_standard_artifact_path(self):
+        """
+        Artifact path of the form: "<name>:<version>/<path>" should be escaped properly.
+        """
+        result = wb_util.escape_artifact_path(
+            f"{self.wandb_prefix}{self.artifact_name}:{self.version}/{self.file_path}"
+        )
+        uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
+        assert uri.path == self.file_path
 
-    assert uri.path == path
+    def test_artifact_path_with_no_version(self):
+        """
+        Artifact path of the form: "<name>/<path>" should be escaped properly.
+        """
+        result = wb_util.escape_artifact_path(
+            f"{self.wandb_prefix}{self.artifact_name}/{self.file_path}"
+        )
+        uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
+        assert uri.path == self.file_path
+
+    def test_artifact_path_with_version_and_file_with_colon(self):
+        """
+        Artifact path of the form: "<name>:<version>/<path>" should be escaped properly,
+        where <path> contains a colon.
+        """
+        result = wb_util.escape_artifact_path(
+            f"{self.wandb_prefix}{self.artifact_name}:{self.version}/{self.file_path_with_colon}"
+        )
+        uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
+        assert uri.path == self.file_path_with_colon
+
+    def test_artifact_path_with_no_version_and_file_with_colon(self):
+        """
+        Artifact path of the form: "<name>/<path>" should be escaped properly,
+        where <path> contains a colon.
+        """
+        result = wb_util.escape_artifact_path(
+            f"{self.wandb_prefix}{self.artifact_name}/{self.file_path_with_colon}"
+        )
+        uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
+        assert uri.path == self.file_path_with_colon
+
+    # def test_artifact_path_with_version_with_colon_and_file_with_colon(self):
+    #     """
+    #     Artifact path of the form: "<name>:<version>/<path>" should be escaped properly,
+    #     where <version> contains a colon and <path> contains a colon.
+    #     """
+    #     result = wb_util.escape_artifact_path(
+    #         f"{self.wandb_prefix}{self.artifact_name}:{self.version_with_colon}/{self.file_path_with_colon}"
+    #     )
+    #     uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
+    #     assert uri.path == self.file_path_with_colon
 
 
 def _do_test_gql_artifact_dir_path(node):

--- a/weave_query/tests/test_wb.py
+++ b/weave_query/tests/test_wb.py
@@ -1782,7 +1782,7 @@ class TestEscapeArtifactPath:
     file_path = "table #3.table.json"
     file_path_with_colon = "(batch: 1) table #3.table.json"
     version = "latest"
-    # version_with_colon = "latest:v0"
+    version_with_colon = "latest:v0"
 
     def test_standard_artifact_path(self):
         """
@@ -1826,16 +1826,16 @@ class TestEscapeArtifactPath:
         uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
         assert uri.path == self.file_path_with_colon
 
-    # def test_artifact_path_with_version_with_colon_and_file_with_colon(self):
-    #     """
-    #     Artifact path of the form: "<name>:<version>/<path>" should be escaped properly,
-    #     where <version> contains a colon and <path> contains a colon.
-    #     """
-    #     result = wb_util.escape_artifact_path(
-    #         f"{self.wandb_prefix}{self.artifact_name}:{self.version_with_colon}/{self.file_path_with_colon}"
-    #     )
-    #     uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
-    #     assert uri.path == self.file_path_with_colon
+    def test_artifact_path_with_version_with_colon_and_file_with_colon(self):
+        """
+        Artifact path of the form: "<name>:<version>/<path>" should be escaped properly,
+        where <version> contains a colon and <path> contains a colon.
+        """
+        result = wb_util.escape_artifact_path(
+            f"{self.wandb_prefix}{self.artifact_name}:{self.version_with_colon}/{self.file_path_with_colon}"
+        )
+        uri = artifact_wandb.WeaveWBLoggedArtifactURI.parse(result)
+        assert uri.path == self.file_path_with_colon
 
 
 def _do_test_gql_artifact_dir_path(node):

--- a/weave_query/weave_query/artifact_wandb.py
+++ b/weave_query/weave_query/artifact_wandb.py
@@ -1031,7 +1031,7 @@ class WeaveWBLoggedArtifactURI(uris.WeaveURI):
         fragment: str,
     ):
         path = parse.unquote(path.strip("/"))
-        spl_netloc = netloc.split(":")
+        spl_netloc = netloc.split(":", 1)
         if len(spl_netloc) == 1:
             name = spl_netloc[0]
             version = None

--- a/weave_query/weave_query/ops_domain/wb_util.py
+++ b/weave_query/weave_query/ops_domain/wb_util.py
@@ -58,12 +58,16 @@ def escape_artifact_path(artifact_path: str) -> str:
     prefix = "wandb-client-artifact://"
     if artifact_path.startswith(prefix):
         artifact_path = artifact_path[len(prefix) :]
-        if ":" in artifact_path:
-            name, version_path = artifact_path.split(":", 1)
-            version, path = version_path.split("/", 1)
+        parts = artifact_path.split("/", 1)
+        name_version = parts[0]
+        path = parts[1] if len(parts) > 1 else ""
+
+        if ":" in name_version:
+            name, version = name_version.split(":", 1)
         else:
+            name = name_version
             version = None
-            name, path = artifact_path.split("/", 1)
+
         path = parse.quote(path, safe="")
         version_string = f":{version}" if version is not None else ""
         artifact_path = f"{prefix}{name}{version_string}/{path}"


### PR DESCRIPTION
## Description

JIRA: [WB-21299](https://wandb.atlassian.net/browse/WB-21299)

When the artifact URI does not have a version, but the path has a colon (`:`), our current implementation to find the path will mistakenly treat part of it as the version string. Instead of splitting on the version delimiter (`:`) and then trying to find the path, we can reverse the order and split on the path delimiter (`/`) first, allowing paths to include `:`.

The PR also updates the tests to include the following cases:
* Standard artifact path: `<name>:<version>/<path>`
* No version and path does not have `:`
* With version and path has `:`
* No version and path has `:` (this is the case we were previously erroring on)

## Testing

* Added unit tests 
* Verified that `test_zlib_playback` now passes





[WB-21299]: https://wandb.atlassian.net/browse/WB-21299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ