### PR TITLE
chore: move Usage table in Call summary

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -110,7 +110,11 @@ const useCallTabs = (call: CallSchema) => {
     },
     {
       label: 'Summary',
-      content: <CallSummary call={call} />,
+      content: (
+        <Tailwind style={{height: '100%', overflow: 'auto'}}>
+          <CallSummary call={call} />
+        </Tailwind>
+      ),
     },
     {
       label: 'Use',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -1,4 +1,3 @@
-import {Divider} from '@mui/material';
 import _ from 'lodash';
 import React from 'react';
 
@@ -32,7 +31,22 @@ export const CallSummary: React.FC<{
   );
 
   return (
-    <div style={{padding: 8, overflow: 'auto'}}>
+    <div className="overflow-auto px-16 pt-12">
+      {span.summary.usage && (
+        <div className="mb-16">
+          {/* This styling is similar to what is is SimpleKeyValueTable */}
+          <p
+            className="mb-10"
+            style={{
+              fontWeight: 600,
+              marginRight: 10,
+              paddingRight: 10,
+            }}>
+            Usage
+          </p>
+          <CostTable usage={span.summary.usage as {[key: string]: UsageData}} />
+        </div>
+      )}
       <SimpleKeyValueTable
         data={{
           Operation:
@@ -63,25 +77,6 @@ export const CallSummary: React.FC<{
           ...(Object.keys(summary).length > 0 ? {Summary: summary} : {}),
         }}
       />
-      {span.summary.usage && (
-        <>
-          <Divider sx={{marginY: '16px'}} />
-          <div>
-            {/* This styling is similar to what is is SimpleKeyValueTable */}
-            <p
-              style={{
-                fontWeight: 600,
-                marginRight: 10,
-                paddingRight: 10,
-              }}>
-              Usage
-            </p>
-            <CostTable
-              usage={span.summary.usage as {[key: string]: UsageData}}
-            />
-          </div>
-        </>
-      )}
     </div>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CostTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CostTable.tsx
@@ -21,30 +21,35 @@ const columns: GridColDef[] = [
   {
     field: 'requests',
     headerName: 'Requests',
+    headerAlign: 'right',
     flex: 2,
     renderCell: renderNumberCell,
   },
   {
     field: 'prompt_tokens',
     headerName: 'Input tokens',
+    headerAlign: 'right',
     flex: 3,
     renderCell: renderNumberCell,
   },
   {
     field: 'completion_tokens',
     headerName: 'Output tokens',
+    headerAlign: 'right',
     flex: 3,
     renderCell: renderNumberCell,
   },
   {
     field: 'total_tokens',
     headerName: 'Total tokens',
+    headerAlign: 'right',
     flex: 3,
     renderCell: renderNumberCell,
   },
   {
     field: 'cost',
     headerName: 'Total Cost',
+    headerAlign: 'right',
     flex: 3,
     renderCell: (params: GridRenderCellParams) => (
       <Box sx={{textAlign: 'right', width: '100%'}}>


### PR DESCRIPTION
## Description

Partial update of call summary tab, incremental progress towards internal Figma:
https://www.notion.so/wandbai/Trace-drawer-items-43c3106f7d2848758d02f89cee2b3540?pvs=4#10ae2f5c7ef3808e8e5de7424dfa0584

Moved usage data to top, adjusted padding. I also right aligned the numeric column headers to match column data.

Before:
<img width="705" alt="Screenshot 2024-10-09 at 12 32 08 PM" src="https://github.com/user-attachments/assets/a1b98c4d-fbc3-40e3-90a8-baf66be21579">

After:
<img width="702" alt="Screenshot 2024-10-09 at 12 31 36 PM" src="https://github.com/user-attachments/assets/d095b69c-3b1d-480c-9e7b-26db6c4cdbae">

## Testing

How was this PR tested?
