### PR TITLE
chore(dev): fix sentry dedupe of useNodevalue error

### DIFF
--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import {
   callOpVeryUnsafe,
   Client,
@@ -48,6 +47,7 @@ import {
   useState,
 } from 'react';
 
+import {captureAndThrowError} from './common/util/sentry';
 import {WEAVE_REF_PREFIX} from './components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants';
 import {PanelCompContext} from './components/Panel2/PanelComp';
 import {usePanelContext} from './components/Panel2/PanelContext';
@@ -352,12 +352,11 @@ export const useNodeValue = <T extends Type>(
     // Just rethrow the error in the render thread so it can be caught
     // by an error boundary.
     if (error != null) {
-      const message =
-        'Node execution failed (useNodeValue): ' + errorToText(error);
-      // console.error(message);
+      const message = `Node execution failed (useNodeValue): ${errorToText(
+        error
+      )}`;
       const err = new UseNodeValueServerExecutionError(message);
-      Sentry.captureException(err, {fingerprint: ['useNodeValue']});
-      throw err;
+      captureAndThrowError(err, {fingerprint: ['useNodeValue']});
     }
     if (isConstNode(node)) {
       if (isFunction(node.type)) {


### PR DESCRIPTION
## Description

Dedupes the recording of the `useNodeValue` error in sentry. Uses a helper to throw the error with a suffix attached that causes the sentry capture at the error boundary to be ignored since we have already captured the error.