### PR TITLE
chore: small hack fix for objects page when reading huge objects

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -104,16 +104,20 @@ const ObjectVersionPageInner: React.FC<{
   const objectName = objectVersion.objectId;
   const objectVersionIndex = objectVersion.versionIndex;
   const refExtra = objectVersion.refExtra;
-  const objectVersions = useRootObjectVersions(
+  const latestObjectVersion = useRootObjectVersions(
     entityName,
     projectName,
     {
       objectIds: [objectName],
     },
-    undefined,
+    1,
+    // HACK, grab the latest version and version_index as count
+    [{field: 'created_at', direction: 'desc'}],
     true
   );
-  const objectVersionCount = (objectVersions.result ?? []).length;
+  const objectVersionCount = latestObjectVersion.result?.[0]?.versionIndex
+    ? latestObjectVersion.result?.[0]?.versionIndex + 1
+    : 0;
   const baseObjectClass = useMemo(() => {
     if (objectVersion.baseObjectClass === 'Dataset') {
       return 'Dataset';
@@ -200,7 +204,7 @@ const ObjectVersionPageInner: React.FC<{
             [refExtra ? 'Parent Object' : 'Name']: (
               <>
                 {objectName}{' '}
-                {objectVersions.loading ? (
+                {latestObjectVersion.loading ? (
                   <LoadingDots />
                 ) : (
                   <>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -133,6 +133,7 @@ export const FilterableObjectVersionsTable: React.FC<{
       latestOnly: effectivelyLatestOnly,
     },
     undefined,
+    undefined,
     effectivelyLatestOnly // metadata only when getting latest
   );
 
@@ -401,6 +402,7 @@ const PeerVersionsLink: React.FC<{obj: ObjectVersionSchema}> = props => {
       objectIds: [obj.objectId],
     },
     100,
+    undefined,
     true // metadataOnly
   );
   if (objectVersionsNode.loading) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -913,6 +913,7 @@ const useRootObjectVersions = makeTraceServerEndpointHook(
     project: string,
     filter: ObjectVersionFilter,
     limit?: number,
+    sortBy?: traceServerTypes.SortBy[],
     metadataOnly?: boolean,
     opts?: {skip?: boolean}
   ) => ({
@@ -925,6 +926,7 @@ const useRootObjectVersions = makeTraceServerEndpointHook(
         is_op: false,
       },
       limit,
+      sort_by: sortBy,
       metadata_only: metadataOnly,
     },
     skip: opts?.skip,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -239,6 +239,7 @@ export type WFDataModelHooksInterface = {
     project: string,
     filter: ObjectVersionFilter,
     limit?: number,
+    sortBy?: traceServerClientTypes.SortBy[],
     metadataOnly?: boolean,
     opts?: {skip?: boolean}
   ) => LoadableWithError<ObjectVersionSchema[]>;


### PR DESCRIPTION
This pr:
- adds sort_by to the fields in `useRootObjectVersions`
- In the `ObjectsVersionsPage` instead of querying for all objects and counting, lets just grab the latest object and use its `version_index`. 