### PR TITLE
feat: Add display_name to ops

### DIFF
--- a/docs/docs/guides/core-types/evaluations.md
+++ b/docs/docs/guides/core-types/evaluations.md
@@ -118,6 +118,13 @@ evaluation = Evaluation(
 
 You can also change the name of individual evaluations by setting the `display_name` key of the `__weave` dictionary.
 
+:::note
+
+Using the `__weave` dictionary sets the call display name which is distinct from the Evaluation object name. In the
+UI, you will see the display name if set, otherwise the Evaluation object name will be used.
+
+:::
+
 ```python
 evaluation = Evaluation(
     dataset=examples, scorers=[match_score1]

--- a/docs/docs/guides/core-types/evaluations.md
+++ b/docs/docs/guides/core-types/evaluations.md
@@ -116,13 +116,13 @@ evaluation = Evaluation(
 )
 ```
 
-You can also change the name of individual evaluations by setting the `display_name` key of the `_weave_` dictionary.
+You can also change the name of individual evaluations by setting the `display_name` key of the `__weave` dictionary.
 
 ```python
 evaluation = Evaluation(
     dataset=examples, scorers=[match_score1]
 )
-evaluation.evaluate(model, _weave_={"display_name": "My Evaluation Run"})
+evaluation.evaluate(model, __weave={"display_name": "My Evaluation Run"})
 ```
 
 ### Define a function to evaluate

--- a/docs/docs/guides/core-types/evaluations.md
+++ b/docs/docs/guides/core-types/evaluations.md
@@ -106,6 +106,25 @@ asyncio.run(evaluation.evaluate(model))
 
 This will run `predict` on each example and score the output with each scoring functions.
 
+#### Custom Naming
+
+You can change the name of the Evaluation itself by passing a `name` parameter to the `Evaluation` class.
+
+```python
+evaluation = Evaluation(
+    dataset=examples, scorers=[match_score1], name="My Evaluation"
+)
+```
+
+You can also change the name of individual evaluations by setting the `display_name` key of the `_weave_` dictionary.
+
+```python
+evaluation = Evaluation(
+    dataset=examples, scorers=[match_score1]
+)
+evaluation.evaluate(model, _weave_={"display_name": "My Evaluation Run"})
+```
+
 ### Define a function to evaluate
 
 Alternatively, you can also evaluate a function that is wrapped in a `@weave.op()`.

--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -104,7 +104,13 @@ instance.my_method.call(instance, "World")
 
 #### Call Display Name
 
-Sometimes you may want to override the display name of a call. You can achieve this in one of three ways:
+Sometimes you may want to override the display name of a call. You can achieve this in one of four ways:
+
+0. Change the display name at the time of calling the op:
+
+```python showLineNumbers
+result = my_function("World", _weave_={"display_name": "My Custom Display Name"})
+```
 
 1. Change the display name on a per-call basis. This uses the [`Op.call`](../../reference/python-sdk/weave/trace/weave.trace.op.md#function-call) method to return a `Call` object, which you can then use to set the display name using [`Call.set_display_name`](../../reference/python-sdk/weave/trace/weave.trace.weave_client.md#method-set_display_name).
 ```python showLineNumbers

--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -109,7 +109,7 @@ Sometimes you may want to override the display name of a call. You can achieve t
 0. Change the display name at the time of calling the op:
 
 ```python showLineNumbers
-result = my_function("World", _weave_={"display_name": "My Custom Display Name"})
+result = my_function("World", __weave={"display_name": "My Custom Display Name"})
 ```
 
 1. Change the display name on a per-call basis. This uses the [`Op.call`](../../reference/python-sdk/weave/trace/weave.trace.op.md#function-call) method to return a `Call` object, which you can then use to set the display name using [`Call.set_display_name`](../../reference/python-sdk/weave/trace/weave.trace.weave_client.md#method-set_display_name).

--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -112,6 +112,12 @@ Sometimes you may want to override the display name of a call. You can achieve t
 result = my_function("World", __weave={"display_name": "My Custom Display Name"})
 ```
 
+:::note
+
+Using the `__weave` dictionary sets the call display name which will take precedence over the Op display name.
+
+:::
+
 1. Change the display name on a per-call basis. This uses the [`Op.call`](../../reference/python-sdk/weave/trace/weave.trace.op.md#function-call) method to return a `Call` object, which you can then use to set the display name using [`Call.set_display_name`](../../reference/python-sdk/weave/trace/weave.trace.weave_client.md#method-set_display_name).
 ```python showLineNumbers
 result, call = my_function.call("World")

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1499,3 +1499,25 @@ def test_object_version_read(client):
                 digest="v1",
             )
         )
+
+
+@pytest.mark.asyncio
+async def test_op_calltime_display_name(client):
+    @weave.op()
+    def my_op(a: int) -> int:
+        return a
+
+    result = my_op(1, _weave_={"display_name": "custom_display_name"})
+    calls = list(my_op.calls())
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.display_name == "custom_display_name"
+
+    evaluation = weave.Evaluation(dataset=[{"a": 1}], scorers=[])
+    res = await evaluation.evaluate(
+        my_op, _weave_={"display_name": "custom_display_name"}
+    )
+    calls = list(evaluation.evaluate.calls())
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.display_name == "custom_display_name"

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1507,7 +1507,7 @@ async def test_op_calltime_display_name(client):
     def my_op(a: int) -> int:
         return a
 
-    result = my_op(1, _weave_={"display_name": "custom_display_name"})
+    result = my_op(1, __weave={"display_name": "custom_display_name"})
     calls = list(my_op.calls())
     assert len(calls) == 1
     call = calls[0]
@@ -1515,7 +1515,7 @@ async def test_op_calltime_display_name(client):
 
     evaluation = weave.Evaluation(dataset=[{"a": 1}], scorers=[])
     res = await evaluation.evaluate(
-        my_op, _weave_={"display_name": "custom_display_name"}
+        my_op, __weave={"display_name": "custom_display_name"}
     )
     calls = list(evaluation.evaluate.calls())
     assert len(calls) == 1

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -32,6 +32,7 @@ from weave.trace.refs import ObjectRef
 
 logger = logging.getLogger(__name__)
 
+WEAVE_KWARGS_KEY = "__weave"
 
 if TYPE_CHECKING:
     from weave.trace.weave_client import Call, CallsIter
@@ -321,7 +322,7 @@ def call(op: Op, *args: Any, **kwargs: Any) -> tuple[Any, "Call"]:
     result, call = add.call(1, 2)
     ```
     """
-    wvkw = kwargs.pop("_weave_", {})
+    wvkw = kwargs.pop(WEAVE_KWARGS_KEY, {})
     c = _create_call(op, *args, _weave_=wvkw, **kwargs)
     return _execute_call(op, c, *args, __should_raise=False, **kwargs)
 
@@ -443,7 +444,7 @@ def op(
 
                 @wraps(func)
                 async def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    wvkw = kwargs.pop("_weave_", {})
+                    wvkw = kwargs.pop(WEAVE_KWARGS_KEY, {})
                     if settings.should_disable_weave():
                         return await func(*args, **kwargs)
                     if weave_client_context.get_weave_client() is None:
@@ -468,7 +469,7 @@ def op(
 
                 @wraps(func)
                 def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    wvkw = kwargs.pop("_weave_", {})
+                    wvkw = kwargs.pop(WEAVE_KWARGS_KEY, {})
                     if settings.should_disable_weave():
                         return func(*args, **kwargs)
                     if weave_client_context.get_weave_client() is None:

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -451,7 +451,7 @@ def op(
 
                 @wraps(func)
                 async def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    __weave: Optional[WeaveKwargs] = kwargs.pop(WEAVE_KWARGS_KEY)
+                    __weave: Optional[WeaveKwargs] = kwargs.pop(WEAVE_KWARGS_KEY, None)
                     if settings.should_disable_weave():
                         return await func(*args, **kwargs)
                     if weave_client_context.get_weave_client() is None:
@@ -476,7 +476,7 @@ def op(
 
                 @wraps(func)
                 def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    __weave: Optional[WeaveKwargs] = kwargs.pop(WEAVE_KWARGS_KEY)
+                    __weave: Optional[WeaveKwargs] = kwargs.pop(WEAVE_KWARGS_KEY, None)
                     if settings.should_disable_weave():
                         return func(*args, **kwargs)
                     if weave_client_context.get_weave_client() is None:

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -323,7 +323,7 @@ def call(op: Op, *args: Any, **kwargs: Any) -> tuple[Any, "Call"]:
     ```
     """
     wvkw = kwargs.pop(WEAVE_KWARGS_KEY, {})
-    c = _create_call(op, *args, _weave_=wvkw, **kwargs)
+    c = _create_call(op, *args, wvkw=wvkw, **kwargs)
     return _execute_call(op, c, *args, __should_raise=False, **kwargs)
 
 


### PR DESCRIPTION
Adds `__weave` dictionary when calling ops that can be used to set settings (to avoid name collisions), in this case `display_name`. Also shows how this can be used to name evals.