### PR TITLE
chore: skip notdiamond in py313

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,14 @@ import nox
 nox.options.default_venv_backend = "uv"
 
 SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
-PY313_INCOMPATIBLE_SHARDS = ["anthropic", "cohere", "dspy", "langchain", "litellm"]
+PY313_INCOMPATIBLE_SHARDS = [
+    "anthropic",
+    "cohere",
+    "dspy",
+    "langchain",
+    "litellm",
+    "notdiamond",
+]
 
 
 @nox.session


### PR DESCRIPTION
## Description

Notdiamond doesn't support python 3.13 yet because `tokenizers` doesn't: 

```
Using Python 3.13.0 environment at .nox/tests-3-13-shard-notdiamond
Resolved 103 packages in 1.76s
error: Failed to prepare distributions
  Caused by: Failed to fetch wheel: tokenizers==0.20.1
  Caused by: Build backend failed to build wheel through `build_wheel` (exit status: 1)
```

[link to failing test](https://github.com/wandb/weave/actions/runs/11278758434/job/31368473846?pr=2665)

