### PR TITLE
fix(ui): Add additional numerical types for table formatting

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/util.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.ts
@@ -33,7 +33,7 @@ import {useTableStateWithRefinedExpressions} from './tableStateReact';
 export const getColumnCellFormats = (colType: Type): WeaveFormatContextType => {
   const t = nullableTaggableStrip(colType);
   const numberFormat =
-    t === 'number'
+    t === 'number' || t === 'float' || t === 'int'
       ? {
           textAlign: 'right' as const,
           justifyContent: 'normal',


### PR DESCRIPTION
## Description

I noticed one of my tables didn't have correct formatting on numerical columns. Didn't realize there were additional numerical types. This PR adds a type check for `float` and `int` to set the column formatting.

**Before**
![image](https://github.com/user-attachments/assets/e8904b33-795a-45be-b503-26d87b4e77a7)

**After**
![image](https://github.com/user-attachments/assets/79caa9c7-b46d-45e3-910e-df60b8c220cf)


## Testing

How was this PR tested?
Visually