### PR TITLE
chore: Cleanup some docs

### DIFF
--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -100,7 +100,7 @@ instance = MyClass()
 print(instance.my_method("World"))
 ```
 
-Sometimes it is useful to get a handle on the `Call` object itself. You can do this by calling the `op.call` method, which returns both the result and the `Call` object. For example:
+Sometimes it is useful to get a handle to the `Call` object itself. You can do this by calling the `op.call` method, which returns both the result and the `Call` object. For example:
 
 ```python showLineNumbers
 result, call = my_function.call("World")
@@ -113,20 +113,8 @@ If your op is a method on a class, you need to pass the instance as the first ar
 :::
 
 ```python showLineNumbers
-import weave
-
-# Initialize Weave Tracing
-weave.init("intro-example")
-
-class MyClass:
-    # Decorate your method
-    @weave.op
-    def my_method(self, name: str):
-        return f"Hello, {name}!"
-
-instance = MyClass()
-
-# Call your method -- Weave will automatically track inputs and outputs
+# Notice that we pass the `instance` as the first argument.
+# highlight-next-line
 print(instance.my_method.call(instance, "World"))
 ```
 

--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -76,12 +76,59 @@ def my_function(name: str):
     return f"Hello, {name}!"
 
 # Call your function -- Weave will automatically track inputs and outputs
-print(my_function.call("World"))
+print(my_function("World"))
 ```
+
+This works for both functions as well as methods on classes:
+
+
+```python showLineNumbers
+import weave
+
+# Initialize Weave Tracing
+weave.init("intro-example")
+
+class MyClass:
+    # Decorate your method
+    @weave.op
+    def my_method(self, name: str):
+        return f"Hello, {name}!"
+
+instance = MyClass()
+
+# Call your method -- Weave will automatically track inputs and outputs
+print(instance.my_method("World"))
+```
+
+Sometimes it is useful to get a handle on the `Call` object itself. You can do this by calling the `op.call` method, which returns both the result and the `Call` object. For example:
+
+```python showLineNumbers
+result, call = my_function.call("World")
+```
+
+Then, `call` can be used to set / update / fetch additional properties (most commonly used to get the ID of the call to be used for feedback).
 
 :::note
 If your op is a method on a class, you need to pass the instance as the first argument to the op (see example below).
 :::
+
+```python showLineNumbers
+import weave
+
+# Initialize Weave Tracing
+weave.init("intro-example")
+
+class MyClass:
+    # Decorate your method
+    @weave.op
+    def my_method(self, name: str):
+        return f"Hello, {name}!"
+
+instance = MyClass()
+
+# Call your method -- Weave will automatically track inputs and outputs
+print(instance.my_method.call(instance, "World"))
+```
 
 
 ```python showLineNumbers
@@ -106,7 +153,7 @@ instance.my_method.call(instance, "World")
 
 Sometimes you may want to override the display name of a call. You can achieve this in one of four ways:
 
-0. Change the display name at the time of calling the op:
+1. Change the display name at the time of calling the op:
 
 ```python showLineNumbers
 result = my_function("World", __weave={"display_name": "My Custom Display Name"})
@@ -118,13 +165,13 @@ Using the `__weave` dictionary sets the call display name which will take preced
 
 :::
 
-1. Change the display name on a per-call basis. This uses the [`Op.call`](../../reference/python-sdk/weave/trace/weave.trace.op.md#function-call) method to return a `Call` object, which you can then use to set the display name using [`Call.set_display_name`](../../reference/python-sdk/weave/trace/weave.trace.weave_client.md#method-set_display_name).
+2. Change the display name on a per-call basis. This uses the [`Op.call`](../../reference/python-sdk/weave/trace/weave.trace.op.md#function-call) method to return a `Call` object, which you can then use to set the display name using [`Call.set_display_name`](../../reference/python-sdk/weave/trace/weave.trace.weave_client.md#method-set_display_name).
 ```python showLineNumbers
 result, call = my_function.call("World")
 call.set_display_name("My Custom Display Name")
 ```
 
-2. Change the display name for all Calls of a given Op:
+3. Change the display name for all Calls of a given Op:
 
 ```python showLineNumbers
 @weave.op(call_display_name="My Custom Display Name")
@@ -132,7 +179,7 @@ def my_function(name: str):
     return f"Hello, {name}!"
 ```
 
-3. The `call_display_name` can also be a function that takes in a `Call` object and returns a string.  The `Call` object will be passed automatically when the function is called, so you can use it to dynamically generate names based on the function's name, call inputs, attributes, etc.
+4. The `call_display_name` can also be a function that takes in a `Call` object and returns a string.  The `Call` object will be passed automatically when the function is called, so you can use it to dynamically generate names based on the function's name, call inputs, attributes, etc.
 
    1. One common use case is just appending a timestamp to the function's name.
 

--- a/docs/docs/reference/gen_notebooks/01-intro_notebook.md
+++ b/docs/docs/reference/gen_notebooks/01-intro_notebook.md
@@ -13,7 +13,6 @@ title: Introduction Notebook
 
 
 
-<img src="http://wandb.me/logo-im-png" width="400" alt="Weights & Biases" />
 <!--- @wandbcode{intro-colab} -->
 
 # 🏃‍♀️ Quickstart

--- a/docs/docs/reference/gen_notebooks/chain_of_density.md
+++ b/docs/docs/reference/gen_notebooks/chain_of_density.md
@@ -13,7 +13,6 @@ title: Chain of Density Summarization
 
 
 
-<img src="http://wandb.me/logo-im-png" width="400" alt="Weights & Biases" />
 <!--- @wandbcode{cod-notebook} -->
 
 # Summarization using Chain of Density

--- a/docs/docs/reference/gen_notebooks/custom_model_cost.md
+++ b/docs/docs/reference/gen_notebooks/custom_model_cost.md
@@ -13,7 +13,6 @@ title: Custom Model Cost
 
 
 
-<img src="http://wandb.me/logo-im-png" width="400" alt="Weights & Biases" />
 <!--- @wandbcode{prompt-optim-notebook} -->
 
 # Setting up a custom cost model

--- a/docs/docs/reference/gen_notebooks/dspy_prompt_optimization.md
+++ b/docs/docs/reference/gen_notebooks/dspy_prompt_optimization.md
@@ -13,7 +13,6 @@ title: Prompt Optimization
 
 
 
-<img src="http://wandb.me/logo-im-png" width="400" alt="Weights & Biases" />
 <!--- @wandbcode{prompt-optim-notebook} -->
 
 # Optimizing LLM Workflows Using DSPy and Weave

--- a/docs/docs/reference/gen_notebooks/feedback_prod.md
+++ b/docs/docs/reference/gen_notebooks/feedback_prod.md
@@ -13,7 +13,6 @@ title: Log Feedback from Production
 
 
 
-<img src="http://wandb.me/logo-im-png" width="400" alt="Weights & Biases" />
 <!--- @wandbcode{feedback-colab} -->
 
 

--- a/docs/docs/reference/gen_notebooks/import_from_csv.md
+++ b/docs/docs/reference/gen_notebooks/import_from_csv.md
@@ -13,7 +13,6 @@ title: Log Calls from Existing CSV
 
 
 
-<img src="http://wandb.me/logo-im-png" width="400" alt="Weights & Biases" />
 <!--- @wandbcode{prompt-optim-notebook} -->
 
 # Import Traces from 3rd Party Systems

--- a/docs/docs/reference/gen_notebooks/online_monitoring.md
+++ b/docs/docs/reference/gen_notebooks/online_monitoring.md
@@ -13,7 +13,6 @@ title: Integrating with Weave - Production Dashboard
 
 
 
-<img src="http://wandb.me/logo-im-png" width="400" alt="Weights & Biases" />
 <!--- @wandbcode{cod-notebook} -->
 
 # Integrating with Weave: Production Dashboard

--- a/docs/docs/reference/gen_notebooks/pii.md
+++ b/docs/docs/reference/gen_notebooks/pii.md
@@ -13,7 +13,6 @@ title: Handling and Redacting PII
 
 
 
-<img src="http://wandb.me/logo-im-png" width="400" alt="Weights & Biases" />
 <!--- @wandbcode{cod-notebook} -->
 
 # How to use Weave with PII data:

--- a/docs/intro_notebook.ipynb
+++ b/docs/intro_notebook.ipynb
@@ -11,7 +11,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{intro-colab} -->"
    ]
   },

--- a/docs/notebooks/chain_of_density.ipynb
+++ b/docs/notebooks/chain_of_density.ipynb
@@ -10,7 +10,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{cod-notebook} -->"
    ]
   },

--- a/docs/notebooks/custom_model_cost.ipynb
+++ b/docs/notebooks/custom_model_cost.ipynb
@@ -12,7 +12,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{prompt-optim-notebook} -->"
    ]
   },

--- a/docs/notebooks/dspy_prompt_optimization.ipynb
+++ b/docs/notebooks/dspy_prompt_optimization.ipynb
@@ -10,7 +10,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{prompt-optim-notebook} -->"
    ]
   },

--- a/docs/notebooks/feedback_prod.ipynb
+++ b/docs/notebooks/feedback_prod.ipynb
@@ -10,7 +10,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{feedback-colab} -->"
    ]
   },

--- a/docs/notebooks/import_from_csv.ipynb
+++ b/docs/notebooks/import_from_csv.ipynb
@@ -10,7 +10,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{prompt-optim-notebook} -->"
    ]
   },

--- a/docs/notebooks/online_monitoring.ipynb
+++ b/docs/notebooks/online_monitoring.ipynb
@@ -10,7 +10,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{cod-notebook} -->"
    ]
   },

--- a/docs/notebooks/pii.ipynb
+++ b/docs/notebooks/pii.ipynb
@@ -10,7 +10,7 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{cod-notebook} -->"
    ]
   },

--- a/weave_query/examples/experimental/prompts_dev/generate_synth_mon_board.ipynb
+++ b/weave_query/examples/experimental/prompts_dev/generate_synth_mon_board.ipynb
@@ -5,7 +5,7 @@
       "id": "4549831c",
       "metadata": {},
       "source": [
-        "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+        
         "<!--- @wandbcode{weave_synth_data_qs} -->\n",
         "\n",
         "<a target=\"_blank\" href=\"https://colab.research.google.com/github/wandb/weave/blob/master/examples/prompts/llm_monitoring/dev/generate_synth_mon_board.ipynb\">\n",

--- a/weave_query/examples/experimental/prompts_dev/synthetic_openai_data.ipynb
+++ b/weave_query/examples/experimental/prompts_dev/synthetic_openai_data.ipynb
@@ -5,7 +5,7 @@
       "id": "4549831c",
       "metadata": {},
       "source": [
-        "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+        
         "\n",
         "# Generate Synthetic Trace Data\n",
         "\n",

--- a/weave_query/examples/prompts/llm_monitoring/openai_client_quickstart.ipynb
+++ b/weave_query/examples/prompts/llm_monitoring/openai_client_quickstart.ipynb
@@ -5,7 +5,7 @@
    "id": "30ccfdbc",
    "metadata": {},
    "source": [
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<!--- @wandbcode{weave_openai_client_qs} -->\n",
     "\n",
     "<br />\n",

--- a/weave_query/examples/prompts/llm_monitoring/openai_proxy_quickstart.ipynb
+++ b/weave_query/examples/prompts/llm_monitoring/openai_proxy_quickstart.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "<br />\n",
     "<br />\n",
     "\n",

--- a/weave_query/examples/prompts/trace_debugging/dev/synthetic_trace_data.ipynb
+++ b/weave_query/examples/prompts/trace_debugging/dev/synthetic_trace_data.ipynb
@@ -5,7 +5,7 @@
    "id": "7aaafefa-ec2f-4feb-ad07-e7f2df83f3ea",
    "metadata": {},
    "source": [
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "\n",
     "<br />\n",
     "<br />\n",

--- a/weave_query/examples/prompts/trace_debugging/trace_quickstart_langchain.ipynb
+++ b/weave_query/examples/prompts/trace_debugging/trace_quickstart_langchain.ipynb
@@ -5,7 +5,7 @@
    "id": "957b839e-ae72-4608-8f17-454e95c6c76c",
    "metadata": {},
    "source": [
-    "<img src=\"http://wandb.me/logo-im-png\" width=\"400\" alt=\"Weights & Biases\" />\n",
+    
     "\n",
     "<a target=\"_blank\" href=\"https://colab.research.google.com/github/wandb/weave/blob/master/examples/prompts/trace_debugging/trace_quickstart_langchain.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",


### PR DESCRIPTION
A few cosmetic things in docs:
1. Remove the `W&B` logo in notebooks since it is broken in Safari
2. Adjust the discussion in `tracing.md` to highlight the non-`.call` based calling.
3. Adjust numbering in tracing.md