### PR TITLE
fix: Evaluations no longer associate incorrect inputs with predictions

### DIFF
--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -148,6 +148,19 @@ async def test_basic_evaluation(client):
     expected_predict_ref = model_obj.val["predict"]
     assert is_op_ref_with_name(expected_predict_ref, "MyModel.predict")
 
+    predict_and_score_calls = [
+        c
+        for (c, d) in flattened_calls
+        if op_name_from_ref(c.op_name) == "Evaluation.predict_and_score"
+    ]
+    assert len(predict_and_score_calls) == 3
+
+    # Assert that all the inputs are unique
+    inputs = set()
+    for call in predict_and_score_calls:
+        inputs.add(call.inputs["example"])
+    assert len(inputs) == 3
+
 
 @weave.op
 def gpt_mocker(question: str):

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -352,7 +352,7 @@ class WeaveTable(Traceable):
 
         for ndx, row in enumerate(self._prefetched_rows):
             next_id_future = wc.future_executor.defer(
-                lambda: cached_table_ref.row_digests[ndx]
+                lambda ndx_closure=ndx: cached_table_ref.row_digests[ndx_closure]
             )
             new_ref = self.ref.with_item(next_id_future)
             val = self._prefetched_rows[ndx]


### PR DESCRIPTION
I introduced a bug: https://github.com/wandb/weave/pull/2434 which resulted in the `predict_and_score` (and child calls) having an incorrect input refs getting assigned to the input. The result is that the inputs are effectively all the same (however the outputs are different). This results in a number of odd effects since the system thinks all the predictions are against the same row:

<img width="1083" alt="Screenshot 2024-10-11 at 10 48 58" src="https://github.com/user-attachments/assets/5463dc3c-c16e-4856-ad63-aebc7fc5e832">

So, what was the issue here? Well a classic case of mutating a closure variable before executing the function! duh!

For more details, consider this basic example:

```python
for ndx, row in enumerate(self._prefetched_rows):
  next_id_future = wc.future_executor.defer(    # <--- this `defer` schedules the function to be ran in a new thread.
    lambda: cached_table_ref.row_digests[ndx]   # <---- this `ndx` is mutated by the outer iterator
  )
```

Since the execution of the function is delayed, by the time the inner function executes, `ndx` has been changed!. Changing parallelism to 0 fixes this (since the `defer` becomes an immediate blocking call). 

I double checked everywhere and there are no other such cases of this pattern. Interestingly, @andrewtruong and I basically discussed this exact thing in extensive detail when he reviewed the original PR. We wrote tests and everything. I just missed this one call site!