### PR TITLE
feat(weave): dictify unknown class instances

### DIFF
--- a/tests/integrations/dspy/dspy_test.py
+++ b/tests/integrations/dspy/dspy_test.py
@@ -106,22 +106,37 @@ def test_dspy_inline_signatures(client: WeaveClient) -> None:
     call_1, _ = flattened_calls[0]
     assert call_1.exception is None and call_1.ended_at is not None
     output_1 = call_1.output
-    assert (
-        output_1
-        == """Prediction(
-    sentiment='Positive'
-)"""
-    )
-
+    assert output_1 == {
+        "__class__": {
+            "module": "dspy.primitives.prediction",
+            "qualname": "Prediction",
+            "name": "Prediction",
+        },
+        "completions": {
+            "__class__": {
+                "module": "dspy.primitives.prediction",
+                "qualname": "Completions",
+                "name": "Completions",
+            },
+        },
+    }
     call_2, _ = flattened_calls[1]
     assert call_2.exception is None and call_2.ended_at is not None
     output_2 = call_2.output
-    assert (
-        output_2
-        == """Prediction(
-    sentiment='Positive'
-)"""
-    )
+    assert output_2 == {
+        "__class__": {
+            "module": "dspy.primitives.prediction",
+            "qualname": "Prediction",
+            "name": "Prediction",
+        },
+        "completions": {
+            "__class__": {
+                "module": "dspy.primitives.prediction",
+                "qualname": "Completions",
+                "name": "Completions",
+            },
+        },
+    }
 
     call_3, _ = flattened_calls[2]
     assert call_3.exception is None and call_3.ended_at is not None

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1477,25 +1477,23 @@ def test_named_reuse(client):
 
 
 def test_unknown_input_and_output_types(client):
-    class MyUnserializableClassA:
+    class MyUnknownClassA:
         a_val: float
 
         def __init__(self, a_val) -> None:
             self.a_val = a_val
 
-    class MyUnserializableClassB:
+    class MyUnknownClassB:
         b_val: float
 
         def __init__(self, b_val) -> None:
             self.b_val = b_val
 
     @weave.op()
-    def op_with_unknown_types(
-        a: MyUnserializableClassA, b: float
-    ) -> MyUnserializableClassB:
-        return MyUnserializableClassB(a.a_val + b)
+    def op_with_unknown_types(a: MyUnknownClassA, b: float) -> MyUnknownClassB:
+        return MyUnknownClassB(a.a_val + b)
 
-    a = MyUnserializableClassA(3)
+    a = MyUnknownClassA(3)
     res = op_with_unknown_types(a, 0.14)
 
     assert res.b_val == 3.14
@@ -1508,25 +1506,39 @@ def test_unknown_input_and_output_types(client):
 
     assert len(inner_res.calls) == 1
     assert inner_res.calls[0].inputs == {
-        "a": repr(a),
+        "a": {
+            "__class__": {
+                "module": "test_client_trace",
+                "qualname": "test_unknown_input_and_output_types.<locals>.MyUnknownClassA",
+                "name": "MyUnknownClassA",
+            },
+            "a_val": 3,
+        },
         "b": 0.14,
     }
-    assert inner_res.calls[0].output == repr(res)
+    assert inner_res.calls[0].output == {
+        "__class__": {
+            "module": "test_client_trace",
+            "qualname": "test_unknown_input_and_output_types.<locals>.MyUnknownClassB",
+            "name": "MyUnknownClassB",
+        },
+        "b_val": 3.14,
+    }
 
 
 def test_unknown_attribute(client):
-    class MyUnserializableClass:
+    class MyUnknownClass:
         val: int
 
         def __init__(self, a_val) -> None:
             self.a_val = a_val
 
     class MySerializableClass(weave.Object):
-        obj: MyUnserializableClass
+        obj: MyUnknownClass
 
-    a_obj = MyUnserializableClass(1)
+    a_obj = MyUnknownClass(1)
     a = MySerializableClass(obj=a_obj)
-    b_obj = MyUnserializableClass(2)
+    b_obj = MyUnknownClass(2)
     b = MySerializableClass(obj=b_obj)
 
     ref_a = weave.publish(a)
@@ -1535,8 +1547,22 @@ def test_unknown_attribute(client):
     a2 = weave.ref(ref_a.uri()).get()
     b2 = weave.ref(ref_b.uri()).get()
 
-    assert a2.obj == repr(a_obj)
-    assert b2.obj == repr(b_obj)
+    assert a2.obj == {
+        "__class__": {
+            "module": "test_client_trace",
+            "qualname": "test_unknown_attribute.<locals>.MyUnknownClass",
+            "name": "MyUnknownClass",
+        },
+        "a_val": 1,
+    }
+    assert b2.obj == {
+        "__class__": {
+            "module": "test_client_trace",
+            "qualname": "test_unknown_attribute.<locals>.MyUnknownClass",
+            "name": "MyUnknownClass",
+        },
+        "a_val": 2,
+    }
 
 
 @contextmanager

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -768,9 +768,9 @@ async def test_eval_with_complex_types(client):
     # So this assertion is checking current state, but not
     # the correct behavior of the dataset (the should be the
     # MyDataclass, MyModel, and MyObj)
-    assert isinstance(row["dc"], str)  #  MyDataclass
-    assert isinstance(row["model"], str)  #  MyModel
-    assert isinstance(row["obj"], str)  #  MyObj
+    assert isinstance(row["dc"], dict)  #  MyDataclass
+    assert isinstance(row["model"], dict)  #  MyModel
+    assert isinstance(row["obj"], dict)  #  MyObj
     assert isinstance(row["text"], str)
 
     access_log = client.server.attribute_access_log

--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -1,0 +1,152 @@
+from weave.trace.serialize import dictify, fallback_encode
+
+
+def test_dictify_simple() -> None:
+    class Point:
+        x: int
+        y: int
+
+        # This should be ignored
+        def sum() -> int:
+            return self.x + self.y
+
+    pt = Point()
+    pt.x = 1
+    pt.y = 2
+    assert dictify(pt) == {
+        "__class__": {
+            "module": "test_serialize",
+            "qualname": "test_dictify_simple.<locals>.Point",
+            "name": "Point",
+        },
+        "x": 1,
+        "y": 2,
+    }
+
+
+def test_dictify_complex() -> None:
+    class Point:
+        x: int
+        y: int
+
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+    class Points:
+        def __init__(self) -> None:
+            self.points = [Point(1, 2), Point(3, 4)]
+
+    pts = Points()
+    assert dictify(pts) == {
+        "__class__": {
+            "module": "test_serialize",
+            "qualname": "test_dictify_complex.<locals>.Points",
+            "name": "Points",
+        },
+        "points": [
+            {
+                "__class__": {
+                    "module": "test_serialize",
+                    "qualname": "test_dictify_complex.<locals>.Point",
+                    "name": "Point",
+                },
+                "x": 1,
+                "y": 2,
+            },
+            {
+                "__class__": {
+                    "module": "test_serialize",
+                    "qualname": "test_dictify_complex.<locals>.Point",
+                    "name": "Point",
+                },
+                "x": 3,
+                "y": 4,
+            },
+        ],
+    }
+
+
+def test_dictify_maxdepth() -> None:
+    obj = {
+        "a": {
+            "b": {
+                "c": {
+                    "d": 1,
+                },
+            },
+        },
+    }
+    assert dictify(obj, maxdepth=0) == obj
+    assert dictify(obj, maxdepth=1) == {
+        "a": "{'b': {'c': {'d': 1}}}",
+    }
+    assert dictify(obj, maxdepth=2) == {
+        "a": {
+            "b": "{'c': {'d': 1}}",
+        },
+    }
+    assert dictify(obj, maxdepth=3) == {
+        "a": {
+            "b": {
+                "c": "{'d': 1}",
+            },
+        },
+    }
+    assert dictify(obj, maxdepth=4) == {
+        "a": {
+            "b": {
+                "c": {
+                    "d": "1",
+                }
+            },
+        },
+    }
+    assert dictify(obj, maxdepth=5) == {
+        "a": {
+            "b": {
+                "c": {
+                    "d": 1,
+                }
+            },
+        },
+    }
+
+
+def test_dictify_to_dict() -> None:
+    class Point:
+        x: int
+        y: int
+
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+        def to_dict(self) -> dict:
+            return {
+                "foo": "bar",
+                "baz": 42,
+            }
+
+    pt = Point(1, 2)
+    assert dictify(pt) == {
+        "foo": "bar",
+        "baz": 42,
+    }
+
+
+def test_fallback_encode_dictify_fails() -> None:
+    class Point:
+        x: int
+        y: int
+
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+        def to_dict(self) -> dict:
+            # Intentionally make dictify fail
+            raise ValueError("a bug in user code")
+
+    pt = Point(1, 2)
+    assert fallback_encode(pt) == repr(pt)

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -674,7 +674,6 @@ def test_save_unknown_type(client):
     obj = SomeUnknownThing(3)
     ref = client._save_object(obj, "my-np-array")
     obj2 = client.get(ref)
-    # Expect None for now
     assert obj2 == {
         "__class__": {
             "module": "test_weave_client",

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -675,7 +675,14 @@ def test_save_unknown_type(client):
     ref = client._save_object(obj, "my-np-array")
     obj2 = client.get(ref)
     # Expect None for now
-    assert obj2 == repr(obj)
+    assert obj2 == {
+        "__class__": {
+            "module": "test_weave_client",
+            "qualname": "test_save_unknown_type.<locals>.SomeUnknownThing",
+            "name": "SomeUnknownThing",
+        },
+        "a": 3,
+    }
 
 
 def test_save_model(client):

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -41,6 +41,14 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
         console.error('Expected ref, found', innerRef, typeof innerRef);
       }
     }
+    if (data.valueType === 'object' && '__class__' in data.value) {
+      const cls = data.value.__class__;
+      let clsName = cls.name;
+      if (cls.module) {
+        clsName = cls.module + '.' + clsName;
+      }
+      return <ValueViewPrimitive>{clsName}</ValueViewPrimitive>;
+    }
     if (USE_TABLE_FOR_ARRAYS && data.valueType === 'array') {
       return <DataTableView data={data.value} autoPageSize={true} />;
     }

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -1,5 +1,6 @@
+import logging
 import typing
-from typing import Any
+from typing import Any, Optional
 
 from weave.trace import custom_objs
 from weave.trace.object_record import ObjectRecord
@@ -73,10 +74,11 @@ def _build_result_from_encoded(
     return result
 
 
-REP_LIMIT = 1000
+STR_LENGTH_LIMIT = 1000
 
 
-def fallback_encode(obj: Any) -> Any:
+def stringify(obj: Any, limit: int = STR_LENGTH_LIMIT) -> str:
+    """This is a fallback for objects that we don't have a better way to serialize."""
     rep = None
     try:
         rep = repr(obj)
@@ -86,9 +88,101 @@ def fallback_encode(obj: Any) -> Any:
         except Exception:
             rep = f"<{type(obj).__name__}: {id(obj)}>"
     if isinstance(rep, str):
-        if len(rep) > REP_LIMIT:
-            rep = rep[:REP_LIMIT] + "..."
+        if len(rep) > limit:
+            rep = rep[: limit - 3] + "..."
     return rep
+
+
+def is_primitive(obj: Any) -> bool:
+    """Check if an object is a known primitive type."""
+    return isinstance(obj, (int, float, str, bool, type(None)))
+
+
+def dictify(
+    obj: Any, maxdepth: int = 0, depth: int = 1, seen: Optional[set[int]] = None
+) -> Any:
+    """Recursively compute a dictionary representation of an object."""
+    if seen is None:
+        seen = set()
+
+    if not is_primitive(obj):
+        obj_id = id(obj)
+        if obj_id in seen:
+            # Avoid infinite recursion with circular references
+            return stringify(obj)
+        else:
+            seen.add(obj_id)
+
+    if maxdepth > 0 and depth > maxdepth:
+        # TODO: If obj at this point is a simple type,
+        #       maybe we should just return it rather than stringify
+        return stringify(obj)
+
+    if isinstance(obj, (int, float, str, bool, type(None))):
+        return obj
+    elif isinstance(obj, (list, tuple)):
+        return [dictify(v, maxdepth, depth + 1, seen) for v in obj]
+    elif isinstance(obj, dict):
+        return {k: dictify(v, maxdepth, depth + 1, seen) for k, v in obj.items()}
+
+    if hasattr(obj, "to_dict"):
+        try:
+            as_dict = obj.to_dict()
+            if isinstance(as_dict, dict):
+                result = {}
+                for k, v in as_dict.items():
+                    if maxdepth == 0 or depth < maxdepth:
+                        result[k] = dictify(v, maxdepth, depth + 1)
+                    else:
+                        result[k] = stringify(v)
+                return result
+        except Exception:
+            raise ValueError("to_dict failed")
+
+    result = {}
+    result["__class__"] = {
+        "module": obj.__class__.__module__,
+        "qualname": obj.__class__.__qualname__,
+        "name": obj.__class__.__name__,
+    }
+    if hasattr(obj, "__len__") and hasattr(obj, "__getitem__"):
+        # Custom list-like object
+        try:
+            n = len(obj)
+            for i in range(n):
+                result[i] = dictify(obj[i], maxdepth, depth + 1, seen)
+        except Exception:
+            raise ValueError("fallback dictify failed")
+    else:
+        for attr in dir(obj):
+            if attr.startswith("_"):
+                continue
+            try:
+                val = getattr(obj, attr)
+                if callable(val):
+                    continue
+                if maxdepth == 0 or depth < maxdepth:
+                    result[attr] = dictify(val, maxdepth, depth + 1, seen)
+                else:
+                    result[attr] = stringify(val)
+            except Exception:
+                raise ValueError("fallback dictify failed")
+    return result
+
+
+# TODO: Investigate why dictifying Logger causes problems
+ALWAYS_STRINGIFY = (logging.Logger,)
+
+
+def fallback_encode(obj: Any) -> Any:
+    # TODO: Should we try to compute an object size and skip if too big?
+    if isinstance(obj, ALWAYS_STRINGIFY):
+        return stringify(obj)
+    try:
+        # Note: Max depth not picked scientifically, just trying to keep things under control.
+        return dictify(obj, maxdepth=10)
+    except Exception:
+        return stringify(obj)
 
 
 def isinstance_namedtuple(obj: Any) -> bool:


### PR DESCRIPTION
## Description

Instead of giving up and resorting to `repr` we try to recursively convert objects into a dict.
See internal doc https://www.notion.so/wandbai/Better-Rendering-of-Gemini-Calls-114e2f5c7ef38037953df7b7a9e5a52b?pvs=4 for more details. This will allow us to build a chat view for Gemini and solves other problems with not logging important data in the trace.

Before:
<img width="651" alt="Screenshot 2024-10-15 at 12 19 41 PM" src="https://github.com/user-attachments/assets/fa69d645-086f-4ec1-9954-3ee365bfa9c4">

After:
<img width="850" alt="Screenshot 2024-10-09 at 2 08 00 PM" src="https://github.com/user-attachments/assets/ee552067-6dcf-465c-ad3d-3b56a52c8add">


## Testing

How was this PR tested?
