### PR TITLE
chore(ui): use sentence case

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -45,7 +45,7 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
       return <DataTableView data={data.value} autoPageSize={true} />;
     }
     if (data.valueType === 'array' && data.value.length === 0) {
-      return <ValueViewPrimitive>Empty List</ValueViewPrimitive>;
+      return <ValueViewPrimitive>Empty list</ValueViewPrimitive>;
     }
     return null;
   }
@@ -87,7 +87,7 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
 
   if (data.valueType === 'array') {
     if (data.value.length === 0) {
-      return <ValueViewPrimitive>Empty List</ValueViewPrimitive>;
+      return <ValueViewPrimitive>Empty list</ValueViewPrimitive>;
     }
     // Compared to toString this keeps the square brackets.
     return <div>{JSON.stringify(data.value)}</div>;


### PR DESCRIPTION
## Description

Design guidelines are to use sentence case.

Before:
<img width="299" alt="Screenshot 2024-10-11 at 4 17 41 PM" src="https://github.com/user-attachments/assets/a6092c43-e9a4-4609-aa98-f403dc51ec8b">

After:
<img width="318" alt="Screenshot 2024-10-11 at 4 17 33 PM" src="https://github.com/user-attachments/assets/6060df0b-70e4-464a-9a7e-4834211ed81e">


## Testing

How was this PR tested?
