### PR TITLE
chore: Test all coroutine patterns and refactor op call

### DIFF
--- a/tests/trace/test_op_coroutines.py
+++ b/tests/trace/test_op_coroutines.py
@@ -7,59 +7,59 @@ import weave
 from weave.trace.weave_client import Call
 
 
-def test_non_async_non_coro(client):
+def test_sync_val(client):
     @weave.op()
-    def non_async_non_coro():
+    def sync_val():
         return 1
 
-    res = non_async_non_coro()
+    res = sync_val()
     assert res == 1
-    res, call = non_async_non_coro.call()
+    res, call = sync_val.call()
     assert isinstance(call, Call)
     assert res == 1
 
 
-def test_non_async_non_coro_method(client):
+def test_sync_val_method(client):
     class TestClass:
         @weave.op()
-        def non_async_non_coro(self):
+        def sync_val(self):
             return 1
 
     test_inst = TestClass()
-    res = test_inst.non_async_non_coro()
+    res = test_inst.sync_val()
     assert res == 1
-    res, call = test_inst.non_async_non_coro.call(test_inst)
+    res, call = test_inst.sync_val.call(test_inst)
     assert isinstance(call, Call)
     assert res == 1
 
 
 @pytest.mark.asyncio
-async def test_non_async_coro(client):
+async def test_sync_coro(client):
     @weave.op()
-    def non_async_coro():
+    def sync_coro():
         return asyncio.to_thread(lambda: 1)
 
-    res = non_async_coro()
+    res = sync_coro()
     assert isinstance(res, Coroutine)
     assert await res == 1
-    res, call = non_async_coro.call()
+    res, call = sync_coro.call()
     assert isinstance(call, Call)
     assert isinstance(res, Coroutine)
     assert await res == 1
 
 
 @pytest.mark.asyncio
-async def test_non_async_coro_method(client):
+async def test_sync_coro_method(client):
     class TestClass:
         @weave.op()
-        def non_async_coro(self):
+        def sync_coro(self):
             return asyncio.to_thread(lambda: 1)
 
     test_inst = TestClass()
-    res = test_inst.non_async_coro()
+    res = test_inst.sync_coro()
     assert isinstance(res, Coroutine)
     assert await res == 1
-    res, call = test_inst.non_async_coro.call(test_inst)
+    res, call = test_inst.sync_coro.call(test_inst)
     assert isinstance(call, Call)
     assert isinstance(res, Coroutine)
     assert await res == 1
@@ -133,58 +133,58 @@ async def test_async_awaited_coro_method(client):
 
 
 @pytest.mark.asyncio
-async def test_async_non_coro(client):
+async def test_async_val(client):
     @weave.op()
-    async def async_non_coro():
+    async def async_val():
         return 1
 
-    res = async_non_coro()
+    res = async_val()
     assert isinstance(res, Coroutine)
     assert await res == 1
-    res, call = await async_non_coro.call()
+    res, call = await async_val.call()
     assert isinstance(call, Call)
     assert res == 1
 
 
 @pytest.mark.asyncio
-async def test_async_non_coro_method(client):
+async def test_async_val_method(client):
     class TestClass:
         @weave.op()
-        async def async_non_coro(self):
+        async def async_val(self):
             return 1
 
     test_inst = TestClass()
-    res = test_inst.async_non_coro()
+    res = test_inst.async_val()
     assert isinstance(res, Coroutine)
     assert await res == 1
-    res, call = await test_inst.async_non_coro.call(test_inst)
+    res, call = await test_inst.async_val.call(test_inst)
     assert isinstance(call, Call)
     assert res == 1
 
 
-def test_non_async_with_exception(client):
+def test_sync_with_exception(client):
     @weave.op()
-    def non_async_with_exception():
+    def sync_with_exception():
         raise ValueError("test")
 
     with pytest.raises(ValueError, match="test"):
-        non_async_with_exception()
-    res, call = non_async_with_exception.call()
+        sync_with_exception()
+    res, call = sync_with_exception.call()
     assert isinstance(call, Call)
     assert call.exception is not None
     assert res == None
 
 
-def test_non_async_with_exception_method(client):
+def test_sync_with_exception_method(client):
     class TestClass:
         @weave.op()
-        def non_async_with_exception(self):
+        def sync_with_exception(self):
             raise ValueError("test")
 
     test_inst = TestClass()
     with pytest.raises(ValueError, match="test"):
-        test_inst.non_async_with_exception()
-    res, call = test_inst.non_async_with_exception.call(test_inst)
+        test_inst.sync_with_exception()
+    res, call = test_inst.sync_with_exception.call(test_inst)
     assert isinstance(call, Call)
     assert call.exception is not None
     assert res == None

--- a/tests/trace/test_op_coroutines.py
+++ b/tests/trace/test_op_coroutines.py
@@ -1,0 +1,220 @@
+import asyncio
+from typing import Coroutine
+
+import pytest
+
+import weave
+from weave.trace.weave_client import Call
+
+
+def test_non_async_non_coro(client):
+    @weave.op()
+    def non_async_non_coro():
+        return 1
+
+    res = non_async_non_coro()
+    assert res == 1
+    res, call = non_async_non_coro.call()
+    assert isinstance(call, Call)
+    assert res == 1
+
+
+def test_non_async_non_coro_method(client):
+    class TestClass:
+        @weave.op()
+        def non_async_non_coro(self):
+            return 1
+
+    test_inst = TestClass()
+    res = test_inst.non_async_non_coro()
+    assert res == 1
+    res, call = test_inst.non_async_non_coro.call(test_inst)
+    assert isinstance(call, Call)
+    assert res == 1
+
+
+@pytest.mark.asyncio
+async def test_non_async_coro(client):
+    @weave.op()
+    def non_async_coro():
+        return asyncio.to_thread(lambda: 1)
+
+    res = non_async_coro()
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+    res, call = non_async_coro.call()
+    assert isinstance(call, Call)
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+
+
+@pytest.mark.asyncio
+async def test_non_async_coro_method(client):
+    class TestClass:
+        @weave.op()
+        def non_async_coro(self):
+            return asyncio.to_thread(lambda: 1)
+
+    test_inst = TestClass()
+    res = test_inst.non_async_coro()
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+    res, call = test_inst.non_async_coro.call(test_inst)
+    assert isinstance(call, Call)
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+
+
+@pytest.mark.asyncio
+async def test_async_coro(client):
+    @weave.op()
+    async def async_coro():
+        return asyncio.to_thread(lambda: 1)
+
+    res = async_coro()
+    assert isinstance(res, Coroutine)
+    res2 = await res
+    assert isinstance(res2, Coroutine)
+    assert await res2 == 1
+    res, call = await async_coro.call()
+    assert isinstance(call, Call)
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+
+
+@pytest.mark.asyncio
+async def test_async_coro_method(client):
+    class TestClass:
+        @weave.op()
+        async def async_coro(self):
+            return asyncio.to_thread(lambda: 1)
+
+    test_inst = TestClass()
+
+    res = test_inst.async_coro()
+    assert isinstance(res, Coroutine)
+    res2 = await res
+    assert isinstance(res2, Coroutine)
+    assert await res2 == 1
+    res, call = await test_inst.async_coro.call(test_inst)
+    assert isinstance(call, Call)
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+
+
+@pytest.mark.asyncio
+async def test_async_awaited_coro(client):
+    @weave.op()
+    async def async_awaited_coro():
+        return await asyncio.to_thread(lambda: 1)
+
+    res = async_awaited_coro()
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+    res, call = await async_awaited_coro.call()
+    assert isinstance(call, Call)
+    assert res == 1
+
+
+@pytest.mark.asyncio
+async def test_async_awaited_coro_method(client):
+    class TestClass:
+        @weave.op()
+        async def async_awaited_coro(self):
+            return await asyncio.to_thread(lambda: 1)
+
+    test_inst = TestClass()
+    res = test_inst.async_awaited_coro()
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+    res, call = await test_inst.async_awaited_coro.call(test_inst)
+    assert isinstance(call, Call)
+    assert res == 1
+
+
+@pytest.mark.asyncio
+async def test_async_non_coro(client):
+    @weave.op()
+    async def async_non_coro():
+        return 1
+
+    res = async_non_coro()
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+    res, call = await async_non_coro.call()
+    assert isinstance(call, Call)
+    assert res == 1
+
+
+@pytest.mark.asyncio
+async def test_async_non_coro_method(client):
+    class TestClass:
+        @weave.op()
+        async def async_non_coro(self):
+            return 1
+
+    test_inst = TestClass()
+    res = test_inst.async_non_coro()
+    assert isinstance(res, Coroutine)
+    assert await res == 1
+    res, call = await test_inst.async_non_coro.call(test_inst)
+    assert isinstance(call, Call)
+    assert res == 1
+
+
+def test_non_async_with_exception(client):
+    @weave.op()
+    def non_async_with_exception():
+        raise ValueError("test")
+
+    with pytest.raises(ValueError, match="test"):
+        non_async_with_exception()
+    res, call = non_async_with_exception.call()
+    assert isinstance(call, Call)
+    assert call.exception is not None
+    assert res == None
+
+
+def test_non_async_with_exception_method(client):
+    class TestClass:
+        @weave.op()
+        def non_async_with_exception(self):
+            raise ValueError("test")
+
+    test_inst = TestClass()
+    with pytest.raises(ValueError, match="test"):
+        test_inst.non_async_with_exception()
+    res, call = test_inst.non_async_with_exception.call(test_inst)
+    assert isinstance(call, Call)
+    assert call.exception is not None
+    assert res == None
+
+
+@pytest.mark.asyncio
+async def test_async_with_exception(client):
+    @weave.op()
+    async def async_with_exception():
+        raise ValueError("test")
+
+    with pytest.raises(ValueError, match="test"):
+        await async_with_exception()
+    res, call = await async_with_exception.call()
+    assert isinstance(call, Call)
+    assert call.exception is not None
+    assert res == None
+
+
+@pytest.mark.asyncio
+async def test_async_with_exception_method(client):
+    class TestClass:
+        @weave.op()
+        async def async_with_exception(self):
+            raise ValueError("test")
+
+    test_inst = TestClass()
+    with pytest.raises(ValueError, match="test"):
+        await test_inst.async_with_exception()
+    res, call = await test_inst.async_with_exception.call(test_inst)
+    assert isinstance(call, Call)
+    assert call.exception is not None
+    assert res == None

--- a/tests/trace/test_op_coroutines.py
+++ b/tests/trace/test_op_coroutines.py
@@ -172,7 +172,7 @@ def test_sync_with_exception(client):
     res, call = sync_with_exception.call()
     assert isinstance(call, Call)
     assert call.exception is not None
-    assert res == None
+    assert res is None
 
 
 def test_sync_with_exception_method(client):
@@ -187,7 +187,7 @@ def test_sync_with_exception_method(client):
     res, call = test_inst.sync_with_exception.call(test_inst)
     assert isinstance(call, Call)
     assert call.exception is not None
-    assert res == None
+    assert res is None
 
 
 @pytest.mark.asyncio
@@ -201,7 +201,7 @@ async def test_async_with_exception(client):
     res, call = await async_with_exception.call()
     assert isinstance(call, Call)
     assert call.exception is not None
-    assert res == None
+    assert res is None
 
 
 @pytest.mark.asyncio
@@ -217,4 +217,4 @@ async def test_async_with_exception_method(client):
     res, call = await test_inst.async_with_exception.call(test_inst)
     assert isinstance(call, Call)
     assert call.exception is not None
-    assert res == None
+    assert res is None

--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -141,7 +141,7 @@ def test_sync_method_call(client, weave_obj, py_obj):
         weave_obj_method2 = weave_obj_method_ref.get()
 
     with pytest.raises(errors.OpCallError):
-        res2, call2 = py_obj.amethod.call(1)
+        res2, call2 = py_obj.method.call(1)
 
 
 @pytest.mark.asyncio

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -241,7 +241,7 @@ def _execute_call(
     *args: Any,
     __should_raise: bool = True,
     **kwargs: Any,
-) -> Any:
+) -> Union[tuple[Any, "Call"], Coroutine[Any, Any, tuple[Any, "Call"]]]:
     func = __op.resolve_fn
     client = weave_client_context.require_weave_client()
     has_finished = False
@@ -266,7 +266,7 @@ def _execute_call(
         finish(output)
         return output
 
-    def process(res: Any) -> Any:
+    def process(res: Any) -> tuple[Any, "Call"]:
         res = box.box(res)
         try:
             # Here we do a try/catch because we don't want to
@@ -285,7 +285,7 @@ def _execute_call(
 
         return res, call
 
-    def handle_exception(e: Exception) -> Any:
+    def handle_exception(e: Exception) -> tuple[Any, "Call"]:
         finish(exception=e)
         if __should_raise:
             raise
@@ -293,7 +293,7 @@ def _execute_call(
 
     if inspect.iscoroutinefunction(func):
 
-        async def _call_async() -> Coroutine[Any, Any, Any]:
+        async def _call_async() -> tuple[Any, "Call"]:
             try:
                 res = await func(*args, **kwargs)
             except Exception as e:
@@ -314,8 +314,12 @@ def _execute_call(
 
 
 def call(
-    op: Op, *args: Any, __weave: Optional[WeaveKwargs] = None, **kwargs: Any
-) -> tuple[Any, "Call"]:
+    op: Op,
+    *args: Any,
+    __weave: Optional[WeaveKwargs] = None,
+    __should_raise: bool = False,
+    **kwargs: Any,
+) -> Union[tuple[Any, "Call"], Coroutine[Any, Any, tuple[Any, "Call"]]]:
     """
     Executes the op and returns both the result and a Call representing the execution.
 
@@ -332,8 +336,111 @@ def call(
     result, call = add.call(1, 2)
     ```
     """
-    c = _create_call(op, *args, __weave=__weave, **kwargs)
-    return _execute_call(op, c, *args, __should_raise=False, **kwargs)
+    if inspect.iscoroutinefunction(op.resolve_fn):
+        return do_call_async(
+            op, *args, __weave=__weave, __should_raise=__should_raise, **kwargs
+        )
+    else:
+        return do_call(
+            op, *args, __weave=__weave, __should_raise=__should_raise, **kwargs
+        )
+
+
+def _placeholder_call() -> "Call":
+    # Import here to avoid circular dependency
+    from weave.trace.weave_client import Call
+
+    return Call(
+        _op_name="",
+        trace_id="",
+        project_id="",
+        parent_id=None,
+        inputs={},
+    )
+
+
+def do_call(
+    op: Op,
+    *args: Any,
+    __weave: Optional[WeaveKwargs] = None,
+    __should_raise: bool = False,
+    **kwargs: Any,
+) -> tuple[Any, "Call"]:
+    func = op.resolve_fn
+    call = _placeholder_call()
+    if settings.should_disable_weave():
+        res = func(*args, **kwargs)
+    elif weave_client_context.get_weave_client() is None:
+        res = func(*args, **kwargs)
+    elif not op._tracing_enabled:
+        res = func(*args, **kwargs)
+    else:
+        try:
+            # This try/except allows us to fail gracefully and
+            # still let the user code continue to execute
+            call = _create_call(op, *args, __weave=__weave, **kwargs)
+        except Exception as e:
+            if get_raise_on_captured_errors():
+                raise
+            log_once(
+                logger.error,
+                CALL_CREATE_MSG.format(traceback.format_exc()),
+            )
+            res = func(*args, **kwargs)
+        else:
+            execute_result = _execute_call(
+                op, call, *args, __should_raise=__should_raise, **kwargs
+            )
+            if inspect.iscoroutine(execute_result):
+                raise Exception(
+                    "Internal error: Expected `_execute_call` to return a sync result"
+                )
+            execute_result = cast(tuple[Any, "Call"], execute_result)
+            res, call = execute_result
+    return res, call
+
+
+async def do_call_async(
+    op: Op,
+    *args: Any,
+    __weave: Optional[WeaveKwargs] = None,
+    __should_raise: bool = False,
+    **kwargs: Any,
+) -> tuple[Any, "Call"]:
+    func = op.resolve_fn
+    call = _placeholder_call()
+    if settings.should_disable_weave():
+        res = await func(*args, **kwargs)
+    elif weave_client_context.get_weave_client() is None:
+        res = await func(*args, **kwargs)
+    elif not op._tracing_enabled:
+        res = await func(*args, **kwargs)
+    else:
+        try:
+            # This try/except allows us to fail gracefully and
+            # still let the user code continue to execute
+            call = _create_call(op, *args, __weave=__weave, **kwargs)
+        except Exception as e:
+            if get_raise_on_captured_errors():
+                raise
+            log_once(
+                logger.error,
+                ASYNC_CALL_CREATE_MSG.format(traceback.format_exc()),
+            )
+            res = await func(*args, **kwargs)
+        else:
+            execute_result = _execute_call(
+                op, call, *args, __should_raise=__should_raise, **kwargs
+            )
+            if not inspect.iscoroutine(execute_result):
+                raise Exception(
+                    "Internal error: Expected `_execute_call` to return a coroutine"
+                )
+            execute_result = cast(
+                Coroutine[Any, Any, tuple[Any, "Call"]], execute_result
+            )
+            res, call = await execute_result
+    return res, call
 
 
 def calls(op: Op) -> "CallsIter":
@@ -453,51 +560,17 @@ def op(
 
                 @wraps(func)
                 async def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    __weave: Optional[WeaveKwargs] = kwargs.pop(WEAVE_KWARGS_KEY, None)
-                    if settings.should_disable_weave():
-                        return await func(*args, **kwargs)
-                    if weave_client_context.get_weave_client() is None:
-                        return await func(*args, **kwargs)
-                    if not wrapper._tracing_enabled:  # type: ignore
-                        return await func(*args, **kwargs)
-                    try:
-                        # This try/except allows us to fail gracefully and
-                        # still let the user code continue to execute
-                        call = _create_call(wrapper, *args, __weave=__weave, **kwargs)  # type: ignore
-                    except Exception as e:
-                        if get_raise_on_captured_errors():
-                            raise
-                        log_once(
-                            logger.error,
-                            ASYNC_CALL_CREATE_MSG.format(traceback.format_exc()),
-                        )
-                        return await func(*args, **kwargs)
-                    res, _ = await _execute_call(wrapper, call, *args, **kwargs)  # type: ignore
+                    res, _ = await do_call_async(
+                        cast(Op, wrapper), *args, __should_raise=True, **kwargs
+                    )
                     return res
             else:
 
                 @wraps(func)
                 def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    __weave: Optional[WeaveKwargs] = kwargs.pop(WEAVE_KWARGS_KEY, None)
-                    if settings.should_disable_weave():
-                        return func(*args, **kwargs)
-                    if weave_client_context.get_weave_client() is None:
-                        return func(*args, **kwargs)
-                    if not wrapper._tracing_enabled:  # type: ignore
-                        return func(*args, **kwargs)
-                    try:
-                        # This try/except allows us to fail gracefully and
-                        # still let the user code continue to execute
-
-                        call = _create_call(wrapper, *args, __weave=__weave, **kwargs)  # type: ignore
-                    except Exception as e:
-                        if get_raise_on_captured_errors():
-                            raise
-                        log_once(
-                            logger.error, CALL_CREATE_MSG.format(traceback.format_exc())
-                        )
-                        return func(*args, **kwargs)
-                    res, _ = _execute_call(wrapper, call, *args, **kwargs)  # type: ignore
+                    res, _ = do_call(
+                        cast(Op, wrapper), *args, __should_raise=True, **kwargs
+                    )
                     return res
 
             # Tack these helpers on to our wrapper

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -379,6 +379,8 @@ def do_call(
             # This try/except allows us to fail gracefully and
             # still let the user code continue to execute
             call = _create_call(op, *args, __weave=__weave, **kwargs)
+        except OpCallError as e:
+            raise e
         except Exception as e:
             if get_raise_on_captured_errors():
                 raise
@@ -420,6 +422,8 @@ async def do_call_async(
             # This try/except allows us to fail gracefully and
             # still let the user code continue to execute
             call = _create_call(op, *args, __weave=__weave, **kwargs)
+        except OpCallError as e:
+            raise e
         except Exception as e:
             if get_raise_on_captured_errors():
                 raise

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -337,11 +337,11 @@ def call(
     ```
     """
     if inspect.iscoroutinefunction(op.resolve_fn):
-        return do_call_async(
+        return _do_call_async(
             op, *args, __weave=__weave, __should_raise=__should_raise, **kwargs
         )
     else:
-        return do_call(
+        return _do_call(
             op, *args, __weave=__weave, __should_raise=__should_raise, **kwargs
         )
 
@@ -359,7 +359,7 @@ def _placeholder_call() -> "Call":
     )
 
 
-def do_call(
+def _do_call(
     op: Op,
     *args: Any,
     __weave: Optional[WeaveKwargs] = None,
@@ -402,7 +402,7 @@ def do_call(
     return res, call
 
 
-async def do_call_async(
+async def _do_call_async(
     op: Op,
     *args: Any,
     __weave: Optional[WeaveKwargs] = None,
@@ -564,7 +564,7 @@ def op(
 
                 @wraps(func)
                 async def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    res, _ = await do_call_async(
+                    res, _ = await _do_call_async(
                         cast(Op, wrapper), *args, __should_raise=True, **kwargs
                     )
                     return res
@@ -572,7 +572,7 @@ def op(
 
                 @wraps(func)
                 def wrapper(*args: Any, **kwargs: Any) -> Any:
-                    res, _ = do_call(
+                    res, _ = _do_call(
                         cast(Op, wrapper), *args, __should_raise=True, **kwargs
                     )
                     return res

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -715,6 +715,8 @@ class WeaveClient:
         *,
         op: Optional[Op] = None,
     ) -> None:
+        ended_at = datetime.datetime.now(tz=datetime.timezone.utc)
+        call.ended_at = ended_at
         original_output = output
 
         if op is not None and op.postprocess_output:
@@ -771,7 +773,6 @@ class WeaveClient:
             call.exception = exception_str
 
         project_id = self._project_id()
-        ended_at = datetime.datetime.now(tz=datetime.timezone.utc)
 
         # The finish handler serves as a last chance for integrations
         # to customize what gets logged for a call.


### PR DESCRIPTION
I am working on another feature and needed to use the `Op.call` pattern. I realized that the typing for this was not exactly correct AND we did not use the same code as the wrapper logic.

So, this PR:
1. Adds a bunch of tests to ensure we do the correct thing for coroutines
2. Shares as much code as possible between `call`, `async wrapper` and `wrapper`
3. Improves typing in various locations