### PR TITLE
fix(ui): add caption overflow scrollbar in AudioViewer component

### DIFF
--- a/weave-js/src/components/Panel2/AudioViewer.tsx
+++ b/weave-js/src/components/Panel2/AudioViewer.tsx
@@ -172,9 +172,10 @@ const AudioViewer = (props: AudioViewerProps) => {
                 style={{
                   background: globals.white,
                   width: '100%',
-                  overflow: 'hidden',
+                  overflowX: 'auto',
+                  overflowY: 'hidden',
                   display: 'flex',
-                  justifyContent: 'center',
+                  justifyContent: 'left',
                   flex: '1 1',
                 }}>
                 {


### PR DESCRIPTION
## Description

- Fixes [WB-10297](https://wandb.atlassian.net/browse/WB-10297)
- Fixes [#3875](https://github.com/wandb/wandb/issues/3875)

This PR addresses an issue where long captions in the AudioViewer component could not be fully read when the caption did overflow. The fix ensures that the horizontal scrollbar only appears when the caption content overflows. The solution replaces overflow: 'hidden' with overflowX: 'auto' and overflowY: 'hidden', preventing unnecessary scrollbars when the content fits within the container.

## Testing
- Locally tested the AudioViewer component (with `governor start invoker_fe_prod.ini`) in different scenarios where the caption both exceeds and fits within the container.
- Verified that the horizontal scrollbar only appears when necessary (i.e., when the caption content overflows).
- Confirmed that no vertical scrollbars appear and that the layout behaves as expected in both cases.

code to generate workspace:
```
import wandb
import numpy as np

wandb.init()
np_array = np.zeros(4 * 32)  # 4 seconds of audio with 32 Hz
caption = 10 * "Very long caption. " # long caption
audio_clip = wandb.Audio(np_array, sample_rate=32, caption=caption)
wandb.log({"whale songs": audio_clip})
wandb.finish()
```

before:
<img width="675" alt="Screenshot 2024-10-14 at 10 14 45" src="https://github.com/user-attachments/assets/da521158-039e-4dbd-bc18-28fd0e519d9f">

after:
![Screenshot 2024-10-14 at 10 14 25](https://github.com/user-attachments/assets/f4b2c986-0e35-4244-a4d8-98b1a7db0a7f)



[WB-10297]: https://wandb.atlassian.net/browse/WB-10297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ