### PR TITLE
fix(ui): use correct router context for eval compare URL construction

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -922,22 +922,12 @@ const OpPageBinding = () => {
 
 const CompareEvaluationsBinding = () => {
   const history = useHistory();
-  const location = useLocation();
+  const routerContext = useWeaveflowCurrentRouteContext();
   const {entity, project} = useParamsDecoded<Browse3TabParams>();
   const query = useURLSearchParamsDict();
   const evaluationCallIds = useMemo(() => {
     return JSON.parse(query.evaluationCallIds);
   }, [query.evaluationCallIds]);
-
-  const onEvaluationCallIdsUpdate = useCallback(
-    (newEvaluationCallIds: string[]) => {
-      const newQuery = new URLSearchParams(location.search);
-      newQuery.set('evaluationCallIds', JSON.stringify(newEvaluationCallIds));
-      history.push({search: newQuery.toString()});
-    },
-    [history, location.search]
-  );
-
   const selectedMetrics: Record<string, boolean> | null = useMemo(() => {
     try {
       return JSON.parse(query.metrics);
@@ -945,10 +935,28 @@ const CompareEvaluationsBinding = () => {
       return null;
     }
   }, [query.metrics]);
+  const onEvaluationCallIdsUpdate = useCallback(
+    (newEvaluationCallIds: string[]) => {
+      history.push(
+        routerContext.compareEvaluationsUri(
+          entity,
+          project,
+          newEvaluationCallIds,
+          selectedMetrics
+        )
+      );
+    },
+    [history, entity, project, routerContext, selectedMetrics]
+  );
   const setSelectedMetrics = (newModel: Record<string, boolean>) => {
-    const newQuery = new URLSearchParams(location.search);
-    newQuery.set('metrics', JSON.stringify(newModel));
-    history.push({search: newQuery.toString()});
+    history.push(
+      routerContext.compareEvaluationsUri(
+        entity,
+        project,
+        evaluationCallIds,
+        newModel
+      )
+    );
   };
   return (
     <CompareEvaluationsPage

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -948,16 +948,19 @@ const CompareEvaluationsBinding = () => {
     },
     [history, entity, project, routerContext, selectedMetrics]
   );
-  const setSelectedMetrics = useCallback((newModel: Record<string, boolean>) => {
-    history.push(
-      routerContext.compareEvaluationsUri(
-        entity,
-        project,
-        evaluationCallIds,
-        newModel
-      )
-    );
-  }, [history, entity, project, routerContext, evaluationCallIds, selectedMetrics]);
+  const setSelectedMetrics = useCallback(
+    (newModel: Record<string, boolean>) => {
+      history.push(
+        routerContext.compareEvaluationsUri(
+          entity,
+          project,
+          evaluationCallIds,
+          newModel
+        )
+      );
+    },
+    [history, entity, project, routerContext, evaluationCallIds]
+  );
   return (
     <CompareEvaluationsPage
       entity={entity}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -948,7 +948,7 @@ const CompareEvaluationsBinding = () => {
     },
     [history, entity, project, routerContext, selectedMetrics]
   );
-  const setSelectedMetrics = (newModel: Record<string, boolean>) => {
+  const setSelectedMetrics = useCallback((newModel: Record<string, boolean>) => {
     history.push(
       routerContext.compareEvaluationsUri(
         entity,
@@ -957,7 +957,7 @@ const CompareEvaluationsBinding = () => {
         newModel
       )
     );
-  };
+  }, [history, entity, project, routerContext, evaluationCallIds, selectedMetrics]);
   return (
     <CompareEvaluationsPage
       entity={entity}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -188,7 +188,8 @@ export const browse2Context = {
   compareEvaluationsUri: (
     entityName: string,
     projectName: string,
-    evaluationCallIds: string[]
+    evaluationCallIds: string[],
+    metrics: Record<string, boolean> | null
   ) => {
     throw new Error('Not implemented');
   },
@@ -408,14 +409,15 @@ export const browse3ContextGen = (
     compareEvaluationsUri: (
       entityName: string,
       projectName: string,
-      evaluationCallIds: string[]
+      evaluationCallIds: string[],
+      metrics: Record<string, boolean> | null
     ) => {
       return `${projectRoot(
         entityName,
         projectName
       )}/compare-evaluations?evaluationCallIds=${encodeURIComponent(
         JSON.stringify(evaluationCallIds)
-      )}`;
+      )}&metrics=${encodeURIComponent(JSON.stringify(metrics))}`;
     },
   };
   return browse3Context;
@@ -498,7 +500,8 @@ type RouteType = {
   compareEvaluationsUri: (
     entityName: string,
     projectName: string,
-    evaluationCallIds: string[]
+    evaluationCallIds: string[],
+    metrics: Record<string, boolean> | null
   ) => string;
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -412,12 +412,15 @@ export const browse3ContextGen = (
       evaluationCallIds: string[],
       metrics: Record<string, boolean> | null
     ) => {
+      const metricsPart = metrics
+        ? `&metrics=${encodeURIComponent(JSON.stringify(metrics))}`
+        : '';
       return `${projectRoot(
         entityName,
         projectName
       )}/compare-evaluations?evaluationCallIds=${encodeURIComponent(
         JSON.stringify(evaluationCallIds)
-      )}&metrics=${encodeURIComponent(JSON.stringify(metrics))}`;
+      )}${metricsPart}`;
     },
   };
   return browse3Context;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -782,7 +782,12 @@ export const CallsTable: FC<{
             <CompareEvaluationsTableButton
               onClick={() => {
                 history.push(
-                  router.compareEvaluationsUri(entity, project, selectedCalls)
+                  router.compareEvaluationsUri(
+                    entity,
+                    project,
+                    selectedCalls,
+                    null
+                  )
                 );
               }}
               disabled={selectedCalls.length === 0}


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Use the correct routerContext constructor for URL construction when selecting metrics (and evaluationIDs)

## Testing

👁️ 👁️ 
