### PR TITLE
chore(ui): example section must have all the metrics -- fix

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/exampleCompareSectionUtil.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/exampleCompareSectionUtil.ts
@@ -118,8 +118,8 @@ const rowIsSelected = (
 export const useFilteredAggregateRows = (state: EvaluationComparisonState) => {
   const leafDims = useMemo(() => getOrderedCallIds(state), [state]);
   const compositeMetricsMap = useMemo(
-    () => buildCompositeMetricsMap(state.data, 'score', state.selectedMetrics),
-    [state.data, state.selectedMetrics]
+    () => buildCompositeMetricsMap(state.data, 'score'),
+    [state.data]
   );
 
   const flattenedRows = useMemo(() => {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fix for issue raised in [this](https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1728947773955989) thread, eval comparison crashes when drilling down into examples.

This pr:
- don't filter down example composite data by selected metrics, this section ignores selected metrics. 

## Testing

clicked around
