### PR TITLE
fix(weave): Use sdk-local deserializer instead of saved deserializer for known types like Images

### DIFF
--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -6,9 +6,11 @@ from weave.trace.custom_objs import decode_custom_obj, encode_custom_obj
 def test_decode_custom_obj_known_type(client):
     img = Image.new("RGB", (100, 100))
     encoded = encode_custom_obj(img)
-    
+
     # Even though something is wrong with the deserializer op, we can still decode
-    decoded = decode_custom_obj(encoded["weave_type"], encoded["files"], "weave:///totally/invalid/uri")
-    
+    decoded = decode_custom_obj(
+        encoded["weave_type"], encoded["files"], "weave:///totally/invalid/uri"
+    )
+
     assert isinstance(decoded, Image.Image)
     assert decoded.tobytes() == img.tobytes()

--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -1,0 +1,14 @@
+from PIL import Image
+
+from weave.trace.custom_objs import decode_custom_obj, encode_custom_obj
+
+
+def test_decode_custom_obj_known_type(client):
+    img = Image.new("RGB", (100, 100))
+    encoded = encode_custom_obj(img)
+    
+    # Even though something is wrong with the deserializer op, we can still decode
+    decoded = decode_custom_obj(encoded["weave_type"], encoded["files"], "weave:///totally/invalid/uri")
+    
+    assert isinstance(decoded, Image.Image)
+    assert decoded.tobytes() == img.tobytes()

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -15,7 +15,11 @@ class DecodeCustomObjectError(Exception):
 
 # in future, could generalize as
 # {target_cls.__module__}.{target_cls.__qualname__}
-KNOWN_TYPES = ["PIL.Image.Image", "wave.Wave_read"]
+KNOWN_TYPES = {
+    "Op",
+    "PIL.Image.Image",
+    "wave.Wave_read",
+}
 
 
 def encode_custom_obj(obj: Any) -> Optional[dict]:
@@ -71,7 +75,7 @@ def _decode_custom_obj(
 def decode_custom_obj(
     weave_type: dict,
     encoded_path_contents: Mapping[str, Union[str, bytes]],
-    load_instance_op_uri: Optional[str],
+    load_instance_op_uri: Optional[str] = None,
 ) -> Any:
     _type = weave_type["type"]
     found_serializer = False

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -8,11 +8,9 @@ from weave.trace.op import Op, op
 from weave.trace.refs import ObjectRef, parse_uri
 from weave.trace.serializer import get_serializer_by_id, get_serializer_for_obj
 
-KNOWN_TYPES = [
-    "PIL.Image.Image",
-    # in future, could generalize as
-    # {target_cls.__module__}.{target_cls.__qualname__}
-]
+# in future, could generalize as
+# {target_cls.__module__}.{target_cls.__qualname__}
+KNOWN_TYPES = ["PIL.Image.Image", "wave.Wave_read"]
 
 
 def encode_custom_obj(obj: Any) -> Optional[dict]:

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -57,7 +57,8 @@ def encode_custom_obj(obj: Any) -> Optional[dict]:
 
 
 def _decode_custom_obj_with_op(
-    encoded_path_contents: Mapping[str, Union[str, bytes]], load_instance_op: Op
+    encoded_path_contents: Mapping[str, Union[str, bytes]],
+    load_instance_op: Op,
 ) -> Any:
     # Disables tracing so that calls to loading data itself don't get traced
     load_instance_op._tracing_enabled = False  # type: ignore

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -8,6 +8,12 @@ from weave.trace.op import Op, op
 from weave.trace.refs import ObjectRef, parse_uri
 from weave.trace.serializer import get_serializer_by_id, get_serializer_for_obj
 
+KNOWN_TYPES = [
+    "PIL.Image.Image",
+    # in future, could generalize as
+    # {target_cls.__module__}.{target_cls.__qualname__}
+]
+
 
 def encode_custom_obj(obj: Any) -> Optional[dict]:
     serializer = get_serializer_for_obj(obj)
@@ -53,7 +59,7 @@ def decode_custom_obj(
     load_instance_op_uri: Optional[str],
 ) -> Any:
     load_instance_op = None
-    if load_instance_op_uri is not None:
+    if weave_type["type"] not in KNOWN_TYPES and load_instance_op_uri is not None:
         ref = parse_uri(load_instance_op_uri)
         if not isinstance(ref, ObjectRef):
             raise ValueError(f"Expected ObjectRef, got {load_instance_op_uri}")

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -60,6 +60,8 @@ def decode_custom_obj(
 ) -> Any:
     if weave_type["type"] in KNOWN_TYPES:
         serializer = get_serializer_by_id(weave_type["type"])
+        if serializer is None:
+            raise ValueError(f"No serializer found for {weave_type}")
         load_instance_op = serializer.load
     elif load_instance_op_uri is not None:
         ref = parse_uri(load_instance_op_uri)


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

https://wandb.atlassian.net/browse/WB-21517

- Prefer using the SDK's local registered deserializer instead of the saved deserializer for known types like Images

## Testing

Unit tests and manual testing