### PR TITLE
feat(weave): add cost logging to Gemini integration

### DIFF
--- a/weave/integrations/google_ai_studio/google_ai_studio_sdk.py
+++ b/weave/integrations/google_ai_studio/google_ai_studio_sdk.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 import weave
 from weave.trace.op_extensions.accumulator import add_accumulator
 from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.weave_client import Call
 
 if TYPE_CHECKING:
     from google.generativeai.types.generation_types import GenerateContentResponse
@@ -28,10 +29,36 @@ def gemini_accumulator(
     return acc
 
 
+def gemini_on_finish(
+    call: Call, output: Any, exception: Optional[BaseException]
+) -> None:
+    original_model_name = call.inputs["self"].model_name
+    model_name = original_model_name.split("/")[-1]
+    usage = {}
+    model_usage = {
+        "requests": 1,
+    }
+    usage[model_name] = model_usage
+    summary_update = {
+        "usage": usage,
+    }
+    if output:
+        model_usage.update(
+            {
+                "prompt_tokens": output.usage_metadata.prompt_token_count,
+                "completion_tokens": output.usage_metadata.candidates_token_count,
+                "total_tokens": output.usage_metadata.total_token_count,
+            }
+        )
+    if call.summary is not None:
+        call.summary.update(summary_update)
+
+
 def gemini_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
         op = weave.op()(fn)
         op.name = name  # type: ignore
+        op._set_on_finish_handler(gemini_on_finish)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: gemini_accumulator,
@@ -54,6 +81,7 @@ def gemini_wrapper_async(name: str) -> Callable[[Callable], Callable]:
         "We need to do this so we can check if `stream` is used"
         op = weave.op()(_fn_wrapper(fn))
         op.name = name  # type: ignore
+        op._set_on_finish_handler(gemini_on_finish)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: gemini_accumulator,


### PR DESCRIPTION
## Description

Updates the Gemini integration to make use of the new "finish handler" support. We register a callback that extracts the token usage information from the Gemini response object and converts it into the format our costs code expects.

Before:
<img width="218" alt="Screenshot 2024-10-15 at 2 18 04 PM" src="https://github.com/user-attachments/assets/c5156f5f-4322-4078-9d81-7573cbf0dc99">

After:
<img width="216" alt="Screenshot 2024-10-15 at 2 31 36 PM" src="https://github.com/user-attachments/assets/90666d14-5393-4cfb-aa02-5f365c0e16bc">

## Testing

How was this PR tested?
