### PR TITLE
chore(ui): audio player for logged wav objects

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/Audio/AudioPlayer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/Audio/AudioPlayer.tsx
@@ -1,0 +1,179 @@
+import {
+  MOON_350,
+  TEAL_500,
+} from '@wandb/weave/common/css/color.styles';
+import {formatDurationWithColons} from '@wandb/weave/common/util/time';
+import {Button} from '@wandb/weave/components/Button';
+import {Tailwind} from '@wandb/weave/components/Tailwind';
+import React, {FC, useEffect, useRef, useState} from 'react';
+import WaveSurfer from 'wavesurfer.js';
+
+import {LoadingDots} from '../../../../../LoadingDots';
+import {useWFHooks} from '../../pages/wfReactInterface/context';
+import {CustomWeaveTypePayload} from '../customWeaveType.types';
+
+type AudioPlayerTypePayload = CustomWeaveTypePayload<
+  'openai._legacy_response.HttpxBinaryResponseContent',
+  {'audio.wav': string}
+>;
+
+export const AudioPlayer: FC<{
+  entity: string;
+  project: string;
+  data: AudioPlayerTypePayload;
+}> = ({entity, project, data}) => {
+  const {useFileContent} = useWFHooks();
+  const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const audioBinary = useFileContent(entity, project, data.files['audio.wav']);
+
+  useEffect(() => {
+    if (audioBinary.result) {
+      setAudioUrl(URL.createObjectURL(new Blob([audioBinary.result])));
+    }
+  }, [audioBinary.result]);
+
+  console.log('audioBinary', audioBinary);
+
+  if (audioBinary.loading) {
+    return <LoadingDots />;
+  } else if (audioBinary.result == null || audioUrl == null) {
+    return <span></span>;
+  }
+
+  return <MiniAudioViewer audioSrc={audioUrl} height={24} />;
+};
+
+const MiniAudioViewer: FC<{
+  audioSrc: string;
+  height: number;
+  downloadFile?: () => void;
+}> = ({audioSrc, height, downloadFile}) => {
+  /* 
+  Heavily inspired by code in weave-js/src/components/Panel2/AudioViewer.tsx 
+  
+  This component has 3 modes, based on the width of the container. Component
+  is responsive to width changes. Modes:
+  - controls: show play/pause, time, and download. ex: (> 0:00/0:05 v)
+  - slider: show play/pause, time, and waveform. ex:   (> 0:01/0:05 --|-----------)
+  - mini: show play/pause and time. ex:                (> 0:01/0:05)
+  */
+  const measureDivRef = useRef<HTMLDivElement>(null);
+  const [showMode, setShowMode] = useState<'controls' | 'slider' | 'mini'>(
+    'controls'
+  );
+
+  const wavesurferRef = useRef<WaveSurfer>();
+  const waveformDomRef = useRef<HTMLDivElement>(null);
+  const [audioLoading, setAudioLoading] = React.useState(true);
+  const [audioPlaying, setAudioPlaying] = React.useState(false);
+  const [audioTotalTime, setAudioTotalTime] = React.useState<number>();
+  const [audioCurrentTime, setAudioCurrentTime] = React.useState<number>();
+
+  // initializes the wavesurfer.js div and object (used to display waveforms)
+  React.useEffect(() => {
+    if (audioSrc && waveformDomRef.current && measureDivRef.current) {
+      const wavesurfer = WaveSurfer.create({
+        backend: 'WebAudio',
+        container: waveformDomRef.current,
+        waveColor: MOON_350,
+        progressColor: TEAL_500,
+        cursorColor: MOON_350,
+        responsive: true,
+        height,
+        barHeight: 1.3, // slightly exaggerated
+      });
+
+      wavesurferRef.current = wavesurfer;
+
+      /* WAVESURFER EVENTS */
+      wavesurfer.on('play', () => {
+        setAudioPlaying(true);
+      });
+      wavesurfer.on('pause', () => {
+        setAudioPlaying(false);
+      });
+      wavesurfer.on('ready', () => {
+        const duration = wavesurfer!.getDuration();
+
+        setAudioLoading(false);
+        setAudioCurrentTime(undefined);
+        setAudioTotalTime(duration || undefined);
+      });
+      // fires when you click a new location in the waveform
+      wavesurfer.on('seek', () => {
+        setAudioCurrentTime(wavesurfer!.getCurrentTime());
+      });
+      // fires continuously while audio is playing
+      wavesurfer.on('audioprocess', () => {
+        setAudioCurrentTime(wavesurfer!.getCurrentTime());
+      });
+
+      wavesurfer.load(audioSrc);
+    }
+
+    return () => {
+      if (wavesurferRef.current) {
+        wavesurferRef.current.destroy();
+      }
+    };
+  }, [audioSrc, height, measureDivRef.current?.offsetWidth]);
+
+  const audioCurrentTimeStr = [audioCurrentTime, audioTotalTime]
+    .map(formatDurationWithColons)
+    .map(x => (x.slice(0, 1) === '0' ? x.slice(1) : x))
+    .join('/');
+
+  useEffect(() => {
+    if (measureDivRef.current) {
+      if (measureDivRef.current.offsetWidth > 250) {
+        setShowMode('slider');
+      } else if (measureDivRef.current.offsetWidth < 50) {
+        setShowMode('mini');
+      } else {
+        setShowMode('controls');
+      }
+    }
+  }, [measureDivRef.current?.offsetWidth]);
+
+  return (
+    <Tailwind>
+      <div ref={measureDivRef} className="w-full">
+        <div
+          className={`rounded-2xl bg-moon-150 ${
+            showMode === 'slider' ? 'w-full' : 'w-fit'
+          }`}>
+          <div className="flex w-full items-center">
+            <Button
+              className="ml-6 pl-1 pr-1"
+              disabled={audioLoading}
+              icon={audioPlaying ? 'pause' : 'play'}
+              onClick={() => {
+                if (wavesurferRef.current) {
+                  wavesurferRef.current.playPause();
+                }
+              }}
+              size="small"
+              variant="ghost"
+            />
+            <div className="text-s mx-4">{audioCurrentTimeStr}</div>
+            <div
+              ref={waveformDomRef}
+              className={`w-full ${showMode === 'slider' ? 'block' : 'hidden'}`}
+            />
+            <div>
+              {showMode === 'controls' && (
+                <Button
+                  icon="download"
+                  onClick={downloadFile}
+                  size="small"
+                  variant="ghost"
+                  className="mr-6"
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </Tailwind>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/Audio/AudioPlayer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/Audio/AudioPlayer.tsx
@@ -99,6 +99,7 @@ const MiniAudioViewer: FC<{
         responsive: true,
         height,
         barHeight: 1.3, // slightly exaggerated
+        hideScrollbar: true,
       });
 
       wavesurferRef.current = wavesurfer;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/CustomWeaveTypeDispatcher.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/CustomWeaveTypeDispatcher.tsx
@@ -29,9 +29,6 @@ const customWeaveTypeRegistry: {
   'PIL.Image.Image': {
     component: PILImageImage,
   },
-  'openai._legacy_response.HttpxBinaryResponseContent': {
-    component: AudioPlayer,
-  },
   'wave.Wave_read': {
     component: AudioPlayer,
   },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/CustomWeaveTypeDispatcher.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/CustomWeaveTypeDispatcher.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {AudioPlayer} from './Audio/AudioPlayer';
 import {CustomWeaveTypePayload} from './customWeaveType.types';
 import {PILImageImage} from './PIL.Image.Image/PILImageImage';
 
@@ -27,6 +28,12 @@ const customWeaveTypeRegistry: {
 } = {
   'PIL.Image.Image': {
     component: PILImageImage,
+  },
+  'openai._legacy_response.HttpxBinaryResponseContent': {
+    component: AudioPlayer,
+  },
+  'wave.Wave_read': {
+    component: AudioPlayer,
   },
 };
 

--- a/weave-js/src/components/Panel2/AudioViewer.tsx
+++ b/weave-js/src/components/Panel2/AudioViewer.tsx
@@ -159,7 +159,6 @@ const AudioViewer = (props: AudioViewerProps) => {
                   wavesurferRef.current.playPause();
                 }
               }}
-              size={controlBarHeight > 20 ? 'small' : 'mini'}
             />
             <div
               style={{flex: '1 1 auto', overflow: 'hidden'}}

--- a/weave-js/src/components/Panel2/AudioViewer.tsx
+++ b/weave-js/src/components/Panel2/AudioViewer.tsx
@@ -159,6 +159,7 @@ const AudioViewer = (props: AudioViewerProps) => {
                   wavesurferRef.current.playPause();
                 }
               }}
+              size={controlBarHeight > 20 ? 'small' : 'mini'}
             />
             <div
               style={{flex: '1 1 auto', overflow: 'hidden'}}


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

https://wandb.atlassian.net/browse/WB-21558

Very simple UI for playing audio. There are three different states the new `AudioPlayer` component can be in: 
- controls: has a play/pause button and the timestamps
- slider: show play/pause, the time, a download link, and a scrubbable waveform visualization
- mini: show play/pause

The width of the component determines what state the viewer will be in. Because columns are restricted to 150px minimum in the calls table there doesn't appear to be any place where we use the mini viewer. 

<img width="303" alt="Screenshot 2024-10-15 at 2 58 05 PM" src="https://github.com/user-attachments/assets/772117cc-bacf-4d8d-8493-aa706b35cf34">
<img width="149" alt="Screenshot 2024-10-15 at 2 58 13 PM" src="https://github.com/user-attachments/assets/d1fa02ba-a2e6-4cfc-bb7b-dd4b06314a91">
<img width="46" alt="Screenshot 2024-10-15 at 3 03 53 PM" src="https://github.com/user-attachments/assets/85b8cc74-081e-40d6-9f23-bb776f340476">

<img width="1420" alt="Screenshot 2024-10-16 at 3 01 36 PM" src="https://github.com/user-attachments/assets/8719b61d-147b-4362-8b53-e4415978e5a4">



TODO:
 - better support for expanding the viewer. When its small there should be some indication that it can get larger. 