### PR TITLE
chore(weave): disable docs build in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,9 +28,6 @@ jobs:
       - name: Build dist
         run: |
           uv build
-      - name: Make docs
-        run: |
-          make docs
       - name: upload test distribution
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ inputs.is_test }}


### PR DESCRIPTION
## Description

Disable the doc build during SDK publish added in https://github.com/wandb/weave/pull/2682 - it is causing publish to fail. Doing this in parallel with another approach to fix in https://github.com/wandb/weave/pull/2722

## Testing

How was this PR tested?
