### PR TITLE
fix(ui): improve styles of audio caption for better readability

### DIFF
--- a/weave-js/src/components/Panel2/AudioViewer.tsx
+++ b/weave-js/src/components/Panel2/AudioViewer.tsx
@@ -161,7 +161,7 @@ const AudioViewer = (props: AudioViewerProps) => {
               }}
             />
             <div
-              style={{flex: '1 1 auto', overflow: 'hidden'}}
+              style={{flex: '0 1 auto', overflow: 'hidden', marginLeft: '10px'}}
               className="audio-card-time">
               {[audioCurrentTime, audioTotalTime]
                 .map(formatDurationWithColons)
@@ -172,11 +172,13 @@ const AudioViewer = (props: AudioViewerProps) => {
                 style={{
                   background: globals.white,
                   width: '100%',
-                  overflowX: 'auto',
-                  overflowY: 'hidden',
+                  maxHeight: '3em',
+                  overflowX: 'hidden',
+                  overflowY: 'auto',
                   display: 'flex',
                   justifyContent: 'left',
                   flex: '1 1',
+                  marginLeft: '10px',
                 }}>
                 {
                   <div style={{flexGrow: 1}}>
@@ -184,6 +186,7 @@ const AudioViewer = (props: AudioViewerProps) => {
                       style={{
                         padding: '0 5px',
                         textOverflow: 'ellipsis',
+                        whiteSpace: 'normal',
                       }}>
                       {caption}
                     </div>


### PR DESCRIPTION
## Description

- Fixes [WB-10297](https://wandb.atlassian.net/browse/WB-10297)
- Fixes https://github.com/wandb/wandb/issues/3875

This follow-up PR further refines the styling of audio captions in the AudioViewer component. The previous fix #2689  addressed horizontal scroll overflow but did not fully resolve readability issues with long captions.

In this update:
- A vertical scrollbar has been introduced instead of a horizontal one for better user experience
- Captions are now split across up to 3 lines to prevent clipping and enhance readability
- Captions are left-aligned for consistency and improved visual structure

## Testing:
- Locally tested the AudioViewer component with various long captions (with `governor start invoker_fe_prod.ini`)

before:
<img width="800" alt="Screenshot 2024-10-18 at 15 57 15" src="https://github.com/user-attachments/assets/0a3da38b-75b7-45cf-86fd-439063e417d2">


after:
<img width="801" alt="Screenshot 2024-10-18 at 15 55 54" src="https://github.com/user-attachments/assets/de9af2af-3e50-427c-b3a4-99a4f674e52b">




[WB-10297]: https://wandb.atlassian.net/browse/WB-10297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ