### PR TITLE
chore(weave): ChatCompletion not imported

### DIFF
--- a/weave/flow/chat_util.py
+++ b/weave/flow/chat_util.py
@@ -100,6 +100,8 @@ class OpenAIStream:
                             )
 
     def final_response(self) -> "ChatCompletion":
+        from openai.types.chat import ChatCompletion
+
         if self.first_chunk is None:
             raise ValueError("No chunks received")
         return ChatCompletion(


### PR DESCRIPTION
## Description

Causes: 

```bash
Traceback (most recent call last):
  File "/Users/griffin/.pyenv/versions/weave-python-service/bin/programmer", line 8, in <module>
    sys.exit(main())
  File "/Users/griffin/.pyenv/versions/3.10.8/envs/weave-python-service/lib/python3.10/site-packages/programmer/programmer.py", line 199, in main
    programmer()
  File "/Users/griffin/.pyenv/versions/3.10.8/envs/weave-python-service/lib/python3.10/site-packages/programmer/programmer.py", line 194, in programmer
    session(agent, state)
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 575, in wrapper
    res, _ = _do_call(
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 393, in _do_call
    execute_result = _execute_call(
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 309, in _execute_call
    handle_exception(e)
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 307, in _execute_call
    res = func(*args, **kwargs)
  File "/Users/griffin/.pyenv/versions/3.10.8/envs/weave-python-service/lib/python3.10/site-packages/programmer/programmer.py", line 100, in session
    result = agent.run(agent_state)
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 575, in wrapper
    res, _ = _do_call(
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 393, in _do_call
    execute_result = _execute_call(
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 309, in _execute_call
    handle_exception(e)
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 307, in _execute_call
    res = func(*args, **kwargs)
  File "/Users/griffin/.pyenv/versions/3.10.8/envs/weave-python-service/lib/python3.10/site-packages/programmer/agent.py", line 140, in run
    state = self.step(state)
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 575, in wrapper
    res, _ = _do_call(
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 393, in _do_call
    execute_result = _execute_call(
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 309, in _execute_call
    handle_exception(e)
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/op.py", line 307, in _execute_call
    res = func(*args, **kwargs)
  File "/Users/griffin/.pyenv/versions/3.10.8/envs/weave-python-service/lib/python3.10/site-packages/programmer/agent.py", line 114, in step
    response = wrapped_stream.final_response()
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/flow/chat_util.py", line 105, in final_response
    return ChatCompletion(
NameError: name 'ChatCompletion' is not defined
```