### PR TITLE
fix(ui): Bump version of `visit` to resolve import error

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -136,7 +136,7 @@
     "tailwindcss-radix": "^2.8.0",
     "umap-js": "^1.3.3",
     "unified": "^10.1.0",
-    "unist-util-visit": "2.0.3",
+    "unist-util-visit": "3.1.0",
     "universal-perf-hooks": "^1.0.1",
     "vega": "^5.24.0",
     "vega-lite": "5.6.0",

--- a/weave-js/src/common/util/markdown.ts
+++ b/weave-js/src/common/util/markdown.ts
@@ -14,7 +14,7 @@ import math from 'remark-math';
 import parse from 'remark-parse';
 import remark2rehype from 'remark-rehype';
 import {Plugin, unified} from 'unified';
-import { visit } from 'unist-util-visit';
+import {visit} from 'unist-util-visit';
 
 import {blankifyLinks, shiftHeadings} from './html';
 

--- a/weave-js/src/common/util/markdown.ts
+++ b/weave-js/src/common/util/markdown.ts
@@ -14,7 +14,7 @@ import math from 'remark-math';
 import parse from 'remark-parse';
 import remark2rehype from 'remark-rehype';
 import {Plugin, unified} from 'unified';
-import visit from 'unist-util-visit';
+import { visit } from 'unist-util-visit';
 
 import {blankifyLinks, shiftHeadings} from './html';
 

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -14318,6 +14318,14 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
+unist-util-visit-parents@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz#e83559a4ad7e6048a46b1bdb22614f2f3f4724f2"
+  integrity sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
 unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz#b4520811b0ca34285633785045df7a8d6776cfeb"
@@ -14326,14 +14334,14 @@ unist-util-visit-parents@^5.0.0, unist-util-visit-parents@^5.1.1:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
-unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
-  integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
+unist-util-visit@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-3.1.0.tgz#9420d285e1aee938c7d9acbafc8e160186dbaf7b"
+  integrity sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==
   dependencies:
     "@types/unist" "^2.0.0"
-    unist-util-is "^4.0.0"
-    unist-util-visit-parents "^3.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^4.0.0"
 
 unist-util-visit@^1.1.0:
   version "1.4.1"
@@ -14341,6 +14349,15 @@ unist-util-visit@^1.1.0:
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
   dependencies:
     unist-util-visit-parents "^2.0.0"
+
+unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
+  integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^4.0.0"
+    unist-util-visit-parents "^3.0.0"
 
 unist-util-visit@^4.0.0:
   version "4.1.2"


### PR DESCRIPTION
`unist-util-visit@2.x` will sometimes resolve to using the 3.x version of `unist-util-visit-parents`, which is incompatible with it. Rather than figure out how to get it to resolve the right old version, creep forward with the dependency a little bit, which resolves the problem.
