### PR TITLE
feat(weave): add byte usage to summary tab and object page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import numeral from 'numeral';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import {Timestamp} from '../../../../../Timestamp';
 import {UserLink} from '../../../../../UserLink';
@@ -35,12 +35,20 @@ export const CallSummary: React.FC<{
   );
   const costData = call.traceCall?.summary?.weave?.costs;
 
-  const inputBytes = call.traceCall?.inputs
-    ? JSON.stringify(call.traceCall?.inputs).length
-    : 0;
-  const outputBytes = call.traceCall?.output
-    ? JSON.stringify(call.traceCall?.output).length
-    : 0;
+  const inputBytes = useMemo(
+    () =>
+      call.traceCall?.inputs
+        ? JSON.stringify(call.traceCall?.inputs).length
+        : 0,
+    [call.traceCall?.inputs]
+  );
+  const outputBytes = useMemo(
+    () =>
+      call.traceCall?.output
+        ? JSON.stringify(call.traceCall?.output).length
+        : 0,
+    [call.traceCall?.output]
+  );
   const totalBytesStored = inputBytes + outputBytes;
 
   return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -7,6 +7,7 @@ import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
 import {SimpleKeyValueTable} from '../common/SimplePageLayout';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CostTable} from './cost';
+import numeral from 'numeral';
 
 const SUMMARY_FIELDS_EXCLUDED_FROM_GENERAL_RENDER = [
   'latency_s',
@@ -33,6 +34,14 @@ export const CallSummary: React.FC<{
     )
   );
   const costData = call.traceCall?.summary?.weave?.costs;
+
+  const inputBytes = call.traceCall?.inputs
+    ? JSON.stringify(call.traceCall?.inputs).length
+    : 0;
+  const outputBytes = call.traceCall?.output
+    ? JSON.stringify(call.traceCall?.output).length
+    : 0;
+  const totalBytesStored = inputBytes + outputBytes;
 
   return (
     <div className="overflow-auto px-16 pt-12">
@@ -75,6 +84,7 @@ export const CallSummary: React.FC<{
                 Latency: span.summary.latency_s.toFixed(3) + 's',
               }
             : {}),
+          'Bytes stored': numeral(totalBytesStored).format('0.0b'),
           ...(Object.keys(attributes).length > 0
             ? {Attributes: attributes}
             : {}),

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import numeral from 'numeral';
 import React from 'react';
 
 import {Timestamp} from '../../../../../Timestamp';
@@ -7,7 +8,6 @@ import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
 import {SimpleKeyValueTable} from '../common/SimplePageLayout';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CostTable} from './cost';
-import numeral from 'numeral';
 
 const SUMMARY_FIELDS_EXCLUDED_FROM_GENERAL_RENDER = [
   'latency_s',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -39,6 +39,7 @@ import {
   KnownBaseObjectClassType,
   ObjectVersionSchema,
 } from './wfReactInterface/wfDataModelHooksInterface';
+import numeral from 'numeral';
 
 type ObjectIconProps = {
   baseObjectClass: KnownBaseObjectClassType;
@@ -194,6 +195,10 @@ const ObjectVersionPageInner: React.FC<{
     return <CenteredAnimatedLoader />;
   }
 
+  const bytesStored = data.result?.[0]
+    ? JSON.stringify(data.result?.[0]).length
+    : 0;
+
   return (
     <SimplePageLayoutWithHeader
       title={
@@ -238,6 +243,15 @@ const ObjectVersionPageInner: React.FC<{
                   Subpath: refExtra,
                 }
               : {}),
+            'Bytes stored': (
+              <>
+                {data.loading ? (
+                  <LoadingDots />
+                ) : (
+                  numeral(bytesStored).format('0.0b')
+                )}
+              </>
+            ),
             // 'Type Version': (
             //   <TypeVersionLink
             //     entityName={entityName}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import {useObjectViewEvent} from '@wandb/weave/integrations/analytics/useViewEvents';
+import numeral from 'numeral';
 import React, {useMemo} from 'react';
 
 import {maybePluralizeWord} from '../../../../../core/util/string';
@@ -39,7 +40,6 @@ import {
   KnownBaseObjectClassType,
   ObjectVersionSchema,
 } from './wfReactInterface/wfDataModelHooksInterface';
-import numeral from 'numeral';
 
 type ObjectIconProps = {
   baseObjectClass: KnownBaseObjectClassType;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -191,13 +191,14 @@ const ObjectVersionPageInner: React.FC<{
   const evalHasCalls = (consumingCalls.result?.length ?? 0) > 0;
   const evalHasCallsLoading = consumingCalls.loading;
 
+  const bytesStored = useMemo(
+    () => (data.result?.[0] ? JSON.stringify(data.result?.[0]).length : 0),
+    [data.result]
+  );
+
   if (isEvaluation && evalHasCallsLoading) {
     return <CenteredAnimatedLoader />;
   }
-
-  const bytesStored = data.result?.[0]
-    ? JSON.stringify(data.result?.[0]).length
-    : 0;
 
   return (
     <SimplePageLayoutWithHeader

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -332,6 +332,7 @@ export const SimpleKeyValueTable: FC<{
                   display: 'flex',
                   flexDirection: 'column',
                   justifyContent: 'flex-start',
+                  width: 100,
                 }}>
                 {key}
               </td>


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

- add bytes usage (size of input message + size of output) to `summary` tab in the Call page
- add bytes usage (size of data.result[0]) to `object` page 

"Bytes stored" in summary tab:

https://github.com/user-attachments/assets/247702dc-1a6c-44cd-be57-1aec300ae90b

"Bytes stored" in object page:

https://github.com/user-attachments/assets/a9429bd4-c445-42f6-809a-6ac1d80e500f




## Testing

How was this PR tested?
