### PR TITLE
chore(ui): updating default style for radix tooltip

### DIFF
--- a/weave-js/src/components/RadixTooltip/index.tsx
+++ b/weave-js/src/components/RadixTooltip/index.tsx
@@ -42,7 +42,7 @@ export const Trigger = ({
   ...props
 }: RadixTooltip.TooltipTriggerProps) => (
   <RadixTooltip.Trigger
-    className={twMerge(classNames('cursor-default', className))}
+    className={twMerge(classNames('cursor-inherit', className))}
     {...props}
   />
 );


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Updates the tooltip style to inherit the cursor of the element as opposed to the default cursor. This helps with tooltips that are on clickable targets (ie the Workspace section headers)

## Testing

How was this PR tested?
