### PR TITLE
chore(ui): don't show focus outline on calls grid

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -913,6 +913,9 @@ export const CallsTable: FC<{
           '& .MuiDataGrid-footerContainer': {
             justifyContent: 'flex-start',
           },
+          '& .MuiDataGrid-main:focus-visible': {
+            outline: 'none',
+          },
         }}
         slots={{
           noRowsOverlay: () => {


### PR DESCRIPTION
## Description

@harukatab noticed that if you click the empty space at the left bottom of the calls table and click arrow key up and down you get a focus outline that doesn't look very good.

Before:

<img width="930" alt="Screenshot 2024-10-23 at 1 13 48 PM" src="https://github.com/user-attachments/assets/2a4b593c-681f-4681-8738-021fce01fe2a">


## Testing

How was this PR tested?
