### PR TITLE
chore(weave): Add back hook to check for weave data

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
@@ -10,9 +10,9 @@
 
 import React, {createContext, FC, useContext} from 'react';
 
+import {useHasTraceServerClientContext} from './traceServerClientContext';
 import {tsWFDataModelHooks} from './tsDataModelHooks';
 import {WFDataModelHooksInterface} from './wfDataModelHooksInterface';
-import {useHasTraceServerClientContext} from './traceServerClientContext';
 
 const WFDataModelHooksContext = createContext<WFDataModelHooksInterface | null>(
   null

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
@@ -8,7 +8,7 @@
  *    project and configures the context accordingly.
  */
 
-import React, {createContext, FC, useContext} from 'react';
+import React, {createContext, FC, useContext, useMemo} from 'react';
 
 import {useHasTraceServerClientContext} from './traceServerClientContext';
 import {tsWFDataModelHooks} from './tsDataModelHooks';
@@ -56,6 +56,7 @@ export const useProjectHasTraceServerData = (
       skip: !hasTraceServer,
     }
   );
+  const columns = useMemo(() => ['id'], []);
 
   const calls = tsWFDataModelHooks.useCalls(
     entity,
@@ -65,15 +66,18 @@ export const useProjectHasTraceServerData = (
     undefined,
     undefined,
     undefined,
-    ['id'],
+    columns,
     undefined,
     {
       skip: !hasTraceServer,
     }
   );
   const loading = objs.loading || calls.loading;
-  return {
-    loading,
-    result: (objs.result ?? []).length > 0 || (calls.result ?? []).length > 0,
-  };
+  return useMemo(
+    () => ({
+      loading,
+      result: (objs.result ?? []).length > 0 || (calls.result ?? []).length > 0,
+    }),
+    [loading, objs.result, calls.result]
+  );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
@@ -12,6 +12,7 @@ import React, {createContext, FC, useContext} from 'react';
 
 import {tsWFDataModelHooks} from './tsDataModelHooks';
 import {WFDataModelHooksInterface} from './wfDataModelHooksInterface';
+import {useHasTraceServerClientContext} from './traceServerClientContext';
 
 const WFDataModelHooksContext = createContext<WFDataModelHooksInterface | null>(
   null
@@ -34,4 +35,45 @@ export const WFDataModelAutoProvider: FC<{
       {children}
     </WFDataModelHooksContext.Provider>
   );
+};
+
+/**
+ * Returns true if the client can connect to trace server and the project has
+ * objects or calls.
+ */
+export const useProjectHasTraceServerData = (
+  entity: string,
+  project: string
+) => {
+  const hasTraceServer = useHasTraceServerClientContext();
+  const objs = tsWFDataModelHooks.useRootObjectVersions(
+    entity,
+    project,
+    {},
+    1,
+    true,
+    {
+      skip: !hasTraceServer,
+    }
+  );
+
+  const calls = tsWFDataModelHooks.useCalls(
+    entity,
+    project,
+    {},
+    1,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      skip: !hasTraceServer,
+    }
+  );
+  const loading = objs.loading || calls.loading;
+  return {
+    loading,
+    result: (objs.result ?? []).length > 0 || (calls.result ?? []).length > 0,
+  };
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
@@ -65,7 +65,7 @@ export const useProjectHasTraceServerData = (
     undefined,
     undefined,
     undefined,
-    undefined,
+    ['id'],
     undefined,
     {
       skip: !hasTraceServer,


### PR DESCRIPTION
## Description

This basically reverts the cleanup from https://github.com/wandb/weave/pull/2132. I believe that the limit issue should've been fixed in https://github.com/wandb/weave/pull/2420, so hopefully we should be able to check if a project has weave data more quickly.

## Testing

How was this PR tested?

This should have no effect since it's unused, will follow up in core with a change similar to this https://github.com/wandb/core/pull/20661/commits/3ca824472beff5023cd0c4926e1f95d9cbc63f1c and see how the performance is now.
