### PR TITLE
chore(ui): Added copy button for exception trace

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
@@ -113,7 +113,7 @@ export const ExceptionDetails = ({exceptionInfo}: ExceptionDetailsProps) => {
     return null;
   }
 
-  const handleCopy = () => {
+  const handleCopyTraceback = () => {
     const tracebackText = exceptionInfo.traceback
       .map(
         frame =>
@@ -138,7 +138,7 @@ export const ExceptionDetails = ({exceptionInfo}: ExceptionDetailsProps) => {
           icon="copy"
           tooltip="Copy"
           variant="ghost"
-          onClick={handleCopy}
+          onClick={handleCopyTraceback}
         />
       </div>
       {exceptionInfo.traceback.map((frame: StackFrame, i: number) => (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
@@ -1,10 +1,11 @@
 import * as Colors from '@wandb/weave/common/css/color.styles';
 import {Alert} from '@wandb/weave/components/Alert';
+import copyToClipboard from 'copy-to-clipboard';
 import React from 'react';
 import styled from 'styled-components';
-import copyToClipboard from 'copy-to-clipboard';
-import {Button} from '../../../../../Button';
+
 import {toast} from '../../../../../../common/components/elements/Toast';
+import {Button} from '../../../../../Button';
 
 const AlertExceptionType = styled.span`
   font-weight: 600;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
@@ -114,6 +114,9 @@ export const ExceptionDetails = ({exceptionInfo}: ExceptionDetailsProps) => {
   }
 
   const handleCopyTraceback = () => {
+    if (!exceptionInfo.traceback) {
+      return;
+    }
     const tracebackText = exceptionInfo.traceback
       .map(
         frame =>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/Exceptions.tsx
@@ -2,6 +2,9 @@ import * as Colors from '@wandb/weave/common/css/color.styles';
 import {Alert} from '@wandb/weave/components/Alert';
 import React from 'react';
 import styled from 'styled-components';
+import copyToClipboard from 'copy-to-clipboard';
+import {Button} from '../../../../../Button';
+import {toast} from '../../../../../../common/components/elements/Toast';
 
 const AlertExceptionType = styled.span`
   font-weight: 600;
@@ -92,6 +95,7 @@ export const ExceptionAlert = ({exception}: ExceptionAlertProps) => {
     return null;
   }
   const {type, message} = info;
+
   return (
     <Alert severity="error">
       <AlertExceptionType>{type}:</AlertExceptionType> {message}
@@ -107,9 +111,35 @@ export const ExceptionDetails = ({exceptionInfo}: ExceptionDetailsProps) => {
   if (!exceptionInfo.traceback) {
     return null;
   }
+
+  const handleCopy = () => {
+    const tracebackText = exceptionInfo.traceback
+      .map(
+        frame =>
+          `File "${frame.filename}", line ${frame.line_number}, in ${frame.function_name}\n  ${frame.text}`
+      )
+      .join('\n');
+    const textToCopy = `${tracebackText}\n${exceptionInfo.type}: ${exceptionInfo.message}`;
+    copyToClipboard(textToCopy);
+    toast('Exception traceback details copied to clipboard');
+  };
+
   return (
     <Traceback>
-      <div>Traceback (most recent call last):</div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}>
+        <div>Traceback (most recent call last):</div>
+        <Button
+          icon="copy"
+          tooltip="Copy"
+          variant="ghost"
+          onClick={handleCopy}
+        />
+      </div>
       {exceptionInfo.traceback.map((frame: StackFrame, i: number) => (
         <React.Fragment key={i}>
           <FileInfo>


### PR DESCRIPTION
## Description

![CleanShot 2024-10-24 at 11 03 31](https://github.com/user-attachments/assets/f5dae326-fd76-4ab3-9229-94ef9ec280a0)

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Added a copy button to the exception which copies the traceback from a call to the clipboard.
- Helps the user easily take the problem and look it up elsewhere > like via an LLM.

## Testing

How was this PR tested?