### PR TITLE
chore(weave): assume latest version if no digest/alias specified

### DIFF
--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -223,6 +223,13 @@ class CallRef(RefWithExtra):
 AnyRef = Union[ObjectRef, TableRef, CallRef, OpRef]
 
 
+def parse_name_version(name_version: str) -> tuple[str, str]:
+    if ":" in name_version:
+        name, version = name_version.rsplit(":", maxsplit=1)
+        return name, version
+    return name_version, "latest"
+
+
 def parse_uri(uri: str) -> AnyRef:
     if not uri.startswith("weave:///"):
         raise ValueError(f"Invalid URI: {uri}")
@@ -238,12 +245,12 @@ def parse_uri(uri: str) -> AnyRef:
     if kind == "call":
         return CallRef(entity=entity, project=project, id=remaining[0], _extra=extra)
     elif kind == "object":
-        name, version = remaining[0].split(":")
+        name, version = parse_name_version(remaining[0])
         return ObjectRef(
             entity=entity, project=project, name=name, _digest=version, _extra=extra
         )
     elif kind == "op":
-        name, version = remaining[0].split(":")
+        name, version = parse_name_version(remaining[0])
         return OpRef(
             entity=entity, project=project, name=name, _digest=version, _extra=extra
         )


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-20811 

This currently works and assumes latest version:
```
weave.init("entity/project")
weave.ref("my_obj").get()
```

However, if you specify:
```
weave.ref("weave:///entity/project/object/my_obj").get()
```
It will raise a `ValueError: not enough values to unpack (expected 2, got 1)`.

This fixes it to assume latest.

## Testing

How was this PR tested?
