### PR TITLE
feat(ui): navigate up/down on the calls page from the peek drawer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -338,7 +338,7 @@ const MainPeekingLayout: FC = () => {
     <WFDataModelAutoProvider
       entityName={params.entity!}
       projectName={params.project!}>
-      <CallsTableRowSelectionProvider>
+      <TableRowSelectionProvider>
         <Box
           sx={{
             flex: '1 1 auto',
@@ -423,7 +423,7 @@ const MainPeekingLayout: FC = () => {
             )}
           </Drawer>
         </Box>
-      </CallsTableRowSelectionProvider>
+      </TableRowSelectionProvider>
     </WFDataModelAutoProvider>
   );
 };
@@ -1083,48 +1083,48 @@ const Browse3Breadcrumbs: FC = props => {
   );
 };
 
-export const CallsTableRowSelectionContext = React.createContext<{
-  setCallIds?: (callIds: string[]) => void;
-  getNextCallId?: (currentId: string) => string | null;
-  getPreviousCallId?: (currentId: string) => string | null;
+export const TableRowSelectionContext = React.createContext<{
+  setRowIds?: (rowIds: string[]) => void;
+  getNextRowId?: (currentId: string) => string | null;
+  getPreviousRowId?: (currentId: string) => string | null;
 }>({
-  setCallIds: () => {},
-  getNextCallId: () => null,
-  getPreviousCallId: () => null,
+  setRowIds: () => {},
+  getNextRowId: () => null,
+  getPreviousRowId: () => null,
 });
 
-const CallsTableRowSelectionProvider: FC<{children: React.ReactNode}> = ({
+const TableRowSelectionProvider: FC<{children: React.ReactNode}> = ({
   children,
 }) => {
-  const [callIds, setCallIds] = useState<string[]>([]);
+  const [rowIds, setRowIds] = useState<string[]>([]);
 
-  const getNextCallId = useCallback(
+  const getNextRowId = useCallback(
     (currentId: string) => {
-      console.log('getNextCallId', currentId, callIds);
-      const currentIndex = callIds.indexOf(currentId);
+      console.log('getNextRowId', currentId, rowIds);
+      const currentIndex = rowIds.indexOf(currentId);
       if (currentIndex !== -1) {
-        return callIds[currentIndex + 1];
+        return rowIds[currentIndex + 1];
       }
       return null;
     },
-    [callIds]
+    [rowIds]
   );
 
-  const getPreviousCallId = useCallback(
+  const getPreviousRowId = useCallback(
     (currentId: string) => {
-      const currentIndex = callIds.indexOf(currentId);
+      const currentIndex = rowIds.indexOf(currentId);
       if (currentIndex !== -1) {
-        return callIds[currentIndex - 1];
+        return rowIds[currentIndex - 1];
       }
       return null;
     },
-    [callIds]
+    [rowIds]
   );
 
   return (
-    <CallsTableRowSelectionContext.Provider
-      value={{setCallIds, getNextCallId, getPreviousCallId}}>
+    <TableRowSelectionContext.Provider
+      value={{setRowIds, getNextRowId, getPreviousRowId}}>
       {children}
-    </CallsTableRowSelectionContext.Provider>
+    </TableRowSelectionContext.Provider>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -338,90 +338,92 @@ const MainPeekingLayout: FC = () => {
     <WFDataModelAutoProvider
       entityName={params.entity!}
       projectName={params.project!}>
-      <Box
-        sx={{
-          flex: '1 1 auto',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          overflow: 'hidden',
-          flexDirection: 'row',
-          alignContent: 'stretch',
-        }}>
+      <CallsTableRowSelectionProvider>
         <Box
           sx={{
-            flex: '1 1 40%',
-            overflow: 'hidden',
+            flex: '1 1 auto',
+            width: '100%',
+            height: '100%',
             display: 'flex',
-            marginRight: !isDrawerOpen ? 0 : `${drawerWidthPx}px`,
+            overflow: 'hidden',
+            flexDirection: 'row',
+            alignContent: 'stretch',
           }}>
-          <Browse3ProjectRoot projectRoot={baseRouterProjectRoot} />
-        </Box>
-
-        <Drawer
-          variant="persistent"
-          anchor="right"
-          open={isDrawerOpen}
-          onClose={closePeek}
-          PaperProps={{
-            ref: drawerRef,
-            style: {
+          <Box
+            sx={{
+              flex: '1 1 40%',
               overflow: 'hidden',
-              display: isDrawerOpen ? 'flex' : 'none',
-              zIndex: 1,
-              width: isDrawerOpen ? `${drawerWidthPx}px` : 0,
-              height: '100%',
-              borderLeft: '1px solid #e0e0e0',
-              position: 'absolute',
-              pointerEvents: isDragging ? 'none' : 'auto',
-            },
-          }}
-          ModalProps={{
-            keepMounted: true,
-          }}>
-          <div
-            id="dragger"
-            onMouseDown={handleDragStart}
-            style={{
-              position: 'absolute',
-              top: 0,
-              bottom: 0,
-              left: 0,
-              width: '5px',
-              cursor: 'col-resize',
-              zIndex: 2,
+              display: 'flex',
+              marginRight: !isDrawerOpen ? 0 : `${drawerWidthPx}px`,
+            }}>
+            <Browse3ProjectRoot projectRoot={baseRouterProjectRoot} />
+          </Box>
+
+          <Drawer
+            variant="persistent"
+            anchor="right"
+            open={isDrawerOpen}
+            onClose={closePeek}
+            PaperProps={{
+              ref: drawerRef,
+              style: {
+                overflow: 'hidden',
+                display: isDrawerOpen ? 'flex' : 'none',
+                zIndex: 1,
+                width: isDrawerOpen ? `${drawerWidthPx}px` : 0,
+                height: '100%',
+                borderLeft: '1px solid #e0e0e0',
+                position: 'absolute',
+                pointerEvents: isDragging ? 'none' : 'auto',
+              },
             }}
-          />
-          {peekLocation && (
-            <WeaveflowPeekContext.Provider value={{isPeeking: true}}>
-              <SimplePageLayoutContext.Provider
-                value={{
-                  headerSuffix: (
-                    <Box sx={{flex: '0 0 auto'}}>
-                      <FullPageButton
-                        query={query}
-                        generalBase={generalBase}
-                        targetBase={targetBase}
-                      />
-                      <Button
-                        tooltip="Close drawer"
-                        icon="close"
-                        variant="ghost"
-                        className="ml-4"
-                        onClick={closePeek}
-                      />
-                    </Box>
-                  ),
-                }}>
-                <Browse3ProjectRoot
-                  customLocation={peekLocation}
-                  projectRoot={generalProjectRoot}
-                />
-              </SimplePageLayoutContext.Provider>
-            </WeaveflowPeekContext.Provider>
-          )}
-        </Drawer>
-      </Box>
+            ModalProps={{
+              keepMounted: true,
+            }}>
+            <div
+              id="dragger"
+              onMouseDown={handleDragStart}
+              style={{
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                left: 0,
+                width: '5px',
+                cursor: 'col-resize',
+                zIndex: 2,
+              }}
+            />
+            {peekLocation && (
+              <WeaveflowPeekContext.Provider value={{isPeeking: true}}>
+                <SimplePageLayoutContext.Provider
+                  value={{
+                    headerSuffix: (
+                      <Box sx={{flex: '0 0 auto'}}>
+                        <FullPageButton
+                          query={query}
+                          generalBase={generalBase}
+                          targetBase={targetBase}
+                        />
+                        <Button
+                          tooltip="Close drawer"
+                          icon="close"
+                          variant="ghost"
+                          className="ml-4"
+                          onClick={closePeek}
+                        />
+                      </Box>
+                    ),
+                  }}>
+                  <Browse3ProjectRoot
+                    customLocation={peekLocation}
+                    projectRoot={generalProjectRoot}
+                  />
+                </SimplePageLayoutContext.Provider>
+              </WeaveflowPeekContext.Provider>
+            )}
+          </Drawer>
+        </Box>
+      </CallsTableRowSelectionProvider>
     </WFDataModelAutoProvider>
   );
 };
@@ -1078,5 +1080,51 @@ const Browse3Breadcrumbs: FC = props => {
         </React.Fragment>
       ))}
     </Breadcrumbs>
+  );
+};
+
+export const CallsTableRowSelectionContext = React.createContext<{
+  setCallIds?: (callIds: string[]) => void;
+  getNextCallId?: (currentId: string) => string | null;
+  getPreviousCallId?: (currentId: string) => string | null;
+}>({
+  setCallIds: () => {},
+  getNextCallId: () => null,
+  getPreviousCallId: () => null,
+});
+
+const CallsTableRowSelectionProvider: FC<{children: React.ReactNode}> = ({
+  children,
+}) => {
+  const [callIds, setCallIds] = useState<string[]>([]);
+
+  const getNextCallId = useCallback(
+    (currentId: string) => {
+      console.log('getNextCallId', currentId, callIds);
+      const currentIndex = callIds.indexOf(currentId);
+      if (currentIndex !== -1) {
+        return callIds[currentIndex + 1];
+      }
+      return null;
+    },
+    [callIds]
+  );
+
+  const getPreviousCallId = useCallback(
+    (currentId: string) => {
+      const currentIndex = callIds.indexOf(currentId);
+      if (currentIndex !== -1) {
+        return callIds[currentIndex - 1];
+      }
+      return null;
+    },
+    [callIds]
+  );
+
+  return (
+    <CallsTableRowSelectionContext.Provider
+      value={{setCallIds, getNextCallId, getPreviousCallId}}>
+      {children}
+    </CallsTableRowSelectionContext.Provider>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -8,7 +8,7 @@ import {makeRefCall} from '../../../../../../util/refs';
 import {Button} from '../../../../../Button';
 import {Tailwind} from '../../../../../Tailwind';
 import {Browse2OpDefCode} from '../../../Browse2/Browse2OpDefCode';
-import {CallsTableRowSelectionContext} from '../../../Browse3';
+import {TableRowSelectionContext} from '../../../Browse3';
 import {TRACETREE_PARAM, useWeaveflowCurrentRouteContext} from '../../context';
 import {FeedbackGrid} from '../../feedback/FeedbackGrid';
 import {NotFoundPanel} from '../../NotFoundPanel';
@@ -196,11 +196,9 @@ const CallPageInnerVertical: FC<{
   }, [callComplete]);
 
   // Call navigation by arrow keys and buttons
-  const {getNextCallId, getPreviousCallId} = useContext(
-    CallsTableRowSelectionContext
-  );
+  const {getNextRowId, getPreviousRowId} = useContext(TableRowSelectionContext);
   const onNextCall = useCallback(() => {
-    const nextCallId = getNextCallId?.(currentCall.callId);
+    const nextCallId = getNextRowId?.(currentCall.callId);
     if (nextCallId) {
       history.replace(
         currentRouter.callUIUrl(
@@ -213,16 +211,16 @@ const CallPageInnerVertical: FC<{
         )
       );
     }
-  }, [currentCall, currentRouter, history, path, showTraceTree, getNextCallId]);
+  }, [currentCall, currentRouter, history, path, showTraceTree, getNextRowId]);
   const onPreviousCall = useCallback(() => {
-    const previousCallId = getPreviousCallId?.(currentCall.callId);
-    if (previousCallId) {
+    const previousRowId = getPreviousRowId?.(currentCall.callId);
+    if (previousRowId) {
       history.replace(
         currentRouter.callUIUrl(
           currentCall.entity,
           currentCall.project,
           currentCall.traceId,
-          previousCallId,
+          previousRowId,
           path,
           showTraceTree
         )
@@ -234,7 +232,7 @@ const CallPageInnerVertical: FC<{
     history,
     path,
     showTraceTree,
-    getPreviousCallId,
+    getPreviousRowId,
   ]);
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -31,6 +31,7 @@ import {Icon} from '@wandb/weave/components/Icon';
 import React, {
   FC,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -42,6 +43,7 @@ import {useViewerInfo} from '../../../../../../common/hooks/useViewerInfo';
 import {A, TargetBlank} from '../../../../../../common/util/links';
 import {TailwindContents} from '../../../../../Tailwind';
 import {flattenObjectPreservingWeaveTypes} from '../../../Browse2/browse2Util';
+import {CallsTableRowSelectionContext} from '../../../Browse3';
 import {useWeaveflowCurrentRouteContext} from '../../context';
 import {OnAddFilter} from '../../filters/CellFilterWrapper';
 import {getDefaultOperatorForValue} from '../../filters/common';
@@ -479,6 +481,15 @@ export const CallsTable: FC<{
       }
     }
   }, [rowIds, peekId]);
+  const {setCallIds} = useContext(CallsTableRowSelectionContext);
+  useEffect(() => {
+    // HACK, hideControls is a proxy for when the table is embedded
+    // in the peek drawer, we only want to track call IDs in the main
+    // table. Ignore call Ids if hiding controls.
+    if (!hideControls && setCallIds) {
+      setCallIds(rowIds);
+    }
+  }, [rowIds, hideControls, setCallIds]);
 
   // CPR (Tim) - (GeneralRefactoring): Co-locate this closer to the effective filter stuff
   const clearFilters = useCallback(() => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -43,7 +43,7 @@ import {useViewerInfo} from '../../../../../../common/hooks/useViewerInfo';
 import {A, TargetBlank} from '../../../../../../common/util/links';
 import {TailwindContents} from '../../../../../Tailwind';
 import {flattenObjectPreservingWeaveTypes} from '../../../Browse2/browse2Util';
-import {CallsTableRowSelectionContext} from '../../../Browse3';
+import {TableRowSelectionContext} from '../../../Browse3';
 import {useWeaveflowCurrentRouteContext} from '../../context';
 import {OnAddFilter} from '../../filters/CellFilterWrapper';
 import {getDefaultOperatorForValue} from '../../filters/common';
@@ -481,15 +481,15 @@ export const CallsTable: FC<{
       }
     }
   }, [rowIds, peekId]);
-  const {setCallIds} = useContext(CallsTableRowSelectionContext);
+  const {setRowIds} = useContext(TableRowSelectionContext);
   useEffect(() => {
     // HACK, hideControls is a proxy for when the table is embedded
     // in the peek drawer, we only want to track call IDs in the main
     // table. Ignore call Ids if hiding controls.
-    if (!hideControls && setCallIds) {
-      setCallIds(rowIds);
+    if (!hideControls && setRowIds) {
+      setRowIds(rowIds);
     }
-  }, [rowIds, hideControls, setCallIds]);
+  }, [rowIds, hideControls, setRowIds]);
 
   // CPR (Tim) - (GeneralRefactoring): Co-locate this closer to the effective filter stuff
   const clearFilters = useCallback(() => {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

use `shift` + `up arrow` or `down arrow` to control the selected call in the calls table. 

implementation can be extended to the other main page tables, although the rowIds behave slightly differently. 

## Testing

How was this PR tested?
