### PR TITLE
chore: add feedback replace endpoint that purges -> creates in one step

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -30,7 +30,6 @@ import logging
 import threading
 from collections import defaultdict
 from contextlib import contextmanager
-from functools import partial
 from typing import (
     Any,
     Dict,
@@ -79,19 +78,6 @@ from weave.trace_server.feedback import (
     validate_feedback_purge_req,
 )
 from weave.trace_server.ids import generate_id
-from weave.trace_server.interface.base_models.action_base_models import (
-    LLM_JUDGE_ACTION_NAME,
-    ConfiguredAction,
-)
-from weave.trace_server.interface.base_models.base_model_registry import (
-    base_model_dump,
-    base_model_name,
-    base_models,
-)
-from weave.trace_server.interface.base_models.feedback_base_model_registry import (
-    ActionScore,
-    feedback_base_models,
-)
 from weave.trace_server.orm import ParamBuilder, Row
 from weave.trace_server.table_query_builder import (
     ROW_ORDER_COLUMN_NAME,
@@ -131,8 +117,6 @@ FILE_CHUNK_SIZE = 100000
 
 MAX_DELETE_CALLS_COUNT = 100
 MAX_CALLS_STREAM_BATCH_SIZE = 500
-
-WEAVE_ACTION_EXECUTOR_PACEHOLDER_ID = "WEAVE_ACTION_EXECUTOR"
 
 
 class NotFoundError(Exception):
@@ -582,28 +566,16 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         return tsi.OpQueryRes(op_objs=objs)
 
     def obj_create(self, req: tsi.ObjCreateReq) -> tsi.ObjCreateRes:
-        req_obj = req.obj
-        dict_val = req_obj.val
-
-        if req.obj.base_object_class:
-            for base_model in base_models:
-                if base_model_name(base_model) == req.obj.base_object_class:
-                    # 1. Validate the object against the base model & re-dump to a dict
-                    dict_val = base_model_dump(base_model.model_validate(dict_val))
-                    break
-            else:
-                raise ValueError(
-                    f"Unknown base object class: {req.obj.base_object_class}"
-                )
-
-        json_val = json.dumps(dict_val)
+        json_val = json.dumps(req.obj.val)
         digest = str_digest(json_val)
+
+        req_obj = req.obj
         ch_obj = ObjCHInsertable(
             project_id=req_obj.project_id,
             object_id=req_obj.object_id,
-            kind=get_kind(dict_val),
-            base_object_class=get_base_object_class(dict_val),
-            refs=extract_refs_from_values(dict_val),
+            kind=get_kind(req.obj.val),
+            base_object_class=get_base_object_class(req.obj.val),
+            refs=extract_refs_from_values(req.obj.val),
             val_dump=json_val,
             digest=digest,
         )
@@ -1346,17 +1318,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         assert_non_null_wb_user_id(req)
         validate_feedback_create_req(req)
 
-        feedback_type = req.feedback_type
-        res_payload = req.payload
-
-        for feedback_base_model in feedback_base_models:
-            if base_model_name(feedback_base_model) == feedback_type:
-                res_payload = base_model_dump(
-                    feedback_base_model.model_validate(res_payload)
-                )
-                break
-
         # Augment emoji with alias.
+        res_payload = {}
         if req.feedback_type == "wandb.reaction.1":
             em = req.payload["emoji"]
             if emoji.emoji_count(em) != 1:
@@ -1419,99 +1382,34 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         query = query.project_id(req.project_id)
         query = query.where(req.query)
         prepared = query.prepare(database_type="clickhouse")
-        self.ch_client.query(prepared.sql, prepared.parameters)
-        return tsi.FeedbackPurgeRes()
+        query_result = self.ch_client.query(prepared.sql, prepared.parameters)
+        return tsi.FeedbackPurgeRes(num_deleted=query_result.row_count)
 
-    def execute_batch_action(
-        self, req: tsi.ExecuteBatchActionReq
-    ) -> tsi.ExecuteBatchActionRes:
-        # WARNING: THIS IS NOT GOING TO WORK IN PRODUCTION
-        # UNTIL WE HAVE THE API KEY PIECE IN PLACE
-        configured_action_ref = req.configured_action_ref
-
-        action_dict_res = self.refs_read_batch(
-            tsi.RefsReadBatchReq(refs=[configured_action_ref])
-        )
-
-        action_dict = action_dict_res.vals[0]
-        action = ConfiguredAction.model_validate(action_dict)
-
-        if action.action.action_type != "builtin":
-            raise InvalidRequest(
-                "Only builtin actions are supported for batch execution"
-            )
-
-        if action.action.name != LLM_JUDGE_ACTION_NAME:
-            raise InvalidRequest("Only llm_judge is supported for batch execution")
-
-        # Step 1: Get all the calls in the batch
-        calls = self.calls_query_stream(
-            tsi.CallsQueryReq(
-                project_id=req.project_id,
-                filter=tsi.CallsFilter(
-                    call_ids=req.call_ids,
-                ),
-            )
-        )
-
-        # Normally we would dispatch here, but just hard coding for now
-        # We should do some validation here
-        config = action.config
-        model = config["model"]
-
-        if model not in ["gpt-4o-mini", "gpt-4o"]:
-            raise InvalidRequest("Only gpt-4o-mini and gpt-4o are supported")
-
-        system_prompt = config["system_prompt"]
-        response_format_schema = config["response_format_schema"]
-        response_format = {
-            "type": "json_schema",
-            "json_schema": {
-                "name": "response_format",
-                "schema": response_format_schema,
+    def feedback_replace(self, req: tsi.FeedbackReplaceReq) -> tsi.FeedbackReplaceRes:
+        # To replace, first purge, then if successful, create.
+        purge_request = tsi.FeedbackPurgeReq(
+            project_id=req.project_id,
+            query={
+                "$expr": {
+                    "$eq": [
+                        {"$getField": "id"},
+                        {"$literal": req.feedback_id},
+                    ],
+                }
             },
-        }
-
-        # mapping = mapping.input_mapping
-
-        # Step 2: For Each call, execute the action: (this needs a lot of safety checks)
-        for call in calls:
-            args = {
-                "inputs": call.inputs,
-                "output": call.output,
-            }
-            from openai import OpenAI
-
-            client = OpenAI()
-            # Silly hack to get around issue in tests:
-            create = client.chat.completions.create
-            if hasattr(create, "resolve_fn"):
-                create = partial(create.resolve_fn, self=client.chat.completions)
-            completion = create(
-                model=model,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": json.dumps(args)},
-                ],
-                response_format=response_format,
-            )
-            self.feedback_create(
-                tsi.FeedbackCreateReq(
-                    project_id=req.project_id,
-                    weave_ref=ri.InternalCallRef(
-                        project_id=req.project_id,
-                        id=call.id,
-                    ).uri(),
-                    feedback_type=base_model_name(ActionScore),
-                    wb_user_id=WEAVE_ACTION_EXECUTOR_PACEHOLDER_ID,  # - THIS IS NOT GOOD!
-                    payload=ActionScore(
-                        configured_action_ref=configured_action_ref,
-                        output=json.loads(completion.choices[0].message.content),
-                    ).model_dump(),
-                )
+        )
+        purge_result = self.feedback_purge(purge_request)
+        if purge_result.num_deleted == 0:
+            raise InvalidRequest(f"Failed to purge feedback with id {req.feedback_id}")
+        if purge_result.num_deleted > 1:
+            raise InvalidRequest(
+                f"Purged more than one feedback with id {req.feedback_id}"
             )
 
-        return tsi.ExecuteBatchActionRes()
+        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
+        create_result = self.feedback_create(create_req)
+
+        return tsi.FeedbackReplaceRes(**create_result.model_dump())
 
     # Private Methods
     @property
@@ -2076,7 +1974,7 @@ def _process_parameters(
 
 
 def get_type(val: Any) -> str:
-    if val is None:
+    if val == None:
         return "none"
     elif isinstance(val, dict):
         if "_type" in val:
@@ -2097,24 +1995,16 @@ def get_kind(val: Any) -> str:
 
 
 def get_base_object_class(val: Any) -> Optional[str]:
-    """
-    Get the base object class of a value using:
-    1. The last base class that is a subclass of BaseModel and not Object
-    2. The _class_name attribute if it exists
-    3. None if no base class is found
-    """
     if isinstance(val, dict):
         if "_bases" in val:
             if isinstance(val["_bases"], list):
-                bases = val["_bases"]
-                if len(bases) > 0 and bases[-1] == "BaseModel":
-                    bases = bases[:-1]
-                    if len(bases) > 0 and bases[-1] == "Object":
-                        bases = bases[:-1]
-                    if len(bases) > 0:
-                        return bases[-1]
-                    elif "_class_name" in val:
-                        return val["_class_name"]
+                if len(val["_bases"]) >= 2:
+                    if val["_bases"][-1] == "BaseModel":
+                        if val["_bases"][-2] == "Object":
+                            if len(val["_bases"]) > 2:
+                                return val["_bases"][-3]
+                            elif "_class_name" in val:
+                                return val["_class_name"]
     return None
 
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -326,6 +326,18 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.feedback_purge, req)
 
+    def feedback_replace(self, req: tsi.FeedbackReplaceReq) -> tsi.FeedbackReplaceRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        original_user_id = req.wb_user_id
+        if original_user_id is None:
+            raise ValueError("wb_user_id cannot be None")
+        req.wb_user_id = self._idc.ext_to_int_user_id(original_user_id)
+        res = self._ref_apply(self._internal_trace_server.feedback_replace, req)
+        if res.wb_user_id != req.wb_user_id:
+            raise ValueError("Internal Error - User Mismatch")
+        res.wb_user_id = original_user_id
+        return res
+
     def cost_create(self, req: tsi.CostCreateReq) -> tsi.CostCreateRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.cost_create, req)
@@ -345,9 +357,3 @@ class ExternalTraceServer(tsi.TraceServerInterface):
                     raise ValueError("Internal Error - Project Mismatch")
                 cost["pricing_level_id"] = original_project_id
         return res
-
-    def execute_batch_action(
-        self, req: tsi.ExecuteBatchActionReq
-    ) -> tsi.ExecuteBatchActionRes:
-        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
-        return self._ref_apply(self._internal_trace_server.execute_batch_action, req)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -189,7 +189,6 @@ class ObjSchema(BaseModel):
 class ObjSchemaForInsert(BaseModel):
     project_id: str
     object_id: str
-    base_object_class: Optional[str] = None
     val: Any
 
 
@@ -689,6 +688,14 @@ class FeedbackPurgeReq(BaseModel):
 
 
 class FeedbackPurgeRes(BaseModel):
+    num_deleted: int
+
+
+class FeedbackReplaceReq(FeedbackCreateReq):
+    feedback_id: str
+
+
+class FeedbackReplaceRes(FeedbackCreateRes):
     pass
 
 
@@ -797,16 +804,6 @@ class CostPurgeRes(BaseModel):
     pass
 
 
-class ExecuteBatchActionReq(BaseModel):
-    project_id: str
-    call_ids: list[str]
-    configured_action_ref: str
-
-
-class ExecuteBatchActionRes(BaseModel):
-    pass
-
-
 class TraceServerInterface(Protocol):
     def ensure_project_exists(
         self, entity: str, project: str
@@ -848,8 +845,4 @@ class TraceServerInterface(Protocol):
     def feedback_create(self, req: FeedbackCreateReq) -> FeedbackCreateRes: ...
     def feedback_query(self, req: FeedbackQueryReq) -> FeedbackQueryRes: ...
     def feedback_purge(self, req: FeedbackPurgeReq) -> FeedbackPurgeRes: ...
-
-    # Action API
-    def execute_batch_action(
-        self, req: ExecuteBatchActionReq
-    ) -> ExecuteBatchActionRes: ...
+    def feedback_replace(self, req: FeedbackReplaceReq) -> FeedbackReplaceRes: ...

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -265,7 +265,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
                 req_as_obj = tsi.CallStartReq.model_validate(req)
             else:
                 req_as_obj = req
-            if req_as_obj.start.id is None or req_as_obj.start.trace_id is None:
+            if req_as_obj.start.id == None or req_as_obj.start.trace_id == None:
                 raise ValueError(
                     "CallStartReq must have id and trace_id when batching."
                 )
@@ -527,6 +527,13 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/feedback/purge", req, tsi.FeedbackPurgeReq, tsi.FeedbackPurgeRes
         )
 
+    def feedback_replace(
+        self, req: Union[tsi.FeedbackReplaceReq, dict[str, Any]]
+    ) -> tsi.FeedbackReplaceRes:
+        return self._generic_request(
+            "/feedback/replace", req, tsi.FeedbackReplaceReq, tsi.FeedbackReplaceRes
+        )
+
     # Cost API
     def cost_query(
         self, req: Union[tsi.CostQueryReq, dict[str, Any]]
@@ -547,16 +554,6 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
     ) -> tsi.CostPurgeRes:
         return self._generic_request(
             "/cost/purge", req, tsi.CostPurgeReq, tsi.CostPurgeRes
-        )
-
-    def execute_batch_action(
-        self, req: tsi.ExecuteBatchActionReq
-    ) -> tsi.ExecuteBatchActionRes:
-        return self._generic_request(
-            "/execute/batch_action",
-            req,
-            tsi.ExecuteBatchActionReq,
-            tsi.ExecuteBatchActionRes,
         )
 
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

Adds `feedback_replace` endpoint that purges then deletes in one request. This is necessary to allow quick edits in the new human feedback flow, as we want to auto-save once the user stops typing, but we don't want many different versions of the feedback. Without this endpoint the extra round-trip makes this very clunky to use. 

## Testing

test
