### PR TITLE
fix(ui): Sorted aggregated columns no longer crash tables during ungrouping

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -1,5 +1,6 @@
 import {
   allObjPaths,
+  canSortType,
   constFunction,
   ConstNode,
   constNodeUnsafe,
@@ -687,6 +688,16 @@ export async function disableGroupByCol(
 ) {
   const colIds = _.isArray(colId) ? colId : [colId];
   const groupBy = ts.groupBy;
+
+  // (WB-16067)
+  // We may try to sort on aggregated columns after ungrouping
+  // To prevent this, disable sorting on all the columns and re-enable
+  // after the ungroup
+  const initiallySortedCols = _.clone(ts.sort)
+  ts.sort.forEach(sortObj => {
+    ts = disableSortByCol(ts, sortObj.columnId)
+  })
+
   ts = produce(ts, draft => {
     draft.autoColumns = false;
     for (const cid of colIds) {
@@ -701,9 +712,12 @@ export async function disableGroupByCol(
     }
   });
   ts = await refreshSelectFunctions(ts, inputArrayNode, weave, stack);
-  if (ts.sort.find(s => s.columnId === colId) !== undefined) {
-    ts = disableSortByCol(ts, colId);
-  }
+
+  initiallySortedCols.forEach(sortObj => {
+    if (sortObj.columnId !== colId && canSortType(ts.columnSelectFunctions[sortObj.columnId].type)) {
+      ts = enableSortByCol(ts, sortObj.columnId, sortObj.dir === 'asc')
+    }
+  })
   return ts;
 }
 

--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -693,10 +693,10 @@ export async function disableGroupByCol(
   // We may try to sort on aggregated columns after ungrouping
   // To prevent this, disable sorting on all the columns and re-enable
   // after the ungroup
-  const initiallySortedCols = _.clone(ts.sort)
+  const initiallySortedCols = _.clone(ts.sort);
   ts.sort.forEach(sortObj => {
-    ts = disableSortByCol(ts, sortObj.columnId)
-  })
+    ts = disableSortByCol(ts, sortObj.columnId);
+  });
 
   ts = produce(ts, draft => {
     draft.autoColumns = false;
@@ -714,10 +714,13 @@ export async function disableGroupByCol(
   ts = await refreshSelectFunctions(ts, inputArrayNode, weave, stack);
 
   initiallySortedCols.forEach(sortObj => {
-    if (sortObj.columnId !== colId && canSortType(ts.columnSelectFunctions[sortObj.columnId].type)) {
-      ts = enableSortByCol(ts, sortObj.columnId, sortObj.dir === 'asc')
+    if (
+      sortObj.columnId !== colId &&
+      canSortType(ts.columnSelectFunctions[sortObj.columnId].type)
+    ) {
+      ts = enableSortByCol(ts, sortObj.columnId, sortObj.dir === 'asc');
     }
-  })
+  });
   return ts;
 }
 


### PR DESCRIPTION
JIRA: [WB-16067](https://wandb.atlassian.net/browse/WB-16067)

## Description

- Quick fix to prevent table crashes during ungrouping when there exists sorting is enabled on a column with aggregated data
- Disables sorting before the ungroup and re-enables it after the ungrouping. Note that sorting isn't allowed on the aggregated column after ungrouping anyway so no existing functionality is broken.

## Testing

Old behaviour:

https://github.com/user-attachments/assets/a5a04f4f-8b91-4efc-8260-801e1b71f4c8

New behaviour:

https://github.com/user-attachments/assets/8f956a5b-b703-46a5-aadc-8d47ca3715fa

Existing behaviour when no sorting is applied (the fix aligns with the existing behaviour):

https://github.com/user-attachments/assets/1e6d5424-f469-4e0c-a0c3-a7c98e28c5be



[WB-16067]: https://wandb.atlassian.net/browse/WB-16067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ