### PR TITLE
style(ui): Fix night colors for Callout

### DIFF
--- a/weave-js/src/components/Callout/Callout.tsx
+++ b/weave-js/src/components/Callout/Callout.tsx
@@ -18,6 +18,7 @@ export const Callout = ({className, color, icon, size}: CalloutProps) => {
     <Tailwind>
       <div
         className={twMerge(
+          'night-aware',
           getTagColorClass(color),
           'flex items-center justify-center rounded-full',
           size === 'x-small' && 'h-[40px] w-[40px]',


### PR DESCRIPTION
## Description

add night-aware class on Callouts so they look right in dark mode

before/after:

https://github.com/user-attachments/assets/272699b6-7753-4f64-acb1-847aa29c395e

## Testing

How was this PR tested?
