### PR TITLE
fix(weave): traces charts margin

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCharts.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCharts.tsx
@@ -181,10 +181,8 @@ export const CallsCharts = ({
 
   return (
     <Tailwind>
-      {/* setting the width to the width of the screen minus the sidebar width because of overflow: 'hidden' properties in SimplePageLayout causing issues */}
-      <div className="md:w-[calc(100vw-56px)]">
-        <div className="mb-20 mt-10">{charts}</div>
-      </div>
+      {/* adding extra right margin because SimplePageLayout causes issues with overflow = hidden */}
+      <div className="mb-20 mr-[5px] mt-10">{charts}</div>
     </Tailwind>
   );
 };


### PR DESCRIPTION
## Description

It appears that we don't always show the sidebar in full screen on the weave traces page:

<img width="1918" alt="Screenshot 2024-10-29 at 5 05 31 PM" src="https://github.com/user-attachments/assets/ca7d662f-ea83-4fab-a6cb-3c88adeb6b7a">

<img width="1918" alt="Screenshot 2024-10-29 at 5 05 41 PM" src="https://github.com/user-attachments/assets/1a859aec-41ed-4ecb-9d39-7cd3527fcd04">

which causes the margin of the traces charts to be off by 56px (not shown since I reverted).

We need the extra margin on the right in order to account for issues in SimplePageLayout with overflow: hidden causing the chart div to not fit full screen by a few pixels

## Testing

How was this PR tested?
