### PR TITLE
feat(weave): enable dictify of inputs and outputs

### DIFF
--- a/tests/integrations/google_ai_studio/google_ai_studio_test.py
+++ b/tests/integrations/google_ai_studio/google_ai_studio_test.py
@@ -65,9 +65,8 @@ def test_content_generation(client):
     trace_name = op_name_from_ref(call.op_name)
     assert trace_name == "google.generativeai.GenerativeModel.generate_content"
     assert call.output is not None
-    # TODO: Re-enable after dictify is fixed
-    # assert_correct_output_shape(call.output)
-    # assert_correct_summary(call.summary, trace_name)
+    assert_correct_output_shape(call.output)
+    assert_correct_summary(call.summary, trace_name)
 
 
 @pytest.mark.retry(max_attempts=5)
@@ -92,9 +91,8 @@ def test_content_generation_stream(client):
     trace_name = op_name_from_ref(call.op_name)
     assert trace_name == "google.generativeai.GenerativeModel.generate_content"
     assert call.output is not None
-    # TODO: Re-enable after dictify is fixed
-    # assert_correct_output_shape(call.output)
-    # assert_correct_summary(call.summary, trace_name)
+    assert_correct_output_shape(call.output)
+    assert_correct_summary(call.summary, trace_name)
 
 
 @pytest.mark.retry(max_attempts=5)
@@ -116,6 +114,5 @@ async def test_content_generation_async(client):
     trace_name = op_name_from_ref(call.op_name)
     assert trace_name == "google.generativeai.GenerativeModel.generate_content_async"
     assert call.output is not None
-    # TODO: Re-enable after dictify is fixed
-    # assert_correct_output_shape(call.output)
-    # assert_correct_summary(call.summary, trace_name)
+    assert_correct_output_shape(call.output)
+    assert_correct_summary(call.summary, trace_name)

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1506,10 +1506,24 @@ def test_unknown_input_and_output_types(client):
 
     assert len(inner_res.calls) == 1
     assert inner_res.calls[0].inputs == {
-        "a": repr(a),
+        "a": {
+            "__class__": {
+                "module": "test_client_trace",
+                "qualname": "test_unknown_input_and_output_types.<locals>.MyUnknownClassA",
+                "name": "MyUnknownClassA",
+            },
+            "a_val": 3,
+        },
         "b": 0.14,
     }
-    assert inner_res.calls[0].output == repr(res)
+    assert inner_res.calls[0].output == {
+        "__class__": {
+            "module": "test_client_trace",
+            "qualname": "test_unknown_input_and_output_types.<locals>.MyUnknownClassB",
+            "name": "MyUnknownClassB",
+        },
+        "b_val": 3.14,
+    }
 
 
 def test_unknown_attribute(client):

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1506,24 +1506,10 @@ def test_unknown_input_and_output_types(client):
 
     assert len(inner_res.calls) == 1
     assert inner_res.calls[0].inputs == {
-        "a": {
-            "__class__": {
-                "module": "test_client_trace",
-                "qualname": "test_unknown_input_and_output_types.<locals>.MyUnknownClassA",
-                "name": "MyUnknownClassA",
-            },
-            "a_val": 3,
-        },
+        "a": repr(a),
         "b": 0.14,
     }
-    assert inner_res.calls[0].output == {
-        "__class__": {
-            "module": "test_client_trace",
-            "qualname": "test_unknown_input_and_output_types.<locals>.MyUnknownClassB",
-            "name": "MyUnknownClassB",
-        },
-        "b_val": 3.14,
-    }
+    assert inner_res.calls[0].output == repr(res)
 
 
 def test_unknown_attribute(client):

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -666,7 +666,6 @@ def test_saveload_customtype(client):
     assert obj2.b == "x"
 
 
-@pytest.mark.skip(reason="Re-enable after dictify is fixed")
 def test_save_unknown_type(client):
     class SomeUnknownThing:
         def __init__(self, a):
@@ -675,14 +674,7 @@ def test_save_unknown_type(client):
     obj = SomeUnknownThing(3)
     ref = client._save_object(obj, "my-np-array")
     obj2 = client.get(ref)
-    assert obj2 == {
-        "__class__": {
-            "module": "test_weave_client",
-            "qualname": "test_save_unknown_type.<locals>.SomeUnknownThing",
-            "name": "SomeUnknownThing",
-        },
-        "a": 3,
-    }
+    assert obj2 == repr(obj)
 
 
 def test_save_model(client):

--- a/weave/trace/sanitize.py
+++ b/weave/trace/sanitize.py
@@ -1,0 +1,6 @@
+REDACT_KEYS = (
+    "api_key",
+    "auth_headers",
+    "Authorization",
+)
+REDACTED_VALUE = "REDACTED"

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -1,10 +1,12 @@
 import logging
 import typing
+from types import CoroutineType
 from typing import Any, Optional, Sequence
 
 from weave.trace import custom_objs
 from weave.trace.object_record import ObjectRecord
 from weave.trace.refs import ObjectRef, TableRef, parse_uri
+from weave.trace.sanitize import REDACT_KEYS, REDACTED_VALUE
 from weave.trace_server.interface.base_object_classes.base_object_registry import (
     BASE_OBJECT_REGISTRY,
 )
@@ -19,7 +21,9 @@ if typing.TYPE_CHECKING:
     from weave.trace.weave_client import WeaveClient
 
 
-def to_json(obj: Any, project_id: str, client: "WeaveClient") -> Any:
+def to_json(
+    obj: Any, project_id: str, client: "WeaveClient", use_dictify: bool = False
+) -> Any:
     if isinstance(obj, TableRef):
         return obj.uri()
     elif isinstance(obj, ObjectRef):
@@ -27,14 +31,17 @@ def to_json(obj: Any, project_id: str, client: "WeaveClient") -> Any:
     elif isinstance(obj, ObjectRecord):
         res = {"_type": obj._class_name}
         for k, v in obj.__dict__.items():
-            res[k] = to_json(v, project_id, client)
+            res[k] = to_json(v, project_id, client, use_dictify)
         return res
     elif isinstance_namedtuple(obj):
-        return {k: to_json(v, project_id, client) for k, v in obj._asdict().items()}
+        return {
+            k: to_json(v, project_id, client, use_dictify)
+            for k, v in obj._asdict().items()
+        }
     elif isinstance(obj, (list, tuple)):
-        return [to_json(v, project_id, client) for v in obj]
+        return [to_json(v, project_id, client, use_dictify) for v in obj]
     elif isinstance(obj, dict):
-        return {k: to_json(v, project_id, client) for k, v in obj.items()}
+        return {k: to_json(v, project_id, client, use_dictify) for k, v in obj.items()}
 
     if isinstance(obj, (int, float, str, bool)) or obj is None:
         return obj
@@ -42,6 +49,12 @@ def to_json(obj: Any, project_id: str, client: "WeaveClient") -> Any:
     # This still blocks potentially on large-file i/o.
     encoded = custom_objs.encode_custom_obj(obj)
     if encoded is None:
+        if (
+            use_dictify
+            and not isinstance(obj, ALWAYS_STRINGIFY)
+            and not has_custom_repr(obj)
+        ):
+            return dictify(obj)
         return fallback_encode(obj)
     result = _build_result_from_encoded(encoded, project_id, client)
 
@@ -101,6 +114,11 @@ def is_primitive(obj: Any) -> bool:
     return isinstance(obj, (int, float, str, bool, type(None)))
 
 
+def has_custom_repr(obj: Any) -> bool:
+    """Return True if the object has a custom __repr__ method."""
+    return obj.__class__.__repr__ is not object.__repr__
+
+
 def dictify(
     obj: Any, maxdepth: int = 0, depth: int = 1, seen: Optional[set[int]] = None
 ) -> Any:
@@ -126,23 +144,31 @@ def dictify(
     elif isinstance(obj, (list, tuple)):
         return [dictify(v, maxdepth, depth + 1, seen) for v in obj]
     elif isinstance(obj, dict):
-        return {k: dictify(v, maxdepth, depth + 1, seen) for k, v in obj.items()}
+        dict_result = {}
+        for k, v in obj.items():
+            if k in REDACT_KEYS:
+                dict_result[k] = REDACTED_VALUE
+            else:
+                dict_result[k] = dictify(v, maxdepth, depth + 1, seen)
+        return dict_result
 
     if hasattr(obj, "to_dict"):
         try:
             as_dict = obj.to_dict()
             if isinstance(as_dict, dict):
-                result = {}
+                to_dict_result = {}
                 for k, v in as_dict.items():
-                    if maxdepth == 0 or depth < maxdepth:
-                        result[k] = dictify(v, maxdepth, depth + 1)
+                    if k in REDACT_KEYS:
+                        to_dict_result[k] = REDACTED_VALUE
+                    elif maxdepth == 0 or depth < maxdepth:
+                        to_dict_result[k] = dictify(v, maxdepth, depth + 1)
                     else:
-                        result[k] = stringify(v)
-                return result
+                        to_dict_result[k] = stringify(v)
+                return to_dict_result
         except Exception:
             raise ValueError("to_dict failed")
 
-    result = {}
+    result: dict[Any, Any] = {}
     result["__class__"] = {
         "module": obj.__class__.__module__,
         "qualname": obj.__class__.__qualname__,
@@ -154,10 +180,13 @@ def dictify(
             for i, item in enumerate(obj):
                 result[i] = dictify(item, maxdepth, depth + 1, seen)
         except Exception:
-            raise ValueError("fallback dictify failed")
+            return stringify(obj)
     else:
         for attr in dir(obj):
             if attr.startswith("_"):
+                continue
+            if attr in REDACT_KEYS:
+                result[attr] = REDACTED_VALUE
                 continue
             try:
                 val = getattr(obj, attr)
@@ -168,12 +197,12 @@ def dictify(
                 else:
                     result[attr] = stringify(val)
             except Exception:
-                raise ValueError("fallback dictify failed")
+                return stringify(obj)
     return result
 
 
 # TODO: Investigate why dictifying Logger causes problems
-ALWAYS_STRINGIFY = (logging.Logger,)
+ALWAYS_STRINGIFY = (logging.Logger, CoroutineType)
 
 
 # Note: Max depth not picked scientifically, just trying to keep things under control.

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -35,6 +35,7 @@ from weave.trace.refs import (
     parse_op_uri,
     parse_uri,
 )
+from weave.trace.sanitize import REDACT_KEYS, REDACTED_VALUE
 from weave.trace.serialize import from_json, isinstance_namedtuple, to_json
 from weave.trace.serializer import get_serializer_for_obj
 from weave.trace.settings import client_parallelism
@@ -698,7 +699,7 @@ class WeaveClient:
         project_id = self._project_id()
 
         def send_start_call() -> None:
-            inputs_json = to_json(inputs_with_refs, project_id, self)
+            inputs_json = to_json(inputs_with_refs, project_id, self, use_dictify=True)
             self.server.call_start(
                 CallStartReq(
                     start=StartedCallSchemaForInsert(
@@ -797,7 +798,7 @@ class WeaveClient:
             op._on_finish_handler(call, original_output, exception)
 
         def send_end_call() -> None:
-            output_json = to_json(call.output, project_id, self)
+            output_json = to_json(call.output, project_id, self, use_dictify=True)
             self.server.call_end(
                 CallEndReq(
                     end=EndedCallSchemaForInsert(
@@ -1518,13 +1519,6 @@ def _build_anonymous_op(name: str, config: Optional[Dict] = None) -> Op:
     op = as_op(op)
     op.name = name
     return op
-
-
-REDACT_KEYS = (
-    "api_key",
-    "Authorization",
-)
-REDACTED_VALUE = "REDACTED"
 
 
 def redact_sensitive_keys(obj: typing.Any) -> typing.Any:

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -699,7 +699,7 @@ class WeaveClient:
         project_id = self._project_id()
 
         def send_start_call() -> None:
-            inputs_json = to_json(inputs_with_refs, project_id, self, use_dictify=True)
+            inputs_json = to_json(inputs_with_refs, project_id, self, use_dictify=False)
             self.server.call_start(
                 CallStartReq(
                     start=StartedCallSchemaForInsert(
@@ -798,7 +798,7 @@ class WeaveClient:
             op._on_finish_handler(call, original_output, exception)
 
         def send_end_call() -> None:
-            output_json = to_json(call.output, project_id, self, use_dictify=True)
+            output_json = to_json(call.output, project_id, self, use_dictify=False)
             self.server.call_end(
                 CallEndReq(
                     end=EndedCallSchemaForInsert(


### PR DESCRIPTION
## Description

Internal Jira: https://wandb.atlassian.net/browse/WB-21699

Adds sanitization to the dictify method, then turns dictify back on for call inputs and outputs only. (An explicit flag needs to be passed for `to_json` to dictify, so code saving won't use it.)

For later we should also take a closer look at why code saving is using to_json - it doesn't seem right to me as you're not going to get runnable code from that and also I think the memory address that is part of the default repr is going to cause your op versions to increase unexpectedly.

---

Update: @tssweeney pointed out that dictify'ing the output of dspy made it unusable when previously it was OK (due to the custom repr). Given the purpose of a repr, it seemed to me that if a custom one was made we should by default use that instead of dictify'ing. However, in the Gemini integration, we explicitly want the inputs and output dictify-ed so that we don't truncate the strings and can build the chat view from structured data. 

## Testing

How was this PR tested?
