### PR TITLE
chore(weave): smart tab defaults w/ chat in call peek drawer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -176,16 +176,28 @@ export const SimplePageLayoutWithHeader: FC<{
   // We try to preserve the selected tab even if the set of tabs changes,
   // falling back to the first tab.
   const [tabId, setTabId] = useState(tabs[0].label);
+  // If the user has manually selected a tab, always keep that tab selected
+  // otherwise, always default to the leftmost tab. Some calls have chat
+  // tabs, others do not, so unless the user has explicitly selected a different
+  // tab, always show the chat tab when possible.
+  const [userSelectedTab, setUserSelectedTab] = useState(false);
   const idxSelected = tabs.findIndex(t => t.label === tabId);
   const tabValue = idxSelected !== -1 ? idxSelected : 0;
   const handleTabChange = (newValue: string) => {
     setTabId(newValue);
+    setUserSelectedTab(true);
   };
   useEffect(() => {
     if (idxSelected === -1) {
       setTabId(tabs[0].label);
+      setUserSelectedTab(false);
+    } else if (!userSelectedTab && idxSelected === 1) {
+      // User has not selected a tab, but the current tab is not the leftmost tab.
+      // Default to the leftmost.
+      // Example: view call w/o chat [tab='call'] -> view call w/ chat [tab='call']
+      setTabId(tabs[0].label);
     }
-  }, [tabs, idxSelected]);
+  }, [tabs, idxSelected, userSelectedTab]);
   const tabContent = useMemo(() => tabs[tabValue].content, [tabs, tabValue]);
 
   return (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-21703](https://wandb.atlassian.net/browse/WB-21703)

Always default to the leftmost tab, unless the user has explicitly selected a tab. In practice, this now defaults to the chat view even if the previous call you were looking at did not have a chat tab. If you only want to look at the call details, you can select it and subsequent navigations should respect that.

Prod:

![chat-drawer-switch-prod](https://github.com/user-attachments/assets/0f1b0df7-622a-4e74-97fe-a7ab26eb46c9)

Branch:

![chat-drawer-switch](https://github.com/user-attachments/assets/d2151fde-b9a3-4940-a0a0-6f0dace23447)


## Testing

👀 


[WB-21703]: https://wandb.atlassian.net/browse/WB-21703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ