### PR TITLE
chore(ui): fix row selection in object versions page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -283,13 +283,21 @@ export const browse3ContextGen = (
       filePath?: string,
       refExtra?: string
     ) => {
-      const path = filePath ? `path=${encodeURIComponent(filePath)}` : '';
-      const extra = refExtra ? `extra=${encodeURIComponent(refExtra)}` : '';
-
-      return `${projectRoot(
+      let url = `${projectRoot(
         entityName,
         projectName
-      )}/objects/${objectName}/versions/${objectVersionHash}?${path}&${extra}`;
+      )}/objects/${objectName}/versions/${objectVersionHash}`;
+      const params = new URLSearchParams();
+      if (filePath !== undefined) {
+        params.set(PATH_PARAM, encodeURIComponent(filePath));
+      }
+      if (refExtra !== undefined) {
+        params.set(EXTRA_PARAM, encodeURIComponent(refExtra));
+      }
+      if (params.toString()) {
+        url += '?' + params.toString();
+      }
+      return url;
     },
     opVersionsUIUrl: (
       entityName: string,
@@ -529,6 +537,7 @@ const useSetSearchParam = () => {
 export const PEEK_PARAM = 'peekPath';
 export const TRACETREE_PARAM = 'tracetree';
 export const PATH_PARAM = 'path';
+export const EXTRA_PARAM = 'extra';
 
 export const baseContext = browse3ContextGen(
   (entityName: string, projectName: string) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -51,7 +51,10 @@ import {
   isTableRef,
   makeRefExpandedPayload,
 } from './wfReactInterface/tsDataModelHooksCallRefExpansion';
-import {objectVersionKeyToRefUri} from './wfReactInterface/utilities';
+import {
+  objectVersionKeyToRefUri,
+  parseUrlPathToRefUri,
+} from './wfReactInterface/utilities';
 import {
   KnownBaseObjectClassType,
   ObjectVersionSchema,
@@ -332,7 +335,10 @@ const ObjectVersionsTable: React.FC<{
   // Highlight table row if it matches peek drawer.
   const query = useURLSearchParamsDict();
   const {peekPath} = query;
-  const peekId = peekPath ? peekPath.split('/').pop() : null;
+
+  const {baseRouter} = useWeaveflowRouteContext();
+  const peekId = parseUrlPathToRefUri(peekPath, baseRouter);
+
   const rowIds = useMemo(() => {
     return rows.map(row => row.id);
   }, [rows]);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
@@ -286,6 +286,43 @@ export const objectVersionNiceString = (ov: ObjectVersionSchema) => {
   return result;
 };
 
+export function parseUrlPathToRefUri(
+  urlPath: string | undefined
+): string | null {
+  if (!urlPath) {
+    return null;
+  }
+
+  // Remove leading and trailing slashes
+  const cleanPath = urlPath.replace(/^\/|\/$/g, '');
+
+  // Split the path into segments
+  const segments = cleanPath.split('/');
+
+  // Check if we have enough segments for a valid object version path
+  if (segments.length < 6) {
+    return null;
+  }
+
+  // Extract relevant parts
+  const entity = segments[0];
+  const project = segments[1];
+  const objectId = segments[3];
+  const versionHash = segments[5];
+
+  // Construct RefUri for object version
+  return objectVersionKeyToRefUri({
+    scheme: 'weave',
+    entity,
+    project,
+    objectId,
+    versionHash,
+    path: '',
+    refExtra: '',
+    weaveKind: 'object',
+  });
+}
+
 /// Hooks ///
 
 export const useParentCall = (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

- When a user clicks a row in Objects page (ObjectVersionsPage.tsx), it didn't keep the correct row selection from the URL. This PR fixes that by parsing the URL into RefURI and using the consistent peek ID to match with row IDs

Before (left) vs. After (right)

https://github.com/user-attachments/assets/fef69fe7-bd9a-44cf-9603-1854e345f792



## Testing

How was this PR tested?
