### PR TITLE
fix(weave): do not automatically apply down migrations

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -150,7 +150,9 @@ class ClickHouseTraceServerMigrator:
             target_version = len(migration_map)
             # Do not run down migrations if not explicitly requesting target_version
             if current_version > target_version:
-                logger.warning(f"NOT running down migration from {current_version} to {target_version}")
+                logger.warning(
+                    f"NOT running down migration from {current_version} to {target_version}"
+                )
                 return []
         if target_version < 0 or target_version > len(migration_map):
             raise Exception(f"Invalid target version: {target_version}")

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -148,6 +148,10 @@ class ClickHouseTraceServerMigrator:
     ) -> typing.List[typing.Tuple[int, str]]:
         if target_version is None:
             target_version = len(migration_map)
+            # Do not run down migrations if not explicitly requesting target_version
+            if current_version > target_version:
+                logger.warning(f"NOT running down migration from {current_version} to {target_version}")
+                return []
         if target_version < 0 or target_version > len(migration_map):
             raise Exception(f"Invalid target version: {target_version}")
 


### PR DESCRIPTION
## Description

- [WB-21739](https://wandb.atlassian.net/browse/WB-21739)

Prevent automatic down migration (but still allow manual down migrations when specifying a target version)

## Testing

Manual tested for now

[WB-21739]: https://wandb.atlassian.net/browse/WB-21739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ