### PR TITLE
feat(weave_query): Add string op to parse number with thousands and decimal separators

### DIFF
--- a/weave_query/tests/test_basic_ops.py
+++ b/weave_query/tests/test_basic_ops.py
@@ -94,12 +94,12 @@ def test_string_ops():
     # assert weave.use(foo in foobar) == True # Broken
     # assert weave.use(foobar in foo) == False # Broken
 
-    assert weave.use(make_const_node(weave.types.String(), "123,456,008").toNumberWithLocale()) == 123456008.0
-    assert weave.use(make_const_node(weave.types.String(), "123,456.008").toNumberWithLocale()) == 123456.008
-    assert weave.use(make_const_node(weave.types.String(), "123_456_008").toNumberWithLocale()) == 123456008.0
-    assert weave.use(make_const_node(weave.types.String(), "123 456 008").toNumberWithLocale()) == 123456008.0
-    assert weave.use(make_const_node(weave.types.String(), "123.456").toNumberWithLocale()) == 123.456
-    assert weave.use(make_const_node(weave.types.String(), "123.456.008").toNumberWithLocale()) == None
+    assert weave.use(make_const_node(weave.types.String(), "123,456,008").parseNumberWithSeparator(",")) == 123456008.0
+    assert weave.use(make_const_node(weave.types.String(), "123,456,008").parseNumberWithSeparator(".")) == None
+    assert weave.use(make_const_node(weave.types.String(), "123,456.008").parseNumberWithSeparator(",")) == 123456.008
+    assert weave.use(make_const_node(weave.types.String(), "123_456_008").parseNumberWithSeparator("_")) == 123456008.0
+    assert weave.use(make_const_node(weave.types.String(), "123 456 008").parseNumberWithSeparator(" ")) == 123456008.0
+    assert weave.use(make_const_node(weave.types.String(), "123.456.008").parseNumberWithSeparator(".")) == 123456008.0
 
 def test_null_consuming_numbers_ops():
     data = [box.box(1), box.box(None), box.box(2)]

--- a/weave_query/tests/test_basic_ops.py
+++ b/weave_query/tests/test_basic_ops.py
@@ -94,12 +94,26 @@ def test_string_ops():
     # assert weave.use(foo in foobar) == True # Broken
     # assert weave.use(foobar in foo) == False # Broken
 
-    assert weave.use(make_const_node(weave.types.String(), "123,456,008").parseNumberWithSeparator(",")) == 123456008.0
-    assert weave.use(make_const_node(weave.types.String(), "123,456,008").parseNumberWithSeparator(".")) == None
-    assert weave.use(make_const_node(weave.types.String(), "123,456.008").parseNumberWithSeparator(",")) == 123456.008
-    assert weave.use(make_const_node(weave.types.String(), "123_456_008").parseNumberWithSeparator("_")) == 123456008.0
-    assert weave.use(make_const_node(weave.types.String(), "123 456 008").parseNumberWithSeparator(" ")) == 123456008.0
-    assert weave.use(make_const_node(weave.types.String(), "123.456.008").parseNumberWithSeparator(".")) == 123456008.0
+class TestStringParseNumberWithSeparator:
+    def test_parseNumberWithSeparatorWithOnlyThousandsSeparatorSpecified(self):
+        assert weave.use(make_const_node(weave.types.String(), "123,456,008").parseNumberWithSeparator(thousands_separator=",", decimal_separator=None)) == 123456008.0
+        assert weave.use(make_const_node(weave.types.String(), "123,456,008").parseNumberWithSeparator(thousands_separator=".", decimal_separator=None)) == None
+        assert weave.use(make_const_node(weave.types.String(), "123,456.008").parseNumberWithSeparator(thousands_separator=",", decimal_separator=None)) == 123456.008
+        assert weave.use(make_const_node(weave.types.String(), "123_456_008").parseNumberWithSeparator(thousands_separator="_", decimal_separator=None)) == 123456008.0
+        assert weave.use(make_const_node(weave.types.String(), "123 456 008").parseNumberWithSeparator(thousands_separator=" ", decimal_separator=None)) == 123456008.0
+        assert weave.use(make_const_node(weave.types.String(), "123.456.008").parseNumberWithSeparator(thousands_separator=".", decimal_separator=None)) == 123456008.0
+    
+    def test_parseNumberWithSeparatorWithOnlyDecimalSeparatorSpecified(self):
+        assert weave.use(make_const_node(weave.types.String(), "123456.008").parseNumberWithSeparator(thousands_separator=None, decimal_separator=".")) == 123456.008
+        assert weave.use(make_const_node(weave.types.String(), "123456,008").parseNumberWithSeparator(thousands_separator=None, decimal_separator=",")) == 123456.008
+        assert weave.use(make_const_node(weave.types.String(), "123456008").parseNumberWithSeparator(thousands_separator=None, decimal_separator=".")) == 123456008.0
+        assert weave.use(make_const_node(weave.types.String(), "123,456,008").parseNumberWithSeparator(thousands_separator=None, decimal_separator=".")) == None
+    
+    def test_parseNumberWithSeparatorWithBothSpecified(self):
+        assert weave.use(make_const_node(weave.types.String(), "123,456.008").parseNumberWithSeparator(thousands_separator=",", decimal_separator=".")) == 123456.008
+        assert weave.use(make_const_node(weave.types.String(), "123.456,008").parseNumberWithSeparator(thousands_separator=".", decimal_separator=",")) == 123456.008
+        assert weave.use(make_const_node(weave.types.String(), "123 456,008").parseNumberWithSeparator(thousands_separator=" ", decimal_separator=",")) == 123456.008
+        assert weave.use(make_const_node(weave.types.String(), "123 456,008").parseNumberWithSeparator(thousands_separator=",", decimal_separator=".")) == None
 
 def test_null_consuming_numbers_ops():
     data = [box.box(1), box.box(None), box.box(2)]

--- a/weave_query/tests/test_basic_ops.py
+++ b/weave_query/tests/test_basic_ops.py
@@ -94,6 +94,12 @@ def test_string_ops():
     # assert weave.use(foo in foobar) == True # Broken
     # assert weave.use(foobar in foo) == False # Broken
 
+    assert weave.use(make_const_node(weave.types.String(), "123,456,008").toNumberWithLocale()) == 123456008.0
+    assert weave.use(make_const_node(weave.types.String(), "123,456.008").toNumberWithLocale()) == 123456.008
+    assert weave.use(make_const_node(weave.types.String(), "123_456_008").toNumberWithLocale()) == 123456008.0
+    assert weave.use(make_const_node(weave.types.String(), "123 456 008").toNumberWithLocale()) == 123456008.0
+    assert weave.use(make_const_node(weave.types.String(), "123.456").toNumberWithLocale()) == 123.456
+    assert weave.use(make_const_node(weave.types.String(), "123.456.008").toNumberWithLocale()) == None
 
 def test_null_consuming_numbers_ops():
     data = [box.box(1), box.box(None), box.box(2)]

--- a/weave_query/weave_query/ops_primitives/string.py
+++ b/weave_query/weave_query/ops_primitives/string.py
@@ -203,16 +203,20 @@ class String:
             return float(self)  # type: ignore
         return None
     
-    @op(
-        name="string-parseNumberWithSeparator",
-        input_type={
-            "self": types.String(), 
-            "separator": types.String()
-        },
-        output_type=types.optional(types.Number())
-    )
-    def parse_number_with_separator(self, separator: str):
-        mNumber = self.replace(separator, '')
+    @op(name="string-parseNumberWithSeparator", output_type=types.optional(types.Number()))
+    def parse_number_with_separator(
+        self, 
+        thousands_separator: typing.Optional[str], 
+        decimal_separator: typing.Optional[str],
+    ):
+        mNumber = self
+        
+        if thousands_separator:
+            mNumber = mNumber.replace(thousands_separator, '')
+            
+        if decimal_separator:
+            mNumber = mNumber.replace(decimal_separator, '.')
+
         try:
             number = float(mNumber)
         except:

--- a/weave_query/weave_query/ops_primitives/string.py
+++ b/weave_query/weave_query/ops_primitives/string.py
@@ -241,7 +241,7 @@ class String:
         current_locale = locale.getlocale(locale.LC_NUMERIC)  # save the current locale
                 
         # Parse commas and underscores
-        locale.setlocale(locale.LC_NUMERIC, 'en_US.UTF-8')
+        locale.setlocale(locale.LC_NUMERIC, 'en_US')
         try:
             number = locale.atof(self)
         except:

--- a/weave_query/weave_query/ops_primitives/string.py
+++ b/weave_query/weave_query/ops_primitives/string.py
@@ -203,7 +203,7 @@ class String:
             return float(self)  # type: ignore
         return None
     
-    @op(name="string-toNumber-with-locale", output_type=types.optional(types.Number()))
+    @op(name="string-toNumberWithLocale", output_type=types.optional(types.Number()))
     def to_number_with_locale(self):
         import locale
         

--- a/weave_query/weave_query/ops_primitives/string.py
+++ b/weave_query/weave_query/ops_primitives/string.py
@@ -205,17 +205,57 @@ class String:
     
     @op(name="string-toNumberWithLocale", output_type=types.optional(types.Number()))
     def to_number_with_locale(self):
+        """
+        Quick solution to WB-16442, but slightly more robust.
+        
+        This function will handle commas (","), underscores ("_") and spaces (" ") as the
+        thousands separator: 
+    
+        >>> String.to_number_with_locale('123,456,008')
+        123456008.0
+
+        >>> String.to_number_with_locale('123_456_008')
+        12345608.0
+
+        >>> String.to_number_with_locale('123 456 008')
+        12345608.0
+        
+        Note that the use of spaces is handled as a special case via setting the locale to "pl_PL"
+        
+        A known limitation is the use of periods (".") as the thousands separator, in which case
+        the period will be treated as a decimal point:
+        
+        >>> String.to_number_with_locale('123.456')
+        123.456
+        
+        >>> String.to_number_with_locale('123.456.008')
+        ValueError: could not convert string to float: '123.456.008'
+        
+        ---
+        A better long-term solution would be to allow the user to set the locale they desire.
+        However, we should be wary that the `setlocale` method is NOT thread-safe (https://docs.python.org/3/library/locale.html#locale.setlocale)
+        and possibly expensive if we do it often.
+        """
         import locale
         
-        current_locale = locale.getlocale('LC_NUMERIC')  # save the current locale
-        locale.setlocale(locale.LC_NUMERIC, '') # sets the locale for LC_NUMERIC to native locale
-        
+        current_locale = locale.getlocale(locale.LC_NUMERIC)  # save the current locale
+                
+        # Parse commas and underscores
+        locale.setlocale(locale.LC_NUMERIC, 'en_US.UTF-8')
         try:
             number = locale.atof(self)
-        except Exception:
+        except:
             number = None
-
-        locale.setlocale(current_locale) # reset locale
+            
+        if not number:            
+            # Parse spaces
+            locale.setlocale(locale.LC_NUMERIC, 'pl_PL')
+            try:
+                number = locale.atof(self)
+            except:
+                number = None
+            
+        locale.setlocale(locale.LC_NUMERIC, current_locale) # reset locale
         return number
 
 types.String.instance_class = String

--- a/weave_query/weave_query/ops_primitives/string.py
+++ b/weave_query/weave_query/ops_primitives/string.py
@@ -202,7 +202,21 @@ class String:
         if self.isnumeric():
             return float(self)  # type: ignore
         return None
+    
+    @op(name="string-toNumber-with-locale", output_type=types.optional(types.Number()))
+    def to_number_with_locale(self):
+        import locale
+        
+        current_locale = locale.getlocale('LC_NUMERIC')  # save the current locale
+        locale.setlocale(locale.LC_NUMERIC, '') # sets the locale for LC_NUMERIC to native locale
+        
+        try:
+            number = locale.atof(self)
+        except Exception:
+            number = None
 
+        locale.setlocale(current_locale) # reset locale
+        return number
 
 types.String.instance_class = String
 


### PR DESCRIPTION
## Description

- Handles [WB-16442](https://wandb.atlassian.net/browse/WB-16442)
- Creates a new string op that will parse numbers with a thousands separator.

## Testing

Added unit tests


[WB-16442]: https://wandb.atlassian.net/browse/WB-16442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ