### PR TITLE
fix(weave): Add deepcopy methods for boxed types

### DIFF
--- a/tests/trace/test_deepcopy.py
+++ b/tests/trace/test_deepcopy.py
@@ -1,8 +1,17 @@
 from copy import deepcopy
 
+import numpy as np
 import pytest
 
 import weave
+from weave.trace.box import (
+    BoxedDatetime,
+    BoxedFloat,
+    BoxedInt,
+    BoxedNDArray,
+    BoxedStr,
+    BoxedTimedelta,
+)
 from weave.trace.object_record import ObjectRecord
 from weave.trace.vals import WeaveDict, WeaveList, WeaveObject
 
@@ -82,6 +91,42 @@ def test_deepcopy_weaveobject_e2e(client, example_class):
     res = deepcopy(o2)
     assert res == expected_record
     assert id(res) != id(o2)
+
+
+@pytest.mark.parametrize(
+    "boxed_val",
+    [
+        BoxedInt(1),
+        BoxedFloat(1.0),
+        BoxedStr("hello"),
+        BoxedDatetime(2024, 1, 1),
+        BoxedTimedelta(seconds=1),
+    ],
+)
+def test_deepcopy_boxed(client, boxed_val):
+    res = deepcopy(boxed_val)
+    assert res == boxed_val
+    assert id(res) != id(boxed_val)
+
+
+def test_deepcopy_boxed_ndarray(client):
+    arr = BoxedNDArray([1, 2, 3])
+    res = deepcopy(arr)
+    assert np.array_equal(res, [1, 2, 3])
+    assert id(res) != id(arr)
+
+
+def test_deepcopy_boxed_model_e2e(client):
+    class Model(weave.Model):
+        system_prompt: str = "You are a helpful assistant."  # this will get boxed
+
+        @weave.op
+        def predict(self, question: str) -> str:
+            return f"{question}, {self.system_prompt}"
+
+    model = Model()
+    res = model.predict("hmm")
+    assert res == "hmm, You are a helpful assistant."
 
 
 # # Not sure about the implications here yet

--- a/weave/trace/box.py
+++ b/weave/trace/box.py
@@ -87,7 +87,8 @@ class BoxedNDArray(np.ndarray):
         if obj is None:
             return
 
-    def __deepcopy__(self, memo: dict) -> "BoxedNDArray":
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> "BoxedNDArray":
+        memo = memo or {}
         res = np.asarray(self).view(BoxedNDArray)
         memo[id(self)] = res
         return res

--- a/weave/trace/box.py
+++ b/weave/trace/box.py
@@ -19,15 +19,30 @@ class BoxedInt(int):
     _id: int | None = None
     ref: Ref | None = None
 
+    def __deepcopy__(self, memo: dict) -> "BoxedInt":
+        res = BoxedInt(self)
+        memo[id(self)] = res
+        return res
+
 
 class BoxedFloat(float):
     _id: int | None = None
     ref: Ref | None = None
 
+    def __deepcopy__(self, memo: dict) -> "BoxedFloat":
+        res = BoxedFloat(self)
+        memo[id(self)] = res
+        return res
+
 
 class BoxedStr(str):
     _id: int | None = None
     ref: Ref | None = None
+
+    def __deepcopy__(self, memo: dict) -> "BoxedStr":
+        res = BoxedStr(self)
+        memo[id(self)] = res
+        return res
 
 
 class BoxedDatetime(datetime.datetime):
@@ -39,6 +54,11 @@ class BoxedDatetime(datetime.datetime):
             and self.timestamp() == other.timestamp()
         )
 
+    def __deepcopy__(self, memo: dict) -> "BoxedDatetime":
+        res = BoxedDatetime.fromtimestamp(self.timestamp(), tz=datetime.timezone.utc)
+        memo[id(self)] = res
+        return res
+
 
 class BoxedTimedelta(datetime.timedelta):
     ref: Ref | None = None
@@ -48,6 +68,11 @@ class BoxedTimedelta(datetime.timedelta):
             isinstance(other, datetime.timedelta)
             and self.total_seconds() == other.total_seconds()
         )
+
+    def __deepcopy__(self, memo: dict) -> "BoxedTimedelta":
+        res = BoxedTimedelta(seconds=self.total_seconds())
+        memo[id(self)] = res
+        return res
 
 
 # See https://numpy.org/doc/stable/user/basics.subclassing.html
@@ -61,6 +86,11 @@ class BoxedNDArray(np.ndarray):
     def __array_finalize__(self, obj: Any) -> None:
         if obj is None:
             return
+
+    def __deepcopy__(self, memo: dict) -> "BoxedNDArray":
+        res = np.asarray(self).view(BoxedNDArray)
+        memo[id(self)] = res
+        return res
 
 
 def box(


### PR DESCRIPTION
## Description

Follow-up to:
https://github.com/wandb/weave/pull/2868

Adds `__deepcopy__` methods to boxed types which resolves issues when using `Model.predict` with `litellm`

## Testing

Unit tests and manual testing of the e2e LiteLLM evaluation example