### PR TITLE
fix(ui): refetch when changing filter state from frozen -> not frozen

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -279,6 +279,11 @@ export const CallsTable: FC<{
       setCallsResult([]);
       setCallsTotal(0);
       callsEffectiveFilter.current = effectiveFilter;
+      // Refetch the calls IFF the filter has changed, this is a
+      // noop if the calls query is already loading, but if the filter
+      // has no effective impact (frozen vs. not frozen) we need to
+      // manually refetch
+      calls.refetch();
     } else if (!calls.loading) {
       setCallsResult(calls.result);
       setCallsTotal(calls.total);


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-21591](https://wandb.atlassian.net/browse/WB-21591)

This PR refetches the calls query when filters have changed. This normally happens automatically, except in the case when the `effectiveFilter` changes without any actual change to the backend query. This frequently occurs during interactions in the UI when navigating back to an already loaded table; the filter changes `frozen` status but none of the actual filter variables. 

## Testing

👀 


[WB-21591]: https://wandb.atlassian.net/browse/WB-21591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ