### PR TITLE
chore(weave): disable markdown in chat view

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanelPart.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanelPart.tsx
@@ -2,9 +2,7 @@ import 'prismjs/components/prism-markup-templating';
 
 import React from 'react';
 
-import Markdown from '../../../../../../common/components/Markdown';
 import {TargetBlank} from '../../../../../../common/util/links';
-import {isLikelyMarkdown} from '../../../../../../util/markdown';
 import {CodeEditor} from '../../../../../CodeEditor';
 import {MessagePart} from './types';
 
@@ -19,9 +17,11 @@ export const MessagePanelPart = ({
       const reformat = JSON.stringify(JSON.parse(value), null, 2);
       return <CodeEditor language="json" value={reformat} />;
     }
-    if (isLikelyMarkdown(value)) {
-      return <Markdown content={value} />;
-    }
+    // Markdown is slowing down chat view, disable for now
+    // Bring back if we can find a faster way to render markdown
+    // if (isLikelyMarkdown(value)) {
+    //   return <Markdown content={value} />;
+    // }
     return <span className="whitespace-break-spaces">{value}</span>;
   }
   if (value.type === 'text' && 'text' in value) {


### PR DESCRIPTION
## Description
markdown has been causing crashes or slow down in chat views with a lot of messages, disable for now

internal notion
https://www.notion.so/wandbai/Minimal-Weave-roadmap-item-specs-11fe2f5c7ef38004b8f3c413b536823e?pvs=4#11fe2f5c7ef3802f86e4ed254cd3250c

## Testing

How was this PR tested?
