### PR TITLE
chore(weave): scaffolding for playground page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -94,6 +94,7 @@ import {OpPage} from './Browse3/pages/OpPage';
 import {OpsPage} from './Browse3/pages/OpsPage';
 import {OpVersionPage} from './Browse3/pages/OpVersionPage';
 import {OpVersionsPage} from './Browse3/pages/OpVersionsPage';
+import {PlaygroundPage} from './Browse3/pages/PlaygroundPage/PlaygroundPage';
 import {TablePage} from './Browse3/pages/TablePage';
 import {TablesPage} from './Browse3/pages/TablesPage';
 import {useURLSearchParamsDict} from './Browse3/pages/util';
@@ -522,6 +523,14 @@ const Browse3ProjectRoot: FC<{
         </Route>
         <Route path={`${projectRoot}/tables`}>
           <TablesPageBinding />
+        </Route>
+        {/* PLAYGROUND */}
+        <Route
+          path={[
+            `${projectRoot}/playground/:itemName`,
+            `${projectRoot}/playground`,
+          ]}>
+          <PlaygroundPageBinding />
         </Route>
       </Switch>
     </Box>
@@ -1034,6 +1043,17 @@ const AppBarLink = (props: ComponentProps<typeof RouterLink>) => (
     component={RouterLink}
   />
 );
+
+const PlaygroundPageBinding = () => {
+  const params = useParamsDecoded<Browse3TabItemParams>();
+  return (
+    <PlaygroundPage
+      entity={params.entity}
+      project={params.project}
+      callId={params.itemName}
+    />
+  );
+};
 
 const Browse3Breadcrumbs: FC = props => {
   const params = useParamsDecoded<Browse3Params>();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -4,7 +4,7 @@ import React, {useEffect, useMemo, useState} from 'react';
 
 import {SimplePageLayout} from '../common/SimplePageLayout';
 import {useWFHooks} from '../wfReactInterface/context';
-import {usePlaygroundState} from './usePlaygroundState';
+import {DEFAULT_SYSTEM_MESSAGE, usePlaygroundState} from './usePlaygroundState';
 
 export type PlaygroundPageProps = {
   entity: string;
@@ -61,12 +61,7 @@ export const PlaygroundPageInner = (props: PlaygroundPageProps) => {
     ) {
       setPlaygroundStateField(0, 'traceCall', {
         inputs: {
-          messages: [
-            {
-              role: 'system',
-              content: 'You are a helpful assistant.',
-            },
-          ],
+          messages: [DEFAULT_SYSTEM_MESSAGE],
         },
         project_id: `${props.entity}/${props.project}`,
       });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -1,0 +1,100 @@
+import {Box} from '@mui/material';
+import {WeaveLoader} from '@wandb/weave/common/components/WeaveLoader';
+import React, {useEffect, useMemo, useState} from 'react';
+
+import {SimplePageLayout} from '../common/SimplePageLayout';
+import {useWFHooks} from '../wfReactInterface/context';
+import {usePlaygroundState} from './usePlaygroundState';
+
+export type PlaygroundPageProps = {
+  entity: string;
+  project: string;
+  callId: string;
+};
+
+export const PlaygroundPage = (props: PlaygroundPageProps) => {
+  return (
+    <SimplePageLayout
+      title={'Playground (dev)'}
+      hideTabsIfSingle
+      tabs={[
+        {
+          label: 'main',
+          content: <PlaygroundPageInner {...props} />,
+        },
+      ]}
+    />
+  );
+};
+
+export const PlaygroundPageInner = (props: PlaygroundPageProps) => {
+  const {
+    setPlaygroundStateFromTraceCall,
+    playgroundStates,
+    setPlaygroundStateField,
+  } = usePlaygroundState();
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [settingsTab, setSettingsTab] = useState<number | null>(null);
+
+  const {useCall} = useWFHooks();
+  const call = useCall(
+    useMemo(() => {
+      return props.callId
+        ? {
+            entity: props.entity,
+            project: props.project,
+            callId: props.callId,
+          }
+        : null;
+    }, [props.entity, props.project, props.callId])
+  );
+
+  useEffect(() => {
+    if (!call.loading && call.result) {
+      if (call.result.traceCall?.inputs) {
+        setPlaygroundStateFromTraceCall(call.result.traceCall);
+      }
+    } else if (
+      playgroundStates.length === 1 &&
+      !playgroundStates[0].traceCall.project_id
+    ) {
+      setPlaygroundStateField(0, 'traceCall', {
+        inputs: {
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful assistant.',
+            },
+          ],
+        },
+        project_id: `${props.entity}/${props.project}`,
+      });
+    }
+    // Only set the call the first time the page loads, and we get the call
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.callId]);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        height: '100%',
+        width: '100%',
+      }}>
+      {call.loading ? (
+        <Box
+          sx={{
+            display: 'flex',
+            height: '100%',
+            width: '100%',
+          }}>
+          <WeaveLoader />
+        </Box>
+      ) : (
+        <div>Playground</div>
+      )}
+      {settingsTab !== null && <div>Settings</div>}
+    </Box>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/index.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/index.ts
@@ -1,0 +1,1 @@
+export * from './PlaygroundPage';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
@@ -1,0 +1,123 @@
+// This is a mapping of LLM names to their max token limits.
+// Directly from the pycache model_providers.json in trace_server.
+// Some were removed because they are not supported when Josiah tried on Oct 30, 2024.
+export const LLM_MAX_TOKENS = {
+  'gpt-4o-mini': {max_tokens: 16384, supports_function_calling: true},
+  'claude-3-5-sonnet-20240620': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'claude-3-5-sonnet-20241022': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'claude-3-haiku-20240307': {
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'claude-3-opus-20240229': {max_tokens: 4096, supports_function_calling: true},
+  'claude-3-sonnet-20240229': {
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-flash-001': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-flash-002': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-flash-8b-exp-0827': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-flash-8b-exp-0924': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-flash-exp-0827': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-flash-latest': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-flash': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-pro-001': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-pro-002': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-pro-exp-0801': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-pro-exp-0827': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-pro-latest': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-1.5-pro': {max_tokens: 8192, supports_function_calling: true},
+  'gemini/gemini-pro': {max_tokens: 8192, supports_function_calling: true},
+  'gpt-3.5-turbo-0125': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-3.5-turbo-1106': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-3.5-turbo-16k': {max_tokens: 4096, supports_function_calling: false},
+  'gpt-3.5-turbo': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4-0125-preview': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4-0314': {max_tokens: 4096, supports_function_calling: false},
+  'gpt-4-0613': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4-1106-preview': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4-32k-0314': {max_tokens: 4096, supports_function_calling: false},
+  'gpt-4-turbo-2024-04-09': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4-turbo-preview': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4-turbo': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4o-2024-05-13': {max_tokens: 4096, supports_function_calling: true},
+  'gpt-4o-2024-08-06': {max_tokens: 16384, supports_function_calling: true},
+  'gpt-4o-mini-2024-07-18': {
+    max_tokens: 16384,
+    supports_function_calling: true,
+  },
+  'gpt-4o': {max_tokens: 4096, supports_function_calling: true},
+  'groq/gemma-7b-it': {max_tokens: 8192, supports_function_calling: true},
+  'groq/gemma2-9b-it': {max_tokens: 8192, supports_function_calling: true},
+  'groq/llama-3.1-70b-versatile': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'groq/llama-3.1-8b-instant': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'groq/llama3-70b-8192': {max_tokens: 8192, supports_function_calling: true},
+  'groq/llama3-8b-8192': {max_tokens: 8192, supports_function_calling: true},
+  'groq/llama3-groq-70b-8192-tool-use-preview': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'groq/llama3-groq-8b-8192-tool-use-preview': {
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'groq/mixtral-8x7b-32768': {
+    max_tokens: 32768,
+    supports_function_calling: true,
+  },
+  'o1-mini-2024-09-12': {max_tokens: 65536, supports_function_calling: true},
+  'o1-mini': {max_tokens: 65536, supports_function_calling: true},
+  'o1-preview-2024-09-12': {max_tokens: 32768, supports_function_calling: true},
+  'o1-preview': {max_tokens: 32768, supports_function_calling: true},
+};
+
+export type LLMMaxTokensKey = keyof typeof LLM_MAX_TOKENS;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/types.ts
@@ -1,0 +1,30 @@
+import {TraceCallSchema} from '../wfReactInterface/traceServerClientTypes';
+import {LLMMaxTokensKey} from './llmMaxTokens';
+
+export enum PlaygroundResponseFormats {
+  Text = 'text',
+  JsonObject = 'json_object',
+  // Fast follow
+  // JsonSchema = 'json_schema',
+}
+
+export type PlaygroundState = {
+  traceCall: OptionalTraceCallSchema;
+  trackLLMCall: boolean;
+  loading: boolean;
+  functions: Array<{name: string; [key: string]: any}>;
+  responseFormat: PlaygroundResponseFormats;
+  temperature: number;
+  maxTokens: number;
+  stopSequences: string[];
+  topP: number;
+  frequencyPenalty: number;
+  presencePenalty: number;
+  //   nTimes: number;
+  maxTokensLimit: number;
+  model: LLMMaxTokensKey;
+};
+
+export type PlaygroundStateKey = keyof PlaygroundState;
+
+export type OptionalTraceCallSchema = Partial<TraceCallSchema>;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -1,0 +1,144 @@
+import {SetStateAction, useCallback, useState} from 'react';
+
+import {LLMMaxTokensKey} from './PlaygroundChat/llmMaxTokens';
+import {
+  OptionalTraceCallSchema,
+  PlaygroundResponseFormats,
+  PlaygroundState,
+  PlaygroundStateKey,
+} from './types';
+
+const DEFAULT_PLAYGROUND_STATE = {
+  traceCall: {
+    inputs: {
+      messages: [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant.',
+        },
+      ],
+    },
+  },
+  trackLLMCall: true,
+  loading: false,
+  functions: [],
+  responseFormat: PlaygroundResponseFormats.Text,
+  temperature: 1,
+  maxTokens: 4096,
+  stopSequences: [],
+  topP: 1,
+  frequencyPenalty: 0,
+  presencePenalty: 0,
+  //   nTimes: 1,
+  maxTokensLimit: 16384,
+  model: 'gpt-4o-mini' as LLMMaxTokensKey,
+};
+
+export const usePlaygroundState = () => {
+  const [playgroundStates, setPlaygroundStates] = useState<PlaygroundState[]>([
+    DEFAULT_PLAYGROUND_STATE,
+  ]);
+
+  const setPlaygroundStateField = useCallback(
+    (
+      index: number,
+      field: PlaygroundStateKey,
+      value: SetStateAction<PlaygroundState[PlaygroundStateKey]>
+    ) => {
+      setPlaygroundStates(prevStates =>
+        prevStates.map((state, i) =>
+          i === index
+            ? {
+                ...state,
+                [field]:
+                  typeof value === 'function'
+                    ? (value as SetStateAction<any>)(state[field])
+                    : value,
+              }
+            : state
+        )
+      );
+    },
+    []
+  );
+
+  // Takes in a function input and sets the state accordingly
+  const setPlaygroundStateFromTraceCall = useCallback(
+    (traceCall: OptionalTraceCallSchema) => {
+      const inputs = traceCall.inputs;
+      // https://docs.litellm.ai/docs/completion/input
+      // pulled from litellm
+      setPlaygroundStates(prevState => {
+        const newState = {...prevState[0]};
+
+        newState.traceCall = traceCall;
+
+        if (!inputs) {
+          return [newState];
+        }
+
+        if (inputs.tools) {
+          newState.functions = [];
+          for (const tool of inputs.tools) {
+            if (tool.type === 'function') {
+              newState.functions = [...newState.functions, tool.function];
+            }
+          }
+        }
+        // if (inputs.n) {
+        //   newState.nTimes = parseInt(inputs.n, 10);
+        // }
+        if (inputs.temperature) {
+          newState.temperature = parseFloat(inputs.temperature);
+        }
+        if (inputs.response_format) {
+          newState.responseFormat = inputs.response_format.type;
+        }
+        if (inputs.top_p) {
+          newState.topP = parseFloat(inputs.top_p);
+        }
+        if (inputs.frequency_penalty) {
+          newState.frequencyPenalty = parseFloat(inputs.frequency_penalty);
+        }
+        if (inputs.presence_penalty) {
+          newState.presencePenalty = parseFloat(inputs.presence_penalty);
+        }
+        return [newState];
+      });
+    },
+    []
+  );
+
+  return {
+    playgroundStates,
+    setPlaygroundStates,
+    setPlaygroundStateField,
+    setPlaygroundStateFromTraceCall,
+  };
+};
+
+export const getInputFromPlaygroundState = (state: PlaygroundState) => {
+  const tools = state.functions.map(func => ({
+    type: 'function',
+    function: func,
+  }));
+  return {
+    // Adding this to prevent the exact same call from not getting run
+    // eg running the same call in parallel
+    key: Math.random() * 1000,
+
+    messages: state.traceCall?.inputs?.messages,
+    model: state.model,
+    temperature: state.temperature,
+    max_tokens: state.maxTokens,
+    stop: state.stopSequences,
+    top_p: state.topP,
+    frequency_penalty: state.frequencyPenalty,
+    presence_penalty: state.presencePenalty,
+    // n: state.nTimes,
+    response_format: {
+      type: state.responseFormat,
+    },
+    tools: tools.length > 0 ? tools : undefined,
+  };
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -1,6 +1,6 @@
 import {SetStateAction, useCallback, useState} from 'react';
 
-import {LLMMaxTokensKey} from './PlaygroundChat/llmMaxTokens';
+import {LLMMaxTokensKey} from './llmMaxTokens';
 import {
   OptionalTraceCallSchema,
   PlaygroundResponseFormats,
@@ -8,15 +8,18 @@ import {
   PlaygroundStateKey,
 } from './types';
 
+export const DEFAULT_SYSTEM_MESSAGE_CONTENT =
+  'You are an AI assistant designed to assist users by providing clear, concise, and helpful responses.';
+
+export const DEFAULT_SYSTEM_MESSAGE = {
+  role: 'system',
+  content: DEFAULT_SYSTEM_MESSAGE_CONTENT,
+};
+
 const DEFAULT_PLAYGROUND_STATE = {
   traceCall: {
     inputs: {
-      messages: [
-        {
-          role: 'system',
-          content: 'You are a helpful assistant.',
-        },
-      ],
+      messages: [DEFAULT_SYSTEM_MESSAGE],
     },
   },
   trackLLMCall: true,


### PR DESCRIPTION
## Description
Adds a route /playground (you can go there explicitly but not in sidebar)
sets up the state for the playground
if theres a call-id in the url, fetch the call and load the call settings into state

<img width="1157" alt="Screenshot 2024-11-06 at 4 56 10 PM" src="https://github.com/user-attachments/assets/38c2367e-c629-4a27-8e66-910e416b701c">

## Testing

How was this PR tested?
