### PR TITLE
chore(weave): Class-based scorer runnable ref fix

### DIFF
--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -973,3 +973,37 @@ async def test_feedback_is_correctly_linked(client):
             id=list(score.calls())[0].id,
         ).uri()
     )
+
+
+@pytest.mark.asyncio
+async def test_feedback_is_correctly_linked_with_scorer_subclass(client):
+    @weave.op
+    def predict(text: str) -> str:
+        return text
+
+    class MyScorer(Scorer):
+        @weave.op()
+        def score(self, text, model_output) -> bool:
+            return text == model_output
+
+    scorer = MyScorer()
+    eval = weave.Evaluation(
+        dataset=[{"text": "hello"}],
+        scorers=[scorer],
+    )
+    res = await eval.evaluate(predict)
+    calls = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=client._project_id(),
+            include_feedback=True,
+            filter=tsi.CallsFilter(op_names=[get_ref(predict).uri()]),
+        )
+    )
+    assert len(calls.calls) == 1
+    assert calls.calls[0].summary["weave"]["feedback"]
+    feedbacks = calls.calls[0].summary["weave"]["feedback"]
+    assert len(feedbacks) == 1
+    feedback = feedbacks[0]
+    assert feedback["feedback_type"] == "wandb.runnable.MyScorer"
+    assert feedback["payload"] == {"output": True}
+    assert feedback["runnable_ref"] == get_ref(scorer).uri()

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -982,9 +982,9 @@ async def test_feedback_is_correctly_linked_with_scorer_subclass(client):
         return text
 
     class MyScorer(Scorer):
-        @weave.op()
-        def score(self, text, model_output) -> bool:
-            return text == model_output
+        @weave.op
+        def score(self, text, output) -> bool:
+            return text == output
 
     scorer = MyScorer()
     eval = weave.Evaluation(

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -372,7 +372,9 @@ class Evaluation(Object):
                     result, score_call = await async_call_op(score_fn, **score_args)
                     wc = get_weave_client()
                     if wc:
-                        wc._send_score_call(model_call, score_call)
+                        scorer_ref = get_ref(scorer_self) if scorer_self else None
+                        scorer_ref_uri = scorer_ref.uri() if scorer_ref else None
+                        wc._send_score_call(model_call, score_call, scorer_ref_uri)
 
                 else:
                     # I would not expect this path to be hit, but keeping it for

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -372,6 +372,9 @@ class Evaluation(Object):
                     result, score_call = await async_call_op(score_fn, **score_args)
                     wc = get_weave_client()
                     if wc:
+                        # Very important: if the score is generated from a Scorer subclass,
+                        # then scorer_ref_uri will be None, and we will use the op_name from
+                        # the score_call instead.
                         scorer_ref = get_ref(scorer_self) if scorer_self else None
                         scorer_ref_uri = scorer_ref.uri() if scorer_ref else None
                         wc._send_score_call(model_call, score_call, scorer_ref_uri)

--- a/weave/trace/box.py
+++ b/weave/trace/box.py
@@ -19,7 +19,7 @@ class BoxedInt(int):
     _id: int | None = None
     ref: Ref | None = None
 
-    def __deepcopy__(self, memo: dict) -> "BoxedInt":
+    def __deepcopy__(self, memo: dict) -> BoxedInt:
         res = BoxedInt(self)
         memo[id(self)] = res
         return res
@@ -29,7 +29,7 @@ class BoxedFloat(float):
     _id: int | None = None
     ref: Ref | None = None
 
-    def __deepcopy__(self, memo: dict) -> "BoxedFloat":
+    def __deepcopy__(self, memo: dict) -> BoxedFloat:
         res = BoxedFloat(self)
         memo[id(self)] = res
         return res
@@ -39,7 +39,7 @@ class BoxedStr(str):
     _id: int | None = None
     ref: Ref | None = None
 
-    def __deepcopy__(self, memo: dict) -> "BoxedStr":
+    def __deepcopy__(self, memo: dict) -> BoxedStr:
         res = BoxedStr(self)
         memo[id(self)] = res
         return res
@@ -54,7 +54,7 @@ class BoxedDatetime(datetime.datetime):
             and self.timestamp() == other.timestamp()
         )
 
-    def __deepcopy__(self, memo: dict) -> "BoxedDatetime":
+    def __deepcopy__(self, memo: dict) -> BoxedDatetime:
         res = BoxedDatetime.fromtimestamp(self.timestamp(), tz=datetime.timezone.utc)
         memo[id(self)] = res
         return res
@@ -69,7 +69,7 @@ class BoxedTimedelta(datetime.timedelta):
             and self.total_seconds() == other.total_seconds()
         )
 
-    def __deepcopy__(self, memo: dict) -> "BoxedTimedelta":
+    def __deepcopy__(self, memo: dict) -> BoxedTimedelta:
         res = BoxedTimedelta(seconds=self.total_seconds())
         memo[id(self)] = res
         return res
@@ -87,7 +87,7 @@ class BoxedNDArray(np.ndarray):
         if obj is None:
             return
 
-    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> "BoxedNDArray":
+    def __deepcopy__(self, memo: dict[int, Any] | None = None) -> BoxedNDArray:
         memo = memo or {}
         res = np.asarray(self).view(BoxedNDArray)
         memo[id(self)] = res

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -42,6 +42,7 @@ from weave.trace.table import Table
 from weave.trace.util import deprecated
 from weave.trace.vals import WeaveObject, WeaveTable, make_trace_obj
 from weave.trace_server.ids import generate_id
+from weave.trace_server.interface.feedback_types import RUNNABLE_FEEDBACK_TYPE_PREFIX
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallSchema,
@@ -1178,7 +1179,7 @@ class WeaveClient:
         freq = FeedbackCreateReq(
             project_id=self._project_id(),
             weave_ref=weave_ref_uri,
-            feedback_type="wandb.runnable." + runnable_ref.name,
+            feedback_type=RUNNABLE_FEEDBACK_TYPE_PREFIX + "." + runnable_ref.name,
             payload=payload,
             runnable_ref=runnable_ref_uri,
             call_ref=call_ref_uri,

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -332,11 +332,11 @@ class Call:
         score_call_ref = get_ref(score_call)
         if score_call_ref is None:
             raise ValueError("Score call has no ref")
-        client._add_score(
-            call_ref_uri=self_ref.uri(),
+        client._add_runnable_feedback(
+            weave_ref_uri=self_ref.uri(),
             runnable_ref_name=score_name,
-            score_results=score_results,
-            scorer_call_ref_uri=score_call_ref.uri(),
+            output=score_results,
+            call_ref_uri=score_call_ref.uri(),
             runnable_ref_uri=scorer_op_ref.uri(),
         )
 
@@ -1106,7 +1106,10 @@ class WeaveClient:
 
     @trace_sentry.global_trace_sentry.watch()
     def _send_score_call(
-        self, predict_call: Call, score_call: Call, scorer_ref_uri: Optional[str] = None
+        self,
+        predict_call: Call,
+        score_call: Call,
+        scorer_object_ref_uri: Optional[str] = None,
     ) -> Future[str]:
         """(Private) Adds a score to a call. This is particularly useful
         for adding evaluation metrics to a call.
@@ -1116,36 +1119,34 @@ class WeaveClient:
             call_ref = get_ref(predict_call)
             if call_ref is None:
                 raise ValueError("Predict call must have a ref")
-            call_ref_uri = call_ref.uri()
+            weave_ref_uri = call_ref.uri()
             scorer_call_ref = get_ref(score_call)
             if scorer_call_ref is None:
                 raise ValueError("Score call must have a ref")
             scorer_call_ref_uri = scorer_call_ref.uri()
-            runnable_ref_uri = scorer_ref_uri or score_call.op_name
-            runnable_ref = parse_uri(runnable_ref_uri)
-            if not isinstance(runnable_ref, (OpRef, ObjectRef)):
-                raise TypeError(f"Invalid scorer op ref: {runnable_ref_uri}")
-            score_name = runnable_ref.name
+
+            # If scorer_object_ref_uri is provided, it is used as the runnable_ref_uri
+            # Otherwise, we use the op_name from the score_call. This should happen
+            # when there is a Scorer subclass that is the source of the score call.
+            runnable_ref_uri = scorer_object_ref_uri or score_call.op_name
             score_results = score_call.output
 
-            return self._add_score(
-                call_ref_uri=call_ref_uri,
-                runnable_ref_name=score_name,
-                score_results=score_results,
-                scorer_call_ref_uri=scorer_call_ref_uri,
+            return self._add_runnable_feedback(
+                weave_ref_uri=weave_ref_uri,
+                output=score_results,
+                call_ref_uri=scorer_call_ref_uri,
                 runnable_ref_uri=runnable_ref_uri,
             )
 
         return self.future_executor.defer(send_score_call)
 
     @trace_sentry.global_trace_sentry.watch()
-    def _add_score(
+    def _add_runnable_feedback(
         self,
         *,
+        weave_ref_uri: str,
+        output: Any,
         call_ref_uri: str,
-        runnable_ref_name: str,
-        score_results: Any,
-        scorer_call_ref_uri: str,
         runnable_ref_uri: str,
         # , supervision: dict
     ) -> str:
@@ -1155,25 +1156,19 @@ class WeaveClient:
         - Should we somehow include supervision (ie. the ground truth) in the payload?
         """
         # Parse the refs (acts as validation)
-        call_ref = parse_uri(call_ref_uri)
+        call_ref = parse_uri(weave_ref_uri)
         if not isinstance(call_ref, CallRef):
-            raise TypeError(f"Invalid call ref: {call_ref_uri}")
-        scorer_call_ref = parse_uri(scorer_call_ref_uri)
+            raise TypeError(f"Invalid call ref: {weave_ref_uri}")
+        scorer_call_ref = parse_uri(call_ref_uri)
         if not isinstance(scorer_call_ref, CallRef):
-            raise TypeError(f"Invalid scorer call ref: {scorer_call_ref_uri}")
+            raise TypeError(f"Invalid scorer call ref: {call_ref_uri}")
         runnable_ref = parse_uri(runnable_ref_uri)
         if not isinstance(runnable_ref, (OpRef, ObjectRef)):
             raise TypeError(f"Invalid scorer op ref: {runnable_ref_uri}")
 
-        # Validate score_name (we might want to relax this in the future)
-        if runnable_ref_name != runnable_ref.name:
-            raise TypeError(
-                f"Score name {runnable_ref_name} does not match scorer op name {runnable_ref.name}"
-            )
-
         # Prepare the result payload - we purposely do not map to refs here
         # because we prefer to have the raw data.
-        results_json = to_json(score_results, self._project_id(), self)
+        results_json = to_json(output, self._project_id(), self)
 
         # # Prepare the supervision payload
 
@@ -1183,11 +1178,11 @@ class WeaveClient:
 
         freq = FeedbackCreateReq(
             project_id=self._project_id(),
-            weave_ref=call_ref_uri,
-            feedback_type="wandb.runnable." + runnable_ref_name,
+            weave_ref=weave_ref_uri,
+            feedback_type="wandb.runnable." + runnable_ref.name,
             payload=payload,
             runnable_ref=runnable_ref_uri,
-            call_ref=scorer_call_ref_uri,
+            call_ref=call_ref_uri,
         )
         response = self.server.feedback_create(freq)
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -334,7 +334,6 @@ class Call:
             raise ValueError("Score call has no ref")
         client._add_runnable_feedback(
             weave_ref_uri=self_ref.uri(),
-            runnable_ref_name=score_name,
             output=score_results,
             call_ref_uri=score_call_ref.uri(),
             runnable_ref_uri=scorer_op_ref.uri(),


### PR DESCRIPTION
Correctly reports runnable refs when the scorer is an object.

Now that I am getting into the nitty-gritty of getting scorers to work, i realized we are not reporting the Evaluation scorer feedback ref correctly when the scorer is an object. Today, we are reporting the Scorer.score fn, not the parent Scorer object. This fixes and tests for that