### PR TITLE
chore(weave): Rename ActionDefintion to ActionSpec to match naming patterns

### DIFF
--- a/tests/integrations/litellm/test_actions_lifecycle_llm_judge.py
+++ b/tests/integrations/litellm/test_actions_lifecycle_llm_judge.py
@@ -71,7 +71,7 @@ def test_action_lifecycle_llm_judge_primitive(client: WeaveClient):
     published_ref = weave.publish(
         ActionSpec(
             name=action_name,
-            spec={
+            config={
                 "action_type": "llm_judge",
                 "model": "gpt-4o-mini",
                 "prompt": "Is the response mindful?",
@@ -156,7 +156,7 @@ def test_action_lifecycle_llm_judge_structured(client: WeaveClient):
     published_ref = weave.publish(
         ActionSpec(
             name=action_name,
-            spec={
+            config={
                 "action_type": "llm_judge",
                 "model": "gpt-4o-mini",
                 "prompt": "Is the response mindful?",

--- a/tests/integrations/litellm/test_actions_lifecycle_llm_judge.py
+++ b/tests/integrations/litellm/test_actions_lifecycle_llm_judge.py
@@ -16,7 +16,7 @@ from tests.integrations.litellm.client_completions_create_test import (
 from tests.trace.util import client_is_sqlite
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server.interface.base_object_classes.actions import (
-    ActionDefinition,
+    ActionSpec,
 )
 from weave.trace_server.trace_server_interface import (
     ActionsExecuteBatchReq,
@@ -69,7 +69,7 @@ def test_action_lifecycle_llm_judge_primitive(client: WeaveClient):
     action_name = "response_is_mindful"
 
     published_ref = weave.publish(
-        ActionDefinition(
+        ActionSpec(
             name=action_name,
             spec={
                 "action_type": "llm_judge",
@@ -154,7 +154,7 @@ def test_action_lifecycle_llm_judge_structured(client: WeaveClient):
     action_name = "response_is_mindful"
 
     published_ref = weave.publish(
-        ActionDefinition(
+        ActionSpec(
             name=action_name,
             spec={
                 "action_type": "llm_judge",

--- a/tests/trace/test_actions_lifecycle.py
+++ b/tests/trace/test_actions_lifecycle.py
@@ -4,7 +4,7 @@ import weave
 from tests.trace.util import client_is_sqlite
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server.interface.base_object_classes.actions import (
-    ActionDefinition,
+    ActionSpec,
 )
 from weave.trace_server.trace_server_interface import (
     ActionsExecuteBatchReq,
@@ -22,7 +22,7 @@ def test_action_lifecycle_word_count(client: WeaveClient):
     action_name = "my_contains_words_action"
 
     published_ref = weave.publish(
-        ActionDefinition(
+        ActionSpec(
             name=action_name,
             spec={
                 "action_type": "contains_words",

--- a/tests/trace/test_actions_lifecycle.py
+++ b/tests/trace/test_actions_lifecycle.py
@@ -24,7 +24,7 @@ def test_action_lifecycle_word_count(client: WeaveClient):
     published_ref = weave.publish(
         ActionSpec(
             name=action_name,
-            spec={
+            config={
                 "action_type": "contains_words",
                 "target_words": ["mindful", "demure"],
             },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBaseObjectClasses.zod.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBaseObjectClasses.zod.ts
@@ -1,5 +1,29 @@
 import * as z from 'zod';
 
+export const ActionTypeSchema = z.enum(['contains_words', 'llm_judge']);
+export type ActionType = z.infer<typeof ActionTypeSchema>;
+
+export const ModelSchema = z.enum(['gpt-4o', 'gpt-4o-mini']);
+export type Model = z.infer<typeof ModelSchema>;
+
+export const ConfigSchema = z.object({
+  action_type: ActionTypeSchema.optional(),
+  model: ModelSchema.optional(),
+  prompt: z.string().optional(),
+  response_schema: z.record(z.string(), z.any()).optional(),
+  target_words: z.array(z.string()).optional(),
+});
+export type Config = z.infer<typeof ConfigSchema>;
+
+export const AnnotationSpecSchema = z.object({
+  description: z.union([z.null(), z.string()]).optional(),
+  json_schema: z.record(z.string(), z.any()).optional(),
+  name: z.union([z.null(), z.string()]).optional(),
+  op_scope: z.union([z.array(z.string()), z.null()]).optional(),
+  unique_among_creators: z.boolean().optional(),
+});
+export type AnnotationSpec = z.infer<typeof AnnotationSpecSchema>;
+
 export const LeaderboardColumnSchema = z.object({
   evaluation_object_ref: z.string(),
   scorer_name: z.string(),
@@ -24,6 +48,13 @@ export type TestOnlyNestedBaseObject = z.infer<
   typeof TestOnlyNestedBaseObjectSchema
 >;
 
+export const ActionSpecSchema = z.object({
+  config: ConfigSchema,
+  description: z.union([z.null(), z.string()]).optional(),
+  name: z.union([z.null(), z.string()]).optional(),
+});
+export type ActionSpec = z.infer<typeof ActionSpecSchema>;
+
 export const LeaderboardSchema = z.object({
   columns: z.array(LeaderboardColumnSchema),
   description: z.union([z.null(), z.string()]).optional(),
@@ -41,6 +72,8 @@ export const TestOnlyExampleSchema = z.object({
 export type TestOnlyExample = z.infer<typeof TestOnlyExampleSchema>;
 
 export const baseObjectClassRegistry = {
+  ActionSpec: ActionSpecSchema,
+  AnnotationSpec: AnnotationSpecSchema,
   Leaderboard: LeaderboardSchema,
   TestOnlyExample: TestOnlyExampleSchema,
   TestOnlyNestedBaseObject: TestOnlyNestedBaseObjectSchema,

--- a/weave/trace_server/actions_worker/actions/contains_words.py
+++ b/weave/trace_server/actions_worker/actions/contains_words.py
@@ -2,7 +2,7 @@ import json
 from typing import Any
 
 from weave.trace_server.interface.base_object_classes.actions import (
-    ContainsWordsActionSpec,
+    ContainsWordsActionConfig,
 )
 from weave.trace_server.trace_server_interface import (
     CallSchema,
@@ -12,7 +12,7 @@ from weave.trace_server.trace_server_interface import (
 
 def do_contains_words_action(
     project_id: str,
-    config: ContainsWordsActionSpec,
+    config: ContainsWordsActionConfig,
     call: CallSchema,
     trace_server: TraceServerInterface,
 ) -> Any:

--- a/weave/trace_server/actions_worker/actions/llm_judge.py
+++ b/weave/trace_server/actions_worker/actions/llm_judge.py
@@ -2,7 +2,7 @@ import json
 from typing import Any
 
 from weave.trace_server.interface.base_object_classes.actions import (
-    LlmJudgeActionSpec,
+    LlmJudgeActionConfig,
 )
 from weave.trace_server.trace_server_interface import (
     CallSchema,
@@ -13,7 +13,7 @@ from weave.trace_server.trace_server_interface import (
 
 def do_llm_judge_action(
     project_id: str,
-    config: LlmJudgeActionSpec,
+    config: LlmJudgeActionConfig,
     call: CallSchema,
     trace_server: TraceServerInterface,
 ) -> Any:

--- a/weave/trace_server/interface/base_object_classes/actions.py
+++ b/weave/trace_server/interface/base_object_classes/actions.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field, field_validator
 from weave.trace_server.interface.base_object_classes import base_object_def
 
 
-class LlmJudgeActionSpec(BaseModel):
+class LlmJudgeActionConfig(BaseModel):
     action_type: Literal["llm_judge"] = "llm_judge"
     # TODO: Remove this restriction (probably after initial release. We need to cross
     # reference which LiteLLM models support structured outputs)
@@ -15,19 +15,19 @@ class LlmJudgeActionSpec(BaseModel):
     response_schema: dict[str, Any]
 
 
-class ContainsWordsActionSpec(BaseModel):
+class ContainsWordsActionConfig(BaseModel):
     action_type: Literal["contains_words"] = "contains_words"
     target_words: list[str]
 
 
-ActionSpecType = Union[
-    LlmJudgeActionSpec,
-    ContainsWordsActionSpec,
+ActionConfigType = Union[
+    LlmJudgeActionConfig,
+    ContainsWordsActionConfig,
 ]
 
 
-class ActionDefinition(base_object_def.BaseObject):
-    spec: ActionSpecType = Field(..., discriminator="action_type")
+class ActionSpec(base_object_def.BaseObject):
+    config: ActionConfigType = Field(..., discriminator="action_type")
 
     # This is needed because the name field is optional in the base class, but required
     # in the derived class. Pyright doesn't like having a stricter type

--- a/weave/trace_server/interface/base_object_classes/base_object_registry.py
+++ b/weave/trace_server/interface/base_object_classes/base_object_registry.py
@@ -1,4 +1,4 @@
-from weave.trace_server.interface.base_object_classes.actions import ActionDefinition
+from weave.trace_server.interface.base_object_classes.actions import ActionSpec
 from weave.trace_server.interface.base_object_classes.base_object_def import BaseObject
 from weave.trace_server.interface.base_object_classes.leaderboard import Leaderboard
 from weave.trace_server.interface.base_object_classes.test_only_example import (
@@ -22,4 +22,4 @@ def register_base_object(cls: type[BaseObject]) -> None:
 register_base_object(TestOnlyExample)
 register_base_object(TestOnlyNestedBaseObject)
 register_base_object(Leaderboard)
-register_base_object(ActionDefinition)
+register_base_object(ActionSpec)

--- a/weave/trace_server/interface/base_object_classes/generated/generated_base_object_class_schemas.json
+++ b/weave/trace_server/interface/base_object_classes/generated/generated_base_object_class_schemas.json
@@ -1,6 +1,6 @@
 {
   "$defs": {
-    "ActionDefinition": {
+    "ActionSpec": {
       "properties": {
         "name": {
           "anyOf": [
@@ -26,29 +26,29 @@
           "default": null,
           "title": "Description"
         },
-        "spec": {
+        "config": {
           "discriminator": {
             "mapping": {
-              "contains_words": "#/$defs/ContainsWordsActionSpec",
-              "llm_judge": "#/$defs/LlmJudgeActionSpec"
+              "contains_words": "#/$defs/ContainsWordsActionConfig",
+              "llm_judge": "#/$defs/LlmJudgeActionConfig"
             },
             "propertyName": "action_type"
           },
           "oneOf": [
             {
-              "$ref": "#/$defs/LlmJudgeActionSpec"
+              "$ref": "#/$defs/LlmJudgeActionConfig"
             },
             {
-              "$ref": "#/$defs/ContainsWordsActionSpec"
+              "$ref": "#/$defs/ContainsWordsActionConfig"
             }
           ],
-          "title": "Spec"
+          "title": "Config"
         }
       },
       "required": [
-        "spec"
+        "config"
       ],
-      "title": "ActionDefinition",
+      "title": "ActionSpec",
       "type": "object"
     },
     "AnnotationSpec": {
@@ -136,7 +136,7 @@
       "title": "AnnotationSpec",
       "type": "object"
     },
-    "ContainsWordsActionSpec": {
+    "ContainsWordsActionConfig": {
       "properties": {
         "action_type": {
           "const": "contains_words",
@@ -158,7 +158,7 @@
       "required": [
         "target_words"
       ],
-      "title": "ContainsWordsActionSpec",
+      "title": "ContainsWordsActionConfig",
       "type": "object"
     },
     "Leaderboard": {
@@ -236,7 +236,7 @@
       "title": "LeaderboardColumn",
       "type": "object"
     },
-    "LlmJudgeActionSpec": {
+    "LlmJudgeActionConfig": {
       "properties": {
         "action_type": {
           "const": "llm_judge",
@@ -269,7 +269,7 @@
         "prompt",
         "response_schema"
       ],
-      "title": "LlmJudgeActionSpec",
+      "title": "LlmJudgeActionConfig",
       "type": "object"
     },
     "TestOnlyExample": {
@@ -379,8 +379,8 @@
     "Leaderboard": {
       "$ref": "#/$defs/Leaderboard"
     },
-    "ActionDefinition": {
-      "$ref": "#/$defs/ActionDefinition"
+    "ActionSpec": {
+      "$ref": "#/$defs/ActionSpec"
     },
     "AnnotationSpec": {
       "$ref": "#/$defs/AnnotationSpec"
@@ -390,7 +390,7 @@
     "TestOnlyExample",
     "TestOnlyNestedBaseObject",
     "Leaderboard",
-    "ActionDefinition",
+    "ActionSpec",
     "AnnotationSpec"
   ],
   "title": "CompositeBaseObject",


### PR DESCRIPTION
This is our only chance to change this (before it ships). Let's get it right