### PR TITLE
style(weave): move the show more buttons to the left

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -647,7 +647,7 @@ const ShowMoreButtons = ({
       sx={{
         display: 'flex',
         width: '100%',
-        justifyContent: 'flex-end',
+        justifyContent: 'flex-start',
         gap: 1,
       }}>
       {truncatedCount > ARRAY_TRUNCATION_LENGTH && (


### PR DESCRIPTION
## Description
after
<img width="1211" alt="Screenshot 2024-11-12 at 12 39 49 PM" src="https://github.com/user-attachments/assets/b3f8607f-48ad-4981-b904-922ae6e7ec1e">

before
<img width="1116" alt="Screenshot 2024-11-12 at 12 35 12 PM" src="https://github.com/user-attachments/assets/54a1dd5f-44a1-4702-95e2-7127b0b80618">

from this old thread
https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1728600051481949?thread_ts=1728599689.095469&cid=C03BSTEBD7F

## Testing

How was this PR tested?
