### PR TITLE
chore(ui): re-query on object creation

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -7,6 +7,8 @@ import {
   FeedbackPurgeRes,
   TraceCallsDeleteReq,
   TraceCallUpdateReq,
+  TraceObjCreateReq,
+  TraceObjCreateRes,
   TraceRefsReadBatchReq,
   TraceRefsReadBatchRes,
 } from './traceServerClientTypes';
@@ -24,6 +26,7 @@ export class TraceServerClient extends DirectTraceServerClient {
   private onDeleteListeners: Array<() => void>;
   private onRenameListeners: Array<() => void>;
   private onFeedbackListeners: Record<string, Array<() => void>>;
+  private onObjectListeners: Array<() => void>;
 
   constructor(baseUrl: string) {
     super(baseUrl);
@@ -32,6 +35,7 @@ export class TraceServerClient extends DirectTraceServerClient {
     this.onDeleteListeners = [];
     this.onRenameListeners = [];
     this.onFeedbackListeners = {};
+    this.onObjectListeners = [];
   }
 
   /**
@@ -78,6 +82,15 @@ export class TraceServerClient extends DirectTraceServerClient {
     };
   }
 
+  public registerOnObjectListener(callback: () => void): () => void {
+    this.onObjectListeners.push(callback);
+    return () => {
+      this.onObjectListeners = this.onObjectListeners.filter(
+        listener => listener !== callback
+      );
+    };
+  }
+
   public callsDelete(req: TraceCallsDeleteReq): Promise<void> {
     const res = super.callsDelete(req).then(() => {
       this.onDeleteListeners.forEach(listener => listener());
@@ -88,6 +101,14 @@ export class TraceServerClient extends DirectTraceServerClient {
   public callUpdate(req: TraceCallUpdateReq): Promise<void> {
     const res = super.callUpdate(req).then(() => {
       this.onRenameListeners.forEach(listener => listener());
+    });
+    return res;
+  }
+
+  public objCreate(req: TraceObjCreateReq): Promise<TraceObjCreateRes> {
+    const res = super.objCreate(req).then(createRes => {
+      this.onObjectListeners.forEach(listener => listener());
+      return createRes;
     });
     return res;
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -914,40 +914,85 @@ export const convertTraceServerObjectVersionToSchema = <
   };
 };
 
-const useRootObjectVersions = makeTraceServerEndpointHook(
-  'objsQuery',
-  (
-    entity: string,
-    project: string,
-    filter: ObjectVersionFilter,
-    limit?: number,
-    metadataOnly?: boolean,
-    opts?: {skip?: boolean}
-  ) => ({
-    params: {
+const useRootObjectVersions = (
+  entity: string,
+  project: string,
+  filter: ObjectVersionFilter,
+  limit?: number,
+  metadataOnly?: boolean,
+  opts?: {skip?: boolean}
+): LoadableWithError<ObjectVersionSchema[]> => {
+  const getTsClient = useGetTraceServerClientContext();
+  const loadingRef = useRef(false);
+  const [objectVersionRes, setObjectVersionRes] = useState<
+    LoadableWithError<ObjectVersionSchema[]>
+  >({
+    loading: false,
+    error: null,
+    result: null,
+  });
+  const deepFilter = useDeepMemo(filter);
+
+  const doFetch = useCallback(() => {
+    if (opts?.skip) {
+      return;
+    }
+    setObjectVersionRes({loading: true, error: null, result: null});
+    loadingRef.current = true;
+
+    const req: traceServerTypes.TraceObjQueryReq = {
       project_id: projectIdFromParts({entity, project}),
       filter: {
-        base_object_classes: filter.baseObjectClasses,
-        object_ids: filter.objectIds,
-        latest_only: filter.latestOnly,
+        base_object_classes: deepFilter.baseObjectClasses,
+        object_ids: deepFilter.objectIds,
+        latest_only: deepFilter.latestOnly,
         is_op: false,
       },
       limit,
       metadata_only: metadataOnly,
-    },
-    skip: opts?.skip,
-  }),
-  (
-    res,
-    inputEntity,
-    inputProject,
-    filter,
+    };
+    const onSuccess = (res: traceServerTypes.TraceObjQueryRes) => {
+      loadingRef.current = false;
+      setObjectVersionRes({
+        loading: false,
+        error: null,
+        result: res.objs.map(convertTraceServerObjectVersionToSchema),
+      });
+    };
+    const onError = (e: any) => {
+      loadingRef.current = false;
+      console.error(e);
+      setObjectVersionRes({loading: false, error: e, result: null});
+    };
+    getTsClient().objsQuery(req).then(onSuccess).catch(onError);
+  }, [
+    deepFilter,
+    getTsClient,
+    opts?.skip,
+    entity,
+    project,
     limit,
     metadataOnly,
-    opts
-  ): ObjectVersionSchema[] =>
-    res.objs.map(convertTraceServerObjectVersionToSchema)
-);
+  ]);
+
+  useEffect(() => {
+    doFetch();
+  }, [doFetch]);
+
+  useEffect(() => {
+    return getTsClient().registerOnObjectListener(doFetch);
+  }, [getTsClient, doFetch]);
+
+  return useMemo(() => {
+    if (opts?.skip) {
+      return {loading: false, error: null, result: null};
+    }
+    if (objectVersionRes == null || loadingRef.current) {
+      return {loading: true, error: null, result: null};
+    }
+    return objectVersionRes;
+  }, [objectVersionRes, opts?.skip]);
+};
 
 const useRefsReadBatch = makeTraceServerEndpointHook<
   'readBatch',


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Automatically requery the object versions query when an object is created. 

## Testing

How was this PR tested?
