### PR TITLE
feat(app): Add corresponding string op to FE to parse number with thousands and decimal separators

### DIFF
--- a/weave-js/src/core/ops/primitives/string.test.ts
+++ b/weave-js/src/core/ops/primitives/string.test.ts
@@ -948,14 +948,14 @@ describe('opStringLevenshtein', () => {
 
 async function parseNumberWithSeparatorQuery(
   str: string, 
-  thousands_separator: string | null,
-  decimal_separator: string | null,
+  thousandsSeparator: string | null,
+  decimalSeparator: string | null,
 ) {
   return (await testClient()).query(
       opParseNumberWithSeparator({
         str: constString(str),
-        thousands_separator: thousands_separator ? constString(thousands_separator) : constNone(),
-        decimal_separator: decimal_separator ? constString(decimal_separator) : constNone(),
+        thousands_separator: thousandsSeparator ? constString(thousandsSeparator) : constNone(),
+        decimal_separator: decimalSeparator ? constString(decimalSeparator) : constNone(),
       })
     )
 }

--- a/weave-js/src/core/ops/primitives/string.test.ts
+++ b/weave-js/src/core/ops/primitives/string.test.ts
@@ -947,42 +947,72 @@ describe('opStringLevenshtein', () => {
 });
 
 async function parseNumberWithSeparatorQuery(
-  str: string, 
+  str: string,
   thousandsSeparator: string | null,
-  decimalSeparator: string | null,
+  decimalSeparator: string | null
 ) {
   return (await testClient()).query(
-      opParseNumberWithSeparator({
-        str: constString(str),
-        thousands_separator: thousandsSeparator ? constString(thousandsSeparator) : constNone(),
-        decimal_separator: decimalSeparator ? constString(decimalSeparator) : constNone(),
-      })
-    )
+    opParseNumberWithSeparator({
+      str: constString(str),
+      thousands_separator: thousandsSeparator
+        ? constString(thousandsSeparator)
+        : constNone(),
+      decimal_separator: decimalSeparator
+        ? constString(decimalSeparator)
+        : constNone(),
+    })
+  );
 }
 
 describe('opParseNumberWithSeparator', () => {
   it('parses the specified thousands separator', async () => {
-    await expect(parseNumberWithSeparatorQuery("123,456,008", ",", null)).resolves.toEqual(123456008.0)
-    await expect(parseNumberWithSeparatorQuery("123,456,008", ".", null)).resolves.toEqual(123)
-    await expect(parseNumberWithSeparatorQuery("123,456.008", ",", null)).resolves.toEqual(123456.008)
-    await expect(parseNumberWithSeparatorQuery("123_456_008", "_", null)).resolves.toEqual(123456008.0)
-    await expect(parseNumberWithSeparatorQuery("123 456 008", " ", null)).resolves.toEqual(123456008.0)
-    await expect(parseNumberWithSeparatorQuery("123.456.008", ".", null)).resolves.toEqual(123456008.0)
+    await expect(
+      parseNumberWithSeparatorQuery('123,456,008', ',', null)
+    ).resolves.toEqual(123456008.0);
+    await expect(
+      parseNumberWithSeparatorQuery('123,456,008', '.', null)
+    ).resolves.toEqual(123);
+    await expect(
+      parseNumberWithSeparatorQuery('123,456.008', ',', null)
+    ).resolves.toEqual(123456.008);
+    await expect(
+      parseNumberWithSeparatorQuery('123_456_008', '_', null)
+    ).resolves.toEqual(123456008.0);
+    await expect(
+      parseNumberWithSeparatorQuery('123 456 008', ' ', null)
+    ).resolves.toEqual(123456008.0);
+    await expect(
+      parseNumberWithSeparatorQuery('123.456.008', '.', null)
+    ).resolves.toEqual(123456008.0);
   });
-
 
   it('parses the specified decimal separator', async () => {
-    await expect(parseNumberWithSeparatorQuery("123456.008", null, ".")).resolves.toEqual(123456.008)
-    await expect(parseNumberWithSeparatorQuery("123456,008", null, ",")).resolves.toEqual(123456.008)
-    await expect(parseNumberWithSeparatorQuery("123456008", null, ".")).resolves.toEqual(123456008.0)
-    await expect(parseNumberWithSeparatorQuery("123,456,008", null, ".")).resolves.toEqual(123)
+    await expect(
+      parseNumberWithSeparatorQuery('123456.008', null, '.')
+    ).resolves.toEqual(123456.008);
+    await expect(
+      parseNumberWithSeparatorQuery('123456,008', null, ',')
+    ).resolves.toEqual(123456.008);
+    await expect(
+      parseNumberWithSeparatorQuery('123456008', null, '.')
+    ).resolves.toEqual(123456008.0);
+    await expect(
+      parseNumberWithSeparatorQuery('123,456,008', null, '.')
+    ).resolves.toEqual(123);
   });
 
-
   it('parses both the specified thousands separator and decimal separator', async () => {
-    await expect(parseNumberWithSeparatorQuery("123,456.008", ",", ".")).resolves.toEqual(123456.008)
-    await expect(parseNumberWithSeparatorQuery("123.456,008", ".", ",")).resolves.toEqual(123456.008)
-    await expect(parseNumberWithSeparatorQuery("123 456,008", " ", ",")).resolves.toEqual(123456.008)
-    await expect(parseNumberWithSeparatorQuery("123 456,008", ",", ".")).resolves.toEqual(123)
+    await expect(
+      parseNumberWithSeparatorQuery('123,456.008', ',', '.')
+    ).resolves.toEqual(123456.008);
+    await expect(
+      parseNumberWithSeparatorQuery('123.456,008', '.', ',')
+    ).resolves.toEqual(123456.008);
+    await expect(
+      parseNumberWithSeparatorQuery('123 456,008', ' ', ',')
+    ).resolves.toEqual(123456.008);
+    await expect(
+      parseNumberWithSeparatorQuery('123 456,008', ',', '.')
+    ).resolves.toEqual(123);
   });
 });

--- a/weave-js/src/core/ops/primitives/string.ts
+++ b/weave-js/src/core/ops/primitives/string.ts
@@ -1,6 +1,6 @@
 import levenshtein from 'js-levenshtein';
 
-import {nullableSkipTaggable} from '../../model';
+import {maybe, nullableSkipTaggable} from '../../model';
 import {docType} from '../../util/docs';
 import {
   makeBinaryStandardOp,
@@ -400,6 +400,40 @@ export const opStringRightStrip = makeStringOp({
   returnType: inputTypes => 'string',
   resolver: ({str}) => str?.trimEnd() ?? '',
 });
+
+export const opParseNumberWithSeparator = makeStringOp({
+  name: 'string-parseNumberWithSeparator',
+  argTypes: {
+    str: {type: 'union', members: ['none', 'string']},
+    thousands_separator: {type: 'union', members: ['none', 'string']},
+    decimal_separator: {type: 'union', members: ['none', 'string']},
+  },
+  description: `Parse a string to a number`,
+  argDescriptions: {
+    str: `The ${docType('string')} to parse.`,
+    thousands_separator: "The delimiter used to partition the string into thousands groupings.",
+    decimal_separator: "The symbol used to separate the integer part of the number from the fractional part.",
+  },
+  returnValueDescription: `A floating point number, if the ${docType('string')} is a valid numeral, and null otherwise.`,
+  returnType: inputTypes => maybe('string'),
+  resolver: ({str, thousands_separator, decimal_separator}) => {
+    if (!str) {
+      return null
+    }
+
+    let maybeNumber = str;
+
+    if (thousands_separator) {
+      maybeNumber = maybeNumber.replaceAll(thousands_separator, '')
+    }
+
+    if (decimal_separator) {
+      maybeNumber = maybeNumber.replace(decimal_separator, '.')
+    }
+
+    return parseFloat(maybeNumber) || null;
+  }
+})
 
 // Levenshtein distance is the minimum number of single-character
 // edits it would take to go from one string to another

--- a/weave-js/src/core/ops/primitives/string.ts
+++ b/weave-js/src/core/ops/primitives/string.ts
@@ -411,29 +411,33 @@ export const opParseNumberWithSeparator = makeStringOp({
   description: `Parse a string to a number`,
   argDescriptions: {
     str: `The ${docType('string')} to parse.`,
-    thousands_separator: "The delimiter used to partition the string into thousands groupings.",
-    decimal_separator: "The symbol used to separate the integer part of the number from the fractional part.",
+    thousands_separator:
+      'The delimiter used to partition the string into thousands groupings.',
+    decimal_separator:
+      'The symbol used to separate the integer part of the number from the fractional part.',
   },
-  returnValueDescription: `A floating point number, if the ${docType('string')} is a valid numeral, and null otherwise.`,
+  returnValueDescription: `A floating point number, if the ${docType(
+    'string'
+  )} is a valid numeral, and null otherwise.`,
   returnType: inputTypes => maybe('string'),
   resolver: ({str, thousands_separator, decimal_separator}) => {
     if (!str) {
-      return null
+      return null;
     }
 
     let maybeNumber = str;
 
     if (thousands_separator) {
-      maybeNumber = maybeNumber.replaceAll(thousands_separator, '')
+      maybeNumber = maybeNumber.replaceAll(thousands_separator, '');
     }
 
     if (decimal_separator) {
-      maybeNumber = maybeNumber.replace(decimal_separator, '.')
+      maybeNumber = maybeNumber.replace(decimal_separator, '.');
     }
 
     return parseFloat(maybeNumber) || null;
-  }
-})
+  },
+});
 
 // Levenshtein distance is the minimum number of single-character
 // edits it would take to go from one string to another


### PR DESCRIPTION
## Description

- Accompanies https://github.com/wandb/weave/pull/2864
- Fixes [WB-16442](https://wandb.atlassian.net/browse/WB-16442)
- Adds new string op to the FE to  parse numbers with a thousands and decimal separator.

## Testing

- Unit tests
- Manually with local FE

<img width="281" alt="Screenshot 2024-11-12 at 3 28 47 PM" src="https://github.com/user-attachments/assets/0985e216-1d0b-40bc-b0fe-e70995b8c796">



[WB-16442]: https://wandb.atlassian.net/browse/WB-16442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ