### PR TITLE
chore(ui): basic foundation for annotation specs

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -53,6 +53,7 @@ const OBJECT_ICONS: Record<KnownBaseObjectClassType, IconName> = {
   Evaluation: 'baseline-alt',
   Leaderboard: 'benchmark-square',
   Scorer: 'type-number-alt',
+  AnnotationSpec: 'forum-chat-bubble',
 };
 const ObjectIcon = ({baseObjectClass}: ObjectIconProps) => {
   if (baseObjectClass in OBJECT_ICONS) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -28,6 +28,7 @@ import {StyledDataGrid} from '../StyledDataGrid';
 import {basicField} from './common/DataTable';
 import {Empty} from './common/Empty';
 import {
+  EMPTY_PROPS_ANNOTATIONS,
   EMPTY_PROPS_DATASETS,
   EMPTY_PROPS_LEADERBOARDS,
   EMPTY_PROPS_MODEL,
@@ -118,6 +119,9 @@ export const FilterableObjectVersionsTable: React.FC<{
   project: string;
   frozenFilter?: WFHighLevelObjectVersionFilter;
   initialFilter?: WFHighLevelObjectVersionFilter;
+  objectTitle?: string;
+  hideCategoryColumn?: boolean;
+  hideCreatedAtColumn?: boolean;
   // Setting this will make the component a controlled component. The parent
   // is responsible for updating the filter.
   onFilterUpdate?: (filter: WFHighLevelObjectVersionFilter) => void;
@@ -170,6 +174,8 @@ export const FilterableObjectVersionsTable: React.FC<{
       propsEmpty = EMPTY_PROPS_LEADERBOARDS;
     } else if (base === 'Scorer') {
       propsEmpty = EMPTY_PROPS_PROGRAMMATIC_SCORERS;
+    } else if (base === 'AnnotationSpec') {
+      propsEmpty = EMPTY_PROPS_ANNOTATIONS;
     }
     return <Empty {...propsEmpty} />;
   }
@@ -185,8 +191,11 @@ export const FilterableObjectVersionsTable: React.FC<{
       )}>
       <ObjectVersionsTable
         objectVersions={objectVersions}
+        objectTitle={props.objectTitle}
         hidePropsAsColumns={!!effectivelyLatestOnly}
         hidePeerVersionsColumn={!effectivelyLatestOnly}
+        hideCategoryColumn={props.hideCategoryColumn}
+        hideCreatedAtColumn={props.hideCreatedAtColumn}
       />
     </FilterLayoutTemplate>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/AnnotationsTab.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/AnnotationsTab.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 
+import {FilterableObjectVersionsTable} from '../ObjectVersionsPage';
+
 export const AnnotationsTab: React.FC<{
   entity: string;
   project: string;
 }> = ({entity, project}) => {
-  return <>Coming Soon - Annotations</>;
+  return (
+    <FilterableObjectVersionsTable
+      entity={entity}
+      project={project}
+      objectTitle="Scorer"
+      hideCategoryColumn
+      initialFilter={{
+        baseObjectClass: 'AnnotationSpec',
+      }}
+    />
+  );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CoreScorersTab.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CoreScorersTab.tsx
@@ -10,6 +10,7 @@ export const ProgrammaticScorersTab: React.FC<{
     <FilterableObjectVersionsTable
       entity={entity}
       project={project}
+      objectTitle="Scorer"
       initialFilter={{
         baseObjectClass: 'Scorer',
       }}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -198,3 +198,18 @@ export const EMPTY_PROPS_PROGRAMMATIC_SCORERS: EmptyProps = {
     </>
   ),
 };
+
+export const EMPTY_PROPS_ANNOTATIONS: EmptyProps = {
+  icon: 'forum-chat-bubble' as const,
+  heading: 'No annotations yet',
+  description: 'Create annotations in Python.',
+  moreInformation: (
+    <>
+      Learn more about{' '}
+      <TargetBlank href="https://weave-docs.wandb.ai/guides/annotations">
+        creating and using annotations
+      </TargetBlank>
+      .
+    </>
+  ),
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/TypeVersionCategoryChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/TypeVersionCategoryChip.tsx
@@ -10,6 +10,7 @@ const colorMap: Record<KnownBaseObjectClassType, TagColorName> = {
   Evaluation: 'cactus',
   Leaderboard: 'gold',
   Scorer: 'purple',
+  AnnotationSpec: 'sienna',
 };
 
 export const TypeVersionCategoryChip: React.FC<{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants.ts
@@ -26,4 +26,5 @@ export const KNOWN_BASE_OBJECT_CLASSES = [
   'Evaluation',
   'Leaderboard',
   'Scorer',
+  'AnnotationSpec',
 ] as const;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -170,6 +170,7 @@ export type Feedback = {
   creator: string | null; // display name
   created_at: string;
   feedback_type: string;
+  annotation_ref?: string;
   payload: Record<string, any>;
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
@@ -18,13 +18,14 @@ import {
 } from './constants';
 import {useWFHooks} from './context';
 import {
+  CallSchema,
   KnownBaseObjectClassType,
+  Loadable,
   ObjectVersionKey,
   ObjectVersionSchema,
   OpCategory,
   OpVersionKey,
 } from './wfDataModelHooksInterface';
-import {CallSchema, Loadable} from './wfDataModelHooksInterface';
 
 type RefUri = string;
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Very basic foundational typing and stubs for annotation specs. Specifically, this pr:
- adds an object table query in an annotation scorer tab
- pipes through more props from the filterableObjectsTable
- adds annotationSpec type for to frontend known objects
- adds `annotation_ref` to feedback type

## Testing

How was this PR tested?
