### PR TITLE
chore(weave): Add `ActionSpec` to known types

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -53,6 +53,7 @@ const OBJECT_ICONS: Record<KnownBaseObjectClassType, IconName> = {
   Evaluation: 'baseline-alt',
   Leaderboard: 'benchmark-square',
   Scorer: 'type-number-alt',
+  ActionSpec: 'rocket-launch',
 };
 const ObjectIcon = ({baseObjectClass}: ObjectIconProps) => {
   if (baseObjectClass in OBJECT_ICONS) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -28,6 +28,7 @@ import {StyledDataGrid} from '../StyledDataGrid';
 import {basicField} from './common/DataTable';
 import {Empty} from './common/Empty';
 import {
+  EMPTY_PROPS_ACTION_SPECS,
   EMPTY_PROPS_DATASETS,
   EMPTY_PROPS_LEADERBOARDS,
   EMPTY_PROPS_MODEL,
@@ -170,6 +171,8 @@ export const FilterableObjectVersionsTable: React.FC<{
       propsEmpty = EMPTY_PROPS_LEADERBOARDS;
     } else if (base === 'Scorer') {
       propsEmpty = EMPTY_PROPS_PROGRAMMATIC_SCORERS;
+    } else if (base === 'ActionSpec') {
+      propsEmpty = EMPTY_PROPS_ACTION_SPECS;
     }
     return <Empty {...propsEmpty} />;
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -198,3 +198,11 @@ export const EMPTY_PROPS_PROGRAMMATIC_SCORERS: EmptyProps = {
     </>
   ),
 };
+
+export const EMPTY_PROPS_ACTION_SPECS: EmptyProps = {
+  icon: 'automation-robot-arm' as const,
+  heading: 'No Actions yet',
+  description:
+    'Use Actions to define workloads to be executed by Weave servers (for example: LLM Judges) ',
+  moreInformation: <></>,
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/TypeVersionCategoryChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/TypeVersionCategoryChip.tsx
@@ -10,6 +10,7 @@ const colorMap: Record<KnownBaseObjectClassType, TagColorName> = {
   Evaluation: 'cactus',
   Leaderboard: 'gold',
   Scorer: 'purple',
+  ActionSpec: 'sienna',
 };
 
 export const TypeVersionCategoryChip: React.FC<{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/constants.ts
@@ -26,4 +26,5 @@ export const KNOWN_BASE_OBJECT_CLASSES = [
   'Evaluation',
   'Leaderboard',
   'Scorer',
+  'ActionSpec',
 ] as const;


### PR DESCRIPTION
Adds the `ActionSpec` to the known types and creates empty state. This is part of the LLM Judge project