### PR TITLE
chore(weave): Extend simple tab border line

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -272,21 +272,23 @@ export const SimplePageLayoutWithHeader: FC<{
                 {props.headerContent}
               </Box>
               {(!props.hideTabsIfSingle || tabs.length > 1) && (
-                <Tabs.Root
-                  style={{margin: '12px 16px 0 16px'}}
-                  value={tabs[tabValue].label}
-                  onValueChange={handleTabChange}>
-                  <Tabs.List>
-                    {tabs.map(tab => (
-                      <Tabs.Trigger
-                        key={tab.label}
-                        value={tab.label}
-                        className="h-[30px] text-sm">
-                        {tab.label}
-                      </Tabs.Trigger>
-                    ))}
-                  </Tabs.List>
-                </Tabs.Root>
+                <Box sx={{borderBottom: '1px solid #e0e0e0'}}>
+                  <Tabs.Root
+                    style={{padding: '12px 16px 0 16px'}}
+                    value={tabs[tabValue].label}
+                    onValueChange={handleTabChange}>
+                    <Tabs.List style={{borderBottom: 'none'}}>
+                      {tabs.map(tab => (
+                        <Tabs.Trigger
+                          key={tab.label}
+                          value={tab.label}
+                          className="h-[30px] text-sm">
+                          {tab.label}
+                        </Tabs.Trigger>
+                      ))}
+                    </Tabs.List>
+                  </Tabs.Root>
+                </Box>
               )}
               <Box
                 sx={{


### PR DESCRIPTION
Extends the border bottom line of the tabs to meet the edges


Before
![e2](https://github.com/user-attachments/assets/35ee2442-314e-46f2-8eee-37f8d2d394e4)

After
![example](https://github.com/user-attachments/assets/fd60f644-d225-4f3f-932d-18e8be8cb638)

Before (bottom), After (Top)

<img width="2056" alt="Screenshot 2024-11-12 at 18 34 20" src="https://github.com/user-attachments/assets/21270e07-9e17-4ede-a6f1-983f8b04e085">
