### PR TITLE
chore(ui): objs query handles null case (??)

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -956,7 +956,7 @@ const useRootObjectVersions = (
       setObjectVersionRes({
         loading: false,
         error: null,
-        result: res.objs.map(convertTraceServerObjectVersionToSchema),
+        result: res.objs?.map(convertTraceServerObjectVersionToSchema) ?? [],
       });
     };
     const onError = (e: any) => {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Hack fix for this sentry event: https://weights-biases.sentry.io/issues/6062366781/?project=1201719&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=1h&stream_index=2

The only way I can get a non `[]` res.objs is when viewing a project that I don't have access to... 
