### PR TITLE
fix(weave): add where clause to cost query

### DIFF
--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -391,7 +391,10 @@ def test_query_light_column_with_costs() -> None:
                             llm_token_prices.effective_date DESC
                     ) AS rank
                 FROM llm_usage
-                LEFT JOIN llm_token_prices ON (llm_usage.llm_id = llm_token_prices.llm_id))
+                LEFT JOIN llm_token_prices ON (llm_usage.llm_id = llm_token_prices.llm_id)
+                WHERE ((llm_token_prices.pricing_level_id = {pb_2:String})
+                    OR (llm_token_prices.pricing_level_id = {pb_3:String})
+                    OR (llm_token_prices.pricing_level_id = {pb_4:String})))
             -- Final Select, which just selects the correct fields, and adds a costs object
             SELECT
                 id,
@@ -433,13 +436,16 @@ def test_query_light_column_with_costs() -> None:
                     '}' )
                 ) AS summary_dump
             FROM ranked_prices
-            WHERE (rank = {pb_2:UInt64})
+            WHERE (rank = {pb_5:UInt64})
             GROUP BY id, started_at
         """,
         {
             "pb_0": ["a", "b"],
             "pb_1": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-            "pb_2": 1,
+            "pb_2": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
+            "pb_3": "default",
+            "pb_4": "",
+            "pb_5": 1,
         },
     )
 

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -231,6 +231,36 @@ def get_ranked_prices(
     select_query = (
         llm_usage_table.select()
         .fields(["*", *ltp_fields, row_number_clause])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$and": [
+                            {
+                                "$or": [
+                                    {
+                                        "$eq": [
+                                            {
+                                                "$getField": f"{LLM_TOKEN_PRICES_TABLE_NAME}.pricing_level_id"
+                                            },
+                                            {"$literal": project_id},
+                                        ]
+                                    },
+                                    {
+                                        "$eq": [
+                                            {
+                                                "$getField": f"{LLM_TOKEN_PRICES_TABLE_NAME}.pricing_level_id"
+                                            },
+                                            {"$literal": DEFAULT_PRICING_LEVEL_ID},
+                                        ]
+                                    },
+                                ]
+                            },
+                        ]
+                    }
+                }
+            )
+        )
         .join(
             LLM_TOKEN_PRICES_TABLE,
             tsi.Query(

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -235,25 +235,29 @@ def get_ranked_prices(
             tsi.Query(
                 **{
                     "$expr": {
-                        "$and": [
+                        "$or": [
                             {
-                                "$or": [
+                                "$eq": [
                                     {
-                                        "$eq": [
-                                            {
-                                                "$getField": f"{LLM_TOKEN_PRICES_TABLE_NAME}.pricing_level_id"
-                                            },
-                                            {"$literal": project_id},
-                                        ]
+                                        "$getField": f"{LLM_TOKEN_PRICES_TABLE_NAME}.pricing_level_id"
                                     },
+                                    {"$literal": project_id},
+                                ]
+                            },
+                            {
+                                "$eq": [
                                     {
-                                        "$eq": [
-                                            {
-                                                "$getField": f"{LLM_TOKEN_PRICES_TABLE_NAME}.pricing_level_id"
-                                            },
-                                            {"$literal": DEFAULT_PRICING_LEVEL_ID},
-                                        ]
+                                        "$getField": f"{LLM_TOKEN_PRICES_TABLE_NAME}.pricing_level_id"
                                     },
+                                    {"$literal": DEFAULT_PRICING_LEVEL_ID},
+                                ]
+                            },
+                            {
+                                "$eq": [
+                                    {
+                                        "$getField": f"{LLM_TOKEN_PRICES_TABLE_NAME}.pricing_level_id"
+                                    },
+                                    {"$literal": ""},
                                 ]
                             },
                         ]


### PR DESCRIPTION
## Description
adds a where clause to the cost query, costs from other projects would be used if there existed no cost within the project
filters out costs that are not in the project, null, or default

https://wandb.atlassian.net/browse/WB-21847
https://wandb.atlassian.net/browse/WB-21851
## Testing

How was this PR tested?
