### PR TITLE
fix(weave): Fix skip in query to fix project page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -984,7 +984,7 @@ const useRootObjectVersions = (
       return;
     }
     return getTsClient().registerOnObjectListener(doFetch);
-  }, [getTsClient, doFetch]);
+  }, [getTsClient, doFetch, opts?.skip]);
 
   return useMemo(() => {
     if (opts?.skip) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -980,6 +980,9 @@ const useRootObjectVersions = (
   }, [doFetch]);
 
   useEffect(() => {
+    if (opts?.skip) {
+      return;
+    }
     return getTsClient().registerOnObjectListener(doFetch);
   }, [getTsClient, doFetch]);
 


### PR DESCRIPTION
## Description

What does the PR do? Include a concise description of the PR contents.

Fixes failing local tests on project page because the query from here https://github.com/wandb/core/pull/25123 didn't skip properly when there would be no TraceServerClientContext because Weave isn't available.

## Testing

How was this PR tested?

Tested using governor start invoker and hardcoding removing the context provider that the error doesn't appear anymore because the query is skipped properly.
