### PR TITLE
fix(ui): paging works after clicking in trace table

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -1,5 +1,5 @@
-import {ApolloProvider} from '@apollo/client';
-import {Home} from '@mui/icons-material';
+import { ApolloProvider } from '@apollo/client';
+import { Home } from '@mui/icons-material';
 import {
   AppBar,
   Box,
@@ -17,10 +17,10 @@ import {
   GridPinnedColumnFields,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
-import {LicenseInfo} from '@mui/x-license';
-import {makeGorillaApolloClient} from '@wandb/weave/apollo';
-import {EVALUATE_OP_NAME_POST_PYDANTIC} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/heuristics';
-import {opVersionKeyToRefUri} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities';
+import { LicenseInfo } from '@mui/x-license';
+import { makeGorillaApolloClient } from '@wandb/weave/apollo';
+import { EVALUATE_OP_NAME_POST_PYDANTIC } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/heuristics';
+import { opVersionKeyToRefUri } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities';
 import _ from 'lodash';
 import React, {
   ComponentProps,
@@ -42,11 +42,11 @@ import {
   useParams,
 } from 'react-router-dom';
 
-import {URL_BROWSE3} from '../../../urls';
-import {Button} from '../../Button';
-import {ErrorBoundary} from '../../ErrorBoundary';
-import {Browse2EntityPage} from './Browse2/Browse2EntityPage';
-import {Browse2HomePage} from './Browse2/Browse2HomePage';
+import { URL_BROWSE3 } from '../../../urls';
+import { Button } from '../../Button';
+import { ErrorBoundary } from '../../ErrorBoundary';
+import { Browse2EntityPage } from './Browse2/Browse2EntityPage';
+import { Browse2HomePage } from './Browse2/Browse2HomePage';
 import {
   baseContext,
   browse2Context,
@@ -59,18 +59,18 @@ import {
   useWeaveflowRouteContext,
   WeaveflowPeekContext,
 } from './Browse3/context';
-import {FullPageButton} from './Browse3/FullPageButton';
-import {getValidFilterModel} from './Browse3/grid/filters';
+import { FullPageButton } from './Browse3/FullPageButton';
+import { getValidFilterModel } from './Browse3/grid/filters';
 import {
   DEFAULT_PAGE_SIZE,
   getValidPaginationModel,
 } from './Browse3/grid/pagination';
-import {getValidPinModel, removeAlwaysLeft} from './Browse3/grid/pin';
-import {getValidSortModel} from './Browse3/grid/sort';
-import {BoardPage} from './Browse3/pages/BoardPage';
-import {BoardsPage} from './Browse3/pages/BoardsPage';
-import {CallPage} from './Browse3/pages/CallPage/CallPage';
-import {CallsPage} from './Browse3/pages/CallsPage/CallsPage';
+import { getValidPinModel, removeAlwaysLeft } from './Browse3/grid/pin';
+import { getValidSortModel } from './Browse3/grid/sort';
+import { BoardPage } from './Browse3/pages/BoardPage';
+import { BoardsPage } from './Browse3/pages/BoardsPage';
+import { CallPage } from './Browse3/pages/CallPage/CallPage';
+import { CallsPage } from './Browse3/pages/CallsPage/CallsPage';
 import {
   ALWAYS_PIN_LEFT_CALLS,
   DEFAULT_COLUMN_VISIBILITY_CALLS,
@@ -78,33 +78,33 @@ import {
   DEFAULT_PIN_CALLS,
   DEFAULT_SORT_CALLS,
 } from './Browse3/pages/CallsPage/CallsTable';
-import {Empty} from './Browse3/pages/common/Empty';
-import {EMPTY_NO_TRACE_SERVER} from './Browse3/pages/common/EmptyContent';
-import {SimplePageLayoutContext} from './Browse3/pages/common/SimplePageLayout';
-import {CompareEvaluationsPage} from './Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage';
-import {LeaderboardListingPage} from './Browse3/pages/LeaderboardPage/LeaderboardListingPage';
-import {LeaderboardPage} from './Browse3/pages/LeaderboardPage/LeaderboardPage';
-import {ObjectPage} from './Browse3/pages/ObjectPage';
-import {ObjectVersionPage} from './Browse3/pages/ObjectVersionPage';
+import { Empty } from './Browse3/pages/common/Empty';
+import { EMPTY_NO_TRACE_SERVER } from './Browse3/pages/common/EmptyContent';
+import { SimplePageLayoutContext } from './Browse3/pages/common/SimplePageLayout';
+import { CompareEvaluationsPage } from './Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage';
+import { LeaderboardListingPage } from './Browse3/pages/LeaderboardPage/LeaderboardListingPage';
+import { LeaderboardPage } from './Browse3/pages/LeaderboardPage/LeaderboardPage';
+import { ObjectPage } from './Browse3/pages/ObjectPage';
+import { ObjectVersionPage } from './Browse3/pages/ObjectVersionPage';
 import {
   ObjectVersionsPage,
   WFHighLevelObjectVersionFilter,
 } from './Browse3/pages/ObjectVersionsPage';
-import {OpPage} from './Browse3/pages/OpPage';
-import {OpsPage} from './Browse3/pages/OpsPage';
-import {OpVersionPage} from './Browse3/pages/OpVersionPage';
-import {OpVersionsPage} from './Browse3/pages/OpVersionsPage';
-import {PlaygroundPage} from './Browse3/pages/PlaygroundPage/PlaygroundPage';
-import {ScorersPage} from './Browse3/pages/ScorersPage/ScorersPage';
-import {TablePage} from './Browse3/pages/TablePage';
-import {TablesPage} from './Browse3/pages/TablesPage';
-import {useURLSearchParamsDict} from './Browse3/pages/util';
+import { OpPage } from './Browse3/pages/OpPage';
+import { OpsPage } from './Browse3/pages/OpsPage';
+import { OpVersionPage } from './Browse3/pages/OpVersionPage';
+import { OpVersionsPage } from './Browse3/pages/OpVersionsPage';
+import { PlaygroundPage } from './Browse3/pages/PlaygroundPage/PlaygroundPage';
+import { ScorersPage } from './Browse3/pages/ScorersPage/ScorersPage';
+import { TablePage } from './Browse3/pages/TablePage';
+import { TablesPage } from './Browse3/pages/TablesPage';
+import { useURLSearchParamsDict } from './Browse3/pages/util';
 import {
   useWFHooks,
   WFDataModelAutoProvider,
 } from './Browse3/pages/wfReactInterface/context';
-import {useHasTraceServerClientContext} from './Browse3/pages/wfReactInterface/traceServerClientContext';
-import {useDrawerResize} from './useDrawerResize';
+import { useHasTraceServerClientContext } from './Browse3/pages/wfReactInterface/traceServerClientContext';
+import { useDrawerResize } from './useDrawerResize';
 
 LicenseInfo.setLicenseKey(
   'c3f549c76a1e054e5e314b2f1ecfca1cTz05OTY3MixFPTE3NjAxMTM3NDAwMDAsUz1wcm8sTE09c3Vic2NyaXB0aW9uLFBWPWluaXRpYWwsS1Y9Mg=='
@@ -1143,11 +1143,13 @@ const Browse3Breadcrumbs: FC = props => {
 
 export const TableRowSelectionContext = React.createContext<{
   rowIdsConfigured: boolean;
+  rowIdInTable: (id: string) => boolean;
   setRowIds?: (rowIds: string[]) => void;
   getNextRowId?: (currentId: string) => string | null;
   getPreviousRowId?: (currentId: string) => string | null;
 }>({
   rowIdsConfigured: false,
+  rowIdInTable: (id: string) => false,
   setRowIds: () => {},
   getNextRowId: () => null,
   getPreviousRowId: () => null,
@@ -1158,6 +1160,10 @@ const TableRowSelectionProvider: FC<{children: React.ReactNode}> = ({
 }) => {
   const [rowIds, setRowIds] = useState<string[]>([]);
   const rowIdsConfigured = useMemo(() => rowIds.length > 0, [rowIds]);
+  const rowIdInTable = useCallback(
+    (currentId: string) => rowIds.includes(currentId),
+    [rowIds]
+  );
 
   const getNextRowId = useCallback(
     (currentId: string) => {
@@ -1183,7 +1189,7 @@ const TableRowSelectionProvider: FC<{children: React.ReactNode}> = ({
 
   return (
     <TableRowSelectionContext.Provider
-      value={{rowIdsConfigured, setRowIds, getNextRowId, getPreviousRowId}}>
+      value={{rowIdsConfigured, rowIdInTable, setRowIds, getNextRowId, getPreviousRowId}}>
       {children}
     </TableRowSelectionContext.Provider>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -33,6 +33,7 @@ import {CallDetails} from './CallDetails';
 import {CallOverview} from './CallOverview';
 import {CallSummary} from './CallSummary';
 import {CallTraceView, useCallFlattenedTraceTree} from './CallTraceView';
+import {PaginationControls} from './PaginationControls';
 export const CallPage: FC<{
   entity: string;
   project: string;
@@ -201,65 +202,9 @@ const CallPageInnerVertical: FC<{
     }
   }, [callComplete]);
 
-  // Call navigation by arrow keys and buttons
-  const {getNextRowId, getPreviousRowId, rowIdsConfigured} = useContext(
-    TableRowSelectionContext
-  );
+  const {rowIdsConfigured} = useContext(TableRowSelectionContext);
   const {isPeeking} = useContext(WeaveflowPeekContext);
   const showPaginationContols = isPeeking && rowIdsConfigured;
-  const onNextCall = useCallback(() => {
-    const nextCallId = getNextRowId?.(currentCall.callId);
-    if (nextCallId) {
-      history.replace(
-        currentRouter.callUIUrl(
-          currentCall.entity,
-          currentCall.project,
-          currentCall.traceId,
-          nextCallId,
-          path,
-          showTraceTree
-        )
-      );
-    }
-  }, [currentCall, currentRouter, history, path, showTraceTree, getNextRowId]);
-  const onPreviousCall = useCallback(() => {
-    const previousRowId = getPreviousRowId?.(currentCall.callId);
-    if (previousRowId) {
-      history.replace(
-        currentRouter.callUIUrl(
-          currentCall.entity,
-          currentCall.project,
-          currentCall.traceId,
-          previousRowId,
-          path,
-          showTraceTree
-        )
-      );
-    }
-  }, [
-    currentCall,
-    currentRouter,
-    history,
-    path,
-    showTraceTree,
-    getPreviousRowId,
-  ]);
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === 'ArrowDown' && event.shiftKey) {
-        onNextCall();
-      } else if (event.key === 'ArrowUp' && event.shiftKey) {
-        onPreviousCall();
-      }
-    },
-    [onNextCall, onPreviousCall]
-  );
-  useEffect(() => {
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [handleKeyDown]);
 
   const callTabs = useCallTabs(currentCall);
 
@@ -278,21 +223,7 @@ const CallPageInnerVertical: FC<{
             alignItems: 'center',
           }}>
           {showPaginationContols && (
-            <Box>
-              <Button
-                icon="sort-ascending"
-                tooltip="Previous call. (Shift + Arrow Up)"
-                variant="ghost"
-                onClick={onPreviousCall}
-                className="mr-2"
-              />
-              <Button
-                icon="sort-descending"
-                tooltip="Next call. (Shift + Arrow Down)"
-                variant="ghost"
-                onClick={onNextCall}
-              />
-            </Box>
+            <PaginationControls call={call} path={path} />
           )}
           <Box sx={{marginLeft: showPaginationContols ? 0 : 'auto'}}>
             <Button

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/PaginationControls.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/PaginationControls.tsx
@@ -1,0 +1,96 @@
+import {Box} from '@mui/material';
+import {Button} from '@wandb/weave/components/Button';
+import React, {FC, useCallback, useContext, useEffect} from 'react';
+import {useHistory} from 'react-router-dom';
+
+import {TableRowSelectionContext} from '../../../Browse3';
+import {TRACETREE_PARAM, useWeaveflowCurrentRouteContext} from '../../context';
+import {isEvaluateOp} from '../common/heuristics';
+import {useURLSearchParamsDict} from '../util';
+import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
+
+export const PaginationControls: FC<{
+  call: CallSchema;
+  path?: string;
+}> = ({call, path}) => {
+  // Call navigation by arrow keys and buttons
+  const {getNextRowId, getPreviousRowId, rowIdInTable} = useContext(
+    TableRowSelectionContext
+  );
+  const history = useHistory();
+  const currentRouter = useWeaveflowCurrentRouteContext();
+  const query = useURLSearchParamsDict();
+  const showTraceTree =
+    TRACETREE_PARAM in query
+      ? query[TRACETREE_PARAM] === '1'
+      : !isEvaluateOp(call.spanName);
+
+  const onNextCall = useCallback(() => {
+    const nextCallId = getNextRowId?.(call.callId);
+    if (nextCallId) {
+      history.replace(
+        currentRouter.callUIUrl(
+          call.entity,
+          call.project,
+          call.traceId,
+          nextCallId,
+          path,
+          showTraceTree
+        )
+      );
+    }
+  }, [call, currentRouter, history, path, showTraceTree, getNextRowId]);
+  const onPreviousCall = useCallback(() => {
+    const previousRowId = getPreviousRowId?.(call.callId);
+    if (previousRowId) {
+      history.replace(
+        currentRouter.callUIUrl(
+          call.entity,
+          call.project,
+          call.traceId,
+          previousRowId,
+          path,
+          showTraceTree
+        )
+      );
+    }
+  }, [call, currentRouter, history, path, showTraceTree, getPreviousRowId]);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'ArrowDown' && event.shiftKey) {
+        onNextCall();
+      } else if (event.key === 'ArrowUp' && event.shiftKey) {
+        onPreviousCall();
+      }
+    },
+    [onNextCall, onPreviousCall]
+  );
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
+  const disabled = !rowIdInTable(call.callId);
+
+  return (
+    <Box>
+      <Button
+        icon="sort-ascending"
+        tooltip="Previous call. (Shift + Arrow Up)"
+        variant="ghost"
+        onClick={onPreviousCall}
+        className="mr-2"
+        disabled={disabled}
+      />
+      <Button
+        icon="sort-descending"
+        tooltip="Next call. (Shift + Arrow Down)"
+        variant="ghost"
+        onClick={onNextCall}
+        disabled={disabled}
+      />
+    </Box>
+  );
+};


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr: 
- refactors the call page pagination arrows (up/down) into its own component
- adds `isIdInTable` fn to check if the current ID is even in the table, if not, disable paging
- use `call` to trace the current call ID when in the calls page, so we aren't affected by trace tree updates

**note: we still have to disable the paging when a users clicks on a parent of the current call in the trace tree, as we update `call` in CallsPage but do not update the `callsTable`, making the Id now not in the table**

## Testing

How was this PR tested?
