### PR TITLE
chore(weave): Make Call.children a property

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -406,7 +406,7 @@ def test_calls_delete_cascade(client):
     evaluate_calls = list(weave.as_op(evaluation.evaluate).calls())
     assert len(evaluate_calls) == 1
     eval_call = evaluate_calls[0]
-    eval_call_children = list(eval_call.children())
+    eval_call_children = list(eval_call.children)
     assert len(eval_call_children) == 3
 
     # delete the evaluation, should cascade to all the calls and sub-calls
@@ -764,7 +764,7 @@ def test_evaluate(client):
     evaluate_calls = list(weave.as_op(evaluation.evaluate).calls())
     assert len(evaluate_calls) == 1
     eval_call = evaluate_calls[0]
-    eval_call_children = list(eval_call.children())
+    eval_call_children = list(eval_call.children)
     assert len(eval_call_children) == 3
 
     # TODO: walk the whole graph and make sure all the refs and relationships

--- a/weave/integrations/integration_utilities.py
+++ b/weave/integrations/integration_utilities.py
@@ -76,7 +76,7 @@ def flatten_calls(calls: Union[Iterable[Call], CallsIter], *, depth: int = 0) ->
     lst = []
     for call in calls:
         lst.append((call, depth))
-        lst.extend(flatten_calls(call.children(), depth=depth + 1))
+        lst.extend(flatten_calls(call.children, depth=depth + 1))
     return lst
 
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -260,6 +260,7 @@ class Call:
         return CallRef(entity, project, self.id)
 
     # These are the children if we're using Call at read-time
+    @property
     def children(self) -> CallsIter:
         client = weave_client_context.require_weave_client()
         if not self.id:


### PR DESCRIPTION
This makes it so you can get the children of a call without the parens.  This is safe because the result is already a lazy iterator, and it's more idiomatic because `children` are a property of the call.

So instead of:
```py
for c in call.children(): ...
```

You can now do:
```py
for c in call.children: ...
```