### PR TITLE
chore(weave): Prep for LLM Judges UI

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ActionScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ActionScorerForm.tsx
@@ -1,0 +1,10 @@
+import React, {FC} from 'react';
+
+import {ScorerFormProps} from './ScorerForms';
+
+export const ActionScorerForm: FC<ScorerFormProps<any>> = ({
+  data,
+  onDataChange,
+}) => {
+  return <div>Action Scorer Form</div>;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ActionSpecsTab.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ActionSpecsTab.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-
-export const ActionSpecsTab: React.FC<{
-  entity: string;
-  project: string;
-}> = ({entity, project}) => {
-  return <>Coming Soon - Configurable Judges</>;
-};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/FormComponents.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/FormComponents.tsx
@@ -1,0 +1,61 @@
+import {Box, InputLabel} from '@material-ui/core';
+import {Select} from '@wandb/weave/components/Form/Select';
+import {TextField} from '@wandb/weave/components/Form/TextField';
+import React from 'react';
+
+export const GAP_BETWEEN_ITEMS_PX = 10;
+export const GAP_BETWEEN_LABEL_AND_FIELD_PX = 10;
+
+type AutocompleteWithLabelType<Option = any> = (
+  props: {
+    label?: string;
+    style?: React.CSSProperties;
+  } & React.ComponentProps<typeof Select<Option>>
+) => React.ReactElement;
+
+export const AutocompleteWithLabel: AutocompleteWithLabelType = ({
+  label,
+  style,
+  ...props
+}) => (
+  <Box
+    style={{
+      marginBottom: GAP_BETWEEN_ITEMS_PX + 'px',
+      padding: '0px 2px',
+      ...style,
+    }}>
+    {label && (
+      <InputLabel style={{marginBottom: GAP_BETWEEN_LABEL_AND_FIELD_PX + 'px'}}>
+        {label}
+      </InputLabel>
+    )}
+    <Select {...props} />
+  </Box>
+);
+
+type TextFieldWithLabelType = (
+  props: {
+    label?: string;
+    style?: React.CSSProperties;
+  } & React.ComponentProps<typeof TextField>
+) => React.ReactElement;
+
+export const TextFieldWithLabel: TextFieldWithLabelType = ({
+  label,
+  style,
+  ...props
+}) => (
+  <Box
+    style={{
+      marginBottom: GAP_BETWEEN_ITEMS_PX + 'px',
+      padding: '0px 2px',
+      ...style,
+    }}>
+    {label && (
+      <InputLabel style={{marginBottom: GAP_BETWEEN_LABEL_AND_FIELD_PX + 'px'}}>
+        {label}
+      </InputLabel>
+    )}
+    <TextField {...props} />
+  </Box>
+);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/LLMJudgeScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/LLMJudgeScorerForm.tsx
@@ -2,9 +2,9 @@ import React, {FC} from 'react';
 
 import {ScorerFormProps} from './ScorerForms';
 
-export const ActionScorerForm: FC<ScorerFormProps<any>> = ({
+export const LLMJudgeScorerForm: FC<ScorerFormProps<any>> = ({
   data,
   onDataChange,
 }) => {
-  return <div>Action Scorer Form</div>;
+  return <div>LLM Judge Form</div>;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/LLMJudgesTab.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/LLMJudgesTab.tsx
@@ -1,0 +1,23 @@
+// TODO: Refactor this to be `LLM Judge` tab and change names everywhere
+
+import React from 'react';
+
+import {FilterableObjectVersionsTable} from '../ObjectVersionsPage';
+export const LLMJudgesTab: React.FC<{
+  entity: string;
+  project: string;
+}> = ({entity, project}) => {
+  return (
+    <FilterableObjectVersionsTable
+      entity={entity}
+      project={project}
+      hideCategoryColumn={true}
+      objectTitle="LLM judge"
+      initialFilter={{
+        // Note: we will need to filter this down to just LLM Judge ActionSpecs, but
+        // for now they are the only kind (!!)
+        baseObjectClass: 'ActionSpec',
+      }}
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
@@ -3,7 +3,7 @@ import {Button} from '@wandb/weave/components/Button';
 import {Icon, IconName, IconNames} from '@wandb/weave/components/Icon';
 import React, {FC, ReactNode, useCallback, useEffect, useState} from 'react';
 
-import {ActionScorerForm} from './ActionScorerForm';
+
 import {AutocompleteWithLabel} from './FormComponents';
 import {
   AnnotationScorerForm,
@@ -44,7 +44,7 @@ export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig<any>> = {
     label: LLM_JUDGE_LABEL,
     value: LLM_JUDGE_VALUE,
     icon: IconNames.RobotServiceMember,
-    Component: ActionScorerForm,
+    Component: () => <>TODO</>,
     onSave: async data => {
       // Implementation for saving llm judge scorer
       console.log('TODO: save llm judge scorer', data);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
@@ -3,8 +3,8 @@ import {Button} from '@wandb/weave/components/Button';
 import {Icon, IconName, IconNames} from '@wandb/weave/components/Icon';
 import React, {FC, ReactNode, useCallback, useEffect, useState} from 'react';
 
-import {ActionScorerForm} from './ActionScorerForm';
 import {AutocompleteWithLabel} from './FormComponents';
+import {LLMJudgeScorerForm} from './LLMJudgeScorerForm';
 import {
   AnnotationScorerForm,
   ProgrammaticScorerForm,
@@ -44,7 +44,7 @@ export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig<any>> = {
     label: LLM_JUDGE_LABEL,
     value: LLM_JUDGE_VALUE,
     icon: IconNames.RobotServiceMember,
-    Component: ActionScorerForm,
+    Component: LLMJudgeScorerForm,
     onSave: async data => {
       // Implementation for saving llm judge scorer
       console.log('TODO: save llm judge scorer', data);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
@@ -3,7 +3,7 @@ import {Button} from '@wandb/weave/components/Button';
 import {Icon, IconName, IconNames} from '@wandb/weave/components/Icon';
 import React, {FC, ReactNode, useCallback, useEffect, useState} from 'react';
 
-
+import {ActionScorerForm} from './ActionScorerForm';
 import {AutocompleteWithLabel} from './FormComponents';
 import {
   AnnotationScorerForm,
@@ -44,7 +44,7 @@ export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig<any>> = {
     label: LLM_JUDGE_LABEL,
     value: LLM_JUDGE_VALUE,
     icon: IconNames.RobotServiceMember,
-    Component: () => <>TODO</>,
+    Component: ActionScorerForm,
     onSave: async data => {
       // Implementation for saving llm judge scorer
       console.log('TODO: save llm judge scorer', data);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
@@ -1,38 +1,35 @@
-import {Box, Drawer, InputLabel} from '@material-ui/core';
+import {Box, Drawer} from '@material-ui/core';
 import {Button} from '@wandb/weave/components/Button';
-import {Select} from '@wandb/weave/components/Form/Select';
 import {Icon, IconName, IconNames} from '@wandb/weave/components/Icon';
 import React, {FC, ReactNode, useCallback, useEffect, useState} from 'react';
 
+import {ActionScorerForm} from './ActionScorerForm';
+import {AutocompleteWithLabel} from './FormComponents';
 import {
-  ActionScorerForm,
   AnnotationScorerForm,
   ProgrammaticScorerForm,
+  ScorerFormProps,
 } from './ScorerForms';
 
-const HUMAN_ANNOTATION_LABEL = 'Human annotations';
+const HUMAN_ANNOTATION_LABEL = 'Human annotation';
 export const HUMAN_ANNOTATION_VALUE = 'ANNOTATION';
-const ACTION_LABEL = 'LLM judges';
-const ACTION_VALUE = 'ACTION';
-const PROGRAMMATIC_LABEL = 'Functional scorers';
+const LLM_JUDGE_LABEL = 'LLM judge';
+const LLM_JUDGE_VALUE = 'LLM_JUDGE';
+const PROGRAMMATIC_LABEL = 'Programmatic scorer';
 const PROGRAMMATIC_VALUE = 'PROGRAMMATIC';
 
 export type ScorerType =
   | typeof HUMAN_ANNOTATION_VALUE
-  | typeof ACTION_VALUE
+  | typeof LLM_JUDGE_VALUE
   | typeof PROGRAMMATIC_VALUE;
 type OptionType = {label: string; value: ScorerType; icon: IconName};
 
-interface ScorerTypeConfig extends OptionType {
-  Component: FC<ScorerFormProps>;
-  onSave: (formData: any) => Promise<void>;
+interface ScorerTypeConfig<T> extends OptionType {
+  Component: FC<ScorerFormProps<T>>;
+  onSave: (formData: T) => Promise<void>;
 }
 
-export interface ScorerFormProps {
-  onDataChange: (isValid: boolean, data: any) => void;
-}
-
-export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig> = {
+export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig<any>> = {
   ANNOTATION: {
     label: HUMAN_ANNOTATION_LABEL,
     value: HUMAN_ANNOTATION_VALUE,
@@ -43,14 +40,14 @@ export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig> = {
       console.log('TODO: save annotation scorer', data);
     },
   },
-  ACTION: {
-    label: ACTION_LABEL,
-    value: ACTION_VALUE,
+  LLM_JUDGE: {
+    label: LLM_JUDGE_LABEL,
+    value: LLM_JUDGE_VALUE,
     icon: IconNames.RobotServiceMember,
     Component: ActionScorerForm,
     onSave: async data => {
-      // Implementation for saving action scorer
-      console.log('TODO: save action scorer', data);
+      // Implementation for saving llm judge scorer
+      console.log('TODO: save llm judge scorer', data);
     },
   },
   PROGRAMMATIC: {
@@ -134,28 +131,13 @@ export const NewScorerDrawer: FC<NewScorerDrawerProps> = ({
           value && setScorerTypeAndResetForm(value.value as ScorerType)
         }
       />
-      <ScorerFormComponent onDataChange={handleFormDataChange} />
+      <ScorerFormComponent
+        data={formData}
+        onDataChange={handleFormDataChange}
+      />
     </SaveableDrawer>
   );
 };
-
-type AutocompleteWithLabelType<Option = any> = (
-  props: {
-    label: string;
-  } & React.ComponentProps<typeof Select<Option>>
-) => React.ReactElement;
-
-const AutocompleteWithLabel: AutocompleteWithLabelType = ({
-  label,
-  ...props
-}) => (
-  <Box style={{marginBottom: '10px', padding: '0px 2px'}}>
-    <InputLabel style={{marginBottom: '10px', fontSize: '14px'}}>
-      {label}
-    </InputLabel>
-    <Select {...props} />
-  </Box>
-);
 
 interface SaveableDrawerProps {
   open: boolean;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorerForms.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorerForms.tsx
@@ -3,19 +3,23 @@ import {MOON_200} from '@wandb/weave/common/css/color.styles';
 import {Link} from '@wandb/weave/common/util/links';
 import React, {FC} from 'react';
 
-import {ScorerFormProps} from './NewScorerDrawer';
+export interface ScorerFormProps<T> {
+  data?: T;
+  onDataChange: (isValid: boolean, data?: T) => void;
+}
 
-export const AnnotationScorerForm: FC<ScorerFormProps> = ({onDataChange}) => {
+export const AnnotationScorerForm: FC<ScorerFormProps<any>> = ({
+  data,
+  onDataChange,
+}) => {
   // Implementation for annotation scorer form
   return <div>Annotation Scorer Form</div>;
 };
 
-export const ActionScorerForm: FC<ScorerFormProps> = ({onDataChange}) => {
-  // Implementation for action scorer form
-  return <div>Action Scorer Form</div>;
-};
-
-export const ProgrammaticScorerForm: FC<ScorerFormProps> = ({onDataChange}) => {
+export const ProgrammaticScorerForm: FC<ScorerFormProps<any>> = ({
+  data,
+  onDataChange,
+}) => {
   return (
     <Box
       style={{
@@ -23,7 +27,7 @@ export const ProgrammaticScorerForm: FC<ScorerFormProps> = ({onDataChange}) => {
         padding: '16px',
         borderRadius: '8px',
       }}>
-      Functional scorers must be written in Python. Please refer to the{' '}
+      Programmatic scorers must be written in Python. Please refer to the{' '}
       <Link to="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">
         scorer documentation
       </Link>{' '}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
@@ -3,9 +3,9 @@ import {IconNames} from '@wandb/weave/components/Icon';
 import React, {useState} from 'react';
 
 import {SimplePageLayoutWithHeader} from '../common/SimplePageLayout';
-import {ActionSpecsTab} from './ActionSpecsTab';
 import {AnnotationsTab} from './AnnotationsTab';
 import {ProgrammaticScorersTab} from './CoreScorersTab';
+import {LLMJudgesTab} from './LLMJudgesTab';
 import {
   HUMAN_ANNOTATION_VALUE,
   NewScorerDrawer,
@@ -28,17 +28,17 @@ export const ScorersPage: React.FC<{
         title="Scorers"
         tabs={[
           {
-            label: scorerTypeRecord.ANNOTATION.label,
+            label: scorerTypeRecord.ANNOTATION.label + 's',
             icon: scorerTypeRecord.ANNOTATION.icon,
             content: <AnnotationsTab entity={entity} project={project} />,
           },
           {
-            label: scorerTypeRecord.ACTION.label,
-            icon: scorerTypeRecord.ACTION.icon,
-            content: <ActionSpecsTab entity={entity} project={project} />,
+            label: scorerTypeRecord.LLM_JUDGE.label + 's',
+            icon: scorerTypeRecord.LLM_JUDGE.icon,
+            content: <LLMJudgesTab entity={entity} project={project} />,
           },
           {
-            label: scorerTypeRecord.PROGRAMMATIC.label,
+            label: scorerTypeRecord.PROGRAMMATIC.label + 's',
             icon: scorerTypeRecord.PROGRAMMATIC.icon,
             content: (
               <ProgrammaticScorersTab entity={entity} project={project} />
@@ -56,8 +56,9 @@ export const ScorersPage: React.FC<{
         headerContent={undefined}
         onTabSelectedCallback={tab =>
           setSelectedTab(
-            Object.values(scorerTypeRecord).find(t => t.label === tab)?.value ??
-              HUMAN_ANNOTATION_VALUE
+            // Hacky that we have to do the `"s"` thing, but it works
+            Object.values(scorerTypeRecord).find(t => t.label + 's' === tab)
+              ?.value ?? HUMAN_ANNOTATION_VALUE
           )
         }
       />


### PR DESCRIPTION
This PR:
1. Renames all components to be `LLM Judge` not "Action"
2. Corrects pluralization of headers
3. Adds the MVP LLM Judge listing page