### PR TITLE
refactor(ui): break import cycle

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/Browse2RootObjectVersionOutputOf.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/Browse2RootObjectVersionOutputOf.tsx
@@ -1,11 +1,11 @@
 import Typography from '@mui/material/Typography';
-import {useNodeValue} from '@wandb/weave/react';
+import {parseRefMaybe, useNodeValue} from '@wandb/weave/react';
 import React, {FC, useMemo} from 'react';
 import {useParams} from 'react-router-dom';
 
 import {callsTableFilter, callsTableNode, callsTableOpCounts} from './callTree';
 import {Browse2RootObjectVersionItemParams} from './CommonLib';
-import {parseRefMaybe, SmallRef} from './SmallRef';
+import {SmallRef} from './SmallRef';
 
 export const Browse2RootObjectVersionOutputOf: FC<{uri: string}> = ({uri}) => {
   const params = useParams<Browse2RootObjectVersionItemParams>();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SpanDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SpanDetails.tsx
@@ -4,6 +4,7 @@ import * as globals from '@wandb/weave/common/css/globals.styles';
 import * as _ from 'lodash';
 import React, {FC} from 'react';
 
+import {parseRefMaybe} from '../../../../react';
 import {StatusChip} from '../Browse3/pages/common/StatusChip';
 import {Call} from './callTree';
 import {DisplayControlChars} from './CommonLib';
@@ -13,7 +14,7 @@ import {
   OpenAIChatInputView,
   OpenAIChatOutputView,
 } from './openai';
-import {parseRefMaybe, SmallRef} from './SmallRef';
+import {SmallRef} from './SmallRef';
 
 const ObjectView: FC<{obj: any}> = ({obj}) => {
   if (_.isPlainObject(obj)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -8,10 +8,9 @@ import {
   GridFilterItem,
   GridFilterModel,
 } from '@mui/x-data-grid-pro';
-import {isWeaveObjectRef} from '@wandb/weave/react';
+import {isWeaveObjectRef, parseRefMaybe} from '@wandb/weave/react';
 import _ from 'lodash';
 
-import {parseRefMaybe} from '../../Browse2/SmallRef';
 import {WEAVE_REF_PREFIX} from '../pages/wfReactInterface/constants';
 import {TraceCallSchema} from '../pages/wfReactInterface/traceServerClientTypes';
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -1,9 +1,10 @@
 import _ from 'lodash';
 import React from 'react';
 
+import {parseRefMaybe} from '../../../../../../react';
 import {Timestamp} from '../../../../../Timestamp';
 import {UserLink} from '../../../../../UserLink';
-import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
+import {SmallRef} from '../../../Browse2/SmallRef';
 import {SimpleKeyValueTable} from '../common/SimplePageLayout';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CostTable} from './cost';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
@@ -28,10 +28,13 @@ import React, {
 } from 'react';
 import {useHistory} from 'react-router-dom';
 
-import {isWeaveObjectRef, parseRef} from '../../../../../../react';
+import {
+  isWeaveObjectRef,
+  parseRef,
+  parseRefMaybe,
+} from '../../../../../../react';
 import {flattenObjectPreservingWeaveTypes} from '../../../Browse2/browse2Util';
 import {CellValue} from '../../../Browse2/CellValue';
-import {parseRefMaybe} from '../../../Browse2/SmallRef';
 import {
   useWeaveflowCurrentRouteContext,
   WeaveflowPeekContext,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -18,9 +18,9 @@ import React, {
   useState,
 } from 'react';
 
+import {parseRefMaybe} from '../../../../../../react';
 import {LoadingDots} from '../../../../../LoadingDots';
 import {Browse2OpDefCode} from '../../../Browse2/Browse2OpDefCode';
-import {parseRefMaybe} from '../../../Browse2/SmallRef';
 import {isWeaveRef} from '../../filters/common';
 import {StyledDataGrid} from '../../StyledDataGrid';
 import {isCustomWeaveTypePayload} from '../../typeViews/customWeaveType.types';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -1,7 +1,11 @@
 import React, {useMemo} from 'react';
 
-import {isWeaveObjectRef, parseRef} from '../../../../../../react';
-import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
+import {
+  isWeaveObjectRef,
+  parseRef,
+  parseRefMaybe,
+} from '../../../../../../react';
+import {SmallRef} from '../../../Browse2/SmallRef';
 import {isWeaveRef} from '../../filters/common';
 import {isCustomWeaveTypePayload} from '../../typeViews/customWeaveType.types';
 import {CustomWeaveTypeDispatcher} from '../../typeViews/CustomWeaveTypeDispatcher';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
@@ -10,11 +10,15 @@ import {
   MOON_300,
   MOON_800,
 } from '../../../../../../../../common/css/color.styles';
-import {parseRef, WeaveObjectRef} from '../../../../../../../../react';
+import {
+  parseRef,
+  parseRefMaybe,
+  WeaveObjectRef,
+} from '../../../../../../../../react';
 import {Button} from '../../../../../../../Button';
 import {CellValue} from '../../../../../Browse2/CellValue';
 import {NotApplicable} from '../../../../../Browse2/NotApplicable';
-import {parseRefMaybe, SmallRef} from '../../../../../Browse2/SmallRef';
+import {SmallRef} from '../../../../../Browse2/SmallRef';
 import {isWeaveRef} from '../../../../filters/common';
 import {isCustomWeaveTypePayload} from '../../../../typeViews/customWeaveType.types';
 import {CustomWeaveTypeDispatcher} from '../../../../typeViews/CustomWeaveTypeDispatcher';
@@ -24,15 +28,18 @@ import {useCompareEvaluationsState} from '../../compareEvaluationsContext';
 import {
   buildCompositeMetricsMap,
   CompositeSummaryMetricGroupForKeyPath,
+  DERIVED_SCORER_REF_PLACEHOLDER,
   resolvePeerDimension,
 } from '../../compositeMetricsUtil';
-import {DERIVED_SCORER_REF_PLACEHOLDER} from '../../compositeMetricsUtil';
 import {CIRCLE_SIZE, SIGNIFICANT_DIGITS} from '../../ecpConstants';
 import {EvaluationComparisonState} from '../../ecpState';
 import {MetricDefinition, MetricValueType} from '../../ecpTypes';
-import {metricDefinitionId} from '../../ecpUtil';
-import {getMetricIds} from '../../ecpUtil';
-import {dimensionUnit, flattenedDimensionPath} from '../../ecpUtil';
+import {
+  dimensionUnit,
+  flattenedDimensionPath,
+  getMetricIds,
+  metricDefinitionId,
+} from '../../ecpUtil';
 import {usePeekCall} from '../../hooks';
 import {HorizontalBox, VerticalBox} from '../../Layout';
 import {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
@@ -9,29 +9,32 @@ import {
   MOON_300,
   MOON_600,
 } from '../../../../../../../../common/css/color.styles';
-import {WeaveObjectRef} from '../../../../../../../../react';
+import {parseRefMaybe, WeaveObjectRef} from '../../../../../../../../react';
 import {Checkbox} from '../../../../../../..';
 import {Pill, TagColorName} from '../../../../../../../Tag';
 import {CellValue} from '../../../../../Browse2/CellValue';
 import {CellValueBoolean} from '../../../../../Browse2/CellValueBoolean';
 import {NotApplicable} from '../../../../../Browse2/NotApplicable';
-import {parseRefMaybe, SmallRef} from '../../../../../Browse2/SmallRef';
+import {SmallRef} from '../../../../../Browse2/SmallRef';
 import {ValueViewNumber} from '../../../CallPage/ValueViewNumber';
 import {
+  buildCompositeMetricsMap,
   CompositeScoreMetrics,
   DERIVED_SCORER_REF_PLACEHOLDER,
   evalCallIdToScorerRefs,
   resolveDimension,
 } from '../../compositeMetricsUtil';
-import {buildCompositeMetricsMap} from '../../compositeMetricsUtil';
 import {
   BOX_RADIUS,
+  SIGNIFICANT_DIGITS,
   STANDARD_BORDER,
   STANDARD_PADDING,
 } from '../../ecpConstants';
-import {SIGNIFICANT_DIGITS} from '../../ecpConstants';
-import {getOrderedCallIds, getOrderedModelRefs} from '../../ecpState';
-import {EvaluationComparisonState} from '../../ecpState';
+import {
+  EvaluationComparisonState,
+  getOrderedCallIds,
+  getOrderedModelRefs,
+} from '../../ecpState';
 import {resolveSummaryMetricResultForEvaluateCall} from '../../ecpUtil';
 import {usePeekCall} from '../../hooks';
 import {HorizontalBox} from '../../Layout';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/LeaderboardPage/leaderboardConfigEditorHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/LeaderboardPage/leaderboardConfigEditorHooks.ts
@@ -1,8 +1,7 @@
-import {refUri} from '@wandb/weave/react';
+import {parseRefMaybe, refUri} from '@wandb/weave/react';
 import {useEffect, useState} from 'react';
 
 import {flattenObjectPreservingWeaveTypes} from '../../../Browse2/browse2Util';
-import {parseRefMaybe} from '../../../Browse2/SmallRef';
 import {ALL_VALUE} from '../../views/Leaderboard/types/leaderboardConfigType';
 import {EVALUATE_OP_NAME_POST_PYDANTIC} from '../common/heuristics';
 import {useGetTraceServerClientContext} from '../wfReactInterface/traceServerClientContext';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/KeyValueTable.tsx
@@ -4,7 +4,8 @@ import _ from 'lodash';
 import moment from 'moment';
 import React, {useContext, useEffect, useState} from 'react';
 
-import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
+import {parseRefMaybe} from '../../../../../../react';
+import {SmallRef} from '../../../Browse2/SmallRef';
 import {isPrimitive} from './util';
 
 const VALUE_SPACE = 4;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/views/Leaderboard/LeaderboardGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/views/Leaderboard/LeaderboardGrid.tsx
@@ -12,8 +12,9 @@ import {Timestamp} from '@wandb/weave/components/Timestamp';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 
+import {parseRefMaybe} from '../../../../../../react';
 import {NotApplicable} from '../../../Browse2/NotApplicable';
-import {parseRefMaybe, SmallRef} from '../../../Browse2/SmallRef';
+import {SmallRef} from '../../../Browse2/SmallRef';
 import {useWeaveflowRouteContext} from '../../context';
 import {PaginationButtons} from '../../pages/CallsPage/CallsTableButtons';
 import {Empty} from '../../pages/common/Empty';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/views/Leaderboard/query/leaderboardQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/views/Leaderboard/query/leaderboardQuery.ts
@@ -1,8 +1,7 @@
-import {isWeaveObjectRef} from '@wandb/weave/react';
+import {isWeaveObjectRef, parseRefMaybe} from '@wandb/weave/react';
 import _ from 'lodash';
 
 import {flattenObjectPreservingWeaveTypes} from '../../../../Browse2/browse2Util';
-import {parseRefMaybe} from '../../../../Browse2/SmallRef';
 import {EVALUATE_OP_NAME_POST_PYDANTIC} from '../../../pages/common/heuristics';
 import {TraceServerClient} from '../../../pages/wfReactInterface/traceServerClient';
 import {TraceObjSchema} from '../../../pages/wfReactInterface/traceServerClientTypes';

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -551,6 +551,14 @@ const RE_WEAVE_CALL_REF_PATHNAME = new RegExp(
   ].join('')
 );
 
+export const parseRefMaybe = (s: string): ObjectRef | null => {
+  try {
+    return parseRef(s);
+  } catch (e) {
+    return null;
+  }
+};
+
 export const parseRef = (ref: string): ObjectRef => {
   const url = new URL(ref);
   let splitLimit: number;


### PR DESCRIPTION
## Description

Copies `parseRefMaybe` from `SmallRef` to `react.tsx`. All other changes are updating import paths (with lint-fix combining a few things unrelated to this change). There is a reference to the SmallRef version in `core` that needs to be updated before we can delete it from SmallRef to complete the move.

This is done to break some import cycle problems that SmallRef has, though others remain. I believe it shouldn't introduce any new problems because anything that imported parseRefMaybe from SmallRef would have transitively depended on parseRef in react. `react.tsx` and the proximity to the `parseRef` method also seems like a better logical location to me.

Results of `npx madge --circular /Users/jamie/source/wandb/core/services/weave-python/weave-public/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx | grep SmallRef`

Before:
```
✖ Found 141 circular dependencies!

136) ../Browse3/context.tsx > ../Browse3/pages/CallsPage/callsTableFilter.ts > ../Browse3/pages/common/Links.tsx > ../Browse3/pages/ObjectVersionsPage.tsx > ../Browse3/pages/common/tabularListViews/columnBuilder.tsx > ../Browse3/filters/common.ts > SmallRef.tsx
137) ../Browse3/pages/common/Links.tsx > ../Browse3/pages/ObjectVersionsPage.tsx > ../Browse3/pages/common/tabularListViews/columnBuilder.tsx > ../Browse3/filters/common.ts > SmallRef.tsx
138) ../Browse3/filters/common.ts > SmallRef.tsx > ../Browse3/pages/wfReactInterface/context.tsx > ../Browse3/pages/wfReactInterface/tsDataModelHooks.ts > ../Browse3/pages/wfReactInterface/tsDataModelHooksCallRefExpansion.ts
139) ../Browse3/filters/common.ts > SmallRef.tsx > ../Browse3/pages/wfReactInterface/context.tsx > ../Browse3/pages/wfReactInterface/tsDataModelHooks.ts > ../Browse3/pages/wfReactInterface/utilities.ts
```

After:
```
✖ Found 139 circular dependencies!

137) ../Browse3/context.tsx > ../Browse3/pages/CallsPage/callsTableFilter.ts > ../Browse3/pages/common/Links.tsx > ../Browse3/pages/ObjectVersionsPage.tsx > ../Browse3/pages/common/tabularListViews/columnBuilder.tsx > CellValue.tsx > SmallRef.tsx
138) ../Browse3/pages/common/Links.tsx > ../Browse3/pages/ObjectVersionsPage.tsx > ../Browse3/pages/common/tabularListViews/columnBuilder.tsx > CellValue.tsx >SmallRef.tsx
```

## Testing

How was this PR tested?
