### PR TITLE
chore(weave): Move to future annotations for weave_client

### DIFF
--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -1,11 +1,13 @@
 """The top-level functions for Weave Trace API."""
 
+from __future__ import annotations
+
 import contextlib
 import os
 import threading
 import time
 from collections.abc import Iterator
-from typing import Any, Optional, Union
+from typing import Any
 
 # TODO: type_serializers is imported here to trigger registration of the image serializer.
 # There is probably a better place for this, but including here for now to get the fix in.
@@ -29,7 +31,7 @@ from weave.trace_server.interface.base_object_classes import leaderboard
 def init(
     project_name: str,
     *,
-    settings: Optional[Union[UserSettings, dict[str, Any]]] = None,
+    settings: UserSettings | dict[str, Any] | None = None,
 ) -> weave_client.WeaveClient:
     """Initialize weave tracking, logging to a wandb project.
 
@@ -76,7 +78,7 @@ def local_client() -> Iterator[weave_client.WeaveClient]:
         inited_client.reset()
 
 
-def publish(obj: Any, name: Optional[str] = None) -> weave_client.ObjectRef:
+def publish(obj: Any, name: str | None = None) -> weave_client.ObjectRef:
     """Save and version a python object.
 
     If an object with name already exists, and the content hash of obj does
@@ -161,11 +163,11 @@ def ref(location: str) -> weave_client.ObjectRef:
     return uri
 
 
-def obj_ref(obj: Any) -> Optional[weave_client.ObjectRef]:
+def obj_ref(obj: Any) -> weave_client.ObjectRef | None:
     return weave_client.get_ref(obj)
 
 
-def output_of(obj: Any) -> Optional[weave_client.Call]:
+def output_of(obj: Any) -> weave_client.Call | None:
     client = weave_client_context.require_weave_client()
 
     ref = obj_ref(obj)
@@ -199,8 +201,8 @@ def attributes(attributes: dict[str, Any]) -> Iterator:
 
 def serve(
     model_ref: ObjectRef,
-    method_name: Optional[str] = None,
-    auth_entity: Optional[str] = None,
+    method_name: str | None = None,
+    auth_entity: str | None = None,
     port: int = 9996,
     thread: bool = False,
 ) -> str:

--- a/weave/trace/concurrent/futures.py
+++ b/weave/trace/concurrent/futures.py
@@ -27,13 +27,15 @@ to manage asynchronous tasks:
     result_future = executor.then([future], process_result)
 """
 
+from __future__ import annotations
+
 import atexit
 import concurrent.futures
 import logging
 from concurrent.futures import Future, wait
 from contextvars import ContextVar
 from threading import Lock
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, TypeVar
 
 from weave.trace.context.tests_context import get_raise_on_captured_errors
 from weave.trace.util import ContextAwareThreadPoolExecutor
@@ -63,11 +65,11 @@ class FutureExecutor:
 
     def __init__(
         self,
-        max_workers: Optional[int] = None,
+        max_workers: int | None = None,
         thread_name_prefix: str = THREAD_NAME_PREFIX,
     ):
         self._max_workers = max_workers
-        self._executor: Optional[ContextAwareThreadPoolExecutor] = None
+        self._executor: ContextAwareThreadPoolExecutor | None = None
         if max_workers != 0:
             self._executor = ContextAwareThreadPoolExecutor(
                 max_workers=max_workers, thread_name_prefix=thread_name_prefix
@@ -138,7 +140,7 @@ class FutureExecutor:
 
         return result_future
 
-    def flush(self, timeout: Optional[float] = None) -> bool:
+    def flush(self, timeout: float | None = None) -> bool:
         """
         Block until all currently submitted items are complete or timeout is reached.
 

--- a/weave/trace/context/call_context.py
+++ b/weave/trace/context/call_context.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import contextlib
 import contextvars
 import copy
 import logging
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from weave.trace.weave_client import Call
@@ -12,20 +14,20 @@ if TYPE_CHECKING:
 class NoCurrentCallError(Exception): ...
 
 
-_call_stack: contextvars.ContextVar[list["Call"]] = contextvars.ContextVar(
+_call_stack: contextvars.ContextVar[list[Call]] = contextvars.ContextVar(
     "call", default=[]
 )
 
 logger = logging.getLogger(__name__)
 
 
-def push_call(call: "Call") -> None:
+def push_call(call: Call) -> None:
     new_stack = copy.copy(_call_stack.get())
     new_stack.append(call)
     _call_stack.set(new_stack)
 
 
-def pop_call(call_id: Optional[str]) -> None:
+def pop_call(call_id: str | None) -> None:
     new_stack = copy.copy(_call_stack.get())
     if len(new_stack) == 0:
         logger.debug(
@@ -58,7 +60,7 @@ def pop_call(call_id: Optional[str]) -> None:
     _call_stack.set(new_stack)
 
 
-def require_current_call() -> "Call":
+def require_current_call() -> Call:
     """Get the Call object for the currently executing Op, within that Op.
 
     This allows you to access attributes of the Call such as its id or feedback
@@ -107,7 +109,7 @@ def require_current_call() -> "Call":
     return call
 
 
-def get_current_call() -> Optional["Call"]:
+def get_current_call() -> Call | None:
     """Get the Call object for the currently executing Op, within that Op.
 
     Returns:
@@ -118,14 +120,12 @@ def get_current_call() -> Optional["Call"]:
     return _call_stack.get()[-1] if _call_stack.get() else None
 
 
-def get_call_stack() -> list["Call"]:
+def get_call_stack() -> list[Call]:
     return _call_stack.get()
 
 
 @contextlib.contextmanager
-def set_call_stack(
-    stack: list["Call"],
-) -> Iterator[list["Call"]]:
+def set_call_stack(stack: list[Call]) -> Iterator[list[Call]]:
     token = _call_stack.set(stack)
     try:
         yield stack

--- a/weave/trace/context/tests_context.py
+++ b/weave/trace/context/tests_context.py
@@ -1,6 +1,6 @@
 import contextlib
 import contextvars
-import typing
+from collections.abc import Generator
 
 test_only_raise_on_captured_errors: contextvars.ContextVar[bool] = (
     contextvars.ContextVar("test_only_raise_on_captured_errors", default=False)
@@ -8,9 +8,7 @@ test_only_raise_on_captured_errors: contextvars.ContextVar[bool] = (
 
 
 @contextlib.contextmanager
-def raise_on_captured_errors(
-    should_raise: bool = True,
-) -> typing.Generator[None, None, None]:
+def raise_on_captured_errors(should_raise: bool = True) -> Generator[None, None, None]:
     token = test_only_raise_on_captured_errors.set(should_raise)
     try:
         yield

--- a/weave/trace/context/weave_client_context.py
+++ b/weave/trace/context/weave_client_context.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 import threading
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from weave.trace.errors import WeaveInitError
 
 if TYPE_CHECKING:
     from weave.trace.weave_client import WeaveClient
 
-_global_weave_client: Optional["WeaveClient"] = None
+_global_weave_client: WeaveClient | None = None
 lock = threading.Lock()
 
 
-def set_weave_client_global(client: Optional["WeaveClient"]) -> None:
+def set_weave_client_global(client: WeaveClient | None) -> None:
     global _global_weave_client
 
     # These outer guards are to avoid expensive lock acquisition
@@ -30,13 +32,13 @@ def set_weave_client_global(client: Optional["WeaveClient"]) -> None:
 #     context_state._graph_client.set(client)
 
 
-def get_weave_client() -> Optional["WeaveClient"]:
+def get_weave_client() -> WeaveClient | None:
     # if (context_client := context_state._graph_client.get()) is not None:
     #     return context_client
     return _global_weave_client
 
 
-def require_weave_client() -> "WeaveClient":
+def require_weave_client() -> WeaveClient:
     if (client := get_weave_client()) is None:
         raise WeaveInitError("You must call `weave.init(<project_name>)` first")
     return client

--- a/weave/trace/custom_objs.py
+++ b/weave/trace/custom_objs.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable
 
 from weave.trace import op_type  # noqa: F401, Must import this to register op save/load
 from weave.trace.context.weave_client_context import require_weave_client
@@ -22,7 +24,7 @@ KNOWN_TYPES = {
 }
 
 
-def encode_custom_obj(obj: Any) -> Optional[dict]:
+def encode_custom_obj(obj: Any) -> dict | None:
     serializer = get_serializer_for_obj(obj)
     if serializer is None:
         # We silently return None right now. We could warn here. This object
@@ -61,7 +63,7 @@ def encode_custom_obj(obj: Any) -> Optional[dict]:
 
 
 def _decode_custom_obj(
-    encoded_path_contents: Mapping[str, Union[str, bytes]],
+    encoded_path_contents: Mapping[str, str | bytes],
     load_instance_op: Callable[..., Any],
 ) -> Any:
     # Disables tracing so that calls to loading data itself don't get traced
@@ -74,8 +76,8 @@ def _decode_custom_obj(
 
 def decode_custom_obj(
     weave_type: dict,
-    encoded_path_contents: Mapping[str, Union[str, bytes]],
-    load_instance_op_uri: Optional[str] = None,
+    encoded_path_contents: Mapping[str, str | bytes],
+    load_instance_op_uri: str | None = None,
 ) -> Any:
     _type = weave_type["type"]
     found_serializer = False

--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import configparser
 import logging
 import netrc
 import os
-from typing import Optional
 from urllib.parse import urlparse
 
 WEAVE_PARALLELISM = "WEAVE_PARALLELISM"
@@ -62,12 +63,12 @@ def weave_trace_server_url() -> str:
     return os.getenv("WF_TRACE_SERVER_URL", default)
 
 
-def _wandb_api_key_via_env() -> Optional[str]:
+def _wandb_api_key_via_env() -> str | None:
     api_key = os.environ.get("WANDB_API_KEY")
     return api_key
 
 
-def _wandb_api_key_via_netrc() -> Optional[str]:
+def _wandb_api_key_via_netrc() -> str | None:
     for filepath in ("~/.netrc", "~/_netrc"):
         api_key = _wandb_api_key_via_netrc_file(filepath)
         if api_key:
@@ -75,7 +76,7 @@ def _wandb_api_key_via_netrc() -> Optional[str]:
     return None
 
 
-def _wandb_api_key_via_netrc_file(filepath: str) -> Optional[str]:
+def _wandb_api_key_via_netrc_file(filepath: str) -> str | None:
     netrc_path = os.path.expanduser(filepath)
     if not os.path.exists(netrc_path):
         return None
@@ -87,7 +88,7 @@ def _wandb_api_key_via_netrc_file(filepath: str) -> Optional[str]:
     return api_key
 
 
-def weave_wandb_api_key() -> Optional[str]:
+def weave_wandb_api_key() -> str | None:
     env_api_key = _wandb_api_key_via_env()
     netrc_api_key = _wandb_api_key_via_netrc()
     if env_api_key and netrc_api_key and env_api_key != netrc_api_key:

--- a/weave/trace/exception.py
+++ b/weave/trace/exception.py
@@ -1,21 +1,23 @@
 """Utility methods for converting exceptions to JSON."""
 
+from __future__ import annotations
+
 import json
 import traceback
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 
 class StackFrameDict(TypedDict):
     filename: str
-    line_number: Optional[int]
+    line_number: int | None
     function_name: str
-    text: Optional[str]
+    text: str | None
 
 
 class ExceptionDict(TypedDict, total=False):
     type: str
     message: str
-    traceback: Optional[list[StackFrameDict]]
+    traceback: list[StackFrameDict] | None
 
 
 def frame_summary_to_dict(frame: traceback.FrameSummary) -> StackFrameDict:

--- a/weave/trace/feedback.py
+++ b/weave/trace/feedback.py
@@ -1,8 +1,10 @@
 """Classes for working with feedback on a project or ref level."""
 
+from __future__ import annotations
+
 import json
 from collections.abc import Iterable, Iterator
-from typing import Any, Optional
+from typing import Any
 
 from rich.table import Table
 
@@ -22,7 +24,7 @@ class Feedbacks(AbstractRichContainer[tsi.Feedback]):
     show_refs: bool
 
     def __init__(
-        self, show_refs: bool, feedbacks: Optional[Iterable[tsi.Feedback]] = None
+        self, show_refs: bool, feedbacks: Iterable[tsi.Feedback] | None = None
     ) -> None:
         super().__init__("Feedback", feedbacks)
         self.show_refs = show_refs
@@ -87,18 +89,18 @@ class FeedbackQuery:
 
     show_refs: bool
     _query: tsi.Query
-    offset: Optional[int]
-    limit: Optional[int]
+    offset: int | None
+    limit: int | None
 
-    feedbacks: Optional[Feedbacks]
+    feedbacks: Feedbacks | None
 
     def __init__(
         self,
         entity: str,
         project: str,
         query: Query,
-        offset: Optional[int] = None,
-        limit: Optional[int] = None,
+        offset: int | None = None,
+        limit: int | None = None,
         show_refs: bool = False,
     ):
         self.client = weave_client_context.require_weave_client()
@@ -186,7 +188,7 @@ class RefFeedbackQuery(FeedbackQuery):
         self.weave_ref = ref
 
     def _add(
-        self, feedback_type: str, payload: dict[str, Any], creator: Optional[str]
+        self, feedback_type: str, payload: dict[str, Any], creator: str | None
     ) -> str:
         freq = tsi.FeedbackCreateReq(
             project_id=f"{self.entity}/{self.project}",
@@ -202,8 +204,8 @@ class RefFeedbackQuery(FeedbackQuery):
     def add(
         self,
         feedback_type: str,
-        payload: Optional[dict[str, Any]] = None,
-        creator: Optional[str] = None,
+        payload: dict[str, Any] | None = None,
+        creator: str | None = None,
         **kwargs: dict[str, Any],
     ) -> str:
         """Add feedback to the ref.
@@ -218,7 +220,7 @@ class RefFeedbackQuery(FeedbackQuery):
         feedback.update(kwargs)
         return self._add(feedback_type, feedback, creator)
 
-    def add_reaction(self, emoji: str, creator: Optional[str] = None) -> str:
+    def add_reaction(self, emoji: str, creator: str | None = None) -> str:
         return self._add(
             "wandb.reaction.1",
             {
@@ -227,7 +229,7 @@ class RefFeedbackQuery(FeedbackQuery):
             creator=creator,
         )
 
-    def add_note(self, note: str, creator: Optional[str] = None) -> str:
+    def add_note(self, note: str, creator: str | None = None) -> str:
         return self._add(
             "wandb.note.1",
             {

--- a/weave/trace/init_message.py
+++ b/weave/trace/init_message.py
@@ -1,15 +1,17 @@
-import typing
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from weave.trace import urls
 from weave.trace.pypi_version_check import check_available
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     import packaging.version  # type: ignore[import-not-found]
 
 REQUIRED_WANDB_VERSION = "0.16.4"
 
 
-def _parse_version(version: str) -> "packaging.version.Version":
+def _parse_version(version: str) -> packaging.version.Version:
     """Parse a version string into a version object.
 
     This function is a wrapper around the `packaging.version.parse` function, which
@@ -72,10 +74,7 @@ def assert_min_weave_version(
 
 
 def print_init_message(
-    username: typing.Optional[str],
-    entity_name: str,
-    project_name: str,
-    read_only: bool,
+    username: str | None, entity_name: str, project_name: str, read_only: bool
 ) -> None:
     try:
         _print_version_check()

--- a/weave/trace/mem_artifact.py
+++ b/weave/trace/mem_artifact.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import contextlib
-import io
 import os
 import tempfile
 from collections.abc import Generator, Iterator, Mapping
-from typing import Optional, Union
+from io import BytesIO, StringIO
 
 from weave.trace import op_type  # noqa: F401, Must import this to register op save/load
 
@@ -13,13 +14,13 @@ from weave.trace import op_type  # noqa: F401, Must import this to register op s
 
 
 class MemTraceFilesArtifact:
-    temp_read_dir: Optional[tempfile.TemporaryDirectory]
+    temp_read_dir: tempfile.TemporaryDirectory | None
     path_contents: dict[str, bytes]
 
     def __init__(
         self,
-        path_contents: Optional[Mapping[str, Union[str, bytes]]] = None,
-        metadata: Optional[dict[str, str]] = None,
+        path_contents: Mapping[str, str | bytes] | None = None,
+        metadata: dict[str, str] | None = None,
     ):
         if path_contents is None:
             path_contents = {}
@@ -30,14 +31,12 @@ class MemTraceFilesArtifact:
         self.temp_read_dir = None
 
     @contextlib.contextmanager
-    def new_file(
-        self, path: str, binary: bool = False
-    ) -> Iterator[Union[io.StringIO, io.BytesIO]]:
-        f: Union[io.StringIO, io.BytesIO]
+    def new_file(self, path: str, binary: bool = False) -> Iterator[StringIO | BytesIO]:
+        f: StringIO | BytesIO
         if binary:
-            f = io.BytesIO()
+            f = BytesIO()
         else:
-            f = io.StringIO()
+            f = StringIO()
         yield f
         self.path_contents[path] = f.getvalue()  # type: ignore
         f.close()
@@ -47,10 +46,8 @@ class MemTraceFilesArtifact:
         return True
 
     @contextlib.contextmanager
-    def open(
-        self, path: str, binary: bool = False
-    ) -> Iterator[Union[io.StringIO, io.BytesIO]]:
-        f: Union[io.StringIO, io.BytesIO]
+    def open(self, path: str, binary: bool = False) -> Iterator[StringIO | BytesIO]:
+        f: StringIO | BytesIO
         try:
             if binary:
                 val = self.path_contents[path]
@@ -58,10 +55,10 @@ class MemTraceFilesArtifact:
                     raise ValueError(
                         f"Expected binary file, but got string for path {path}"
                     )
-                f = io.BytesIO(val)
+                f = BytesIO(val)
             else:
                 val = self.path_contents[path]
-                f = io.StringIO(val.decode("utf-8"))
+                f = StringIO(val.decode("utf-8"))
         except KeyError:
             raise FileNotFoundError(path)
         yield f

--- a/weave/trace/object_record.py
+++ b/weave/trace/object_record.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import types
 from inspect import getmro, isclass
@@ -33,7 +35,7 @@ class ObjectRecord:
                 return False
         return True
 
-    def map_values(self, fn: Callable) -> "ObjectRecord":
+    def map_values(self, fn: Callable) -> ObjectRecord:
         return ObjectRecord({k: fn(v) for k, v in self.__dict__.items()})
 
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -1,5 +1,7 @@
 """Defines the Op protocol and related functions."""
 
+from __future__ import annotations
+
 import inspect
 import logging
 import sys
@@ -15,7 +17,6 @@ from typing import (
     Optional,
     Protocol,
     TypedDict,
-    Union,
     cast,
     overload,
     runtime_checkable,
@@ -77,7 +78,7 @@ ON_OUTPUT_MSG = "Error capturing call output:\n{}"
 class DisplayNameFuncError(ValueError): ...
 
 
-def print_call_link(call: "Call") -> None:
+def print_call_link(call: Call) -> None:
     if settings.should_print_call_link():
         print(f"{TRACE_CALL_EMOJI} {call.ui_url}")
 
@@ -134,7 +135,7 @@ def _apply_fn_defaults_to_inputs(
 
 
 class WeaveKwargs(TypedDict):
-    display_name: Optional[str]
+    display_name: str | None
 
 
 @runtime_checkable
@@ -157,26 +158,26 @@ class Op(Protocol):
     """
 
     name: str
-    call_display_name: Union[str, Callable[["Call"], str]]
+    call_display_name: str | Callable[[Call], str]
     signature: inspect.Signature
-    ref: Optional[ObjectRef]
+    ref: ObjectRef | None
     resolve_fn: Callable
 
-    postprocess_inputs: Optional[Callable[[dict[str, Any]], dict[str, Any]]]
-    postprocess_output: Optional[Callable[..., Any]]
+    postprocess_inputs: Callable[[dict[str, Any]], dict[str, Any]] | None
+    postprocess_output: Callable[..., Any] | None
 
     call: Callable[..., Any]
-    calls: Callable[..., "CallsIter"]
+    calls: Callable[..., CallsIter]
 
     _set_on_input_handler: Callable[[OnInputHandlerType], None]
-    _on_input_handler: Optional[OnInputHandlerType]
+    _on_input_handler: OnInputHandlerType | None
 
     # not sure if this is the best place for this, but kept for compat
     _set_on_output_handler: Callable[[OnOutputHandlerType], None]
-    _on_output_handler: Optional[OnOutputHandlerType]
+    _on_output_handler: OnOutputHandlerType | None
 
     _set_on_finish_handler: Callable[[OnFinishHandlerType], None]
-    _on_finish_handler: Optional[OnFinishHandlerType]
+    _on_finish_handler: OnFinishHandlerType | None
 
     __call__: Callable[..., Any]
     __self__: Any
@@ -241,8 +242,8 @@ def default_on_input_handler(func: Op, args: tuple, kwargs: dict) -> ProcessedIn
 
 
 def _create_call(
-    func: Op, *args: Any, __weave: Optional[WeaveKwargs] = None, **kwargs: Any
-) -> "Call":
+    func: Op, *args: Any, __weave: WeaveKwargs | None = None, **kwargs: Any
+) -> Call:
     client = weave_client_context.require_weave_client()
 
     pargs = None
@@ -279,12 +280,12 @@ def _execute_call(
     *args: Any,
     __should_raise: bool = True,
     **kwargs: Any,
-) -> Union[tuple[Any, "Call"], Coroutine[Any, Any, tuple[Any, "Call"]]]:
+) -> tuple[Any, Call] | Coroutine[Any, Any, tuple[Any, Call]]:
     func = __op.resolve_fn
     client = weave_client_context.require_weave_client()
     has_finished = False
 
-    def finish(output: Any = None, exception: Optional[BaseException] = None) -> None:
+    def finish(output: Any = None, exception: BaseException | None = None) -> None:
         nonlocal has_finished
         if has_finished:
             raise ValueError("Should not call finish more than once")
@@ -304,7 +305,7 @@ def _execute_call(
         finish(output)
         return output
 
-    def process(res: Any) -> tuple[Any, "Call"]:
+    def process(res: Any) -> tuple[Any, Call]:
         res = box.box(res)
         try:
             # Here we do a try/catch because we don't want to
@@ -323,7 +324,7 @@ def _execute_call(
 
         return res, call
 
-    def handle_exception(e: Exception) -> tuple[Any, "Call"]:
+    def handle_exception(e: Exception) -> tuple[Any, Call]:
         finish(exception=e)
         if __should_raise:
             raise
@@ -331,7 +332,7 @@ def _execute_call(
 
     if inspect.iscoroutinefunction(func):
 
-        async def _call_async() -> tuple[Any, "Call"]:
+        async def _call_async() -> tuple[Any, Call]:
             try:
                 res = await func(*args, **kwargs)
             except Exception as e:
@@ -354,10 +355,10 @@ def _execute_call(
 def call(
     op: Op,
     *args: Any,
-    __weave: Optional[WeaveKwargs] = None,
+    __weave: WeaveKwargs | None = None,
     __should_raise: bool = False,
     **kwargs: Any,
-) -> Union[tuple[Any, "Call"], Coroutine[Any, Any, tuple[Any, "Call"]]]:
+) -> tuple[Any, Call] | Coroutine[Any, Any, tuple[Any, Call]]:
     """
     Executes the op and returns both the result and a Call representing the execution.
 
@@ -384,7 +385,7 @@ def call(
         )
 
 
-def _placeholder_call() -> "Call":
+def _placeholder_call() -> Call:
     # Import here to avoid circular dependency
     from weave.trace.weave_client import Call
 
@@ -400,10 +401,10 @@ def _placeholder_call() -> "Call":
 def _do_call(
     op: Op,
     *args: Any,
-    __weave: Optional[WeaveKwargs] = None,
+    __weave: WeaveKwargs | None = None,
     __should_raise: bool = False,
     **kwargs: Any,
-) -> tuple[Any, "Call"]:
+) -> tuple[Any, Call]:
     func = op.resolve_fn
     call = _placeholder_call()
 
@@ -450,10 +451,10 @@ def _do_call(
 async def _do_call_async(
     op: Op,
     *args: Any,
-    __weave: Optional[WeaveKwargs] = None,
+    __weave: WeaveKwargs | None = None,
     __should_raise: bool = False,
     **kwargs: Any,
-) -> tuple[Any, "Call"]:
+) -> tuple[Any, Call]:
     func = op.resolve_fn
     call = _placeholder_call()
     if settings.should_disable_weave():
@@ -492,7 +493,7 @@ async def _do_call_async(
     return res, call
 
 
-def calls(op: Op) -> "CallsIter":
+def calls(op: Op) -> CallsIter:
     """
     Get an iterator over all calls to this op.
 
@@ -522,31 +523,31 @@ PostprocessOutputFunc = Callable[..., Any]
 def op(
     func: Callable,
     *,
-    name: Optional[str] = None,
-    call_display_name: Optional[Union[str, CallDisplayNameFunc]] = None,
-    postprocess_inputs: Optional[PostprocessInputsFunc] = None,
-    postprocess_output: Optional[PostprocessOutputFunc] = None,
+    name: str | None = None,
+    call_display_name: str | CallDisplayNameFunc | None = None,
+    postprocess_inputs: PostprocessInputsFunc | None = None,
+    postprocess_output: PostprocessOutputFunc | None = None,
 ) -> Op: ...
 
 
 @overload
 def op(
     *,
-    name: Optional[str] = None,
-    call_display_name: Optional[Union[str, CallDisplayNameFunc]] = None,
-    postprocess_inputs: Optional[PostprocessInputsFunc] = None,
-    postprocess_output: Optional[PostprocessOutputFunc] = None,
+    name: str | None = None,
+    call_display_name: str | CallDisplayNameFunc | None = None,
+    postprocess_inputs: PostprocessInputsFunc | None = None,
+    postprocess_output: PostprocessOutputFunc | None = None,
 ) -> Callable[[Callable], Op]: ...
 
 
 def op(
-    func: Optional[Callable] = None,
+    func: Callable | None = None,
     *,
-    name: Optional[str] = None,
-    call_display_name: Optional[Union[str, CallDisplayNameFunc]] = None,
-    postprocess_inputs: Optional[PostprocessInputsFunc] = None,
-    postprocess_output: Optional[PostprocessOutputFunc] = None,
-) -> Union[Callable[[Any], Op], Op]:
+    name: str | None = None,
+    call_display_name: str | CallDisplayNameFunc | None = None,
+    postprocess_inputs: PostprocessInputsFunc | None = None,
+    postprocess_output: PostprocessOutputFunc | None = None,
+) -> Callable[[Callable], Op] | Op:
     """
     A decorator to weave op-ify a function or method.  Works for both sync and async.
 
@@ -673,7 +674,7 @@ def op(
     return op_deco(func)
 
 
-def maybe_bind_method(func: Callable, self: Any = None) -> Union[Callable, MethodType]:
+def maybe_bind_method(func: Callable, self: Any = None) -> Callable | MethodType:
     """Bind a function to any object (even if it's not a class)
 
     If self is None, return the function as is.
@@ -685,7 +686,7 @@ def maybe_bind_method(func: Callable, self: Any = None) -> Union[Callable, Metho
     return func
 
 
-def maybe_unbind_method(oplike: Union[Op, MethodType, partial]) -> Op:
+def maybe_unbind_method(oplike: Op | MethodType | partial) -> Op:
     """Unbind an Op-like method or partial to a plain Op function.
 
     For:

--- a/weave/trace/patcher.py
+++ b/weave/trace/patcher.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 from collections.abc import Sequence
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 from weave.trace.context.tests_context import get_raise_on_captured_errors
 
@@ -63,7 +65,7 @@ class SymbolPatcher(Patcher):
         self._attribute_name = attribute_name
         self._make_new_value = make_new_value
 
-    def _get_symbol_target(self) -> Optional[_SymbolTarget]:
+    def _get_symbol_target(self) -> _SymbolTarget | None:
         try:
             base_symbol = self._get_base_symbol()
         except Exception:

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import urllib
 from concurrent.futures import Future
 from dataclasses import asdict, dataclass, fields
-from typing import Any, Optional, Union, cast
+from typing import Any, Union, cast
 
 from weave.trace_server import refs_internal
 
@@ -23,7 +25,7 @@ class Ref:
     def as_param_dict(self) -> dict:
         return asdict(self)
 
-    def __deepcopy__(self, memo: dict) -> "Ref":
+    def __deepcopy__(self, memo: dict) -> Ref:
         d = {f.name: getattr(self, f.name) for f in fields(self)}
         res = self.__class__(**d)
         memo[id(self)] = res
@@ -34,8 +36,8 @@ class Ref:
 class TableRef(Ref):
     entity: str
     project: str
-    _digest: Union[str, Future[str]]
-    _row_digests: Optional[Union[list[str], Future[list[str]]]] = None
+    _digest: str | Future[str]
+    _row_digests: list[str] | Future[list[str]] | None = None
 
     def as_param_dict(self) -> dict:
         return {
@@ -83,21 +85,21 @@ class TableRef(Ref):
 
 @dataclass(frozen=True)
 class RefWithExtra(Ref):
-    def with_extra(self, extra: tuple[Union[str, Future[str]], ...]) -> "RefWithExtra":
+    def with_extra(self, extra: tuple[str | Future[str], ...]) -> RefWithExtra:
         params = self.as_param_dict()
         params["_extra"] = self._extra + tuple(extra)  # type: ignore
         return self.__class__(**params)
 
-    def with_key(self, key: str) -> "RefWithExtra":
+    def with_key(self, key: str) -> RefWithExtra:
         return self.with_extra((DICT_KEY_EDGE_NAME, key))
 
-    def with_attr(self, attr: str) -> "RefWithExtra":
+    def with_attr(self, attr: str) -> RefWithExtra:
         return self.with_extra((OBJECT_ATTR_EDGE_NAME, attr))
 
-    def with_index(self, index: int) -> "RefWithExtra":
+    def with_index(self, index: int) -> RefWithExtra:
         return self.with_extra((LIST_INDEX_EDGE_NAME, str(index)))
 
-    def with_item(self, item_digest: Union[str, Future[str]]) -> "RefWithExtra":
+    def with_item(self, item_digest: str | Future[str]) -> RefWithExtra:
         return self.with_extra((TABLE_ROW_ID_EDGE_NAME, item_digest))
 
 
@@ -106,8 +108,8 @@ class ObjectRef(RefWithExtra):
     entity: str
     project: str
     name: str
-    _digest: Union[str, Future[str]]
-    _extra: tuple[Union[str, Future[str]], ...] = ()
+    _digest: str | Future[str]
+    _extra: tuple[str | Future[str], ...] = ()
 
     def as_param_dict(self) -> dict:
         return {
@@ -193,7 +195,7 @@ class ObjectRef(RefWithExtra):
             init_client.reset()
         return self.objectify(res)
 
-    def is_descended_from(self, potential_ancestor: "ObjectRef") -> bool:
+    def is_descended_from(self, potential_ancestor: ObjectRef) -> bool:
         if self.entity != potential_ancestor.entity:
             return False
         if self.project != potential_ancestor.project:
@@ -224,7 +226,7 @@ class CallRef(RefWithExtra):
     entity: str
     project: str
     id: str
-    _extra: tuple[Union[str, Future[str]], ...] = ()
+    _extra: tuple[str | Future[str], ...] = ()
 
     def as_param_dict(self) -> dict:
         return {

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import logging
-import typing
 from collections.abc import Sequence
 from types import CoroutineType
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from weave.trace import custom_objs
 from weave.trace.object_record import ObjectRecord
@@ -18,12 +19,12 @@ from weave.trace_server.trace_server_interface import (
 )
 from weave.trace_server.trace_server_interface_util import bytes_digest
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from weave.trace.weave_client import WeaveClient
 
 
 def to_json(
-    obj: Any, project_id: str, client: "WeaveClient", use_dictify: bool = False
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool = False
 ) -> Any:
     if isinstance(obj, TableRef):
         return obj.uri()
@@ -63,7 +64,7 @@ def to_json(
 
 
 def _build_result_from_encoded(
-    encoded: dict, project_id: str, client: "WeaveClient"
+    encoded: dict, project_id: str, client: WeaveClient
 ) -> Any:
     file_digests = {}
     for name, val in encoded["files"].items():
@@ -121,7 +122,7 @@ def has_custom_repr(obj: Any) -> bool:
 
 
 def dictify(
-    obj: Any, maxdepth: int = 0, depth: int = 1, seen: Optional[set[int]] = None
+    obj: Any, maxdepth: int = 0, depth: int = 1, seen: set[int] | None = None
 ) -> Any:
     """Recursively compute a dictionary representation of an object."""
     if seen is None:

--- a/weave/trace/serializer.py
+++ b/weave/trace/serializer.py
@@ -34,8 +34,10 @@ deserialized in a Python runtime that does not have the serializer
 registered.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 
 @dataclass
@@ -46,7 +48,7 @@ class Serializer:
 
     # Added to provide a function to check if an object is an instance of the
     # target class because protocol isinstance checks can fail in python3.12+
-    instance_check: Optional[Callable[[Any], bool]] = None
+    instance_check: Callable[[Any], bool] | None = None
 
     def id(self) -> str:
         ser_id = self.target_class.__module__ + "." + self.target_class.__name__
@@ -66,19 +68,19 @@ def register_serializer(
     target_class: type,
     save: Callable,
     load: Callable,
-    instance_check: Optional[Callable[[Any], bool]] = None,
+    instance_check: Callable[[Any], bool] | None = None,
 ) -> None:
     SERIALIZERS.append(Serializer(target_class, save, load, instance_check))
 
 
-def get_serializer_by_id(id: str) -> Optional[Serializer]:
+def get_serializer_by_id(id: str) -> Serializer | None:
     for serializer in SERIALIZERS:
         if serializer.id() == id:
             return serializer
     return None
 
 
-def get_serializer_for_obj(obj: Any) -> Optional[Serializer]:
+def get_serializer_for_obj(obj: Any) -> Serializer | None:
     for serializer in SERIALIZERS:
         if serializer.instance_check and serializer.instance_check(obj):
             return serializer

--- a/weave/trace/table.py
+++ b/weave/trace/table.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 
 from weave.trace.refs import TableRef
 
 
 class Table:
-    ref: Optional[TableRef]
+    ref: TableRef | None
 
     def __init__(self, rows: list[dict]) -> None:
         if not isinstance(rows, list):

--- a/weave/trace/trace_sentry.py
+++ b/weave/trace/trace_sentry.py
@@ -8,14 +8,17 @@ and that we don't interfere with the user's own Sentry SDK setup.
 This file is a trimmed down version of the original WandB Sentry module.
 """
 
+from __future__ import annotations
+
 __all__ = ("Sentry",)
+
 
 import atexit
 import functools
 import os
 import site
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 if TYPE_CHECKING:
     from sentry_sdk._types import ExcInfo
@@ -33,7 +36,7 @@ def _safe_noop(func: Callable) -> Callable:
     """Decorator to ensure that Sentry methods do nothing if disabled and don't raise."""
 
     @functools.wraps(func)
-    def wrapper(self: type["Sentry"], *args: Any, **kwargs: Any) -> Any:
+    def wrapper(self: type[Sentry], *args: Any, **kwargs: Any) -> Any:
         if self._disabled:
             return None
         try:
@@ -55,7 +58,7 @@ class Sentry:
 
         self.dsn = SENTRY_DEFAULT_DSN
 
-        self.hub: Optional[sentry_sdk.hub.Hub] = None
+        self.hub: sentry_sdk.hub.Hub | None = None
 
         self._disabled = False
 
@@ -98,14 +101,9 @@ class Sentry:
     @_safe_noop
     def exception(
         self,
-        exc: Union[
-            str,
-            BaseException,
-            "ExcInfo",
-            None,
-        ],
+        exc: str | BaseException | ExcInfo | None,
         handled: bool = False,
-        status: Optional["SessionStatus"] = None,
+        status: SessionStatus | None = None,
     ) -> None:
         """Log an exception to Sentry."""
         error = Exception(exc) if isinstance(exc, str) else exc
@@ -161,7 +159,7 @@ class Sentry:
             client.flush()
 
     @_safe_noop
-    def mark_session(self, status: Optional["SessionStatus"] = None) -> None:
+    def mark_session(self, status: SessionStatus | None = None) -> None:
         """Mark the current session with a status."""
         assert self.hub is not None
         _, scope = self.hub._stack[-1]
@@ -173,7 +171,7 @@ class Sentry:
     @_safe_noop
     def configure_scope(
         self,
-        tags: Optional[dict[str, Any]] = None,
+        tags: dict[str, Any] | None = None,
     ) -> None:
         """Configure the Sentry scope for the current thread.
 

--- a/weave/trace/util.py
+++ b/weave/trace/util.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import warnings
 from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor as _ThreadPoolExecutor
 from contextvars import Context, copy_context
 from functools import partial, wraps
 from threading import Thread as _Thread
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 
 class ContextAwareThreadPoolExecutor(_ThreadPoolExecutor):
@@ -47,7 +49,7 @@ class ContextAwareThreadPoolExecutor(_ThreadPoolExecutor):
         self,
         fn: Callable,
         *iterables: Iterable[Iterable],
-        timeout: Optional[float] = None,
+        timeout: float | None = None,
         chunksize: int = 1,
     ) -> Iterator:
         contexts = [copy_context() for _ in range(len(list(iterables[0])))]

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -1,4 +1,4 @@
-import typing
+from __future__ import annotations
 
 from weave.trace import autopatch, errors, init_message, trace_sentry, weave_client
 from weave.trace.context import weave_client_context as weave_client_context
@@ -15,10 +15,10 @@ class InitializedClient:
         weave_client_context.set_weave_client_global(None)
 
 
-_current_inited_client: typing.Optional[InitializedClient] = None
+_current_inited_client: InitializedClient | None = None
 
 
-def get_username() -> typing.Optional[str]:
+def get_username() -> str | None:
     from weave.wandb_interface import wandb_api
 
     api = wandb_api.get_wandb_api_sync()
@@ -176,7 +176,7 @@ def init_weave_disabled() -> InitializedClient:
 
 
 def init_weave_get_server(
-    api_key: typing.Optional[str] = None,
+    api_key: str | None = None,
     should_batch: bool = True,
 ) -> remote_http_trace_server.RemoteHTTPTraceServer:
     res = remote_http_trace_server.RemoteHTTPTraceServer.from_env(should_batch)


### PR DESCRIPTION
Move to modern python syntax:
https://peps.python.org/pep-0604/

This excludes files that define classes that derive from `BaseModel` because it can cause strange behaviour in py39.  Once we move to py310+, we can update that code