### PR TITLE
chore(weave): Retry HTTP500 errors

### DIFF
--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -59,10 +59,12 @@ def _is_retryable_exception(e: Exception) -> bool:
         # TODO(np): We need to fix the server to return proper status codes
         # for downstream 401, 403, 404, etc... Those should propagate back to
         # the client.
-        if e.response.status_code == 500:
-            return False
 
-    # Otherwise, retry: Non-500 5xx, OSError, ConnectionError, ConnectionResetError, IOError, etc...
+        # Internal server error, bad gateway, service unavailable, gateway timeout
+        if e.response.status_code in (500, 502, 503, 504):
+            return True
+
+    # Otherwise, retry: OSError, ConnectionError, ConnectionResetError, IOError, etc...
     return True
 
 

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -59,9 +59,10 @@ def _is_retryable_exception(e: Exception) -> bool:
         # TODO(np): We need to fix the server to return proper status codes
         # for downstream 401, 403, 404, etc... Those should propagate back to
         # the client.
-
-        # Internal server error, bad gateway, service unavailable, gateway timeout
-        if e.response.status_code in (500, 502, 503, 504):
+        # NOTE(at): Previously this was set to False.  We're now intentionally retrying
+        # 500s because they could be blips from the server.  This is probably safe, and
+        # will become safer as we add more precise error codes to the server.
+        if e.response.status_code == 500:
             return True
 
     # Otherwise, retry: OSError, ConnectionError, ConnectionResetError, IOError, etc...


### PR DESCRIPTION
HTTP500 usually means ephemeral errors and are retry-able

Separately, we should work to improve the errors that the server sends back.