### PR TITLE
docs(weave): new feature WEAVE_PRINT_CALL_LINK

### DIFF
--- a/docs/docs/guides/tracking/ops.md
+++ b/docs/docs/guides/tracking/ops.md
@@ -115,3 +115,11 @@ A Weave op is a versioned function that automatically logs all calls.
     ```
   </TabItem>
 </Tabs>
+
+### Control call link output 
+
+If you want to suppress the printing of call links during logging, you can use the `WEAVE_PRINT_CALL_LINK` environment variable to `false`. This can be useful if you want to reduce  output verbosity and reduce clutter in your logs.
+
+```bash
+export WEAVE_PRINT_CALL_LINK=false
+```


### PR DESCRIPTION
## Description

Adds documentation about the new WEAVE_PRINT_CALL_LINK environment variable. When `WEAVE_PRINT_CALL_LINK=false`, logging of urls is suppressed.

Fixes https://wandb.atlassian.net/browse/DOCS-1045

