### PR TITLE
chore(ui): remove old parseRefMaybe

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -4,7 +4,6 @@ import {
   isWandbArtifactRef,
   isWeaveObjectRef,
   ObjectRef,
-  parseRef,
   refUri,
 } from '@wandb/weave/react';
 import React, {FC} from 'react';
@@ -200,12 +199,4 @@ export const SmallRef: FC<{
       {Item}
     </Link>
   );
-};
-
-export const parseRefMaybe = (s: string): ObjectRef | null => {
-  try {
-    return parseRef(s);
-  } catch (e) {
-    return null;
-  }
 };


### PR DESCRIPTION
## Description

Last change related to https://github.com/wandb/weave/pull/2994 and https://github.com/wandb/core/pull/25684 - remove old copy of parseRefMaybe as part of breaking import cycles.

## Testing

How was this PR tested?
