### PR TITLE
chore(weave): Remove deprecated methods from weave client

### DIFF
--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -592,7 +592,7 @@ The easiest way to get started is to construct a view in the UI, then learn more
 
 <Tabs groupId="client-layer">
     <TabItem value="python_sdk" label="Python">
-    To fetch calls using the Python API, you can use the [`client.calls`](../../reference/python-sdk/weave/trace/weave.trace.weave_client.md#method-calls) method:
+    To fetch calls using the Python API, you can use the [`client.get_calls`](../../reference/python-sdk/weave/trace/weave.trace.weave_client.md#method-calls) method:
 
     ```python
     import weave

--- a/tests/integrations/anthropic/anthropic_test.py
+++ b/tests/integrations/anthropic/anthropic_test.py
@@ -30,7 +30,7 @@ def test_anthropic(
     all_content = message.content[0]
     exp = "Hello! It's nice to meet you. How can I assist you today?"
     assert all_content.text == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
     assert call.exception is None and call.ended_at is not None
@@ -77,7 +77,7 @@ def test_anthropic_stream(
             output_tokens = event.usage.output_tokens
     exp = "Hello there! How can I assist you today?"
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -118,7 +118,7 @@ async def test_async_anthropic(
     all_content = message.content[0]
     exp = "Hello! It's nice to meet you. How can I assist you today?"
     assert all_content.text == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -168,7 +168,7 @@ async def test_async_anthropic_stream(
             output_tokens = event.usage.output_tokens
     exp = "Hello! It's nice to meet you. How can I assist you today?"
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -229,7 +229,7 @@ def test_tools_calling(
     all_content = message.content[0]
     assert all_content.input["location"] == exp
     assert all_content.type == "tool_use"
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -278,7 +278,7 @@ def test_anthropic_messages_stream_ctx_manager(
 
     exp = "Hello there!"
     assert all_content.strip() == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -327,7 +327,7 @@ async def test_async_anthropic_messages_stream_ctx_manager(
     exp = "Hello there!"
     assert all_content.strip() == exp
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -374,7 +374,7 @@ def test_anthropic_messages_stream_ctx_manager_text(
 
     exp = "Hello there!"
     assert all_content.strip() == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -422,7 +422,7 @@ async def test_async_anthropic_messages_stream_ctx_manager_text(
     exp = "Hello there!"
     assert all_content.strip() == exp
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 

--- a/tests/integrations/cerebras/cerebras_test.py
+++ b/tests/integrations/cerebras/cerebras_test.py
@@ -24,7 +24,7 @@ def test_cerebras_sync(client: weave.trace.weave_client.WeaveClient) -> None:
     exp = "The capital of France is Paris."
     assert response.choices[0].message.content.strip() == exp
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -60,7 +60,7 @@ async def test_cerebras_async(client: weave.trace.weave_client.WeaveClient) -> N
     exp = "The capital of France is Paris."
     assert response.choices[0].message.content.strip() == exp
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 

--- a/tests/integrations/cohere/cohere_test.py
+++ b/tests/integrations/cohere/cohere_test.py
@@ -29,7 +29,7 @@ def test_cohere(
 
     exp = response.text
     assert exp.strip() != ""
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -84,7 +84,7 @@ def test_cohere_stream(
         pass
 
     response = event.response  # the NonStreamedChatResponse
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -141,7 +141,7 @@ async def test_cohere_async(
 
     exp = response.text
     assert exp.strip() != ""
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -196,7 +196,7 @@ async def test_cohere_async_stream(
         pass
 
     response = event.response  # the NonStreamedChatResponse
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -249,7 +249,7 @@ def test_cohere_v2(
         messages=[{"role": "user", "content": "count to three"}],
         max_tokens=1024,
     )
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -296,7 +296,7 @@ async def test_cohere_async_v2(
         messages=[{"role": "user", "content": "count to three"}],
         max_tokens=1024,
     )
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -354,7 +354,7 @@ def test_cohere_stream_v2(
             if event.type == "message-end":
                 finish_reason = event.delta.finish_reason
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -404,7 +404,7 @@ async def test_cohere_async_stream_v2(
             if event.type == "message-end":
                 finish_reason = event.delta.finish_reason
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 

--- a/tests/integrations/dspy/dspy_test.py
+++ b/tests/integrations/dspy/dspy_test.py
@@ -29,7 +29,7 @@ def test_dspy_language_models(client: WeaveClient) -> None:
     prediction = gpt3_turbo("hello! this is a raw prompt to GPT-3.5")
     expected_prediction = "Hello! How can I assist you today?"
     assert prediction == [expected_prediction]
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert len(flattened_calls) == 4
 
@@ -90,7 +90,7 @@ def test_dspy_inline_signatures(client: WeaveClient) -> None:
     ).sentiment
     expected_prediction = "Positive"
     assert prediction == expected_prediction
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert len(flattened_calls) == 6
 

--- a/tests/integrations/google_ai_studio/google_ai_studio_test.py
+++ b/tests/integrations/google_ai_studio/google_ai_studio_test.py
@@ -59,7 +59,7 @@ def test_content_generation(client):
     model = genai.GenerativeModel("gemini-1.5-flash")
     model.generate_content("Explain how AI works in simple terms")
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
 
     call = calls[0]
@@ -88,7 +88,7 @@ def test_content_generation_stream(client):
     chunks = [chunk.text for chunk in response]
     assert len(chunks) > 1
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
 
     call = calls[0]
@@ -115,7 +115,7 @@ async def test_content_generation_async(client):
 
     _ = await model.generate_content_async("Explain how AI works in simple terms")
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
 
     call = calls[0]

--- a/tests/integrations/groq/groq_test.py
+++ b/tests/integrations/groq/groq_test.py
@@ -40,7 +40,7 @@ def test_groq_quickstart(
         chat_completion.choices[0].message.content
         == "The capital of India is New Delhi."
     )
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert len(flattened_calls) == 1
 
@@ -95,7 +95,7 @@ def test_groq_async_chat_completion(
 
     asyncio.run(complete_chat())
 
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert len(flattened_calls) == 1
 
@@ -157,7 +157,7 @@ def test_groq_streaming_chat_completion(
         if chunk.choices[0].delta.content is not None:
             all_content += chunk.choices[0].delta.content
 
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert len(flattened_calls) == 1
 
@@ -243,7 +243,7 @@ def test_groq_async_streaming_chat_completion(
 
     asyncio.run(generate_reponse())
 
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert len(flattened_calls) == 1
 
@@ -416,7 +416,7 @@ def test_groq_tool_call(
 
     response = run_conversation("What was the score of the Warriors game?")
 
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert len(flattened_calls) == 4
 

--- a/tests/integrations/instructor/instructor_test.py
+++ b/tests/integrations/instructor/instructor_test.py
@@ -49,7 +49,7 @@ def test_instructor_openai(
         messages=[{"role": "user", "content": "My name is John and I am 20 years old"}],
     )
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
 
     call = calls[0]
@@ -97,7 +97,7 @@ def test_instructor_openai_async(
 
     asyncio.run(extract_person("My name is John and I am 20 years old"))
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
 
     call = calls[0]
@@ -150,7 +150,7 @@ def test_instructor_iterable(
         ],
     )
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
 
     call = calls[0]
@@ -210,7 +210,7 @@ def test_instructor_iterable_sync_stream(
     )
     _ = list(users)
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
 
     call = calls[0]
@@ -264,7 +264,7 @@ def test_instructor_iterable_async_stream(
 
     asyncio.run(print_iterable_results())
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
 
     call = calls[0]
@@ -327,7 +327,7 @@ list of speakers.
     )
     _ = list(extraction_stream)
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
 
     call = calls[0]
@@ -399,7 +399,7 @@ list of speakers.
 
     _ = asyncio.run(fetch_results(text_block))
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
 
     call = calls[0]

--- a/tests/integrations/langchain/langchain_test.py
+++ b/tests/integrations/langchain/langchain_test.py
@@ -74,7 +74,7 @@ def test_simple_chain_invoke(
     llm_chain = prompt | llm
     _ = llm_chain.invoke({"number": 2})
 
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_chain_invoke(calls, exp_name)
 
 
@@ -102,7 +102,7 @@ async def test_simple_chain_ainvoke(
     llm_chain = prompt | llm
     _ = await llm_chain.ainvoke({"number": 2})
 
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_chain_invoke(calls)
 
 
@@ -129,7 +129,7 @@ def test_simple_chain_stream(
     for _ in llm_chain.stream({"number": 2}):
         pass
 
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_chain_invoke(calls)
 
 
@@ -158,7 +158,7 @@ async def test_simple_chain_astream(
     async for _ in llm_chain.astream({"number": 2}):
         pass
 
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_chain_invoke(calls)
 
 
@@ -205,7 +205,7 @@ def test_simple_chain_batch(
     llm_chain = prompt | llm
     _ = llm_chain.batch([{"number": 2}, {"number": 3}])
 
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_chain_batch(calls)
 
 
@@ -233,7 +233,7 @@ async def test_simple_chain_abatch(
     llm_chain = prompt | llm
     _ = await llm_chain.abatch([{"number": 2}, {"number": 3}])
 
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_chain_batch(calls)
 
 
@@ -287,7 +287,7 @@ def test_simple_chain_batch_inside_op(
 
     run_batch([{"number": 2}, {"number": 3}])
 
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_chain_batch_from_op(calls)
 
 
@@ -406,7 +406,7 @@ def test_simple_rag_chain(client: WeaveClient, fix_chroma_ci: None) -> None:
         input="What is the essay about?",
     )
 
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_rag_chain(calls)
 
 
@@ -523,7 +523,7 @@ def test_agent_run_with_tools(
     _ = agent_executor.invoke(
         {"input": "What is 3 times 4 ?", "chat_history": []},
     )
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_agent_with_tool(calls)
 
 
@@ -641,5 +641,5 @@ def test_agent_run_with_function_call(
     _ = agent_executor.invoke(
         {"input": "What is 3 times 4 ?", "chat_history": []},
     )
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_agent_with_function_call(calls)

--- a/tests/integrations/litellm/litellm_test.py
+++ b/tests/integrations/litellm/litellm_test.py
@@ -61,7 +61,7 @@ def test_litellm_quickstart(
     exp = """Hello! I'm just a computer program, so I don't have feelings, but I'm here to help you. How can I assist you today?"""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
     call = calls[0]
     assert call.exception is None and call.ended_at is not None
@@ -102,7 +102,7 @@ async def test_litellm_quickstart_async(
     exp = """Hello! I'm just a computer program, so I don't have feelings, but I'm here to help you with whatever you need. How can I assist you today?"""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
     call = calls[0]
     assert call.exception is None and call.ended_at is not None
@@ -148,7 +148,7 @@ def test_litellm_quickstart_stream(
     exp = """Hello! I'm just a computer program, so I don't have feelings, but I'm here to help you. How can I assist you today?"""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
     call = calls[0]
     assert call.exception is None and call.ended_at is not None
@@ -196,7 +196,7 @@ async def test_litellm_quickstart_stream_async(
     exp = """Hello! I'm just a computer program, so I don't have feelings, but I'm here and ready to assist you with any questions or tasks you may have. How can I help you today?"""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 2
     call = calls[0]
     assert call.exception is None and call.ended_at is not None

--- a/tests/integrations/llamaindex/llamaindex_test.py
+++ b/tests/integrations/llamaindex/llamaindex_test.py
@@ -73,7 +73,7 @@ def test_llamaindex_quickstart(
     query_engine = index.as_query_engine()
     response = query_engine.query("What did the author do growing up?")
 
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert_calls_correct_for_quickstart(flattened_calls)
     call, _ = flattened_calls[-2]
@@ -99,7 +99,7 @@ async def test_llamaindex_quickstart_async(
     query_engine = index.as_query_engine()
     response = await query_engine.aquery("What did the author do growing up?")
 
-    calls = list(client.calls(filter=CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
     assert_calls_correct_for_quickstart(flattened_calls)
     call, _ = flattened_calls[-2]

--- a/tests/integrations/mistral/v0/mistral_test.py
+++ b/tests/integrations/mistral/v0/mistral_test.py
@@ -39,7 +39,7 @@ def test_mistral_quickstart(client: weave.trace.weave_client.WeaveClient) -> Non
 6. Époisses: Known for its pungent smell, Époisses is a soft, washed-rind cheese with a rich and creamy flavor."""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -91,7 +91,7 @@ async def test_mistral_quickstart_async(
 Ultimately, the best French cheese is a matter of personal taste. I would recommend trying a variety of cheeses and seeing which ones you enjoy the most."""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -149,7 +149,7 @@ def test_mistral_quickstart_with_stream(
 6. Époisses: This is a pungent soft cheese with a distinctive orange rind. It's known for its strong flavor and creamy texture."""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -206,7 +206,7 @@ async def test_mistral_quickstart_with_stream_async(
 5. Chèvre: This is a general term for goat cheese in French. It can come in many forms and flavors, from fresh and mild to aged and tangy."""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 

--- a/tests/integrations/mistral/v1/mistral_test.py
+++ b/tests/integrations/mistral/v1/mistral_test.py
@@ -48,7 +48,7 @@ def test_mistral_quickstart(client: weave.trace.weave_client.WeaveClient) -> Non
 
 Each of these cheeses has its unique characteristics, so the "best" one depends on your preferences. It's always fun to try several and decide which you like the most!"""
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -106,7 +106,7 @@ async def test_mistral_quickstart_async(
 Each of these cheeses offers a unique taste and texture, so the "best" one is a matter of personal preference."""
 
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -165,7 +165,7 @@ def test_mistral_quickstart_with_stream(
 
 Each of these cheeses offers a unique taste and texture, so the "best" one depends on your personal preference. It's always fun to try a variety to see which you like best!"""
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -233,7 +233,7 @@ async def test_mistral_quickstart_with_stream_async(
 
 Each of these cheeses has its unique characteristics, so the "best" one depends on your preferences. It's always fun to try several types to discover your favorite!"""
     assert all_content == exp
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 

--- a/tests/integrations/notdiamond/custom_router_test.py
+++ b/tests/integrations/notdiamond/custom_router_test.py
@@ -69,8 +69,8 @@ def test_train_router(
         preference_id=preference_id,
     )
 
-    assert len(list(client.calls())) > 0
-    nd_calls = [call for call in client.calls() if "train_router" in call.op_name]
+    assert len(list(client.get_calls())) > 0
+    nd_calls = [call for call in client.get_calls() if "train_router" in call.op_name]
     assert len(nd_calls) == 1
 
     # confirm router was trained
@@ -91,6 +91,8 @@ def test_evaluate_router(
         api_key=api_key,
     )
 
-    assert len(list(client.calls())) > 0
-    nd_calls = [call for call in client.calls() if "evaluate_router" in call.op_name]
+    assert len(list(client.get_calls())) > 0
+    nd_calls = [
+        call for call in client.get_calls() if "evaluate_router" in call.op_name
+    ]
     assert len(nd_calls) == 1

--- a/tests/integrations/notdiamond/tracing_test.py
+++ b/tests/integrations/notdiamond/tracing_test.py
@@ -26,6 +26,6 @@ def test_notdiamond_quickstart(
     _, results = nd_client.model_select(
         model=llm_configs, messages=[{"role": "user", "content": "Hello, world!"}]
     )
-    calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     flattened_calls = flattened_calls_to_names(flatten_calls(calls))
     assert len([call for call in flattened_calls if "model_select" in call[0]]) == 1

--- a/tests/integrations/openai/openai_test.py
+++ b/tests/integrations/openai/openai_test.py
@@ -26,7 +26,7 @@ def test_openai_quickstart(client: weave.trace.weave_client.WeaveClient) -> None
         max_tokens=64,
         top_p=1,
     )
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -74,7 +74,7 @@ async def test_openai_async_quickstart(
         max_tokens=64,
         top_p=1,
     )
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -126,7 +126,7 @@ def test_openai_stream_quickstart(client: weave.trace.weave_client.WeaveClient) 
         if chunk.choices[0].delta.content:
             all_content += chunk.choices[0].delta.content
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -183,7 +183,7 @@ async def test_openai_async_stream_quickstart(
         if chunk.choices[0].delta.content:
             all_content += chunk.choices[0].delta.content
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -237,7 +237,7 @@ def test_openai_stream_usage_quickstart(
 
     for chunk in response:
         pass
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -303,7 +303,7 @@ def test_openai_function_call(client: weave.trace.weave_client.WeaveClient) -> N
         top_p=1,
     )
     print(response)
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -389,7 +389,7 @@ async def test_openai_function_call_async(
         max_tokens=64,
         top_p=1,
     )
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -480,7 +480,7 @@ async def test_openai_function_call_async_stream(
     async for chunk in response:
         pass
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -565,7 +565,7 @@ def test_openai_tool_call(client: weave.trace.weave_client.WeaveClient) -> None:
     )
     print(response)
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -652,7 +652,7 @@ async def test_openai_tool_call_async(
         max_tokens=64,
         top_p=1,
     )
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -747,7 +747,7 @@ async def test_openai_tool_call_async_stream(
     async for chunk in response:
         pass
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -809,7 +809,7 @@ def test_openai_as_context_manager(
             if chunk.choices[0].delta.content:
                 all_content += chunk.choices[0].delta.content
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 
@@ -864,7 +864,7 @@ async def test_openai_as_context_manager_async(
             if chunk.choices[0].delta.content:
                 all_content += chunk.choices[0].delta.content
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert len(calls) == 1
     call = calls[0]
 

--- a/tests/trace/test_evaluation_performance.py
+++ b/tests/trace/test_evaluation_performance.py
@@ -138,13 +138,11 @@ async def test_evaluation_performance(client: WeaveClient):
         }
     )
 
-    calls = client.calls()
-    objects = client._objects()
+    calls = list(client.get_calls())
+    objects = list(client._objects())
 
-    assert (
-        len(list(calls)) == 14
-    )  # eval, summary, 4 predict_and_score, 4 predicts, 4 scores
-    assert len(list(objects)) == 3  # model, dataset, evaluation
+    assert len(calls) == 14  # eval, summary, 4 predict_and_score, 4 predicts, 4 scores
+    assert len(objects) == 3  # model, dataset, evaluation
 
 
 @pytest.mark.asyncio

--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -289,7 +289,7 @@ def test_postprocessing_funcs(client):
     res = func(1, "should_be_hidden", "also_hidden")
     assert res == {"b": 2, "also_hide_me": "12345"}
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     call = calls[0]
 
     assert call.inputs == {"a": 1}
@@ -303,7 +303,7 @@ def test_op_call_display_name_str(client):
 
     func()
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     call = calls[0]
 
     assert call.display_name == "example"
@@ -324,7 +324,7 @@ def test_op_call_display_name_callable_lambda(client):
 
     func()
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     call = calls[0]
 
     assert call.display_name == "shawn/test-project-123"
@@ -342,7 +342,7 @@ def test_op_call_display_name_callable_func(client):
 
     func()
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     call = calls[0]
 
     assert call.display_name == "wow-1844-tcejorp-tset/nwahs"
@@ -378,7 +378,7 @@ def test_op_call_display_name_callable_other_attributes(client):
     ):
         func()
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert calls[0].display_name == "finetuned-llama-3.1-8b__v0.1.2__2024-08-01"
     assert calls[1].display_name == "finetuned-gpt-4o__v0.1.3__2024-08-02"
 
@@ -402,7 +402,7 @@ def test_op_call_display_name_modified_dynamically(client):
     func.call_display_name = custom_display_name2
     func()
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     assert calls[0].display_name == "string"
     assert calls[1].display_name == "wow"
     assert calls[2].display_name == "amazing"
@@ -415,7 +415,7 @@ def test_op_name(client):
 
     func()
 
-    calls = list(client.calls())
+    calls = list(client.get_calls())
     call = calls[0]
 
     parsed = parse_uri(call.op_name)

--- a/weave/integrations/README.md
+++ b/weave/integrations/README.md
@@ -69,7 +69,7 @@ This directory contains various integrations for Weave. As of this writing, ther
    4. Add any assertions to validate correct logging. The base case to validate that a call was logged would be:
 
    ```
-   calls = list(client.calls())
+   calls = list(client.get_calls())
    assert len(calls) == 1
    ```
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1380,8 +1380,11 @@ class WeaveClient:
             [res_future], lambda res: res[0].digest
         )
 
-        ref_cls = OpRef if is_op(orig_val) else ObjectRef
-        ref = ref_cls(self.entity, self.project, name, digest_future)
+        ref: Ref
+        if is_op(orig_val):
+            ref = OpRef(self.entity, self.project, name, digest_future)
+        else:
+            ref = ObjectRef(self.entity, self.project, name, digest_future)
 
         # Attach the ref to the object
         try:

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -41,7 +41,6 @@ from weave.trace.serialize import from_json, isinstance_namedtuple, to_json
 from weave.trace.serializer import get_serializer_for_obj
 from weave.trace.settings import client_parallelism
 from weave.trace.table import Table
-from weave.trace.util import deprecated
 from weave.trace.vals import WeaveObject, WeaveTable, make_trace_obj
 from weave.trace_server.ids import generate_id
 from weave.trace_server.interface.feedback_types import RUNNABLE_FEEDBACK_TYPE_PREFIX
@@ -623,14 +622,6 @@ class WeaveClient:
             self.server, self._project_id(), filter, include_costs or False
         )
 
-    @deprecated(new_name="get_calls")
-    def calls(
-        self,
-        filter: CallsFilter | None = None,
-        include_costs: bool = False,
-    ) -> CallsIter:
-        return self.get_calls(filter=filter, include_costs=include_costs)
-
     @trace_sentry.global_trace_sentry.watch()
     def get_call(
         self,
@@ -648,14 +639,6 @@ class WeaveClient:
             raise ValueError(f"Call not found: {call_id}")
         response_call = response.calls[0]
         return make_client_call(self.entity, self.project, response_call, self.server)
-
-    @deprecated(new_name="get_call")
-    def call(
-        self,
-        call_id: str,
-        include_costs: bool = False,
-    ) -> WeaveObject:
-        return self.get_call(call_id=call_id, include_costs=include_costs)
 
     @trace_sentry.global_trace_sentry.watch()
     def create_call(
@@ -951,19 +934,6 @@ class WeaveClient:
             offset=offset,
             limit=limit,
             show_refs=True,
-        )
-
-    @deprecated(new_name="get_feedback")
-    def feedback(
-        self,
-        query: Query | str | None = None,
-        *,
-        reaction: str | None = None,
-        offset: int = 0,
-        limit: int = 100,
-    ) -> FeedbackQuery:
-        return self.get_feedback(
-            query=query, reaction=reaction, offset=offset, limit=limit
         )
 
     def add_cost(


### PR DESCRIPTION
These were deprecated 3 months ago in `0.51.2`