### PR TITLE
chore(weave): Rethrow useExpandedNode error for proper serialization

### DIFF
--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -1270,7 +1270,7 @@ export const useExpandedNode = (
     if (error != null) {
       // rethrow in render thread
       console.error('useExpanded error', error);
-      throw new Error(error);
+      throw error;
     }
     return {
       loading: node.nodeType !== 'output' ? false : node !== result.node,


### PR DESCRIPTION
## Description
This PR rethrows the `useExpandedNode` original error instead of using the original error as a message to the Error constructor.

Pic below shows how the error shows up in DD currently:
![image](https://github.com/user-attachments/assets/b417527c-28d5-459c-b2bb-36c214597a33)


## Testing

How was this PR tested?
