### PR TITLE
style(weave): make show more button not absolute

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanel.tsx
@@ -54,7 +54,6 @@ export const MessagePanel = ({
 
       <div
         className={classNames('relative overflow-visible rounded-lg', {
-          'pb-40': isOverflowing && isShowingMore,
           'border-t border-moon-250': isTool,
           'bg-moon-100': isSystemPrompt,
           'bg-cactus-300/[0.24]': isUser,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ShowMoreButton.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ShowMoreButton.tsx
@@ -15,10 +15,10 @@ export const ShowMoreButton = ({
   return (
     <div
       className={classNames(
-        'absolute bottom-0 left-0 flex w-full items-center justify-center pb-4 pt-32',
+        'mb-[-8px] flex w-full items-center justify-center pb-8',
         {
           [`from-34% rounded-b-xl bg-gradient-to-t ${
-            isUser ? 'from-cactus-300/[0.24]' : 'from-moon-100'
+            isUser ? 'from-cactus-300/[0.32]' : 'from-moon-150'
           } to-transparent`]: !isShowingMore,
         }
       )}>


### PR DESCRIPTION
## Description
show more gradient wasnt acting enough as a background, make it not absolute for now

![Screenshot 2024-11-19 at 8 44 01 AM](https://github.com/user-attachments/assets/bd4fb56b-d7ea-4e87-9f7d-e8e8a08df74c)
![Screenshot 2024-11-19 at 8 43 57 AM](https://github.com/user-attachments/assets/490e1b9b-26dc-427e-a542-c21c657bf72d)
![Screenshot 2024-11-19 at 8 43 53 AM](https://github.com/user-attachments/assets/698532c3-3e3b-4571-8c50-659321e4c6cc)
![Screenshot 2024-11-19 at 8 43 48 AM](https://github.com/user-attachments/assets/9546f2c3-874a-4425-b8db-bf37ae2d0a9c)
![Screenshot 2024-11-19 at 8 43 44 AM](https://github.com/user-attachments/assets/db6bb973-d8dd-4972-8010-e4e8a39ee361)
![Screenshot 2024-11-19 at 8 44 07 AM](https://github.com/user-attachments/assets/a4c8fc98-4da6-4fdc-9ff8-0d588c0a8242)


## Testing

How was this PR tested?
