### PR TITLE
docs(weave): Remove `#highlight-next-line` to fix indentation issue

### DIFF
--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -194,7 +194,6 @@ However, often LLM applications have additional logic (such as pre/post processi
 
     ```python showLineNumbers
     # Notice that we pass the `instance` as the first argument.
-    # highlight-next-line
     print(instance.my_method.call(instance, "World"))
     ```
 


### PR DESCRIPTION
## Description

- Fixes https://wandb.atlassian.net/browse/DOCS-1049

Fixes indentation issue in code sample by removing the magic comment `#highlight-next-line` in the Python code sample on L197 of `weave/docs/docs/guides/tracking/tracing.mdx`. See https://weightsandbiases.slack.com/archives/C01DX8LRZEJ/p1732038958244399?thread_ts=1732032632.859409&cid=C01DX8LRZEJ for context

> The long term fix here would be to fiddle with the CSS. However, this at least prevents the issue on this page.

## Testing

1. Viewed in prod docs and confirmed indentation issue was present
2. Viewed in local docs and confirmed that no indentation issue was present.
3. Inspected HTML on both local and prod, confirmed that prod HTML has CSS class `#theme-code-block-highlighted-line` that appears to be indenting the block
4. Confirmed that removing magic comment `#highlight-next-line` removes CSS class
