### PR TITLE
chore(weave): feedback payload 1024 -> 1024*1024

### DIFF
--- a/tests/trace/test_client_feedback.py
+++ b/tests/trace/test_client_feedback.py
@@ -228,7 +228,7 @@ def test_feedback_payload(client):
 def test_feedback_create_too_large(client):
     project_id = client._project_id()
 
-    value = "a" * 10000
+    value = "a" * 1024 * 1024
     req = tsi.FeedbackCreateReq(
         project_id=project_id,
         wb_user_id="VXNlcjo0NTI1NDQ=",

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1350,7 +1350,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         created_at = datetime.datetime.now(ZoneInfo("UTC"))
         # TODO: Any validation on weave_ref?
         payload = _dict_value_to_dump(req.payload)
-        MAX_PAYLOAD = 1024
+        # 1MB max payload size
+        MAX_PAYLOAD = 1024 * 1024
         if len(payload) > MAX_PAYLOAD:
             raise InvalidRequest("Feedback payload too large")
         row: Row = {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Per @shawnlewis 's request, bump limit on payload to basically maxed. 