### PR TITLE
chore(ui): fix Category pill column truncation

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -333,7 +333,7 @@ export const ObjectVersionsTable: React.FC<{
     if (!props.hideCategoryColumn) {
       cols.push(
         basicField('baseObjectClass', 'Category', {
-          width: 100,
+          width: 120,
           display: 'flex',
           valueGetter: (unused: any, row: any) => {
             return row.obj.baseObjectClass;


### PR DESCRIPTION
## Description

In the objects listing grid, the "Category" column is not resizable. The hardcoded width was causing the AnnotationSpec pill to get truncated - that label is longer than other values.

<img width="119" alt="Screenshot 2024-11-20 at 2 52 04 PM" src="https://github.com/user-attachments/assets/5e986a0a-7c8a-4726-ab60-92fbafeea86c">
<img width="155" alt="Screenshot 2024-11-20 at 2 51 12 PM" src="https://github.com/user-attachments/assets/5a505866-ba40-4377-bb14-291be3041d5a">


## Testing

How was this PR tested?
