### PR TITLE
chore(ui): lighten trace tree lines

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import React, {FC, MouseEvent, useMemo} from 'react';
 import styled from 'styled-components';
 
-import {MOON_500} from '../../../../../../common/css/color.styles';
+import {MOON_250, MOON_500} from '../../../../../../common/css/color.styles';
 import {IconParentBackUp} from '../../../../../Icon';
 import {Tooltip} from '../../../../../Tooltip';
 import {opNiceName} from '../common/Links';
@@ -18,7 +18,7 @@ import {CursorBox} from './CursorBox';
 
 const INSET_SPACING = 54;
 const TREE_COLOR = '#aaaeb2';
-const BORDER_STYLE = `1px solid ${TREE_COLOR}`;
+const BORDER_STYLE = `1px solid ${MOON_250}`;
 
 const CallOrCountRow = styled.div`
   width: 100%;


### PR DESCRIPTION
## Description

Lighten trace tree lines per design.

Internal Notion: https://www.notion.so/wandbai/Trace-tree-lines-10de2f5c7ef3801899dfc0f37ecbd317?pvs=4#143e2f5c7ef3806b9abee486a42a0cca

Before:
<img width="497" alt="Screenshot 2024-11-20 at 4 49 40 PM" src="https://github.com/user-attachments/assets/94a8bd19-9c41-43b3-b44f-092fcace0cba">

After:
<img width="491" alt="Screenshot 2024-11-20 at 4 47 43 PM" src="https://github.com/user-attachments/assets/31b8f5b5-df01-44c3-aec9-976a3ea77277">


## Testing

How was this PR tested?
