### PR TITLE
fix(weave): Fix issue where Evaluation can raise unexpectedly due to bad scorer

### DIFF
--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -133,6 +133,16 @@ class Evaluation(Object):
                 pass
             else:
                 raise ValueError(f"Invalid scorer: {scorer}")
+
+            # Having both `output` and `model_output` in the scorer signature
+            # causes issues with scoring because it's ambigious as to which
+            # one is the canonical "output", and which is just a regular kwarg.
+            params = inspect.signature(scorer.resolve_fn).parameters
+            if "output" in params and "model_output" in params:
+                raise ValueError(
+                    "Both 'output' and 'model_output' cannot be in the scorer signature; prefer just using `output`."
+                )
+
             scorers.append(scorer)
 
         # Determine output key based on scorer types

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -135,9 +135,6 @@ class Evaluation(Object):
             else:
                 raise ValueError(f"Invalid scorer: {scorer}")
 
-            # Having both `output` and `model_output` in the scorer signature
-            # causes issues with scoring because it's ambigious as to which
-            # one is the canonical "output", and which is just a regular kwarg.
             _validate_scorer_signature(scorer)
 
             scorers.append(scorer)

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -19,6 +19,7 @@ from weave.flow.obj import Object
 from weave.scorers import (
     Scorer,
     _has_oldstyle_scorers,
+    _validate_scorer_signature,
     auto_summarize,
     get_scorer_attributes,
     transpose,
@@ -137,11 +138,7 @@ class Evaluation(Object):
             # Having both `output` and `model_output` in the scorer signature
             # causes issues with scoring because it's ambigious as to which
             # one is the canonical "output", and which is just a regular kwarg.
-            params = inspect.signature(scorer.resolve_fn).parameters
-            if "output" in params and "model_output" in params:
-                raise ValueError(
-                    "Both 'output' and 'model_output' cannot be in the scorer signature; prefer just using `output`."
-                )
+            _validate_scorer_signature(scorer)
 
             scorers.append(scorer)
 

--- a/weave/scorers/__init__.py
+++ b/weave/scorers/__init__.py
@@ -1,6 +1,7 @@
 from weave.scorers.base_scorer import (
     Scorer,
     _has_oldstyle_scorers,
+    _validate_scorer_signature,
     auto_summarize,
     get_scorer_attributes,
 )
@@ -54,4 +55,5 @@ __all__ = [
     "SummarizationScorer",
     "transpose",
     "ValidXMLScorer",
+    "_validate_scorer_signature",
 ]

--- a/weave/scorers/base_scorer.py
+++ b/weave/scorers/base_scorer.py
@@ -33,6 +33,12 @@ class Scorer(Object):
 
 
 def _validate_scorer_signature(scorer: Union[Callable, Op, Scorer]) -> bool:
+    """Validate that the scorer signature does not have both `output` and `model_output`.
+
+    Having both `output` and `model_output` in the scorer signature causes
+    issues with scoring because it's ambigious as to which one is the
+    canonical "output", and which is just a regular kwarg.
+    """
     if isinstance(scorer, Scorer):
         params = inspect.signature(scorer.score).parameters
     else:

--- a/weave/scorers/base_scorer.py
+++ b/weave/scorers/base_scorer.py
@@ -19,6 +19,10 @@ class Scorer(Object):
         description="A mapping from column names in the dataset to the names expected by the scorer",
     )
 
+    def model_post_init(self, __context: Any) -> None:
+        super().model_post_init(__context)
+        _validate_scorer_signature(self)
+
     @weave.op
     def score(self, *, output: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
@@ -26,6 +30,18 @@ class Scorer(Object):
     @weave.op()
     def summarize(self, score_rows: list) -> Optional[dict]:
         return auto_summarize(score_rows)
+
+
+def _validate_scorer_signature(scorer: Union[Callable, Op, Scorer]) -> bool:
+    if isinstance(scorer, Scorer):
+        params = inspect.signature(scorer.score).parameters
+    else:
+        params = inspect.signature(scorer).parameters
+    if "output" in params and "model_output" in params:
+        raise ValueError(
+            "Both 'output' and 'model_output' cannot be in the scorer signature; prefer just using `output`."
+        )
+    return True
 
 
 def stderr(data: Sequence[Union[int, float]]) -> float:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Resolves an issue where a scorer with both `output` and `model_output` could cause issues with argument parsing.  This PR prevents having both of these params specified because it's ambiguous which is the intended "output" and which is just another kwarg

Internal thread:
https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1732122258661749


## Testing

Unit tests, manual testing