### PR TITLE
chore(weave): Wrap up loose ends with Annotations

### DIFF
--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -1,6 +1,10 @@
 from weave.flow.annotation_spec import AnnotationSpec
-from weave.trace_server.trace_server_interface import ObjQueryReq
-
+from weave.trace_server.clickhouse_trace_server_batched import InvalidRequest
+from weave.trace_server.trace_server_interface import FeedbackCreateReq, ObjQueryReq
+from pydantic import BaseModel, Field
+import pytest
+import jsonschema
+import weave
 
 def test_human_feedback_basic(client):
     # create a human feedback spec
@@ -8,7 +12,7 @@ def test_human_feedback_basic(client):
     col1 = AnnotationSpec(
         name="Numerical field #1",
         description="A numerical field with a range of -1 to 1",
-        json_schema={
+        field_schema={
             "type": "number",
             "minimum": -1,
             "maximum": 1,
@@ -16,15 +20,15 @@ def test_human_feedback_basic(client):
         unique_among_creators=True,
         op_scope=None,
     )
-    ref1 = client.save(col1, "my numerical spec")
+    ref1 = weave.publish(col1, "my numerical spec")
     assert ref1
 
     col2 = AnnotationSpec(
         name="Text field #1",
-        json_schema={"type": "string", "max_length": 100},
+        field_schema={"type": "string", "max_length": 100},
         op_scope=["weave:///entity/project/op/name:digest"],
     )
-    ref2 = client.save(col2, "my text spec")
+    ref2 = weave.publish(col2, "my text spec")
     assert ref2
 
     # query it by object type
@@ -47,12 +51,380 @@ def test_human_feedback_basic(client):
     assert not objects.objs[1].val["description"]
     assert not objects.objs[0].val["op_scope"]
     assert objects.objs[1].val["op_scope"] == ["weave:///entity/project/op/name:digest"]
-    assert objects.objs[0].val["json_schema"] == {
+    assert objects.objs[0].val["field_schema"] == {
         "type": "number",
         "minimum": -1,
         "maximum": 1,
     }
-    assert objects.objs[1].val["json_schema"] == {
+    assert objects.objs[1].val["field_schema"] == {
         "type": "string",
         "max_length": 100,
     }
+
+    # Attempt to add valid and invalid payloads
+    client.server.feedback_create(FeedbackCreateReq.model_validate({
+        "project_id": client._project_id(),
+        "weave_ref": "weave:///entity/project/call/name:digest",
+        "feedback_type": "wandb.annotation." + ref1.name,
+        "annotation_ref": ref1.uri(),
+        "payload": {"value": 0},
+    }))
+
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(FeedbackCreateReq.model_validate({
+            "project_id": client._project_id(),
+            "weave_ref": "weave:///entity/project/call/name:digest",
+            "feedback_type": "wandb.annotation." + ref1.name,
+            "annotation_ref": ref1.uri(),
+            "payload": {"value": 42},
+        }))
+
+
+def test_field_schema_with_pydantic_model(client):
+    # Test using a Pydantic model as field_schema
+    class FeedbackModel(BaseModel):
+        rating: int = Field(ge=1, le=5, description="Rating from 1 to 5")
+        comment: str = Field(max_length=200, description="Optional comment")
+        category: str = Field(enum=["good", "bad", "neutral"])
+
+    col = AnnotationSpec(
+        name="Pydantic Model Feedback",
+        description="A feedback spec using a Pydantic model schema",
+        field_schema=FeedbackModel,
+    )
+    ref = weave.publish(col, "pydantic model spec")
+    assert ref
+
+    # Query and verify the converted schema
+    objects = client.server.objs_query(
+        ObjQueryReq.model_validate(
+            {
+                "project_id": client._project_id(),
+                "filter": {"base_object_classes": ["AnnotationSpec"]},
+            }
+        )
+    )
+
+    # Find our new spec
+    pydantic_spec = next(obj for obj in objects.objs if obj.val["name"] == "Pydantic Model Feedback")
+    
+    # Verify the schema was properly converted
+    assert pydantic_spec.val["field_schema"]["type"] == "object"
+    assert "properties" in pydantic_spec.val["field_schema"]
+    assert set(pydantic_spec.val["field_schema"]["properties"].keys()) == {"rating", "comment", "category"}
+    
+    # Verify specific field constraints were preserved
+    rating_schema = pydantic_spec.val["field_schema"]["properties"]["rating"]
+    assert rating_schema["type"] == "integer"
+    assert rating_schema["minimum"] == 1
+    assert rating_schema["maximum"] == 5
+
+    comment_schema = pydantic_spec.val["field_schema"]["properties"]["comment"]
+    assert comment_schema["type"] == "string"
+    assert comment_schema["maxLength"] == 200
+
+    category_schema = pydantic_spec.val["field_schema"]["properties"]["category"]
+    assert category_schema["type"] == "string"
+    assert set(category_schema["enum"]) == {"good", "bad", "neutral"}
+
+        # Attempt to add valid and invalid payloads
+    client.server.feedback_create(FeedbackCreateReq.model_validate({
+        "project_id": client._project_id(),
+        "weave_ref": "weave:///entity/project/call/name:digest",
+        "feedback_type": "wandb.annotation." + ref.name,
+        "annotation_ref": ref.uri(),
+        "payload": {"value": {
+            "rating": 1,
+            "comment": "Good work!",
+            "category": "good",
+        }},
+    }))
+
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(FeedbackCreateReq.model_validate({
+            "project_id": client._project_id(),
+            "weave_ref": "weave:///entity/project/call/name:digest",
+            "feedback_type": "wandb.annotation." + ref.name,
+            "annotation_ref": ref.uri(),
+            "payload": {"value": {
+                "rating": 'not a number',
+                "comment": "Good work!",
+                "category": "good",
+            }},
+        }))
+
+
+def test_field_schema_with_pydantic_field(client):
+    # Test various field types
+    rating_field = Field(ge=1, le=5, description="Rating from 1 to 5")
+    text_field = Field(min_length=10, max_length=100, pattern="^[A-Za-z ]+$", description="Text feedback")
+    enum_field = Field(enum=["excellent", "good", "fair", "poor"], description="Category selection")
+    
+    # Test rating field
+    col1 = AnnotationSpec(
+        name="Rating Field",
+        description="A rating field using Pydantic Field",
+        field_schema=rating_field
+    )
+    ref1 = weave.publish(col1, "rating field spec")
+    assert ref1
+
+    # Test text field
+    col2 = AnnotationSpec(
+        name="Text Field",
+        description="A text field using Pydantic Field",
+        field_schema=text_field
+    )
+    ref2 = weave.publish(col2, "text field spec")
+    assert ref2
+
+    # Test enum field
+    col3 = AnnotationSpec(
+        name="Enum Field",
+        description="An enum field using Pydantic Field",
+        field_schema=enum_field
+    )
+    ref3 = weave.publish(col3, "enum field spec")
+    assert ref3
+
+    # Query and verify all specs
+    objects = client.server.objs_query(
+        ObjQueryReq.model_validate(
+            {
+                "project_id": client._project_id(),
+                "filter": {"base_object_classes": ["AnnotationSpec"]},
+            }
+        )
+    )
+
+    # Find our specs
+    rating_spec = next(obj for obj in objects.objs if obj.val["name"] == "Rating Field")
+    text_spec = next(obj for obj in objects.objs if obj.val["name"] == "Text Field")
+    enum_spec = next(obj for obj in objects.objs if obj.val["name"] == "Enum Field")
+    
+    # Verify rating field schema
+    assert rating_spec.val["field_schema"]["minimum"] == 1
+    assert rating_spec.val["field_schema"]["maximum"] == 5
+    assert rating_spec.val["field_schema"]["description"] == "Rating from 1 to 5"
+
+    # Verify text field schema
+    assert text_spec.val["field_schema"]["minLength"] == 10
+    assert text_spec.val["field_schema"]["maxLength"] == 100
+    assert text_spec.val["field_schema"]["pattern"] == "^[A-Za-z ]+$"
+    assert text_spec.val["field_schema"]["description"] == "Text feedback"
+
+    # Verify enum field schema
+    assert text_spec.val["field_schema"]["type"] == "string"
+    assert set(enum_spec.val["field_schema"]["enum"]) == {"excellent", "good", "fair", "poor"}
+    assert enum_spec.val["field_schema"]["description"] == "Category selection"
+
+
+def test_annotation_spec_validation():
+    # Test validation with direct schema
+    number_spec = AnnotationSpec(
+        name="Number Rating",
+        field_schema={
+            "type": "number",
+            "minimum": 1,
+            "maximum": 5,
+        }
+    )
+    
+    # Valid cases
+    number_spec.validate(3)
+    number_spec.validate(1)
+    number_spec.validate(5)
+    
+    # Invalid cases
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        number_spec.validate(0)  # too low
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        number_spec.validate(6)  # too high
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        number_spec.validate("3")  # wrong type
+    
+    # Test validation with Pydantic model schema
+    class FeedbackModel(BaseModel):
+        rating: int = Field(ge=1, le=5)
+        comment: str = Field(max_length=100)
+        tags: list[str] = Field(min_length=1, max_length=3)
+
+    model_spec = AnnotationSpec(
+        name="Complex Feedback",
+        field_schema=FeedbackModel
+    )
+    
+    # Valid cases
+    model_spec.validate({
+        "rating": 4,
+        "comment": "Good work!",
+        "tags": ["positive", "helpful"]
+    })
+    
+    # Invalid cases
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        model_spec.validate({
+            "rating": 4,
+            "comment": "Good work!"
+            # missing tags
+        })
+    
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        model_spec.validate({
+            "rating": 6,  # invalid rating
+            "comment": "Good work!",
+            "tags": ["positive"]
+        })
+    
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        model_spec.validate({
+            "rating": 4,
+            "comment": "Good work!",
+            "tags": []  # empty tags list
+        })
+    
+    # Test validation with Pydantic Field schema
+    enum_field = Field(enum=["excellent", "good", "fair", "poor"])
+    enum_spec = AnnotationSpec(
+        name="Simple Enum",
+        field_schema=enum_field
+    )
+    
+    # Valid cases
+    enum_spec.validate("good")
+    enum_spec.validate("excellent")
+    
+    # Invalid cases
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        enum_spec.validate("invalid_choice")
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        enum_spec.validate(123)
+
+def test_annotation_spec_validation_with_complex_types():
+    # Test nested object validation
+    class Address(BaseModel):
+        street: str
+        city: str
+        zip_code: str = Field(pattern=r'^\d{5}$')
+
+    class PersonFeedback(BaseModel):
+        name: str
+        age: int = Field(ge=0, le=120)
+        addresses: list[Address] = Field(min_length=1, max_length=3)
+
+    person_spec = AnnotationSpec(
+        name="Person Feedback",
+        field_schema=PersonFeedback
+    )
+    
+    # Valid case
+    person_spec.validate({
+        "name": "John Doe",
+        "age": 30,
+        "addresses": [
+            {
+                "street": "123 Main St",
+                "city": "Springfield",
+                "zip_code": "12345"
+            }
+        ]
+    })
+    
+    # Invalid cases
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        person_spec.validate({
+            "name": "John Doe",
+            "age": 30,
+            "addresses": [
+                {
+                    "street": "123 Main St",
+                    "city": "Springfield",
+                    "zip_code": "123"  # invalid zip code
+                }
+            ]
+        })
+    
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        person_spec.validate({
+            "name": "John Doe",
+            "age": 150,  # invalid age
+            "addresses": [
+                {
+                    "street": "123 Main St",
+                    "city": "Springfield",
+                    "zip_code": "12345"
+                }
+            ]
+        })
+
+def test_annotation_spec_validate_return_value():
+    # Test with a simple numeric schema
+    number_spec = AnnotationSpec(
+        name="Number Rating",
+        field_schema={
+            "type": "number",
+            "minimum": 1,
+            "maximum": 5,
+        }
+    )
+    
+    # Valid cases should return True
+    assert number_spec.validate(3) is True
+    assert number_spec.validate(1) is True
+    assert number_spec.validate(5) is True
+    
+    # Invalid cases should return False
+    assert number_spec.validate(0) is False  # too low
+    assert number_spec.validate(6) is False  # too high
+    assert number_spec.validate("3") is False  # wrong type
+    
+    # Test with a Pydantic model schema
+    class FeedbackModel(BaseModel):
+        rating: int = Field(ge=1, le=5)
+        comment: str = Field(max_length=100)
+        tags: list[str] = Field(min_length=1, max_length=3)
+
+    model_spec = AnnotationSpec(
+        name="Complex Feedback",
+        field_schema=FeedbackModel
+    )
+    
+    # Valid case should return True
+    assert model_spec.validate({
+        "rating": 4,
+        "comment": "Good work!",
+        "tags": ["positive", "helpful"]
+    }) is True
+    
+    # Invalid cases should return False
+    assert model_spec.validate({
+        "rating": 4,
+        "comment": "Good work!"
+        # missing tags
+    }) is False
+    
+    assert model_spec.validate({
+        "rating": 6,  # invalid rating
+        "comment": "Good work!",
+        "tags": ["positive"]
+    }) is False
+    
+    assert model_spec.validate({
+        "rating": 4,
+        "comment": "Good work!",
+        "tags": []  # empty tags list
+    }) is False
+    
+    # Test with a Pydantic Field schema
+    enum_spec = AnnotationSpec(
+        name="Simple Enum",
+        field_schema=Field(enum=["excellent", "good", "fair", "poor"])
+    )
+    
+    # Valid cases should return True
+    assert enum_spec.validate("good") is True
+    assert enum_spec.validate("excellent") is True
+    
+    # Invalid cases should return False
+    assert enum_spec.validate("invalid_choice") is False
+    assert enum_spec.validate(123) is False

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/HumanAnnotation.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/HumanAnnotation.tsx
@@ -129,8 +129,8 @@ export const HumanAnnotationCell: React.FC<HumanAnnotationProps> = props => {
   const {rawValues, mostRecentVal, viewerFeedbackVal} = extractedValues;
 
   const type = useMemo(
-    () => inferTypeFromJsonSchema(props.hfSpec.json_schema ?? {}),
-    [props.hfSpec.json_schema]
+    () => inferTypeFromJsonSchema(props.hfSpec.field_schema ?? {}),
+    [props.hfSpec.field_schema]
   );
 
   if (query?.loading) {
@@ -151,7 +151,7 @@ export const HumanAnnotationCell: React.FC<HumanAnnotationProps> = props => {
     <div className="w-full py-4">
       <FeedbackComponentSelector
         type={type}
-        jsonSchema={props.hfSpec.json_schema ?? {}}
+        jsonSchema={props.hfSpec.field_schema ?? {}}
         focused={props.focused ?? false}
         onAddFeedback={onAddFeedback}
         foundValue={foundValue}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/AnnotationScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/AnnotationScorerForm.tsx
@@ -95,7 +95,7 @@ export const onAnnotationScorerSave = async (
       val: {
         name: data.Name,
         description: data.Description,
-        json_schema: {
+        field_schema: {
           ...data.Type,
           type,
         },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBaseObjectClasses.zod.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBaseObjectClasses.zod.ts
@@ -17,7 +17,7 @@ export type Config = z.infer<typeof ConfigSchema>;
 
 export const AnnotationSpecSchema = z.object({
   description: z.union([z.null(), z.string()]).optional(),
-  json_schema: z.record(z.string(), z.any()).optional(),
+  field_schema: z.record(z.string(), z.any()).optional(),
   name: z.union([z.null(), z.string()]).optional(),
   op_scope: z.union([z.array(z.string()), z.null()]).optional(),
   unique_among_creators: z.boolean().optional(),

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1334,6 +1334,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         validate_feedback_create_req(req)
 
         if req.annotation_ref is not None:
+            # TODO: Make this more robust
             data = self.refs_read_batch(tsi.RefsReadBatchReq(refs=[req.annotation_ref]))
             if len(data.vals) == 0:
                 raise InvalidRequest(f"Annotation ref {req.annotation_ref} not found")
@@ -1341,10 +1342,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             if not is_valid:
                 raise InvalidRequest(f"Feedback payload does not match annotation spec")
             
-            # data.
-            # annotation_ref = ensure_ref_is_valid(
-            #     req.annotation_ref, (ri.InternalObjectRef,)
-            # )
 
         # Augment emoji with alias.
         res_payload = {}

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1338,10 +1338,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             data = self.refs_read_batch(tsi.RefsReadBatchReq(refs=[req.annotation_ref]))
             if len(data.vals) == 0:
                 raise InvalidRequest(f"Annotation ref {req.annotation_ref} not found")
-            is_valid = AnnotationSpec.model_validate(data.vals[0]).validate(req.payload['value'])
+            is_valid = AnnotationSpec.model_validate(data.vals[0]).validate(
+                req.payload["value"]
+            )
             if not is_valid:
-                raise InvalidRequest(f"Feedback payload does not match annotation spec")
-            
+                raise InvalidRequest("Feedback payload does not match annotation spec")
 
         # Augment emoji with alias.
         res_payload = {}

--- a/weave/trace_server/interface/base_object_classes/generated/generated_base_object_class_schemas.json
+++ b/weave/trace_server/interface/base_object_classes/generated/generated_base_object_class_schemas.json
@@ -77,31 +77,36 @@
           "default": null,
           "title": "Description"
         },
-        "json_schema": {
+        "field_schema": {
           "default": {},
-          "description": "Expected to be valid JSON Schema",
+          "description": "Expected to be valid JSON Schema. Can be provided as a dict or a Pydantic model class",
           "examples": [
             {
               "max_length": 100,
               "type": "string"
             },
             {
-              "max": 100,
-              "min": 0,
+              "maximum": 100,
+              "minimum": 0,
               "type": "number"
+            },
+            {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
             },
             {
               "type": "boolean"
             },
             {
-              "options": [
+              "enum": [
                 "option1",
                 "option2"
               ],
-              "type": "categorical"
+              "type": "string"
             }
           ],
-          "title": "Json Schema",
+          "title": "Field Schema",
           "type": "object"
         },
         "unique_among_creators": {


### PR DESCRIPTION
1. Rename `json_schema` to `field_schema`
  - [ ] Todo: verify UI still works
2. Adds backend validation when creating feedback records
  - [ ] Todo: add to sqlite & write better code
3. Allows user to pass a Pydantic BaseModel or Field to the field_schema and not worry about json.