### PR TITLE
fix(weave_query): add refinement op to get types for artifactVersion-files op

### DIFF
--- a/weave-js/src/core/ops/domain/artifactVersion.ts
+++ b/weave-js/src/core/ops/domain/artifactVersion.ts
@@ -179,58 +179,6 @@ export const opArtifactVersionFileCount = makeArtifactVersionOp({
   resolver: ({artifactVersion}) => artifactVersion.fileCount,
 });
 
-export const opArtifactVersionFilesType = makeArtifactVersionOp({
-  name: 'artifactVersion-_files_refine_output_type',
-  argTypes: artifactVersionArgTypes,
-  description: `Returns the type of a ${docType('list')} of ${docType('file', {
-    plural: true,
-  })} of the ${docType('artifactVersion')}`,
-  argDescriptions: {
-    artifactVersion: artifactVersionArgDescription,
-  },
-  hidden: true,
-  returnValueDescription: `The type of a ${docType('list')} of ${docType(
-    'file',
-    {
-      plural: true,
-    }
-  )} of the ${docType('artifactVersion')}`,
-  returnType: inputTypes => 'type',
-  resolver: async (
-    {artifactVersion},
-    rawInputs,
-    inputTypes,
-    forwardGraph,
-    forwardOp,
-    context
-  ) => {
-    try {
-      // This errors if the sequence has been deleted (or a race case in which
-      // the artifact is not created before the history step referencing it comes in)
-      // Note these awaits happen serially!
-      const result = await context.backend.getArtifactFileMetadata(
-        artifactVersion.id,
-        ''
-      );
-      if (result == null || result.type !== 'dir') {
-        throw new Error('opArtifactVersionFiles: not a directory');
-      }
-      // See comment in opArtifactFiles for info about how this currently works.
-      const types = [];
-      for (const fileName of Object.keys(result.files)) {
-        const type = TypeHelpers.filePathToType(
-          result.files[fileName].fullPath
-        );
-        types.push(type);
-      }
-      return list(union(types));
-    } catch (e) {
-      console.warn('Error loading artifact', {err: e, artifactVersion});
-      return list(union([]));
-    }
-  },
-});
-
 export const opArtifactVersionFiles = makeArtifactVersionOp({
   name: 'artifactVersion-files',
   argTypes: artifactVersionArgTypes,
@@ -274,26 +222,6 @@ export const opArtifactVersionFiles = makeArtifactVersionOp({
       console.warn('Error loading artifact', {err: e, artifactVersion});
       return [];
     }
-  },
-  resolveOutputType: async (inputTypes, node, executableNode, client) => {
-    const artifactVersionNode = replaceInputVariables(
-      executableNode.fromOp.inputs.artifactVersion,
-      client.opStore
-    );
-    const refineOp = opArtifactVersionFilesType({
-      artifactVersion: artifactVersionNode,
-    });
-    let result = await client.query(refineOp);
-
-    // This is a Weave1 hack. Weave1's type refinement ops return
-    // tagged/mapped results. But the Weave0 opKinds framework is going to do
-    // the same wrapping to the result we return here. So we unwrap the Weave1
-    // result and let it be rewrapped.
-    if (TypeHelpers.isTaggedValue(result)) {
-      result = TypeHelpers.taggedValueValueType(result);
-    }
-
-    return result ?? 'none';
   },
 });
 

--- a/weave_query/weave_query/ops_domain/artifact_version_ops.py
+++ b/weave_query/weave_query/ops_domain/artifact_version_ops.py
@@ -640,10 +640,21 @@ def file_(
     art_local = _artifact_version_to_wb_artifact(artifactVersion)
     return art_local.path_info(path)  # type: ignore
 
+@op(
+    name="artifactVersion-_files_refine_output_type",
+    hidden=True,
+    output_type=types.TypeType(),
+    plugins=wb_gql_op_plugin(lambda inputs, inner: static_art_file_gql),
+)
+def _files_refine_output_type(artifactVersion: wdt.ArtifactVersion):
+    art_local = _artifact_version_to_wb_artifact(artifactVersion)
+    return types.TypeRegistry.type_of(artifact_wandb.FilesystemArtifactFileIterator(art_local))
+
 
 @op(
     name="artifactVersion-files",
     plugins=wb_gql_op_plugin(lambda inputs, inner: static_art_file_gql),
+    refine_output_type=_files_refine_output_type,
 )
 def files(
     artifactVersion: wdt.ArtifactVersion,


### PR DESCRIPTION
## Description
Fixes [WB-21719](https://wandb.atlassian.net/browse/WB-21719)

A user attempted to render a list of images from an artifact version using **`project.artifactVersion("<art_name>", "<version>").files.content`** which crashes the panel because the **`.content()`** op is meant to display the contents of a text file, not a png.

Since the intention of the user is to render a list of images and the expression **`project.artifactVersion().file("<image.(png|jpg|jpeg)>")`** renders one image file with a `PanelImage`, the **`.files()`** op should also render a list of images.

I added a refinement op for the **`artifactVersion-files`** op.

Accompanying weave-js changes: https://github.com/wandb/weave/pull/3083

## Testing

Before:
![image](https://github.com/user-attachments/assets/27c1f008-f5cc-4325-b0d8-c844009b527d)
![image](https://github.com/user-attachments/assets/db866167-25ba-4a17-a2ec-80d5f4609766)

After:
![image](https://github.com/user-attachments/assets/5608a3c5-db13-4ff0-aad3-bc8e2485392c)


My dev setup doesn't properly show the image assets due to an ssl issue, but in the next screenshot, you can see a table of images being rendered because the file type has been refined:
![image](https://github.com/user-attachments/assets/b8f4c993-a723-44e4-8747-490abb354d06)


How was this PR tested?
- Manually


[WB-21719]: https://wandb.atlassian.net/browse/WB-21719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ