### PR TITLE
fix(weave_query): Ensure newVars are passed in when expanding a panel op

### DIFF
--- a/weave-js/src/components/Panel2/PanelExpression/hooks.ts
+++ b/weave-js/src/components/Panel2/PanelExpression/hooks.ts
@@ -35,8 +35,7 @@ import {
 } from 'react';
 import {DropdownProps} from 'semantic-ui-react';
 
-import {useWeaveFeaturesContext} from '../../../context';
-import {useWeaveContext} from '../../../context';
+import {useWeaveContext, useWeaveFeaturesContext} from '../../../context';
 import {usePrevious} from '../../../hookUtils';
 import {useExpandedNode} from '../../../react';
 import {PanelStack, usePanelStacksForType} from '../availablePanels';
@@ -237,8 +236,10 @@ export function usePanelExpressionState(props: PanelExpressionProps) {
     ? exp
     : refinedExpressionLoader.result;
 
-  const {loading: isExpanding, result: expanded} =
-    useExpandedNode(refinedExpression);
+  const {loading: isExpanding, result: expanded} = useExpandedNode(
+    refinedExpression,
+    newVars
+  );
 
   // Call the user's expression. If the expression contains variables that
   // are no longer present in the frame, then the result is void.

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -1235,10 +1235,15 @@ export const useNodeWithServerType: typeof useNodeWithServerTypeDoNotCallMeDirec
   };
 
 export const useExpandedNode = (
-  node: NodeOrVoidNode
+  node: NodeOrVoidNode,
+  newVars?: {[key: string]: Node} | null
 ): {loading: boolean; result: NodeOrVoidNode} => {
   const [error, setError] = useState();
-  const {stack} = usePanelContext();
+  const {stack: origStack} = usePanelContext();
+
+  const stack = useMemo(() => {
+    return pushFrame(origStack, newVars ?? {});
+  }, [newVars, origStack]);
 
   let dereffedNode: NodeOrVoidNode;
   ({node, dereffedNode} = useRefEqualExpr(node, stack));


### PR DESCRIPTION
## Description

- Fixes [WB-15574](https://wandb.atlassian.net/browse/WB-15574)

The panel op, **`.table()`** crashes the panel when it is used in the following manner:
- `runs.summary["table"].run.table`
- `runs.summary["table"].table.run.table`

The error occurs from a var node being sent to the query engine service. After much debugging and pairing on this with @shawnlewis, we determined that the **`useExpandedNode`** hook was not receiving the frame with the `runs` node, so the solution was to pass in `newVars` from the **`usePanelExpressionState`** hook.

No longer crashes:
![image](https://github.com/user-attachments/assets/f9124487-12b4-400c-8dc2-d343c26dac75)

![image](https://github.com/user-attachments/assets/cd2a6d5b-af20-48dd-82b5-55a9eb551b44)



## Testing

How was this PR tested?
* Manually

[WB-15574]: https://wandb.atlassian.net/browse/WB-15574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ