### PR TITLE
fix(weave_query): prevent table state loss when encountering a new logged column

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/config.ts
+++ b/weave-js/src/components/Panel2/PanelTable/config.ts
@@ -10,7 +10,7 @@ import * as _ from 'lodash';
 import {useCallback} from 'react';
 
 import * as Table from './tableState';
-import {typeShapesMatch} from './util';
+import {typesAreConcattable} from './util';
 
 export enum RowSize {
   Small = 1,
@@ -175,7 +175,7 @@ const typeSafeTableState = (
   if (
     config?.tableStateInputType == null ||
     incomingType == null ||
-    typeShapesMatch(incomingType, config.tableStateInputType)
+    typesAreConcattable(incomingType, config.tableStateInputType)
   ) {
     return config?.tableState;
   } else {
@@ -206,7 +206,7 @@ export const getTableConfig = (
   const mConfig = migrateConfig(config, node);
   const configNeedsReset =
     mConfig?.tableStateInputType != null &&
-    !typeShapesMatch(node.type, mConfig?.tableStateInputType);
+    !typesAreConcattable(node.type, mConfig?.tableStateInputType);
 
   const currentTableState: PanelTableConfig['tableState'] = configNeedsReset
     ? undefined

--- a/weave-js/src/components/Panel2/PanelTable/util.test.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.test.ts
@@ -1,0 +1,75 @@
+import {list, typedDict, union} from '../../../core/model/helpers';
+import {typeShapesMatch} from './util';
+
+describe('typeShapesMatch', () => {
+  it('Matches union types', () => {
+    const colsRunOne = {
+      id: union(['none', 'string']),
+      prediction: union(['none', 'number']),
+      truth: union(['none', 'number']),
+    };
+    const colsRunTwo = {...colsRunOne, has_img: union(['none', 'number'])};
+    const colsRunThree = {...colsRunTwo, test: union(['none', 'number'])};
+    const toType = list(union([typedDict(colsRunTwo), typedDict(colsRunOne)]));
+    const type = list(
+      union([
+        typedDict(colsRunThree),
+        typedDict(colsRunTwo),
+        typedDict(colsRunOne),
+      ])
+    );
+    expect(typeShapesMatch(type, toType)).toBe(true);
+  });
+
+  it('Matches union types that contain typedDict', () => {
+    const colsRunOne = {
+      id: union(['none', 'string']),
+      prediction: union(['none', 'number']),
+      truth: union(['none', 'number']),
+    };
+    const colsRunTwo = {...colsRunOne, prediction: union(['none', 'number'])};
+    const toType = list(typedDict(colsRunOne));
+    const type = list(union([typedDict(colsRunTwo), typedDict(colsRunOne)]));
+    expect(typeShapesMatch(type, toType)).toBe(true);
+  });
+
+  it('Fails when union member of type do not contain all keys of toType', () => {
+    const toType = list(
+      union([
+        typedDict({
+          id: union(['none', 'string']),
+          prediction: union(['none', 'number']),
+        }),
+      ])
+    );
+    const type = list(
+      union([
+        typedDict({id: union(['none', 'string'])}),
+        typedDict({
+          id: union(['none', 'string']),
+          truth: union(['none', 'number']),
+        }),
+      ])
+    );
+    expect(typeShapesMatch(type, toType)).toBe(false);
+  });
+
+  it('matches simple typed dicts', () => {
+    const type1 = typedDict({a: 'number', b: 'string'});
+    const type2 = typedDict({a: 'number', b: 'string'});
+    expect(typeShapesMatch(type1, type2)).toBe(true);
+  });
+
+  it('fails when typed dict is missing properties', () => {
+    const type1 = typedDict({a: 'number'});
+    const type2 = typedDict({a: 'number', b: 'string'});
+    expect(typeShapesMatch(type2, type1)).toBe(true); // type1 can be assigned to type2
+    expect(typeShapesMatch(type1, type2)).toBe(false); // type2 cannot be assigned to type1
+  });
+
+  it('fails when union contains non-typed dict', () => {
+    const baseType = typedDict({a: 'number'});
+    const unionType = union(['string', typedDict({a: 'number'})]);
+    expect(typeShapesMatch(unionType, baseType)).toBe(false);
+  });
+});

--- a/weave-js/src/components/Panel2/PanelTable/util.test.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.test.ts
@@ -1,7 +1,7 @@
 import {list, typedDict, union} from '../../../core/model/helpers';
-import {typeShapesMatch} from './util';
+import {typesAreConcattable} from './util';
 
-describe('typeShapesMatch', () => {
+describe('typesAreConcattable', () => {
   it('Matches union types', () => {
     const colsRunOne = {
       id: union(['none', 'string']),
@@ -18,7 +18,7 @@ describe('typeShapesMatch', () => {
         typedDict(colsRunOne),
       ])
     );
-    expect(typeShapesMatch(type, toType)).toBe(true);
+    expect(typesAreConcattable(type, toType)).toBe(true);
   });
 
   it('Matches union types that contain typedDict', () => {
@@ -30,7 +30,7 @@ describe('typeShapesMatch', () => {
     const colsRunTwo = {...colsRunOne, prediction: union(['none', 'number'])};
     const toType = list(typedDict(colsRunOne));
     const type = list(union([typedDict(colsRunTwo), typedDict(colsRunOne)]));
-    expect(typeShapesMatch(type, toType)).toBe(true);
+    expect(typesAreConcattable(type, toType)).toBe(true);
   });
 
   it('Fails when union member of type do not contain all keys of toType', () => {
@@ -51,25 +51,25 @@ describe('typeShapesMatch', () => {
         }),
       ])
     );
-    expect(typeShapesMatch(type, toType)).toBe(false);
+    expect(typesAreConcattable(type, toType)).toBe(false);
   });
 
   it('matches simple typed dicts', () => {
     const type1 = typedDict({a: 'number', b: 'string'});
     const type2 = typedDict({a: 'number', b: 'string'});
-    expect(typeShapesMatch(type1, type2)).toBe(true);
+    expect(typesAreConcattable(type1, type2)).toBe(true);
   });
 
   it('fails when typed dict is missing properties', () => {
     const type1 = typedDict({a: 'number'});
     const type2 = typedDict({a: 'number', b: 'string'});
-    expect(typeShapesMatch(type2, type1)).toBe(true); // type1 can be assigned to type2
-    expect(typeShapesMatch(type1, type2)).toBe(false); // type2 cannot be assigned to type1
+    expect(typesAreConcattable(type2, type1)).toBe(true); // type1 can be assigned to type2
+    expect(typesAreConcattable(type1, type2)).toBe(false); // type2 cannot be assigned to type1
   });
 
   it('fails when union contains non-typed dict', () => {
     const baseType = typedDict({a: 'number'});
     const unionType = union(['string', typedDict({a: 'number'})]);
-    expect(typeShapesMatch(unionType, baseType)).toBe(false);
+    expect(typesAreConcattable(unionType, baseType)).toBe(false);
   });
 });

--- a/weave-js/src/components/Panel2/PanelTable/util.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.ts
@@ -116,6 +116,13 @@ export const typeShapesMatch = (type: Type, toType: Type): boolean => {
   // This util's original behavior never properly handled comparing two union types together;
   // it just returned true. To minimize the risk of shipping a regression, I am leaving this
   // legacy behavior alone for now.
+
+  // This returns true when comparing:
+  //   Two compatible TypedDicts
+  //   One TypedDict to a compatible Union<TypedDict[]>
+  //   Two Unions of any type
+  //
+  //   Two Lists that contain any of the types mentioned above
   return true;
 };
 

--- a/weave-js/src/components/Panel2/PanelTable/util.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.ts
@@ -5,6 +5,7 @@ import {
   isListLike,
   isTaggedValue,
   isTypedDict,
+  isUnion,
   listObjectType,
   ListType,
   MemoizedHasher,
@@ -18,6 +19,7 @@ import {
   OutputNode,
   taggedValueValueType,
   Type,
+  TypedDictType,
   WeaveInterface,
 } from '@wandb/weave/core';
 import _ from 'lodash';
@@ -60,29 +62,60 @@ export const stripTag = (type: Type): Type => {
   return isTaggedValue(type) ? taggedValueValueType(type) : type;
 };
 
-// Very simple type shape comparison
+// Very simple type shape comparison util used to determine if tableState
+// needs to be reset or not.
 export const typeShapesMatch = (type: Type, toType: Type): boolean => {
-  type = stripTag(type);
-  toType = stripTag(toType);
-  if (isList(type) || isList(toType)) {
-    if (!isList(type) || !isList(toType)) {
-      return false;
-    } else {
-      return typeShapesMatch(listObjectType(type), listObjectType(toType));
-    }
-  } else if (isTypedDict(type) || isTypedDict(toType)) {
-    if (!isTypedDict(type) || !isTypedDict(toType)) {
-      return false;
-    } else {
-      for (const key of Object.keys(toType.propertyTypes)) {
-        const toKeyType = toType.propertyTypes[key]!;
-        const keyType = type.propertyTypes[key];
-        if (keyType === undefined || !typeShapesMatch(keyType, toKeyType)) {
-          return false;
-        }
+  function propertyTypesAreCompatible(
+    incomingTypedDict: TypedDictType,
+    toTypedDict: TypedDictType
+  ) {
+    for (const key of Object.keys(toTypedDict.propertyTypes)) {
+      const keyType = incomingTypedDict.propertyTypes[key];
+      const toKeyType = toTypedDict.propertyTypes[key];
+      if (keyType === undefined || !typeShapesMatch(keyType, toKeyType!)) {
+        return false;
       }
     }
+    return true;
   }
+
+  type = stripTag(type);
+  toType = stripTag(toType);
+
+  // List type handling
+  if (isList(type) || isList(toType)) {
+    return (
+      isList(type) &&
+      isList(toType) &&
+      typeShapesMatch(listObjectType(type), listObjectType(toType))
+    );
+  }
+  // TypedDict type handling
+  if (isTypedDict(type) || isTypedDict(toType)) {
+    // Handle union<typedDict> case
+    //
+    // This is meant for special cases where a user adds another column to their table
+    // in a subsequent run.
+    if (isTypedDict(toType) && isUnion(type)) {
+      return type.members.every(
+        member =>
+          isTypedDict(member) &&
+          isTypedDict(toType) &&
+          propertyTypesAreCompatible(member, toType)
+      );
+    }
+
+    if (!isTypedDict(type) || !isTypedDict(toType)) {
+      return false;
+    }
+
+    return propertyTypesAreCompatible(type, toType);
+  }
+
+  // 2024/11/20, Note from Dom:
+  // This util's original behavior never properly handled comparing two union types together;
+  // it just returned true. To minimize the risk of shipping a regression, I am leaving this
+  // legacy behavior alone for now.
   return true;
 };
 

--- a/weave-js/src/components/Panel2/PanelTable/util.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.ts
@@ -64,7 +64,7 @@ export const stripTag = (type: Type): Type => {
 
 // Very simple type shape comparison util used to determine if tableState
 // needs to be reset or not.
-export const typeShapesMatch = (type: Type, toType: Type): boolean => {
+export const typesAreConcattable = (type: Type, toType: Type): boolean => {
   function propertyTypesAreCompatible(
     incomingTypedDict: TypedDictType,
     toTypedDict: TypedDictType
@@ -72,7 +72,7 @@ export const typeShapesMatch = (type: Type, toType: Type): boolean => {
     for (const key of Object.keys(toTypedDict.propertyTypes)) {
       const keyType = incomingTypedDict.propertyTypes[key];
       const toKeyType = toTypedDict.propertyTypes[key];
-      if (keyType === undefined || !typeShapesMatch(keyType, toKeyType!)) {
+      if (keyType === undefined || !typesAreConcattable(keyType, toKeyType!)) {
         return false;
       }
     }
@@ -87,7 +87,7 @@ export const typeShapesMatch = (type: Type, toType: Type): boolean => {
     return (
       isList(type) &&
       isList(toType) &&
-      typeShapesMatch(listObjectType(type), listObjectType(toType))
+      typesAreConcattable(listObjectType(type), listObjectType(toType))
     );
   }
   // TypedDict type handling


### PR DESCRIPTION
## Description
- Fixes [WB-17336](https://wandb.atlassian.net/browse/WB-17336)

There was a user experience issue causing a table's state (derived columns, sorting, etc) to be wiped when the user logged an additional column with their table in a subsequent run.

Initially I couldn't reproduce it, but realized the issue only occurs after the first new column is added-- subsequent added columns did not reset the table state.

**Root cause**: the **`typeShapesMatch`** util function (only used to determine if tableState should be migrated) does not handle the case of a `type` being a `union<typedDict, typedDict>` and the `toType` being a `typedDict` where the union members match the property types of the `toType`'s `typedDict`.

This fix adds a check when the `toType` is a `typedDict` and the `type` is a `union<typedDict>`. It uses the existing typedDict checking logic to confirm all the members of the union are compatible. I also refactored some of the conditional checks to make it a bit more readable.

I also need to note that the existing behavior did not correctly check the case where two unions are passed in. It will by default return true. In order to reduce the chances of shipping a regression, I've left that untouched and left a comment in the code.

https://github.com/user-attachments/assets/53384985-f791-42f1-859a-108197a9a20b

## Testing
* Unit tests
* Local dev QA


[WB-17336]: https://wandb.atlassian.net/browse/WB-17336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ