### PR TITLE
chore(ui): Update compare evaluation page to use new ToggleButtonGroup

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/ComparePageObjectsLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/ComparePageObjectsLoaded.tsx
@@ -12,6 +12,7 @@ import {useHistory} from 'react-router-dom';
 import {Button} from '../../../../Button';
 import {Icon} from '../../../../Icon';
 import {TailwindContents} from '../../../../Tailwind';
+import {ToggleButtonGroup} from '../../../../ToggleButtonGroup';
 import {isWeaveRef} from '../filters/common';
 import {mapObject, TraverseContext} from '../pages/CallPage/traverse';
 import {SimplePageLayout} from '../pages/common/SimplePageLayout';
@@ -319,26 +320,25 @@ export const ComparePageObjectsLoaded = ({
                   </label>
                 </div>
                 {hasModes && (
-                  <div>
-                    <Button
-                      size="small"
-                      icon="split"
-                      variant="secondary"
-                      onClick={() => onSetMode('parallel')}
-                      active={checkedMode === 'parallel'}
-                      tooltip="Show double column view">
-                      Side-by-side
-                    </Button>
-                    <Button
-                      size="small"
-                      icon="content-full-width"
-                      variant="secondary"
-                      onClick={() => onSetMode('unified')}
-                      active={checkedMode === 'unified'}
-                      tooltip="Show single column view">
-                      Unified
-                    </Button>
-                  </div>
+                  <ToggleButtonGroup
+                    options={[
+                      {
+                        value: 'parallel',
+                        label: 'Side-by-side',
+                        icon: 'split',
+                        tooltip: 'Show double column view',
+                      },
+                      {
+                        value: 'unified',
+                        label: 'Unified',
+                        icon: 'content-full-width',
+                        tooltip: 'Show single column view',
+                      },
+                    ]}
+                    size="small"
+                    value={checkedMode}
+                    onValueChange={value => onSetMode(value as Mode)}
+                  />
                 )}
                 {tooManyCols && (
                   <div>Viewing first {MAX_OBJECT_COLS} columns only</div>

--- a/weave-js/src/components/ToggleButtonGroup.tsx
+++ b/weave-js/src/components/ToggleButtonGroup.tsx
@@ -1,5 +1,5 @@
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
-import React from 'react';
+import React, {ReactElement} from 'react';
 import {twMerge} from 'tailwind-merge';
 
 import {Button, ButtonSize} from './Button';
@@ -10,6 +10,8 @@ export type ToggleOption = {
   value: string;
   icon?: IconName;
   isDisabled?: boolean;
+  label?: string;
+  tooltip?: ReactElement | string;
 };
 
 export type ToggleButtonGroupProps = {
@@ -54,7 +56,13 @@ export const ToggleButtonGroup = React.forwardRef<
         className="flex gap-px"
         ref={ref}>
         {options.map(
-          ({value: optionValue, icon, isDisabled: optionIsDisabled}) => (
+          ({
+            value: optionValue,
+            icon,
+            isDisabled: optionIsDisabled,
+            label,
+            tooltip,
+          }) => (
             <ToggleGroup.Item
               key={optionValue}
               value={optionValue}
@@ -63,6 +71,7 @@ export const ToggleButtonGroup = React.forwardRef<
               <Button
                 icon={icon}
                 size={size}
+                tooltip={tooltip}
                 className={twMerge(
                   size === 'small' &&
                     (icon ? 'gap-4 px-4 py-3 text-sm' : 'px-8 py-3 text-sm'),
@@ -81,7 +90,7 @@ export const ToggleButtonGroup = React.forwardRef<
                   'first:rounded-l-sm', // First button rounded left
                   'last:rounded-r-sm' // Last button rounded right
                 )}>
-                {optionValue}
+                {label ?? optionValue}
               </Button>
             </ToggleGroup.Item>
           )


### PR DESCRIPTION
## Description

Use the new ToggleButtonGroup component on the Weave Compare page.

## Testing

How was this PR tested?
