### PR TITLE
chore(weave): hide litellm from error messages

### DIFF
--- a/weave/trace_server/llm_completion.py
+++ b/weave/trace_server/llm_completion.py
@@ -14,4 +14,6 @@ def lite_llm_completion(
         )
         return tsi.CompletionsCreateRes(response=res.model_dump())
     except Exception as e:
-        return tsi.CompletionsCreateRes(response={"error": str(e)})
+        error_message = str(e)
+        error_message = error_message.replace("litellm.", "")
+        return tsi.CompletionsCreateRes(response={"error": error_message})


### PR DESCRIPTION
## Description
before 
<img width="568" alt="Screenshot 2024-11-22 at 4 49 16 PM" src="https://github.com/user-attachments/assets/c9608c38-7f4a-4930-a3e2-201a9c70b25f">

after
<img width="553" alt="Screenshot 2024-11-22 at 4 50 28 PM" src="https://github.com/user-attachments/assets/ad25d727-93ab-408b-84f8-f8f214ed9104">
<img width="320" alt="Screenshot 2024-11-22 at 4 50 18 PM" src="https://github.com/user-attachments/assets/5ee84b64-e484-4fef-86d3-859018a8003c">
