### PR TITLE
fix(weave): netrc entry handling in Weave JS SDK login method

### DIFF
--- a/sdks/node/src/__tests__/login.test.ts
+++ b/sdks/node/src/__tests__/login.test.ts
@@ -43,7 +43,7 @@ describe('login', () => {
     });
     expect(mockSave).toHaveBeenCalled();
     expect(console.log).toHaveBeenCalledWith(
-      'Successfully logged in.  Credentials saved for api.wandb.ai'
+      'Successfully logged in. Credentials saved for api.wandb.ai'
     );
   });
 

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -24,6 +24,9 @@ export async function login(apiKey: string, host?: string) {
     console.warn('No host provided, using default host:', defaultHost);
     host = defaultHost;
   }
+  if (!apiKey) {
+    throw new Error('API key is required for login. Please provide a valid API key.');
+  }
   const {traceBaseUrl} = getUrls(host);
 
   // Test the connection to the traceServerApi
@@ -45,9 +48,12 @@ export async function login(apiKey: string, host?: string) {
   }
 
   const netrc = new Netrc();
-  netrc.setEntry({machine: host, login: 'user', password: apiKey});
-  netrc.save();
-  console.log(`Successfully logged in.  Credentials saved for ${host}`);
+  // Only save to netrc if host and a non-empty apiKey are provided
+  if (host && apiKey.trim()) {
+    netrc.setEntry({machine: host, login: 'user', password: apiKey});
+    netrc.save();
+    console.log(`Successfully logged in. Credentials saved for ${host}`);
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-22046](https://wandb.atlassian.net/browse/WB-22046)

This PR resolves an issue in the Weave JS SDK's login method where the `.netrc` file was being modified or created incorrectly if the `apiKey` arg was empty.

Changes:
- Added a validation check to ensure the `apiKey` is provided and non-empty
- Throws an error if the `apiKey` is missing
- Prevents overwriting existing `.netrc` entries unless both `host` and `apiKey` are valid and non-empty

Key fixes:
- Ensures that `.netrc` entries remain intact and prevent removal of the password line for existing entries
- Avoids introducing extra blank lines between machine blocks in the `.netrc` file

## Testing

To reproduce the issue:
- Start with an existing `.netrc` file containing valid machine entries
- Execute the following JS script where `login` method is missing the `apiKey` arg
```
import * as weave from 'weave';
async function main() {
    await weave.login()
    await weave.init('examples');
    console.log('Hello there, Weave JS');
}
main().catch(console.error);
```
- The .netrc file gets modified incorrectly (password line of api.wandb.ai is removed and blank lines are introduced between machine blocks)

Fix testing:
- Verified that `.netrc` won't be created, if doesn't already exist, and no `apiKey` is provided
- Verified that previous valid entries in `.netrc` remain intact when `weave.login()` is invoked


[WB-22046]: https://wandb.atlassian.net/browse/WB-22046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ