### PR TITLE
fixed a bug where Evaluation.predict_and_score tried accessing __name

### DIFF
--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -107,6 +107,23 @@ def test_evaluate_other_model_method_names():
     assert result == expected_eval_result
 
 
+def test_evaluate_model_with__call__(client):
+    class EvalModel(Model):
+        @weave.op()
+        async def infer(self, input) -> str:
+            return eval(input)
+
+        def __call__(self, *args, **kwargs):
+            return self.infer(*args, **kwargs)
+
+    evaluation = Evaluation(
+        dataset=dataset_rows,
+        scorers=[score],
+    )
+    result = asyncio.run(evaluation.evaluate(EvalModel()))
+    assert result == expected_eval_result
+
+
 def test_score_as_class(client):
     class MyScorer(weave.Scorer):
         @weave.op()

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -5,6 +5,7 @@ import textwrap
 import time
 import traceback
 from collections.abc import Coroutine
+from inspect import isfunction
 from typing import Any, Callable, Literal, Optional, Union, cast
 
 from pydantic import PrivateAttr
@@ -165,9 +166,12 @@ class Evaluation(Object):
 
         model_self = None
         model_predict: Union[Callable, Model]
-        if callable(model):
+        if callable(model) and isfunction(model):
             model_predict = model
         else:
+            if not isinstance(model, Model):
+                raise ValueError(INVALID_MODEL_ERROR)
+
             model_self = model
             model_predict = get_infer_method(model)
 


### PR DESCRIPTION
…__ on a Callable instance

## Description

Fixes #3070 

What does the PR do? Include a concise description of the PR contents.

Added a check for whether the given callable to `Evaluation.evaluate` is a function. This prevents trying to access the `__name__` attribute on an instance of `Model`, and the instance predict method is correctly picked by `get_infer_method`

## Testing

Added a test in `tests/trace/test_evaluate.py` that defines a Model class with a `__call__` method and runs an evaluation. Validated that if I remove my fix the test fails
