### PR TITLE
chore(weave): add headers to llm dropdown, and default the value

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
@@ -2,7 +2,12 @@ import {Box} from '@mui/material';
 import {Select} from '@wandb/weave/components/Form/Select';
 import React from 'react';
 
-import {LLM_MAX_TOKENS, LLMMaxTokensKey} from '../llmMaxTokens';
+import {
+  LLM_MAX_TOKENS,
+  LLM_PROVIDER_LABELS,
+  LLM_PROVIDERS,
+  LLMMaxTokensKey,
+} from '../llmMaxTokens';
 
 interface LLMDropdownProps {
   value: LLMMaxTokensKey;
@@ -10,11 +15,23 @@ interface LLMDropdownProps {
 }
 
 export const LLMDropdown: React.FC<LLMDropdownProps> = ({value, onChange}) => {
-  const options: Array<{value: LLMMaxTokensKey; label: LLMMaxTokensKey}> =
-    Object.keys(LLM_MAX_TOKENS).map(llm => ({
-      value: llm as LLMMaxTokensKey,
-      label: llm as LLMMaxTokensKey,
-    }));
+  const options = LLM_PROVIDERS.map(provider => ({
+    // for each provider, get all the LLMs that are supported by that provider
+    label: LLM_PROVIDER_LABELS[provider],
+    // filtering to the LLMs that are supported by that provider
+    options: Object.keys(LLM_MAX_TOKENS).reduce<
+      Array<{group: string; label: string; value: string}>
+    >((acc, llm) => {
+      if (LLM_MAX_TOKENS[llm as LLMMaxTokensKey].provider === provider) {
+        acc.push({
+          group: provider,
+          label: llm,
+          value: llm,
+        });
+      }
+      return acc;
+    }, []),
+  }));
 
   return (
     <Box
@@ -29,14 +46,12 @@ export const LLMDropdown: React.FC<LLMDropdownProps> = ({value, onChange}) => {
         },
       }}>
       <Select
-        value={options.find(opt => opt.value === value)}
+        value={options.flatMap(o => o.options).find(o => o.value === value)}
         onChange={option => {
           if (option) {
             const maxTokens =
-              LLM_MAX_TOKENS[
-                (option as {value: string}).value as keyof typeof LLM_MAX_TOKENS
-              ]?.max_tokens || 0;
-            onChange((option as {value: LLMMaxTokensKey}).value, maxTokens);
+              LLM_MAX_TOKENS[option.value as LLMMaxTokensKey]?.max_tokens || 0;
+            onChange(option.value as LLMMaxTokensKey, maxTokens);
           }
         }}
         options={options}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
@@ -1,123 +1,252 @@
 // This is a mapping of LLM names to their max token limits.
 // Directly from the pycache model_providers.json in trace_server.
 // Some were removed because they are not supported when Josiah tried on Oct 30, 2024.
+// Others were removed because we want users to use models with the dates
 export const LLM_MAX_TOKENS = {
-  'gpt-4o-mini': {max_tokens: 16384, supports_function_calling: true},
+  'gpt-4o-mini-2024-07-18': {
+    provider: 'openai',
+    max_tokens: 16384,
+    supports_function_calling: true,
+  },
+  'gpt-3.5-turbo-0125': {
+    provider: 'openai',
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'gpt-3.5-turbo-1106': {
+    provider: 'openai',
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'gpt-3.5-turbo-16k': {
+    provider: 'openai',
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'gpt-4o-2024-05-13': {
+    provider: 'openai',
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'gpt-4o-2024-08-06': {
+    provider: 'openai',
+    max_tokens: 16384,
+    supports_function_calling: true,
+  },
+  'o1-mini-2024-09-12': {
+    provider: 'openai',
+    max_tokens: 32768,
+    supports_function_calling: true,
+  },
+
   'claude-3-5-sonnet-20240620': {
+    provider: 'anthropic',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'claude-3-5-sonnet-20241022': {
+    provider: 'anthropic',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'claude-3-haiku-20240307': {
+    provider: 'anthropic',
     max_tokens: 4096,
     supports_function_calling: true,
   },
-  'claude-3-opus-20240229': {max_tokens: 4096, supports_function_calling: true},
+  'claude-3-opus-20240229': {
+    provider: 'anthropic',
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
   'claude-3-sonnet-20240229': {
+    provider: 'anthropic',
     max_tokens: 4096,
     supports_function_calling: true,
   },
+
   'gemini/gemini-1.5-flash-001': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-flash-002': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-flash-8b-exp-0827': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-flash-8b-exp-0924': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-flash-exp-0827': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-flash-latest': {
-    max_tokens: 8192,
-    supports_function_calling: true,
-  },
-  'gemini/gemini-1.5-flash': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-pro-001': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-pro-002': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-pro-exp-0801': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-pro-exp-0827': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'gemini/gemini-1.5-pro-latest': {
+    provider: 'gemini',
     max_tokens: 8192,
     supports_function_calling: true,
   },
-  'gemini/gemini-1.5-pro': {max_tokens: 8192, supports_function_calling: true},
-  'gemini/gemini-pro': {max_tokens: 8192, supports_function_calling: true},
-  'gpt-3.5-turbo-0125': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-3.5-turbo-1106': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-3.5-turbo-16k': {max_tokens: 4096, supports_function_calling: false},
-  'gpt-3.5-turbo': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4-0125-preview': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4-0314': {max_tokens: 4096, supports_function_calling: false},
-  'gpt-4-0613': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4-1106-preview': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4-32k-0314': {max_tokens: 4096, supports_function_calling: false},
-  'gpt-4-turbo-2024-04-09': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4-turbo-preview': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4-turbo': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4o-2024-05-13': {max_tokens: 4096, supports_function_calling: true},
-  'gpt-4o-2024-08-06': {max_tokens: 16384, supports_function_calling: true},
-  'gpt-4o-mini-2024-07-18': {
-    max_tokens: 16384,
+  'gemini/gemini-pro': {
+    provider: 'gemini',
+    max_tokens: 8192,
     supports_function_calling: true,
   },
-  'gpt-4o': {max_tokens: 4096, supports_function_calling: true},
-  'groq/gemma-7b-it': {max_tokens: 8192, supports_function_calling: true},
-  'groq/gemma2-9b-it': {max_tokens: 8192, supports_function_calling: true},
+
+  'groq/gemma-7b-it': {
+    provider: 'groq',
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'groq/gemma2-9b-it': {
+    provider: 'groq',
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
   'groq/llama-3.1-70b-versatile': {
+    provider: 'groq',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'groq/llama-3.1-8b-instant': {
+    provider: 'groq',
     max_tokens: 8192,
     supports_function_calling: true,
   },
-  'groq/llama3-70b-8192': {max_tokens: 8192, supports_function_calling: true},
-  'groq/llama3-8b-8192': {max_tokens: 8192, supports_function_calling: true},
+  'groq/llama3-70b-8192': {
+    provider: 'groq',
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'groq/llama3-8b-8192': {
+    provider: 'groq',
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
   'groq/llama3-groq-70b-8192-tool-use-preview': {
+    provider: 'groq',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'groq/llama3-groq-8b-8192-tool-use-preview': {
+    provider: 'groq',
     max_tokens: 8192,
     supports_function_calling: true,
   },
   'groq/mixtral-8x7b-32768': {
+    provider: 'groq',
     max_tokens: 32768,
     supports_function_calling: true,
   },
-  'o1-mini-2024-09-12': {max_tokens: 65536, supports_function_calling: true},
-  'o1-mini': {max_tokens: 65536, supports_function_calling: true},
-  'o1-preview-2024-09-12': {max_tokens: 32768, supports_function_calling: true},
-  'o1-preview': {max_tokens: 32768, supports_function_calling: true},
 };
 
 export type LLMMaxTokensKey = keyof typeof LLM_MAX_TOKENS;
+
+export const LLM_PROVIDERS = ['openai', 'anthropic', 'gemini', 'groq'];
+export const LLM_PROVIDER_LABELS: Record<
+  (typeof LLM_PROVIDERS)[number],
+  string
+> = {
+  openai: 'OpenAI',
+  anthropic: 'Anthropic',
+  gemini: 'Gemini',
+  groq: 'Groq',
+};
+
+export const LLM_MAX_TOKENS_KEYS: LLMMaxTokensKey[] = Object.keys(
+  LLM_MAX_TOKENS
+) as LLMMaxTokensKey[];
+
+// Helper function to calculate string similarity using Levenshtein distance
+const getLevenshteinDistance = (str1: string, str2: string): number => {
+  const track = Array(str2.length + 1)
+    .fill(null)
+    .map(() => Array(str1.length + 1).fill(null));
+
+  for (let i = 0; i <= str1.length; i++) {
+    track[0][i] = i;
+  }
+  for (let j = 0; j <= str2.length; j++) {
+    track[j][0] = j;
+  }
+
+  for (let j = 1; j <= str2.length; j++) {
+    for (let i = 1; i <= str1.length; i++) {
+      const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
+      track[j][i] = Math.min(
+        track[j][i - 1] + 1, // deletion
+        track[j - 1][i] + 1, // insertion
+        track[j - 1][i - 1] + indicator // substitution
+      );
+    }
+  }
+  return track[str2.length][str1.length];
+};
+
+// Main function to find most similar LLM name
+export const findMostSimilarLLMName = (
+  input: string,
+  llmList: LLMMaxTokensKey[]
+): string => {
+  const normalizedInput = input.toLowerCase().trim();
+
+  // If exact match exists, return it
+  if (llmList.includes(normalizedInput as LLMMaxTokensKey)) {
+    return normalizedInput;
+  }
+
+  let closestMatch = llmList[0];
+  let smallestDistance = Infinity;
+
+  llmList.forEach(llmName => {
+    const distance = getLevenshteinDistance(
+      normalizedInput,
+      llmName.toLowerCase()
+    );
+
+    if (distance < smallestDistance) {
+      smallestDistance = distance;
+      closestMatch = llmName;
+    }
+
+    if (llmName.includes(normalizedInput)) {
+      closestMatch = llmName;
+      smallestDistance = 0;
+    }
+  });
+
+  return closestMatch;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -1,6 +1,11 @@
+import {toast} from '@wandb/weave/common/components/elements/Toast';
 import {SetStateAction, useCallback, useState} from 'react';
 
-import {LLMMaxTokensKey} from './llmMaxTokens';
+import {
+  findMostSimilarLLMName,
+  LLM_MAX_TOKENS_KEYS,
+  LLMMaxTokensKey,
+} from './llmMaxTokens';
 import {
   OptionalTraceCallSchema,
   PlaygroundResponseFormats,
@@ -34,7 +39,7 @@ const DEFAULT_PLAYGROUND_STATE = {
   presencePenalty: 0,
   //   nTimes: 1,
   maxTokensLimit: 16384,
-  model: 'gpt-4o-mini' as LLMMaxTokensKey,
+  model: 'gpt-4o-mini-2024-07-18' as LLMMaxTokensKey,
 };
 
 export const usePlaygroundState = () => {
@@ -105,6 +110,20 @@ export const usePlaygroundState = () => {
         }
         if (inputs.presence_penalty) {
           newState.presencePenalty = parseFloat(inputs.presence_penalty);
+        }
+        if (inputs.model) {
+          if (LLM_MAX_TOKENS_KEYS.includes(inputs.model as LLMMaxTokensKey)) {
+            newState.model = inputs.model as LLMMaxTokensKey;
+          } else {
+            const closestModel = findMostSimilarLLMName(
+              inputs.model,
+              LLM_MAX_TOKENS_KEYS
+            );
+            toast(
+              `We currently don't support ${inputs.model}, in the playground. We will default to ${closestModel}`
+            );
+            newState.model = closestModel as LLMMaxTokensKey;
+          }
         }
         return [newState];
       });


### PR DESCRIPTION
## Description

most of the changes are the smart default functions, and moving the llms around in the llmMaxTokens file
adds headers to llm dropdown
loads in the value of the llm properly
adds functionality to smart default the llm choice
removes llms that dont have the date per this [message](https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1732302017535609?thread_ts=1732301870.749439&cid=C03BSTEBD7F)


![Screenshot 2024-11-25 at 12 11 47 PM](https://github.com/user-attachments/assets/ad51febf-a0f8-4b11-bab1-03fad14891e1)
![Screenshot 2024-11-25 at 12 00 19 PM](https://github.com/user-attachments/assets/2ca90dba-ddf8-401e-bf4a-998e43995b23)


## Testing

How was this PR tested?
