### PR TITLE
perf(ui): second cost query ignore all expensive columns

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/costUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/costUtils.ts
@@ -102,7 +102,23 @@ export const addCostsToCallResults = (
 
   return callResults.map(call => {
     if (call.callId && costDict[call.callId]) {
-      return {...call, ...costDict[call.callId]};
+      if (!call.traceCall) {
+        return call;
+      }
+      return {
+        ...call,
+        traceCall: {
+          ...call.traceCall,
+          summary: {
+            ...call.traceCall?.summary,
+            usage: costDict[call.callId].traceCall?.summary?.usage,
+            weave: {
+              ...call.traceCall?.summary?.weave,
+              costs: costDict[call.callId].traceCall?.summary?.weave?.costs,
+            },
+          },
+        },
+      };
     }
     return call;
   });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/costUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/costUtils.ts
@@ -111,7 +111,6 @@ export const addCostsToCallResults = (
           ...call.traceCall,
           summary: {
             ...call.traceCall?.summary,
-            usage: costDict[call.callId].traceCall?.summary?.usage,
             weave: {
               ...call.traceCall?.summary?.weave,
               costs: costDict[call.callId].traceCall?.summary?.weave?.costs,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -96,6 +96,7 @@ export const useCallsForQuery = (
     [calls.result]
   );
 
+  const costCols = useMemo(() => ['id'], []);
   const costs = useCalls(
     entity,
     project,
@@ -104,12 +105,11 @@ export const useCallsForQuery = (
     undefined,
     sortBy,
     undefined,
-    undefined,
+    costCols,
     expandedColumns,
     {
       skip: calls.loading,
       includeCosts: true,
-      includeFeedback: true,
     }
   );
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr removes all expensive columns from the second calls query intended to inject costs into the calls table. There are currently many queries that fail in the UI due to the sheer amount of data required to load the trace page, either causing a memory exception or a timeout on formatting. Most of these errors occur in the full fat cost query, lets see if this reduces the impact of these.

## Testing

👀 

### Openui
Prod: 
<img width="604" alt="Screenshot 2024-11-25 at 2 23 35 PM" src="https://github.com/user-attachments/assets/dc1aeb48-b4fd-4d02-820d-c545fae96026">

This branch:
<img width="603" alt="Screenshot 2024-11-25 at 2 23 55 PM" src="https://github.com/user-attachments/assets/26a92dbd-91f7-490f-a7c7-bbe01f708ace">

### Heavy proj
Prod:
<img width="603" alt="Screenshot 2024-11-25 at 2 29 24 PM" src="https://github.com/user-attachments/assets/df97e82d-e0bb-4615-a6ee-0ab187124f65">


This branch:
<img width="603" alt="Screenshot 2024-11-25 at 2 28 01 PM" src="https://github.com/user-attachments/assets/1cf4fee9-c93d-4949-b20e-3b17c1c7e775">
