### PR TITLE
fix(ui): compare cells with boolean values appearing empty

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridCellValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridCellValue.tsx
@@ -66,5 +66,9 @@ export const CompareGridCellValue = ({
     return <ValueViewNumber value={value} />;
   }
 
+  if (valueType === 'boolean') {
+    return <ValueViewPrimitive>{value.toString()}</ValueViewPrimitive>;
+  }
+
   return <div>{value}</div>;
 };


### PR DESCRIPTION
## Description

Boolean values in comparison grid were not rendering.

Before:
<img width="1034" alt="Screenshot 2024-11-25 at 3 28 05 PM" src="https://github.com/user-attachments/assets/78ce689e-d98a-4453-b92a-72593f9c4347">

After:
<img width="1067" alt="Screenshot 2024-11-25 at 3 25 46 PM" src="https://github.com/user-attachments/assets/b4c00901-f7fd-450a-b725-b9dc2d8ecbbb">


## Testing

How was this PR tested?
