### PR TITLE
chore(ui): call tree costs fix

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -417,14 +417,11 @@ export const useCallFlattenedTraceTree = (
   );
 
   const costResult = useMemo(() => {
-    return costs.result ?? [];
-  }, [costs.result]);
+    return addCostsToCallResults(traceCallsResult, costs.result ?? []);
+  }, [costs.result, traceCallsResult]);
 
   const traceCallMap = useMemo(() => {
-    const result =
-      costResult.length > 0
-        ? addCostsToCallResults(traceCallsResult, costResult)
-        : traceCallsResult;
+    const result = costResult.length > 0 ? costResult : traceCallsResult;
     return _.keyBy(result, 'callId');
   }, [costResult, traceCallsResult]);
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[This pr](https://github.com/wandb/weave/commit/c16ac3dcae10c8d02117898c361073af67e0988b) broke the summary in top level trace tree components. 

Trace tree blows away existing summary by updating twice. Set the costs once at the source of truth.
