### PR TITLE
fix(ui): improved comparison performance and object handling

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeDiff.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeDiff.tsx
@@ -17,6 +17,8 @@ type CodeDiffProps = {
   maxLines?: number;
 };
 
+const DEFAULT_MAX_LINES = 20;
+
 export const CodeDiff = ({
   oldValueRef,
   newValueRef,
@@ -81,7 +83,7 @@ export const CodeDiff = ({
     );
 
   const totalLines = sanitizedNew.split('\n').length ?? 0;
-  const showLines = Math.min(totalLines, maxLines ?? 20);
+  const showLines = Math.min(totalLines, maxLines ?? DEFAULT_MAX_LINES);
   const lineHeight = 18;
   const padding = 20;
   const height = showLines * lineHeight + padding + 'px';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeDiff.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeDiff.tsx
@@ -9,31 +9,19 @@ import React from 'react';
 import {sanitizeString} from '../../../../../util/sanitizeSecrets';
 import {Loading} from '../../../../Loading';
 import {useWFHooks} from '../pages/wfReactInterface/context';
-
-// Simple language detection based on file extension or content
-// TODO: Unify this utility method with Browse2OpDefCode.tsx
-const detectLanguage = (uri: string, code: string) => {
-  if (uri.endsWith('.py')) {
-    return 'python';
-  }
-  if (uri.endsWith('.js') || uri.endsWith('.ts')) {
-    return 'javascript';
-  }
-  if (code.includes('def ') || code.includes('import ')) {
-    return 'python';
-  }
-  if (code.includes('function ') || code.includes('const ')) {
-    return 'javascript';
-  }
-  return 'plaintext';
-};
+import {detectLanguage} from './CodeView';
 
 type CodeDiffProps = {
   oldValueRef: string;
   newValueRef: string;
+  maxLines?: number;
 };
 
-export const CodeDiff = ({oldValueRef, newValueRef}: CodeDiffProps) => {
+export const CodeDiff = ({
+  oldValueRef,
+  newValueRef,
+  maxLines,
+}: CodeDiffProps) => {
   const {
     derived: {useCodeForOpRef},
   } = useWFHooks();
@@ -65,6 +53,10 @@ export const CodeDiff = ({oldValueRef, newValueRef}: CodeDiffProps) => {
           readOnly: true,
           minimap: {enabled: false},
           scrollBeyondLastLine: false,
+          scrollbar: {
+            handleMouseWheel: true, // Make horizontal scrolling with wheel work
+            alwaysConsumeMouseWheel: false, // Don't capture page scroll
+          },
           padding: {top: 10, bottom: 10},
           renderSideBySide: false,
         }}
@@ -79,14 +71,17 @@ export const CodeDiff = ({oldValueRef, newValueRef}: CodeDiffProps) => {
           readOnly: true,
           minimap: {enabled: false},
           scrollBeyondLastLine: false,
+          scrollbar: {
+            handleMouseWheel: true, // Make horizontal scrolling with wheel work
+            alwaysConsumeMouseWheel: false, // Don't capture page scroll
+          },
           padding: {top: 10, bottom: 10},
         }}
       />
     );
 
-  const maxRowsInView = 20;
   const totalLines = sanitizedNew.split('\n').length ?? 0;
-  const showLines = Math.min(totalLines, maxRowsInView);
+  const showLines = Math.min(totalLines, maxLines ?? 20);
   const lineHeight = 18;
   const padding = 20;
   const height = showLines * lineHeight + padding + 'px';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeView.tsx
@@ -1,0 +1,76 @@
+/**
+ * Show code in the Monaco editor.
+ */
+
+import {Editor} from '@monaco-editor/react';
+import {Box} from '@mui/material';
+import React from 'react';
+
+import {sanitizeString} from '../../../../../util/sanitizeSecrets';
+import {Loading} from '../../../../Loading';
+import {useWFHooks} from '../pages/wfReactInterface/context';
+
+// Simple language detection based on file extension or content
+// TODO: Unify this utility method with Browse2OpDefCode.tsx
+export const detectLanguage = (uri: string, code: string) => {
+  if (uri.endsWith('.py')) {
+    return 'python';
+  }
+  if (uri.endsWith('.js') || uri.endsWith('.ts')) {
+    return 'javascript';
+  }
+  if (code.includes('def ') || code.includes('import ')) {
+    return 'python';
+  }
+  if (code.includes('function ') || code.includes('const ')) {
+    return 'javascript';
+  }
+  return 'plaintext';
+};
+
+type CodeViewProps = {
+  uri: string;
+  maxLines?: number;
+};
+
+export const CodeView = ({uri, maxLines}: CodeViewProps) => {
+  const {
+    derived: {useCodeForOpRef},
+  } = useWFHooks();
+  const opContentsQuery = useCodeForOpRef(uri);
+  const text = opContentsQuery.result ?? '';
+  const {loading} = opContentsQuery;
+
+  if (loading) {
+    return <Loading centered size={25} />;
+  }
+
+  const sanitized = sanitizeString(text);
+  const language = detectLanguage(uri, sanitized);
+
+  const inner = (
+    <Editor
+      height="100%"
+      language={language}
+      loading={loading}
+      value={sanitized}
+      options={{
+        readOnly: true,
+        minimap: {enabled: false},
+        scrollBeyondLastLine: false,
+        scrollbar: {
+          handleMouseWheel: true, // Make horizontal scrolling with wheel work
+          alwaysConsumeMouseWheel: false, // Don't capture page scroll
+        },
+        padding: {top: 10, bottom: 10},
+      }}
+    />
+  );
+
+  const totalLines = sanitized.split('\n').length ?? 0;
+  const showLines = Math.min(totalLines, maxLines ?? 20);
+  const lineHeight = 18;
+  const padding = 20;
+  const height = showLines * lineHeight + padding + 'px';
+  return <Box sx={{height}}>{inner}</Box>;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeView.tsx
@@ -33,6 +33,8 @@ type CodeViewProps = {
   maxLines?: number;
 };
 
+const DEFAULT_MAX_LINES = 20;
+
 export const CodeView = ({uri, maxLines}: CodeViewProps) => {
   const {
     derived: {useCodeForOpRef},
@@ -68,7 +70,7 @@ export const CodeView = ({uri, maxLines}: CodeViewProps) => {
   );
 
   const totalLines = sanitized.split('\n').length ?? 0;
-  const showLines = Math.min(totalLines, maxLines ?? 20);
+  const showLines = Math.min(totalLines, maxLines ?? DEFAULT_MAX_LINES);
   const lineHeight = 18;
   const padding = 20;
   const height = showLines * lineHeight + padding + 'px';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridCell.tsx
@@ -11,7 +11,6 @@ import {ObjectPath} from '../pages/CallPage/traverse';
 import {CodeDiff} from './CodeDiff';
 import {CompareGridCellValue} from './CompareGridCellValue';
 import {CompareGridPill} from './CompareGridPill';
-import {RESOLVED_REF_KEY} from './refUtil';
 
 const ARROW = '→';
 
@@ -34,21 +33,11 @@ export const CompareGridCell = ({
   compareValueType,
   rowChangeType,
 }: CompareGridCellProps) => {
-  if (valueType === 'array') {
-    return null;
-  }
-
   // If all of the row values are the same we can just display the value
   if (rowChangeType === 'UNCHANGED' && _.isEqual(value, compareValue)) {
     return (
       <CompareGridCellValue path={path} value={value} valueType={valueType} />
     );
-  }
-
-  if (valueType === 'object' && compareValueType === 'object') {
-    if (!(RESOLVED_REF_KEY in value) || !(RESOLVED_REF_KEY in compareValue)) {
-      return null;
-    }
   }
 
   if (valueType === 'code' && compareValueType === 'code') {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridCellValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridCellValue.tsx
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 
+import {maybePluralizeWord} from '../../../../../core/util/string';
 import {parseRef} from '../../../../../react';
 import {UserLink} from '../../../../UserLink';
 import {SmallRef} from '../../Browse2/SmallRef';
@@ -49,11 +50,26 @@ export const CompareGridCellValue = ({
     if (RESOLVED_REF_KEY in value) {
       return <SmallRef objRef={parseRef(value[RESOLVED_REF_KEY])} />;
     }
-    // We don't need to show anything for this row because user can expand it to compare child keys
-    return null;
+    const objSize = Object.keys(value).length;
+    return (
+      <div className="flex items-center gap-4">
+        <ValueViewPrimitive>object</ValueViewPrimitive>{' '}
+        <span>
+          {objSize.toLocaleString()} {maybePluralizeWord(objSize, 'key')}
+        </span>
+      </div>
+    );
   }
   if (valueType === 'array') {
-    return <ValueViewPrimitive>array</ValueViewPrimitive>;
+    const arrSize = value.length;
+    return (
+      <div className="flex items-center gap-4">
+        <ValueViewPrimitive>array</ValueViewPrimitive>{' '}
+        <span>
+          {arrSize.toLocaleString()} {maybePluralizeWord(arrSize, 'item')}
+        </span>
+      </div>
+    );
   }
 
   if (valueType === 'number') {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridCellValueCode.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridCellValueCode.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {Browse2OpDefCode} from '../../Browse2/Browse2OpDefCode';
+import {CodeView} from './CodeView';
 
 type CompareGridCellValueCodeProps = {
   value: string;
@@ -10,11 +10,9 @@ export const CompareGridCellValueCode = ({
   value,
 }: CompareGridCellValueCodeProps) => {
   // Negative margin used to invert (mostly) the padding that we add to other cell types
-  // TODO: For better code layout/dependency management might be better to duplicate
-  //       Browse2OpDefCode instead of referencing something in Browse2.
   return (
     <div className="m-[-6px] w-full">
-      <Browse2OpDefCode uri={value} maxRowsInView={20} />
+      <CodeView uri={value} maxLines={20} />
     </div>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridPill.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CompareGridPill.tsx
@@ -21,6 +21,33 @@ type CompareGridPillProps = {
 
 export const CompareGridPill = (props: CompareGridPillProps) => {
   const {value, valueType, compareValue, compareValueType} = props;
+
+  if (valueType === 'object' && compareValueType === 'object') {
+    const keyCount = Object.keys(value).length;
+    const keyCountCompare = Object.keys(compareValue).length;
+    return (
+      <CompareGridPill
+        value={keyCount}
+        compareValue={keyCountCompare}
+        valueType="number"
+        compareValueType="number"
+      />
+    );
+  }
+
+  if (valueType === 'array' && compareValueType === 'array') {
+    const itemCount = value.length;
+    const itemCountCompare = compareValue.length;
+    return (
+      <CompareGridPill
+        value={itemCount}
+        compareValue={itemCountCompare}
+        valueType="number"
+        compareValueType="number"
+      />
+    );
+  }
+
   if (valueType !== 'number' || compareValueType !== 'number') {
     return null;
   }


### PR DESCRIPTION
## Description

Internal Jira: https://wandb.atlassian.net/browse/WB-22043

This PR handles a few problems with the comparison page:

* We were autoexpanding all groups. With large objects this causes the page to repeatedly freeze for several seconds. Two mitigations:
  * Limit the depth we'll consider auto expanding for
  * Don't autoexpand rows with no changes (a better UX for emphasizing differences anyway)
* The code editor component was capturing scroll events, which could make the page appear frozen as you tried to scroll. 
* For non-ref objects and arrays, we now display a key/item count and a pill if it has changed. This helps user understand the change (especially if not expanded) but also mentally prepare for possible slowness expanding large objects.
<img width="420" alt="Screenshot 2024-11-26 at 10 33 41 AM" src="https://github.com/user-attachments/assets/a12b4f93-f9fc-4a42-9e14-043b6d646b70">
<img width="163" alt="Screenshot 2024-11-26 at 10 36 13 AM" src="https://github.com/user-attachments/assets/f6f85a18-3592-4617-ab1a-4408e4868935">


## Testing

How was this PR tested?
