### PR TITLE
chore(ui): hide feedbackSidebar url param if false

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -361,8 +361,8 @@ export const browse3ContextGen = (
       if (tracetree !== undefined) {
         params.set(TRACETREE_PARAM, tracetree ? '1' : '0');
       }
-      if (feedbackExpand !== undefined && feedbackExpand) {
-        params.set(FEEDBACK_EXPAND_PARAM, '1');
+      if (feedbackExpand !== undefined) {
+        params.set(FEEDBACK_EXPAND_PARAM, feedbackExpand ? '1' : '0');
       }
       if (params.toString()) {
         url += '?' + params.toString();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -361,8 +361,8 @@ export const browse3ContextGen = (
       if (tracetree !== undefined) {
         params.set(TRACETREE_PARAM, tracetree ? '1' : '0');
       }
-      if (feedbackExpand !== undefined) {
-        params.set(FEEDBACK_EXPAND_PARAM, feedbackExpand ? '1' : '0');
+      if (feedbackExpand !== undefined && feedbackExpand) {
+        params.set(FEEDBACK_EXPAND_PARAM, '1');
       }
       if (params.toString()) {
         url += '?' + params.toString();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -215,7 +215,7 @@ const CallPageInnerVertical: FC<{
         call.callId,
         path,
         !showTraceTree,
-        showFeedbackExpand
+        showFeedbackExpand ? true : undefined
       )
     );
   }, [
@@ -238,7 +238,7 @@ const CallPageInnerVertical: FC<{
         call.callId,
         path,
         showTraceTree,
-        !showFeedbackExpand
+        !showFeedbackExpand ? true : undefined
       )
     );
   }, [currentRouter, history, path, showTraceTree, call, showFeedbackExpand]);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/PaginationControls.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/PaginationControls.tsx
@@ -28,7 +28,7 @@ export const PaginationControls: FC<{
   const showFeedbackExpand =
     FEEDBACK_EXPAND_PARAM in query
       ? query[FEEDBACK_EXPAND_PARAM] === '1'
-      : false;
+      : undefined;
 
   const onNextCall = useCallback(() => {
     const nextCallId = getNextRowId?.(call.callId);


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

When the human feedback drawer is closed, don't add a url param. (Assume `undefined` = `false`)

Prod:
"/wandb-designers/martin-weave-test/weave/traces?peekPath=...calls%2F01935651-cb1f-7643-9e96-fd3cc263f579%3F**tracetree%3D1**"

Branch:
"/wandb-designers/martin-weave-test/weave/traces?peekPath=...calls%2F01935651-cb1f-7643-9e96-fd3cc263f579%3F"

## Testing

![test-url-param](https://github.com/user-attachments/assets/5e76ca61-5afc-4591-b82a-9fc025a26bd9)
