### PR TITLE
chore(ui): add back costs to call summary page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -249,11 +249,14 @@ const CallPageInnerVertical: FC<{
 
   const tree = useCallFlattenedTraceTree(call, path ?? null);
   const {rows, expandKeys, loading, costLoading, selectedCall} = tree;
-  const callComplete = useCall({
-    entity: selectedCall.entity,
-    project: selectedCall.project,
-    callId: selectedCall.callId,
-  });
+  const callComplete = useCall(
+    {
+      entity: selectedCall.entity,
+      project: selectedCall.project,
+      callId: selectedCall.callId,
+    },
+    {includeCosts: true}
+  );
 
   const assumeCallIsSelectedCall = path == null || path === '';
   const [currentCall, setCurrentCall] = useState(call);
@@ -273,6 +276,21 @@ const CallPageInnerVertical: FC<{
   const {rowIdsConfigured} = useContext(TableRowSelectionContext);
   const {isPeeking} = useContext(WeaveflowPeekContext);
   const showPaginationContols = isPeeking && rowIdsConfigured;
+
+  console.log(
+    'callComplete',
+    callComplete.result?.callId,
+    callComplete.result?.traceCall?.summary?.weave?.costs,
+    'selectedCall',
+    selectedCall.callId,
+    selectedCall.traceCall?.summary?.weave?.costs,
+    'call',
+    call.callId,
+    call.traceCall?.summary?.weave?.costs,
+    'currentCall',
+    currentCall.callId,
+    currentCall.traceCall?.summary?.weave?.costs
+  );
 
   const callTabs = useCallTabs(currentCall);
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -295,7 +295,7 @@ const CallPageInnerVertical: FC<{
     if (callCompleteWithCosts != null) {
       setCurrentCall(callCompleteWithCosts);
     }
-  }, [callComplete]);
+  }, [callCompleteWithCosts]);
 
   const {rowIdsConfigured} = useContext(TableRowSelectionContext);
   const {isPeeking} = useContext(WeaveflowPeekContext);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallTraceView.tsx
@@ -417,14 +417,11 @@ export const useCallFlattenedTraceTree = (
   );
 
   const costResult = useMemo(() => {
-    return costs.result ?? [];
-  }, [costs.result]);
+    return addCostsToCallResults(traceCallsResult, costs.result ?? []);
+  }, [costs.result, traceCallsResult]);
 
   const traceCallMap = useMemo(() => {
-    const result =
-      costResult.length > 0
-        ? addCostsToCallResults(traceCallsResult, costResult)
-        : traceCallsResult;
+    const result = costResult.length > 0 ? costResult : traceCallsResult;
     return _.keyBy(result, 'callId');
   }, [costResult, traceCallsResult]);
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Uses costs from trace tree to render the callSummary costs. 

## Testing

Prod: 
<img width="520" alt="Screenshot 2024-11-26 at 12 16 27 PM" src="https://github.com/user-attachments/assets/e1f34ced-1d70-42f5-afc5-b3727684af7c">

Branch:
<img width="691" alt="Screenshot 2024-11-26 at 12 16 03 PM" src="https://github.com/user-attachments/assets/61ea79cf-1fd1-486f-a527-5002620af21b">
