### PR TITLE
docs(weave): Include Prompt classes in generated API docs

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -12,9 +12,7 @@ from weave.flow.dataset import Dataset
 from weave.flow.eval import Evaluation, Scorer
 from weave.flow.model import Model
 from weave.flow.obj import Object
-from weave.flow.prompt.prompt import EasyPrompt, Prompt
-from weave.flow.prompt.prompt import MessagesPrompt as MessagesPrompt
-from weave.flow.prompt.prompt import StringPrompt as StringPrompt
+from weave.flow.prompt.prompt import EasyPrompt, MessagesPrompt, Prompt, StringPrompt
 from weave.trace.util import Thread as Thread
 from weave.trace.util import ThreadPoolExecutor as ThreadPoolExecutor
 
@@ -38,6 +36,8 @@ __docspec__ = [
     Dataset,
     Model,
     Prompt,
+    StringPrompt,
+    MessagesPrompt,
     Evaluation,
     Scorer,
 ]


### PR DESCRIPTION
## Description

Adds the `StringPrompt` and `MessagesPrompt` classes to our generated API docs.

Still needed followups are improving the docstrings on the classes and executing `make generate_python_sdk_docs`

## Testing

How was this PR tested?
