### PR TITLE
fix(ui): Fixes z-index issue with Playground and navigation sidebar

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
@@ -72,7 +72,7 @@ export const PlaygroundChatInput: React.FC<PlaygroundChatInputProps> = ({
           settingsTab !== null
             ? 'calc(100% - 58px - 320px)'
             : 'calc(100% - 58px)',
-        zIndex: 1,
+        zIndex: 1, // WARN: z-index position of navbar overflow menu is `2`, check first if changing
       }}>
       <Box
         sx={{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
@@ -72,7 +72,7 @@ export const PlaygroundChatInput: React.FC<PlaygroundChatInputProps> = ({
           settingsTab !== null
             ? 'calc(100% - 58px - 320px)'
             : 'calc(100% - 58px)',
-        zIndex: 100,
+        zIndex: 1,
       }}>
       <Box
         sx={{


### PR DESCRIPTION
- Fixes z-index position of chat input area to not overlap the main nav overflow menu.
- Main nav overflow menu has z-index of 2.