### PR TITLE
fix(ui): Prevent Switch component from shrinking in flex containers

### DIFF
--- a/weave-js/src/components/Switch/index.tsx
+++ b/weave-js/src/components/Switch/index.tsx
@@ -12,6 +12,7 @@ export const Root = ({
     className={twMerge(
       'flex items-center rounded-[12px] p-[1px] transition-colors duration-100 ease-out',
       'focus-visible:outline focus-visible:outline-[2px] focus-visible:outline-teal-500',
+      'flex-shrink-0',
       props.checked ? ' bg-teal-500' : 'bg-moon-350',
       size === 'small' ? 'h-[16px] w-[28px]' : 'h-[24px] w-[44px]',
       className


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-21938

What does the PR do? Include a concise description of the PR contents.

Adds the `flex-shrink-0` class to the `Switch.Root` component to prevent shrinking in flex containers across viewport sizes. Affects the following files:

- `ArtifactDag.tsx`
- `SearchAutoExpandToggle.tsx`
- `WBTableActionsFilter.tsx`
- `OrgPrivacySettings.tsx`

## Testing

Org Privacy Settings:

Before:

<img width="572" alt="Screenshot 2024-11-25 at 5 15 48 PM" src="https://github.com/user-attachments/assets/b426b64e-2cce-4d11-8a6e-b6841cb8a217">


After:

https://github.com/user-attachments/assets/b1c78765-145c-4772-8739-f5ce07dea0cc



How was this PR tested?

