### PR TITLE
chore(weave): Pin instructor for python3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,10 @@ cohere = ["cohere>=5.9.1,<5.9.3"]
 dspy = ["dspy>=0.1.5", "litellm<=1.49.1"]
 google_ai_studio = ["google-generativeai>=0.8.3"]
 groq = ["groq>=0.9.0"]
-instructor = ["instructor>=1.4.3"]
+instructor = [
+  "instructor>=1.4.3,<1.7.0; python_version <= '3.9'",
+  "instructor>=1.4.3; python_version > '3.9'",
+]
 langchain = [
   "langchain-core>=0.2.1",
   "langchain-openai>=0.1.7",


### PR DESCRIPTION
Resolves a bad interaction between the instructor 1.7.0 release and our use of `from __future__ import annotations`