### PR TITLE
fix(ui): better defaults for trace/eval trace tree

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -47,6 +47,7 @@ import {
 } from './callsTableColumnsUtil';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {OpVersionIndexText} from './OpVersionIndexText';
+import {isEvaluateOp} from '../common/heuristics';
 
 const HIDDEN_DYNAMIC_COLUMN_PREFIXES = [
   'summary.usage',
@@ -228,6 +229,7 @@ function buildCallsTableColumns(
           rowParams.row.display_name ??
           opVersionRefOpName(rowParams.row.op_name) ??
           rowParams.row.op_name;
+        const isEval = isEvaluateOp(opVersionRefOpName(rowParams.row.op_name));
         return (
           <CallLink
             entityName={entity}
@@ -237,6 +239,7 @@ function buildCallsTableColumns(
             fullWidth={true}
             preservePath={preservePath}
             color={TEAL_600}
+            isEval={isEval}
           />
         );
       },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -29,6 +29,7 @@ import {
   getCostsFromCellParams,
   getTokensFromCellParams,
 } from '../CallPage/cost';
+import {isEvaluateOp} from '../common/heuristics';
 import {CallLink} from '../common/Links';
 import {StatusChip} from '../common/StatusChip';
 import {buildDynamicColumns} from '../common/tabularListViews/columnBuilder';
@@ -47,7 +48,6 @@ import {
 } from './callsTableColumnsUtil';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {OpVersionIndexText} from './OpVersionIndexText';
-import {isEvaluateOp} from '../common/heuristics';
 
 const HIDDEN_DYNAMIC_COLUMN_PREFIXES = [
   'summary.usage',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -20,6 +20,7 @@ import {WFHighLevelCallFilter} from '../CallsPage/callsTableFilter';
 import {WFHighLevelObjectVersionFilter} from '../ObjectVersionsPage';
 import {WFHighLevelOpVersionFilter} from '../OpVersionsPage';
 import {Id} from './Id';
+import {isEvaluateOp} from './heuristics';
 
 type LinkVariant = 'primary' | 'secondary';
 
@@ -282,6 +283,7 @@ export const CallLink: React.FC<{
   tracetree?: boolean;
   icon?: React.ReactNode;
   color?: string;
+  isEval?: boolean;
 }> = props => {
   const history = useHistory();
   const {peekingRouter} = useWeaveflowRouteContext();
@@ -297,8 +299,14 @@ export const CallLink: React.FC<{
   const existingPath = peekParams.get(PATH_PARAM) ?? '';
   // Preserve the path only when showing trace tree
   const path = props.preservePath ? existingPath : null;
-  // default to true if not specified
-  const showTraceTree = !(peekParams.get(TRACETREE_PARAM) === '0');
+  // default to true if not specified and not an eval
+  const traceTreeParam = peekParams.get(TRACETREE_PARAM);
+  const showTraceTree =
+    traceTreeParam === '1'
+      ? true
+      : traceTreeParam === '0'
+      ? false
+      : !props.isEval;
   // default to false if not specified
   const showFeedbackExpand = peekParams.get(FEEDBACK_EXPAND_PARAM) === '1';
   const to = peekingRouter.callUIUrl(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -20,7 +20,6 @@ import {WFHighLevelCallFilter} from '../CallsPage/callsTableFilter';
 import {WFHighLevelObjectVersionFilter} from '../ObjectVersionsPage';
 import {WFHighLevelOpVersionFilter} from '../OpVersionsPage';
 import {Id} from './Id';
-import {isEvaluateOp} from './heuristics';
 
 type LinkVariant = 'primary' | 'secondary';
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

While adding support for maintaining show-annotation state, I broke the trace tree defaults. Specifically we want to be able to show or hide the trace tree when the user sets it, but default to showing when a trace is normal, or hiding when the trace is an evaluation. 

## Testing

![test-url-param-tree](https://github.com/user-attachments/assets/5709ab4f-9d6d-465e-a3e7-dd0cd345a347)
