### PR TITLE
chore(ui): night mode text color for More link in nav

### DIFF
--- a/weave-js/src/components/FancyPage/FancyPageMenu.tsx
+++ b/weave-js/src/components/FancyPage/FancyPageMenu.tsx
@@ -44,7 +44,9 @@ export const FancyPageMenu = ({
             <ItemIcon color={colorIconBg}>
               <IconOverflowHorizontal />
             </ItemIcon>
-            <ItemLabel color={colorText}>More</ItemLabel>
+            <ItemLabel className="night-aware" color={colorText}>
+              More
+            </ItemLabel>
           </MenuButton>
         </div>
       </DropdownMenu.Trigger>


### PR DESCRIPTION
## Description

Make text color for overflow menu in nav consistent

Before:
<img width="65" alt="Screenshot 2024-11-27 at 2 55 11 PM" src="https://github.com/user-attachments/assets/2025fbe9-e069-4560-bb8c-5058edef1016">

After:
<img width="66" alt="Screenshot 2024-11-27 at 2 55 04 PM" src="https://github.com/user-attachments/assets/006f8633-d078-4b4e-8c9a-82596c3114a3">



## Testing

How was this PR tested?
