### PR TITLE
chore(weave): remote trace server client retries http 500

### DIFF
--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -55,14 +55,7 @@ def _is_retryable_exception(e: Exception) -> bool:
         if code_class == 4 and e.response.status_code != 429:
             return False
 
-        # Unknown server error
-        # TODO(np): We need to fix the server to return proper status codes
-        # for downstream 401, 403, 404, etc... Those should propagate back to
-        # the client.
-        if e.response.status_code == 500:
-            return False
-
-    # Otherwise, retry: Non-500 5xx, OSError, ConnectionError, ConnectionResetError, IOError, etc...
+    # Otherwise, retry: 5xx, OSError, ConnectionError, ConnectionResetError, IOError, etc...
     return True
 
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-21911

What does the PR do? Include a concise description of the PR contents.

Remote http trace server client now retries 500 errors. The trace server used to send back 500 for things that should have been 400, fixed here https://github.com/wandb/core/pull/25931

## Testing

How was this PR tested?
