### PR TITLE
fix(ui): emojis looking bad in night mode

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/EmojiDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/EmojiDetails.tsx
@@ -63,7 +63,7 @@ export const EmojiDetails = ({
   return (
     <Tailwind>
       <div className="max-w-xs">
-        <div className="text-center text-7xl">{emoji}</div>
+        <div className="night-aware text-center text-7xl">{emoji}</div>
         {Object.entries(groupedByAlias).map(([alias, aliasReactions]) => {
           // TODO (Tim): After https://github.com/wandb/core/pull/22947 is deployed,
           // change the fallback from `r.wb_user_id` to `null`-like (this means no access)

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -40,7 +40,9 @@ export const FeedbackGridInner = ({
           return <CellValueString value={params.row.payload.note} />;
         }
         if (params.row.feedback_type === 'wandb.reaction.1') {
-          return params.row.payload.emoji;
+          return (
+            <span className="night-aware">{params.row.payload.emoji}</span>
+          );
         }
         if (params.row.feedback_type.startsWith('wandb.annotation.')) {
           return (


### PR DESCRIPTION
## Description

While watching GA release video I saw that emojis in places were getting incorrectly inverted by night mode.
https://www.youtube.com/watch?v=IQcGGNLN3zo&t=113s

Before:
<img width="437" alt="Screenshot 2024-12-02 at 1 42 30 PM" src="https://github.com/user-attachments/assets/2cf2cb6a-e3c8-4737-bb6c-95ddbb89652e">

After:
<img width="449" alt="Screenshot 2024-12-02 at 1 42 16 PM" src="https://github.com/user-attachments/assets/cadd83f6-c9e4-4769-8817-e18cf650dc80">




## Testing

How was this PR tested?
