### PR TITLE
chore(weave): increase call start/end timestamp resolution to microseconds

### DIFF
--- a/weave/trace_server/migrations/009_increase_call_timestamp_resolution.down.sql
+++ b/weave/trace_server/migrations/009_increase_call_timestamp_resolution.down.sql
@@ -1,0 +1,6 @@
+-- Decrease the resolution of the call timestamps to 3 decimal places from 6
+ALTER TABLE call_parts MODIFY COLUMN started_at Nullable(DateTime64(3));
+ALTER TABLE call_parts MODIFY COLUMN ended_at Nullable(DateTime64(3));
+
+ALTER TABLE calls_merged MODIFY COLUMN started_at SimpleAggregateFunction(any, Nullable(DateTime64(3)));
+ALTER TABLE calls_merged MODIFY COLUMN ended_at SimpleAggregateFunction(any, Nullable(DateTime64(3)));

--- a/weave/trace_server/migrations/009_increase_call_timestamp_resolution.up.sql
+++ b/weave/trace_server/migrations/009_increase_call_timestamp_resolution.up.sql
@@ -1,0 +1,6 @@
+-- Increase the resolution of the call timestamps to 6 decimal places from 3
+ALTER TABLE call_parts MODIFY COLUMN started_at Nullable(DateTime64(6));
+ALTER TABLE call_parts MODIFY COLUMN ended_at Nullable(DateTime64(6));
+
+ALTER TABLE calls_merged MODIFY COLUMN started_at SimpleAggregateFunction(any, Nullable(DateTime64(6)));
+ALTER TABLE calls_merged MODIFY COLUMN ended_at SimpleAggregateFunction(any, Nullable(DateTime64(6)));


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-18987

Changes the type of 4 columns across 2 tables in the clickhouse database from `DateTime64(3)` (millisecond resolution) to `DateTime64(6)` (microsecond resolution).  The  columns migrated are the `started_at` and `ended_at` columns of `call_parts` and `calls_merged` tables.

## Testing

The migration was tested up and down manually against a database with tens of millions of rows. The `ALTER TABLE` statements finish almost immediately and do not change the way that the underlying data is stored.

`calls_merged` is aggregated with a materialized view from `call_parts`. To make sure inserts between steps of the migration would not result in data loss, I tested what would happen if I inserted into `call_parts` while its timestamp columns had microsecond resolution but the corresponding column in `calls_merged` had millisecond resolution. Clickhouse handles this gracefully by casting the data automatically. The same is true with millisecond resolution in `call_parts` and microsecond resolution in `calls_merged`.
