### PR TITLE
fix(ui): latency chart with unfinshed calls

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCharts.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCharts.tsx
@@ -149,7 +149,7 @@ export const CallsCharts = ({
         data.errors.push({started_at, isError: false});
       }
 
-      if (ended_at !== undefined) {
+      if (ended_at != null) {
         const startTime = new Date(started_at).getTime();
         const endTime = new Date(ended_at).getTime();
         const latency = endTime - startTime;


### PR DESCRIPTION
## Description

Internal Slack: 
https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1733198885250169

Calls with `null` ended_at values were not getting filtered out of graph, resulting in huge negative values.

Before:
<img width="657" alt="Screenshot 2024-12-02 at 10 33 00 PM" src="https://github.com/user-attachments/assets/f85d2d8d-b4ee-4702-bee9-4d6f285af558">

After:
<img width="674" alt="Screenshot 2024-12-02 at 10 32 43 PM" src="https://github.com/user-attachments/assets/f4982198-e885-45dd-8291-fde7c7080dc4">



## Testing

How was this PR tested?
