### PR TITLE
chore(weave): unhide completion iterations

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundSettings/PlaygroundSettings.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundSettings/PlaygroundSettings.tsx
@@ -59,6 +59,12 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                 gap: '4px',
                 mt: 2,
               }}>
+              <ResponseFormatEditor
+                responseFormat={playgroundState.responseFormat}
+                setResponseFormat={value =>
+                  setPlaygroundStateField(idx, 'responseFormat', value)
+                }
+              />
               <FunctionEditor
                 playgroundState={playgroundState}
                 functions={playgroundState.functions}
@@ -71,22 +77,24 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                 }
               />
 
-              <ResponseFormatEditor
-                responseFormat={playgroundState.responseFormat}
-                setResponseFormat={value =>
-                  setPlaygroundStateField(idx, 'responseFormat', value)
+              <StopSequenceEditor
+                stopSequences={playgroundState.stopSequences}
+                setStopSequences={value =>
+                  setPlaygroundStateField(idx, 'stopSequences', value)
                 }
               />
 
+              {/* TODO: N times to run is not supported for all models */}
+              {/* TODO: rerun if this is not supported in the backend */}
               <PlaygroundSlider
-                min={0}
-                max={2}
-                step={0.01}
+                min={1}
+                max={100}
+                step={1}
                 setValue={value =>
-                  setPlaygroundStateField(idx, 'temperature', value)
+                  setPlaygroundStateField(idx, 'nTimes', value)
                 }
-                label="Temperature"
-                value={playgroundState.temperature}
+                label="Completion iterations"
+                value={playgroundState.nTimes}
               />
 
               <PlaygroundSlider
@@ -100,11 +108,15 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                 value={playgroundState.maxTokens}
               />
 
-              <StopSequenceEditor
-                stopSequences={playgroundState.stopSequences}
-                setStopSequences={value =>
-                  setPlaygroundStateField(idx, 'stopSequences', value)
+              <PlaygroundSlider
+                min={0}
+                max={2}
+                step={0.01}
+                setValue={value =>
+                  setPlaygroundStateField(idx, 'temperature', value)
                 }
+                label="Temperature"
+                value={playgroundState.temperature}
               />
 
               <PlaygroundSlider
@@ -137,6 +149,7 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                 label="Presence penalty"
                 value={playgroundState.presencePenalty}
               />
+
               <Box
                 sx={{
                   width: '100%',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/types.ts
@@ -20,7 +20,7 @@ export type PlaygroundState = {
   topP: number;
   frequencyPenalty: number;
   presencePenalty: number;
-  //   nTimes: number;
+  nTimes: number;
   maxTokensLimit: number;
   model: LLMMaxTokensKey;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -34,7 +34,7 @@ const DEFAULT_PLAYGROUND_STATE = {
   topP: 1,
   frequencyPenalty: 0,
   presencePenalty: 0,
-  //   nTimes: 1,
+  nTimes: 1,
   maxTokensLimit: 16384,
   model: DEFAULT_MODEL,
 };
@@ -90,9 +90,9 @@ export const usePlaygroundState = () => {
             }
           }
         }
-        // if (inputs.n) {
-        //   newState.nTimes = parseInt(inputs.n, 10);
-        // }
+        if (inputs.n) {
+          newState.nTimes = parseInt(inputs.n, 10);
+        }
         if (inputs.temperature) {
           newState.temperature = parseFloat(inputs.temperature);
         }
@@ -147,7 +147,7 @@ export const getInputFromPlaygroundState = (state: PlaygroundState) => {
     top_p: state.topP,
     frequency_penalty: state.frequencyPenalty,
     presence_penalty: state.presencePenalty,
-    // n: state.nTimes,
+    n: state.nTimes,
     response_format: {
       type: state.responseFormat,
     },


### PR DESCRIPTION
## Description

Show completion iterations in Playground settings
Rearranged the settings menu a little to be more in line with designs

before
![Screenshot 2024-12-03 at 11 57 59 AM](https://github.com/user-attachments/assets/fecd68c5-9f18-4245-b361-9bcd57af4a1a)


After
![Screenshot 2024-12-03 at 11 57 45 AM](https://github.com/user-attachments/assets/6dff4f23-06e9-485e-a1ed-054fd86c649f)


## Testing

How was this PR tested?
