### PR TITLE
feat(weave): Expose simple way to get the captured code for an op

### DIFF
--- a/tests/trace/test_exec.py
+++ b/tests/trace/test_exec.py
@@ -101,7 +101,7 @@ def test_publish_works_for_code_with_no_source_file(
 
     ref = captured["ref"]
     op = ref.get()
-    actual_captured_code = op.art.path_contents["obj.py"].decode()
+    actual_captured_code = op.get_source()
     expected_captured_code = expected_captured_code[1:]  # ignore first newline
 
     assert actual_captured_code == expected_captured_code

--- a/tests/trace/test_exec.py
+++ b/tests/trace/test_exec.py
@@ -101,7 +101,7 @@ def test_publish_works_for_code_with_no_source_file(
 
     ref = captured["ref"]
     op = ref.get()
-    actual_captured_code = op.get_source()
+    actual_captured_code = op.get_captured_code()
     expected_captured_code = expected_captured_code[1:]  # ignore first newline
 
     assert actual_captured_code == expected_captured_code

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -104,7 +104,7 @@ def test_should_capture_code_setting(client):
 
     ref = weave.publish(test_func)
     test_func2 = ref.get()
-    code2 = test_func2.art.path_contents["obj.py"].decode()
+    code2 = test_func2.get_source()
     assert "Code-capture was disabled" in code2
 
     parse_and_apply_settings(UserSettings(capture_code=True))
@@ -117,7 +117,7 @@ def test_should_capture_code_setting(client):
 
     ref2 = weave.publish(test_func)
     test_func3 = ref2.get()
-    code3 = test_func3.art.path_contents["obj.py"].decode()
+    code3 = test_func3.get_source()
     assert "Code-capture was disabled" not in code3
 
 
@@ -130,7 +130,7 @@ def test_should_capture_code_env(client):
 
     ref = weave.publish(test_func)
     test_func2 = ref.get()
-    code2 = test_func2.art.path_contents["obj.py"].decode()
+    code2 = test_func2.get_source()
     assert "Code-capture was disabled" in code2
 
     os.environ["WEAVE_CAPTURE_CODE"] = "true"
@@ -141,7 +141,7 @@ def test_should_capture_code_env(client):
 
     ref2 = weave.publish(test_func)
     test_func3 = ref2.get()
-    code3 = test_func3.art.path_contents["obj.py"].decode()
+    code3 = test_func3.get_source()
     assert "Code-capture was disabled" not in code3
 
 

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -104,7 +104,7 @@ def test_should_capture_code_setting(client):
 
     ref = weave.publish(test_func)
     test_func2 = ref.get()
-    code2 = test_func2.get_source()
+    code2 = test_func2.get_captured_code()
     assert "Code-capture was disabled" in code2
 
     parse_and_apply_settings(UserSettings(capture_code=True))
@@ -117,7 +117,7 @@ def test_should_capture_code_setting(client):
 
     ref2 = weave.publish(test_func)
     test_func3 = ref2.get()
-    code3 = test_func3.get_source()
+    code3 = test_func3.get_captured_code()
     assert "Code-capture was disabled" not in code3
 
 
@@ -130,7 +130,7 @@ def test_should_capture_code_env(client):
 
     ref = weave.publish(test_func)
     test_func2 = ref.get()
-    code2 = test_func2.get_source()
+    code2 = test_func2.get_captured_code()
     assert "Code-capture was disabled" in code2
 
     os.environ["WEAVE_CAPTURE_CODE"] = "true"
@@ -141,7 +141,7 @@ def test_should_capture_code_env(client):
 
     ref2 = weave.publish(test_func)
     test_func3 = ref2.get()
-    code3 = test_func3.get_source()
+    code3 = test_func3.get_captured_code()
     assert "Code-capture was disabled" not in code3
 
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import inspect
 import logging
 import sys
-import textwrap
 import traceback
 from collections.abc import Coroutine, Mapping
 from dataclasses import dataclass
@@ -683,19 +682,19 @@ def op(
 
 
 def get_source(op: Op) -> str:
+    """Get the source code of the op.
+
+    This only works when you get an op back from a ref.  The pattern is:
+
+    ref = weave.publish(func)
+    op = ref.get()
+    source = op.get_source()
+    """
     try:
         return op.art.path_contents["obj.py"].decode()
     except Exception:
         raise RuntimeError(
-            textwrap.dedent(
-                """
-                Failed to get source for op (this only works when you get an op back from a ref).  The pattern is:
-
-                ref = weave.publish(func)
-                op = ref.get()
-                source = op.get_source()
-                """
-            )
+            "Failed to get source for op (this only works when you get an op back from a ref)."
         )
 
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -662,7 +662,7 @@ def op(
 
             wrapper._tracing_enabled = True  # type: ignore
 
-            wrapper.get_source = partial(get_source, wrapper)  # type: ignore
+            wrapper.get_captured_code = partial(get_captured_code, wrapper)  # type: ignore
 
             if callable(call_display_name):
                 params = inspect.signature(call_display_name).parameters
@@ -681,20 +681,20 @@ def op(
     return op_deco(func)
 
 
-def get_source(op: Op) -> str:
-    """Get the source code of the op.
+def get_captured_code(op: Op) -> str:
+    """Get the captured code of the op.
 
     This only works when you get an op back from a ref.  The pattern is:
 
     ref = weave.publish(func)
     op = ref.get()
-    source = op.get_source()
+    captured_code = op.get_captured_code()
     """
     try:
         return op.art.path_contents["obj.py"].decode()
     except Exception:
         raise RuntimeError(
-            "Failed to get source for op (this only works when you get an op back from a ref)."
+            "Failed to get captured code for op (this only works when you get an op back from a ref)."
         )
 
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -691,7 +691,7 @@ def get_captured_code(op: Op) -> str:
     captured_code = op.get_captured_code()
     """
     try:
-        return op.art.path_contents["obj.py"].decode()
+        return op.art.path_contents["obj.py"].decode()  # type: ignore
     except Exception:
         raise RuntimeError(
             "Failed to get captured code for op (this only works when you get an op back from a ref)."

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -662,6 +662,8 @@ def op(
 
             wrapper._tracing_enabled = True  # type: ignore
 
+            wrapper.get_source = partial(get_source, wrapper)  # type: ignore
+
             if callable(call_display_name):
                 params = inspect.signature(call_display_name).parameters
                 if len(params) != 1:
@@ -677,6 +679,15 @@ def op(
     if func is None:
         return op_deco
     return op_deco(func)
+
+
+def get_source(op: Op) -> str:
+    try:
+        return op.art.path_contents["obj.py"].decode()
+    except Exception:
+        raise RuntimeError(
+            "Failed to get source for op (did you get this op back from a ref?)"
+        )
 
 
 def maybe_bind_method(func: Callable, self: Any = None) -> Callable | MethodType:

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import logging
 import sys
+import textwrap
 import traceback
 from collections.abc import Coroutine, Mapping
 from dataclasses import dataclass
@@ -686,7 +687,15 @@ def get_source(op: Op) -> str:
         return op.art.path_contents["obj.py"].decode()
     except Exception:
         raise RuntimeError(
-            "Failed to get source for op (did you get this op back from a ref?)"
+            textwrap.dedent(
+                """
+                Failed to get source for op (this only works when you get an op back from a ref).  The pattern is:
+
+                ref = weave.publish(func)
+                op = ref.get()
+                source = op.get_source()
+                """
+            )
         )
 
 


### PR DESCRIPTION
We always had this, it just wasn't easily accessible.