### PR TITLE
chore(ui): unhide scorer, no admin text

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -1,4 +1,5 @@
 import Box from '@mui/material/Box';
+import {useViewerInfo} from '@wandb/weave/common/hooks/useViewerInfo';
 import {Loading} from '@wandb/weave/components/Loading';
 import {urlPrefixed} from '@wandb/weave/config';
 import {useViewTraceEvent} from '@wandb/weave/integrations/analytics/useViewEvents';
@@ -70,10 +71,8 @@ export const CallPage: FC<{
 };
 
 export const useShowRunnableUI = () => {
-  return false;
-  // Uncomment to re-enable.
-  // const viewerInfo = useViewerInfo();
-  // return viewerInfo.loading ? false : viewerInfo.userInfo?.admin;
+  const viewerInfo = useViewerInfo();
+  return viewerInfo.loading ? false : viewerInfo.userInfo?.admin;
 };
 
 const useCallTabs = (call: CallSchema) => {
@@ -185,7 +184,7 @@ const useCallTabs = (call: CallSchema) => {
     ...(showScores
       ? [
           {
-            label: 'Scores (W&B Admin Preview)',
+            label: 'Scores',
             content: (
               <Tailwind>
                 <CallScoresViewer call={call} />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
@@ -50,7 +50,7 @@ export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig<any>> = {
     onSave: AnnotationScorerForm.onAnnotationScorerSave,
   },
   LLM_JUDGE: {
-    label: LLM_JUDGE_LABEL + ' (W&B Admin Preview)',
+    label: LLM_JUDGE_LABEL,
     value: LLM_JUDGE_VALUE,
     icon: IconNames.RobotServiceMember,
     Component: LLMJudgeScorerForm.LLMJudgeScorerForm,


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1733244393638349

Re-enable the scorer tabs for demos, still only available to W&B admins, but without text indicating that.

After:
<img width="438" alt="Screenshot 2024-12-03 at 3 40 47 PM" src="https://github.com/user-attachments/assets/814462b9-3a8c-43ec-8e08-c1da5c01d469">
<img width="672" alt="Screenshot 2024-12-03 at 3 40 33 PM" src="https://github.com/user-attachments/assets/d0b78036-5ba9-42bc-afe1-aa4cf17c9c40">


## Testing

How was this PR tested?
