### PR TITLE
chore(ui): move Overview back to sidebar top for Models-only projects

### DIFF
--- a/weave-js/src/components/FancyPage/useProjectSidebar.ts
+++ b/weave-js/src/components/FancyPage/useProjectSidebar.ts
@@ -43,6 +43,13 @@ export const useProjectSidebar = (
           },
           {
             type: 'button' as const,
+            name: 'Overview',
+            slug: 'overview',
+            isShown: isModelsOnly,
+            iconName: IconNames.Info,
+          },
+          {
+            type: 'button' as const,
             name: 'Workspace',
             slug: 'workspace',
             isShown: !isWeaveOnly,
@@ -97,13 +104,6 @@ export const useProjectSidebar = (
             isShown: isModelsOnly,
             iconName: IconNames.VersionsLayers,
             isDisabled: viewingRestricted,
-          },
-          {
-            type: 'button' as const,
-            name: 'Overview',
-            slug: 'overview',
-            isShown: isModelsOnly,
-            iconName: IconNames.Info,
           },
           {
             type: 'menuPlaceholder' as const,


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/CA4PBB2TF/p1733261109636749?thread_ts=1732492325.984729&cid=CA4PBB2TF

Design team asked to move the Overview button in nav sidebar back to the top for Models-only projects.

Before:
<img width="74" alt="Screenshot 2024-12-03 at 6 43 35 PM" src="https://github.com/user-attachments/assets/1995669f-a155-4fef-a7b6-087ee5dc4603">


After:
<img width="59" alt="Screenshot 2024-12-03 at 6 43 16 PM" src="https://github.com/user-attachments/assets/c0f5932b-f23f-4934-9c4b-8c1f7898ec44">

## Testing

How was this PR tested?
