### PR TITLE
feat(ui): support base64 encoded images in markdown rendering

### DIFF
--- a/weave-js/src/common/util/markdown.ts
+++ b/weave-js/src/common/util/markdown.ts
@@ -57,7 +57,6 @@ export function buildSanitizationSchema(rules?: SanitizationRules) {
 }
 
 export function generateHTML(markdown: string, rules?: SanitizationRules) {
-  console.log('generateHTML', markdown);
   const sanitizationSchema = buildSanitizationSchema(rules);
   // IMPORTANT: We must sanitize as the final step of the pipeline to prevent XSS
   const vfile = (
@@ -80,13 +79,9 @@ export function generateHTML(markdown: string, rules?: SanitizationRules) {
     .processSync(markdown);
 
   if (typeof vfile.value === 'string') {
-    console.log('generateHTML before blankifyLinks', vfile.value);
     vfile.value = blankifyLinks(vfile.value);
-    console.log('generateHTML after blankifyLinks', vfile.value);
     vfile.value = shiftHeadings(vfile.value);
-    console.log('generateHTML after shiftHeadings', vfile.value);
   }
-  console.log('generateHTML', vfile.value);
   return vfile;
 }
 

--- a/weave-js/src/common/util/markdown.ts
+++ b/weave-js/src/common/util/markdown.ts
@@ -20,7 +20,12 @@ import {blankifyLinks, shiftHeadings} from './html';
 
 // exported only for tests
 export const DEFAULT_SANITIZATION_SCHEMA = _.merge(gh, {
-  attributes: {'*': ['className', 'style']},
+  attributes: {
+    '*': ['className', 'style'],
+  },
+  protocols: {
+    src: ['http', 'https', 'data'],
+  },
 });
 
 const SANITIZATION_SCHEMAS_FOR_RULES: Record<keyof SanitizationRules, Schema> =
@@ -52,6 +57,7 @@ export function buildSanitizationSchema(rules?: SanitizationRules) {
 }
 
 export function generateHTML(markdown: string, rules?: SanitizationRules) {
+  console.log('generateHTML', markdown);
   const sanitizationSchema = buildSanitizationSchema(rules);
   // IMPORTANT: We must sanitize as the final step of the pipeline to prevent XSS
   const vfile = (
@@ -74,9 +80,13 @@ export function generateHTML(markdown: string, rules?: SanitizationRules) {
     .processSync(markdown);
 
   if (typeof vfile.value === 'string') {
+    console.log('generateHTML before blankifyLinks', vfile.value);
     vfile.value = blankifyLinks(vfile.value);
+    console.log('generateHTML after blankifyLinks', vfile.value);
     vfile.value = shiftHeadings(vfile.value);
+    console.log('generateHTML after shiftHeadings', vfile.value);
   }
+  console.log('generateHTML', vfile.value);
   return vfile;
 }
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-22155](https://wandb.atlassian.net/browse/WB-22155)

What does the PR do? Include a concise description of the PR contents.

Resolves issues with base64-encoded PNG images not rendering correctly in dataset descriptions when using markdown format. The [SanitizationSchema](https://github.com/wandb/weave/blob/master/weave-js/src/common/util/markdown.ts#L22) restricted `src` protocols that were not `http` or `https`. Included `data` as a valid protocol since that is used to render base64 encoded images. 

## Testing

How was this PR tested?
- Local `invoker_fe_prod.ini` 
- Tested on Dataset cards, artifact descriptions and Reports

### Before

### Dataset Card
![Screenshot 2024-12-03 at 6 51 10 PM](https://github.com/user-attachments/assets/c43bd36c-6346-4260-b793-ad9bb1b81cbb)

### Report
![Screenshot 2024-12-03 at 6 48 05 PM](https://github.com/user-attachments/assets/eb3a228b-185e-475e-8828-5bc486d5aed3)

### After

### Dataset Card
![Screenshot 2024-12-03 at 6 50 19 PM](https://github.com/user-attachments/assets/d33ebf4e-d475-410e-bdba-f8b7d8cc91f4)

### Report
![Screenshot 2024-12-03 at 6 48 46 PM](https://github.com/user-attachments/assets/909b516c-ffa9-4dde-b26a-23ac1baa8977)
