### PR TITLE
feat(weave_query): add ability to view traces on query panels

### DIFF
--- a/weave-js/src/core/ll.test.ts
+++ b/weave-js/src/core/ll.test.ts
@@ -340,6 +340,7 @@ describe('ll', () => {
       'project-artifactTypes',
       'project-artifact',
       'project-artifactVersion',
+      'project-traces',
     ]);
   });
 

--- a/weave-js/src/core/model/helpers.ts
+++ b/weave-js/src/core/model/helpers.ts
@@ -897,10 +897,14 @@ export function isObjectTypeLike(t: any): t is ObjectType | Union {
   );
 }
 
-export function typedDict(propertyTypes: {[key: string]: Type}): TypedDictType {
+export function typedDict(
+  propertyTypes: {[key: string]: Type},
+  notRequiredKeys?: string[]
+): TypedDictType {
   return {
     type: 'typedDict',
     propertyTypes,
+    notRequiredKeys,
   };
 }
 

--- a/weave-js/src/core/ops/domain/project.ts
+++ b/weave-js/src/core/ops/domain/project.ts
@@ -1,5 +1,5 @@
 import * as Urls from '../../_external/util/urls';
-import {hash, list} from '../../model';
+import {hash, list, typedDict} from '../../model';
 import {docType} from '../../util/docs';
 import * as OpKinds from '../opKinds';
 import {connectionToNodes} from './util';
@@ -296,4 +296,46 @@ export const opProjectRunQueues = makeProjectOp({
   })} for a ${docType('project')}`,
   returnType: inputTypes => list('runQueue'),
   resolver: ({project}) => project.runQueues,
+});
+
+export const opProjectTracesType = makeProjectOp({
+  name: 'project-tracesType',
+  argTypes: projectArgTypes,
+  description: `Returns the ${docType('list', {
+    plural: true,
+  })} for a ${docType('project')}`,
+  argDescriptions: {project: projectArgDescription},
+  returnValueDescription: `The ${docType('list', {
+    plural: true,
+  })} for a ${docType('project')}`,
+  returnType: inputTypes => 'type',
+  resolver: ({project}) => project.traces,
+  hidden: true,
+});
+
+export const opProjectTraces = makeProjectOp({
+  name: 'project-traces',
+  argTypes: projectArgTypes,
+  description: `Returns the ${docType('list', {
+    plural: true,
+  })} for a ${docType('project')}`,
+  argDescriptions: {project: projectArgDescription},
+  returnValueDescription: `The ${docType('list', {
+    plural: true,
+  })} for a ${docType('project')}`,
+  returnType: inputTypes => list(typedDict({})),
+  resolver: ({project}) => project.traces,
+  // resolveOutputType: async (
+  //   inputTypes,
+  //   node,
+  //   executableNode,
+  //   client,
+  //   stack
+  // ) => {
+  //   console.log(executableNode);
+  //   const res = await client.query(
+  //     opProjectTracesType(executableNode.fromOp.inputs as any)
+  //   );
+  //   return res;
+  // },
 });

--- a/weave-js/src/core/ops/domain/project.ts
+++ b/weave-js/src/core/ops/domain/project.ts
@@ -1,5 +1,5 @@
 import * as Urls from '../../_external/util/urls';
-import {hash, list, maybe, typedDict, union} from '../../model';
+import {hash, list, typedDict, union} from '../../model';
 import {docType} from '../../util/docs';
 import * as OpKinds from '../opKinds';
 import {
@@ -7,6 +7,7 @@ import {
   traceFilterType,
   traceLimitType,
   traceOffsetType,
+  traceQueryType,
   traceSortByType,
 } from './util';
 
@@ -314,8 +315,9 @@ const projectTracesArgTypes = {
         limit: traceLimitType,
         offset: traceOffsetType,
         sort_by: traceSortByType,
+        query: traceQueryType,
       },
-      ['filter', 'limit', 'offset', 'sort_by']
+      ['filter', 'limit', 'offset', 'sort_by', 'query']
     ),
   ]),
 };
@@ -327,6 +329,7 @@ const projectTracesArgTypesDescription = {
   'payload.limit': `A number representing the limit for number of trace calls`,
   'payload.offset': `A number representing the offset for the number of trace calls`,
   'payload.sort_by': `An array with a dictionary with keys \`field\`(<string>) and \`direction\` ("asc"|"desc")`,
+  'payload.query': `A dictionary to query data inspired by mongodb aggregation operators`,
 };
 
 export const opProjectTracesType = makeProjectOp({

--- a/weave-js/src/core/ops/domain/util.ts
+++ b/weave-js/src/core/ops/domain/util.ts
@@ -1,4 +1,4 @@
-import {list, typedDict, TypedDictType, union} from '../../model';
+import {dict, list, typedDict, union} from '../../model';
 
 /**
  * `connectionToNodes` is a helper function that converts a `connection` type
@@ -66,3 +66,4 @@ export const traceSortByType = union([
   'none',
   list(typedDict({field: 'string', direction: 'string'})),
 ]);
+export const traceQueryType = union(['none', dict('any')])

--- a/weave-js/src/core/ops/domain/util.ts
+++ b/weave-js/src/core/ops/domain/util.ts
@@ -1,3 +1,5 @@
+import {list, typedDict, TypedDictType, union} from '../../model';
+
 /**
  * `connectionToNodes` is a helper function that converts a `connection` type
  * returned from gql to its list of nodes. In many, many location in our
@@ -41,3 +43,26 @@ export const connectionToNodes = <T>(connection: MaybeConnection<T>): T[] =>
   (connection?.edges ?? [])
     .map(edge => edge?.node)
     .filter(node => node != null) as T[];
+
+const traceFilterPropertyTypes = {
+  trace_roots_only: union(['none', 'boolean']),
+  op_names: union(['none', list('string')]),
+  input_refs: union(['none', list('string')]),
+  output_refs: union(['none', list('string')]),
+  parent_ids: union(['none', list('string')]),
+  trace_ids: union(['none', list('string')]),
+  call_ids: union(['none', list('string')]),
+  wb_user_ids: union(['none', list('string')]),
+  wb_run_ids: union(['none', list('string')]),
+};
+
+export const traceFilterType = union([
+  'none',
+  typedDict(traceFilterPropertyTypes, Object.keys(traceFilterPropertyTypes)),
+]);
+export const traceLimitType = union(['none', 'number']);
+export const traceOffsetType = union(['none', 'number']);
+export const traceSortByType = union([
+  'none',
+  list(typedDict({field: 'string', direction: 'string'})),
+]);

--- a/weave-js/src/core/ops/domain/util.ts
+++ b/weave-js/src/core/ops/domain/util.ts
@@ -66,4 +66,4 @@ export const traceSortByType = union([
   'none',
   list(typedDict({field: 'string', direction: 'string'})),
 ]);
-export const traceQueryType = union(['none', dict('any')])
+export const traceQueryType = union(['none', dict('any')]);

--- a/weave_query/weave_query/io_service.py
+++ b/weave_query/weave_query/io_service.py
@@ -432,11 +432,11 @@ class Server:
     ) -> list[dict]:
         return await self.wandb_trace_server_api.query_calls_stream(
             project_id,
-            filter,
-            limit,
-            offset,
-            sort_by,
-            query,
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            sort_by=sort_by,
+            query=query,
         )
 
     async def handle_ensure_file_downloaded(
@@ -611,7 +611,7 @@ class AsyncConnection:
         offset: typing.Optional[int] = None,
         sort_by: typing.Optional[list] = None,
         query: typing.Optional[dict] = None,
-    ):
+    ) -> typing.Optional[list[dict]]:
         res = await self.request(
             "query_traces",
             project_id,
@@ -718,6 +718,24 @@ class SyncClient:
     def sleep(self, seconds: float) -> None:
         return self.request("sleep", seconds)
 
+    def query_traces(
+        self,
+        project_id: str,
+        filter: typing.Optional[dict] = None,
+        limit: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
+        sort_by: typing.Optional[list] = None,
+        query: typing.Optional[dict] = None,
+    ) -> typing.Optional[list[dict]]:
+        return self.request(
+            "query_traces",
+            project_id,
+            filter,
+            limit,
+            offset,
+            sort_by,
+            query,
+        )
 
 class ServerlessClient:
     def __init__(self, fs: filesystem.Filesystem) -> None:
@@ -727,6 +745,7 @@ class ServerlessClient:
         self.wandb_file_manager = wandb_file_manager.WandbFileManager(
             self.fs, self.http, self.wandb_api
         )
+        self.wandb_trace_server_api = wandb_trace_server_api.WandbTraceApiSync(self.http)
 
     def manifest(
         self,
@@ -757,6 +776,25 @@ class ServerlessClient:
 
     def sleep(self, seconds: float) -> None:
         time.sleep(seconds)
+
+    def query_traces(
+        self,
+        project_id: str,
+        filter: typing.Optional[dict] = None,
+        limit: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
+        sort_by: typing.Optional[list] = None,
+        query: typing.Optional[dict] = None,
+    ) -> typing.Optional[list[dict]]:
+        res = self.wandb_trace_server_api.query_calls_stream(
+            project_id,
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            sort_by=sort_by,
+            query=query,
+        )
+        return res
 
 
 def get_sync_client() -> typing.Union[SyncClient, ServerlessClient]:

--- a/weave_query/weave_query/io_service.py
+++ b/weave_query/weave_query/io_service.py
@@ -35,6 +35,7 @@ from weave_query import (
     uris,
     wandb_api,
     wandb_file_manager,
+    wandb_trace_server_api
 )
 
 tracer = engine_trace.tracer()  # type: ignore
@@ -217,6 +218,7 @@ class Server:
         self.register_handler_fn("ensure_file", self.handle_ensure_file)
         self.register_handler_fn("direct_url", self.handle_direct_url)
         self.register_handler_fn("sleep", self.handle_sleep)
+        self.register_handler_fn("query_traces", self.handle_query_traces)
 
         if process:
             self.request_handler = aioprocessing.AioProcess(
@@ -343,6 +345,7 @@ class Server:
             self.wandb_file_manager = wandb_file_manager.WandbFileManagerAsync(
                 fs, net, await wandb_api.get_wandb_api()
             )
+            self.wandb_trace_server_api = wandb_trace_server_api.WandbTraceApiAsync(net)
 
             self._request_handler_ready_event.set()
             while True:
@@ -417,6 +420,28 @@ class Server:
         ):
             raise errors.WeaveInternalError("invalid scheme ", uri)
         return await self.wandb_file_manager.ensure_file(uri)
+    
+    async def handle_query_traces(
+        self,
+        project_id: str,
+        filter: typing.Optional[dict] = None,
+        limit: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
+        sort_by: typing.Optional[list] = None,
+        query: typing.Optional[dict] = None,
+        include_costs: bool = False,
+        include_feedback: bool = False,
+    ) -> list[dict]:
+        return await self.wandb_trace_server_api.query_calls_stream(
+            project_id,
+            filter,
+            limit,
+            offset,
+            sort_by,
+            query,
+            include_costs,
+            include_feedback
+        )
 
     async def handle_ensure_file_downloaded(
         self, download_url: str
@@ -481,12 +506,24 @@ class AsyncConnection:
 
     async def close(self) -> None:
         self.connected = False
+        sentinel = ServerResponse(http_error_code=200, error=False, client_id=self.client_id, id=-1, value=None)
+        await self.response_queue.async_put(sentinel)
+        await self.response_task
 
     async def handle_responses(self) -> None:
-        while self.connected:
-            resp = await self.response_queue.async_get()
-            self.response_queue.task_done()
-            self.requests[resp.id].set_result(resp)
+        try:
+            while self.connected:
+                resp = await self.response_queue.async_get()
+
+                if resp.id == -1:
+                    break
+
+                self.response_queue.task_done()
+                self.requests[resp.id].set_result(resp)
+        finally:
+            for future in self.requests.values():
+                if not future.done():
+                    future.cancel()
 
     async def request(self, name: str, *args: typing.Any) -> typing.Any:
         # Caller must check ServerResponse.error!
@@ -569,6 +606,30 @@ class AsyncConnection:
 
     async def sleep(self, seconds: float) -> float:
         return await self.request("sleep", seconds)
+    
+    async def query_traces(
+        self,
+        project_id: str,
+        filter: typing.Optional[dict] = None,
+        limit: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
+        sort_by: typing.Optional[list] = None,
+        query: typing.Optional[dict] = None,
+        include_costs: bool = False,
+        include_feedback: bool = False
+    ):
+        res = await self.request(
+            "query_traces",
+            project_id,
+            filter,
+            limit,
+            offset,
+            sort_by,
+            query,
+            include_costs,
+            include_feedback
+        )
+        return res
 
 
 class AsyncClient:

--- a/weave_query/weave_query/io_service.py
+++ b/weave_query/weave_query/io_service.py
@@ -429,8 +429,6 @@ class Server:
         offset: typing.Optional[int] = None,
         sort_by: typing.Optional[list] = None,
         query: typing.Optional[dict] = None,
-        include_costs: bool = False,
-        include_feedback: bool = False,
     ) -> list[dict]:
         return await self.wandb_trace_server_api.query_calls_stream(
             project_id,
@@ -439,8 +437,6 @@ class Server:
             offset,
             sort_by,
             query,
-            include_costs,
-            include_feedback
         )
 
     async def handle_ensure_file_downloaded(
@@ -615,8 +611,6 @@ class AsyncConnection:
         offset: typing.Optional[int] = None,
         sort_by: typing.Optional[list] = None,
         query: typing.Optional[dict] = None,
-        include_costs: bool = False,
-        include_feedback: bool = False
     ):
         res = await self.request(
             "query_traces",
@@ -626,8 +620,6 @@ class AsyncConnection:
             offset,
             sort_by,
             query,
-            include_costs,
-            include_feedback
         )
         return res
 

--- a/weave_query/weave_query/ops_domain/project_ops.py
+++ b/weave_query/weave_query/ops_domain/project_ops.py
@@ -331,8 +331,10 @@ traces_input_types = {
 )
 def traces_type(project, payload):
     res = asyncio.run(_get_project_traces(project, payload))
-    ttype = types.TypeRegistry.type_of(res)
-    return ttype
+    if res:
+        return types.TypeRegistry.type_of(res)
+    else:
+        return types.TypeRegistry.type_of([])
 
 @op(
     name="project-traces",

--- a/weave_query/weave_query/wandb_trace_server_api.py
+++ b/weave_query/weave_query/wandb_trace_server_api.py
@@ -3,8 +3,10 @@
 import contextlib
 import contextvars
 import typing
+import json
 
 import aiohttp
+import requests
 
 from weave_query import errors
 from weave_query import environment as weave_env
@@ -17,6 +19,7 @@ tracer = engine_trace.tracer()  # type: ignore
 def get_wandb_api_context() -> typing.Optional[WandbApiContext]:
     return _wandb_api_context.get()
 
+# todo(dom): Figure out how to use this async client API within ops.
 class WandbTraceApiAsync:
     def __init__(self) -> None:
         self.connector = aiohttp.TCPConnector(limit=50)
@@ -27,15 +30,13 @@ class WandbTraceApiAsync:
             filter: typing.Optional[dict] = None,
             limit: typing.Optional[int] = None,
             offset: typing.Optional[int] = None,
+            sort_by: typing.Optional[list] = None,
             include_costs: bool = False,
             include_feedback: bool = False,
             **kwargs: typing.Any
-        ) -> typing.Any:
+        ) -> typing.AsyncIterator[dict]:
             wandb_context = get_wandb_api_context()
-            headers = {
-                "Accept": "application/jsonl",
-                "Content-Type": "application/json"
-            }
+            headers = {'content-type: application/json'}
             auth = None
             
             if wandb_context is not None:
@@ -48,7 +49,9 @@ class WandbTraceApiAsync:
             if api_key_override:
                 auth = aiohttp.BasicAuth("api", api_key_override)
 
-            url = f"{weave_env.weave_trace_server_url()}/calls/stream_query"
+            # todo(dom): Add env var support instead of hardcoding
+            # url = f"{weave_env.weave_trace_server_url()}/calls/stream_query"
+            url = "http://127.0.0.1:6345/calls/stream_query"
             
             payload = {
                 "project_id": project_id,
@@ -62,17 +65,22 @@ class WandbTraceApiAsync:
                 payload["limit"] = limit
             if offset:
                 payload["offset"] = offset
+            if sort_by:
+                payload["sort_by"] = sort_by
             
             payload.update(kwargs)
 
             async with aiohttp.ClientSession(
                 connector=self.connector,
                 headers=headers,
-                auth=auth
             ) as session:
                 async with session.post(url, json=payload) as response:
                     response.raise_for_status()
-                    return await response.json()
+                    async for line in response.content:
+                        if line:
+                            decoded_line = line.decode('utf-8').strip()
+                            if decoded_line:
+                                yield json.loads(decoded_line)
 
 class WandbTraceApiSync:
     def query_calls_stream(
@@ -81,28 +89,28 @@ class WandbTraceApiSync:
         filter: typing.Optional[dict] = None,
         limit: typing.Optional[int] = None,
         offset: typing.Optional[int] = None,
+        sort_by: typing.Optional[list] = None,
         include_costs: bool = False,
         include_feedback: bool = False,
         **kwargs: typing.Any
     ) -> typing.Any:
         wandb_context = get_wandb_api_context()
-        headers = {
-            "Accept": "application/jsonl",
-            "Content-Type": "application/json"
-        }
-        auth = None
+        headers = {}
         
         if wandb_context is not None:
             if wandb_context.headers:
                 headers.update(wandb_context.headers)
+                headers["authorization"] = "Basic Og=="
             if wandb_context.api_key is not None:
-                auth = ( "api", wandb_context.api_key)
+                auth = ("api", wandb_context.api_key)
 
         api_key_override = kwargs.pop("api_key", None)
         if api_key_override:
             auth = ("api", api_key_override)
 
-        url = f"{weave_env.wandb_base_url()}/calls/stream_query"
+        # todo(dom): Add env var support instead of hardcoding
+        # url = f"https://trace_server.wandb.test/calls/stream_query"
+        url = "http://127.0.0.1:6345/calls/stream_query"
         
         payload = {
             "project_id": project_id,
@@ -116,21 +124,27 @@ class WandbTraceApiSync:
             payload["limit"] = limit
         if offset:
             payload["offset"] = offset
+        if sort_by:
+            payload["sort_by"] = sort_by
         
         payload.update(kwargs)
 
-        with aiohttp.ClientSession(
-            connector=self.connector,
+        # todo(dom): Figure out a way to specify the auth kwarg with it
+        # causing a 403 error when it is None (when using the authorization header)
+        response = requests.post(
+            url,
+            json=payload,
             headers=headers,
-            auth=auth
-        ) as session:
-            with session.post(url, json=payload) as response:
-                response.raise_for_status()
-                return response.json()
-            
-async def get_wandb_api() -> WandbTraceApiAsync:
+            stream=True
+        )
+        response.raise_for_status()
+
+        for line in response.iter_lines():
+            if line:
+                yield json.loads(line.decode('utf-8'))
+
+async def get_wandb_trace_api() -> WandbTraceApiAsync:
     return WandbTraceApiAsync()
 
-
-def get_wandb_api_sync() -> WandbTraceApiSync:
+def get_wandb_trace_api_sync() -> WandbTraceApiSync:
     return WandbTraceApiSync()

--- a/weave_query/weave_query/wandb_trace_server_api.py
+++ b/weave_query/weave_query/wandb_trace_server_api.py
@@ -31,8 +31,6 @@ class WandbTraceApiAsync:
             offset: typing.Optional[int] = None,
             sort_by: typing.Optional[list] = None,
             query: typing.Optional[dict] = None,
-            include_costs: bool = False,
-            include_feedback: bool = False,
         ) -> typing.List[dict]:
             wandb_api_context = get_wandb_api_context()
             headers = {'content-type': 'application/json'}
@@ -44,14 +42,12 @@ class WandbTraceApiAsync:
                 if wandb_api_context.api_key is not None:
                     auth = aiohttp.BasicAuth("api", wandb_api_context.api_key)
                 if cookies:
-                    headers["authorization"] = "Basic Og=="
+                    headers["authorization"] = "Basic Og==" # base64 encoding of ":"
 
             url = f"{weave_env.weave_trace_server_url()}/calls/stream_query"
 
             payload = {
                 "project_id": project_id,
-                "include_costs": include_costs,
-                "include_feedback": include_feedback,
             }
             
             if filter:
@@ -76,21 +72,21 @@ class WandbTraceApiSync:
         offset: typing.Optional[int] = None,
         sort_by: typing.Optional[list] = None,
         query: typing.Optional[dict] = None,
-        include_costs: bool = False,
-        include_feedback: bool = False,
         **kwargs: typing.Any
     ) -> typing.Any:
-        wandb_context = get_wandb_api_context()
+        wandb_api_context = get_wandb_api_context()
         headers = {'content-type': 'application/json'}
         auth = None
-        
-        if wandb_context is not None:
-            if wandb_context.headers:
-                headers.update(wandb_context.headers)
-            if wandb_context.api_key is not None:
-                auth = ("api", wandb_context.api_key)
-            else:
-                headers["authorization"] = "Basic Og=="
+        cookies = None
+        if wandb_api_context is not None:
+            headers = wandb_api_context.headers
+            cookies = wandb_api_context.cookies
+            if wandb_api_context.api_key is not None:
+                auth = aiohttp.BasicAuth("api", wandb_api_context.api_key)
+            if cookies:
+                headers["authorization"] = "Basic Og==" # base64 encoding of ":"
+
+        url = f"{weave_env.weave_trace_server_url()}/calls/stream_query"
 
         api_key_override = kwargs.pop("api_key", None)
         if api_key_override:
@@ -100,8 +96,6 @@ class WandbTraceApiSync:
         
         payload = {
             "project_id": project_id,
-            "include_costs": include_costs,
-            "include_feedback": include_feedback,
         }
         
         if filter:

--- a/weave_query/weave_query/wandb_trace_server_api.py
+++ b/weave_query/weave_query/wandb_trace_server_api.py
@@ -1,0 +1,136 @@
+# This is an experimental client api used to make requests to the
+# Weave Trace Server
+import contextlib
+import contextvars
+import typing
+
+import aiohttp
+
+from weave_query import errors
+from weave_query import environment as weave_env
+from weave_query import wandb_client_api, engine_trace
+
+from weave_query.context_state import WandbApiContext, _wandb_api_context
+
+tracer = engine_trace.tracer()  # type: ignore
+
+def get_wandb_api_context() -> typing.Optional[WandbApiContext]:
+    return _wandb_api_context.get()
+
+class WandbTraceApiAsync:
+    def __init__(self) -> None:
+        self.connector = aiohttp.TCPConnector(limit=50)
+    
+    async def query_calls_stream(
+            self,
+            project_id: str,
+            filter: typing.Optional[dict] = None,
+            limit: typing.Optional[int] = None,
+            offset: typing.Optional[int] = None,
+            include_costs: bool = False,
+            include_feedback: bool = False,
+            **kwargs: typing.Any
+        ) -> typing.Any:
+            wandb_context = get_wandb_api_context()
+            headers = {
+                "Accept": "application/jsonl",
+                "Content-Type": "application/json"
+            }
+            auth = None
+            
+            if wandb_context is not None:
+                if wandb_context.headers:
+                    headers.update(wandb_context.headers)
+                if wandb_context.api_key is not None:
+                    auth = aiohttp.BasicAuth("api", wandb_context.api_key)
+
+            api_key_override = kwargs.pop("api_key", None)
+            if api_key_override:
+                auth = aiohttp.BasicAuth("api", api_key_override)
+
+            url = f"{weave_env.weave_trace_server_url()}/calls/stream_query"
+            
+            payload = {
+                "project_id": project_id,
+                "include_costs": include_costs,
+                "include_feedback": include_feedback,
+            }
+            
+            if filter:
+                payload["filter"] = filter
+            if limit:
+                payload["limit"] = limit
+            if offset:
+                payload["offset"] = offset
+            
+            payload.update(kwargs)
+
+            async with aiohttp.ClientSession(
+                connector=self.connector,
+                headers=headers,
+                auth=auth
+            ) as session:
+                async with session.post(url, json=payload) as response:
+                    response.raise_for_status()
+                    return await response.json()
+
+class WandbTraceApiSync:
+    def query_calls_stream(
+        self,
+        project_id: str,
+        filter: typing.Optional[dict] = None,
+        limit: typing.Optional[int] = None,
+        offset: typing.Optional[int] = None,
+        include_costs: bool = False,
+        include_feedback: bool = False,
+        **kwargs: typing.Any
+    ) -> typing.Any:
+        wandb_context = get_wandb_api_context()
+        headers = {
+            "Accept": "application/jsonl",
+            "Content-Type": "application/json"
+        }
+        auth = None
+        
+        if wandb_context is not None:
+            if wandb_context.headers:
+                headers.update(wandb_context.headers)
+            if wandb_context.api_key is not None:
+                auth = ( "api", wandb_context.api_key)
+
+        api_key_override = kwargs.pop("api_key", None)
+        if api_key_override:
+            auth = ("api", api_key_override)
+
+        url = f"{weave_env.wandb_base_url()}/calls/stream_query"
+        
+        payload = {
+            "project_id": project_id,
+            "include_costs": include_costs,
+            "include_feedback": include_feedback,
+        }
+        
+        if filter:
+            payload["filter"] = filter
+        if limit:
+            payload["limit"] = limit
+        if offset:
+            payload["offset"] = offset
+        
+        payload.update(kwargs)
+
+        with aiohttp.ClientSession(
+            connector=self.connector,
+            headers=headers,
+            auth=auth
+        ) as session:
+            with session.post(url, json=payload) as response:
+                response.raise_for_status()
+                return response.json()
+            
+async def get_wandb_api() -> WandbTraceApiAsync:
+    return WandbTraceApiAsync()
+
+
+def get_wandb_api_sync() -> WandbTraceApiSync:
+    return WandbTraceApiSync()

--- a/weave_query/weave_query/weave_http.py
+++ b/weave_query/weave_query/weave_http.py
@@ -12,6 +12,7 @@ import aiohttp
 import requests
 import requests.auth
 import yarl
+import json
 
 from weave_query import engine_trace, filesystem, server_error_handling
 
@@ -128,6 +129,29 @@ class HttpAsync:
                         r.status, "Download failed"
                     )
 
+    async def query_traces(
+        self,
+        url: str,
+        payload: typing.Optional[dict],
+        headers: typing.Optional[dict[str, str]] = None,
+        cookies: typing.Optional[dict[str, str]] = None,
+        auth: typing.Optional[aiohttp.BasicAuth] = None,
+    ) -> list[dict]:
+        with tracer.trace("query_traces"):
+            results = []
+            async with self.session.post(url, json=payload, headers=headers, cookies=cookies, auth=auth) as response:
+                if response.status == 200:
+                    async for line in response.content:
+                        if line:
+                            decoded_line = line.decode('utf-8').strip()
+                            if decoded_line:
+                                results.append(json.loads(decoded_line))
+                    return results
+                else:
+                    raise server_error_handling.WeaveInternalHttpException.from_code(
+                        response.status_code,
+                        "Traces query failed",
+                    )
 
 class Http:
     def __init__(self, fs: filesystem.Filesystem) -> None:
@@ -169,3 +193,25 @@ class Http:
                         r.status_code,
                         "Download failed",  # type: ignore
                     )
+                
+    def query_traces(
+        self,
+        url: str,
+        payload: typing.Optional[dict],
+        headers: typing.Optional[dict[str, str]] = None,
+        cookies: typing.Optional[dict[str, str]] = None,
+        auth: typing.Optional[aiohttp.BasicAuth] = None,
+    ) -> list[dict]:
+        with tracer.trace("query_traces"):
+            results = []
+            with self.session.post(url, json=payload, headers=headers, cookies=cookies, auth=auth) as response:
+                if response.status_code == 200:
+                    for line in response.iter_lines():
+                        if line:
+                            results.append(json.loads(line))
+                else:
+                    raise server_error_handling.WeaveInternalHttpException.from_code(
+                        response.status_code,
+                        "Traces query failed",
+                    )
+            return results

--- a/weave_query/weave_query/weave_http.py
+++ b/weave_query/weave_query/weave_http.py
@@ -149,7 +149,7 @@ class HttpAsync:
                     return results
                 else:
                     raise server_error_handling.WeaveInternalHttpException.from_code(
-                        response.status_code,
+                        response.status,
                         "Traces query failed",
                     )
 


### PR DESCRIPTION
## Description
## 🚧 This is WIP 🚧 

[Internal doc](https://www.notion.so/wandbai/Query-Panel-Weave-Traces-13de2f5c7ef380dcb6b7c3cd00976849?pvs=4)

This draft (as of PR creation) contains two ops and an api client to handle loading weave traces onto query panels.
* The query panel can be tested by using the expression `project.traces({})`
  * Another example with currently implemented payload fields: `project.traces({filter: {trace_roots_only: true}, limit: 10000, offset: 0, sort_by: [{field: "started_at", direction: "desc"}]})`

@nicholaspun-wandb , there are minor tweaks to be made like adding feedback and cost support, but I think some interesting meaty items to take on could be:
1. A spike on figuring out a more efficient way to get the column types of the calls
2. Adding feature flagging support to limit access to this op

### Development Notes / Tips
I spent too much time toiling over the ops not matching only to realize that my changes to `weave-public` weren't being reflected in the dev environment.

**Make sure you:**
1. navigate to `weave-python` and `pip install -e ./weave-public/weave_query/`
2. every time you make a change to weave_query (python), [s]top and [r]eload `weave_server.wandb` thru governor. I found that I needed to do this to propagate code changes and flush any stdout I debug printed.
3. if you switch branches on `core` then switch back, make sure you redo step 1 from above.
4. Don't always wait for `app.wandb`'s HMR. I found that this takes way too long due to import cycles (depending on the file you updated).  Sometimes it's faster to [s]top and [r]eload it on governor.

<img width="659" alt="image" src="https://github.com/user-attachments/assets/1207e69a-3b00-4df8-a18c-dd3ada0a3bc9">


<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

_tbd_

## Testing

_tbd_
