### PR TITLE
chore(ui): right drawer doesn't occlude call metrics charts

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCharts.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCharts.tsx
@@ -182,7 +182,7 @@ export const CallsCharts = ({
   return (
     <Tailwind>
       {/* setting the width to the width of the screen minus the sidebar width because of overflow: 'hidden' properties in SimplePageLayout causing issues */}
-      <div className="md:w-[calc(100vw-56px)]">
+      <div className="w-full md:max-w-[calc(100vw-56px)]">
         <div className="mb-20 mt-10">{charts}</div>
       </div>
     </Tailwind>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/Charts.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/Charts.tsx
@@ -2,7 +2,7 @@ import {quantile} from 'd3-array';
 import _ from 'lodash';
 import moment from 'moment';
 import * as Plotly from 'plotly.js';
-import React, {useEffect, useMemo, useRef} from 'react';
+import React, {useMemo, useRef} from 'react';
 
 import {
   BLUE_500,
@@ -63,6 +63,8 @@ const Y_AXIS_STYLE: Partial<Plotly.LayoutAxis> = {
   tickfont: {color: MOON_500},
   zeroline: false,
 };
+
+const PLOT_DEBOUNCE_MS = 200;
 
 export const calculateBinSize = (
   data: ChartDataLatency[] | ChartDataErrors[] | ChartDataRequests[],
@@ -147,28 +149,28 @@ export const LatencyPlotlyChart: React.FC<{
     ];
   }, [chartData, binSize]);
 
-  useEffect(() => {
-    const plotlyLayout: Partial<Plotly.Layout> = {
-      height,
-      margin: CHART_MARGIN_STYLE,
-      xaxis: X_AXIS_STYLE_WITH_SPIKES,
-      yaxis: Y_AXIS_STYLE,
-      hovermode: 'x unified',
-      showlegend: false,
-      hoverlabel: {
-        bordercolor: MOON_200,
-      },
-    };
+  const plotlyLayout: Partial<Plotly.Layout> = {
+    height,
+    margin: CHART_MARGIN_STYLE,
+    xaxis: X_AXIS_STYLE_WITH_SPIKES,
+    yaxis: Y_AXIS_STYLE,
+    hovermode: 'x unified',
+    showlegend: false,
+    hoverlabel: {
+      bordercolor: MOON_200,
+    },
+  };
 
-    const plotlyConfig: Partial<Plotly.Config> = {
-      displayModeBar: false,
-      responsive: true,
-    };
+  const plotlyConfig: Partial<Plotly.Config> = {
+    displayModeBar: false,
+    responsive: true,
+  };
 
-    if (divRef.current) {
-      Plotly.newPlot(divRef.current, plotlyData, plotlyLayout, plotlyConfig);
-    }
-  }, [plotlyData, height]);
+  if (divRef.current) {
+    _.debounce(() => {
+      Plotly.newPlot(divRef.current!, plotlyData, plotlyLayout, plotlyConfig);
+    }, PLOT_DEBOUNCE_MS)();
+  }
 
   return <div ref={divRef}></div>;
 };
@@ -206,29 +208,29 @@ export const ErrorPlotlyChart: React.FC<{
     ];
   }, [chartData, binSize]);
 
-  useEffect(() => {
-    const plotlyLayout: Partial<Plotly.Layout> = {
-      height,
-      margin: CHART_MARGIN_STYLE,
-      bargap: 0.2,
-      xaxis: X_AXIS_STYLE,
-      yaxis: Y_AXIS_STYLE,
-      hovermode: 'x unified',
-      hoverlabel: {
-        bordercolor: MOON_200,
-      },
-      dragmode: 'zoom',
-    };
+  const plotlyLayout: Partial<Plotly.Layout> = {
+    height,
+    margin: CHART_MARGIN_STYLE,
+    bargap: 0.2,
+    xaxis: X_AXIS_STYLE,
+    yaxis: Y_AXIS_STYLE,
+    hovermode: 'x unified',
+    hoverlabel: {
+      bordercolor: MOON_200,
+    },
+    dragmode: 'zoom',
+  };
 
-    const plotlyConfig: Partial<Plotly.Config> = {
-      displayModeBar: false,
-      responsive: true,
-    };
+  const plotlyConfig: Partial<Plotly.Config> = {
+    displayModeBar: false,
+    responsive: true,
+  };
 
-    if (divRef.current) {
-      Plotly.newPlot(divRef.current, plotlyData, plotlyLayout, plotlyConfig);
-    }
-  }, [plotlyData, height]);
+  if (divRef.current) {
+    _.debounce(() => {
+      Plotly.newPlot(divRef.current!, plotlyData, plotlyLayout, plotlyConfig);
+    }, PLOT_DEBOUNCE_MS)();
+  }
 
   return <div ref={divRef}></div>;
 };
@@ -266,28 +268,28 @@ export const RequestsPlotlyChart: React.FC<{
     ];
   }, [chartData, binSize]);
 
-  useEffect(() => {
-    const plotlyLayout: Partial<Plotly.Layout> = {
-      height,
-      margin: CHART_MARGIN_STYLE,
-      xaxis: X_AXIS_STYLE,
-      yaxis: Y_AXIS_STYLE,
-      bargap: 0.2,
-      hovermode: 'x unified',
-      hoverlabel: {
-        bordercolor: MOON_200,
-      },
-    };
+  const plotlyLayout: Partial<Plotly.Layout> = {
+    height,
+    margin: CHART_MARGIN_STYLE,
+    xaxis: X_AXIS_STYLE,
+    yaxis: Y_AXIS_STYLE,
+    bargap: 0.2,
+    hovermode: 'x unified',
+    hoverlabel: {
+      bordercolor: MOON_200,
+    },
+  };
 
-    const plotlyConfig: Partial<Plotly.Config> = {
-      displayModeBar: false,
-      responsive: true,
-    };
+  const plotlyConfig: Partial<Plotly.Config> = {
+    displayModeBar: false,
+    responsive: true,
+  };
 
-    if (divRef.current) {
-      Plotly.newPlot(divRef.current, plotlyData, plotlyLayout, plotlyConfig);
-    }
-  }, [plotlyData, height]);
+  if (divRef.current) {
+    _.debounce(() => {
+      Plotly.newPlot(divRef.current!, plotlyData, plotlyLayout, plotlyConfig);
+    }, PLOT_DEBOUNCE_MS)();
+  }
 
   return <div ref={divRef}></div>;
 };


### PR DESCRIPTION
## Description

Change size of metric charts section to be full container width instead of fixed based on window size.

Create plotly chart directly in the component render for metric charts, instead of in an effect that depends on only a few of the props.

Adds a 200ms debounce to all metric chart updates so resizing the drawer doesn't cause excessive re-rendering of the plots.

before:
![Screenshot 2024-12-04 at 2 15 04 PM](https://github.com/user-attachments/assets/49a77718-a4e2-486f-af37-8dfae977d63d)

after:
![Screenshot 2024-12-04 at 2 15 26 PM](https://github.com/user-attachments/assets/fb2288b4-3e44-475f-b40f-b310ccdcb129)
