### PR TITLE
feat(weave): Support op kwarg passthrough to autopatched functions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -477,7 +477,9 @@ def make_server_recorder(server: tsi.TraceServerInterface):  # type: ignore
     return ServerRecorder(server)
 
 
-def create_client(request) -> weave_init.InitializedClient:
+def create_client(
+    request, autopatch_settings: typing.Optional[autopatch.AutopatchSettings] = None
+) -> weave_init.InitializedClient:
     inited_client = None
     weave_server_flag = request.config.getoption("--weave-server")
     server: tsi.TraceServerInterface
@@ -513,7 +515,7 @@ def create_client(request) -> weave_init.InitializedClient:
             entity, project, make_server_recorder(server)
         )
         inited_client = weave_init.InitializedClient(client)
-        autopatch.autopatch()
+        autopatch.autopatch(autopatch_settings)
 
     return inited_client
 
@@ -527,6 +529,7 @@ def client(request):
         yield inited_client.client
     finally:
         inited_client.reset()
+        autopatch.reset_autopatch()
 
 
 @pytest.fixture()
@@ -534,12 +537,13 @@ def client_creator(request):
     """This fixture is useful for delaying the creation of the client (ex. when you want to set settings first)"""
 
     @contextlib.contextmanager
-    def client():
-        inited_client = create_client(request)
+    def client(autopatch_settings: typing.Optional[autopatch.AutopatchSettings] = None):
+        inited_client = create_client(request, autopatch_settings)
         try:
             yield inited_client.client
         finally:
             inited_client.reset()
+            autopatch.reset_autopatch()
 
     yield client
 

--- a/tests/integrations/litellm/litellm_test.py
+++ b/tests/integrations/litellm/litellm_test.py
@@ -8,7 +8,7 @@ import pytest
 from packaging.version import parse as version_parse
 
 import weave
-from weave.integrations.litellm.litellm import litellm_patcher
+from weave.integrations.litellm.litellm import get_litellm_patcher
 
 # This PR:
 # https://github.com/BerriAI/litellm/commit/fe2aa706e8ff4edbcd109897e5da6b83ef6ad693
@@ -38,9 +38,9 @@ def patch_litellm(request: Any) -> Generator[None, None, None]:
         yield
         return
 
-    litellm_patcher.attempt_patch()
+    get_litellm_patcher().attempt_patch()
     yield
-    litellm_patcher.undo_patch()
+    get_litellm_patcher().undo_patch()
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode

--- a/tests/integrations/openai/cassettes/test_autopatch/test_disabled_integration_doesnt_patch.yaml
+++ b/tests/integrations/openai/cassettes/test_autopatch/test_disabled_integration_doesnt_patch.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"tell me a joke"}],"model":"gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '74'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.57.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.57.2
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.0rc2
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFI7b9swEN71K65cstiFLKm246XI4KEF2gZoiw5NITDkSWQs8RjylNYI
+        /N8DyQ85SAJ04fC9+N2RjwmAsFqsQCgjWbW+mV7p4vP229fL9TV9+cR/6f6+08X1Vfbwc75ei0nv
+        oNs7VHx0vVfU+gbZktvTKqBk7FNnizxfLorFfD4QLWlselvteVrQNEuzYpoup+n8YDRkFUaxgt8J
+        AMDjcPYVncZ/YgXp5Ii0GKOsUaxOIgARqOkRIWO0kaVjMRlJRY7RDa2/dwEnYDDgRQQJd7RBqCjA
+        lrrVjbtxv8wWNLkLhrjBBplchMrWhgGlMkBsMHzshT8MHpVGPiCwQag7ju/OLw5YdVH2c7uuaQ74
+        7jRJQ7UPdBsP/AmvrLPRlAFlJNe3jkxeDOwuAfgzbKx7tgThA7WeS6YNuj5wNtvHifGJRjLLDiQT
+        y2bE83zySlqpkaVt4tnGhZLKoB6d4/PITls6I5KzmV+WeS17P7d19f/Ej4RS6Bl16QNqq54PPMoC
+        9h/4Ldlpx0NhEbeRsS0r62oMPtj9H6p8eZnmH4p5tqwykeySJwAAAP//AwDsub+4TAMAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f01268b5ba3b402-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 10 Dec 2024 23:52:47 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=kEqF1CQbu.b5Hj.uQyXQoSVdWXlcAi0AbLLGUjfH1gQ-1733874767-1.0.1.1-ETetKjoNAOuQBBxqMN3rAGRa1pzDB4EwoftLgEzxEwPw5.sm4HTFCKFmbZhXJaqVML87NrQKE6mO27ku2KAV7Q;
+        path=/; expires=Wed, 11-Dec-24 00:22:47 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=IQYRXY2QUWKC6TtEhjI6akHEqIJKHsAkZhYWb1OHJfI-1733874767375-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - wandb
+      openai-processing-ms:
+      - '689'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999979'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_af7c20c1c588dfcd212c11600f870f86
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/openai/cassettes/test_autopatch/test_enabled_integration_patches.yaml
+++ b/tests/integrations/openai/cassettes/test_autopatch/test_enabled_integration_patches.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"tell me a joke"}],"model":"gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '74'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.57.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.57.2
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.0rc2
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrKxa89GIFsi1HgS9FC/SQtocWLWCkTSHQ5EpkQpEsuSqc
+        Bv73gvJDCpoAufAwszOYWe5jBsC0ZGtgQnESnTf5O1l+/Lv6fL2a+/ebL5uv3+5uPm1+/L6+2S13
+        H9gsKdz2DgWdVBfCdd4gaWcPtAjICZPrvFour6qyuqwGonMSTZK1nvLS5YtiUebFVV5cHoXKaYGR
+        reFnBgDwOLwpopW4Y2soZiekwxh5i2x9HgJgwZmEMB6jjsQtsdlICmcJ7ZB6ox5AOvuGIN6jQXI2
+        QqNbRYBcKHCkMLy9tbf2u8LTpOJ/EEghtD3Fi6lxwKaPPPWyvTFHfH9Oalzrg9vGI3/GG211VHVA
+        Hp1NqSI5zwZ2nwH8GjbSPynJfHCdp5rcPdpkOJ8f7Nj4BROyPJLkiJsRX6xmz7jVEolrEycbZYIL
+        hXJUjuvnvdRuQmSTzv+Hec770Fvb9jX2IyEEekJZ+4BSi6eFx7GA6UBfGjvveAjM4kMk7OpG2xaD
+        D/pwI42vRSV4gVsuOMv22T8AAAD//wMA1ERGoiwDAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f0126912f7daabc-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 10 Dec 2024 23:52:48 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=0xyK_x9hey0mfKrIKa6aI6Bp4aV1elQHzHgl1cUWH74-1733874768-1.0.1.1-LxA5omiotFuJSAT1JKPQ4IqDhwGwBZh8Wczr3GxxW4RSP77hGjArNOOiPn4BaKNV95HJMC5m8lzn9jZc4k9_vQ;
+        path=/; expires=Wed, 11-Dec-24 00:22:48 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=JV4iuxRZOkykxg7chIE1w8pJ86bkuFcBZPeA4diCZXI-1733874768055-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - wandb
+      openai-processing-ms:
+      - '455'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999979'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_679152317e836e5058b9a66ab8516b61
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/openai/cassettes/test_autopatch/test_passthrough_op_kwargs.yaml
+++ b/tests/integrations/openai/cassettes/test_autopatch/test_passthrough_op_kwargs.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"tell me a joke"}],"model":"gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '74'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.57.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.57.2
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.0rc2
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrK7a85GIX8gOxoUuQoqcGPRVI0DaFQFNriQ3FJbjLom7g
+        fy8oP+SgKZALDzM7g9lZPhcAyjaqAmU6LaYPbnrbLO9Kufv4tSdz+3Avn9KfcB/m8Zsr02c1yQra
+        /EQjJ9V7Q31wKJb8gTYRtWB2na0Wi/VqubpeD0RPDbosa4NMlzSdl/PltFxPy+ujsCNrkFUF3wsA
+        gOfhzRF9g79VBeXkhPTIrFtU1XkIQEVyGVGa2bJoL2oykoa8oB9Sf0kRJ9BhxCsGDcZlgQHyCFuK
+        sKNUPfpH/9DtoCF/JcDGohfLwiAxsYAW6vkmD31AoxMjSIc76PUTQgqAvzDupLO+fXcZIeI2sc4N
+        +OTcEd+fd3LUhkgbPvJnfGu95a6OqJl8zs9CQQ3svgD4MXSXXtShQqQ+SC30hD4bzmYHOzUeayTn
+        J1JItBvxxXzyilvdoGjr+KJ7ZbTpsBmV46F0aixdEMXFzv+Gec37sLf17VvsR8IYDIJNHSI21rxc
+        eByLmL/y/8bOHQ+BFe9YsK+31rcYQ7SH37QNtVkZXeJGG62KffEXAAD//wMA80Go2FYDAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f012696ad82a252-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 10 Dec 2024 23:52:49 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=EEPH7w7RfXuYImGQM6Acgu9mV7ujHQnsW0VmC4PVCvc-1733874769-1.0.1.1-TBI.d0yS7aWRTluLMTtf3f9HoasHRZH8ilZwQIVfNMn7WxtPATluDGa2JcrxNoTnE2ohfn14m_B_oAijbT6o1A;
+        path=/; expires=Wed, 11-Dec-24 00:22:49 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=updpU3xEaY_7yS9bEBemTGcpozB27mgBUiS5TDYitHk-1733874769005-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - wandb
+      openai-processing-ms:
+      - '513'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999979'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_487696abbe294c61e600a7fcdbf9cd2e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/openai/test_autopatch.py
+++ b/tests/integrations/openai/test_autopatch.py
@@ -1,0 +1,87 @@
+# This is included here for convenience.  Instead of creating a dummy API, we can test
+# autopatching against the actual OpenAI API.
+
+from typing import Any
+
+import pytest
+from openai import OpenAI
+
+from weave.integrations.openai import openai_sdk
+from weave.trace.autopatch import AutopatchSettings, IntegrationSettings, OpSettings
+
+
+@pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
+@pytest.mark.vcr(
+    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
+)
+def test_disabled_integration_doesnt_patch(client_creator):
+    autopatch_settings = AutopatchSettings(
+        openai=IntegrationSettings(enabled=False),
+    )
+
+    with client_creator(autopatch_settings=autopatch_settings) as client:
+        oaiclient = OpenAI()
+        oaiclient.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "tell me a joke"}],
+        )
+
+        calls = list(client.get_calls())
+        assert len(calls) == 0
+
+
+@pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
+@pytest.mark.vcr(
+    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
+)
+def test_enabled_integration_patches(client_creator):
+    autopatch_settings = AutopatchSettings(
+        openai=IntegrationSettings(enabled=True),
+    )
+
+    with client_creator(autopatch_settings=autopatch_settings) as client:
+        oaiclient = OpenAI()
+        oaiclient.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "tell me a joke"}],
+        )
+
+        calls = list(client.get_calls())
+        assert len(calls) == 1
+
+
+@pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
+@pytest.mark.vcr(
+    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
+)
+def test_passthrough_op_kwargs(client_creator):
+    def redact_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+        print("CALLING THIS FUNC")
+        return dict.fromkeys(inputs, "REDACTED")
+
+    autopatch_settings = AutopatchSettings(
+        openai=IntegrationSettings(
+            op_settings=OpSettings(
+                postprocess_inputs=redact_inputs,
+            )
+        )
+    )
+
+    # Explicitly reset the patcher here to pretend like we're starting fresh.  We need
+    # to do this because `_openai_patcher` is a global variable that is shared across
+    # tests.  If we don't reset it, it will retain the state from the previous test,
+    # which can cause this test to fail.
+    openai_sdk._openai_patcher = None
+
+    with client_creator(autopatch_settings=autopatch_settings) as client:
+        oaiclient = OpenAI()
+        oaiclient.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "tell me a joke"}],
+        )
+
+        calls = list(client.get_calls())
+        assert len(calls) == 1
+
+        call = calls[0]
+        assert all(v == "REDACTED" for v in call.inputs.values())

--- a/weave/integrations/anthropic/anthropic_sdk.py
+++ b/weave/integrations/anthropic/anthropic_sdk.py
@@ -204,6 +204,10 @@ def get_anthropic_patcher(
         base,
         name=base.name or "anthropic.Messages.stream",
     )
+    async_stream_settings = dataclasses.replace(
+        base,
+        name=base.name or "anthropic.AsyncMessages.stream",
+    )
 
     _anthropic_patcher = MultiPatcher(
         [
@@ -226,7 +230,7 @@ def get_anthropic_patcher(
             SymbolPatcher(
                 lambda: importlib.import_module("anthropic.resources.messages"),
                 "AsyncMessages.stream",
-                create_stream_wrapper(stream_settings),
+                create_stream_wrapper(async_stream_settings),
             ),
         ]
     )

--- a/weave/integrations/anthropic/anthropic_sdk.py
+++ b/weave/integrations/anthropic/anthropic_sdk.py
@@ -1,21 +1,19 @@
+import dataclasses
 import importlib
 from collections.abc import AsyncIterator, Iterator
 from functools import wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Optional,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_extensions.accumulator import _IteratorWrapper, add_accumulator
 from weave.trace.patcher import MultiPatcher, SymbolPatcher
 
 if TYPE_CHECKING:
     from anthropic.lib.streaming import MessageStream
     from anthropic.types import Message, MessageStreamEvent
+
+_anthropic_patcher: Optional[MultiPatcher] = None
 
 
 def anthropic_accumulator(
@@ -73,13 +71,11 @@ def should_use_accumulator(inputs: dict) -> bool:
     return isinstance(inputs, dict) and bool(inputs.get("stream"))
 
 
-def create_wrapper_sync(
-    name: str,
-) -> Callable[[Callable], Callable]:
+def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
         "We need to do this so we can check if `stream` is used"
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: anthropic_accumulator,
@@ -92,9 +88,7 @@ def create_wrapper_sync(
 # Surprisingly, the async `client.chat.completions.create` does not pass
 # `inspect.iscoroutinefunction`, so we can't dispatch on it and must write
 # it manually here...
-def create_wrapper_async(
-    name: str,
-) -> Callable[[Callable], Callable]:
+def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
         def _fn_wrapper(fn: Callable) -> Callable:
             @wraps(fn)
@@ -104,8 +98,8 @@ def create_wrapper_async(
             return _async_wrapper
 
         "We need to do this so we can check if `stream` is used"
-        op = weave.op()(_fn_wrapper(fn))
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(_fn_wrapper(fn), **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: anthropic_accumulator,
@@ -171,12 +165,10 @@ class AnthropicIteratorWrapper(_IteratorWrapper):
         return self.__stream_text__()
 
 
-def create_stream_wrapper(
-    name: str,
-) -> Callable[[Callable], Callable]:
+def create_stream_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda _: anthropic_stream_accumulator,
@@ -187,28 +179,56 @@ def create_stream_wrapper(
     return wrapper
 
 
-anthropic_patcher = MultiPatcher(
-    [
-        # Patch the sync messages.create method for all messages.create methods
-        SymbolPatcher(
-            lambda: importlib.import_module("anthropic.resources.messages"),
-            "Messages.create",
-            create_wrapper_sync(name="anthropic.Messages.create"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("anthropic.resources.messages"),
-            "AsyncMessages.create",
-            create_wrapper_async(name="anthropic.AsyncMessages.create"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("anthropic.resources.messages"),
-            "Messages.stream",
-            create_stream_wrapper(name="anthropic.Messages.stream"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("anthropic.resources.messages"),
-            "AsyncMessages.stream",
-            create_stream_wrapper(name="anthropic.AsyncMessages.stream"),
-        ),
-    ]
-)
+def get_anthropic_patcher(
+    settings: Optional[IntegrationSettings] = None,
+) -> MultiPatcher:
+    global _anthropic_patcher
+
+    if _anthropic_patcher is not None:
+        return _anthropic_patcher
+
+    if settings is None:
+        settings = IntegrationSettings()
+
+    base = settings.op_settings
+
+    completions_create_settings = dataclasses.replace(
+        base,
+        name=base.name or "anthropic.Messages.create",
+    )
+    async_completions_create_settings = dataclasses.replace(
+        base,
+        name=base.name or "anthropic.AsyncMessages.create",
+    )
+    stream_settings = dataclasses.replace(
+        base,
+        name=base.name or "anthropic.Messages.stream",
+    )
+
+    _anthropic_patcher = MultiPatcher(
+        [
+            # Patch the sync messages.create method for all messages.create methods
+            SymbolPatcher(
+                lambda: importlib.import_module("anthropic.resources.messages"),
+                "Messages.create",
+                create_wrapper_sync(completions_create_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("anthropic.resources.messages"),
+                "AsyncMessages.create",
+                create_wrapper_async(async_completions_create_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("anthropic.resources.messages"),
+                "Messages.stream",
+                create_stream_wrapper(stream_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("anthropic.resources.messages"),
+                "AsyncMessages.stream",
+                create_stream_wrapper(stream_settings),
+            ),
+        ]
+    )
+
+    return _anthropic_patcher

--- a/weave/integrations/cohere/__init__.py
+++ b/weave/integrations/cohere/__init__.py
@@ -1,1 +1,3 @@
-from weave.integrations.cohere.cohere_sdk import cohere_patcher as cohere_patcher
+from weave.integrations.cohere.cohere_sdk import (
+    get_cohere_patcher as get_cohere_patcher,
+)

--- a/weave/integrations/cohere/cohere_sdk.py
+++ b/weave/integrations/cohere/cohere_sdk.py
@@ -1,14 +1,18 @@
+import dataclasses
 import importlib
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
 from weave.trace.patcher import MultiPatcher, SymbolPatcher
 
 if TYPE_CHECKING:
     from cohere.types.non_streamed_chat_response import NonStreamedChatResponse
     from cohere.v2.types.non_streamed_chat_response2 import NonStreamedChatResponse2
+
+_cohere_patcher: Optional[MultiPatcher] = None
 
 
 def cohere_accumulator(
@@ -86,16 +90,16 @@ def cohere_accumulator_v2(
     return acc
 
 
-def cohere_wrapper(name: str) -> Callable:
+def cohere_wrapper(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return op
 
     return wrapper
 
 
-def cohere_wrapper_v2(name: str) -> Callable:
+def cohere_wrapper_v2(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
         def _post_process_response(fn: Callable) -> Any:
             @wraps(fn)
@@ -122,14 +126,14 @@ def cohere_wrapper_v2(name: str) -> Callable:
 
             return _wrapper
 
-        op = weave.op(_post_process_response(fn))
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(_post_process_response(fn), **op_kwargs)
         return op
 
     return wrapper
 
 
-def cohere_wrapper_async_v2(name: str) -> Callable:
+def cohere_wrapper_async_v2(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
         def _post_process_response(fn: Callable) -> Any:
             @wraps(fn)
@@ -156,26 +160,26 @@ def cohere_wrapper_async_v2(name: str) -> Callable:
 
             return _wrapper
 
-        op = weave.op(_post_process_response(fn))
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(_post_process_response(fn), **op_kwargs)
         return op
 
     return wrapper
 
 
-def cohere_stream_wrapper(name: str) -> Callable:
+def cohere_stream_wrapper(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(op, lambda inputs: cohere_accumulator)  # type: ignore
 
     return wrapper
 
 
-def cohere_stream_wrapper_v2(name: str) -> Callable:
+def cohere_stream_wrapper_v2(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op, make_accumulator=lambda inputs: cohere_accumulator_v2
         )
@@ -183,54 +187,100 @@ def cohere_stream_wrapper_v2(name: str) -> Callable:
     return wrapper
 
 
-cohere_patcher = MultiPatcher(
-    [
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "Client.chat",
-            cohere_wrapper("cohere.Client.chat"),
-        ),
-        # Patch the async chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "AsyncClient.chat",
-            cohere_wrapper("cohere.AsyncClient.chat"),
-        ),
-        # Add patch for chat_stream method
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "Client.chat_stream",
-            cohere_stream_wrapper("cohere.Client.chat_stream"),
-        ),
-        # Add patch for async chat_stream method
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "AsyncClient.chat_stream",
-            cohere_stream_wrapper("cohere.AsyncClient.chat_stream"),
-        ),
-        # Add patch for cohere v2
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "ClientV2.chat",
-            cohere_wrapper_v2("cohere.ClientV2.chat"),
-        ),
-        # Add patch for cohre v2 async chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "AsyncClientV2.chat",
-            cohere_wrapper_async_v2("cohere.AsyncClientV2.chat"),
-        ),
-        # Add patch for chat_stream method v2
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "ClientV2.chat_stream",
-            cohere_stream_wrapper_v2("cohere.ClientV2.chat_stream"),
-        ),
-        # Add patch for async chat_stream method v2
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "AsyncClientV2.chat_stream",
-            cohere_stream_wrapper_v2("cohere.AsyncClientV2.chat_stream"),
-        ),
-    ]
-)
+def get_cohere_patcher(settings: Optional[IntegrationSettings] = None) -> MultiPatcher:
+    global _cohere_patcher
+
+    if _cohere_patcher is not None:
+        return _cohere_patcher
+
+    if settings is None:
+        settings = IntegrationSettings()
+
+    base = settings.op_settings
+
+    chat_settings = dataclasses.replace(
+        base,
+        name="cohere.Client.chat",
+    )
+    async_chat_settings = dataclasses.replace(
+        base,
+        name="cohere.AsyncClient.chat",
+    )
+    chat_stream_settings = dataclasses.replace(
+        base,
+        name="cohere.Client.chat_stream",
+    )
+    async_chat_stream_settings = dataclasses.replace(
+        base,
+        name="cohere.AsyncClient.chat_stream",
+    )
+    chat_v2_settings = dataclasses.replace(
+        base,
+        name="cohere.ClientV2.chat",
+    )
+    async_chat_v2_settings = dataclasses.replace(
+        base,
+        name="cohere.AsyncClientV2.chat",
+    )
+    chat_stream_v2_settings = dataclasses.replace(
+        base,
+        name="cohere.ClientV2.chat_stream",
+    )
+    async_chat_stream_v2_settings = dataclasses.replace(
+        base,
+        name="cohere.AsyncClientV2.chat_stream",
+    )
+
+    _cohere_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "Client.chat",
+                cohere_wrapper(chat_settings),
+            ),
+            # Patch the async chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "AsyncClient.chat",
+                cohere_wrapper(async_chat_settings),
+            ),
+            # Add patch for chat_stream method
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "Client.chat_stream",
+                cohere_stream_wrapper(chat_stream_settings),
+            ),
+            # Add patch for async chat_stream method
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "AsyncClient.chat_stream",
+                cohere_stream_wrapper(async_chat_stream_settings),
+            ),
+            # Add patch for cohere v2
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "ClientV2.chat",
+                cohere_wrapper_v2(chat_v2_settings),
+            ),
+            # Add patch for cohre v2 async chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "AsyncClientV2.chat",
+                cohere_wrapper_async_v2(async_chat_v2_settings),
+            ),
+            # Add patch for chat_stream method v2
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "ClientV2.chat_stream",
+                cohere_stream_wrapper_v2(chat_stream_v2_settings),
+            ),
+            # Add patch for async chat_stream method v2
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "AsyncClientV2.chat_stream",
+                cohere_stream_wrapper_v2(async_chat_stream_v2_settings),
+            ),
+        ]
+    )
+
+    return _cohere_patcher

--- a/weave/integrations/dspy/dspy_sdk.py
+++ b/weave/integrations/dspy/dspy_sdk.py
@@ -1,216 +1,346 @@
+import dataclasses
 import importlib
-from typing import Callable
+from typing import Callable, Optional
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.patcher import MultiPatcher, SymbolPatcher
 
+_dspy_patcher: Optional[MultiPatcher] = None
 
-def dspy_wrapper(name: str) -> Callable[[Callable], Callable]:
+
+def dspy_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return op
 
     return wrapper
 
 
 def dspy_get_patched_lm_functions(
-    base_symbol: str, lm_class_name: str
+    base_symbol: str, lm_class_name: str, settings: OpSettings
 ) -> list[SymbolPatcher]:
     patchable_functional_attributes = [
         "basic_request",
         "request",
         "__call__",
     ]
+
+    basic_request_settings = dataclasses.replace(
+        settings,
+        name=settings.name or f"dspy.{lm_class_name}.basic_request",
+    )
+    request_settings = dataclasses.replace(
+        settings,
+        name=settings.name or f"dspy.{lm_class_name}.request",
+    )
+    call_settings = dataclasses.replace(
+        settings,
+        name=settings.name or f"dspy.{lm_class_name}",
+    )
+
     return [
         SymbolPatcher(
             get_base_symbol=lambda: importlib.import_module(base_symbol),
             attribute_name=f"{lm_class_name}.basic_request",
-            make_new_value=dspy_wrapper(f"dspy.{lm_class_name}.basic_request"),
+            make_new_value=dspy_wrapper(basic_request_settings),
         ),
         SymbolPatcher(
             get_base_symbol=lambda: importlib.import_module(base_symbol),
             attribute_name=f"{lm_class_name}.request",
-            make_new_value=dspy_wrapper(f"dspy.{lm_class_name}.request"),
+            make_new_value=dspy_wrapper(request_settings),
         ),
         SymbolPatcher(
             get_base_symbol=lambda: importlib.import_module(base_symbol),
             attribute_name=f"{lm_class_name}.__call__",
-            make_new_value=dspy_wrapper(f"dspy.{lm_class_name}"),
+            make_new_value=dspy_wrapper(call_settings),
         ),
     ]
 
 
-patched_functions = [
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Predict.__call__",
-        make_new_value=dspy_wrapper("dspy.Predict"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Predict.forward",
-        make_new_value=dspy_wrapper("dspy.Predict.forward"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="TypedPredictor.__call__",
-        make_new_value=dspy_wrapper("dspy.TypedPredictor"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="TypedPredictor.forward",
-        make_new_value=dspy_wrapper("dspy.TypedPredictor.forward"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Module.__call__",
-        make_new_value=dspy_wrapper("dspy.Module"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="TypedChainOfThought.__call__",
-        make_new_value=dspy_wrapper("dspy.TypedChainOfThought"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Retrieve.__call__",
-        make_new_value=dspy_wrapper("dspy.Retrieve"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Retrieve.forward",
-        make_new_value=dspy_wrapper("dspy.Retrieve.forward"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.evaluate.evaluate"),
-        attribute_name="Evaluate.__call__",
-        make_new_value=dspy_wrapper("dspy.evaluate.Evaluate"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BootstrapFewShot.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.BootstrapFewShot.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="COPRO.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.COPRO.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="Ensemble.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.Ensemble.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BootstrapFinetune.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.BootstrapFinetune.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="KNNFewShot.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.KNNFewShot.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="MIPRO.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.MIPRO.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BootstrapFewShotWithRandomSearch.compile",
-        make_new_value=dspy_wrapper(
-            "dspy.teleprompt.BootstrapFewShotWithRandomSearch.compile"
-        ),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="SignatureOptimizer.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.SignatureOptimizer.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BayesianSignatureOptimizer.compile",
-        make_new_value=dspy_wrapper(
-            "dspy.teleprompt.BayesianSignatureOptimizer.compile"
-        ),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module(
-            "dspy.teleprompt.signature_opt_typed"
-        ),
-        attribute_name="optimize_signature",
-        make_new_value=dspy_wrapper(
-            "dspy.teleprompt.signature_opt_typed.optimize_signature"
-        ),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BootstrapFewShotWithOptuna.compile",
-        make_new_value=dspy_wrapper(
-            "dspy.teleprompt.BootstrapFewShotWithOptuna.compile"
-        ),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="LabeledFewShot.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.LabeledFewShot.compile"),
-    ),
-]
+def get_dspy_patcher(settings: Optional[IntegrationSettings] = None) -> MultiPatcher:
+    global _dspy_patcher
 
-# Patch LM classes
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="AzureOpenAI"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="OpenAI"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Cohere"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Clarifai"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Google"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="HFClientTGI"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="HFClientVLLM"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Anyscale"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Together"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="OllamaLocal"
-)
-patched_functions += [
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Databricks.basic_request",
-        make_new_value=dspy_wrapper("dspy.Databricks.basic_request"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Databricks.__call__",
-        make_new_value=dspy_wrapper("dspy.Databricks"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="ColBERTv2.__call__",
-        make_new_value=dspy_wrapper("dspy.ColBERTv2"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Pyserini.__call__",
-        make_new_value=dspy_wrapper("dspy.Pyserini"),
-    ),
-]
+    if _dspy_patcher is not None:
+        return _dspy_patcher
 
-dspy_patcher = MultiPatcher(patched_functions)
+    if settings is None:
+        settings = IntegrationSettings()
+
+    base = settings.op_settings
+
+    predict_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.Predict",
+    )
+    forward_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.Predict.forward",
+    )
+    typed_predictor_call_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.TypedPredictor",
+    )
+    typed_predictor_forward_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.TypedPredictor.forward",
+    )
+    module_call_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.Module",
+    )
+    typed_chain_of_thought_call_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.TypedChainOfThought",
+    )
+    retrieve_call_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.Retrieve",
+    )
+    retrieve_forward_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.Retrieve.forward",
+    )
+    retrieve_evaluate_call_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.evaluate.Evaluate",
+    )
+    bootstrap_few_shot_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.BootstrapFewShot.compile",
+    )
+    copro_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.COPRO.compile",
+    )
+    ensemble_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.Ensemble.compile",
+    )
+    bootstrap_finetune_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.BootstrapFinetune.compile",
+    )
+    knn_few_shot_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.KNNFewShot.compile",
+    )
+    mi_pro_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.MIPRO.compile",
+    )
+    bootstrap_few_shot_with_random_search_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.BootstrapFewShotWithRandomSearch.compile",
+    )
+    signature_optimizer_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.SignatureOptimizer.compile",
+    )
+    bayesian_signature_optimizer_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.BayesianSignatureOptimizer.compile",
+    )
+    optimize_signature_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.signature_opt_typed.optimize_signature",
+    )
+    bootstrap_few_shot_with_optuna_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.BootstrapFewShotWithOptuna.compile",
+    )
+    labeled_few_shot_compile_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.teleprompt.LabeledFewShot.compile",
+    )
+
+    patched_functions = [
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Predict.__call__",
+            make_new_value=dspy_wrapper(predict_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Predict.forward",
+            make_new_value=dspy_wrapper(forward_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="TypedPredictor.__call__",
+            make_new_value=dspy_wrapper(typed_predictor_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="TypedPredictor.forward",
+            make_new_value=dspy_wrapper(typed_predictor_forward_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Module.__call__",
+            make_new_value=dspy_wrapper(module_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="TypedChainOfThought.__call__",
+            make_new_value=dspy_wrapper(typed_chain_of_thought_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Retrieve.__call__",
+            make_new_value=dspy_wrapper(retrieve_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Retrieve.forward",
+            make_new_value=dspy_wrapper(retrieve_forward_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.evaluate.evaluate"),
+            attribute_name="Evaluate.__call__",
+            make_new_value=dspy_wrapper(retrieve_evaluate_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BootstrapFewShot.compile",
+            make_new_value=dspy_wrapper(bootstrap_few_shot_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="COPRO.compile",
+            make_new_value=dspy_wrapper(copro_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="Ensemble.compile",
+            make_new_value=dspy_wrapper(ensemble_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BootstrapFinetune.compile",
+            make_new_value=dspy_wrapper(bootstrap_finetune_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="KNNFewShot.compile",
+            make_new_value=dspy_wrapper(knn_few_shot_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="MIPRO.compile",
+            make_new_value=dspy_wrapper(mi_pro_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BootstrapFewShotWithRandomSearch.compile",
+            make_new_value=dspy_wrapper(
+                bootstrap_few_shot_with_random_search_compile_settings
+            ),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="SignatureOptimizer.compile",
+            make_new_value=dspy_wrapper(signature_optimizer_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BayesianSignatureOptimizer.compile",
+            make_new_value=dspy_wrapper(bayesian_signature_optimizer_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module(
+                "dspy.teleprompt.signature_opt_typed"
+            ),
+            attribute_name="optimize_signature",
+            make_new_value=dspy_wrapper(optimize_signature_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BootstrapFewShotWithOptuna.compile",
+            make_new_value=dspy_wrapper(
+                bootstrap_few_shot_with_optuna_compile_settings
+            ),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="LabeledFewShot.compile",
+            make_new_value=dspy_wrapper(labeled_few_shot_compile_settings),
+        ),
+    ]
+
+    # Patch LM classes
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="AzureOpenAI", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="OpenAI", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Cohere", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Clarifai", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Google", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="HFClientTGI", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="HFClientVLLM", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Anyscale", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Together", settings=settings.op_settings
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="OllamaLocal", settings=settings.op_settings
+    )
+
+    databricks_basic_request_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.Databricks.basic_request",
+    )
+    databricks_call_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.Databricks",
+    )
+    colbertv2_call_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.ColBERTv2",
+    )
+    pyserini_call_settings = dataclasses.replace(
+        base,
+        name=base.name or "dspy.Pyserini",
+    )
+
+    patched_functions += [
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Databricks.basic_request",
+            make_new_value=dspy_wrapper(databricks_basic_request_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Databricks.__call__",
+            make_new_value=dspy_wrapper(databricks_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="ColBERTv2.__call__",
+            make_new_value=dspy_wrapper(colbertv2_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Pyserini.__call__",
+            make_new_value=dspy_wrapper(pyserini_call_settings),
+        ),
+    ]
+
+    _dspy_patcher = MultiPatcher(patched_functions)
+
+    return _dspy_patcher

--- a/weave/integrations/instructor/instructor_iterable_utils.py
+++ b/weave/integrations/instructor/instructor_iterable_utils.py
@@ -1,9 +1,11 @@
+import dataclasses
 from functools import wraps
 from typing import Any, Callable, Optional
 
 from pydantic import BaseModel
 
 import weave
+from weave.trace.autopatch import OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
 
 
@@ -27,10 +29,10 @@ def should_accumulate_iterable(inputs: dict) -> bool:
     return False
 
 
-def instructor_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
+def instructor_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: instructor_iterable_accumulator,
@@ -40,7 +42,7 @@ def instructor_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
     return wrapper
 
 
-def instructor_wrapper_async(name: str) -> Callable[[Callable], Callable]:
+def instructor_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
         def _fn_wrapper(fn: Callable) -> Callable:
             @wraps(fn)
@@ -50,8 +52,8 @@ def instructor_wrapper_async(name: str) -> Callable[[Callable], Callable]:
             return _async_wrapper
 
         "We need to do this so we can check if `stream` is used"
-        op = weave.op(_fn_wrapper(fn))
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(_fn_wrapper(fn), **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: instructor_iterable_accumulator,

--- a/weave/integrations/instructor/instructor_partial_utils.py
+++ b/weave/integrations/instructor/instructor_partial_utils.py
@@ -1,8 +1,10 @@
+import dataclasses
 from typing import Callable, Optional
 
 from pydantic import BaseModel
 
 import weave
+from weave.trace.autopatch import OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
 
 
@@ -14,10 +16,10 @@ def instructor_partial_accumulator(
     return acc
 
 
-def instructor_wrapper_partial(name: str) -> Callable[[Callable], Callable]:
+def instructor_wrapper_partial(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: instructor_partial_accumulator,

--- a/weave/integrations/instructor/instructor_sdk.py
+++ b/weave/integrations/instructor/instructor_sdk.py
@@ -1,31 +1,69 @@
+import dataclasses
 import importlib
+from typing import Optional
 
+from weave.trace.autopatch import IntegrationSettings
 from weave.trace.patcher import MultiPatcher, SymbolPatcher
 
 from .instructor_iterable_utils import instructor_wrapper_async, instructor_wrapper_sync
 from .instructor_partial_utils import instructor_wrapper_partial
 
-instructor_patcher = MultiPatcher(
-    [
-        SymbolPatcher(
-            lambda: importlib.import_module("instructor.client"),
-            "Instructor.create",
-            instructor_wrapper_sync(name="Instructor.create"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("instructor.client"),
-            "AsyncInstructor.create",
-            instructor_wrapper_async(name="AsyncInstructor.create"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("instructor.client"),
-            "Instructor.create_partial",
-            instructor_wrapper_partial(name="Instructor.create_partial"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("instructor.client"),
-            "AsyncInstructor.create_partial",
-            instructor_wrapper_partial(name="AsyncInstructor.create_partial"),
-        ),
-    ]
-)
+_instructor_patcher: Optional[MultiPatcher] = None
+
+
+def get_instructor_patcher(
+    settings: Optional[IntegrationSettings] = None,
+) -> MultiPatcher:
+    global _instructor_patcher
+
+    if _instructor_patcher is not None:
+        return _instructor_patcher
+
+    if settings is None:
+        settings = IntegrationSettings()
+
+    base = settings.op_settings
+
+    create_settings = dataclasses.replace(
+        base,
+        name=base.name or "Instructor.create",
+    )
+    async_create_settings = dataclasses.replace(
+        base,
+        name=base.name or "AsyncInstructor.create",
+    )
+    create_partial_settings = dataclasses.replace(
+        base,
+        name=base.name or "Instructor.create_partial",
+    )
+    async_create_partial_settings = dataclasses.replace(
+        base,
+        name=base.name or "AsyncInstructor.create_partial",
+    )
+
+    _instructor_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("instructor.client"),
+                "Instructor.create",
+                instructor_wrapper_sync(create_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("instructor.client"),
+                "AsyncInstructor.create",
+                instructor_wrapper_async(async_create_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("instructor.client"),
+                "Instructor.create_partial",
+                instructor_wrapper_partial(create_partial_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("instructor.client"),
+                "AsyncInstructor.create_partial",
+                instructor_wrapper_partial(async_create_partial_settings),
+            ),
+        ]
+    )
+
+    return _instructor_patcher

--- a/weave/integrations/litellm/litellm.py
+++ b/weave/integrations/litellm/litellm.py
@@ -10,6 +10,8 @@ from weave.trace.patcher import MultiPatcher, SymbolPatcher
 if TYPE_CHECKING:
     from litellm.utils import ModelResponse
 
+_litellm_patcher: Optional[MultiPatcher] = None
+
 
 # This accumulator is nearly identical to the mistral accumulator, just with different types.
 def litellm_accumulator(

--- a/weave/integrations/litellm/litellm.py
+++ b/weave/integrations/litellm/litellm.py
@@ -89,7 +89,7 @@ def should_use_accumulator(inputs: dict) -> bool:
 def make_wrapper(settings: OpSettings) -> Callable:
     def litellm_wrapper(fn: Callable) -> Callable:
         op_kwargs = dataclasses.asdict(settings)
-        op = weave.op()(fn, **op_kwargs)
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: litellm_accumulator,

--- a/weave/integrations/mistral/__init__.py
+++ b/weave/integrations/mistral/__init__.py
@@ -8,10 +8,10 @@ except metadata.PackageNotFoundError:
     mistral_version = "1.0"  # we need to return a patching function
 
 if version.parse(mistral_version) < version.parse("1.0.0"):
-    from .v0.mistral import mistral_patcher
+    from .v0.mistral import get_mistral_patcher
 
     print(
         f"Using MistralAI version {mistral_version}. Please consider upgrading to version 1.0.0 or later."
     )
 else:
-    from .v1.mistral import mistral_patcher  # noqa: F401
+    from .v1.mistral import get_mistral_patcher  # noqa: F401

--- a/weave/integrations/mistral/v0/mistral.py
+++ b/weave/integrations/mistral/v0/mistral.py
@@ -1,7 +1,9 @@
+import dataclasses
 import importlib
 from typing import TYPE_CHECKING, Callable, Optional
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
 from weave.trace.patcher import MultiPatcher, SymbolPatcher
 
@@ -10,6 +12,8 @@ if TYPE_CHECKING:
         ChatCompletionResponse,
         ChatCompletionStreamResponse,
     )
+
+_mistral_patcher: Optional[MultiPatcher] = None
 
 
 def mistral_accumulator(
@@ -72,37 +76,72 @@ def mistral_accumulator(
     return acc
 
 
-def mistral_stream_wrapper(fn: Callable) -> Callable:
-    op = weave.op()(fn)
-    acc_op = add_accumulator(op, lambda inputs: mistral_accumulator)  # type: ignore
-    return acc_op
+def mistral_stream_wrapper(settings: OpSettings) -> Callable:
+    def wrapper(fn: Callable) -> Callable:
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
+        acc_op = add_accumulator(op, lambda inputs: mistral_accumulator)  # type: ignore
+        return acc_op
+
+    return wrapper
 
 
-mistral_patcher = MultiPatcher(
-    [
-        # Patch the sync, non-streaming chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("mistralai.client"),
-            "MistralClient.chat",
-            weave.op(),
-        ),
-        # Patch the sync, streaming chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("mistralai.client"),
-            "MistralClient.chat_stream",
-            mistral_stream_wrapper,
-        ),
-        # Patch the async, non-streaming chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("mistralai.async_client"),
-            "MistralAsyncClient.chat",
-            weave.op(),
-        ),
-        # Patch the async, streaming chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("mistralai.async_client"),
-            "MistralAsyncClient.chat_stream",
-            mistral_stream_wrapper,
-        ),
-    ]
-)
+def mistral_wrapper(settings: OpSettings) -> Callable:
+    def wrapper(fn: Callable) -> Callable:
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
+        return op
+
+    return wrapper
+
+
+def get_mistral_patcher(settings: Optional[IntegrationSettings] = None) -> MultiPatcher:
+    global _mistral_patcher
+
+    if _mistral_patcher is not None:
+        return _mistral_patcher
+
+    if settings is None:
+        settings = IntegrationSettings()
+
+    base = settings.op_settings
+
+    chat_complete_settings = dataclasses.replace(
+        base,
+        name=base.name or "mistralai.chat.complete",
+    )
+    chat_stream_settings = dataclasses.replace(
+        base,
+        name=base.name or "mistralai.chat.stream",
+    )
+
+    _mistral_patcher = MultiPatcher(
+        [
+            # Patch the sync, non-streaming chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("mistralai.client"),
+                "MistralClient.chat",
+                mistral_wrapper(chat_complete_settings),
+            ),
+            # Patch the sync, streaming chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("mistralai.client"),
+                "MistralClient.chat_stream",
+                mistral_stream_wrapper(chat_stream_settings),
+            ),
+            # Patch the async, non-streaming chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("mistralai.async_client"),
+                "MistralAsyncClient.chat",
+                mistral_wrapper(chat_complete_settings),
+            ),
+            # Patch the async, streaming chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("mistralai.async_client"),
+                "MistralAsyncClient.chat_stream",
+                mistral_stream_wrapper(chat_stream_settings),
+            ),
+        ]
+    )
+
+    return _mistral_patcher

--- a/weave/integrations/notdiamond/__init__.py
+++ b/weave/integrations/notdiamond/__init__.py
@@ -1,1 +1,1 @@
-from .tracing import notdiamond_patcher as notdiamond_patcher
+from .tracing import get_notdiamond_patcher as get_notdiamond_patcher

--- a/weave/integrations/notdiamond/tracing.py
+++ b/weave/integrations/notdiamond/tracing.py
@@ -1,64 +1,113 @@
+import dataclasses
 import importlib
-from typing import Callable
+from typing import Callable, Optional
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.patcher import MultiPatcher, SymbolPatcher
 
+_notdiamond_patcher: Optional[MultiPatcher] = None
 
-def nd_wrapper(name: str) -> Callable[[Callable], Callable]:
+
+def nd_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = dataclasses.asdict(settings)
+        op = weave.op(fn, **op_kwargs)
         return op
 
     return wrapper
 
 
-def _patch_client_op(method_name: str) -> list[SymbolPatcher]:
-    return [
+def passthrough_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
+    def wrapper(fn: Callable) -> Callable:
+        op_kwargs = dataclasses.asdict(settings)
+        return weave.op(fn, **op_kwargs)
+
+    return wrapper
+
+
+def get_notdiamond_patcher(
+    settings: Optional[IntegrationSettings] = None,
+) -> MultiPatcher:
+    global _notdiamond_patcher
+
+    if _notdiamond_patcher is not None:
+        return _notdiamond_patcher
+
+    if settings is None:
+        settings = IntegrationSettings()
+
+    base = settings.op_settings
+
+    model_select_settings = dataclasses.replace(
+        base,
+        name=base.name or "NotDiamond.model_select",
+    )
+    async_model_select_settings = dataclasses.replace(
+        base,
+        name=base.name or "NotDiamond.amodel_select",
+    )
+    patched_client_functions = [
         SymbolPatcher(
             lambda: importlib.import_module("notdiamond"),
-            f"NotDiamond.a{method_name}",
-            weave.op(),
+            "NotDiamond.amodel_select",
+            passthrough_wrapper(async_model_select_settings),
         ),
         SymbolPatcher(
             lambda: importlib.import_module("notdiamond"),
-            f"NotDiamond.{method_name}",
-            weave.op(),
+            "NotDiamond.model_select",
+            passthrough_wrapper(model_select_settings),
         ),
     ]
 
+    llm_config_init_settings = dataclasses.replace(
+        base,
+        name=base.name or "NotDiamond.LLMConfig.__init__",
+    )
+    llm_config_from_string_settings = dataclasses.replace(
+        base,
+        name=base.name or "NotDiamond.LLMConfig.from_string",
+    )
+    patched_llmconfig_functions = [
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond"),
+            "LLMConfig.__init__",
+            passthrough_wrapper(llm_config_init_settings),
+        ),
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond"),
+            "LLMConfig.from_string",
+            passthrough_wrapper(llm_config_from_string_settings),
+        ),
+    ]
 
-patched_client_functions = _patch_client_op("model_select")
+    custom_router_fit_settings = dataclasses.replace(
+        base,
+        name=base.name or "CustomRouter.fit",
+    )
+    custom_router_eval_settings = dataclasses.replace(
+        base,
+        name=base.name or "CustomRouter.eval",
+    )
+    patched_toolkit_functions = [
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond.toolkit.custom_router"),
+            "CustomRouter.fit",
+            passthrough_wrapper(custom_router_fit_settings),
+        ),
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond.toolkit.custom_router"),
+            "CustomRouter.eval",
+            passthrough_wrapper(custom_router_eval_settings),
+        ),
+    ]
 
-patched_llmconfig_functions = [
-    SymbolPatcher(
-        lambda: importlib.import_module("notdiamond"),
-        "LLMConfig.__init__",
-        weave.op(),
-    ),
-    SymbolPatcher(
-        lambda: importlib.import_module("notdiamond"),
-        "LLMConfig.from_string",
-        weave.op(),
-    ),
-]
+    all_patched_functions = (
+        patched_client_functions
+        + patched_toolkit_functions
+        + patched_llmconfig_functions
+    )
 
-patched_toolkit_functions = [
-    SymbolPatcher(
-        lambda: importlib.import_module("notdiamond.toolkit.custom_router"),
-        "CustomRouter.fit",
-        weave.op(),
-    ),
-    SymbolPatcher(
-        lambda: importlib.import_module("notdiamond.toolkit.custom_router"),
-        "CustomRouter.eval",
-        weave.op(),
-    ),
-]
+    _notdiamond_patcher = MultiPatcher(all_patched_functions)
 
-all_patched_functions = (
-    patched_client_functions + patched_toolkit_functions + patched_llmconfig_functions
-)
-
-notdiamond_patcher = MultiPatcher(all_patched_functions)
+    return _notdiamond_patcher

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -406,28 +406,33 @@ def get_openai_patcher(settings: Optional[IntegrationSettings] = None) -> MultiP
         name=base.name or "openai.beta.chat.completions.parse",
     )
 
-    symbol_patchers = [
-        SymbolPatcher(
-            lambda: importlib.import_module("openai.resources.chat.completions"),
-            "Completions.create",
-            create_wrapper_sync(settings=completions_create_settings),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("openai.resources.chat.completions"),
-            "AsyncCompletions.create",
-            create_wrapper_async(settings=async_completions_create_settings),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("openai.resources.beta.chat.completions"),
-            "Completions.parse",
-            create_wrapper_sync(settings=completions_parse_settings),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("openai.resources.beta.chat.completions"),
-            "AsyncCompletions.parse",
-            create_wrapper_async(settings=async_completions_parse_settings),
-        ),
-    ]
-    _openai_patcher = MultiPatcher(symbol_patchers)  # type: ignore
+    _openai_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("openai.resources.chat.completions"),
+                "Completions.create",
+                create_wrapper_sync(settings=completions_create_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("openai.resources.chat.completions"),
+                "AsyncCompletions.create",
+                create_wrapper_async(settings=async_completions_create_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module(
+                    "openai.resources.beta.chat.completions"
+                ),
+                "Completions.parse",
+                create_wrapper_sync(settings=completions_parse_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module(
+                    "openai.resources.beta.chat.completions"
+                ),
+                "AsyncCompletions.parse",
+                create_wrapper_async(settings=async_completions_parse_settings),
+            ),
+        ]
+    )
 
     return _openai_patcher

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -388,7 +388,7 @@ def create_wrapper_async(
 def get_openai_patcher(settings: Optional[IntegrationSettings] = None) -> MultiPatcher:
     global _openai_patcher
 
-    if _openai_patcher is None:
+    if _openai_patcher is not None:
         return _openai_patcher
 
     if settings is None:

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -327,7 +327,7 @@ def create_wrapper_sync(
                 return True
             return False
 
-        op = weave.op()(_add_stream_options(fn))
+        op = weave.op(call_display_name="hmmmm")(_add_stream_options(fn))
         op.name = name  # type: ignore
         op._set_on_input_handler(openai_on_input_handler)
         return add_accumulator(

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -7,7 +7,7 @@ import weave
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import Op, ProcessedInputs
 from weave.trace.op_extensions.accumulator import add_accumulator
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 
 if TYPE_CHECKING:
     from openai.types.chat import ChatCompletionChunk
@@ -379,13 +379,15 @@ def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]
 
 
 def get_openai_patcher(settings: Optional[IntegrationSettings] = None) -> MultiPatcher:
-    global _openai_patcher
-
-    if _openai_patcher is not None:
-        return _openai_patcher
-
     if settings is None:
         settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _openai_patcher
+    if _openai_patcher is not None:
+        return _openai_patcher
 
     base = settings.op_settings
 

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -395,7 +395,7 @@ def get_openai_patcher(settings: Optional[IntegrationSettings] = None) -> MultiP
     )
     async_completions_create_settings = dataclasses.replace(
         base,
-        name=base.name or "openai.async_chat.completions.create",
+        name=base.name or "openai.chat.completions.create",
     )
     completions_parse_settings = dataclasses.replace(
         base,
@@ -403,7 +403,7 @@ def get_openai_patcher(settings: Optional[IntegrationSettings] = None) -> MultiP
     )
     async_completions_parse_settings = dataclasses.replace(
         base,
-        name=base.name or "openai.async_beta.chat.completions.parse",
+        name=base.name or "openai.beta.chat.completions.parse",
     )
 
     symbol_patchers = [

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -316,11 +316,9 @@ def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
         def _add_stream_options(fn: Callable) -> Callable:
             @wraps(fn)
             def _wrapper(*args: Any, **kwargs: Any) -> Any:
-                if bool(kwargs.get("stream")) and kwargs.get("stream_options") is None:
+                if kwargs.get("stream") and kwargs.get("stream_options") is None:
                     kwargs["stream_options"] = {"include_usage": True}
-                return fn(
-                    *args, **kwargs
-                )  # This is where the final execution of fn is happening.
+                return fn(*args, **kwargs)
 
             return _wrapper
 
@@ -354,7 +352,7 @@ def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]
         def _add_stream_options(fn: Callable) -> Callable:
             @wraps(fn)
             async def _wrapper(*args: Any, **kwargs: Any) -> Any:
-                if bool(kwargs.get("stream")) and kwargs.get("stream_options") is None:
+                if kwargs.get("stream") and kwargs.get("stream_options") is None:
                     kwargs["stream_options"] = {"include_usage": True}
                 return await fn(*args, **kwargs)
 

--- a/weave/scorers/llm_utils.py
+++ b/weave/scorers/llm_utils.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Union
 
-from weave.trace.autopatch import autopatch
-
-autopatch()  # ensure both weave patching and instructor patching are applied
+# autopatch()  # ensure both weave patching and instructor patching are applied
 
 OPENAI_DEFAULT_MODEL = "gpt-4o"
 OPENAI_DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -13,6 +13,7 @@ from typing import Any
 # There is probably a better place for this, but including here for now to get the fix in.
 from weave import type_handlers  # noqa: F401
 from weave.trace import urls, util, weave_client, weave_init
+from weave.trace.autopatch import AutopatchSettings
 from weave.trace.constants import TRACE_OBJECT_EMOJI
 from weave.trace.context import call_context
 from weave.trace.context import weave_client_context as weave_client_context
@@ -32,6 +33,7 @@ def init(
     project_name: str,
     *,
     settings: UserSettings | dict[str, Any] | None = None,
+    autopatch_settings: AutopatchSettings | None = None,
 ) -> weave_client.WeaveClient:
     """Initialize weave tracking, logging to a wandb project.
 
@@ -52,7 +54,12 @@ def init(
     if should_disable_weave():
         return weave_init.init_weave_disabled().client
 
-    return weave_init.init_weave(project_name).client
+    initialized_client = weave_init.init_weave(
+        project_name,
+        autopatch_settings=autopatch_settings,
+    )
+
+    return initialized_client.client
 
 
 @contextlib.contextmanager

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -33,18 +33,41 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     if settings is None:
         settings = AutopatchSettings()
 
-    get_openai_patcher(settings.openai).attempt_patch()
-    get_mistral_patcher(settings.mistral).attempt_patch()
-    get_litellm_patcher(settings.litellm).attempt_patch()
-    get_anthropic_patcher(settings.anthropic).attempt_patch()
-    get_groq_patcher(settings.groq).attempt_patch()
-    get_instructor_patcher(settings.instructor).attempt_patch()
-    get_dspy_patcher(settings.dspy).attempt_patch()
-    get_cerebras_patcher(settings.cerebras).attempt_patch()
-    get_cohere_patcher(settings.cohere).attempt_patch()
-    get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
-    get_notdiamond_patcher(settings.notdiamond).attempt_patch()
-    get_vertexai_patcher(settings.vertexai).attempt_patch()
+    if settings.openai.enabled:
+        get_openai_patcher(settings.openai).attempt_patch()
+
+    if settings.mistral.enabled:
+        get_mistral_patcher(settings.mistral).attempt_patch()
+
+    if settings.litellm.enabled:
+        get_litellm_patcher(settings.litellm).attempt_patch()
+
+    if settings.anthropic.enabled:
+        get_anthropic_patcher(settings.anthropic).attempt_patch()
+
+    if settings.groq.enabled:
+        get_groq_patcher(settings.groq).attempt_patch()
+
+    if settings.instructor.enabled:
+        get_instructor_patcher(settings.instructor).attempt_patch()
+
+    if settings.dspy.enabled:
+        get_dspy_patcher(settings.dspy).attempt_patch()
+
+    if settings.cerebras.enabled:
+        get_cerebras_patcher(settings.cerebras).attempt_patch()
+
+    if settings.cohere.enabled:
+        get_cohere_patcher(settings.cohere).attempt_patch()
+
+    if settings.google_ai_studio.enabled:
+        get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
+
+    if settings.notdiamond.enabled:
+        get_notdiamond_patcher(settings.notdiamond).attempt_patch()
+
+    if settings.vertexai.enabled:
+        get_vertexai_patcher(settings.vertexai).attempt_patch()
 
     # These integrations don't use the op decorator, so there are no settings to pass through
     llamaindex_patcher.attempt_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -28,7 +28,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
-    from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
+    from weave.integrations.vertexai.vertexai_sdk import get_vertexai_patcher
 
     if settings is None:
         settings = AutopatchSettings()
@@ -46,7 +46,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     get_cohere_patcher(settings.cohere).attempt_patch()
     get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
     get_notdiamond_patcher(settings.notdiamond).attempt_patch()
-    vertexai_patcher.attempt_patch()
+    get_vertexai_patcher(settings.vertexai).attempt_patch()
 
 
 def reset_autopatch() -> None:
@@ -65,7 +65,7 @@ def reset_autopatch() -> None:
     from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
-    from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
+    from weave.integrations.vertexai.vertexai_sdk import get_vertexai_patcher
 
     get_openai_patcher().undo_patch()
     get_mistral_patcher().undo_patch()
@@ -80,7 +80,7 @@ def reset_autopatch() -> None:
     get_cohere_patcher().undo_patch()
     get_google_genai_patcher().undo_patch()
     get_notdiamond_patcher().undo_patch()
-    vertexai_patcher.undo_patch()
+    get_vertexai_patcher().undo_patch()
 
 
 @dataclass

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -15,7 +15,7 @@ from weave.trace.weave_client import Call
 def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
-    from weave.integrations.cohere.cohere_sdk import cohere_patcher
+    from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         google_genai_patcher,
@@ -43,7 +43,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     get_instructor_patcher(settings.instructor).attempt_patch()
     dspy_patcher.attempt_patch()
     get_cerebras_patcher(settings.cerebras).attempt_patch()
-    cohere_patcher.attempt_patch()
+    get_cohere_patcher(settings.cohere).attempt_patch()
     google_genai_patcher.attempt_patch()
     notdiamond_patcher.attempt_patch()
     vertexai_patcher.attempt_patch()
@@ -52,7 +52,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
 def reset_autopatch() -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
-    from weave.integrations.cohere.cohere_sdk import cohere_patcher
+    from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         google_genai_patcher,
@@ -77,7 +77,7 @@ def reset_autopatch() -> None:
     get_instructor_patcher().undo_patch()
     dspy_patcher.undo_patch()
     get_cerebras_patcher().undo_patch()
-    cohere_patcher.undo_patch()
+    get_cohere_patcher().undo_patch()
     google_genai_patcher.undo_patch()
     notdiamond_patcher.undo_patch()
     vertexai_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -13,7 +13,7 @@ from weave.trace.weave_client import Call
 
 
 def autopatch(settings: AutopatchSettings | None = None) -> None:
-    from weave.integrations.anthropic.anthropic_sdk import anthropic_patcher
+    from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
@@ -38,7 +38,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     litellm_patcher.attempt_patch()
     llamaindex_patcher.attempt_patch()
     langchain_patcher.attempt_patch()
-    anthropic_patcher.attempt_patch()
+    get_anthropic_patcher(settings.anthropic).attempt_patch()
     groq_patcher.attempt_patch()
     instructor_patcher.attempt_patch()
     dspy_patcher.attempt_patch()
@@ -50,7 +50,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
 
 
 def reset_autopatch() -> None:
-    from weave.integrations.anthropic.anthropic_sdk import anthropic_patcher
+    from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
@@ -72,7 +72,7 @@ def reset_autopatch() -> None:
     litellm_patcher.undo_patch()
     llamaindex_patcher.undo_patch()
     langchain_patcher.undo_patch()
-    anthropic_patcher.undo_patch()
+    get_anthropic_patcher().undo_patch()
     groq_patcher.undo_patch()
     instructor_patcher.undo_patch()
     dspy_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -20,7 +20,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         google_genai_patcher,
     )
-    from weave.integrations.groq.groq_sdk import groq_patcher
+    from weave.integrations.groq.groq_sdk import get_groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import get_litellm_patcher
@@ -39,7 +39,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     llamaindex_patcher.attempt_patch()
     langchain_patcher.attempt_patch()
     get_anthropic_patcher(settings.anthropic).attempt_patch()
-    groq_patcher.attempt_patch()
+    get_groq_patcher(settings.groq).attempt_patch()
     instructor_patcher.attempt_patch()
     dspy_patcher.attempt_patch()
     cerebras_patcher.attempt_patch()
@@ -57,7 +57,7 @@ def reset_autopatch() -> None:
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         google_genai_patcher,
     )
-    from weave.integrations.groq.groq_sdk import groq_patcher
+    from weave.integrations.groq.groq_sdk import get_groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import get_litellm_patcher
@@ -73,7 +73,7 @@ def reset_autopatch() -> None:
     llamaindex_patcher.undo_patch()
     langchain_patcher.undo_patch()
     get_anthropic_patcher().undo_patch()
-    groq_patcher.undo_patch()
+    get_groq_patcher().undo_patch()
     instructor_patcher.undo_patch()
     dspy_patcher.undo_patch()
     cerebras_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -23,9 +23,9 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.groq.groq_sdk import groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
-    from weave.integrations.litellm.litellm import litellm_patcher
+    from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
-    from weave.integrations.mistral import mistral_patcher
+    from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
@@ -34,8 +34,8 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
         settings = AutopatchSettings()
 
     get_openai_patcher(settings.openai).attempt_patch()
-    mistral_patcher.attempt_patch()
-    litellm_patcher.attempt_patch()
+    get_mistral_patcher(settings.mistral).attempt_patch()
+    get_litellm_patcher(settings.litellm).attempt_patch()
     llamaindex_patcher.attempt_patch()
     langchain_patcher.attempt_patch()
     get_anthropic_patcher(settings.anthropic).attempt_patch()
@@ -60,16 +60,16 @@ def reset_autopatch() -> None:
     from weave.integrations.groq.groq_sdk import groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
-    from weave.integrations.litellm.litellm import litellm_patcher
+    from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
-    from weave.integrations.mistral import mistral_patcher
+    from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
     get_openai_patcher().undo_patch()
-    mistral_patcher.undo_patch()
-    litellm_patcher.undo_patch()
+    get_mistral_patcher().undo_patch()
+    get_litellm_patcher().undo_patch()
     llamaindex_patcher.undo_patch()
     langchain_patcher.undo_patch()
     get_anthropic_patcher().undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -20,10 +20,10 @@ def autopatch() -> None:
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import mistral_patcher
     from weave.integrations.notdiamond.tracing import notdiamond_patcher
-    from weave.integrations.openai.openai_sdk import openai_patcher
+    from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
-    openai_patcher.attempt_patch()
+    get_openai_patcher().attempt_patch()
     mistral_patcher.attempt_patch()
     litellm_patcher.attempt_patch()
     llamaindex_patcher.attempt_patch()
@@ -54,10 +54,10 @@ def reset_autopatch() -> None:
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import mistral_patcher
     from weave.integrations.notdiamond.tracing import notdiamond_patcher
-    from weave.integrations.openai.openai_sdk import openai_patcher
+    from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
-    openai_patcher.undo_patch()
+    get_openai_patcher().undo_patch()
     mistral_patcher.undo_patch()
     litellm_patcher.undo_patch()
     llamaindex_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -89,6 +89,7 @@ class OpSettings:
     These currently subset the `op` decorator args to provide a consistent interface
     when working with auto-patched functions.  See the `op` decorator for more details."""
 
+    name: str | None = None
     call_display_name: str | Callable[[Call], str] | None = None
     postprocess_inputs: Callable[[dict[str, Any]], dict[str, Any]] | None = None
     postprocess_output: Callable[[Any], Any] | None = None

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -33,41 +33,84 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     if settings is None:
         settings = AutopatchSettings()
 
-    if settings.openai.enabled:
+        get_openai_patcher(settings.openai).attempt_patch()
         get_openai_patcher(settings.openai).attempt_patch()
 
     if settings.mistral.enabled:
+    get_openai_patcher(settings.openai).attempt_patch()
+
+    if settings.mistral.enabled:
+        get_mistral_patcher(settings.mistral).attempt_patch()
         get_mistral_patcher(settings.mistral).attempt_patch()
 
     if settings.litellm.enabled:
+    get_mistral_patcher(settings.mistral).attempt_patch()
+
+    if settings.litellm.enabled:
+        get_litellm_patcher(settings.litellm).attempt_patch()
         get_litellm_patcher(settings.litellm).attempt_patch()
 
     if settings.anthropic.enabled:
+    get_litellm_patcher(settings.litellm).attempt_patch()
+
+    if settings.anthropic.enabled:
+        get_anthropic_patcher(settings.anthropic).attempt_patch()
         get_anthropic_patcher(settings.anthropic).attempt_patch()
 
     if settings.groq.enabled:
+    get_anthropic_patcher(settings.anthropic).attempt_patch()
+
+    if settings.groq.enabled:
+        get_groq_patcher(settings.groq).attempt_patch()
         get_groq_patcher(settings.groq).attempt_patch()
 
     if settings.instructor.enabled:
+    get_groq_patcher(settings.groq).attempt_patch()
+
+    if settings.instructor.enabled:
+        get_instructor_patcher(settings.instructor).attempt_patch()
         get_instructor_patcher(settings.instructor).attempt_patch()
 
     if settings.dspy.enabled:
+    get_instructor_patcher(settings.instructor).attempt_patch()
+
+    if settings.dspy.enabled:
+        get_dspy_patcher(settings.dspy).attempt_patch()
         get_dspy_patcher(settings.dspy).attempt_patch()
 
     if settings.cerebras.enabled:
+    get_dspy_patcher(settings.dspy).attempt_patch()
+
+    if settings.cerebras.enabled:
+        get_cerebras_patcher(settings.cerebras).attempt_patch()
         get_cerebras_patcher(settings.cerebras).attempt_patch()
 
     if settings.cohere.enabled:
+    get_cerebras_patcher(settings.cerebras).attempt_patch()
+
+    if settings.cohere.enabled:
+        get_cohere_patcher(settings.cohere).attempt_patch()
         get_cohere_patcher(settings.cohere).attempt_patch()
 
     if settings.google_ai_studio.enabled:
+    get_cohere_patcher(settings.cohere).attempt_patch()
+
+    if settings.google_ai_studio.enabled:
+        get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
         get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
 
     if settings.notdiamond.enabled:
+    get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
+
+    if settings.notdiamond.enabled:
+        get_notdiamond_patcher(settings.notdiamond).attempt_patch()
         get_notdiamond_patcher(settings.notdiamond).attempt_patch()
 
     if settings.vertexai.enabled:
-        get_vertexai_patcher(settings.vertexai).attempt_patch()
+    get_notdiamond_patcher(settings.notdiamond).attempt_patch()
+
+    if settings.vertexai.enabled:
+    get_vertexai_patcher(settings.vertexai).attempt_patch()
 
     # These integrations don't use the op decorator, so there are no settings to pass through
     llamaindex_patcher.attempt_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -14,7 +14,7 @@ from weave.trace.weave_client import Call
 
 def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
-    from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
+    from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
@@ -42,7 +42,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     get_groq_patcher(settings.groq).attempt_patch()
     get_instructor_patcher(settings.instructor).attempt_patch()
     dspy_patcher.attempt_patch()
-    cerebras_patcher.attempt_patch()
+    get_cerebras_patcher(settings.cerebras).attempt_patch()
     cohere_patcher.attempt_patch()
     google_genai_patcher.attempt_patch()
     notdiamond_patcher.attempt_patch()
@@ -51,7 +51,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
 
 def reset_autopatch() -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
-    from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
+    from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
@@ -76,7 +76,7 @@ def reset_autopatch() -> None:
     get_groq_patcher().undo_patch()
     get_instructor_patcher().undo_patch()
     dspy_patcher.undo_patch()
-    cerebras_patcher.undo_patch()
+    get_cerebras_patcher().undo_patch()
     cohere_patcher.undo_patch()
     google_genai_patcher.undo_patch()
     notdiamond_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -26,7 +26,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import get_mistral_patcher
-    from weave.integrations.notdiamond.tracing import notdiamond_patcher
+    from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
@@ -45,7 +45,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     get_cerebras_patcher(settings.cerebras).attempt_patch()
     get_cohere_patcher(settings.cohere).attempt_patch()
     get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
-    notdiamond_patcher.attempt_patch()
+    get_notdiamond_patcher(settings.notdiamond).attempt_patch()
     vertexai_patcher.attempt_patch()
 
 
@@ -63,7 +63,7 @@ def reset_autopatch() -> None:
     from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import get_mistral_patcher
-    from weave.integrations.notdiamond.tracing import notdiamond_patcher
+    from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
@@ -79,7 +79,7 @@ def reset_autopatch() -> None:
     get_cerebras_patcher().undo_patch()
     get_cohere_patcher().undo_patch()
     get_google_genai_patcher().undo_patch()
-    notdiamond_patcher.undo_patch()
+    get_notdiamond_patcher().undo_patch()
     vertexai_patcher.undo_patch()
 
 

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -107,5 +107,17 @@ class IntegrationSettings:
 class AutopatchSettings:
     """Settings for auto-patching integrations."""
 
-    openai: IntegrationSettings = field(default_factory=IntegrationSettings)
     anthropic: IntegrationSettings = field(default_factory=IntegrationSettings)
+    cerebras: IntegrationSettings = field(default_factory=IntegrationSettings)
+    cohere: IntegrationSettings = field(default_factory=IntegrationSettings)
+    dspy: IntegrationSettings = field(default_factory=IntegrationSettings)
+    google_ai_studio: IntegrationSettings = field(default_factory=IntegrationSettings)
+    groq: IntegrationSettings = field(default_factory=IntegrationSettings)
+    instructor: IntegrationSettings = field(default_factory=IntegrationSettings)
+    langchain: IntegrationSettings = field(default_factory=IntegrationSettings)
+    litellm: IntegrationSettings = field(default_factory=IntegrationSettings)
+    llamaindex: IntegrationSettings = field(default_factory=IntegrationSettings)
+    mistral: IntegrationSettings = field(default_factory=IntegrationSettings)
+    notdiamond: IntegrationSettings = field(default_factory=IntegrationSettings)
+    openai: IntegrationSettings = field(default_factory=IntegrationSettings)
+    vertexai: IntegrationSettings = field(default_factory=IntegrationSettings)

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -18,7 +18,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
-        google_genai_patcher,
+        get_google_genai_patcher,
     )
     from weave.integrations.groq.groq_sdk import get_groq_patcher
     from weave.integrations.instructor.instructor_sdk import get_instructor_patcher
@@ -44,7 +44,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     dspy_patcher.attempt_patch()
     get_cerebras_patcher(settings.cerebras).attempt_patch()
     get_cohere_patcher(settings.cohere).attempt_patch()
-    google_genai_patcher.attempt_patch()
+    get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
     notdiamond_patcher.attempt_patch()
     vertexai_patcher.attempt_patch()
 
@@ -55,7 +55,7 @@ def reset_autopatch() -> None:
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
-        google_genai_patcher,
+        get_google_genai_patcher,
     )
     from weave.integrations.groq.groq_sdk import get_groq_patcher
     from weave.integrations.instructor.instructor_sdk import get_instructor_patcher
@@ -78,7 +78,7 @@ def reset_autopatch() -> None:
     dspy_patcher.undo_patch()
     get_cerebras_patcher().undo_patch()
     get_cohere_patcher().undo_patch()
-    google_genai_patcher.undo_patch()
+    get_google_genai_patcher().undo_patch()
     notdiamond_patcher.undo_patch()
     vertexai_patcher.undo_patch()
 

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -32,84 +32,17 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
 
     if settings is None:
         settings = AutopatchSettings()
-
-        get_openai_patcher(settings.openai).attempt_patch()
-        get_openai_patcher(settings.openai).attempt_patch()
-
-    if settings.mistral.enabled:
     get_openai_patcher(settings.openai).attempt_patch()
-
-    if settings.mistral.enabled:
-        get_mistral_patcher(settings.mistral).attempt_patch()
-        get_mistral_patcher(settings.mistral).attempt_patch()
-
-    if settings.litellm.enabled:
     get_mistral_patcher(settings.mistral).attempt_patch()
-
-    if settings.litellm.enabled:
-        get_litellm_patcher(settings.litellm).attempt_patch()
-        get_litellm_patcher(settings.litellm).attempt_patch()
-
-    if settings.anthropic.enabled:
     get_litellm_patcher(settings.litellm).attempt_patch()
-
-    if settings.anthropic.enabled:
-        get_anthropic_patcher(settings.anthropic).attempt_patch()
-        get_anthropic_patcher(settings.anthropic).attempt_patch()
-
-    if settings.groq.enabled:
     get_anthropic_patcher(settings.anthropic).attempt_patch()
-
-    if settings.groq.enabled:
-        get_groq_patcher(settings.groq).attempt_patch()
-        get_groq_patcher(settings.groq).attempt_patch()
-
-    if settings.instructor.enabled:
     get_groq_patcher(settings.groq).attempt_patch()
-
-    if settings.instructor.enabled:
-        get_instructor_patcher(settings.instructor).attempt_patch()
-        get_instructor_patcher(settings.instructor).attempt_patch()
-
-    if settings.dspy.enabled:
     get_instructor_patcher(settings.instructor).attempt_patch()
-
-    if settings.dspy.enabled:
-        get_dspy_patcher(settings.dspy).attempt_patch()
-        get_dspy_patcher(settings.dspy).attempt_patch()
-
-    if settings.cerebras.enabled:
     get_dspy_patcher(settings.dspy).attempt_patch()
-
-    if settings.cerebras.enabled:
-        get_cerebras_patcher(settings.cerebras).attempt_patch()
-        get_cerebras_patcher(settings.cerebras).attempt_patch()
-
-    if settings.cohere.enabled:
     get_cerebras_patcher(settings.cerebras).attempt_patch()
-
-    if settings.cohere.enabled:
-        get_cohere_patcher(settings.cohere).attempt_patch()
-        get_cohere_patcher(settings.cohere).attempt_patch()
-
-    if settings.google_ai_studio.enabled:
     get_cohere_patcher(settings.cohere).attempt_patch()
-
-    if settings.google_ai_studio.enabled:
-        get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
-        get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
-
-    if settings.notdiamond.enabled:
     get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
-
-    if settings.notdiamond.enabled:
-        get_notdiamond_patcher(settings.notdiamond).attempt_patch()
-        get_notdiamond_patcher(settings.notdiamond).attempt_patch()
-
-    if settings.vertexai.enabled:
     get_notdiamond_patcher(settings.notdiamond).attempt_patch()
-
-    if settings.vertexai.enabled:
     get_vertexai_patcher(settings.vertexai).attempt_patch()
 
     # These integrations don't use the op decorator, so there are no settings to pass through

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -21,7 +21,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
         google_genai_patcher,
     )
     from weave.integrations.groq.groq_sdk import get_groq_patcher
-    from weave.integrations.instructor.instructor_sdk import instructor_patcher
+    from weave.integrations.instructor.instructor_sdk import get_instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
@@ -40,7 +40,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     langchain_patcher.attempt_patch()
     get_anthropic_patcher(settings.anthropic).attempt_patch()
     get_groq_patcher(settings.groq).attempt_patch()
-    instructor_patcher.attempt_patch()
+    get_instructor_patcher(settings.instructor).attempt_patch()
     dspy_patcher.attempt_patch()
     cerebras_patcher.attempt_patch()
     cohere_patcher.attempt_patch()
@@ -58,7 +58,7 @@ def reset_autopatch() -> None:
         google_genai_patcher,
     )
     from weave.integrations.groq.groq_sdk import get_groq_patcher
-    from weave.integrations.instructor.instructor_sdk import instructor_patcher
+    from weave.integrations.instructor.instructor_sdk import get_instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
@@ -74,7 +74,7 @@ def reset_autopatch() -> None:
     langchain_patcher.undo_patch()
     get_anthropic_patcher().undo_patch()
     get_groq_patcher().undo_patch()
-    instructor_patcher.undo_patch()
+    get_instructor_patcher().undo_patch()
     dspy_patcher.undo_patch()
     cerebras_patcher.undo_patch()
     cohere_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -32,6 +32,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
 
     if settings is None:
         settings = AutopatchSettings()
+
     get_openai_patcher(settings.openai).attempt_patch()
     get_mistral_patcher(settings.mistral).attempt_patch()
     get_litellm_patcher(settings.litellm).attempt_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -16,7 +16,7 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
-    from weave.integrations.dspy.dspy_sdk import dspy_patcher
+    from weave.integrations.dspy.dspy_sdk import get_dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         get_google_genai_patcher,
     )
@@ -36,24 +36,26 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     get_openai_patcher(settings.openai).attempt_patch()
     get_mistral_patcher(settings.mistral).attempt_patch()
     get_litellm_patcher(settings.litellm).attempt_patch()
-    llamaindex_patcher.attempt_patch()
-    langchain_patcher.attempt_patch()
     get_anthropic_patcher(settings.anthropic).attempt_patch()
     get_groq_patcher(settings.groq).attempt_patch()
     get_instructor_patcher(settings.instructor).attempt_patch()
-    dspy_patcher.attempt_patch()
+    get_dspy_patcher(settings.dspy).attempt_patch()
     get_cerebras_patcher(settings.cerebras).attempt_patch()
     get_cohere_patcher(settings.cohere).attempt_patch()
     get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
     get_notdiamond_patcher(settings.notdiamond).attempt_patch()
     get_vertexai_patcher(settings.vertexai).attempt_patch()
 
+    # These integrations don't use the op decorator, so there are no settings to pass through
+    llamaindex_patcher.attempt_patch()
+    langchain_patcher.attempt_patch()
+
 
 def reset_autopatch() -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
-    from weave.integrations.dspy.dspy_sdk import dspy_patcher
+    from weave.integrations.dspy.dspy_sdk import get_dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         get_google_genai_patcher,
     )
@@ -70,17 +72,18 @@ def reset_autopatch() -> None:
     get_openai_patcher().undo_patch()
     get_mistral_patcher().undo_patch()
     get_litellm_patcher().undo_patch()
-    llamaindex_patcher.undo_patch()
-    langchain_patcher.undo_patch()
     get_anthropic_patcher().undo_patch()
     get_groq_patcher().undo_patch()
     get_instructor_patcher().undo_patch()
-    dspy_patcher.undo_patch()
+    get_dspy_patcher().undo_patch()
     get_cerebras_patcher().undo_patch()
     get_cohere_patcher().undo_patch()
     get_google_genai_patcher().undo_patch()
     get_notdiamond_patcher().undo_patch()
     get_vertexai_patcher().undo_patch()
+
+    llamaindex_patcher.undo_patch()
+    langchain_patcher.undo_patch()
 
 
 @dataclass

--- a/weave/trace/patcher.py
+++ b/weave/trace/patcher.py
@@ -17,6 +17,14 @@ class Patcher:
         raise NotImplementedError()
 
 
+class NoOpPatcher(Patcher):
+    def attempt_patch(self) -> bool:
+        return True
+
+    def undo_patch(self) -> bool:
+        return True
+
+
 class MultiPatcher(Patcher):
     def __init__(self, patchers: Sequence[Patcher]) -> None:
         self.patchers = patchers

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -63,7 +63,9 @@ Args:
 
 
 def init_weave(
-    project_name: str, ensure_project_exists: bool = True
+    project_name: str,
+    ensure_project_exists: bool = True,
+    autopatch_settings: AutopatchSettings | None = None,
 ) -> InitializedClient:
     global _current_inited_client
     if _current_inited_client is not None:
@@ -120,7 +122,7 @@ def init_weave(
     # autopatching is only supported for the wandb client, because OpenAI calls are not
     # logged in local mode currently. When that's fixed, this autopatch call can be
     # moved to InitializedClient.__init__
-    autopatch.autopatch()
+    autopatch.autopatch(autopatch_settings)
 
     username = get_username()
     try:

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -65,7 +65,7 @@ Args:
 def init_weave(
     project_name: str,
     ensure_project_exists: bool = True,
-    autopatch_settings: AutopatchSettings | None = None,
+    autopatch_settings: autopatch.AutopatchSettings | None = None,
 ) -> InitializedClient:
     global _current_inited_client
     if _current_inited_client is not None:


### PR DESCRIPTION
This is a fast-follow PR to: https://github.com/wandb/weave/pull/3197

It implements op kwarg passthrough for the remaining integrations, except Langchain and Llamaindex because they don't use the op decorator.