### PR TITLE
refactor(ui): break an import cycle

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -104,6 +104,7 @@ import {
   WFDataModelAutoProvider,
 } from './Browse3/pages/wfReactInterface/context';
 import {useHasTraceServerClientContext} from './Browse3/pages/wfReactInterface/traceServerClientContext';
+import {TableRowSelectionProvider} from './TableRowSelectionContext';
 import {useDrawerResize} from './useDrawerResize';
 
 LicenseInfo.setLicenseKey(
@@ -1147,65 +1148,5 @@ const Browse3Breadcrumbs: FC = props => {
         </React.Fragment>
       ))}
     </Breadcrumbs>
-  );
-};
-
-export const TableRowSelectionContext = React.createContext<{
-  rowIdsConfigured: boolean;
-  rowIdInTable: (id: string) => boolean;
-  setRowIds?: (rowIds: string[]) => void;
-  getNextRowId?: (currentId: string) => string | null;
-  getPreviousRowId?: (currentId: string) => string | null;
-}>({
-  rowIdsConfigured: false,
-  rowIdInTable: (id: string) => false,
-  setRowIds: () => {},
-  getNextRowId: () => null,
-  getPreviousRowId: () => null,
-});
-
-const TableRowSelectionProvider: FC<{children: React.ReactNode}> = ({
-  children,
-}) => {
-  const [rowIds, setRowIds] = useState<string[]>([]);
-  const rowIdsConfigured = useMemo(() => rowIds.length > 0, [rowIds]);
-  const rowIdInTable = useCallback(
-    (currentId: string) => rowIds.includes(currentId),
-    [rowIds]
-  );
-
-  const getNextRowId = useCallback(
-    (currentId: string) => {
-      const currentIndex = rowIds.indexOf(currentId);
-      if (currentIndex !== -1) {
-        return rowIds[currentIndex + 1];
-      }
-      return null;
-    },
-    [rowIds]
-  );
-
-  const getPreviousRowId = useCallback(
-    (currentId: string) => {
-      const currentIndex = rowIds.indexOf(currentId);
-      if (currentIndex !== -1) {
-        return rowIds[currentIndex - 1];
-      }
-      return null;
-    },
-    [rowIds]
-  );
-
-  return (
-    <TableRowSelectionContext.Provider
-      value={{
-        rowIdsConfigured,
-        rowIdInTable,
-        setRowIds,
-        getNextRowId,
-        getPreviousRowId,
-      }}>
-      {children}
-    </TableRowSelectionContext.Provider>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -17,7 +17,7 @@ import {makeRefCall} from '../../../../../../util/refs';
 import {Button} from '../../../../../Button';
 import {Tailwind} from '../../../../../Tailwind';
 import {Browse2OpDefCode} from '../../../Browse2/Browse2OpDefCode';
-import {TableRowSelectionContext} from '../../../Browse3';
+import {TableRowSelectionContext} from '../../../TableRowSelectionContext';
 import {
   FEEDBACK_EXPAND_PARAM,
   TRACETREE_PARAM,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/PaginationControls.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/PaginationControls.tsx
@@ -3,7 +3,7 @@ import {Button} from '@wandb/weave/components/Button';
 import React, {FC, useCallback, useContext, useEffect} from 'react';
 import {useHistory} from 'react-router-dom';
 
-import {TableRowSelectionContext} from '../../../Browse3';
+import {TableRowSelectionContext} from '../../../TableRowSelectionContext';
 import {
   FEEDBACK_EXPAND_PARAM,
   TRACETREE_PARAM,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -45,7 +45,7 @@ import {useViewerInfo} from '../../../../../../common/hooks/useViewerInfo';
 import {A, TargetBlank} from '../../../../../../common/util/links';
 import {TailwindContents} from '../../../../../Tailwind';
 import {flattenObjectPreservingWeaveTypes} from '../../../Browse2/browse2Util';
-import {TableRowSelectionContext} from '../../../Browse3';
+import {TableRowSelectionContext} from '../../../TableRowSelectionContext';
 import {
   useWeaveflowCurrentRouteContext,
   WeaveflowPeekContext,

--- a/weave-js/src/components/PagePanelComponents/Home/TableRowSelectionContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/TableRowSelectionContext.tsx
@@ -1,0 +1,61 @@
+import React, {FC, useCallback, useMemo, useState} from 'react';
+
+export const TableRowSelectionContext = React.createContext<{
+  rowIdsConfigured: boolean;
+  rowIdInTable: (id: string) => boolean;
+  setRowIds?: (rowIds: string[]) => void;
+  getNextRowId?: (currentId: string) => string | null;
+  getPreviousRowId?: (currentId: string) => string | null;
+}>({
+  rowIdsConfigured: false,
+  rowIdInTable: (id: string) => false,
+  setRowIds: () => {},
+  getNextRowId: () => null,
+  getPreviousRowId: () => null,
+});
+
+export const TableRowSelectionProvider: FC<{children: React.ReactNode}> = ({
+  children,
+}) => {
+  const [rowIds, setRowIds] = useState<string[]>([]);
+  const rowIdsConfigured = useMemo(() => rowIds.length > 0, [rowIds]);
+  const rowIdInTable = useCallback(
+    (currentId: string) => rowIds.includes(currentId),
+    [rowIds]
+  );
+
+  const getNextRowId = useCallback(
+    (currentId: string) => {
+      const currentIndex = rowIds.indexOf(currentId);
+      if (currentIndex !== -1) {
+        return rowIds[currentIndex + 1];
+      }
+      return null;
+    },
+    [rowIds]
+  );
+
+  const getPreviousRowId = useCallback(
+    (currentId: string) => {
+      const currentIndex = rowIds.indexOf(currentId);
+      if (currentIndex !== -1) {
+        return rowIds[currentIndex - 1];
+      }
+      return null;
+    },
+    [rowIds]
+  );
+
+  return (
+    <TableRowSelectionContext.Provider
+      value={{
+        rowIdsConfigured,
+        rowIdInTable,
+        setRowIds,
+        getNextRowId,
+        getPreviousRowId,
+      }}>
+      {children}
+    </TableRowSelectionContext.Provider>
+  );
+};


### PR DESCRIPTION
## Description

Pure refactor, breaking some import cycles that cause reloading problem in development. 

Before:
```
npx madge --circular  /Users/jamie/source/wandb/core/services/weave-python/weave-public/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx  | grep Browse3.t

✖ Found 142 circular dependencies!

139) Browse3.tsx > Browse3/pages/CallPage/CallPage.tsx
141) Browse3.tsx > Browse3/pages/CallPage/CallPage.tsx > Browse3/pages/CallPage/CallDetails.tsx > Browse3/pages/CallsPage/CallsTable.tsx
142) Browse3.tsx > Browse3/pages/CallPage/CallPage.tsx > Browse3/pages/CallPage/PaginationControls.tsx
```

After:
```
npx madge --circular  /Users/jamie/source/wandb/core/services/weave-python/weave-public/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx  | grep Browse3.t
✖ Found 139 circular dependencies!
```


## Testing

How was this PR tested?
