### PR TITLE
chore(weave): add secondary client, refactor batching, set initial batch to 100

### DIFF
--- a/tests/trace/test_trace_server_common.py
+++ b/tests/trace/test_trace_server_common.py
@@ -64,23 +64,15 @@ def test_dynamic_batch_processor():
     # - growth factor of 2
     processor = DynamicBatchProcessor(initial_size=2, max_size=8, growth_factor=2)
 
-    # Create test data
     test_data = range(15)
 
-    # Process the data into batches
     batches = list(processor.process(iter(test_data)))
 
     # Expected batch sizes: 2, 4, 8, 1
-    # First batch should have 2 items
     assert batches[0] == [0, 1]
-    # Second batch should have 4 items
     assert batches[1] == [2, 3, 4, 5]
-    # Third batch should have 8 items
     assert batches[2] == [6, 7, 8, 9, 10, 11, 12, 13]
-    # Last batch should have remaining item
     assert batches[3] == [14]
-
-    # Verify total number of batches
     assert len(batches) == 4
 
     # Verify all items were processed

--- a/tests/trace/test_trace_server_common.py
+++ b/tests/trace/test_trace_server_common.py
@@ -1,4 +1,5 @@
 from weave.trace_server.trace_server_common import (
+    DynamicBatchProcessor,
     LRUCache,
     get_nested_key,
     set_nested_key,
@@ -54,3 +55,34 @@ def test_lru_cache():
     cache["c"] = 10
     assert cache["c"] == 10
     assert cache["d"] == 4
+
+
+def test_dynamic_batch_processor():
+    # Initialize processor with:
+    # - initial batch size of 2
+    # - max size of 8
+    # - growth factor of 2
+    processor = DynamicBatchProcessor(initial_size=2, max_size=8, growth_factor=2)
+
+    # Create test data
+    test_data = range(15)
+
+    # Process the data into batches
+    batches = list(processor.process(iter(test_data)))
+
+    # Expected batch sizes: 2, 4, 8, 1
+    # First batch should have 2 items
+    assert batches[0] == [0, 1]
+    # Second batch should have 4 items
+    assert batches[1] == [2, 3, 4, 5]
+    # Third batch should have 8 items
+    assert batches[2] == [6, 7, 8, 9, 10, 11, 12, 13]
+    # Last batch should have remaining item
+    assert batches[3] == [14]
+
+    # Verify total number of batches
+    assert len(batches) == 4
+
+    # Verify all items were processed
+    flattened = [item for batch in batches for item in batch]
+    assert flattened == list(range(15))

--- a/tests/trace/test_trace_server_common.py
+++ b/tests/trace/test_trace_server_common.py
@@ -66,7 +66,7 @@ def test_dynamic_batch_processor():
 
     test_data = range(15)
 
-    batches = list(processor.process(iter(test_data)))
+    batches = list(processor.make_batches(iter(test_data)))
 
     # Expected batch sizes: 2, 4, 8, 1
     assert batches[0] == [0, 1]

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1090,6 +1090,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             for i, extra_result in enumerate(extra_results):
                 if extra_result.unresolved_obj_ref is not None:
                     needed_extra_results.append((i, extra_result))
+
             if len(needed_extra_results) > 0:
                 refs: list[ri.InternalObjectRef] = []
                 for i, extra_result in needed_extra_results:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -366,11 +366,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         for batch in batch_processor.process(raw_res):
             call_dicts = [row_to_call_schema_dict(row) for row in batch]
             hydrated_calls = self._hydrate_calls(
-                req.project_id,
-                call_dicts,
-                expand_columns,
-                include_feedback,
-                ref_cache
+                req.project_id, call_dicts, expand_columns, include_feedback, ref_cache
             )
             for call in hydrated_calls:
                 yield tsi.CallSchema.model_validate(call)
@@ -385,9 +381,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
     ) -> list[dict[str, Any]]:
         if len(calls) == 0:
             return calls
-
-        # Collect calls into memory before making additional queries
-        calls = list(calls)
 
         if expand_columns:
             self._expand_call_refs(project_id, calls, expand_columns, ref_cache)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -500,7 +500,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         if req.include_feedback:
             feedback_query_req = make_feedback_query_req(req.project_id, calls)
             feedback = self.feedback_query(feedback_query_req)
-            hydrate_calls_with_feedback(calls, feedback)
+            hydrate_calls_with_feedback(calls, feedback.result)
 
         return tsi.CallsQueryRes(calls=[tsi.CallSchema(**call) for call in calls])
 
@@ -566,7 +566,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     WHERE c.deleted_at IS NULL
                 )
                 SELECT id FROM Descendants;
-            """.format(", ".join("?" * len(req.call_ids)))
+            """.format(
+                ", ".join("?" * len(req.call_ids))
+            )
 
             params = [req.project_id] + req.call_ids
             cursor.execute(recursive_query, params)
@@ -578,7 +580,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 SET deleted_at = CURRENT_TIMESTAMP
                 WHERE deleted_at is NULL AND
                     id IN ({})
-            """.format(", ".join("?" * len(all_ids)))
+            """.format(
+                ", ".join("?" * len(all_ids))
+            )
             print("MUTATION", delete_query)
             cursor.execute(delete_query, all_ids)
             conn.commit()

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -500,7 +500,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         if req.include_feedback:
             feedback_query_req = make_feedback_query_req(req.project_id, calls)
             feedback = self.feedback_query(feedback_query_req)
-            hydrate_calls_with_feedback(calls, feedback.result)
+            hydrate_calls_with_feedback(calls, feedback)
 
         return tsi.CallsQueryRes(calls=[tsi.CallSchema(**call) for call in calls])
 
@@ -566,9 +566,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     WHERE c.deleted_at IS NULL
                 )
                 SELECT id FROM Descendants;
-            """.format(
-                ", ".join("?" * len(req.call_ids))
-            )
+            """.format(", ".join("?" * len(req.call_ids)))
 
             params = [req.project_id] + req.call_ids
             cursor.execute(recursive_query, params)
@@ -580,9 +578,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 SET deleted_at = CURRENT_TIMESTAMP
                 WHERE deleted_at is NULL AND
                     id IN ({})
-            """.format(
-                ", ".join("?" * len(all_ids))
-            )
+            """.format(", ".join("?" * len(all_ids)))
             print("MUTATION", delete_query)
             cursor.execute(delete_query, all_ids)
             conn.commit()

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 from collections import OrderedDict, defaultdict
+from collections.abc import Iterator
 from typing import Any, Optional, cast
 
 from weave.trace_server import refs_internal as ri
@@ -168,6 +169,32 @@ class LRUCache(OrderedDict):
         if key not in self and len(self) >= self.max_size:
             self.popitem(last=False)
         super().__setitem__(key, value)
+
+
+class DynamicBatchProcessor:
+    """Helper class to handle dynamic batch processing with growing batch sizes."""
+
+    def __init__(self, initial_size: int, max_size: int, growth_factor: int):
+        self.batch_size = initial_size
+        self.max_size = max_size
+        self.growth_factor = growth_factor
+
+    def process(self, iterator: Iterator[Any]) -> Iterator[list[Any]]:
+        """Process an iterator into dynamically sized batches."""
+        batch = []
+
+        for item in iterator:
+            batch.append(item)
+
+            if len(batch) >= self.batch_size:
+                yield batch
+                batch = []
+                self.batch_size = min(
+                    self.max_size, self.batch_size * self.growth_factor
+                )
+
+        if batch:
+            yield batch
 
 
 def digest_is_version_like(digest: str) -> tuple[bool, int]:

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -49,12 +49,12 @@ def make_feedback_query_req(
 
 
 def hydrate_calls_with_feedback(
-    calls: list[dict[str, Any]], feedback: tsi.FeedbackQueryRes
+    calls: list[dict[str, Any]], feedback: list[dict[str, Any]]
 ) -> None:
     """Hydrate calls with feedback inplace."""
     feedback_map = defaultdict(list)
     # map feedback to calls
-    for feedback_item in feedback.result:
+    for feedback_item in feedback:
         uri = ri.parse_internal_uri(feedback_item["weave_ref"])
         if isinstance(uri, ri.InternalCallRef):
             feedback_map[uri.id].append(feedback_item)

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -179,8 +179,7 @@ class DynamicBatchProcessor:
         self.max_size = max_size
         self.growth_factor = growth_factor
 
-    def process(self, iterator: Iterator[Any]) -> Iterator[list[Any]]:
-        """Process an iterator into dynamically sized batches."""
+    def make_batches(self, iterator: Iterator[Any]) -> Iterator[list[Any]]:
         batch = []
 
         for item in iterator:
@@ -188,13 +187,15 @@ class DynamicBatchProcessor:
 
             if len(batch) >= self.batch_size:
                 yield batch
+
                 batch = []
-                self.batch_size = min(
-                    self.max_size, self.batch_size * self.growth_factor
-                )
+                self.batch_size = self._compute_batch_size()
 
         if batch:
             yield batch
+
+    def _compute_batch_size(self) -> int:
+        return min(self.max_size, self.batch_size * self.growth_factor)
 
 
 def digest_is_version_like(digest: str) -> tuple[bool, int]:

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -49,12 +49,12 @@ def make_feedback_query_req(
 
 
 def hydrate_calls_with_feedback(
-    calls: list[dict[str, Any]], feedback: list[dict[str, Any]]
+    calls: list[dict[str, Any]], feedback: tsi.FeedbackQueryRes
 ) -> None:
     """Hydrate calls with feedback inplace."""
     feedback_map = defaultdict(list)
     # map feedback to calls
-    for feedback_item in feedback:
+    for feedback_item in feedback.result:
         uri = ri.parse_internal_uri(feedback_item["weave_ref"])
         if isinstance(uri, ri.InternalCallRef):
             feedback_map[uri.id].append(feedback_item)


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr:
- Add a secondary client connection to the CHBatched to make queries while streaming results from other queries... It should be pretty easily accessible, just wrap your chclient query in `with self.use_secondary_client():`  so use the second connection. 
- bumps the initial batch size for hydrating calls (adding feedback and expanding refs) from 10 to 100. This reduces the number of iterations from 2 -> 1 for the now most common use case of `include_feedback` which is rendering the call table. 
- refactor the batch processing for readability and sanity 

## Testing

- existing tests with `include_feedback` will hit this codepath
- add tests for new batch processor class
