### PR TITLE
chore(ui): add filled circle icon

### DIFF
--- a/weave-js/src/assets/icons/icon-filled-circle.svg
+++ b/weave-js/src/assets/icons/icon-filled-circle.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 12C19 15.866 15.866 19 12 19C8.13401 19 5 15.866 5 12C5 8.13401 8.13401 5 12 5C15.866 5 19 8.13401 19 12Z" fill="currentColor"/>
+</svg>

--- a/weave-js/src/components/Icon/Icon.tsx
+++ b/weave-js/src/components/Icon/Icon.tsx
@@ -74,6 +74,7 @@ import {ReactComponent as ImportExpandUncollapse} from '../../assets/icons/icon-
 import {ReactComponent as ImportExportShareUpload} from '../../assets/icons/icon-export-share-upload.svg';
 import {ReactComponent as ImportFacebookSocial} from '../../assets/icons/icon-facebook-social.svg';
 import {ReactComponent as ImportFailed} from '../../assets/icons/icon-failed.svg';
+import {ReactComponent as ImportFilledCircle} from '../../assets/icons/icon-filled-circle.svg';
 import {ReactComponent as ImportFilterAlt} from '../../assets/icons/icon-filter-alt.svg';
 import {ReactComponent as ImportFlashBolt} from '../../assets/icons/icon-flash-bolt.svg';
 import {ReactComponent as ImportFolderAlt} from '../../assets/icons/icon-folder-alt.svg';
@@ -496,6 +497,9 @@ export const IconFacebookSocial = (props: SVGIconProps) => (
 );
 export const IconFailed = (props: SVGIconProps) => (
   <ImportFailed {...updateIconProps(props)} />
+);
+export const IconFilledCircle = (props: SVGIconProps) => (
+  <ImportFilledCircle {...updateIconProps(props)} />
 );
 export const IconFilterAlt = (props: SVGIconProps) => (
   <ImportFilterAlt {...updateIconProps(props)} />
@@ -1134,6 +1138,7 @@ const ICON_NAME_TO_ICON: Record<IconName, ElementType> = {
   'export-share-upload': IconExportShareUpload,
   'facebook-social': IconFacebookSocial,
   failed: IconFailed,
+  'filled-circle': IconFilledCircle,
   'filter-alt': IconFilterAlt,
   'flash-bolt': IconFlashBolt,
   'folder-alt': IconFolderAlt,

--- a/weave-js/src/components/Icon/index.ts
+++ b/weave-js/src/components/Icon/index.ts
@@ -74,6 +74,7 @@ export {
   IconExportShareUpload,
   IconFacebookSocial,
   IconFailed,
+  IconFilledCircle,
   IconFilterAlt,
   IconFlashBolt,
   IconFolderAlt,

--- a/weave-js/src/components/Icon/types.ts
+++ b/weave-js/src/components/Icon/types.ts
@@ -73,6 +73,7 @@ export const IconNames = {
   ExportShareUpload: 'export-share-upload',
   FacebookSocial: 'facebook-social',
   Failed: 'failed',
+  FilledCircle: 'filled-circle',
   FilterAlt: 'filter-alt',
   FlashBolt: 'flash-bolt',
   FolderAlt: 'folder-alt',


### PR DESCRIPTION
## Description

addicon codegen. An initial planned use is to replace the circle icon from material icons that we are using here:

![image](https://github.com/user-attachments/assets/fd6f018a-ef79-4581-bc8d-89b9ec1bc965)


## Testing

How was this PR tested?
