### PR TITLE
chore(ui): fix warning about key attr spread

### DIFF
--- a/weave-js/src/components/FancyPage/FancyPageMenu.tsx
+++ b/weave-js/src/components/FancyPage/FancyPageMenu.tsx
@@ -60,7 +60,6 @@ export const FancyPageMenu = ({
               return null;
             }
             const linkProps = {
-              key: menuItem.slug,
               to: menuItem.isDisabled
                 ? {}
                 : {
@@ -76,7 +75,7 @@ export const FancyPageMenu = ({
               },
             };
             return (
-              <Link {...linkProps}>
+              <Link key={menuItem.slug} {...linkProps}>
                 <DropdownMenu.Item {...menuItemProps}>
                   <Icon name={menuItem.iconName} />
                   {menuItem.nameTooltip || menuItem.name}


### PR DESCRIPTION
## Description

Fix this developer console warning:

<img width="478" alt="Screenshot 2024-12-06 at 3 58 20 PM" src="https://github.com/user-attachments/assets/43fe8311-2a12-4cca-9d05-0750cb88e300">


## Testing

How was this PR tested?
