### PR TITLE
chore(ui): Add TooltipDeprecated

### DIFF
--- a/weave-js/src/components/TooltipDeprecated.tsx
+++ b/weave-js/src/components/TooltipDeprecated.tsx
@@ -1,0 +1,36 @@
+/**
+ * @deprecated Don't use this in any new code, we're trying to get rid of semantic-ui.
+ */
+import {Popup} from 'semantic-ui-react';
+import styled from 'styled-components';
+
+import {
+  hexToRGB,
+  MOON_650,
+  MOON_800,
+  OBLIVION,
+  WHITE,
+} from '../common/css/globals.styles';
+
+export const TooltipDeprecated = styled(Popup).attrs({
+  basic: true, // This removes the pointing arrow.
+  mouseEnterDelay: 500,
+  popperModifiers: {
+    preventOverflow: {
+      // Prevent popper from erroneously constraining the popup.
+      // Without this, tooltips in single row table cells get positioned under the cursor,
+      // causing them to immediately close.
+      boundariesElement: 'viewport',
+    },
+  },
+})`
+  && {
+    color: ${WHITE};
+    background: ${MOON_800};
+    border-color: ${MOON_650};
+    box-shadow: 0px 4px 6px ${hexToRGB(OBLIVION, 0.2)};
+    font-size: 14px;
+    line-height: 140%;
+    max-width: 300px;
+  }
+`;


### PR DESCRIPTION
## Description

First steps on https://wandb.atlassian.net/browse/WB-22063

The dev console is filling up with warnings, making development harder. A common warning looks like:
```
tsDataModelHooks.ts:968 Warning: findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here: https://reactjs.org/link/strict-mode-find-node Error Component Stack
    at Timestamp (Timestamp.tsx:75:28)
    at div (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at div (<anonymous>)
    at StyledDataGrid.tsx:35:5
    at ObjectVersionsTable (ObjectVersionsPage.tsx:252:10)
    at div (<anonymous>)
    at FilterLayoutTemplate (SimpleFilterableDataTable.tsx:20:14)
    at FilterableObjectVersionsTable (ObjectVersionsPage.tsx:160:35)
    at ErrorBoundary (ErrorBoundary.tsx:16:8)
```

Our current Tooltip component is used in many places and is just a styled version of Semantic UI's [Popup](https://semantic-ui.com/modules/popup.html). We would like to replace it with a component based on [Radix Tooltip](https://www.radix-ui.com/primitives/docs/components/tooltip). Unfortunately many places make direct use of Popup props.

This PR clones the Tooltip component as TooltipDeprecated. We can next update Tooltip uses where there are props that won't be part of the revised Tooltip props to use TooltipDeprecated instead.

## Testing

How was this PR tested?
