### PR TITLE
chore(ui): pluralize calls link

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -9,6 +9,7 @@ import {Link as LinkComp, useHistory} from 'react-router-dom';
 import styled, {css} from 'styled-components';
 
 import {TargetBlank} from '../../../../../../common/util/links';
+import {maybePluralizeWord} from '../../../../../../core/util/string';
 import {
   FEEDBACK_EXPAND_PARAM,
   PATH_PARAM,
@@ -414,7 +415,8 @@ export const CallsLink: React.FC<{
       $variant={props.variant}
       to={router.callsUIUrl(props.entity, props.project, props.filter)}>
       {props.callCount}
-      {props.countIsLimited ? '+' : ''} calls
+      {props.countIsLimited ? '+' : ''}{' '}
+      {maybePluralizeWord(props.callCount, 'call')}
     </Link>
   );
 };


### PR DESCRIPTION
## Description

Before:
<img width="113" alt="Screenshot 2024-12-09 at 9 18 22 AM" src="https://github.com/user-attachments/assets/0a84632d-1633-4877-9a4e-ffb5341a0f4f">

After:
<img width="122" alt="Screenshot 2024-12-09 at 9 18 15 AM" src="https://github.com/user-attachments/assets/a375d73c-307e-4eca-b2c3-9fdf842778fc">

This should still work with the styling changes coming in https://github.com/wandb/weave/pull/3049

## Testing

How was this PR tested?
