### PR TITLE
chore(ui): disable refresh while refreshing

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -744,7 +744,10 @@ export const CallsTable: FC<{
       }}
       filterListItems={
         <TailwindContents>
-          <RefreshButton onClick={() => calls.refetch()} />
+          <RefreshButton
+            onClick={() => calls.refetch()}
+            disabled={callsLoading}
+          />
           {!hideOpSelector && (
             <OpSelector
               frozenFilter={frozenFilter}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -471,7 +471,8 @@ export const BulkDeleteButton: FC<{
 
 export const RefreshButton: FC<{
   onClick: () => void;
-}> = ({onClick}) => {
+  disabled?: boolean;
+}> = ({onClick, disabled}) => {
   return (
     <Box
       sx={{
@@ -483,6 +484,7 @@ export const RefreshButton: FC<{
         variant="outline"
         size="medium"
         onClick={onClick}
+        disabled={disabled}
         tooltip="Refresh"
         icon="reload-refresh"
       />


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Disables refresh button while calls are loading, either on page load or refresh click

## Testing

<img width="255" alt="Screenshot 2024-12-09 at 10 19 25 AM" src="https://github.com/user-attachments/assets/567c1840-2c29-4147-ab20-d3ee43da3b4c">
