### PR TITLE
fix(ui): Add start and stop timestamps to loader tracking

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -55,6 +55,7 @@
     "@sentry/react": "^6.17.3",
     "@testing-library/jest-dom": "6.4.5",
     "@testing-library/react": "11.2.3",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "14.4.3",
     "@types/query-string": "^6.3.0",
     "@types/react-hook-mousetrap": "^2.0.2",

--- a/weave-js/src/common/components/WandbLoader.test.tsx
+++ b/weave-js/src/common/components/WandbLoader.test.tsx
@@ -1,4 +1,8 @@
-import {fireOnRandom} from './WandbLoader';
+import {render} from '@testing-library/react';
+import React from 'react';
+import {vi} from 'vitest';
+
+import {fireOnRandom, TrackedWaveLoader} from './WandbLoader';
 
 describe('fireOnRandom', () => {
   test('should fire the callback', () => {
@@ -36,3 +40,47 @@ describe('fireOnRandom', () => {
     }).toThrow();
   });
 });
+
+describe('<TrackedWaveLoader />', () => {
+  it('tracks component lifecycle using track prop', () => {
+    const track = vi.fn();
+    const {unmount} = render(
+      <TrackedWaveLoader
+        name="my-wave-loader"
+        track={track}
+        size="huge"
+        samplingRate={1}
+      />
+    );
+    unmount();
+
+    expect(track).toHaveBeenCalledOnce();
+    const [trackName, {componentId, duration, start, stop}] =
+      track.mock.lastCall;
+    expect(trackName).toBe('wandb-loader-onscreen');
+    expect(componentId).toBe('my-wave-loader');
+    expect(typeof duration).toBe('number');
+    expect(typeof start).toBe('number');
+    expect(typeof stop).toBe('number');
+  });
+  it('tracks component lifecycle using onStart and onComplete', () => {
+    const onStart = vi.fn();
+    const onComplete = vi.fn();
+    const {unmount} = render(
+      <TrackedWaveLoader
+        name="my-wave-loader"
+        track={vi.fn()}
+        onStart={onStart}
+        onComplete={onComplete}
+        size="huge"
+        samplingRate={1}
+      />
+    );
+
+    expect(onStart).toHaveBeenCalledOnce();
+    expect(onComplete).not.toHaveBeenCalled();
+    unmount();
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+});
+describe('<TrackedWandbLoader />', () => {});

--- a/weave-js/src/common/components/WandbLoader.test.tsx
+++ b/weave-js/src/common/components/WandbLoader.test.tsx
@@ -2,7 +2,11 @@ import {render} from '@testing-library/react';
 import React from 'react';
 import {vi} from 'vitest';
 
-import {fireOnRandom, TrackedWaveLoader} from './WandbLoader';
+import {
+  fireOnRandom,
+  TrackedWandbLoader,
+  TrackedWaveLoader,
+} from './WandbLoader';
 
 describe('fireOnRandom', () => {
   test('should fire the callback', () => {
@@ -54,7 +58,7 @@ describe('<TrackedWaveLoader />', () => {
     );
     unmount();
 
-    expect(track).toHaveBeenCalledOnce();
+    expect(track).toHaveBeenCalledTimes(1);
     const [trackName, {componentId, duration, start, stop}] =
       track.mock.lastCall;
     expect(trackName).toBe('wandb-loader-onscreen');
@@ -73,14 +77,54 @@ describe('<TrackedWaveLoader />', () => {
         onStart={onStart}
         onComplete={onComplete}
         size="huge"
-        samplingRate={1}
       />
     );
 
-    expect(onStart).toHaveBeenCalledOnce();
+    expect(onStart).toHaveBeenCalledTimes(1);
     expect(onComplete).not.toHaveBeenCalled();
     unmount();
-    expect(onComplete).toHaveBeenCalledOnce();
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 });
-describe('<TrackedWandbLoader />', () => {});
+
+describe('<TrackedWandbLoader />', () => {
+  it('tracks component lifecycle using track prop', () => {
+    const track = vi.fn();
+    const {unmount} = render(
+      <TrackedWandbLoader
+        name="my-wandb-loader"
+        track={track}
+        size="huge"
+        samplingRate={1}
+      />
+    );
+    unmount();
+
+    expect(track).toHaveBeenCalledTimes(1);
+    const [trackName, {componentId, duration, start, stop}] =
+      track.mock.lastCall;
+    expect(trackName).toBe('wandb-loader-onscreen');
+    expect(componentId).toBe('my-wandb-loader');
+    expect(typeof duration).toBe('number');
+    expect(typeof start).toBe('number');
+    expect(typeof stop).toBe('number');
+  });
+  it('tracks component lifecycle using onStart and onComplete', () => {
+    const onStart = vi.fn();
+    const onComplete = vi.fn();
+    const {unmount} = render(
+      <TrackedWaveLoader
+        name="my-wandb-loader"
+        track={vi.fn()}
+        onStart={onStart}
+        onComplete={onComplete}
+        size="huge"
+      />
+    );
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+    unmount();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/weave-js/src/common/components/WandbLoader.tsx
+++ b/weave-js/src/common/components/WandbLoader.tsx
@@ -125,6 +125,8 @@ export const TrackedWaveLoader = ({
         const trackedData = {
           componentId: data.id,
           duration: data.duration,
+          start: data.start,
+          stop: data.stop,
           ...additionalData,
         };
         if (onComplete) {

--- a/weave-js/src/common/components/WandbLoader.tsx
+++ b/weave-js/src/common/components/WandbLoader.tsx
@@ -85,6 +85,8 @@ export const TrackedWandbLoader = ({
         const trackedData = {
           componentId: data.id,
           duration: data.duration,
+          start: data.start,
+          stop: data.stop,
           ...additionalData,
         };
         if (onComplete) {

--- a/weave-js/src/common/hooks/useLifecycleProfiling.test.ts
+++ b/weave-js/src/common/hooks/useLifecycleProfiling.test.ts
@@ -6,22 +6,21 @@ import {useLifecycleProfiling} from './useLifecycleProfiling';
 describe('useLifecycleProfiling', () => {
   it('tracks the lifecycle of a React component from start to finish', () => {
     const onUnmount = vi.fn();
-    const onMount = vi.fn()
-    const result = renderHook(() => useLifecycleProfiling('my-component', onUnmount, onMount));
-
-    // Hook returns nothing:
-    expect(result.current).toBe(undefined);
+    const onMount = vi.fn();
+    const result = renderHook(() =>
+      useLifecycleProfiling('my-component', onUnmount, onMount)
+    );
 
     // Hook calls the onStart callback immediately
-    expect(onMount).toHaveBeenCalledWith('my-component')
+    expect(onMount).toHaveBeenCalledWith('my-component');
     result.unmount();
 
     expect(onUnmount).toHaveBeenCalledTimes(1);
-    const [{ start, stop, duration, id }] = onUnmount.mock.lastCall
+    const [{start, stop, duration, id}] = onUnmount.mock.lastCall;
 
-    expect(typeof start).toBe('number')
-    expect(typeof stop).toBe('number')
-    expect(typeof duration).toBe('number')
-    expect(id).toBe('my-component')
+    expect(typeof start).toBe('number');
+    expect(typeof stop).toBe('number');
+    expect(typeof duration).toBe('number');
+    expect(id).toBe('my-component');
   });
 });

--- a/weave-js/src/common/hooks/useLifecycleProfiling.test.ts
+++ b/weave-js/src/common/hooks/useLifecycleProfiling.test.ts
@@ -1,0 +1,27 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {vi} from 'vitest';
+
+import {useLifecycleProfiling} from './useLifecycleProfiling';
+
+describe('useLifecycleProfiling', () => {
+  it('tracks the lifecycle of a React component from start to finish', () => {
+    const onUnmount = vi.fn();
+    const onMount = vi.fn()
+    const result = renderHook(() => useLifecycleProfiling('my-component', onUnmount, onMount));
+
+    // Hook returns nothing:
+    expect(result.current).toBe(undefined);
+
+    // Hook calls the onStart callback immediately
+    expect(onMount).toHaveBeenCalledWith('my-component')
+    result.unmount();
+
+    expect(onUnmount).toHaveBeenCalledTimes(1);
+    const [{ start, stop, duration, id }] = onUnmount.mock.lastCall
+
+    expect(typeof start).toBe('number')
+    expect(typeof stop).toBe('number')
+    expect(typeof duration).toBe('number')
+    expect(id).toBe('my-component')
+  });
+});

--- a/weave-js/src/common/hooks/useLifecycleProfiling.ts
+++ b/weave-js/src/common/hooks/useLifecycleProfiling.ts
@@ -11,6 +11,7 @@ export type ProfileData = {
  * Tracks the duration that a component is mounted.
  * @param id - a unique identifier for the component
  * @param cb - a callback to handle the data, e.g. log it for performance profiling
+ * @param onStart - invoked when the containing component mounts
  */
 export function useLifecycleProfiling(
   id: string,

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -4202,6 +4202,14 @@
     lodash "^4.17.21"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@11.2.3":
   version "11.2.3"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.3.tgz#9971ede1c8465a231d7982eeca3c39fc362d5443"
@@ -12419,6 +12427,13 @@ react-draggable@^4.0.3:
   dependencies:
     clsx "^1.1.1"
     prop-types "^15.8.1"
+
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-hook-mousetrap@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
Useful for forwarding vitals to Datadog or other analytics providers.
