### PR TITLE
fix(ui): feedback header when empty

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/FeedbackSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/FeedbackSidebar.tsx
@@ -96,7 +96,7 @@ export const FeedbackSidebar = ({
         <div className="text-lg font-semibold">Feedback</div>
         <div className="flex-grow" />
       </div>
-      <div className="min-h-1 mb-8 h-1 flex-grow overflow-auto bg-moon-300" />
+      <div className="min-h-1 mb-8 h-1 overflow-auto bg-moon-300" />
       {humanAnnotationSpecs.length > 0 ? (
         <>
           <div className="ml-6 h-full flex-grow overflow-auto">


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fixes header div being massive. 

## Testing

Prod:
<img width="1728" alt="Screenshot 2024-12-10 at 11 54 28 AM" src="https://github.com/user-attachments/assets/c29491cc-6b87-4e53-add3-658ae3d08d42">


Branch:
<img width="1728" alt="Screenshot 2024-12-10 at 11 54 15 AM" src="https://github.com/user-attachments/assets/55d42300-0929-456b-b997-aadc0611b721">

