### PR TITLE
feat(weave): Support op configuration for autopatched functions (starting with OpenAI)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -477,7 +477,9 @@ def make_server_recorder(server: tsi.TraceServerInterface):  # type: ignore
     return ServerRecorder(server)
 
 
-def create_client(request) -> weave_init.InitializedClient:
+def create_client(
+    request, autopatch_settings: typing.Optional[autopatch.AutopatchSettings] = None
+) -> weave_init.InitializedClient:
     inited_client = None
     weave_server_flag = request.config.getoption("--weave-server")
     server: tsi.TraceServerInterface
@@ -513,7 +515,7 @@ def create_client(request) -> weave_init.InitializedClient:
             entity, project, make_server_recorder(server)
         )
         inited_client = weave_init.InitializedClient(client)
-        autopatch.autopatch()
+        autopatch.autopatch(autopatch_settings)
 
     return inited_client
 
@@ -527,6 +529,7 @@ def client(request):
         yield inited_client.client
     finally:
         inited_client.reset()
+        autopatch.reset_autopatch()
 
 
 @pytest.fixture()
@@ -534,12 +537,13 @@ def client_creator(request):
     """This fixture is useful for delaying the creation of the client (ex. when you want to set settings first)"""
 
     @contextlib.contextmanager
-    def client():
-        inited_client = create_client(request)
+    def client(autopatch_settings: typing.Optional[autopatch.AutopatchSettings] = None):
+        inited_client = create_client(request, autopatch_settings)
         try:
             yield inited_client.client
         finally:
             inited_client.reset()
+            autopatch.reset_autopatch()
 
     yield client
 

--- a/tests/integrations/openai/cassettes/test_autopatch/test_configuration_with_dicts.yaml
+++ b/tests/integrations/openai/cassettes/test_autopatch/test_configuration_with_dicts.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"tell me a joke"}],"model":"gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '74'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.57.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.57.2
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.0rc2
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFJNa9wwEL37V0x1yWVd7P3KspcSSKE5thvooSlGK40tJbJGSOOSNOx/
+        L/Z+2KEp9KLDe/Me743mNQMQVostCGUkqza4/Eav1f1O/v4aVvvbL/Pdt7tVHUp1s/vsnhsx6xW0
+        f0TFZ9VHRW1wyJb8kVYRJWPvWl4vFpvNYl2UA9GSRtfLmsD5kvJ5MV/mxSYv1iehIaswiS38yAAA
+        Xoe3j+g1PostFLMz0mJKskGxvQwBiEiuR4RMySaWnsVsJBV5Rj+k/m5eQJO/YkhP6JDJJ6htYxhQ
+        KgPEBuOnB//g7w2eJ438hcAGoek4fZgaR6y7JPtevnPuhB8uSR01IdI+nfgLXltvk6kiykS+T5WY
+        ghjYQwbwc9hI96akCJHawBXTE/resCyPdmL8ggm5PJFMLN2Iz1ezd9wqjSytS5ONCiWVQT0qx/XL
+        TluaENmk899h3vM+9ra++R/7kVAKA6OuQkRt1dvC41jE/kD/NXbZ8RBYpJfE2Fa19Q3GEO3xRupQ
+        qWslC9xLJUV2yP4AAAD//wMA4O+DUSwDAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f01fe3aabd037cf-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 11 Dec 2024 02:20:01 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=xqe_jHZdTV5LijJQYQ3GMY5MjtVrCyxbFO4glgLvgD0-1733883601-1.0.1.1-p.DDUca_cHppJu2hXzzA0CXU1mtalxHUNfBWVgPIQj.UkU603pbNscCvSIi4_Zjlz9Zuc3.hjlvoyZxcDBJTsw;
+        path=/; expires=Wed, 11-Dec-24 02:50:01 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=WEjxXqkGswaEDhllTROGX_go9tgaWNJcUJ3cCd50xDI-1733883601764-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - wandb
+      openai-processing-ms:
+      - '607'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999979'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_8592a74b531c806f65c63c7471101cb6
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/openai/cassettes/test_autopatch/test_disabled_integration_doesnt_patch.yaml
+++ b/tests/integrations/openai/cassettes/test_autopatch/test_disabled_integration_doesnt_patch.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"tell me a joke"}],"model":"gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '74'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.57.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.57.2
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.0rc2
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFLJbtswEL3rK6a85GIV8lYvl6KX9NQFrYEckkKgyZHImOII5KiJEfjf
+        C8qLHDQFeuHhbXgzw5cMQFgt1iCUkaya1uWf9Hyuv5H29ebu89Pt80Z9//H0RS2nX/e3LEbJQdtH
+        VHx2vVfUtA7Zkj/SKqBkTKnjxXS6XCwWk3FPNKTRJVvdcj6jfFJMZnmxzIsPJ6MhqzCKNdxnAAAv
+        /Zsqeo3PYg3F6Iw0GKOsUawvIgARyCVEyBhtZOmPdU+kIs/o+9Y/u4AjMBjwJoIEZ2vDuUEZGDU8
+        0g6hogB76tYP/sHfmT1o8jcMcYcOmXyEKlkApTJAbDB8TMKNwbPSyN8IbBDqjuO76xoBqy7KtAXf
+        OXfCD5e5HNVtoG088Re8st5GUwaUkXyaITK1omcPGcCvfn/dq5WINlDTcsm0Q58Cx+NjnBgONpCT
+        2YlkYukGfDofvZFWamRpXbzav1BSGdSDcziW7LSlKyK7mvnvMm9lH+e2vv6f+IFQCltGXbYBtVWv
+        Bx5kAdN3/pfssuO+sIj7yNiUlfU1hjbY44+q2nKl54XSq1WxFdkh+wMAAP//AwAWTTnuWgMAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f016eadbff439d2-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 11 Dec 2024 00:42:01 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=8FO1yMjc3pMQWRpWrkIe5mcs39GLeqQPmgHQq0YTT8s-1733877721-1.0.1.1-i4G06DBN08aH1F1H73U_TB9OLK3jLsV1jXydB1cQ4Hqx7I.r8xDn.7hFRZe2hy3D_nABTG1nDcdDoXL_wYiqug;
+        path=/; expires=Wed, 11-Dec-24 01:12:01 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=jxwySgtriPkUP8L2os1nb_gRq_SSUo3yWFUyJmHPmGY-1733877721989-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - wandb
+      openai-processing-ms:
+      - '652'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999979'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_1c86d4fda2ad715edfd41bcd2f4bdd89
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/openai/cassettes/test_autopatch/test_enabled_integration_patches.yaml
+++ b/tests/integrations/openai/cassettes/test_autopatch/test_enabled_integration_patches.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"tell me a joke"}],"model":"gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '74'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.57.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.57.2
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.0rc2
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFLBjtMwEL3nKwZfuDQoTXc3VS8IBOIACCQOHHZR5NrTxDTxWJ4J2rDq
+        v6Ok2SYrFomLD+/Ne3pvxg8JgHJW7UCZWotpQ5O+sdfXaL9+/PDp+L6gG3ffyudv735v+y82eLUa
+        FLT/iUYeVa8MtaFBcTTRJqIWHFzXxWazLYoiz0eiJYvNIKuCpFeU5ll+lWbbNLuZhDU5g6x2cJsA
+        ADyM7xDRW7xXO8hWj0iLzLpCtbsMAahIzYAozexYtBe1mklDXtCPqb/XPVjyLwXYOPTiWBgkdiyg
+        hVp+fefv/Fs0umMEqbGHVh8RugD4C2MvtfPVi6V3xEPHeqjmu6aZ8NMlbENViLTnib/gB+cd12VE
+        zeSHYCwU1MieEoAf41K6Jz1ViNQGKYWO6AfD9fpsp+YrLMh8IoVENzOeb1bPuJUWRbuGF0tVRpsa
+        7aycL6A762hBJIvOf4d5zvvc2/nqf+xnwhgMgrYMEa0zTwvPYxGHP/qvscuOx8CKexZsy4PzFcYQ
+        3fmbHEJpCqMz3GujVXJK/gAAAP//AwAyhdwOLwMAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f016eb36bb3a240-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 11 Dec 2024 00:42:02 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=Q_ATX8JU4jFqXJPdwlneOua9wmNmAaASyAfcbPyPqng-1733877722-1.0.1.1-eTMEvBW7oqQa2i3l.Or2I3LF_cCESxfseq.S9DBr8dAJWsVoFfPxKtr5vMaO6yj4hRW8XOSOHcgIcwwqbHrLbg;
+        path=/; expires=Wed, 11-Dec-24 01:12:02 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=2ak.tRpn6uEHbM8GrWy_ALtrN34jVSNIJI1mFG2etvM-1733877722703-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - wandb
+      openai-processing-ms:
+      - '476'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999979'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_52e061e1cc55cdd8847a7ba9342f1a14
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/openai/cassettes/test_autopatch/test_passthrough_op_kwargs.yaml
+++ b/tests/integrations/openai/cassettes/test_autopatch/test_passthrough_op_kwargs.yaml
@@ -1,0 +1,102 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"tell me a joke"}],"model":"gpt-4o"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '74'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.57.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.57.2
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.0rc2
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrK7a89GIVsmLXsS9Fr0UvBQIERVMINLkS2VBcglwVcQL/
+        e0H5IQVNgV54mNkZzCz3pQAQVosdCGUkqz648rNer7G2z3fL8ITq+X6lvn7x/SHhN/d9LxZZQftf
+        qPii+qCoDw7Zkj/RKqJkzK7Lzc3N7WazqeuR6Emjy7IucLmisq7qVVndltXHs9CQVZjEDn4UAAAv
+        45sjeo1PYgfV4oL0mJLsUOyuQwAiksuIkCnZxNKzWEykIs/ox9T35gCa/HuG9IgOmXyC1naGAaUy
+        QGwwfnrwD/7O4GXSyN8IbBC6gdO7uXHEdkgy9/KDc2f8eE3qqAuR9unMX/HWeptME1Em8jlVYgpi
+        ZI8FwM9xI8OrkiJE6gM3TI/os+FyebIT0xfMyNWZZGLpJrxeL95wazSytC7NNiqUVAb1pJzWLwdt
+        aUYUs85/h3nL+9Tb+u5/7CdCKQyMugkRtVWvC09jEfOB/mvsuuMxsEiHxNg3rfUdxhDt6Uba0Gz1
+        ulJ6u632ojgWfwAAAP//AwCOwDMjLAMAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f016eb76b71ac9a-YYZ
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 11 Dec 2024 00:42:03 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=r.xSSsYQNFPvMiizFSvjQiecNA6Q1wQa0VR1YElfXi4-1733877723-1.0.1.1-GVW0i7wrpHCQSY5eXu7sIQgxYWl6jfeSordQ7JFxV3lO6UfFhwxRT92bBP4DfnrSYpBpRw3k4aONAURyvKctiQ;
+        path=/; expires=Wed, 11-Dec-24 01:12:03 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=CQJVOdASzL9ency5_q6SDaInTsvpjA240cIxf.AUwXM-1733877723385-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - wandb
+      openai-processing-ms:
+      - '523'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '10000'
+      x-ratelimit-limit-tokens:
+      - '30000000'
+      x-ratelimit-remaining-requests:
+      - '9999'
+      x-ratelimit-remaining-tokens:
+      - '29999979'
+      x-ratelimit-reset-requests:
+      - 6ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_c9c57cfa6f37a99aaf0abac013237ed6
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/openai/test_autopatch.py
+++ b/tests/integrations/openai/test_autopatch.py
@@ -56,7 +56,6 @@ def test_enabled_integration_patches(client_creator):
 )
 def test_passthrough_op_kwargs(client_creator):
     def redact_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
-        print("CALLING THIS FUNC")
         return dict.fromkeys(inputs, "REDACTED")
 
     autopatch_settings = AutopatchSettings(

--- a/tests/integrations/openai/test_autopatch.py
+++ b/tests/integrations/openai/test_autopatch.py
@@ -1,0 +1,87 @@
+# This is included here for convenience.  Instead of creating a dummy API, we can test
+# autopatching against the actual OpenAI API.
+
+from typing import Any
+
+import pytest
+from openai import OpenAI
+
+from weave.integrations.openai import openai_sdk
+from weave.trace.autopatch import AutopatchSettings, IntegrationSettings, OpSettings
+
+
+@pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
+@pytest.mark.vcr(
+    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
+)
+def test_disabled_integration_doesnt_patch(client_creator):
+    autopatch_settings = AutopatchSettings(
+        openai=IntegrationSettings(enabled=False),
+    )
+
+    with client_creator(autopatch_settings=autopatch_settings) as client:
+        oaiclient = OpenAI()
+        oaiclient.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "tell me a joke"}],
+        )
+
+        calls = list(client.get_calls())
+        assert len(calls) == 0
+
+
+@pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
+@pytest.mark.vcr(
+    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
+)
+def test_enabled_integration_patches(client_creator):
+    autopatch_settings = AutopatchSettings(
+        openai=IntegrationSettings(enabled=True),
+    )
+
+    with client_creator(autopatch_settings=autopatch_settings) as client:
+        oaiclient = OpenAI()
+        oaiclient.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "tell me a joke"}],
+        )
+
+        calls = list(client.get_calls())
+        assert len(calls) == 1
+
+
+@pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
+@pytest.mark.vcr(
+    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
+)
+def test_passthrough_op_kwargs(client_creator):
+    def redact_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+        print("CALLING THIS FUNC")
+        return dict.fromkeys(inputs, "REDACTED")
+
+    autopatch_settings = AutopatchSettings(
+        openai=IntegrationSettings(
+            op_settings=OpSettings(
+                postprocess_inputs=redact_inputs,
+            )
+        )
+    )
+
+    # Explicitly reset the patcher here to pretend like we're starting fresh.  We need
+    # to do this because `_openai_patcher` is a global variable that is shared across
+    # tests.  If we don't reset it, it will retain the state from the previous test,
+    # which can cause this test to fail.
+    openai_sdk._openai_patcher = None
+
+    with client_creator(autopatch_settings=autopatch_settings) as client:
+        oaiclient = OpenAI()
+        oaiclient.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "tell me a joke"}],
+        )
+
+        calls = list(client.get_calls())
+        assert len(calls) == 1
+
+        call = calls[0]
+        assert all(v == "REDACTED" for v in call.inputs.values())

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/FeedbackSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/FeedbackSidebar.tsx
@@ -96,7 +96,7 @@ export const FeedbackSidebar = ({
         <div className="text-lg font-semibold">Feedback</div>
         <div className="flex-grow" />
       </div>
-      <div className="min-h-1 mb-8 h-1 flex-grow overflow-auto bg-moon-300" />
+      <div className="min-h-1 mb-8 h-1 overflow-auto bg-moon-300" />
       {humanAnnotationSpecs.length > 0 ? (
         <>
           <div className="ml-6 h-full flex-grow overflow-auto">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/FeedbackSidebar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/FeedbackSidebar.tsx
@@ -96,7 +96,7 @@ export const FeedbackSidebar = ({
         <div className="text-lg font-semibold">Feedback</div>
         <div className="flex-grow" />
       </div>
-      <div className="min-h-1 mb-8 h-1 overflow-auto bg-moon-300" />
+      <div className="min-h-1 mb-8 h-1 flex-grow overflow-auto bg-moon-300" />
       {humanAnnotationSpecs.length > 0 ? (
         <>
           <div className="ml-6 h-full flex-grow overflow-auto">

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -378,7 +378,9 @@ def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]
     return wrapper
 
 
-def get_openai_patcher(settings: Optional[IntegrationSettings] = None) -> MultiPatcher:
+def get_openai_patcher(
+    settings: Optional[IntegrationSettings] = None,
+) -> MultiPatcher | NoOpPatcher:
     if settings is None:
         settings = IntegrationSettings()
 

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import dataclasses
 import importlib
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
@@ -327,7 +326,7 @@ def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
                 return True
             return False
 
-        op_kwargs = dataclasses.asdict(settings)
+        op_kwargs = settings.model_dump()
         op = weave.op(_add_stream_options(fn), **op_kwargs)
         op._set_on_input_handler(openai_on_input_handler)
         return add_accumulator(
@@ -363,7 +362,7 @@ def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]
                 return True
             return False
 
-        op_kwargs = dataclasses.asdict(settings)
+        op_kwargs = settings.model_dump()
         op = weave.op(_add_stream_options(fn), **op_kwargs)
         op._set_on_input_handler(openai_on_input_handler)
         return add_accumulator(
@@ -393,21 +392,17 @@ def get_openai_patcher(
 
     base = settings.op_settings
 
-    completions_create_settings = dataclasses.replace(
-        base,
-        name=base.name or "openai.chat.completions.create",
+    completions_create_settings = base.model_copy(
+        update={"name": base.name or "openai.chat.completions.create"}
     )
-    async_completions_create_settings = dataclasses.replace(
-        base,
-        name=base.name or "openai.chat.completions.create",
+    async_completions_create_settings = base.model_copy(
+        update={"name": base.name or "openai.chat.completions.create"}
     )
-    completions_parse_settings = dataclasses.replace(
-        base,
-        name=base.name or "openai.beta.chat.completions.parse",
+    completions_parse_settings = base.model_copy(
+        update={"name": base.name or "openai.beta.chat.completions.parse"}
     )
-    async_completions_parse_settings = dataclasses.replace(
-        base,
-        name=base.name or "openai.beta.chat.completions.parse",
+    async_completions_parse_settings = base.model_copy(
+        update={"name": base.name or "openai.beta.chat.completions.parse"}
     )
 
     _openai_patcher = MultiPatcher(

--- a/weave/scorers/llm_utils.py
+++ b/weave/scorers/llm_utils.py
@@ -2,10 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Union
 
-from weave.trace.autopatch import autopatch
-
-autopatch()  # ensure both weave patching and instructor patching are applied
-
 OPENAI_DEFAULT_MODEL = "gpt-4o"
 OPENAI_DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 OPENAI_DEFAULT_MODERATION_MODEL = "text-moderation-latest"

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -13,6 +13,7 @@ from typing import Any
 # There is probably a better place for this, but including here for now to get the fix in.
 from weave import type_handlers  # noqa: F401
 from weave.trace import urls, util, weave_client, weave_init
+from weave.trace.autopatch import AutopatchSettings
 from weave.trace.constants import TRACE_OBJECT_EMOJI
 from weave.trace.context import call_context
 from weave.trace.context import weave_client_context as weave_client_context
@@ -32,6 +33,7 @@ def init(
     project_name: str,
     *,
     settings: UserSettings | dict[str, Any] | None = None,
+    autopatch_settings: AutopatchSettings | None = None,
 ) -> weave_client.WeaveClient:
     """Initialize weave tracking, logging to a wandb project.
 
@@ -52,7 +54,12 @@ def init(
     if should_disable_weave():
         return weave_init.init_weave_disabled().client
 
-    return weave_init.init_weave(project_name).client
+    initialized_client = weave_init.init_weave(
+        project_name,
+        autopatch_settings=autopatch_settings,
+    )
+
+    return initialized_client.client
 
 
 @contextlib.contextmanager

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -32,20 +32,22 @@ class IntegrationSettings(BaseModel):
 class AutopatchSettings(BaseModel):
     """Settings for auto-patching integrations."""
 
-    anthropic: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    langchain: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    litellm: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    llamaindex: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    mistral: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    notdiamond: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # These will be uncommented as we add support for more integrations.  Note that
+
+    # anthropic: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # langchain: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # litellm: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # llamaindex: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # mistral: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # notdiamond: IntegrationSettings = Field(default_factory=IntegrationSettings)
     openai: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    vertexai: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    # vertexai: IntegrationSettings = Field(default_factory=IntegrationSettings)
 
 
 @validate_call

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -4,7 +4,7 @@ This module should not require any dependencies beyond the standard library. It 
 check if libraries are installed and imported and patch in the case that they are.
 """
 
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 from pydantic import BaseModel, Field, validate_call
 
@@ -17,7 +17,7 @@ class OpSettings(BaseModel):
     when working with auto-patched functions.  See the `op` decorator for more details."""
 
     name: Optional[str] = None
-    call_display_name: Optional[str | Callable[[Call], str]] = None
+    call_display_name: Optional[Union[str, Callable[[Call], str]]] = None
     postprocess_inputs: Optional[Callable[[dict[str, Any]], dict[str, Any]]] = None
     postprocess_output: Optional[Callable[[Any], Any]] = None
 

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -4,8 +4,15 @@ This module should not require any dependencies beyond the standard library. It 
 check if libraries are installed and imported and patch in the case that they are.
 """
 
+from __future__ import annotations
 
-def autopatch() -> None:
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from weave.trace.weave_client import Call
+
+
+def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.anthropic.anthropic_sdk import anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
@@ -20,10 +27,10 @@ def autopatch() -> None:
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import mistral_patcher
     from weave.integrations.notdiamond.tracing import notdiamond_patcher
-    from weave.integrations.openai.openai_sdk import openai_patcher
+    from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
-    openai_patcher.attempt_patch()
+    get_openai_patcher(settings.openai).attempt_patch()
     mistral_patcher.attempt_patch()
     litellm_patcher.attempt_patch()
     llamaindex_patcher.attempt_patch()
@@ -54,10 +61,10 @@ def reset_autopatch() -> None:
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import mistral_patcher
     from weave.integrations.notdiamond.tracing import notdiamond_patcher
-    from weave.integrations.openai.openai_sdk import openai_patcher
+    from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
-    openai_patcher.undo_patch()
+    get_openai_patcher().undo_patch()
     mistral_patcher.undo_patch()
     litellm_patcher.undo_patch()
     llamaindex_patcher.undo_patch()
@@ -71,3 +78,43 @@ def reset_autopatch() -> None:
     google_genai_patcher.undo_patch()
     notdiamond_patcher.undo_patch()
     vertexai_patcher.undo_patch()
+
+
+@dataclass
+class OpSettings:
+    """Op settings for a specific integration.
+    These currently subset the `op` decorator args to provide a consistent interface
+    when working with auto-patched functions.  See the `op` decorator for more details."""
+
+    name: str | None = None
+    call_display_name: str | Callable[[Call], str] | None = None
+    postprocess_inputs: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    postprocess_output: Callable[[Any], Any] | None = None
+
+
+@dataclass
+class IntegrationSettings:
+    """Configuration for a specific integration."""
+
+    enabled: bool = True
+    op_settings: OpSettings = field(default_factory=OpSettings)
+
+
+@dataclass
+class AutopatchSettings:
+    """Settings for auto-patching integrations."""
+
+    anthropic: IntegrationSettings = field(default_factory=IntegrationSettings)
+    cerebras: IntegrationSettings = field(default_factory=IntegrationSettings)
+    cohere: IntegrationSettings = field(default_factory=IntegrationSettings)
+    dspy: IntegrationSettings = field(default_factory=IntegrationSettings)
+    google_ai_studio: IntegrationSettings = field(default_factory=IntegrationSettings)
+    groq: IntegrationSettings = field(default_factory=IntegrationSettings)
+    instructor: IntegrationSettings = field(default_factory=IntegrationSettings)
+    langchain: IntegrationSettings = field(default_factory=IntegrationSettings)
+    litellm: IntegrationSettings = field(default_factory=IntegrationSettings)
+    llamaindex: IntegrationSettings = field(default_factory=IntegrationSettings)
+    mistral: IntegrationSettings = field(default_factory=IntegrationSettings)
+    notdiamond: IntegrationSettings = field(default_factory=IntegrationSettings)
+    openai: IntegrationSettings = field(default_factory=IntegrationSettings)
+    vertexai: IntegrationSettings = field(default_factory=IntegrationSettings)

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -30,6 +30,9 @@ def autopatch(settings: AutopatchSettings | None = None) -> None:
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
+    if settings is None:
+        settings = AutopatchSettings()
+
     get_openai_patcher(settings.openai).attempt_patch()
     mistral_patcher.attempt_patch()
     litellm_patcher.attempt_patch()

--- a/weave/trace/patcher.py
+++ b/weave/trace/patcher.py
@@ -17,6 +17,14 @@ class Patcher:
         raise NotImplementedError()
 
 
+class NoOpPatcher(Patcher):
+    def attempt_patch(self) -> bool:
+        return True
+
+    def undo_patch(self) -> bool:
+        return True
+
+
 class MultiPatcher(Patcher):
     def __init__(self, patchers: Sequence[Patcher]) -> None:
         self.patchers = patchers

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -63,7 +63,9 @@ Args:
 
 
 def init_weave(
-    project_name: str, ensure_project_exists: bool = True
+    project_name: str,
+    ensure_project_exists: bool = True,
+    autopatch_settings: autopatch.AutopatchSettings | None = None,
 ) -> InitializedClient:
     global _current_inited_client
     if _current_inited_client is not None:
@@ -120,7 +122,7 @@ def init_weave(
     # autopatching is only supported for the wandb client, because OpenAI calls are not
     # logged in local mode currently. When that's fixed, this autopatch call can be
     # moved to InitializedClient.__init__
-    autopatch.autopatch()
+    autopatch.autopatch(autopatch_settings)
 
     username = get_username()
     try:


### PR DESCRIPTION
This PR adds a new kwarg to `weave.init`, called `autopatch_settings`.

Normally, we provide sane defaults to autopatched functions.  However, some users may want to customize how that patching happens, e.g.:
1. Configuring a custom `postprocess_inputs` to strip out PII
2. Configuring the names of autopatched functions
3. Disabling patching altogether

Now, users can configure this easily at init time before patching:
```py
client = weave.init(
    ...,
    autopatch_settings={
        "openai": {
            "op_settings": {
                "postprocess_inputs": ...,
                "postprocess_output": ...,
            }
        },
        "anthropic": {
            "enabled": False,
        }
    },
)

```

---

This PR provides the core functionality and implements OpenAI to show what integration changes would look like.  A second fast-follow PR implements the remaining integrations: https://github.com/wandb/weave/pull/3154

Resolves:
- https://wandb.atlassian.net/browse/WB-21231
- https://wandb.atlassian.net/browse/WB-21752