### PR TITLE
docs(weave): Remove api_key hardcodes in code examples

### DIFF
--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -455,7 +455,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
     from weave.scorers import OpenAIModerationScorer
     from openai import OpenAI
 
-    oai_client = OpenAI(api_key=...) # initialize your LLM client here
+    oai_client = OpenAI() # initialize your LLM client here
 
     scorer = OpenAIModerationScorer(
         client=oai_client,

--- a/docs/docs/guides/integrations/local_models.md
+++ b/docs/docs/guides/integrations/local_models.md
@@ -14,7 +14,6 @@ First and most important, is the `base_url` change during the `openai.OpenAI()` 
 
 ```python
 client = openai.OpenAI(
-    api_key='fake',
     base_url="http://localhost:1234",
 )
 ```

--- a/docs/docs/guides/integrations/notdiamond.md
+++ b/docs/docs/guides/integrations/notdiamond.md
@@ -68,7 +68,6 @@ preference_id = train_router(
     response_column="actual",
     language="en",
     maximize=True,
-    api_key=api_key,
 )
 ```
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -50,7 +50,7 @@ _In this example, we're using openai so you will need to add an OpenAI [API key]
     import weave
     from openai import OpenAI
 
-    client = OpenAI(api_key="...")
+    client = OpenAI()
 
     # Weave will track the inputs, outputs and code of this function
     # highlight-next-line

--- a/docs/docs/tutorial-tracing_2.md
+++ b/docs/docs/tutorial-tracing_2.md
@@ -24,7 +24,7 @@ Building on our [basic tracing example](/quickstart), we will now add additional
     import json
     from openai import OpenAI
 
-    client = OpenAI(api_key="...")
+    client = OpenAI()
 
     # highlight-next-line
     @weave.op()


### PR DESCRIPTION
Addresses https://wandb.atlassian.net/browse/DOCS-1120

Removes `api_key="..."` from examples like https://weave-docs.wandb.ai/tutorial-tracing_2 so that we aren't promoting bad practices. Leaves instances where the api_key is loaded from the environment e.g. `os.environ`
