### PR TITLE
feat(ui): Add error details button

### DIFF
--- a/weave-js/src/components/ErrorBoundary.tsx
+++ b/weave-js/src/components/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import {datadogRum} from '@datadog/browser-rum';
 import * as Sentry from '@sentry/react';
 import React, {Component, ErrorInfo, ReactNode} from 'react';
+import {v7 as uuidv7} from 'uuid';
 
 import {weaveErrorToDDPayload} from '../errors';
 import {ErrorPanel} from './ErrorPanel';
@@ -10,24 +11,31 @@ type Props = {
 };
 
 type State = {
-  hasError: boolean;
+  uuid: string | undefined;
+  timestamp: Date | undefined;
+  error: Error | undefined;
 };
 
 export class ErrorBoundary extends Component<Props, State> {
-  public static getDerivedStateFromError(_: Error): State {
-    return {hasError: true};
+  public static getDerivedStateFromError(error: Error): State {
+    return {uuid: uuidv7(), timestamp: new Date(), error};
   }
   public state: State = {
-    hasError: false,
+    uuid: undefined,
+    timestamp: undefined,
+    error: undefined,
   };
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    const {uuid} = this.state;
     datadogRum.addAction(
       'weave_panel_error_boundary',
-      weaveErrorToDDPayload(error)
+      weaveErrorToDDPayload(error, undefined, uuid)
     );
-
     Sentry.captureException(error, {
+      extra: {
+        uuid,
+      },
       tags: {
         weaveErrorBoundary: 'true',
       },
@@ -35,8 +43,9 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   public render() {
-    if (this.state.hasError) {
-      return <ErrorPanel />;
+    const {uuid, timestamp, error} = this.state;
+    if (error != null) {
+      return <ErrorPanel uuid={uuid} timestamp={timestamp} error={error} />;
     }
 
     return this.props.children;

--- a/weave-js/src/components/ErrorPanel.tsx
+++ b/weave-js/src/components/ErrorPanel.tsx
@@ -1,7 +1,19 @@
-import React, {forwardRef, useEffect, useRef, useState} from 'react';
+import copyToClipboard from 'copy-to-clipboard';
+import _ from 'lodash';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import styled from 'styled-components';
 
+import {toast} from '../common/components/elements/Toast';
 import {hexToRGB, MOON_300, MOON_600} from '../common/css/globals.styles';
+import {useViewerInfo} from '../common/hooks/useViewerInfo';
+import {getCookieBool, getFirebaseCookie} from '../common/util/cookie';
+import {Button} from './Button';
 import {Icon} from './Icon';
 import {Tooltip} from './Tooltip';
 
@@ -14,6 +26,11 @@ type ErrorPanelProps = {
   title?: string;
   subtitle?: string;
   subtitle2?: string;
+
+  // These props are for error details object
+  uuid?: string;
+  timestamp?: Date;
+  error?: Error;
 };
 
 export const Centered = styled.div`
@@ -85,11 +102,87 @@ export const ErrorPanelSmall = ({
   );
 };
 
+const getDateObject = (timestamp?: Date): Record<string, any> | null => {
+  if (!timestamp) {
+    return null;
+  }
+  return {
+    // e.g. "2024-12-12T06:10:19.475Z",
+    iso: timestamp.toISOString(),
+    // e.g. "Thursday, December 12, 2024 at 6:10:19 AM Coordinated Universal Time"
+    long: timestamp.toLocaleString('en-US', {
+      weekday: 'long',
+      year: 'numeric', // Full year
+      month: 'long', // Full month name
+      day: 'numeric', // Day of the month
+      hour: 'numeric', // Hour (12-hour or 24-hour depending on locale)
+      minute: 'numeric',
+      second: 'numeric',
+      timeZone: 'UTC', // Ensures it's in UTC
+      timeZoneName: 'long', // Full time zone name
+    }),
+    user: timestamp.toLocaleString('en-US', {
+      dateStyle: 'full',
+      timeStyle: 'full',
+    }),
+  };
+};
+
+const getErrorObject = (error?: Error): Record<string, any> | null => {
+  if (!error) {
+    return null;
+  }
+
+  // Error object properties are not enumerable so we have to copy them manually
+  const stack = (error.stack ?? '').split('\n');
+  return {
+    message: error.message,
+    stack,
+  };
+};
+
 export const ErrorPanelLarge = forwardRef<HTMLDivElement, ErrorPanelProps>(
-  ({title, subtitle, subtitle2}, ref) => {
+  ({title, subtitle, subtitle2, uuid, timestamp, error}, ref) => {
     const titleStr = title ?? DEFAULT_TITLE;
     const subtitleStr = subtitle ?? DEFAULT_SUBTITLE;
     const subtitle2Str = subtitle2 ?? DEFAULT_SUBTITLE2;
+
+    const {userInfo} = useViewerInfo();
+
+    const onClick = useCallback(() => {
+      const betaVersion = getFirebaseCookie('betaVersion');
+      const isUsingAdminPrivileges = getCookieBool('use_admin_privileges');
+      const {location, navigator, screen} = window;
+      const {userAgent, language} = navigator;
+      const details = {
+        uuid,
+        url: location.href,
+        error: getErrorObject(error),
+        timestamp_err: getDateObject(timestamp),
+        timestamp_copied: getDateObject(new Date()),
+        user: _.pick(userInfo, ['id', 'username']), // Skipping teams and admin
+        cookies: {
+          ...(betaVersion && {betaVersion}),
+          ...(isUsingAdminPrivileges && {use_admin_privileges: true}),
+        },
+        browser: {
+          userAgent,
+          language,
+          screenSize: {
+            width: screen.width,
+            height: screen.height,
+          },
+          viewportSize: {
+            width: window.innerWidth,
+            height: window.innerHeight,
+          },
+        },
+      };
+      const detailsText = JSON.stringify(details, null, 2);
+      copyToClipboard(detailsText);
+      toast('Copied to clipboard');
+    }, [uuid, timestamp, error, userInfo]);
+
     return (
       <Large ref={ref}>
         <Circle $size={40} $hoverHighlight={false}>
@@ -98,6 +191,14 @@ export const ErrorPanelLarge = forwardRef<HTMLDivElement, ErrorPanelProps>(
         <Title>{titleStr}</Title>
         <Subtitle>{subtitleStr}</Subtitle>
         <Subtitle>{subtitle2Str}</Subtitle>
+        <Button
+          style={{marginTop: 16}}
+          size="small"
+          variant="secondary"
+          icon="copy"
+          onClick={onClick}>
+          Copy error details
+        </Button>
       </Large>
     );
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseCall.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseCall.tsx
@@ -48,6 +48,9 @@ os.environ["WF_TRACE_SERVER_URL"] = "http://127.0.0.1:6345"
   const codeFeedback =
     selectedTab === 'javascript' ? codeFeedbackJS : codeFeedbackPython;
 
+  if (1 + 1 === 2) {
+    throw new Error('Not implemented');
+  }
   return (
     <Box className="text-sm">
       <Tabs.Root

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseCall.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseCall.tsx
@@ -48,9 +48,6 @@ os.environ["WF_TRACE_SERVER_URL"] = "http://127.0.0.1:6345"
   const codeFeedback =
     selectedTab === 'javascript' ? codeFeedbackJS : codeFeedbackPython;
 
-  if (1 + 1 === 2) {
-    throw new Error('Not implemented');
-  }
   return (
     <Box className="text-sm">
       <Tabs.Root

--- a/weave-js/src/errors.ts
+++ b/weave-js/src/errors.ts
@@ -37,7 +37,8 @@ type DDErrorPayload = {
 
 export const weaveErrorToDDPayload = (
   error: Error,
-  weave?: WeaveApp
+  weave?: WeaveApp,
+  uuid?: string
 ): DDErrorPayload => {
   try {
     return {
@@ -49,6 +50,7 @@ export const weaveErrorToDDPayload = (
       windowLocationURL: trimString(window.location.href),
       weaveContext: weave?.client.debugMeta(),
       isServerError: error instanceof UseNodeValueServerExecutionError,
+      ...(uuid != null && {uuid}),
     };
   } catch (e) {
     // If we fail to serialize the error, just return an empty object.


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1733949860779329

Adds a "Copy error details" button to our large error panel. This copies a bunch of useful information to the clipboard in JSON format. Note the TabUseCall change here is just for testing and will be removed before merge.

<img width="388" alt="Screenshot 2024-12-12 at 1 53 17 AM" src="https://github.com/user-attachments/assets/f1259e97-2a8d-41d0-9cd6-d44783f9cde3" />

Example error details from FeatureBee:
```
{
  "uuid": "0193b9da-ee39-752f-a112-76066dfa2d03",
  "url": "https://beta.wandb.ai/jamie-rasmussen/2024-12-12_intro-example/weave/traces?cols=%7B%22attributes.weave.client_version%22%3Afalse%2C%22attributes.weave.os_name%22%3Afalse%2C%22attributes.weave.os_release%22%3Afalse%2C%22attributes.weave.os_version%22%3Afalse%2C%22attributes.weave.source%22%3Afalse%2C%22attributes.weave.sys_version%22%3Afalse%7D&peekPath=%2Fjamie-rasmussen%2F2024-12-12_intro-example%2Fcalls%2F0193b9c4-40ee-77d0-b6e3-b2ec4b1ecfa1%3Ftracetree%3D0%26feedbackExpand%3D0",
  "error": {
    "message": "Not implemented",
    "stack": [
      "Error: Not implemented",
      "    at vke (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-yzTDyFzw.js:924:702)",
      "    at Nh (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:100:18945)",
      "    at Vk (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:102:48625)",
      "    at Uk (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:102:43875)",
      "    at Tk (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:102:43798)",
      "    at Ik (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:102:43638)",
      "    at Ek (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:102:40439)",
      "    at jg (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:100:3536)",
      "    at Qk (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:102:40798)",
      "    at Jb (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:99:9570)",
      "    at hd (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:99:35530)",
      "    at fd (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:99:18619)",
      "    at ed (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:99:18361)",
      "    at HTMLDivElement.rt (https://cdn.wandb.ai/beta/77f5a8a29/assets/index-C4_309S1.js:45:2042)"
    ]
  },
  "timestamp_err": {
    "iso": "2024-12-12T07:52:33.082Z",
    "long": "Thursday, December 12, 2024 at 7:52:33 AM Coordinated Universal Time",
    "user": "Thursday, December 12, 2024 at 1:52:33 AM Central Standard Time"
  },
  "timestamp_copied": {
    "iso": "2024-12-12T07:54:58.814Z",
    "long": "Thursday, December 12, 2024 at 7:54:58 AM Coordinated Universal Time",
    "user": "Thursday, December 12, 2024 at 1:54:58 AM Central Standard Time"
  },
  "user": {
    "id": "VXNlcjo0NTI1NDQ=",
    "username": "jamie-rasmussen"
  },
  "cookies": {
    "betaVersion": "77f5a8a29",
  },
  "browser": {
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
    "language": "en-IE",
    "screenSize": {
      "width": 1728,
      "height": 1117
    },
    "viewportSize": {
      "width": 1589,
      "height": 799
    }
  }
}
```

## Testing

How was this PR tested? See FeatureBee
