### PR TITLE
feat(weave): Support op configuration for autopatched functions for remaining integrations

### DIFF
--- a/tests/integrations/litellm/litellm_test.py
+++ b/tests/integrations/litellm/litellm_test.py
@@ -8,7 +8,7 @@ import pytest
 from packaging.version import parse as version_parse
 
 import weave
-from weave.integrations.litellm.litellm import litellm_patcher
+from weave.integrations.litellm.litellm import get_litellm_patcher
 
 # This PR:
 # https://github.com/BerriAI/litellm/commit/fe2aa706e8ff4edbcd109897e5da6b83ef6ad693
@@ -38,9 +38,9 @@ def patch_litellm(request: Any) -> Generator[None, None, None]:
         yield
         return
 
-    litellm_patcher.attempt_patch()
+    get_litellm_patcher().attempt_patch()
     yield
-    litellm_patcher.undo_patch()
+    get_litellm_patcher().undo_patch()
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode

--- a/weave/integrations/cohere/__init__.py
+++ b/weave/integrations/cohere/__init__.py
@@ -1,1 +1,1 @@
-from weave.integrations.cohere.cohere_sdk import cohere_patcher as cohere_patcher
+from weave.integrations.cohere.cohere_sdk import get_cohere_patcher  # noqa: F401

--- a/weave/integrations/cohere/cohere_sdk.py
+++ b/weave/integrations/cohere/cohere_sdk.py
@@ -1,20 +1,23 @@
+from __future__ import annotations
+
 import importlib
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 
 if TYPE_CHECKING:
     from cohere.types.non_streamed_chat_response import NonStreamedChatResponse
     from cohere.v2.types.non_streamed_chat_response2 import NonStreamedChatResponse2
 
 
-def cohere_accumulator(
-    acc: Optional[dict],
-    value: Any,
-) -> "NonStreamedChatResponse":
+_cohere_patcher: MultiPatcher | None = None
+
+
+def cohere_accumulator(acc: dict | None, value: Any) -> NonStreamedChatResponse:
     # don't need to accumulate, is build-in by cohere!
     # https://docs.cohere.com/docs/streaming
     # A stream-end event is the final event of the stream, and is returned only when streaming is finished.
@@ -31,10 +34,7 @@ def cohere_accumulator(
     return acc
 
 
-def cohere_accumulator_v2(
-    acc: Optional[dict],
-    value: Any,
-) -> "NonStreamedChatResponse2":
+def cohere_accumulator_v2(acc: dict | None, value: Any) -> NonStreamedChatResponse2:
     from cohere.v2.types.assistant_message_response import AssistantMessageResponse
     from cohere.v2.types.non_streamed_chat_response2 import NonStreamedChatResponse2
 
@@ -86,16 +86,16 @@ def cohere_accumulator_v2(
     return acc
 
 
-def cohere_wrapper(name: str) -> Callable:
+def cohere_wrapper(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         return op
 
     return wrapper
 
 
-def cohere_wrapper_v2(name: str) -> Callable:
+def cohere_wrapper_v2(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
         def _post_process_response(fn: Callable) -> Any:
             @wraps(fn)
@@ -122,14 +122,14 @@ def cohere_wrapper_v2(name: str) -> Callable:
 
             return _wrapper
 
-        op = weave.op(_post_process_response(fn))
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(_post_process_response(fn), **op_kwargs)
         return op
 
     return wrapper
 
 
-def cohere_wrapper_async_v2(name: str) -> Callable:
+def cohere_wrapper_async_v2(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
         def _post_process_response(fn: Callable) -> Any:
             @wraps(fn)
@@ -156,81 +156,119 @@ def cohere_wrapper_async_v2(name: str) -> Callable:
 
             return _wrapper
 
-        op = weave.op(_post_process_response(fn))
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(_post_process_response(fn), **op_kwargs)
         return op
 
     return wrapper
 
 
-def cohere_stream_wrapper(name: str) -> Callable:
+def cohere_stream_wrapper(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(fn)
-        op.name = name  # type: ignore
-        return add_accumulator(op, lambda inputs: cohere_accumulator)  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
+        return add_accumulator(op, lambda inputs: cohere_accumulator)
 
     return wrapper
 
 
-def cohere_stream_wrapper_v2(name: str) -> Callable:
+def cohere_stream_wrapper_v2(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(fn)
-        op.name = name  # type: ignore
-        return add_accumulator(
-            op, make_accumulator=lambda inputs: cohere_accumulator_v2
-        )
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
+        return add_accumulator(op, lambda inputs: cohere_accumulator_v2)
 
     return wrapper
 
 
-cohere_patcher = MultiPatcher(
-    [
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "Client.chat",
-            cohere_wrapper("cohere.Client.chat"),
-        ),
-        # Patch the async chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "AsyncClient.chat",
-            cohere_wrapper("cohere.AsyncClient.chat"),
-        ),
-        # Add patch for chat_stream method
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "Client.chat_stream",
-            cohere_stream_wrapper("cohere.Client.chat_stream"),
-        ),
-        # Add patch for async chat_stream method
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "AsyncClient.chat_stream",
-            cohere_stream_wrapper("cohere.AsyncClient.chat_stream"),
-        ),
-        # Add patch for cohere v2
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "ClientV2.chat",
-            cohere_wrapper_v2("cohere.ClientV2.chat"),
-        ),
-        # Add patch for cohre v2 async chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "AsyncClientV2.chat",
-            cohere_wrapper_async_v2("cohere.AsyncClientV2.chat"),
-        ),
-        # Add patch for chat_stream method v2
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "ClientV2.chat_stream",
-            cohere_stream_wrapper_v2("cohere.ClientV2.chat_stream"),
-        ),
-        # Add patch for async chat_stream method v2
-        SymbolPatcher(
-            lambda: importlib.import_module("cohere"),
-            "AsyncClientV2.chat_stream",
-            cohere_stream_wrapper_v2("cohere.AsyncClientV2.chat_stream"),
-        ),
-    ]
-)
+def get_cohere_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _cohere_patcher
+    if _cohere_patcher is not None:
+        return _cohere_patcher
+
+    base = settings.op_settings
+
+    chat_settings = base.model_copy(update={"name": base.name or "cohere.Client.chat"})
+    async_chat_settings = base.model_copy(
+        update={"name": base.name or "cohere.AsyncClient.chat"}
+    )
+    chat_stream_settings = base.model_copy(
+        update={"name": base.name or "cohere.Client.chat_stream"}
+    )
+    async_chat_stream_settings = base.model_copy(
+        update={"name": base.name or "cohere.AsyncClient.chat_stream"}
+    )
+    chat_v2_settings = base.model_copy(
+        update={"name": base.name or "cohere.ClientV2.chat"}
+    )
+    async_chat_v2_settings = base.model_copy(
+        update={"name": base.name or "cohere.AsyncClientV2.chat"}
+    )
+    chat_stream_v2_settings = base.model_copy(
+        update={"name": base.name or "cohere.ClientV2.chat_stream"}
+    )
+    async_chat_stream_v2_settings = base.model_copy(
+        update={"name": base.name or "cohere.AsyncClientV2.chat_stream"}
+    )
+
+    _cohere_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "Client.chat",
+                cohere_wrapper(chat_settings),
+            ),
+            # Patch the async chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "AsyncClient.chat",
+                cohere_wrapper(async_chat_settings),
+            ),
+            # Add patch for chat_stream method
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "Client.chat_stream",
+                cohere_stream_wrapper(chat_stream_settings),
+            ),
+            # Add patch for async chat_stream method
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "AsyncClient.chat_stream",
+                cohere_stream_wrapper(async_chat_stream_settings),
+            ),
+            # Add patch for cohere v2
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "ClientV2.chat",
+                cohere_wrapper_v2(chat_v2_settings),
+            ),
+            # Add patch for cohre v2 async chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "AsyncClientV2.chat",
+                cohere_wrapper_async_v2(async_chat_v2_settings),
+            ),
+            # Add patch for chat_stream method v2
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "ClientV2.chat_stream",
+                cohere_stream_wrapper_v2(chat_stream_v2_settings),
+            ),
+            # Add patch for async chat_stream method v2
+            SymbolPatcher(
+                lambda: importlib.import_module("cohere"),
+                "AsyncClientV2.chat_stream",
+                cohere_stream_wrapper_v2(async_chat_stream_v2_settings),
+            ),
+        ]
+    )
+
+    return _cohere_patcher

--- a/weave/integrations/dspy/dspy_sdk.py
+++ b/weave/integrations/dspy/dspy_sdk.py
@@ -1,216 +1,331 @@
+from __future__ import annotations
+
 import importlib
 from typing import Callable
 
 import weave
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.autopatch import IntegrationSettings, OpSettings
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
+
+_dspy_patcher: MultiPatcher | None = None
 
 
-def dspy_wrapper(name: str) -> Callable[[Callable], Callable]:
+def dspy_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         return op
 
     return wrapper
 
 
 def dspy_get_patched_lm_functions(
-    base_symbol: str, lm_class_name: str
+    base_symbol: str, lm_class_name: str, settings: OpSettings
 ) -> list[SymbolPatcher]:
     patchable_functional_attributes = [
         "basic_request",
         "request",
         "__call__",
     ]
+    basic_request_settings = settings.model_copy(
+        update={"name": settings.name or f"{base_symbol}.{lm_class_name}.basic_request"}
+    )
+    request_settings = settings.model_copy(
+        update={"name": settings.name or f"{base_symbol}.{lm_class_name}.request"}
+    )
+    call_settings = settings.model_copy(
+        update={"name": settings.name or f"{base_symbol}.{lm_class_name}"}
+    )
     return [
         SymbolPatcher(
             get_base_symbol=lambda: importlib.import_module(base_symbol),
             attribute_name=f"{lm_class_name}.basic_request",
-            make_new_value=dspy_wrapper(f"dspy.{lm_class_name}.basic_request"),
+            make_new_value=dspy_wrapper(basic_request_settings),
         ),
         SymbolPatcher(
             get_base_symbol=lambda: importlib.import_module(base_symbol),
             attribute_name=f"{lm_class_name}.request",
-            make_new_value=dspy_wrapper(f"dspy.{lm_class_name}.request"),
+            make_new_value=dspy_wrapper(request_settings),
         ),
         SymbolPatcher(
             get_base_symbol=lambda: importlib.import_module(base_symbol),
             attribute_name=f"{lm_class_name}.__call__",
-            make_new_value=dspy_wrapper(f"dspy.{lm_class_name}"),
+            make_new_value=dspy_wrapper(call_settings),
         ),
     ]
 
 
-patched_functions = [
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Predict.__call__",
-        make_new_value=dspy_wrapper("dspy.Predict"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Predict.forward",
-        make_new_value=dspy_wrapper("dspy.Predict.forward"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="TypedPredictor.__call__",
-        make_new_value=dspy_wrapper("dspy.TypedPredictor"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="TypedPredictor.forward",
-        make_new_value=dspy_wrapper("dspy.TypedPredictor.forward"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Module.__call__",
-        make_new_value=dspy_wrapper("dspy.Module"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="TypedChainOfThought.__call__",
-        make_new_value=dspy_wrapper("dspy.TypedChainOfThought"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Retrieve.__call__",
-        make_new_value=dspy_wrapper("dspy.Retrieve"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Retrieve.forward",
-        make_new_value=dspy_wrapper("dspy.Retrieve.forward"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.evaluate.evaluate"),
-        attribute_name="Evaluate.__call__",
-        make_new_value=dspy_wrapper("dspy.evaluate.Evaluate"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BootstrapFewShot.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.BootstrapFewShot.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="COPRO.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.COPRO.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="Ensemble.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.Ensemble.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BootstrapFinetune.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.BootstrapFinetune.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="KNNFewShot.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.KNNFewShot.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="MIPRO.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.MIPRO.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BootstrapFewShotWithRandomSearch.compile",
-        make_new_value=dspy_wrapper(
-            "dspy.teleprompt.BootstrapFewShotWithRandomSearch.compile"
-        ),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="SignatureOptimizer.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.SignatureOptimizer.compile"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BayesianSignatureOptimizer.compile",
-        make_new_value=dspy_wrapper(
-            "dspy.teleprompt.BayesianSignatureOptimizer.compile"
-        ),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module(
-            "dspy.teleprompt.signature_opt_typed"
-        ),
-        attribute_name="optimize_signature",
-        make_new_value=dspy_wrapper(
-            "dspy.teleprompt.signature_opt_typed.optimize_signature"
-        ),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="BootstrapFewShotWithOptuna.compile",
-        make_new_value=dspy_wrapper(
-            "dspy.teleprompt.BootstrapFewShotWithOptuna.compile"
-        ),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
-        attribute_name="LabeledFewShot.compile",
-        make_new_value=dspy_wrapper("dspy.teleprompt.LabeledFewShot.compile"),
-    ),
-]
+def get_dspy_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
 
-# Patch LM classes
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="AzureOpenAI"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="OpenAI"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Cohere"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Clarifai"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Google"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="HFClientTGI"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="HFClientVLLM"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Anyscale"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="Together"
-)
-patched_functions += dspy_get_patched_lm_functions(
-    base_symbol="dspy", lm_class_name="OllamaLocal"
-)
-patched_functions += [
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Databricks.basic_request",
-        make_new_value=dspy_wrapper("dspy.Databricks.basic_request"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Databricks.__call__",
-        make_new_value=dspy_wrapper("dspy.Databricks"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="ColBERTv2.__call__",
-        make_new_value=dspy_wrapper("dspy.ColBERTv2"),
-    ),
-    SymbolPatcher(
-        get_base_symbol=lambda: importlib.import_module("dspy"),
-        attribute_name="Pyserini.__call__",
-        make_new_value=dspy_wrapper("dspy.Pyserini"),
-    ),
-]
+    if not settings.enabled:
+        return NoOpPatcher()
 
-dspy_patcher = MultiPatcher(patched_functions)
+    global _dspy_patcher
+    if _dspy_patcher is not None:
+        return _dspy_patcher
+
+    base = settings.op_settings
+
+    predict_call_settings = base.model_copy(
+        update={"name": base.name or "dspy.Predict"}
+    )
+    predict_forward_settings = base.model_copy(
+        update={"name": base.name or "dspy.Predict.forward"}
+    )
+    typed_predictor_call_settings = base.model_copy(
+        update={"name": base.name or "dspy.TypedPredictor"}
+    )
+    typed_predictor_forward_settings = base.model_copy(
+        update={"name": base.name or "dspy.TypedPredictor.forward"}
+    )
+    module_call_settings = base.model_copy(update={"name": base.name or "dspy.Module"})
+    typed_chain_of_thought_call_settings = base.model_copy(
+        update={"name": base.name or "dspy.TypedChainOfThought"}
+    )
+    retrieve_call_settings = base.model_copy(
+        update={"name": base.name or "dspy.Retrieve"}
+    )
+    retrieve_forward_settings = base.model_copy(
+        update={"name": base.name or "dspy.Retrieve.forward"}
+    )
+    evaluate_call_settings = base.model_copy(
+        update={"name": base.name or "dspy.evaluate.Evaluate"}
+    )
+    bootstrap_few_shot_compile_settings = base.model_copy(
+        update={"name": base.name or "dspy.teleprompt.BootstrapFewShot.compile"}
+    )
+    copro_compile_settings = base.model_copy(
+        update={"name": base.name or "dspy.teleprompt.COPRO.compile"}
+    )
+    ensemble_compile_settings = base.model_copy(
+        update={"name": base.name or "dspy.teleprompt.Ensemble.compile"}
+    )
+    bootstrap_finetune_compile_settings = base.model_copy(
+        update={"name": base.name or "dspy.teleprompt.BootstrapFinetune.compile"}
+    )
+    knn_few_shot_compile_settings = base.model_copy(
+        update={"name": base.name or "dspy.teleprompt.KNNFewShot.compile"}
+    )
+    mipro_compile_settings = base.model_copy(
+        update={"name": base.name or "dspy.teleprompt.MIPRO.compile"}
+    )
+    bootstrap_few_shot_with_random_search_compile_settings = base.model_copy(
+        update={
+            "name": base.name
+            or "dspy.teleprompt.BootstrapFewShotWithRandomSearch.compile"
+        }
+    )
+    signature_optimizer_compile_settings = base.model_copy(
+        update={"name": base.name or "dspy.teleprompt.SignatureOptimizer.compile"}
+    )
+    bayesian_signature_optimizer_compile_settings = base.model_copy(
+        update={
+            "name": base.name or "dspy.teleprompt.BayesianSignatureOptimizer.compile"
+        }
+    )
+    signature_opt_typed_optimize_signature_settings = base.model_copy(
+        update={
+            "name": base.name
+            or "dspy.teleprompt.signature_opt_typed.optimize_signature"
+        }
+    )
+    bootstrap_few_shot_with_optuna_compile_settings = base.model_copy(
+        update={
+            "name": base.name or "dspy.teleprompt.BootstrapFewShotWithOptuna.compile"
+        }
+    )
+    labeled_few_shot_compile_settings = base.model_copy(
+        update={"name": base.name or "dspy.teleprompt.LabeledFewShot.compile"}
+    )
+
+    patched_functions = [
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Predict.__call__",
+            make_new_value=dspy_wrapper(predict_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Predict.forward",
+            make_new_value=dspy_wrapper(predict_forward_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="TypedPredictor.__call__",
+            make_new_value=dspy_wrapper(typed_predictor_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="TypedPredictor.forward",
+            make_new_value=dspy_wrapper(typed_predictor_forward_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Module.__call__",
+            make_new_value=dspy_wrapper(module_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="TypedChainOfThought.__call__",
+            make_new_value=dspy_wrapper(typed_chain_of_thought_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Retrieve.__call__",
+            make_new_value=dspy_wrapper(retrieve_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Retrieve.forward",
+            make_new_value=dspy_wrapper(retrieve_forward_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.evaluate.evaluate"),
+            attribute_name="Evaluate.__call__",
+            make_new_value=dspy_wrapper(evaluate_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BootstrapFewShot.compile",
+            make_new_value=dspy_wrapper(bootstrap_few_shot_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="COPRO.compile",
+            make_new_value=dspy_wrapper(copro_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="Ensemble.compile",
+            make_new_value=dspy_wrapper(ensemble_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BootstrapFinetune.compile",
+            make_new_value=dspy_wrapper(bootstrap_finetune_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="KNNFewShot.compile",
+            make_new_value=dspy_wrapper(knn_few_shot_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="MIPRO.compile",
+            make_new_value=dspy_wrapper(mipro_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BootstrapFewShotWithRandomSearch.compile",
+            make_new_value=dspy_wrapper(
+                bootstrap_few_shot_with_random_search_compile_settings
+            ),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="SignatureOptimizer.compile",
+            make_new_value=dspy_wrapper(signature_optimizer_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BayesianSignatureOptimizer.compile",
+            make_new_value=dspy_wrapper(bayesian_signature_optimizer_compile_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module(
+                "dspy.teleprompt.signature_opt_typed"
+            ),
+            attribute_name="optimize_signature",
+            make_new_value=dspy_wrapper(
+                signature_opt_typed_optimize_signature_settings
+            ),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="BootstrapFewShotWithOptuna.compile",
+            make_new_value=dspy_wrapper(
+                bootstrap_few_shot_with_optuna_compile_settings
+            ),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy.teleprompt"),
+            attribute_name="LabeledFewShot.compile",
+            make_new_value=dspy_wrapper(labeled_few_shot_compile_settings),
+        ),
+    ]
+
+    # Patch LM classes
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="AzureOpenAI", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="OpenAI", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Cohere", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Clarifai", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Google", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="HFClientTGI", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="HFClientVLLM", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Anyscale", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="Together", settings=base
+    )
+    patched_functions += dspy_get_patched_lm_functions(
+        base_symbol="dspy", lm_class_name="OllamaLocal", settings=base
+    )
+
+    databricks_basic_request_settings = base.model_copy(
+        update={"name": base.name or "dspy.Databricks.basic_request"}
+    )
+    databricks_call_settings = base.model_copy(
+        update={"name": base.name or "dspy.Databricks"}
+    )
+    colbertv2_call_settings = base.model_copy(
+        update={"name": base.name or "dspy.ColBERTv2"}
+    )
+    pyserini_call_settings = base.model_copy(
+        update={"name": base.name or "dspy.Pyserini"}
+    )
+
+    patched_functions += [
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Databricks.basic_request",
+            make_new_value=dspy_wrapper(databricks_basic_request_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Databricks.__call__",
+            make_new_value=dspy_wrapper(databricks_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="ColBERTv2.__call__",
+            make_new_value=dspy_wrapper(colbertv2_call_settings),
+        ),
+        SymbolPatcher(
+            get_base_symbol=lambda: importlib.import_module("dspy"),
+            attribute_name="Pyserini.__call__",
+            make_new_value=dspy_wrapper(pyserini_call_settings),
+        ),
+    ]
+
+    _dspy_patcher = MultiPatcher(patched_functions)
+
+    return _dspy_patcher

--- a/weave/integrations/google_ai_studio/google_ai_studio_sdk.py
+++ b/weave/integrations/google_ai_studio/google_ai_studio_sdk.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 import importlib
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.serialize import dictify
 from weave.trace.weave_client import Call
 
 if TYPE_CHECKING:
     from google.generativeai.types.generation_types import GenerateContentResponse
+
+_google_genai_patcher: MultiPatcher | None = None
 
 
 def gemini_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -19,8 +24,8 @@ def gemini_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
 
 
 def gemini_accumulator(
-    acc: Optional["GenerateContentResponse"], value: "GenerateContentResponse"
-) -> "GenerateContentResponse":
+    acc: GenerateContentResponse | None, value: GenerateContentResponse
+) -> GenerateContentResponse:
     if acc is None:
         return value
 
@@ -64,9 +69,7 @@ def gemini_accumulator(
     return acc
 
 
-def gemini_on_finish(
-    call: Call, output: Any, exception: Optional[BaseException]
-) -> None:
+def gemini_on_finish(call: Call, output: Any, exception: BaseException | None) -> None:
     if "model_name" in call.inputs["self"]:
         original_model_name = call.inputs["self"]["model_name"]
     elif "model" in call.inputs["self"]:
@@ -89,10 +92,13 @@ def gemini_on_finish(
         call.summary.update(summary_update)
 
 
-def gemini_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
+def gemini_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(postprocess_inputs=gemini_postprocess_inputs)(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        if not op_kwargs.get("postprocess_inputs"):
+            op_kwargs["postprocess_inputs"] = gemini_postprocess_inputs
+
+        op = weave.op(fn, **op_kwargs)
         op._set_on_finish_handler(gemini_on_finish)
         return add_accumulator(
             op,  # type: ignore
@@ -104,7 +110,7 @@ def gemini_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
     return wrapper
 
 
-def gemini_wrapper_async(name: str) -> Callable[[Callable], Callable]:
+def gemini_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
         def _fn_wrapper(fn: Callable) -> Callable:
             @wraps(fn)
@@ -113,9 +119,11 @@ def gemini_wrapper_async(name: str) -> Callable[[Callable], Callable]:
 
             return _async_wrapper
 
-        "We need to do this so we can check if `stream` is used"
-        op = weave.op(postprocess_inputs=gemini_postprocess_inputs)(_fn_wrapper(fn))
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        if not op_kwargs.get("postprocess_inputs"):
+            op_kwargs["postprocess_inputs"] = gemini_postprocess_inputs
+
+        op = weave.op(_fn_wrapper(fn), **op_kwargs)
         op._set_on_finish_handler(gemini_on_finish)
         return add_accumulator(
             op,  # type: ignore
@@ -127,33 +135,72 @@ def gemini_wrapper_async(name: str) -> Callable[[Callable], Callable]:
     return wrapper
 
 
-google_genai_patcher = MultiPatcher(
-    [
-        SymbolPatcher(
-            lambda: importlib.import_module("google.generativeai.generative_models"),
-            "GenerativeModel.generate_content",
-            gemini_wrapper_sync(
-                name="google.generativeai.GenerativeModel.generate_content"
+def get_google_genai_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _google_genai_patcher
+    if _google_genai_patcher is not None:
+        return _google_genai_patcher
+
+    base = settings.op_settings
+
+    generate_content_settings = base.model_copy(
+        update={
+            "name": base.name or "google.generativeai.GenerativeModel.generate_content"
+        }
+    )
+    generate_content_async_settings = base.model_copy(
+        update={
+            "name": base.name
+            or "google.generativeai.GenerativeModel.generate_content_async"
+        }
+    )
+    send_message_settings = base.model_copy(
+        update={"name": base.name or "google.generativeai.ChatSession.send_message"}
+    )
+    send_message_async_settings = base.model_copy(
+        update={
+            "name": base.name or "google.generativeai.ChatSession.send_message_async"
+        }
+    )
+
+    _google_genai_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module(
+                    "google.generativeai.generative_models"
+                ),
+                "GenerativeModel.generate_content",
+                gemini_wrapper_sync(generate_content_settings),
             ),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("google.generativeai.generative_models"),
-            "GenerativeModel.generate_content_async",
-            gemini_wrapper_async(
-                name="google.generativeai.GenerativeModel.generate_content_async"
+            SymbolPatcher(
+                lambda: importlib.import_module(
+                    "google.generativeai.generative_models"
+                ),
+                "GenerativeModel.generate_content_async",
+                gemini_wrapper_async(generate_content_async_settings),
             ),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("google.generativeai.generative_models"),
-            "ChatSession.send_message",
-            gemini_wrapper_sync(name="google.generativeai.ChatSession.send_message"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("google.generativeai.generative_models"),
-            "ChatSession.send_message_async",
-            gemini_wrapper_async(
-                name="google.generativeai.ChatSession.send_message_async"
+            SymbolPatcher(
+                lambda: importlib.import_module(
+                    "google.generativeai.generative_models"
+                ),
+                "ChatSession.send_message",
+                gemini_wrapper_sync(send_message_settings),
             ),
-        ),
-    ]
-)
+            SymbolPatcher(
+                lambda: importlib.import_module(
+                    "google.generativeai.generative_models"
+                ),
+                "ChatSession.send_message_async",
+                gemini_wrapper_async(send_message_async_settings),
+            ),
+        ]
+    )
+
+    return _google_genai_patcher

--- a/weave/integrations/groq/groq_sdk.py
+++ b/weave/integrations/groq/groq_sdk.py
@@ -1,17 +1,23 @@
+from __future__ import annotations
+
 import importlib
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable
+
+import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
+from weave.trace.op_extensions.accumulator import add_accumulator
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 
 if TYPE_CHECKING:
     from groq.types.chat import ChatCompletion, ChatCompletionChunk
 
-import weave
-from weave.trace.op_extensions.accumulator import add_accumulator
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+
+_groq_patcher: MultiPatcher | None = None
 
 
 def groq_accumulator(
-    acc: Optional["ChatCompletion"], value: "ChatCompletionChunk"
-) -> "ChatCompletion":
+    acc: ChatCompletion | None, value: ChatCompletionChunk
+) -> ChatCompletion:
     from groq.types.chat import ChatCompletion, ChatCompletionMessage
     from groq.types.chat.chat_completion import Choice
     from groq.types.chat.chat_completion_chunk import Choice as ChoiceChunk
@@ -83,11 +89,10 @@ def should_use_accumulator(inputs: dict) -> bool:
     return isinstance(inputs, dict) and bool(inputs.get("stream"))
 
 
-def groq_wrapper(name: str) -> Callable[[Callable], Callable]:
+def groq_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
-        # return op
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: groq_accumulator,
@@ -97,17 +102,41 @@ def groq_wrapper(name: str) -> Callable[[Callable], Callable]:
     return wrapper
 
 
-groq_patcher = MultiPatcher(
-    [
-        SymbolPatcher(
-            lambda: importlib.import_module("groq.resources.chat.completions"),
-            "Completions.create",
-            groq_wrapper(name="groq.chat.completions.create"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("groq.resources.chat.completions"),
-            "AsyncCompletions.create",
-            groq_wrapper(name="groq.async.chat.completions.create"),
-        ),
-    ]
-)
+def get_groq_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _groq_patcher
+    if _groq_patcher is not None:
+        return _groq_patcher
+
+    base = settings.op_settings
+
+    chat_completions_settings = base.model_copy(
+        update={"name": base.name or "groq.chat.completions.create"}
+    )
+    async_chat_completions_settings = base.model_copy(
+        update={"name": base.name or "groq.async.chat.completions.create"}
+    )
+
+    _groq_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("groq.resources.chat.completions"),
+                "Completions.create",
+                groq_wrapper(chat_completions_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("groq.resources.chat.completions"),
+                "AsyncCompletions.create",
+                groq_wrapper(async_chat_completions_settings),
+            ),
+        ]
+    )
+
+    return _groq_patcher

--- a/weave/integrations/instructor/instructor_iterable_utils.py
+++ b/weave/integrations/instructor/instructor_iterable_utils.py
@@ -4,6 +4,7 @@ from typing import Any, Callable, Optional
 from pydantic import BaseModel
 
 import weave
+from weave.trace.autopatch import OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
 
 
@@ -27,10 +28,10 @@ def should_accumulate_iterable(inputs: dict) -> bool:
     return False
 
 
-def instructor_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
+def instructor_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: instructor_iterable_accumulator,
@@ -40,7 +41,7 @@ def instructor_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
     return wrapper
 
 
-def instructor_wrapper_async(name: str) -> Callable[[Callable], Callable]:
+def instructor_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
         def _fn_wrapper(fn: Callable) -> Callable:
             @wraps(fn)
@@ -49,9 +50,8 @@ def instructor_wrapper_async(name: str) -> Callable[[Callable], Callable]:
 
             return _async_wrapper
 
-        "We need to do this so we can check if `stream` is used"
-        op = weave.op(_fn_wrapper(fn))
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(_fn_wrapper(fn), **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: instructor_iterable_accumulator,

--- a/weave/integrations/instructor/instructor_partial_utils.py
+++ b/weave/integrations/instructor/instructor_partial_utils.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional
 from pydantic import BaseModel
 
 import weave
+from weave.trace.autopatch import OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
 
 
@@ -14,10 +15,10 @@ def instructor_partial_accumulator(
     return acc
 
 
-def instructor_wrapper_partial(name: str) -> Callable[[Callable], Callable]:
+def instructor_wrapper_partial(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: instructor_partial_accumulator,

--- a/weave/integrations/instructor/instructor_sdk.py
+++ b/weave/integrations/instructor/instructor_sdk.py
@@ -1,31 +1,65 @@
+from __future__ import annotations
+
 import importlib
 
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.autopatch import IntegrationSettings
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 
 from .instructor_iterable_utils import instructor_wrapper_async, instructor_wrapper_sync
 from .instructor_partial_utils import instructor_wrapper_partial
 
-instructor_patcher = MultiPatcher(
-    [
-        SymbolPatcher(
-            lambda: importlib.import_module("instructor.client"),
-            "Instructor.create",
-            instructor_wrapper_sync(name="Instructor.create"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("instructor.client"),
-            "AsyncInstructor.create",
-            instructor_wrapper_async(name="AsyncInstructor.create"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("instructor.client"),
-            "Instructor.create_partial",
-            instructor_wrapper_partial(name="Instructor.create_partial"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("instructor.client"),
-            "AsyncInstructor.create_partial",
-            instructor_wrapper_partial(name="AsyncInstructor.create_partial"),
-        ),
-    ]
-)
+_instructor_patcher: MultiPatcher | None = None
+
+
+def get_instructor_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _instructor_patcher
+    if _instructor_patcher is not None:
+        return _instructor_patcher
+
+    base = settings.op_settings
+
+    create_settings = base.model_copy(update={"name": base.name or "Instructor.create"})
+    async_create_settings = base.model_copy(
+        update={"name": base.name or "AsyncInstructor.create"}
+    )
+    create_partial_settings = base.model_copy(
+        update={"name": base.name or "Instructor.create_partial"}
+    )
+    async_create_partial_settings = base.model_copy(
+        update={"name": base.name or "AsyncInstructor.create_partial"}
+    )
+
+    _instructor_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("instructor.client"),
+                "Instructor.create",
+                instructor_wrapper_sync(create_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("instructor.client"),
+                "AsyncInstructor.create",
+                instructor_wrapper_async(async_create_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("instructor.client"),
+                "Instructor.create_partial",
+                instructor_wrapper_partial(create_partial_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("instructor.client"),
+                "AsyncInstructor.create_partial",
+                instructor_wrapper_partial(async_create_partial_settings),
+            ),
+        ]
+    )
+
+    return _instructor_patcher

--- a/weave/integrations/litellm/litellm.py
+++ b/weave/integrations/litellm/litellm.py
@@ -1,19 +1,24 @@
+from __future__ import annotations
+
 import importlib
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 
 if TYPE_CHECKING:
     from litellm.utils import ModelResponse
 
+_litellm_patcher: MultiPatcher | None = None
+
 
 # This accumulator is nearly identical to the mistral accumulator, just with different types.
 def litellm_accumulator(
-    acc: Optional["ModelResponse"],
-    value: "ModelResponse",
-) -> "ModelResponse":
+    acc: ModelResponse | None,
+    value: ModelResponse,
+) -> ModelResponse:
     # This import should be safe at this point
     from litellm.utils import Choices, Message, ModelResponse, Usage
 
@@ -82,10 +87,10 @@ def should_use_accumulator(inputs: dict) -> bool:
     return isinstance(inputs, dict) and bool(inputs.get("stream"))
 
 
-def make_wrapper(name: str) -> Callable:
+def make_wrapper(settings: OpSettings) -> Callable:
     def litellm_wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         return add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: litellm_accumulator,
@@ -96,17 +101,41 @@ def make_wrapper(name: str) -> Callable:
     return litellm_wrapper
 
 
-litellm_patcher = MultiPatcher(
-    [
-        SymbolPatcher(
-            lambda: importlib.import_module("litellm"),
-            "completion",
-            make_wrapper("litellm.completion"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("litellm"),
-            "acompletion",
-            make_wrapper("litellm.acompletion"),
-        ),
-    ]
-)
+def get_litellm_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _litellm_patcher
+    if _litellm_patcher is not None:
+        return _litellm_patcher
+
+    base = settings.op_settings
+
+    completion_settings = base.model_copy(
+        update={"name": base.name or "litellm.completion"}
+    )
+    acompletion_settings = base.model_copy(
+        update={"name": base.name or "litellm.acompletion"}
+    )
+
+    _litellm_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("litellm"),
+                "completion",
+                make_wrapper(completion_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("litellm"),
+                "acompletion",
+                make_wrapper(acompletion_settings),
+            ),
+        ]
+    )
+
+    return _litellm_patcher

--- a/weave/integrations/mistral/__init__.py
+++ b/weave/integrations/mistral/__init__.py
@@ -8,10 +8,10 @@ except metadata.PackageNotFoundError:
     mistral_version = "1.0"  # we need to return a patching function
 
 if version.parse(mistral_version) < version.parse("1.0.0"):
-    from .v0.mistral import mistral_patcher
+    from .v0.mistral import get_mistral_patcher  # noqa: F401
 
     print(
         f"Using MistralAI version {mistral_version}. Please consider upgrading to version 1.0.0 or later."
     )
 else:
-    from .v1.mistral import mistral_patcher  # noqa: F401
+    from .v1.mistral import get_mistral_patcher  # noqa: F401

--- a/weave/integrations/mistral/v1/mistral.py
+++ b/weave/integrations/mistral/v1/mistral.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import importlib
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Callable
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 
 if TYPE_CHECKING:
     from mistralai.models import (
@@ -11,11 +14,13 @@ if TYPE_CHECKING:
         CompletionEvent,
     )
 
+_mistral_patcher: MultiPatcher | None = None
+
 
 def mistral_accumulator(
-    acc: Optional["ChatCompletionResponse"],
-    value: "CompletionEvent",
-) -> "ChatCompletionResponse":
+    acc: ChatCompletionResponse | None,
+    value: CompletionEvent,
+) -> ChatCompletionResponse:
     # This import should be safe at this point
     from mistralai.models import (
         AssistantMessage,
@@ -79,50 +84,79 @@ def mistral_accumulator(
     return acc
 
 
-def mistral_stream_wrapper(name: str) -> Callable:
+def mistral_stream_wrapper(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         acc_op = add_accumulator(op, lambda inputs: mistral_accumulator)  # type: ignore
-        acc_op.name = name  # type: ignore
         return acc_op
 
     return wrapper
 
 
-def mistral_wrapper(name: str) -> Callable:
+def mistral_wrapper(settings: OpSettings) -> Callable:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         return op
 
     return wrapper
 
 
-mistral_patcher = MultiPatcher(
-    [
-        # Patch the sync, non-streaming chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("mistralai.chat"),
-            "Chat.complete",
-            mistral_wrapper(name="Mistral.chat.complete"),
-        ),
-        # Patch the sync, streaming chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("mistralai.chat"),
-            "Chat.stream",
-            mistral_stream_wrapper(name="Mistral.chat.stream"),
-        ),
-        # Patch the async, non-streaming chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("mistralai.chat"),
-            "Chat.complete_async",
-            mistral_wrapper(name="Mistral.chat.complete_async"),
-        ),
-        # Patch the async, streaming chat method
-        SymbolPatcher(
-            lambda: importlib.import_module("mistralai.chat"),
-            "Chat.stream_async",
-            mistral_stream_wrapper(name="Mistral.chat.stream_async"),
-        ),
-    ]
-)
+def get_mistral_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _mistral_patcher
+    if _mistral_patcher is not None:
+        return _mistral_patcher
+
+    base = settings.op_settings
+    chat_complete_settings = base.model_copy(
+        update={"name": base.name or "mistralai.chat.complete"}
+    )
+    chat_stream_settings = base.model_copy(
+        update={"name": base.name or "mistralai.chat.stream"}
+    )
+    async_chat_complete_settings = base.model_copy(
+        update={"name": base.name or "mistralai.async_client.chat.complete"}
+    )
+    async_chat_stream_settings = base.model_copy(
+        update={"name": base.name or "mistralai.async_client.chat.stream"}
+    )
+
+    _mistral_patcher = MultiPatcher(
+        [
+            # Patch the sync, non-streaming chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("mistralai.chat"),
+                "Chat.complete",
+                mistral_wrapper(chat_complete_settings),
+            ),
+            # Patch the sync, streaming chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("mistralai.chat"),
+                "Chat.stream",
+                mistral_stream_wrapper(chat_stream_settings),
+            ),
+            # Patch the async, non-streaming chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("mistralai.chat"),
+                "Chat.complete_async",
+                mistral_wrapper(async_chat_complete_settings),
+            ),
+            # Patch the async, streaming chat method
+            SymbolPatcher(
+                lambda: importlib.import_module("mistralai.chat"),
+                "Chat.stream_async",
+                mistral_stream_wrapper(async_chat_stream_settings),
+            ),
+        ]
+    )
+
+    return _mistral_patcher

--- a/weave/integrations/notdiamond/__init__.py
+++ b/weave/integrations/notdiamond/__init__.py
@@ -1,1 +1,1 @@
-from .tracing import notdiamond_patcher as notdiamond_patcher
+from .tracing import get_notdiamond_patcher  # noqa: F401

--- a/weave/integrations/notdiamond/tracing.py
+++ b/weave/integrations/notdiamond/tracing.py
@@ -1,15 +1,28 @@
+from __future__ import annotations
+
 import importlib
 from typing import Callable
 
 import weave
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.autopatch import IntegrationSettings, OpSettings
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
+
+_notdiamond_patcher: MultiPatcher | None = None
 
 
-def nd_wrapper(name: str) -> Callable[[Callable], Callable]:
+def nd_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op()(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_dump()
+        op = weave.op(fn, **op_kwargs)
         return op
+
+    return wrapper
+
+
+def passthrough_wrapper(settings: OpSettings) -> Callable:
+    def wrapper(fn: Callable) -> Callable:
+        op_kwargs = settings.model_dump()
+        return weave.op(fn, **op_kwargs)
 
     return wrapper
 
@@ -29,36 +42,84 @@ def _patch_client_op(method_name: str) -> list[SymbolPatcher]:
     ]
 
 
-patched_client_functions = _patch_client_op("model_select")
+def get_notdiamond_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
 
-patched_llmconfig_functions = [
-    SymbolPatcher(
-        lambda: importlib.import_module("notdiamond"),
-        "LLMConfig.__init__",
-        weave.op(),
-    ),
-    SymbolPatcher(
-        lambda: importlib.import_module("notdiamond"),
-        "LLMConfig.from_string",
-        weave.op(),
-    ),
-]
+    if not settings.enabled:
+        return NoOpPatcher()
 
-patched_toolkit_functions = [
-    SymbolPatcher(
-        lambda: importlib.import_module("notdiamond.toolkit.custom_router"),
-        "CustomRouter.fit",
-        weave.op(),
-    ),
-    SymbolPatcher(
-        lambda: importlib.import_module("notdiamond.toolkit.custom_router"),
-        "CustomRouter.eval",
-        weave.op(),
-    ),
-]
+    global _notdiamond_patcher
+    if _notdiamond_patcher is not None:
+        return _notdiamond_patcher
 
-all_patched_functions = (
-    patched_client_functions + patched_toolkit_functions + patched_llmconfig_functions
-)
+    base = settings.op_settings
 
-notdiamond_patcher = MultiPatcher(all_patched_functions)
+    model_select_settings = base.model_copy(
+        update={"name": base.name or "NotDiamond.model_select"}
+    )
+    async_model_select_settings = base.model_copy(
+        update={"name": base.name or "NotDiamond.amodel_select"}
+    )
+    patched_client_functions = [
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond"),
+            "NotDiamond.model_select",
+            passthrough_wrapper(model_select_settings),
+        ),
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond"),
+            "NotDiamond.amodel_select",
+            passthrough_wrapper(async_model_select_settings),
+        ),
+    ]
+
+    llm_config_init_settings = base.model_copy(
+        update={"name": base.name or "NotDiamond.LLMConfig.__init__"}
+    )
+    llm_config_from_string_settings = base.model_copy(
+        update={"name": base.name or "NotDiamond.LLMConfig.from_string"}
+    )
+    patched_llmconfig_functions = [
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond"),
+            "LLMConfig.__init__",
+            passthrough_wrapper(llm_config_init_settings),
+        ),
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond"),
+            "LLMConfig.from_string",
+            passthrough_wrapper(llm_config_from_string_settings),
+        ),
+    ]
+
+    toolkit_custom_router_fit_settings = base.model_copy(
+        update={"name": base.name or "NotDiamond.toolkit.custom_router.fit"}
+    )
+    toolkit_custom_router_eval_settings = base.model_copy(
+        update={"name": base.name or "NotDiamond.toolkit.custom_router.eval"}
+    )
+    patched_toolkit_functions = [
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond.toolkit.custom_router"),
+            "CustomRouter.fit",
+            passthrough_wrapper(toolkit_custom_router_fit_settings),
+        ),
+        SymbolPatcher(
+            lambda: importlib.import_module("notdiamond.toolkit.custom_router"),
+            "CustomRouter.eval",
+            passthrough_wrapper(toolkit_custom_router_eval_settings),
+        ),
+    ]
+
+    all_patched_functions = (
+        patched_client_functions
+        + patched_toolkit_functions
+        + patched_llmconfig_functions
+    )
+
+    _notdiamond_patcher = MultiPatcher(all_patched_functions)
+
+    return _notdiamond_patcher

--- a/weave/integrations/vertexai/vertexai_sdk.py
+++ b/weave/integrations/vertexai/vertexai_sdk.py
@@ -1,15 +1,21 @@
+from __future__ import annotations
+
 import importlib
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 import weave
+from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_extensions.accumulator import add_accumulator
-from weave.trace.patcher import MultiPatcher, SymbolPatcher
+from weave.trace.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.serialize import dictify
 from weave.trace.weave_client import Call
 
 if TYPE_CHECKING:
     from vertexai.generative_models import GenerationResponse
+
+
+_vertexai_patcher: MultiPatcher | None = None
 
 
 def vertexai_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -25,8 +31,8 @@ def vertexai_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
 
 
 def vertexai_accumulator(
-    acc: Optional["GenerationResponse"], value: "GenerationResponse"
-) -> "GenerationResponse":
+    acc: GenerationResponse | None, value: GenerationResponse
+) -> GenerationResponse:
     from google.cloud.aiplatform_v1beta1.types import content as gapic_content_types
     from google.cloud.aiplatform_v1beta1.types import (
         prediction_service as gapic_prediction_service_types,
@@ -62,7 +68,7 @@ def vertexai_accumulator(
 
 
 def vertexai_on_finish(
-    call: Call, output: Any, exception: Optional[BaseException]
+    call: Call, output: Any, exception: BaseException | None
 ) -> None:
     original_model_name = call.inputs["model_name"]
     model_name = original_model_name.split("/")[-1]
@@ -81,10 +87,13 @@ def vertexai_on_finish(
         call.summary.update(summary_update)
 
 
-def vertexai_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
+def vertexai_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(postprocess_inputs=vertexai_postprocess_inputs)(fn)
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_copy()
+        if not op_kwargs.get("postprocess_inputs"):
+            op_kwargs["postprocess_inputs"] = vertexai_postprocess_inputs
+
+        op = weave.op(fn, **op_kwargs)
         op._set_on_finish_handler(vertexai_on_finish)
         return add_accumulator(
             op,  # type: ignore
@@ -96,7 +105,7 @@ def vertexai_wrapper_sync(name: str) -> Callable[[Callable], Callable]:
     return wrapper
 
 
-def vertexai_wrapper_async(name: str) -> Callable[[Callable], Callable]:
+def vertexai_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
         def _fn_wrapper(fn: Callable) -> Callable:
             @wraps(fn)
@@ -105,9 +114,11 @@ def vertexai_wrapper_async(name: str) -> Callable[[Callable], Callable]:
 
             return _async_wrapper
 
-        "We need to do this so we can check if `stream` is used"
-        op = weave.op(postprocess_inputs=vertexai_postprocess_inputs)(_fn_wrapper(fn))
-        op.name = name  # type: ignore
+        op_kwargs = settings.model_copy()
+        if not op_kwargs.get("postprocess_inputs"):
+            op_kwargs["postprocess_inputs"] = vertexai_postprocess_inputs
+
+        op = weave.op(_fn_wrapper(fn), **op_kwargs)
         op._set_on_finish_handler(vertexai_on_finish)
         return add_accumulator(
             op,  # type: ignore
@@ -119,34 +130,65 @@ def vertexai_wrapper_async(name: str) -> Callable[[Callable], Callable]:
     return wrapper
 
 
-vertexai_patcher = MultiPatcher(
-    [
-        SymbolPatcher(
-            lambda: importlib.import_module("vertexai.generative_models"),
-            "GenerativeModel.generate_content",
-            vertexai_wrapper_sync(name="vertexai.GenerativeModel.generate_content"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("vertexai.generative_models"),
-            "GenerativeModel.generate_content_async",
-            vertexai_wrapper_async(
-                name="vertexai.GenerativeModel.generate_content_async"
+def get_vertexai_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _vertexai_patcher
+    if _vertexai_patcher is not None:
+        return _vertexai_patcher
+
+    base = settings.op_settings
+
+    generate_content_settings = base.model_copy(
+        update={"name": base.name or "vertexai.GenerativeModel.generate_content"}
+    )
+    generate_content_async_settings = base.model_copy(
+        update={"name": base.name or "vertexai.GenerativeModel.generate_content_async"}
+    )
+    send_message_settings = base.model_copy(
+        update={"name": base.name or "vertexai.ChatSession.send_message"}
+    )
+    send_message_async_settings = base.model_copy(
+        update={"name": base.name or "vertexai.ChatSession.send_message_async"}
+    )
+    generate_images_settings = base.model_copy(
+        update={"name": base.name or "vertexai.ImageGenerationModel.generate_images"}
+    )
+
+    _vertexai_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("vertexai.generative_models"),
+                "GenerativeModel.generate_content",
+                vertexai_wrapper_sync(generate_content_settings),
             ),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("vertexai.generative_models"),
-            "ChatSession.send_message",
-            vertexai_wrapper_sync(name="vertexai.ChatSession.send_message"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("vertexai.generative_models"),
-            "ChatSession.send_message_async",
-            vertexai_wrapper_async(name="vertexai.ChatSession.send_message_async"),
-        ),
-        SymbolPatcher(
-            lambda: importlib.import_module("vertexai.preview.vision_models"),
-            "ImageGenerationModel.generate_images",
-            vertexai_wrapper_sync(name="vertexai.ImageGenerationModel.generate_images"),
-        ),
-    ]
-)
+            SymbolPatcher(
+                lambda: importlib.import_module("vertexai.generative_models"),
+                "GenerativeModel.generate_content_async",
+                vertexai_wrapper_async(generate_content_async_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("vertexai.generative_models"),
+                "ChatSession.send_message",
+                vertexai_wrapper_sync(send_message_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("vertexai.generative_models"),
+                "ChatSession.send_message_async",
+                vertexai_wrapper_async(send_message_async_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("vertexai.preview.vision_models"),
+                "ImageGenerationModel.generate_images",
+                vertexai_wrapper_sync(generate_images_settings),
+            ),
+        ]
+    )
+
+    return _vertexai_patcher

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -34,7 +34,7 @@ class AutopatchSettings(BaseModel):
 
     # These will be uncommented as we add support for more integrations.  Note that
 
-    # anthropic: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    anthropic: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -52,7 +52,7 @@ class AutopatchSettings(BaseModel):
 
 @validate_call
 def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
-    from weave.integrations.anthropic.anthropic_sdk import anthropic_patcher
+    from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
@@ -77,7 +77,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     litellm_patcher.attempt_patch()
     llamaindex_patcher.attempt_patch()
     langchain_patcher.attempt_patch()
-    anthropic_patcher.attempt_patch()
+    get_anthropic_patcher(settings.anthropic).attempt_patch()
     groq_patcher.attempt_patch()
     instructor_patcher.attempt_patch()
     dspy_patcher.attempt_patch()
@@ -89,7 +89,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
 
 
 def reset_autopatch() -> None:
-    from weave.integrations.anthropic.anthropic_sdk import anthropic_patcher
+    from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
@@ -111,7 +111,7 @@ def reset_autopatch() -> None:
     litellm_patcher.undo_patch()
     llamaindex_patcher.undo_patch()
     langchain_patcher.undo_patch()
-    anthropic_patcher.undo_patch()
+    get_anthropic_patcher().undo_patch()
     groq_patcher.undo_patch()
     instructor_patcher.undo_patch()
     dspy_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -40,7 +40,7 @@ class AutopatchSettings(BaseModel):
     dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
     google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
     groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
     litellm: IntegrationSettings = Field(default_factory=IntegrationSettings)
     mistral: IntegrationSettings = Field(default_factory=IntegrationSettings)
     notdiamond: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -58,7 +58,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
         get_google_genai_patcher,
     )
     from weave.integrations.groq.groq_sdk import get_groq_patcher
-    from weave.integrations.instructor.instructor_sdk import instructor_patcher
+    from weave.integrations.instructor.instructor_sdk import get_instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
@@ -75,7 +75,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     get_litellm_patcher(settings.litellm).attempt_patch()
     get_anthropic_patcher(settings.anthropic).attempt_patch()
     get_groq_patcher(settings.groq).attempt_patch()
-    instructor_patcher.attempt_patch()
+    get_instructor_patcher(settings.instructor).attempt_patch()
     get_dspy_patcher(settings.dspy).attempt_patch()
     get_cerebras_patcher(settings.cerebras).attempt_patch()
     get_cohere_patcher(settings.cohere).attempt_patch()
@@ -96,7 +96,7 @@ def reset_autopatch() -> None:
         get_google_genai_patcher,
     )
     from weave.integrations.groq.groq_sdk import get_groq_patcher
-    from weave.integrations.instructor.instructor_sdk import instructor_patcher
+    from weave.integrations.instructor.instructor_sdk import get_instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
@@ -110,7 +110,7 @@ def reset_autopatch() -> None:
     get_litellm_patcher().undo_patch()
     get_anthropic_patcher().undo_patch()
     get_groq_patcher().undo_patch()
-    instructor_patcher.undo_patch()
+    get_instructor_patcher().undo_patch()
     get_dspy_patcher().undo_patch()
     get_cerebras_patcher().undo_patch()
     get_cohere_patcher().undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -35,7 +35,7 @@ class AutopatchSettings(BaseModel):
     # These will be uncommented as we add support for more integrations.  Note that
 
     anthropic: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -53,7 +53,7 @@ class AutopatchSettings(BaseModel):
 @validate_call
 def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
-    from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
+    from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
@@ -81,7 +81,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     groq_patcher.attempt_patch()
     instructor_patcher.attempt_patch()
     dspy_patcher.attempt_patch()
-    cerebras_patcher.attempt_patch()
+    get_cerebras_patcher(settings.cerebras).attempt_patch()
     cohere_patcher.attempt_patch()
     google_genai_patcher.attempt_patch()
     notdiamond_patcher.attempt_patch()
@@ -90,7 +90,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
 
 def reset_autopatch() -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
-    from weave.integrations.cerebras.cerebras_sdk import cerebras_patcher
+    from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
@@ -115,7 +115,7 @@ def reset_autopatch() -> None:
     groq_patcher.undo_patch()
     instructor_patcher.undo_patch()
     dspy_patcher.undo_patch()
-    cerebras_patcher.undo_patch()
+    get_cerebras_patcher().undo_patch()
     cohere_patcher.undo_patch()
     google_genai_patcher.undo_patch()
     notdiamond_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -43,7 +43,7 @@ class AutopatchSettings(BaseModel):
     # instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # litellm: IntegrationSettings = Field(default_factory=IntegrationSettings)
     mistral: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # notdiamond: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    notdiamond: IntegrationSettings = Field(default_factory=IntegrationSettings)
     openai: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # vertexai: IntegrationSettings = Field(default_factory=IntegrationSettings)
 
@@ -63,7 +63,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.litellm.litellm import litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import get_mistral_patcher
-    from weave.integrations.notdiamond.tracing import notdiamond_patcher
+    from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
@@ -82,7 +82,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     get_cerebras_patcher(settings.cerebras).attempt_patch()
     get_cohere_patcher(settings.cohere).attempt_patch()
     get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
-    notdiamond_patcher.attempt_patch()
+    get_notdiamond_patcher(settings.notdiamond).attempt_patch()
     vertexai_patcher.attempt_patch()
 
 
@@ -100,7 +100,7 @@ def reset_autopatch() -> None:
     from weave.integrations.litellm.litellm import litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import get_mistral_patcher
-    from weave.integrations.notdiamond.tracing import notdiamond_patcher
+    from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
@@ -116,5 +116,5 @@ def reset_autopatch() -> None:
     get_cerebras_patcher().undo_patch()
     get_cohere_patcher().undo_patch()
     get_google_genai_patcher().undo_patch()
-    notdiamond_patcher.undo_patch()
+    get_notdiamond_patcher().undo_patch()
     vertexai_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -41,7 +41,7 @@ class AutopatchSettings(BaseModel):
     google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
     groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # litellm: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    litellm: IntegrationSettings = Field(default_factory=IntegrationSettings)
     mistral: IntegrationSettings = Field(default_factory=IntegrationSettings)
     notdiamond: IntegrationSettings = Field(default_factory=IntegrationSettings)
     openai: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -60,7 +60,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.groq.groq_sdk import get_groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
-    from weave.integrations.litellm.litellm import litellm_patcher
+    from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
@@ -72,9 +72,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
 
     get_openai_patcher(settings.openai).attempt_patch()
     get_mistral_patcher(settings.mistral).attempt_patch()
-    litellm_patcher.attempt_patch()
-    llamaindex_patcher.attempt_patch()
-    langchain_patcher.attempt_patch()
+    get_litellm_patcher(settings.litellm).attempt_patch()
     get_anthropic_patcher(settings.anthropic).attempt_patch()
     get_groq_patcher(settings.groq).attempt_patch()
     instructor_patcher.attempt_patch()
@@ -84,6 +82,9 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
     get_notdiamond_patcher(settings.notdiamond).attempt_patch()
     get_vertexai_patcher(settings.vertexai).attempt_patch()
+
+    llamaindex_patcher.attempt_patch()
+    langchain_patcher.attempt_patch()
 
 
 def reset_autopatch() -> None:
@@ -97,7 +98,7 @@ def reset_autopatch() -> None:
     from weave.integrations.groq.groq_sdk import get_groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
-    from weave.integrations.litellm.litellm import litellm_patcher
+    from weave.integrations.litellm.litellm import get_litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
     from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
@@ -106,9 +107,7 @@ def reset_autopatch() -> None:
 
     get_openai_patcher().undo_patch()
     get_mistral_patcher().undo_patch()
-    litellm_patcher.undo_patch()
-    llamaindex_patcher.undo_patch()
-    langchain_patcher.undo_patch()
+    get_litellm_patcher().undo_patch()
     get_anthropic_patcher().undo_patch()
     get_groq_patcher().undo_patch()
     instructor_patcher.undo_patch()
@@ -118,3 +117,6 @@ def reset_autopatch() -> None:
     get_google_genai_patcher().undo_patch()
     get_notdiamond_patcher().undo_patch()
     get_vertexai_patcher().undo_patch()
+
+    llamaindex_patcher.undo_patch()
+    langchain_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -41,10 +41,8 @@ class AutopatchSettings(BaseModel):
     google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
     groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # langchain: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # litellm: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # llamaindex: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # mistral: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    mistral: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # notdiamond: IntegrationSettings = Field(default_factory=IntegrationSettings)
     openai: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # vertexai: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -64,7 +62,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
-    from weave.integrations.mistral import mistral_patcher
+    from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
@@ -73,7 +71,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
         settings = AutopatchSettings()
 
     get_openai_patcher(settings.openai).attempt_patch()
-    mistral_patcher.attempt_patch()
+    get_mistral_patcher(settings.mistral).attempt_patch()
     litellm_patcher.attempt_patch()
     llamaindex_patcher.attempt_patch()
     langchain_patcher.attempt_patch()
@@ -101,13 +99,13 @@ def reset_autopatch() -> None:
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import litellm_patcher
     from weave.integrations.llamaindex.llamaindex import llamaindex_patcher
-    from weave.integrations.mistral import mistral_patcher
+    from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
 
     get_openai_patcher().undo_patch()
-    mistral_patcher.undo_patch()
+    get_mistral_patcher().undo_patch()
     litellm_patcher.undo_patch()
     llamaindex_patcher.undo_patch()
     langchain_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -54,7 +54,7 @@ class AutopatchSettings(BaseModel):
 def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
-    from weave.integrations.cohere.cohere_sdk import cohere_patcher
+    from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         google_genai_patcher,
@@ -82,7 +82,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     instructor_patcher.attempt_patch()
     dspy_patcher.attempt_patch()
     get_cerebras_patcher(settings.cerebras).attempt_patch()
-    cohere_patcher.attempt_patch()
+    get_cohere_patcher(settings.cohere).attempt_patch()
     google_genai_patcher.attempt_patch()
     notdiamond_patcher.attempt_patch()
     vertexai_patcher.attempt_patch()
@@ -91,7 +91,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
 def reset_autopatch() -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
-    from weave.integrations.cohere.cohere_sdk import cohere_patcher
+    from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
     from weave.integrations.dspy.dspy_sdk import dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         google_genai_patcher,
@@ -116,7 +116,7 @@ def reset_autopatch() -> None:
     instructor_patcher.undo_patch()
     dspy_patcher.undo_patch()
     get_cerebras_patcher().undo_patch()
-    cohere_patcher.undo_patch()
+    get_cohere_patcher().undo_patch()
     google_genai_patcher.undo_patch()
     notdiamond_patcher.undo_patch()
     vertexai_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -38,7 +38,7 @@ class AutopatchSettings(BaseModel):
     cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
     cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
     dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # langchain: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -57,7 +57,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
     from weave.integrations.dspy.dspy_sdk import get_dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
-        google_genai_patcher,
+        get_google_genai_patcher,
     )
     from weave.integrations.groq.groq_sdk import groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
@@ -83,7 +83,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     get_dspy_patcher(settings.dspy).attempt_patch()
     get_cerebras_patcher(settings.cerebras).attempt_patch()
     get_cohere_patcher(settings.cohere).attempt_patch()
-    google_genai_patcher.attempt_patch()
+    get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
     notdiamond_patcher.attempt_patch()
     vertexai_patcher.attempt_patch()
 
@@ -94,7 +94,7 @@ def reset_autopatch() -> None:
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
     from weave.integrations.dspy.dspy_sdk import get_dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
-        google_genai_patcher,
+        get_google_genai_patcher,
     )
     from weave.integrations.groq.groq_sdk import groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
@@ -117,6 +117,6 @@ def reset_autopatch() -> None:
     get_dspy_patcher().undo_patch()
     get_cerebras_patcher().undo_patch()
     get_cohere_patcher().undo_patch()
-    google_genai_patcher.undo_patch()
+    get_google_genai_patcher().undo_patch()
     notdiamond_patcher.undo_patch()
     vertexai_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -37,7 +37,7 @@ class AutopatchSettings(BaseModel):
     anthropic: IntegrationSettings = Field(default_factory=IntegrationSettings)
     cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
     cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -55,7 +55,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
-    from weave.integrations.dspy.dspy_sdk import dspy_patcher
+    from weave.integrations.dspy.dspy_sdk import get_dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         google_genai_patcher,
     )
@@ -80,7 +80,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     get_anthropic_patcher(settings.anthropic).attempt_patch()
     groq_patcher.attempt_patch()
     instructor_patcher.attempt_patch()
-    dspy_patcher.attempt_patch()
+    get_dspy_patcher(settings.dspy).attempt_patch()
     get_cerebras_patcher(settings.cerebras).attempt_patch()
     get_cohere_patcher(settings.cohere).attempt_patch()
     google_genai_patcher.attempt_patch()
@@ -92,7 +92,7 @@ def reset_autopatch() -> None:
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
-    from weave.integrations.dspy.dspy_sdk import dspy_patcher
+    from weave.integrations.dspy.dspy_sdk import get_dspy_patcher
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         google_genai_patcher,
     )
@@ -114,7 +114,7 @@ def reset_autopatch() -> None:
     get_anthropic_patcher().undo_patch()
     groq_patcher.undo_patch()
     instructor_patcher.undo_patch()
-    dspy_patcher.undo_patch()
+    get_dspy_patcher().undo_patch()
     get_cerebras_patcher().undo_patch()
     get_cohere_patcher().undo_patch()
     google_genai_patcher.undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -45,7 +45,7 @@ class AutopatchSettings(BaseModel):
     mistral: IntegrationSettings = Field(default_factory=IntegrationSettings)
     notdiamond: IntegrationSettings = Field(default_factory=IntegrationSettings)
     openai: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # vertexai: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    vertexai: IntegrationSettings = Field(default_factory=IntegrationSettings)
 
 
 @validate_call
@@ -65,7 +65,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
-    from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
+    from weave.integrations.vertexai.vertexai_sdk import get_vertexai_patcher
 
     if settings is None:
         settings = AutopatchSettings()
@@ -83,7 +83,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     get_cohere_patcher(settings.cohere).attempt_patch()
     get_google_genai_patcher(settings.google_ai_studio).attempt_patch()
     get_notdiamond_patcher(settings.notdiamond).attempt_patch()
-    vertexai_patcher.attempt_patch()
+    get_vertexai_patcher(settings.vertexai).attempt_patch()
 
 
 def reset_autopatch() -> None:
@@ -102,7 +102,7 @@ def reset_autopatch() -> None:
     from weave.integrations.mistral import get_mistral_patcher
     from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
-    from weave.integrations.vertexai.vertexai_sdk import vertexai_patcher
+    from weave.integrations.vertexai.vertexai_sdk import get_vertexai_patcher
 
     get_openai_patcher().undo_patch()
     get_mistral_patcher().undo_patch()
@@ -117,4 +117,4 @@ def reset_autopatch() -> None:
     get_cohere_patcher().undo_patch()
     get_google_genai_patcher().undo_patch()
     get_notdiamond_patcher().undo_patch()
-    vertexai_patcher.undo_patch()
+    get_vertexai_patcher().undo_patch()

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -36,7 +36,7 @@ class AutopatchSettings(BaseModel):
 
     anthropic: IntegrationSettings = Field(default_factory=IntegrationSettings)
     cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # groq: IntegrationSettings = Field(default_factory=IntegrationSettings)

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -39,7 +39,7 @@ class AutopatchSettings(BaseModel):
     cohere: IntegrationSettings = Field(default_factory=IntegrationSettings)
     dspy: IntegrationSettings = Field(default_factory=IntegrationSettings)
     google_ai_studio: IntegrationSettings = Field(default_factory=IntegrationSettings)
-    # groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
+    groq: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # instructor: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # langchain: IntegrationSettings = Field(default_factory=IntegrationSettings)
     # litellm: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -59,7 +59,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         get_google_genai_patcher,
     )
-    from weave.integrations.groq.groq_sdk import groq_patcher
+    from weave.integrations.groq.groq_sdk import get_groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import litellm_patcher
@@ -78,7 +78,7 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     llamaindex_patcher.attempt_patch()
     langchain_patcher.attempt_patch()
     get_anthropic_patcher(settings.anthropic).attempt_patch()
-    groq_patcher.attempt_patch()
+    get_groq_patcher(settings.groq).attempt_patch()
     instructor_patcher.attempt_patch()
     get_dspy_patcher(settings.dspy).attempt_patch()
     get_cerebras_patcher(settings.cerebras).attempt_patch()
@@ -96,7 +96,7 @@ def reset_autopatch() -> None:
     from weave.integrations.google_ai_studio.google_ai_studio_sdk import (
         get_google_genai_patcher,
     )
-    from weave.integrations.groq.groq_sdk import groq_patcher
+    from weave.integrations.groq.groq_sdk import get_groq_patcher
     from weave.integrations.instructor.instructor_sdk import instructor_patcher
     from weave.integrations.langchain.langchain import langchain_patcher
     from weave.integrations.litellm.litellm import litellm_patcher
@@ -112,7 +112,7 @@ def reset_autopatch() -> None:
     llamaindex_patcher.undo_patch()
     langchain_patcher.undo_patch()
     get_anthropic_patcher().undo_patch()
-    groq_patcher.undo_patch()
+    get_groq_patcher().undo_patch()
     instructor_patcher.undo_patch()
     get_dspy_patcher().undo_patch()
     get_cerebras_patcher().undo_patch()


### PR DESCRIPTION
This is a fast-follow PR to: https://github.com/wandb/weave/pull/3197

It implements op kwarg passthrough for the remaining integrations, except Langchain and Llamaindex because they don't use the op decorator.