### PR TITLE
chore(ui): Trace tree: center line to point to the title of the call

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
@@ -173,7 +173,7 @@ export const CustomGridTreeDataGroupingCell: FC<
             <Box
               sx={{
                 width: '100%',
-                height: '100%',
+                height: '34px',
                 borderBottom: BORDER_STYLE,
               }}></Box>
             <Box sx={{width: '100%', height: '100%'}}></Box>


### PR DESCRIPTION
## Description

- One-liner that aligns the line with the trace-tree to the center of the call title (vs. the center of the call card).

| Before    | After |
| -------- | ------- |
| ![CleanShot 2024-12-12 at 11 55 57@2x](https://github.com/user-attachments/assets/e501e454-3260-4085-8ea5-7e054072fab4)  | ![CleanShot 2024-12-12 at 11 57 55@2x](https://github.com/user-attachments/assets/a20ec022-8f80-413f-8ecc-2be1cf906a80) |
