### PR TITLE
chore(app): Allow skipping night-aware class for TextField

### DIFF
--- a/weave-js/src/components/Form/TextField.tsx
+++ b/weave-js/src/components/Form/TextField.tsx
@@ -37,6 +37,7 @@ type TextFieldProps = {
   dataTest?: string;
   step?: number;
   variant?: 'default' | 'ghost';
+  isContainerNightAware?: boolean;
 };
 
 export const TextField = ({
@@ -59,6 +60,7 @@ export const TextField = ({
   autoComplete,
   dataTest,
   step,
+  isContainerNightAware,
 }: TextFieldProps) => {
   const textFieldSize = size ?? 'medium';
   const leftPaddingForIcon = textFieldSize === 'medium' ? 'pl-34' : 'pl-36';
@@ -83,7 +85,6 @@ export const TextField = ({
     <Tailwind style={{width: '100%'}}>
       <div
         className={classNames(
-          'night-aware',
           'relative rounded-sm',
           textFieldSize === 'medium' ? 'h-32' : 'h-40',
           'bg-white dark:bg-moon-900',
@@ -93,6 +94,9 @@ export const TextField = ({
           variant === 'ghost' &&
             'outline outline-1 outline-transparent dark:outline-transparent',
           {
+            // must not add "night-aware" class if already in a night-aware
+            // container, otherwise they'll cancel each other out
+            'night-aware': !isContainerNightAware,
             'hover:outline-2 [&:hover:not(:focus-within)]:outline-[#83E4EB] dark:[&:hover:not(:focus-within)]:outline-teal-650':
               !errorState && variant === 'default',
             'focus-within:outline-2 focus-within:outline-teal-400 dark:focus-within:outline-teal-600':


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-22311

If an element has the `night-aware` class, its contents won't receive the default "invert colors" treatment. Instead, dark mode styling should be explicitly defined for all inner contents. However, if you have a night-aware element _inside_ another night-aware element, this messes up the inner element and displays it with light colors instead. I'm actually not sure how this interaction works exactly, I just know that if you remove the `night-aware` class from the inner element, the problem is fixed.

Many of our common comps have `night-aware` class attached by default and have specific dark mode styling defined. This becomes an issue if you every need to use of them inside another night-aware component. For example, if you're working on a feature where the design provided specific dark mode styles so you're building the feature inside a `night-aware` wrapper. Another example is if you have to use a night-aware common comp inside another night-aware common comp (e.g. basically anything inside a Dialog or Tooltip).

The specific issue I have right now is this TextField in the workspaces menu:

<img width="605" alt="Screenshot 2024-12-12 at 9 59 06 AM" src="https://github.com/user-attachments/assets/24172652-ddb9-486a-b99e-94ea20a80cc8" />


The fix I decided on is to add an `isContainerNightAware` prop to `TextField`, which will skip adding the night-aware class if true. IDK if there's a better solution or this is it. Other common comps probably need this too, but I figured I'll just start with this.

## Testing

after setting `isContainerNightAware` to true:

<img width="415" alt="Screenshot 2024-12-12 at 3 35 04 PM" src="https://github.com/user-attachments/assets/f3405331-f23d-49f3-a7ad-f481a36736db" />
