### PR TITLE
chore(tools):  Instructions for cleaning up the repo 

### DIFF
--- a/dev_docs/REPO_CLEANUP.md
+++ b/dev_docs/REPO_CLEANUP.md
@@ -20,13 +20,21 @@ If we start getting north of 200MB, we should likely clean the repo.
 brew install java
 ```
 
-### Clean the repo
+### Clone the repo
 
 Checkout a bare version of the repo with the following command:
 
 ```bash
 git clone --mirror https://github.com/wandb/weave.git weave-cleanup.git
 ```
+
+### Backup the repo
+
+```bash
+git bundle create weave-$(date +%Y-%m-%d).bundle --all
+```
+
+### Clean the repo
 
 The below command will remove all files larger than 500K and delete the files with the following extensions:
 
@@ -41,3 +49,8 @@ git reflog expire --expire=now --all && git gc --prune=now --aggressive
 git count-objects -vH
 ```
 
+### YOLO
+
+```bash
+git push --force --all
+```

--- a/dev_docs/REPO_CLEANUP.md
+++ b/dev_docs/REPO_CLEANUP.md
@@ -1,0 +1,43 @@
+# Repo Cleanup
+
+This document is a guide on cleaning old blobs from the repo if it get's too big.
+
+## Steps
+
+You can see how big the repo is by running the following command:
+
+```bash
+git count-objects -vH
+```
+
+If we start getting north of 200MB, we should likely clean the repo.
+
+### Install BFG Repo-Cleaner
+
+[Download BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) and install java if you don't have it.
+
+```bash
+brew install java
+```
+
+### Clean the repo
+
+Checkout a bare version of the repo with the following command:
+
+```bash
+git clone --mirror https://github.com/wandb/weave.git weave-cleanup.git
+```
+
+The below command will remove all files larger than 500K and delete the files with the following extensions:
+
+```bash
+java -jar bfg.jar --strip-blobs-bigger-than 500K --delete-files "*.{so,pdb,pyx,whl,dat,dylib}" weave-cleanup.git
+```
+
+Then gc the repo and see how much space it saved:
+
+```bash
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+git count-objects -vH
+```
+


### PR DESCRIPTION
## Description

A fresh clone of weave is north of 1GB.  These instructions get it down to 195MB.  Things to consider still:

1. Will this bust anything?
2. This currently get's rid of 20 or so mega yarn.lock files, we ok with that?
3. Should we also setup git-lfs? 

## Testing

How was this PR tested?
