### PR TITLE
docs(weave): Don't use scary warnings if we don't need to

### DIFF
--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -226,7 +226,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
     ### Mapping Column Names with `columnMapping`
     :::important
 
-    In TypeScript, this feature is currently on the `Evaluation` object, not individual scorers!
+    In TypeScript, this feature is currently on the `Evaluation` object, not individual scorers.
 
     :::
 

--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -224,7 +224,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
     ```
 
     ### Mapping Column Names with `columnMapping`
-    :::warning
+    :::important
 
     In TypeScript, this feature is currently on the `Evaluation` object, not individual scorers!
 

--- a/docs/docs/tutorial-eval.md
+++ b/docs/docs/tutorial-eval.md
@@ -17,7 +17,7 @@ Weave automatically captures when they are used and updates the version when the
 
 `Model`s are declared by subclassing `Model` and implementing a `predict` function definition, which takes one example and returns the response.
 
-:::warning
+:::important
 
 **Known Issue**: If you are using Google Colab, remove `async` from the following examples.
 

--- a/docs/docs/tutorial-rag.md
+++ b/docs/docs/tutorial-rag.md
@@ -3,9 +3,9 @@ import TabItem from '@theme/TabItem';
 
 # Tutorial: Model-Based Evaluation of RAG applications
 
-:::warning
+:::important
 
-This tutorial is currently only available for Python!
+This tutorial is currently only available for Python.
 
 :::
 

--- a/docs/docs/tutorial-weave_models.md
+++ b/docs/docs/tutorial-weave_models.md
@@ -12,9 +12,9 @@ In this tutorial you'll learn:
 
 ## Using `weave.Model`
 
-:::warning
+:::important
 
-The `weave.Model` class is currently only supported in Python!
+The `weave.Model` class is currently only supported in Python.
 
 :::
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/DOCS-1107

Replaces `:::warning` callouts with `:::important` where we don't need to scare the reader 👻 
