### PR TITLE
chore(weave): small ui changes

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChoicesDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChoicesDrawer.tsx
@@ -47,6 +47,7 @@ export const ChoicesDrawer = ({
           flexDirection: 'row',
           alignItems: 'center',
           justifyContent: 'space-between',
+          backgroundColor: 'white',
         }}>
         <Box
           sx={{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundSettings/PlaygroundSettings.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundSettings/PlaygroundSettings.tsx
@@ -88,7 +88,7 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
               />
 
               {/* TODO: N times to run is not supported for all models */}
-              {/* TODO: rerun if this is not supported in the backend */}
+              {/* TODO: rerun in backend if this is not supported */}
               <PlaygroundSlider
                 min={1}
                 max={100}
@@ -96,7 +96,7 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                 setValue={value =>
                   setPlaygroundStateField(idx, 'nTimes', value)
                 }
-                label="Completion iterations"
+                label="Number of trials"
                 value={playgroundState.nTimes}
               />
 


### PR DESCRIPTION
## Description

fixes two small ui things

Changes this from Completion iterations -> Number of trials
<img width="364" alt="Screenshot 2024-12-16 at 11 20 26 AM" src="https://github.com/user-attachments/assets/b33db803-5c7c-4e9e-ae52-59c0685a637d" />

adds a background to this
![screenshot_2024-12-16_at_12 48 53___pm_720](https://github.com/user-attachments/assets/13c00673-891a-477a-9430-7cffcbaea0e2)


## Testing

How was this PR tested?
