### PR TITLE
chore(weave): Fix notebook docs: OpenAI and model_output

### DIFF
--- a/docs/intro_notebook.ipynb
+++ b/docs/intro_notebook.ipynb
@@ -11,7 +11,6 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    
     "<!--- @wandbcode{intro-colab} -->"
    ]
   },
@@ -52,6 +51,20 @@
    "source": [
     "%%capture\n",
     "!pip install weave openai set-env-colab-kaggle-dotenv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e188ab8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# Temporary workaround to fix bug in openai:\n",
+    "# TypeError: Client.__init__() got an unexpected keyword argument 'proxies'\n",
+    "# See https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/15\n",
+    "!pip install \"httpx<0.28\""
    ]
   },
   {
@@ -586,9 +599,9 @@
     "\n",
     "# Define any custom scoring function\n",
     "@weave.op()\n",
-    "def exact_match(expected: str, model_output: dict) -> dict:\n",
+    "def exact_match(expected: str, output: dict) -> dict:\n",
     "    # Here is where you'd define the logic to score the model output\n",
-    "    return {\"match\": expected == model_output}\n",
+    "    return {\"match\": expected == output}\n",
     "\n",
     "\n",
     "# Score your examples using scoring functions\n",

--- a/docs/notebooks/audio_with_weave.ipynb
+++ b/docs/notebooks/audio_with_weave.ipynb
@@ -56,6 +56,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# Temporary workaround to fix bug in openai:\n",
+    "# TypeError: Client.__init__() got an unexpected keyword argument 'proxies'\n",
+    "# See https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/15\n",
+    "!pip install \"httpx<0.28\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "aSsInJkXxTUi"

--- a/docs/notebooks/chain_of_density.ipynb
+++ b/docs/notebooks/chain_of_density.ipynb
@@ -10,7 +10,6 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    
     "<!--- @wandbcode{cod-notebook} -->"
    ]
   },
@@ -502,8 +501,8 @@
    "source": [
     "# Define the scorer function\n",
     "@weave.op()\n",
-    "def quality_scorer(instruction: str, model_output: dict) -> dict:\n",
-    "    result = evaluate_summary(model_output[\"final_summary\"], instruction)\n",
+    "def quality_scorer(instruction: str, output: dict) -> dict:\n",
+    "    result = evaluate_summary(output[\"final_summary\"], instruction)\n",
     "    return result"
    ]
   },

--- a/docs/notebooks/codegen.ipynb
+++ b/docs/notebooks/codegen.ipynb
@@ -73,6 +73,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%capture\n",
+    "# Temporary workaround to fix bug in openai:\n",
+    "# TypeError: Client.__init__() got an unexpected keyword argument 'proxies'\n",
+    "# See https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/15\n",
+    "!pip install \"httpx<0.28\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import ast\n",
     "import os\n",
     "import re\n",
@@ -383,8 +396,8 @@
    "outputs": [],
    "source": [
     "@weave.op()\n",
-    "async def score_humaneval_test(test: str, entry_point: str, model_output: str):\n",
-    "    generated_code = model_output\n",
+    "async def score_humaneval_test(test: str, entry_point: str, output: str):\n",
+    "    generated_code = output\n",
     "\n",
     "    # Extract test cases from the test string\n",
     "    test_cases = re.findall(r\"assert.*\", test)\n",

--- a/docs/notebooks/dspy_prompt_optimization.ipynb
+++ b/docs/notebooks/dspy_prompt_optimization.ipynb
@@ -10,7 +10,6 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    
     "<!--- @wandbcode{prompt-optim-notebook} -->"
    ]
   },
@@ -300,8 +299,8 @@
    "outputs": [],
    "source": [
     "@weave.op()\n",
-    "def weave_evaluation_scorer(answer: str, model_output: Output) -> dict:\n",
-    "    return {\"match\": int(answer.lower() == model_output[\"answer\"].lower())}"
+    "def weave_evaluation_scorer(answer: str, output: Output) -> dict:\n",
+    "    return {\"match\": int(answer.lower() == output[\"answer\"].lower())}"
    ]
   },
   {

--- a/docs/notebooks/feedback_prod.ipynb
+++ b/docs/notebooks/feedback_prod.ipynb
@@ -10,7 +10,6 @@
     "---\n",
     "docusaurus_head_meta::end -->\n",
     "\n",
-    
     "<!--- @wandbcode{feedback-colab} -->"
    ]
   },
@@ -47,6 +46,19 @@
    "outputs": [],
    "source": [
     "!pip install weave openai streamlit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# Temporary workaround to fix bug in openai:\n",
+    "# TypeError: Client.__init__() got an unexpected keyword argument 'proxies'\n",
+    "# See https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/15\n",
+    "!pip install \"httpx<0.28\""
    ]
   },
   {

--- a/docs/notebooks/multi-agent-structured-output.ipynb
+++ b/docs/notebooks/multi-agent-structured-output.ipynb
@@ -64,6 +64,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# Temporary workaround to fix bug in openai:\n",
+    "# TypeError: Client.__init__() got an unexpected keyword argument 'proxies'\n",
+    "# See https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/15\n",
+    "!pip install \"httpx<0.28\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "id": "TJdhzuPuK3H2"

--- a/docs/notebooks/notdiamond_custom_routing.ipynb
+++ b/docs/notebooks/notdiamond_custom_routing.ipynb
@@ -251,7 +251,7 @@
    "outputs": [],
    "source": [
     "@weave.op()\n",
-    "def is_correct(score: int, model_output: dict) -> dict:\n",
+    "def is_correct(score: int, output: dict) -> dict:\n",
     "    # We hack score, since we already have model responses\n",
     "    return {\"correct\": score}\n",
     "\n",

--- a/examples/tutorial_scripts/05_eval_pipeline.py
+++ b/examples/tutorial_scripts/05_eval_pipeline.py
@@ -64,8 +64,8 @@ from weave.scorers import MultiTaskBinaryClassificationF1
 
 
 @weave.op()
-def fruit_name_score(target: dict, model_output: dict) -> dict:
-    return {"correct": target["fruit"] == model_output["fruit"]}
+def fruit_name_score(target: dict, output: dict) -> dict:
+    return {"correct": target["fruit"] == output["fruit"]}
 
 
 evaluation = weave.Evaluation(

--- a/examples/tutorial_scripts/06_eval_pipeline_all.py
+++ b/examples/tutorial_scripts/06_eval_pipeline_all.py
@@ -65,8 +65,8 @@ examples = [
 
 # We define a scoring functions to compare our model predictions with a ground truth label.
 @weave.op()
-def fruit_name_score(target: dict, model_output: dict) -> dict:
-    return {"correct": target["fruit"] == model_output["fruit"]}
+def fruit_name_score(target: dict, output: dict) -> dict:
+    return {"correct": target["fruit"] == output["fruit"]}
 
 
 # Finally, we run an evaluation of this model.

--- a/weave_query/examples/prompts/llm_monitoring/openai_proxy_quickstart_enterprise_mode.ipynb
+++ b/weave_query/examples/prompts/llm_monitoring/openai_proxy_quickstart_enterprise_mode.ipynb
@@ -26,6 +26,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "# Temporary workaround to fix bug in openai:\n",
+    "# TypeError: Client.__init__() got an unexpected keyword argument 'proxies'\n",
+    "# See https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/15\n",
+    "!pip install \"httpx<0.28\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
All our colab notebooks fail right now which is pretty ugly. This is because OpenAI has a bug: https://community.openai.com/t/error-with-openai-1-56-0-client-init-got-an-unexpected-keyword-argument-proxies/1040332/15. The fix is to ensure httpx<0.28 since OpenAI uses a now-removed keyword and does not pin that httpx version.

This PR ensures that all our notebooks that install openai correctly install a version of httpx<0.28.

Further, notebooks that use `model_output` for scorers have been refactored to just use `output` so no warnings are shown.