### PR TITLE
chore(ui): Fix React warning in PopupDropdown

### DIFF
--- a/weave-js/src/common/components/PopupDropdown.tsx
+++ b/weave-js/src/common/components/PopupDropdown.tsx
@@ -56,7 +56,11 @@ const PopupDropdownComp: React.FC<PopupDropdownProps> = props => {
     (opts, i: number) => (
       <Dropdown.Item
         key={i}
-        {...opts}
+        // React keys must be passed directly to JSX without using spread.
+        // For backwards compatibility leaving the key prop here as the index though
+        // having opts.key take precedence is probably what was expected.
+        // We should be transitioning away from this semantic-ui based component anyway.
+        {...omit(opts, 'key')}
         onClick={e => {
           opts.onClick?.(e);
           handleClose();


### PR DESCRIPTION
## Description

Fix this warning:
<img width="517" alt="Screenshot 2024-12-17 at 4 36 17 PM" src="https://github.com/user-attachments/assets/68ef085b-f832-43ba-bf04-a9faf043d627" />



## Testing

How was this PR tested?
