### PR TITLE
fix(weave): Prevent sending null message in playground

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
@@ -41,7 +41,6 @@ export const PlaygroundChat = ({
   const {handleRetry, handleSend} = useChatCompletionFunctions(
     setPlaygroundStates,
     setIsLoading,
-    chatText,
     playgroundStates,
     entity,
     project,
@@ -168,7 +167,13 @@ export const PlaygroundChat = ({
                             content: string,
                             toolCallId?: string
                           ) => {
-                            handleSend(role, idx, content, toolCallId);
+                            handleSend(
+                              role,
+                              chatText,
+                              idx,
+                              content,
+                              toolCallId
+                            );
                           },
                           setSelectedChoiceIndex: (choiceIndex: number) =>
                             setPlaygroundStateField(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
@@ -10,7 +10,7 @@ type PlaygroundChatInputProps = {
   chatText: string;
   setChatText: (text: string) => void;
   isLoading: boolean;
-  onSend: (role: PlaygroundMessageRole) => void;
+  onSend: (role: PlaygroundMessageRole, text: string) => void;
   onAdd: (role: PlaygroundMessageRole, text: string) => void;
   settingsTab: number | null;
 };
@@ -43,7 +43,7 @@ export const PlaygroundChatInput: React.FC<PlaygroundChatInputProps> = ({
   };
 
   const handleSend = (role: PlaygroundMessageRole) => {
-    onSend(role);
+    onSend(role, chatText);
     handleReset();
   };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
@@ -10,8 +10,8 @@ type PlaygroundChatInputProps = {
   chatText: string;
   setChatText: (text: string) => void;
   isLoading: boolean;
-  onSend: (role: PlaygroundMessageRole, text: string) => void;
-  onAdd: (role: PlaygroundMessageRole, text: string) => void;
+  onSend: (role: PlaygroundMessageRole, chatText: string) => void;
+  onAdd: (role: PlaygroundMessageRole, chatText: string) => void;
   settingsTab: number | null;
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
@@ -72,6 +72,7 @@ export const useChatCompletionFunctions = (
           return state;
         }
         const updatedState = appendChoiceToMessages(state);
+        // If the new message is not empty, add it to the messages
         if (newMessageContent && updatedState.traceCall?.inputs?.messages) {
           updatedState.traceCall.inputs.messages.push(newMessage);
         }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
@@ -13,7 +13,6 @@ import {clearTraceCall} from './useChatFunctions';
 export const useChatCompletionFunctions = (
   setPlaygroundStates: (states: PlaygroundState[]) => void,
   setIsLoading: (isLoading: boolean) => void,
-  chatText: string,
   playgroundStates: PlaygroundState[],
   entity: string,
   project: string,
@@ -59,19 +58,21 @@ export const useChatCompletionFunctions = (
 
   const handleSend = async (
     role: PlaygroundMessageRole,
+    chatText: string,
     callIndex?: number,
     content?: string,
     toolCallId?: string
   ) => {
     try {
       setIsLoading(true);
-      const newMessage = createMessage(role, content || chatText, toolCallId);
+      const newMessageContent = content || chatText;
+      const newMessage = createMessage(role, newMessageContent, toolCallId);
       const updatedStates = playgroundStates.map((state, index) => {
         if (callIndex !== undefined && callIndex !== index) {
           return state;
         }
         const updatedState = appendChoiceToMessages(state);
-        if (updatedState.traceCall?.inputs?.messages) {
+        if (newMessageContent && updatedState.traceCall?.inputs?.messages) {
           updatedState.traceCall.inputs.messages.push(newMessage);
         }
         return updatedState;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -153,9 +153,7 @@ export const getInputFromPlaygroundState = (state: PlaygroundState) => {
     // eg running the same call in parallel
     key: Math.random() * 1000,
 
-    messages: state.traceCall?.inputs?.messages.filter(
-      (message: any) => message.content
-    ),
+    messages: state.traceCall?.inputs?.messages,
     model: state.model,
     temperature: state.temperature,
     max_tokens: state.maxTokens,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -153,7 +153,9 @@ export const getInputFromPlaygroundState = (state: PlaygroundState) => {
     // eg running the same call in parallel
     key: Math.random() * 1000,
 
-    messages: state.traceCall?.inputs?.messages,
+    messages: state.traceCall?.inputs?.messages.filter(
+      (message: any) => message.content
+    ),
     model: state.model,
     temperature: state.temperature,
     max_tokens: state.maxTokens,


### PR DESCRIPTION
## Description

If in an empty chat box you hit send you get an error in playground 
<img width="1417" alt="Screenshot 2024-12-17 at 3 55 27 PM" src="https://github.com/user-attachments/assets/c868fea1-abc0-4360-8699-020775603271" />

## Testing

How was this PR tested?
