### PR TITLE
chore(weave): add better search function to llm dropdown

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
@@ -20,20 +20,23 @@ export const LLMDropdown: React.FC<LLMDropdownProps> = ({value, onChange}) => {
     label: LLM_PROVIDER_LABELS[provider],
     // filtering to the LLMs that are supported by that provider
     options: Object.keys(LLM_MAX_TOKENS)
-      .reduce<Array<{group: string; label: string; value: string}>>(
-        (acc, llm) => {
-          if (LLM_MAX_TOKENS[llm as LLMMaxTokensKey].provider === provider) {
-            acc.push({
-              group: provider,
-              // add provider to the label if the LLM is not already prefixed with it
-              label: llm.includes(provider) ? llm : provider + '/' + llm,
-              value: llm,
-            });
-          }
-          return acc;
-        },
-        []
-      )
+      .reduce<
+        Array<{
+          provider_label: string;
+          label: string;
+          value: string;
+        }>
+      >((acc, llm) => {
+        if (LLM_MAX_TOKENS[llm as LLMMaxTokensKey].provider === provider) {
+          acc.push({
+            provider_label: LLM_PROVIDER_LABELS[provider],
+            // add provider to the label if the LLM is not already prefixed with it
+            label: llm.includes(provider) ? llm : provider + '/' + llm,
+            value: llm,
+          });
+        }
+        return acc;
+      }, [])
       .sort((a, b) => a.label.localeCompare(b.label)),
   }));
 
@@ -74,6 +77,14 @@ export const LLMDropdown: React.FC<LLMDropdownProps> = ({value, onChange}) => {
         options={options}
         size="medium"
         isSearchable
+        filterOption={(option, inputValue) => {
+          const searchTerm = inputValue.toLowerCase();
+          return (
+            option.data.provider_label.toLowerCase().includes(searchTerm) ||
+            option.data.label.toLowerCase().includes(searchTerm) ||
+            option.data.value.toLowerCase().includes(searchTerm)
+          );
+        }}
       />
     </Box>
   );


### PR DESCRIPTION
## Description
Allows searching for stuff like aws and google, which werent included in the search before

https://github.com/user-attachments/assets/34e97a5e-cc9d-40dc-ae10-f5cd7d7b30bd



## Testing

How was this PR tested?
