### PR TITLE
chore(ui): fix spacing for annotation types in feedback grid

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -147,17 +147,16 @@ export const FeedbackGridInner = ({
       }}
       columnHeaderHeight={40}
       getRowHeight={(params: GridRowHeightParams) => {
-        if (
-          params.model.feedback_type !== 'wandb.reaction.1' &&
-          params.model.feedback_type !== 'wandb.note.1' &&
-          !isHumanAnnotationType(params.model.feedback_type)
-        ) {
-          return 'auto';
+        if (isWandbFeedbackType(params.model.feedback_type)) {
+          return 38;
         }
-        return 38;
+        return 'auto';
       }}
       columns={columns}
       disableRowSelectionOnClick
     />
   );
 };
+
+const isWandbFeedbackType = (feedbackType: string) =>
+  feedbackType.startsWith('wandb.');

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -9,6 +9,7 @@ import {Feedback} from '../pages/wfReactInterface/traceServerClientTypes';
 import {StyledDataGrid} from '../StyledDataGrid';
 import {FeedbackGridActions} from './FeedbackGridActions';
 import {FeedbackTypeChip} from './FeedbackTypeChip';
+import {isHumanAnnotationType} from './StructuredFeedback/humanAnnotationTypes';
 
 type FeedbackGridInnerProps = {
   feedback: Feedback[];
@@ -44,7 +45,10 @@ export const FeedbackGridInner = ({
             <span className="night-aware">{params.row.payload.emoji}</span>
           );
         }
-        if (params.row.feedback_type.startsWith('wandb.annotation.')) {
+        if (isHumanAnnotationType(params.row.feedback_type)) {
+          if (typeof params.row.payload.value === 'string') {
+            return <CellValueString value={params.row.payload.value} />;
+          }
           return (
             <CellValueString
               value={JSON.stringify(params.row.payload.value ?? null)}
@@ -145,7 +149,8 @@ export const FeedbackGridInner = ({
       getRowHeight={(params: GridRowHeightParams) => {
         if (
           params.model.feedback_type !== 'wandb.reaction.1' &&
-          params.model.feedback_type !== 'wandb.note.1'
+          params.model.feedback_type !== 'wandb.note.1' &&
+          !isHumanAnnotationType(params.model.feedback_type)
         ) {
           return 'auto';
         }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/humanAnnotationTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/humanAnnotationTypes.ts
@@ -23,3 +23,6 @@ export type HumanAnnotationPayload = {
 };
 
 export type HumanAnnotation = Feedback & {};
+
+export const isHumanAnnotationType = (feedbackType: string) =>
+  feedbackType.startsWith(HUMAN_ANNOTATION_BASE_TYPE);


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22443](https://wandb.atlassian.net/browse/WB-22443)

- Adds the correct spacing around annotation feedback types
- removes quotes around string annotation values

## Testing

Prod:
<img width="663" alt="Screenshot 2024-12-18 at 2 22 01 PM" src="https://github.com/user-attachments/assets/32796779-f710-408d-82f9-ae7a456d726b" />
<img width="661" alt="Screenshot 2024-12-18 at 2 24 41 PM" src="https://github.com/user-attachments/assets/e92c0922-fa37-44a5-8489-04d26a49dca5" />


Branch:
<img width="678" alt="Screenshot 2024-12-18 at 2 22 32 PM" src="https://github.com/user-attachments/assets/069a215d-9284-4b62-b285-87bd4d55b392" />
<img width="680" alt="Screenshot 2024-12-18 at 2 24 19 PM" src="https://github.com/user-attachments/assets/918cb66f-4af9-4eda-b3ca-c0b73179a8b2" />


[WB-22443]: https://wandb.atlassian.net/browse/WB-22443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ