### PR TITLE
docs(weave): fix small error in EmbeddingSimilarityScorer docs

### DIFF
--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -515,8 +515,9 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
     llm_client = ...  # initialise your LlM client
 
     similarity_scorer = EmbeddingSimilarityScorer(
-        client=llm_client
-        threshold=0.4  # the cosine similarity threshold to use
+        client=llm_client,
+        threshold=0.4,  # the cosine similarity threshold to use
+        column_mapping={'target':'other_col'}
     )
     ```
 

--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -516,14 +516,13 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
 
     similarity_scorer = EmbeddingSimilarityScorer(
         client=llm_client
-        target_column="reference_text",  # the dataset column to compare the output against
         threshold=0.4  # the cosine similarity threshold to use
     )
     ```
 
     **Parameters:**
 
-    - `target`: This scorer expects a `target` column in your dataset, it will calculate the cosine similarity of the embeddings of the `target` column to the AI system output. If your dataset doesn't contain a column called `target` you can use the scorers `column_map` attribute to map `target` to the appropriate column name in your dataset. See the Column Mapping section for more.
+    - This scorer expects a `target` column in your dataset, it will calculate the cosine similarity of the embeddings of the `target` column to the AI system output. If your dataset doesn't contain a column called `target` you can use the scorers `column_map` attribute to map `target` to the appropriate column name in your dataset. See the Column Mapping section for more.
     - `threshold` (float): The minimum cosine similarity score between the embedding of the AI system output and the embdedding of the `target`, above which the 2 samples are considered "similar", (defaults to `0.5`). `threshold` can be in a range from -1 to 1:
     - 1 indicates identical direction.
     - 0 indicates orthogonal vectors.


### PR DESCRIPTION


currently it states that EmbeddingSimilarityScorer uses target_column as an argument to the scorer, which is not valid (and raises an error). i made a quick pr to update the docs to include column_mapping

## Testing

How was this PR tested?
yarn start

