### PR TITLE
chore(ui): Call Use TypeScript indentation

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseCall.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/TabUseCall.tsx
@@ -34,8 +34,8 @@ os.environ["WF_TRACE_SERVER_URL"] = "http://127.0.0.1:6345"
   const codeFeedbackPython = `call.feedback.add("correctness", {"value": 4})`;
 
   const codeFetchJS = `import * as weave from 'weave';
-  const client = await weave.init("${entity}/${project}");
-  const call = await client.getCall("${callId}")`;
+const client = await weave.init("${entity}/${project}");
+const call = await client.getCall("${callId}")`;
   const codeReactionJS = `await call.feedback.addReaction('👍')`;
   const codeNoteJS = `await call.feedback.addNote('This is delightful!')`;
   const codeFeedbackJS = `await call.feedback.add({correctness: {value: 4}})`;


### PR DESCRIPTION
## Description

Remove unintended whitespace prefix in TypeScript call use code example. We might also consider writing a general purpose dedent method for uses like this.

Before:
<img width="563" alt="Screenshot 2024-12-19 at 1 15 24 AM" src="https://github.com/user-attachments/assets/9aca10a1-b1ca-416e-a8cf-8faae3de9699" />

After:
<img width="576" alt="Screenshot 2024-12-19 at 1 14 50 AM" src="https://github.com/user-attachments/assets/0d137bac-300b-4fad-ba17-84b589f6a691" />


## Testing

How was this PR tested?
