### PR TITLE
chore(ui): replace circle icon

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/ecpConstants.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/ecpConstants.ts
@@ -2,7 +2,6 @@ import {MOON_300} from '../../../../../../common/css/color.styles';
 
 export const EVAL_DEF_HEIGHT = 45;
 export const STANDARD_PADDING = 16;
-export const CIRCLE_SIZE = '16px';
 export const BOX_RADIUS = '6px';
 export const STANDARD_BORDER = `1px solid ${MOON_300}`;
 export const PLOT_HEIGHT = 300;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/EvaluationDefinition.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/EvaluationDefinition.tsx
@@ -1,5 +1,4 @@
 import {Box} from '@material-ui/core';
-import {Circle} from '@mui/icons-material';
 import React, {useMemo} from 'react';
 
 import {
@@ -14,7 +13,6 @@ import {SmallRef} from '../../../../../Browse2/SmallRef';
 import {CallLink, ObjectVersionLink} from '../../../common/Links';
 import {useWFHooks} from '../../../wfReactInterface/context';
 import {ObjectVersionKey} from '../../../wfReactInterface/wfDataModelHooksInterface';
-import {CIRCLE_SIZE} from '../../ecpConstants';
 import {EvaluationComparisonState} from '../../ecpState';
 
 export const EvaluationCallLink: React.FC<{
@@ -33,14 +31,7 @@ export const EvaluationCallLink: React.FC<{
       projectName={project}
       opName={evaluationCall.name}
       callId={props.callId}
-      icon={
-        <Circle
-          sx={{
-            color: evaluationCall.color,
-            height: CIRCLE_SIZE,
-          }}
-        />
-      }
+      icon={<Icon name="filled-circle" color={evaluationCall.color} />}
       color={MOON_800}
     />
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
@@ -1,5 +1,5 @@
 import {Box, Tooltip} from '@material-ui/core';
-import {Circle, WarningAmberOutlined} from '@mui/icons-material';
+import {WarningAmberOutlined} from '@mui/icons-material';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 import styled from 'styled-components';
@@ -16,6 +16,7 @@ import {
   WeaveObjectRef,
 } from '../../../../../../../../react';
 import {Button} from '../../../../../../../Button';
+import {Icon} from '../../../../../../../Icon';
 import {CellValue} from '../../../../../Browse2/CellValue';
 import {NotApplicable} from '../../../../../Browse2/NotApplicable';
 import {SmallRef} from '../../../../../Browse2/SmallRef';
@@ -31,7 +32,7 @@ import {
   DERIVED_SCORER_REF_PLACEHOLDER,
   resolvePeerDimension,
 } from '../../compositeMetricsUtil';
-import {CIRCLE_SIZE, SIGNIFICANT_DIGITS} from '../../ecpConstants';
+import {SIGNIFICANT_DIGITS} from '../../ecpConstants';
 import {EvaluationComparisonState} from '../../ecpState';
 import {MetricDefinition, MetricValueType} from '../../ecpTypes';
 import {
@@ -495,14 +496,7 @@ export const ExampleCompareSection: React.FC<{
             projectName={trialProject}
             opName={trialOpName}
             callId={trialCallId}
-            icon={
-              <Circle
-                sx={{
-                  color: evaluationCall.color,
-                  height: CIRCLE_SIZE,
-                }}
-              />
-            }
+            icon={<Icon name="filled-circle" color={evaluationCall.color} />}
             color={MOON_800}
           />
         </Box>


### PR DESCRIPTION
## Description

Continuing quest to only use our own icon library.

Note: our filled circle icon at its default size renders the circle slightly smaller than what we had with Material, going from 13.33x13.33 to 11.67x11.67. But I think this actually looks a bit better with the font size it accompanies.

Before:
<img width="507" alt="Screenshot 2024-12-19 at 1 43 45 AM" src="https://github.com/user-attachments/assets/2760509b-8cf0-4287-b1ce-ecf9c8df0b90" />
<img width="634" alt="Screenshot 2024-12-19 at 1 43 38 AM" src="https://github.com/user-attachments/assets/0cc63d5f-0479-4f3d-8c6e-443dd91827aa" />


After:
<img width="496" alt="Screenshot 2024-12-19 at 1 42 44 AM" src="https://github.com/user-attachments/assets/529ea7a1-3894-46c5-af3f-0b5b71f890b6" />
<img width="662" alt="Screenshot 2024-12-19 at 1 42 58 AM" src="https://github.com/user-attachments/assets/f6d1ef92-b101-40f6-b662-1ee5cf952f0d" />



## Testing

How was this PR tested?
