### PR TITLE
fix(weave_ts): Fix issue where batch processing could crash

### DIFF
--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -132,6 +132,8 @@ describe('WeaveClient', () => {
       };
       const smallData = {mode: 'start', data: {id: '2', payload: 'small'}};
 
+      (client as any).callQueue.push(largeData, smallData);
+
       await (client as any).processBatch();
 
       expect(

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -122,6 +122,10 @@ describe('WeaveClient', () => {
     });
 
     it('should handle oversized batch items', async () => {
+      const mockApiCall = mockTraceServerApi.call
+        .callStartBatchCallUpsertBatchPost as jest.Mock;
+      mockApiCall.mockResolvedValue({});
+
       const largeData = {
         mode: 'start',
         data: {id: '1', payload: 'x'.repeat(11 * 1024 * 1024)},


### PR DESCRIPTION
Fixes an issues where batch processing could crash for batches that are too large.

Now the batches are put back in the queue and retried up until a limit.

Resolves: https://wandb.atlassian.net/browse/WB-22435