### PR TITLE
chore(ui): Simplified object viewer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -133,7 +133,7 @@ export const CallDetails: FC<{
           sx={{
             flex: '0 0 auto',
             maxHeight: `calc(100% - ${HEADER_HEIGHT_BUFFER}px)`,
-            p: 2,
+            padding: '4px 16px',
           }}>
           <CustomWeaveTypeProjectContext.Provider
             value={{entity: call.entity, project: call.project}}>
@@ -146,7 +146,7 @@ export const CallDetails: FC<{
             maxHeight: `calc(100% - ${
               multipleChildCallOpRefs.length > 0 ? HEADER_HEIGHT_BUFFER : 0
             }px)`,
-            p: 2,
+            padding: '4px 16px',
           }}>
           {'traceback' in excInfo ? (
             <div style={{overflow: 'auto', height: '100%'}}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -44,7 +44,7 @@ TitleRow.displayName = 'S.TitleRow';
 const Title = styled.div`
   flex: 1 1 auto;
   font-family: Source Sans Pro;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 600;
   line-height: 32px;
   letter-spacing: 0px;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -22,6 +22,7 @@ import {WeaveCHTable, WeaveCHTableSourceRefContext} from './DataTableView';
 import {ObjectViewer} from './ObjectViewer';
 import {getValueType, traverse} from './traverse';
 import {ValueView} from './ValueView';
+import {Icon} from '../../../../../Icon';
 
 const EXPANDED_IDS_LENGTH = 200;
 
@@ -49,6 +50,13 @@ const Title = styled.div`
   line-height: 32px;
   letter-spacing: 0px;
   text-align: left;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  
+  &:hover {
+    opacity: 0.8;
+  }
 `;
 Title.displayName = 'S.Title';
 
@@ -172,6 +180,14 @@ const ObjectViewerSectionNonEmpty = ({
     }
   };
 
+  const onToggleExpansion = () => {
+    if (mode === 'expanded') {
+      onClickCollapsed();
+    } else {
+      onClickExpanded();
+    }
+  };
+
   // On first render and when data changes, recompute expansion state
   useEffect(() => {
     const isSimple = isSimpleData(data);
@@ -187,21 +203,23 @@ const ObjectViewerSectionNonEmpty = ({
   return (
     <Box sx={{height: '100%', display: 'flex', flexDirection: 'column'}}>
       <TitleRow>
-        <Title>{title}</Title>
+        <Title onClick={() => setMode(mode === 'hidden' ? 'collapsed' : 'hidden')}>
+          <Icon
+            name={mode === 'hidden' ? 'chevron-next' : 'chevron-down'}
+            width={16}
+            height={16}
+            style={{marginRight: '8px'}}
+          />
+          {title}
+        </Title>
         <Button
           variant="quiet"
-          icon="row-height-small"
-          active={mode === 'collapsed'}
-          onClick={onClickCollapsed}
-          tooltip="View collapsed"
-        />
-        <Button
-          variant="quiet"
-          icon="expand-uncollapse"
-          active={mode === 'expanded'}
-          onClick={onClickExpanded}
+          icon={mode === 'expanded' ? 'collapse' : 'expand-uncollapse'}
+          onClick={onToggleExpansion}
           tooltip={
-            isExpandAllSmall
+            mode === 'expanded'
+              ? 'View collapsed'
+              : isExpandAllSmall
               ? 'Expand all'
               : `Expand next ${EXPANDED_IDS_LENGTH} rows`
           }
@@ -213,15 +231,6 @@ const ObjectViewerSectionNonEmpty = ({
           onClick={() => setMode('json')}
           tooltip="View as JSON"
         />
-        {!noHide && (
-          <Button
-            variant="quiet"
-            icon="hide-hidden"
-            active={mode === 'hidden'}
-            onClick={() => setMode('hidden')}
-            tooltip="Hide"
-          />
-        )}
       </TitleRow>
       {body}
     </Box>


### PR DESCRIPTION
## Description
- Simplified object viewer buttons to use one button for collapse / expand.
- Show / hide functionality for clicking the header to hide/show the object viewer.
- Adjusted the sizing of the header for the object viewer.
- Adjusted padding for the object viewer in the calls panel.

## Screenshot [ToDo]