### PR TITLE
fix(app): dropdown separator width fluctuates on zoom out

### DIFF
--- a/weave-js/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/weave-js/src/components/DropdownMenu/DropdownMenu.tsx
@@ -111,7 +111,10 @@ export const Separator = ({
 }: RadixDropdownMenu.DropdownMenuSeparatorProps) => (
   <RadixDropdownMenu.Separator
     className={twMerge(
-      classNames('my-6 h-px bg-moon-250 dark:bg-moon-750', className)
+      classNames(
+        'my-6 border-t border-moon-250 dark:border-moon-750',
+        className
+      )
     )}
     {...props}
   />


### PR DESCRIPTION
## Description

Re: https://weightsandbiases.slack.com/archives/C072533MCA1/p1735677532676429

The separators on our radix dropdown menu are changing height when zooming out, see https://stackoverflow.com/questions/63991447/why-do-elements-with-the-same-height-look-differently-when-zoom-changes that Connie shared. We need to use a border instead of height to avoid this.

Before:


https://github.com/user-attachments/assets/68217a22-84d7-4fbe-947a-918854948d1e

<img width="788" alt="Screenshot 2024-12-31 at 12 31 50 PM" src="https://github.com/user-attachments/assets/1b1ac949-53b3-41bf-997f-b2546c9c0dfb" />



After:


https://github.com/user-attachments/assets/a92d0ebd-1499-4f37-a6dc-565458345870



## Testing

How was this PR tested?
