### PR TITLE
fix(weave): ChatNVIDIA shouldn't depend on openai being installed

### DIFF
--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_quickstart.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-27f078655c474169b58fb0bc6f21965e","object":"chat.completion","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
+      string: '{"id":"chat-2367a743cbef417884cd10acca16fc26","object":"chat.completion","created":1735865751,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
         It''s nice to meet you. Is there something I can help you with or would you
         like to chat?"},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24},"prompt_logprobs":null}'
     headers:
@@ -34,9 +34,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jan 2025 00:44:36 GMT
+      - Fri, 03 Jan 2025 00:55:52 GMT
       Nvcf-Reqid:
-      - d28b75a6-3e6a-4c19-a227-ebf589665701
+      - e2c3a5d0-fc7f-4ff0-b96e-024df34244a4
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_quickstart.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-8bfccc9544b64c70b47605a647b69b8a","object":"chat.completion","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
+      string: '{"id":"chat-27f078655c474169b58fb0bc6f21965e","object":"chat.completion","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
         It''s nice to meet you. Is there something I can help you with or would you
         like to chat?"},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24},"prompt_logprobs":null}'
     headers:
@@ -34,9 +34,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 23 Dec 2024 22:21:45 GMT
+      - Fri, 03 Jan 2025 00:44:36 GMT
       Nvcf-Reqid:
-      - 704f40c5-4d25-46fb-8d76-66364bc9e156
+      - d28b75a6-3e6a-4c19-a227-ebf589665701
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_quickstart.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-2367a743cbef417884cd10acca16fc26","object":"chat.completion","created":1735865751,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
+      string: '{"id":"chat-47f4caab87cf4741abf6b20e7cb7fd7f","object":"chat.completion","created":1735929357,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
         It''s nice to meet you. Is there something I can help you with or would you
         like to chat?"},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24},"prompt_logprobs":null}'
     headers:
@@ -34,9 +34,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jan 2025 00:55:52 GMT
+      - Fri, 03 Jan 2025 18:35:58 GMT
       Nvcf-Reqid:
-      - e2c3a5d0-fc7f-4ff0-b96e-024df34244a4
+      - 83a0a3b7-ea17-401d-8ba4-20559fcb9516
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_stream_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_stream_quickstart.yaml
@@ -20,104 +20,104 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
+      string: 'data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         It"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":15,"completion_tokens":3}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         nice"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":17,"completion_tokens":5}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":18,"completion_tokens":6}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         meet"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":19,"completion_tokens":7}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":20,"completion_tokens":8}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         Is"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":22,"completion_tokens":10}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         there"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":23,"completion_tokens":11}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         something"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":24,"completion_tokens":12}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         I"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":25,"completion_tokens":13}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         can"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":26,"completion_tokens":14}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         help"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":27,"completion_tokens":15}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":28,"completion_tokens":16}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         with"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":29,"completion_tokens":17}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         or"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":30,"completion_tokens":18}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         would"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":31,"completion_tokens":19}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":32,"completion_tokens":20}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         like"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":33,"completion_tokens":21}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":34,"completion_tokens":22}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         chat"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":35,"completion_tokens":23}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
         data: [DONE]
@@ -134,9 +134,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 03 Jan 2025 00:44:37 GMT
+      - Fri, 03 Jan 2025 00:55:53 GMT
       Nvcf-Reqid:
-      - ce19194d-bcf7-4de3-94a8-d0c1a5012643
+      - fd3e3c87-6b04-4672-a73b-fa318969e9e2
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_stream_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_stream_quickstart.yaml
@@ -20,104 +20,104 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
+      string: 'data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         It"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":15,"completion_tokens":3}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         nice"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":17,"completion_tokens":5}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":18,"completion_tokens":6}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         meet"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":19,"completion_tokens":7}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":20,"completion_tokens":8}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         Is"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":22,"completion_tokens":10}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         there"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":23,"completion_tokens":11}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         something"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":24,"completion_tokens":12}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         I"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":25,"completion_tokens":13}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         can"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":26,"completion_tokens":14}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         help"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":27,"completion_tokens":15}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":28,"completion_tokens":16}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         with"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":29,"completion_tokens":17}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         or"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":30,"completion_tokens":18}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         would"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":31,"completion_tokens":19}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":32,"completion_tokens":20}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         like"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":33,"completion_tokens":21}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":34,"completion_tokens":22}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         chat"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":35,"completion_tokens":23}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-2b7381c521b64c34a1d4a4cdccaf32e2","object":"chat.completion.chunk","created":1735865753,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-ebf3fd9b28674719b66b92ebe257b8a8","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
         data: [DONE]
@@ -134,9 +134,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 03 Jan 2025 00:55:53 GMT
+      - Fri, 03 Jan 2025 18:35:58 GMT
       Nvcf-Reqid:
-      - fd3e3c87-6b04-4672-a73b-fa318969e9e2
+      - 63c6afa3-695d-46d0-b00a-367c31300aab
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_stream_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_async_stream_quickstart.yaml
@@ -20,104 +20,104 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
+      string: 'data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         It"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":15,"completion_tokens":3}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         nice"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":17,"completion_tokens":5}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":18,"completion_tokens":6}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         meet"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":19,"completion_tokens":7}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":20,"completion_tokens":8}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         Is"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":22,"completion_tokens":10}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         there"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":23,"completion_tokens":11}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         something"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":24,"completion_tokens":12}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         I"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":25,"completion_tokens":13}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         can"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":26,"completion_tokens":14}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         help"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":27,"completion_tokens":15}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":28,"completion_tokens":16}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         with"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":29,"completion_tokens":17}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         or"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":30,"completion_tokens":18}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         would"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":31,"completion_tokens":19}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":32,"completion_tokens":20}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         like"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":33,"completion_tokens":21}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":34,"completion_tokens":22}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         chat"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":35,"completion_tokens":23}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-dbf248718ebc4c52a1a04269c275c78e","object":"chat.completion.chunk","created":1734992506,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-cbd243c0e03749da94b6f37856f1117d","object":"chat.completion.chunk","created":1735865077,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
         data: [DONE]
@@ -134,9 +134,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Mon, 23 Dec 2024 22:21:46 GMT
+      - Fri, 03 Jan 2025 00:44:37 GMT
       Nvcf-Reqid:
-      - 5d8ef74f-0537-47a5-b0dc-0735d916776f
+      - ce19194d-bcf7-4de3-94a8-d0c1a5012643
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_quickstart.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-55c0d02e9caa471694b571312c012a34","object":"chat.completion","created":1734992504,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
+      string: '{"id":"chat-6aa74156f37143c5b0c5847d7c446449","object":"chat.completion","created":1735865075,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
         It''s nice to meet you. Is there something I can help you with or would you
         like to chat?"},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24},"prompt_logprobs":null}'
     headers:
@@ -34,9 +34,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 23 Dec 2024 22:21:44 GMT
+      - Fri, 03 Jan 2025 00:44:35 GMT
       Nvcf-Reqid:
-      - ea89199e-9f54-4c8d-8895-b1fd9034b86e
+      - f923ec4f-c071-4bef-8353-d9d2f084d7d0
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_quickstart.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-53176f9111814482ad83788b3c17f1b8","object":"chat.completion","created":1735865751,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
+      string: '{"id":"chat-3532f1c8e7184b08af496723ae649ddd","object":"chat.completion","created":1735929357,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
         It''s nice to meet you. Is there something I can help you with or would you
         like to chat?"},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24},"prompt_logprobs":null}'
     headers:
@@ -34,9 +34,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jan 2025 00:55:51 GMT
+      - Fri, 03 Jan 2025 18:35:57 GMT
       Nvcf-Reqid:
-      - b92709a3-8648-4e59-8210-53053d26552a
+      - b0e6ba91-bc54-4ab7-a4ef-2b1a3f66e52b
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_quickstart.yaml
@@ -19,7 +19,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-6aa74156f37143c5b0c5847d7c446449","object":"chat.completion","created":1735865075,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
+      string: '{"id":"chat-53176f9111814482ad83788b3c17f1b8","object":"chat.completion","created":1735865751,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":"Hello!
         It''s nice to meet you. Is there something I can help you with or would you
         like to chat?"},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24},"prompt_logprobs":null}'
     headers:
@@ -34,9 +34,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jan 2025 00:44:35 GMT
+      - Fri, 03 Jan 2025 00:55:51 GMT
       Nvcf-Reqid:
-      - f923ec4f-c071-4bef-8353-d9d2f084d7d0
+      - b92709a3-8648-4e59-8210-53053d26552a
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_stream_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_stream_quickstart.yaml
@@ -20,104 +20,104 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
+      string: 'data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         It"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":15,"completion_tokens":3}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         nice"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":17,"completion_tokens":5}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":18,"completion_tokens":6}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         meet"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":19,"completion_tokens":7}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":20,"completion_tokens":8}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         Is"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":22,"completion_tokens":10}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         there"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":23,"completion_tokens":11}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         something"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":24,"completion_tokens":12}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         I"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":25,"completion_tokens":13}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         can"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":26,"completion_tokens":14}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         help"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":27,"completion_tokens":15}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":28,"completion_tokens":16}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         with"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":29,"completion_tokens":17}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         or"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":30,"completion_tokens":18}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         would"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":31,"completion_tokens":19}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":32,"completion_tokens":20}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         like"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":33,"completion_tokens":21}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":34,"completion_tokens":22}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         chat"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":35,"completion_tokens":23}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
         data: [DONE]
@@ -134,9 +134,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 03 Jan 2025 00:44:36 GMT
+      - Fri, 03 Jan 2025 00:55:52 GMT
       Nvcf-Reqid:
-      - cc59d60a-961e-4dfe-b582-8a0cc81c3ebf
+      - 9409cdfe-b85c-47b8-8e32-d9b52f39d211
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_stream_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_stream_quickstart.yaml
@@ -20,104 +20,104 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
+      string: 'data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         It"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":15,"completion_tokens":3}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         nice"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":17,"completion_tokens":5}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":18,"completion_tokens":6}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         meet"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":19,"completion_tokens":7}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":20,"completion_tokens":8}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         Is"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":22,"completion_tokens":10}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         there"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":23,"completion_tokens":11}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         something"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":24,"completion_tokens":12}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         I"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":25,"completion_tokens":13}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         can"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":26,"completion_tokens":14}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         help"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":27,"completion_tokens":15}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":28,"completion_tokens":16}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         with"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":29,"completion_tokens":17}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         or"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":30,"completion_tokens":18}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         would"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":31,"completion_tokens":19}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":32,"completion_tokens":20}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         like"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":33,"completion_tokens":21}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":34,"completion_tokens":22}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         chat"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":35,"completion_tokens":23}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-595e0ba8ceb643f89b82d8b3e95cdd67","object":"chat.completion.chunk","created":1734992505,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-7121ceef362245b3b01ed13d428d686d","object":"chat.completion.chunk","created":1735865076,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
         data: [DONE]
@@ -134,9 +134,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Mon, 23 Dec 2024 22:21:45 GMT
+      - Fri, 03 Jan 2025 00:44:36 GMT
       Nvcf-Reqid:
-      - ca6cf115-a5f7-447c-95e7-eafced589f5d
+      - cc59d60a-961e-4dfe-b582-8a0cc81c3ebf
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_stream_quickstart.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_stream_quickstart.yaml
@@ -20,104 +20,104 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
+      string: 'data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":12,"completion_tokens":0}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":13,"completion_tokens":1}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"!"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":14,"completion_tokens":2}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         It"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":15,"completion_tokens":3}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"''s"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":16,"completion_tokens":4}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         nice"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":17,"completion_tokens":5}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":18,"completion_tokens":6}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         meet"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":19,"completion_tokens":7}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":20,"completion_tokens":8}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"."},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":21,"completion_tokens":9}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         Is"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":22,"completion_tokens":10}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         there"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":23,"completion_tokens":11}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         something"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":24,"completion_tokens":12}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         I"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":25,"completion_tokens":13}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         can"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":26,"completion_tokens":14}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         help"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":27,"completion_tokens":15}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":28,"completion_tokens":16}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         with"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":29,"completion_tokens":17}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         or"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":30,"completion_tokens":18}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         would"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":31,"completion_tokens":19}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         you"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":32,"completion_tokens":20}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         like"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":33,"completion_tokens":21}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":34,"completion_tokens":22}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"
         chat"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":35,"completion_tokens":23}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":"?"},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":""},"logprobs":null,"finish_reason":"stop","stop_reason":null}],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
-        data: {"id":"chat-9e7cc075cb10407fb1a0f92b0c6476a0","object":"chat.completion.chunk","created":1735865752,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
+        data: {"id":"chat-5e392da91d234788a10970aa0dc478e1","object":"chat.completion.chunk","created":1735929358,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":12,"total_tokens":36,"completion_tokens":24}}
 
 
         data: [DONE]
@@ -134,9 +134,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 03 Jan 2025 00:55:52 GMT
+      - Fri, 03 Jan 2025 18:35:58 GMT
       Nvcf-Reqid:
-      - 9409cdfe-b85c-47b8-8e32-d9b52f39d211
+      - 8ca0c36f-6917-4286-a189-00b543b433b1
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call.yaml
@@ -26,8 +26,8 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-c827eb3e9dad425dbde170c946ff7cf7","object":"chat.completion","created":1734992507,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-3b35163e6a5a4961aa22b93581a0c5b2","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
-        \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 183}"}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30},"prompt_logprobs":null}'
+      string: '{"id":"chat-bd09916dc83a470cb4acde2b6d0800ad","object":"chat.completion","created":1735865078,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-748a01681ada466e97eee93b3693bf64","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+        \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30},"prompt_logprobs":null}'
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -40,9 +40,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 23 Dec 2024 22:21:48 GMT
+      - Fri, 03 Jan 2025 00:44:39 GMT
       Nvcf-Reqid:
-      - 497f5f82-973e-4224-8593-97664a04b39c
+      - 7e3a0138-d31c-44ca-b519-7c45ab908548
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call.yaml
@@ -26,7 +26,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-bd09916dc83a470cb4acde2b6d0800ad","object":"chat.completion","created":1735865078,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-748a01681ada466e97eee93b3693bf64","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+      string: '{"id":"chat-832d36b5c03540a88b7052bae1f0c48e","object":"chat.completion","created":1735865754,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-3b156a22eacc41ff98985c77f57b6c52","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
         \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30},"prompt_logprobs":null}'
     headers:
       Access-Control-Allow-Credentials:
@@ -40,9 +40,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jan 2025 00:44:39 GMT
+      - Fri, 03 Jan 2025 00:55:54 GMT
       Nvcf-Reqid:
-      - 7e3a0138-d31c-44ca-b519-7c45ab908548
+      - ec018b8b-32f6-4a38-9c26-7e5edfb56487
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call.yaml
@@ -26,7 +26,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-832d36b5c03540a88b7052bae1f0c48e","object":"chat.completion","created":1735865754,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-3b156a22eacc41ff98985c77f57b6c52","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+      string: '{"id":"chat-47a53c8ab28845b39a0f27712da52bbd","object":"chat.completion","created":1735929359,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-f6a1750c001246a0a5edeeea8be28e6b","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
         \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30},"prompt_logprobs":null}'
     headers:
       Access-Control-Allow-Credentials:
@@ -40,9 +40,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jan 2025 00:55:54 GMT
+      - Fri, 03 Jan 2025 18:36:00 GMT
       Nvcf-Reqid:
-      - ec018b8b-32f6-4a38-9c26-7e5edfb56487
+      - 3ae2e86b-10f8-4faf-9b8b-483de1b3efd9
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async.yaml
@@ -26,8 +26,8 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-5e1b429e3b704443992df3e6a1f95021","object":"chat.completion","created":1734992509,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-b16ddfa73cb94d9b95d6572615e71589","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
-        \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 183}"}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30},"prompt_logprobs":null}'
+      string: '{"id":"chat-9953e5b635694614a42d8ef5d2ac6de3","object":"chat.completion","created":1735865079,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-f8b702d5d3a647c5ab4e7c7e5c22b095","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+        \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30},"prompt_logprobs":null}'
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -40,9 +40,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 23 Dec 2024 22:21:49 GMT
+      - Fri, 03 Jan 2025 00:44:40 GMT
       Nvcf-Reqid:
-      - 60deff33-b1fe-46d1-abc4-35978ee01613
+      - 08601f82-6baa-401c-8268-1a49ccf33112
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async.yaml
@@ -26,7 +26,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-596fcfd0f8344d60a74eeef8d48132da","object":"chat.completion","created":1735865755,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-e37665319ac249b588c71f6244551f00","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+      string: '{"id":"chat-1710d5df51b9466eb1f57b3e8758a57a","object":"chat.completion","created":1735929361,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-475f88d43b494e2b984e1d3019511bf7","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
         \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30},"prompt_logprobs":null}'
     headers:
       Access-Control-Allow-Credentials:
@@ -40,9 +40,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jan 2025 00:55:55 GMT
+      - Fri, 03 Jan 2025 18:36:01 GMT
       Nvcf-Reqid:
-      - b4a39773-82ff-486f-8813-f6d91fbf26c7
+      - 6175baf3-2617-4501-b6bd-446dc0bc3f89
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async.yaml
@@ -26,7 +26,7 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: '{"id":"chat-9953e5b635694614a42d8ef5d2ac6de3","object":"chat.completion","created":1735865079,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-f8b702d5d3a647c5ab4e7c7e5c22b095","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+      string: '{"id":"chat-596fcfd0f8344d60a74eeef8d48132da","object":"chat.completion","created":1735865755,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"message":{"role":"assistant","content":null,"tool_calls":[{"id":"chatcmpl-tool-e37665319ac249b588c71f6244551f00","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
         \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"}}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30},"prompt_logprobs":null}'
     headers:
       Access-Control-Allow-Credentials:
@@ -40,9 +40,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Jan 2025 00:44:40 GMT
+      - Fri, 03 Jan 2025 00:55:55 GMT
       Nvcf-Reqid:
-      - 08601f82-6baa-401c-8268-1a49ccf33112
+      - b4a39773-82ff-486f-8813-f6d91fbf26c7
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async_stream.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async_stream.yaml
@@ -26,14 +26,14 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-9d2c1fd08f5f416b8d16e848ff6cafe3","object":"chat.completion.chunk","created":1735865757,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
+      string: 'data: {"id":"chat-b3afc3517360412dac604a174b1ed0ce","object":"chat.completion.chunk","created":1735929363,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
 
 
-        data: {"id":"chat-9d2c1fd08f5f416b8d16e848ff6cafe3","object":"chat.completion.chunk","created":1735865757,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-66fceef7c1ea4bb694615e47f392621d","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+        data: {"id":"chat-b3afc3517360412dac604a174b1ed0ce","object":"chat.completion.chunk","created":1735929363,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-110e54e033b14f4da0cc49b633141568","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
         \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"},"index":0}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
-        data: {"id":"chat-9d2c1fd08f5f416b8d16e848ff6cafe3","object":"chat.completion.chunk","created":1735865757,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
+        data: {"id":"chat-b3afc3517360412dac604a174b1ed0ce","object":"chat.completion.chunk","created":1735929363,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
         data: [DONE]
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 03 Jan 2025 00:55:57 GMT
+      - Fri, 03 Jan 2025 18:36:03 GMT
       Nvcf-Reqid:
-      - 2a0a7367-79f9-4daa-bed6-6af3bc2caa97
+      - c302f2c3-bcf2-452b-89e9-ac7cffaa7f60
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async_stream.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async_stream.yaml
@@ -26,14 +26,14 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-43c44c15b2274e9e94fec57c04543f80","object":"chat.completion.chunk","created":1734992511,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
+      string: 'data: {"id":"chat-ecf1fe6421b0481893bf0984c6f7c664","object":"chat.completion.chunk","created":1735865082,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
 
 
-        data: {"id":"chat-43c44c15b2274e9e94fec57c04543f80","object":"chat.completion.chunk","created":1734992511,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-df3daa09595c462297a7253930e4d915","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
-        \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 183}"},"index":0}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
+        data: {"id":"chat-ecf1fe6421b0481893bf0984c6f7c664","object":"chat.completion.chunk","created":1735865082,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-7e24ddb88c2f4e7ebcadd8aa96d334a8","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+        \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"},"index":0}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
-        data: {"id":"chat-43c44c15b2274e9e94fec57c04543f80","object":"chat.completion.chunk","created":1734992511,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
+        data: {"id":"chat-ecf1fe6421b0481893bf0984c6f7c664","object":"chat.completion.chunk","created":1735865082,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
         data: [DONE]
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Mon, 23 Dec 2024 22:21:51 GMT
+      - Fri, 03 Jan 2025 00:44:42 GMT
       Nvcf-Reqid:
-      - 43d997a5-3e0a-485d-9567-e16813f1b183
+      - d1acb6d2-6245-4f68-9974-276d3ab86284
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async_stream.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_async_stream.yaml
@@ -26,14 +26,14 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-ecf1fe6421b0481893bf0984c6f7c664","object":"chat.completion.chunk","created":1735865082,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
+      string: 'data: {"id":"chat-9d2c1fd08f5f416b8d16e848ff6cafe3","object":"chat.completion.chunk","created":1735865757,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
 
 
-        data: {"id":"chat-ecf1fe6421b0481893bf0984c6f7c664","object":"chat.completion.chunk","created":1735865082,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-7e24ddb88c2f4e7ebcadd8aa96d334a8","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+        data: {"id":"chat-9d2c1fd08f5f416b8d16e848ff6cafe3","object":"chat.completion.chunk","created":1735865757,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-66fceef7c1ea4bb694615e47f392621d","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
         \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"},"index":0}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
-        data: {"id":"chat-ecf1fe6421b0481893bf0984c6f7c664","object":"chat.completion.chunk","created":1735865082,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
+        data: {"id":"chat-9d2c1fd08f5f416b8d16e848ff6cafe3","object":"chat.completion.chunk","created":1735865757,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
         data: [DONE]
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 03 Jan 2025 00:44:42 GMT
+      - Fri, 03 Jan 2025 00:55:57 GMT
       Nvcf-Reqid:
-      - d1acb6d2-6245-4f68-9974-276d3ab86284
+      - 2a0a7367-79f9-4daa-bed6-6af3bc2caa97
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_stream.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_stream.yaml
@@ -26,14 +26,14 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-4c0f7aead39b4e8f916c259cf9941b5e","object":"chat.completion.chunk","created":1734992510,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
+      string: 'data: {"id":"chat-3a6d6d221c1a4378a9b7989f215aae52","object":"chat.completion.chunk","created":1735865081,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
 
 
-        data: {"id":"chat-4c0f7aead39b4e8f916c259cf9941b5e","object":"chat.completion.chunk","created":1734992510,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-d0d074128af94984bfc40534381b5860","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
-        \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 183}"},"index":0}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
+        data: {"id":"chat-3a6d6d221c1a4378a9b7989f215aae52","object":"chat.completion.chunk","created":1735865081,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-8b2ad972fee14a65a8274e11aea27023","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+        \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"},"index":0}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
-        data: {"id":"chat-4c0f7aead39b4e8f916c259cf9941b5e","object":"chat.completion.chunk","created":1734992510,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
+        data: {"id":"chat-3a6d6d221c1a4378a9b7989f215aae52","object":"chat.completion.chunk","created":1735865081,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
         data: [DONE]
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Mon, 23 Dec 2024 22:21:50 GMT
+      - Fri, 03 Jan 2025 00:44:41 GMT
       Nvcf-Reqid:
-      - 2746750e-86b1-4959-bd8b-1da038003578
+      - 9d1dc3bd-7f9f-48d3-8375-b7b4f3e17280
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_stream.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_stream.yaml
@@ -26,14 +26,14 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-f105fe99089447dd87c957d5a59b0779","object":"chat.completion.chunk","created":1735865756,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
+      string: 'data: {"id":"chat-5ebfe9e3bc2a47c48a4b9171ae79e9be","object":"chat.completion.chunk","created":1735929362,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
 
 
-        data: {"id":"chat-f105fe99089447dd87c957d5a59b0779","object":"chat.completion.chunk","created":1735865756,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-bb845d42bae94382acd753f31c93acfe","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+        data: {"id":"chat-5ebfe9e3bc2a47c48a4b9171ae79e9be","object":"chat.completion.chunk","created":1735929362,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-1729f8ff1aef46cd97bb293117894dba","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
         \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"},"index":0}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
-        data: {"id":"chat-f105fe99089447dd87c957d5a59b0779","object":"chat.completion.chunk","created":1735865756,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
+        data: {"id":"chat-5ebfe9e3bc2a47c48a4b9171ae79e9be","object":"chat.completion.chunk","created":1735929362,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
         data: [DONE]
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 03 Jan 2025 00:55:56 GMT
+      - Fri, 03 Jan 2025 18:36:02 GMT
       Nvcf-Reqid:
-      - bd97ce3c-1040-4487-a5ec-02d4cf07a2c7
+      - 54484272-cdbc-48a7-99e5-c5a458aa3d60
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_stream.yaml
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/cassettes/langchain_nv_ai_endpoints_test/test_chatnvidia_tool_call_stream.yaml
@@ -26,14 +26,14 @@ interactions:
     uri: https://integrate.api.nvidia.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chat-3a6d6d221c1a4378a9b7989f215aae52","object":"chat.completion.chunk","created":1735865081,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
+      string: 'data: {"id":"chat-f105fe99089447dd87c957d5a59b0779","object":"chat.completion.chunk","created":1735865756,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":318,"completion_tokens":0}}
 
 
-        data: {"id":"chat-3a6d6d221c1a4378a9b7989f215aae52","object":"chat.completion.chunk","created":1735865081,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-8b2ad972fee14a65a8274e11aea27023","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
+        data: {"id":"chat-f105fe99089447dd87c957d5a59b0779","object":"chat.completion.chunk","created":1735865756,"model":"meta/llama-3.1-8b-instruct","choices":[{"index":0,"delta":{"role":null,"content":null,"tool_calls":[{"id":"chatcmpl-tool-bb845d42bae94382acd753f31c93acfe","type":"function","function":{"name":"cricket_player_names","arguments":"{\"name\":
         \"Virat Kohli\", \"team:\": \"India\", \"highest_score\": 254}"},"index":0}]},"logprobs":null,"finish_reason":"tool_calls","stop_reason":null}],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
-        data: {"id":"chat-3a6d6d221c1a4378a9b7989f215aae52","object":"chat.completion.chunk","created":1735865081,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
+        data: {"id":"chat-f105fe99089447dd87c957d5a59b0779","object":"chat.completion.chunk","created":1735865756,"model":"meta/llama-3.1-8b-instruct","choices":[],"usage":{"prompt_tokens":318,"total_tokens":348,"completion_tokens":30}}
 
 
         data: [DONE]
@@ -50,9 +50,9 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 03 Jan 2025 00:44:41 GMT
+      - Fri, 03 Jan 2025 00:55:56 GMT
       Nvcf-Reqid:
-      - 9d1dc3bd-7f9f-48d3-8375-b7b4f3e17280
+      - bd97ce3c-1040-4487-a5ec-02d4cf07a2c7
       Nvcf-Status:
       - fulfilled
       Server:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints_test.py
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints_test.py
@@ -40,7 +40,7 @@ def test_chatnvidia_quickstart(client: weave.trace.weave_client.WeaveClient) -> 
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "chat.completion"
+    assert output["object"] == "ChatNVIDIA._generate"
 
     usage = call.summary["usage"][output["model"]]  # type: ignore
     assert usage["requests"] == 1
@@ -88,7 +88,7 @@ async def test_chatnvidia_async_quickstart(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "chat.completion"
+    assert output["object"] == "ChatNVIDIA._generate"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1
@@ -140,7 +140,7 @@ def test_chatnvidia_stream_quickstart(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "chat.completion"
+    assert output["object"] == "ChatNVIDIA._stream"
 
     print(call.summary["usage"][output["model"]])
     usage = call.summary["usage"][output["model"]]
@@ -192,7 +192,7 @@ async def test_chatnvidia_async_stream_quickstart(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "chat.completion"
+    assert output["object"] == "ChatNVIDIA._stream"
 
     print(call.summary["usage"][output["model"]])
     usage = call.summary["usage"][output["model"]]
@@ -273,7 +273,7 @@ def test_chatnvidia_tool_call(client: weave.trace.weave_client.WeaveClient) -> N
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "chat.completion"
+    assert output["object"] == "ChatNVIDIA._generate"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1
@@ -361,7 +361,7 @@ async def test_chatnvidia_tool_call_async(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "chat.completion"
+    assert output["object"] == "ChatNVIDIA._generate"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1
@@ -453,7 +453,7 @@ def test_chatnvidia_tool_call_stream(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "chat.completion"
+    assert output["object"] == "ChatNVIDIA._stream"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1
@@ -546,7 +546,7 @@ async def test_chatnvidia_tool_call_async_stream(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "chat.completion"
+    assert output["object"] == "ChatNVIDIA._stream"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1

--- a/tests/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints_test.py
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints_test.py
@@ -40,7 +40,6 @@ def test_chatnvidia_quickstart(client: weave.trace.weave_client.WeaveClient) -> 
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "ChatNVIDIA._generate"
 
     usage = call.summary["usage"][output["model"]]  # type: ignore
     assert usage["requests"] == 1
@@ -88,7 +87,6 @@ async def test_chatnvidia_async_quickstart(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "ChatNVIDIA._generate"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1
@@ -140,7 +138,6 @@ def test_chatnvidia_stream_quickstart(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "ChatNVIDIA._stream"
 
     print(call.summary["usage"][output["model"]])
     usage = call.summary["usage"][output["model"]]
@@ -192,7 +189,6 @@ async def test_chatnvidia_async_stream_quickstart(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "ChatNVIDIA._stream"
 
     print(call.summary["usage"][output["model"]])
     usage = call.summary["usage"][output["model"]]
@@ -273,7 +269,6 @@ def test_chatnvidia_tool_call(client: weave.trace.weave_client.WeaveClient) -> N
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "ChatNVIDIA._generate"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1
@@ -361,7 +356,6 @@ async def test_chatnvidia_tool_call_async(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "ChatNVIDIA._generate"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1
@@ -453,7 +447,6 @@ def test_chatnvidia_tool_call_stream(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "ChatNVIDIA._stream"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1
@@ -546,7 +539,6 @@ async def test_chatnvidia_tool_call_async_stream(
 
     output = call.output
     assert output["model"] == model
-    assert output["object"] == "ChatNVIDIA._stream"
 
     usage = call.summary["usage"][output["model"]]
     assert usage["requests"] == 1

--- a/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
+++ b/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
@@ -63,7 +63,6 @@ def postprocess_output_to_openai_format(output: Any) -> dict:
                 }
             ],
             "model": message.get("model_name", ""),
-            "object": "ChatNVIDIA._generate",
             "tool_calls": message.get("tool_calls", []),
             "usage": enhanced_usage,
         }
@@ -101,7 +100,6 @@ def postprocess_output_to_openai_format(output: Any) -> dict:
             "model": getattr(orig_message, "response_metadata", {}).get(
                 "model_name", None
             ),
-            "object": "ChatNVIDIA._stream",
             "tool_calls": openai_message.get("tool_calls", []),
             "usage": enhanced_usage,
         }
@@ -138,7 +136,6 @@ def postprocess_inputs_to_openai_format(
         "max_tokens": chat_nvidia_obj.max_tokens,
         "temperature": chat_nvidia_obj.temperature,
         "top_p": chat_nvidia_obj.top_p,
-        "object": "ChatNVIDIA._stream" if stream else "ChatNVIDIA._generate",
         "n": n,
         "stream": stream,
     }

--- a/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
+++ b/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
@@ -138,11 +138,11 @@ def postprocess_inputs_to_openai_format(
         "max_tokens": chat_nvidia_obj.max_tokens,
         "temperature": chat_nvidia_obj.temperature,
         "top_p": chat_nvidia_obj.top_p,
-        "object": "ChatNVIDIA._generate",
+        "object": "ChatNVIDIA._stream" if stream else "ChatNVIDIA._generate",
         "n": n,
         "stream": stream,
     }
-    
+
     weave_report.update(chat_nvidia_obj.model_dump(exclude_unset=True, exclude_none=True))
 
     return ProcessedInputs(

--- a/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
+++ b/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import time
 from typing import Any, Callable
 
 import_failed = False
@@ -40,8 +39,6 @@ def postprocess_output_to_openai_format(output: Any) -> dict:
     Need to post process the output reported to weave to send it on openai format so that Weave front end renders
     chat view. This only affects what is sent to weave.
     """
-    from openai.types.chat import ChatCompletion
-
     if isinstance(output, ChatResult):  # its ChatResult
         message = output.llm_output
         enhanced_usage = message.get("token_usage", {})
@@ -52,9 +49,8 @@ def postprocess_output_to_openai_format(output: Any) -> dict:
             "prompt_tokens", 0
         )
 
-        returnable = ChatCompletion(
-            id="None",
-            choices=[
+        returnable = {
+            "choices": [
                 {
                     "index": 0,
                     "message": {
@@ -66,15 +62,15 @@ def postprocess_output_to_openai_format(output: Any) -> dict:
                     "finish_reason": message.get("finish_reason", ""),
                 }
             ],
-            created=int(time.time()),
-            model=message.get("model_name", ""),
-            object="chat.completion",
-            tool_calls=message.get("tool_calls", []),
-            system_fingerprint=None,
-            usage=enhanced_usage,
-        )
+            "model": message.get("model_name", ""),
+            "object": "ChatNVIDIA._generate",
+            "tool_calls": message.get("tool_calls", []),
+            "usage": enhanced_usage,
+        }
 
-        return returnable.model_dump(exclude_unset=True, exclude_none=True)
+        returnable.update(output.model_dump(exclude_unset=True, exclude_none=True))
+
+        return returnable
 
     elif isinstance(output, ChatGenerationChunk):  # its ChatGenerationChunk
         orig_message = output.message
@@ -87,9 +83,8 @@ def postprocess_output_to_openai_format(output: Any) -> dict:
             "input_tokens", 0
         )
 
-        returnable = ChatCompletion(
-            id="None",
-            choices=[
+        returnable = {
+            "choices": [
                 {
                     "index": 0,
                     "message": {
@@ -103,17 +98,18 @@ def postprocess_output_to_openai_format(output: Any) -> dict:
                     ),
                 }
             ],
-            created=int(time.time()),
-            model=getattr(orig_message, "response_metadata", {}).get(
+            "model": getattr(orig_message, "response_metadata", {}).get(
                 "model_name", None
             ),
-            tool_calls=openai_message.get("tool_calls", []),
-            object="chat.completion",
-            system_fingerprint=None,
-            usage=enhanced_usage,
-        )
+            "object": "ChatNVIDIA._stream",
+            "tool_calls": openai_message.get("tool_calls", []),
+            "usage": enhanced_usage,
+        }
 
-        return returnable.model_dump(exclude_unset=True, exclude_none=True)
+        returnable.update(output.model_dump(exclude_unset=True, exclude_none=True))
+
+        return returnable
+
     return output
 
 

--- a/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
+++ b/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
@@ -143,7 +143,9 @@ def postprocess_inputs_to_openai_format(
         "stream": stream,
     }
 
-    weave_report.update(chat_nvidia_obj.model_dump(exclude_unset=True, exclude_none=True))
+    weave_report.update(
+        chat_nvidia_obj.model_dump(exclude_unset=True, exclude_none=True)
+    )
 
     return ProcessedInputs(
         original_args=original_args,

--- a/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
+++ b/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
@@ -142,6 +142,8 @@ def postprocess_inputs_to_openai_format(
         "n": n,
         "stream": stream,
     }
+    
+    weave_report.update(chat_nvidia_obj.model_dump(exclude_unset=True, exclude_none=True))
 
     return ProcessedInputs(
         original_args=original_args,


### PR DESCRIPTION
## Description

Previous impl relied on openai being installed for typing. That has been removed.
This also adds original inputs to the input / output reported

## Testing

All tests updated.

<img width="1719" alt="image" src="https://github.com/user-attachments/assets/b732d5a6-0c6b-4993-bb8f-86d811744179" />

