### PR TITLE
chore(weave): Fix typo in vertex wrapper settings

### DIFF
--- a/weave/integrations/vertexai/vertexai_sdk.py
+++ b/weave/integrations/vertexai/vertexai_sdk.py
@@ -114,7 +114,7 @@ def vertexai_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callabl
 
             return _async_wrapper
 
-        op_kwargs = settings.model_copy()
+        op_kwargs = settings.model_dump()
         if not op_kwargs.get("postprocess_inputs"):
             op_kwargs["postprocess_inputs"] = vertexai_postprocess_inputs
 

--- a/weave/integrations/vertexai/vertexai_sdk.py
+++ b/weave/integrations/vertexai/vertexai_sdk.py
@@ -89,7 +89,7 @@ def vertexai_on_finish(
 
 def vertexai_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op_kwargs = settings.model_copy()
+        op_kwargs = settings.model_dump()
         if not op_kwargs.get("postprocess_inputs"):
             op_kwargs["postprocess_inputs"] = vertexai_postprocess_inputs
 


### PR DESCRIPTION
We need to `model_dump` to get back a dict instead of the same object 