### PR TITLE
chore(weave): Fix deploy by unpinning vcr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,11 +102,7 @@ test = [
 
   # Integration Tests
   "pytest-recording>=0.13.2",
-  # "vcrpy>=6.0.1",
-  # https://github.com/kevin1024/vcrpy/pull/889
-  # This resolves test issues until a new pypi release can be made.  Once that release
-  # is made, we can remove this and revert to the vcrpy>=6.0.1 dependency.
-  "vcrpy @ git+https://github.com/kevin1024/vcrpy.git@48d0a2e453f6635af343000cdaf9794a781e807e",
+  "vcrpy>=7.0.0",
 
   # serving tests
   "flask",
@@ -115,7 +111,6 @@ test = [
   "filelock",
   "httpx",
 ]
-
 
 [project.scripts]
 weave = "weave.trace.cli:cli"
@@ -146,9 +141,6 @@ exclude = [
   "dev_docs",
   "weave/clear_cache.py",
 ]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
Unpins VCR from https://github.com/wandb/weave/commit/709e145650b1b357b9ecc863cfa3fad5ac3f9179#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R115 in order to fix deploy