### PR TITLE
chore(weave): allow call.feedback.add() for annotations

### DIFF
--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -510,6 +510,6 @@ def test_annotation_feedback_sdk(client):
     # no wandb.annotation prefix
     with pytest.raises(
         ValueError,
-        match="Feedback type must conform to the format: 'wandb.annotation.<name>'.",
+        match="To add annotation feedback, feedback_type must conform to the format: 'wandb.annotation.<name>'.",
     ):
         calls[0].feedback.add("number_rating", {"value": 3}, annotation_ref=ref.uri())

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -483,7 +483,7 @@ def test_annotation_feedback_sdk(client):
 
     # Add annotation feedback
     calls[0].feedback.add(
-        "wandb.annotation.number_rating",
+        "wandb.annotation.number-spec",
         {"value": 3},
         annotation_ref=ref.uri(),
     )

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -1,6 +1,5 @@
 import pytest
 from pydantic import BaseModel, Field
-from requests import HTTPError
 
 import weave
 from weave.flow.annotation_spec import AnnotationSpec
@@ -505,9 +504,9 @@ def test_annotation_feedback_sdk(client):
         )
 
     # invalid annotation_ref
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         calls[0].feedback.add("number_rating", {"value": 3}, annotation_ref="ssss")
 
     # no wandb.annotation prefix
-    with pytest.raises(HTTPError):
+    with pytest.raises(Exception):
         calls[0].feedback.add("number_rating", {"value": 3}, annotation_ref=ref.uri())

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -459,7 +459,7 @@ def test_annotation_spec_validate_return_value():
     assert not enum_spec.value_is_valid(123)
 
 
-def test_annotation_feedback_sdk():
+def test_annotation_feedback_sdk(client):
     number_spec = AnnotationSpec(
         name="Number Rating",
         field_schema={

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -491,8 +491,8 @@ def test_annotation_feedback_sdk(client):
     # Query the feedback
     feedback = calls[0].feedback.refresh()
     assert len(feedback) == 1
-    assert feedback[0].val["value"] == 3
-    assert feedback[0].val["annotation_ref"] == ref.uri()
+    assert feedback[0].payload["value"] == 3
+    assert feedback[0].annotation_ref == ref.uri()
 
     # no annotation_ref
     with pytest.raises(ValueError):

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -508,5 +508,8 @@ def test_annotation_feedback_sdk(client):
         calls[0].feedback.add("number_rating", {"value": 3}, annotation_ref="ssss")
 
     # no wandb.annotation prefix
-    with pytest.raises(Exception):
+    with pytest.raises(
+        ValueError,
+        match="Feedback type must conform to the format: 'wandb.annotation.<name>'.",
+    ):
         calls[0].feedback.add("number_rating", {"value": 3}, annotation_ref=ref.uri())

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -479,7 +479,7 @@ def test_annotation_feedback_sdk(client):
     do_call()
 
     calls = do_call.calls()
-    assert len(calls) == 2
+    assert len(list(calls)) == 2
 
     # Add annotation feedback
     calls[0].feedback.add(

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -305,3 +305,9 @@ def parse_op_uri(uri: str) -> OpRef:
     if not isinstance(parsed := parse_uri(uri), OpRef):
         raise TypeError(f"URI is not for an Op: {uri}")
     return parsed
+
+
+def parse_object_uri(uri: str) -> ObjectRef:
+    if not isinstance(parsed := parse_uri(uri), ObjectRef):
+        raise TypeError(f"URI is not for an Object: {uri}")
+    return parsed


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22606](https://wandb.atlassian.net/browse/WB-22606)

Add annotation feedback with an annotation spec ref like: 

```python
spec_name = "wandb.annotation.number-spec"
annotation_ref = ref.uri()
payload = {"value": 3}

call.feedback.add(spec_name, payload, annotation_ref=annotation_ref)
```

## Testing

Add test


[WB-22606]: https://wandb.atlassian.net/browse/WB-22606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ