### PR TITLE
chore(weave): Remove dead code paths from `Evaluation.evaluate` by implementing correct typing.

### DIFF
--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -181,6 +181,10 @@ class Evaluation(Object):
         if self.name is None and self.dataset.name is not None:
             self.name = self.dataset.name + "-evaluation"  # type: ignore
 
+    # _post_init_dataset and _post_init_scorers are a more tightly typed property.
+    # This is because the initialization code can accept lists and callables respectively,
+    # but after initialization, they are more tightly typed to the respective weave objects.
+    # Using these reduces casting below and allows us to have less logical branches
     @property
     def _post_init_dataset(self) -> Dataset:
         if not weave_isinstance(self.dataset, Dataset):

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -43,6 +43,9 @@ INVALID_MODEL_ERROR = (
 )
 
 
+PreprocessModelInput = Callable[[dict], dict]
+
+
 def default_evaluation_display_name(call: Call) -> str:
     date = datetime.now().strftime("%Y-%m-%d")
     unique_name = make_memorable_name()
@@ -121,7 +124,7 @@ class Evaluation(Object):
 
     dataset: Union[Dataset, list[dict]]
     scorers: Optional[list[Union[Callable, Op, Scorer]]] = None
-    preprocess_model_input: Optional[Callable] = None
+    preprocess_model_input: Optional[PreprocessModelInput] = None
     trials: int = 1
 
     # Custom evaluation name for display in the UI.  This is the same API as passing a
@@ -516,7 +519,7 @@ def evaluate(
     dataset: Union[Dataset, list],
     model: Union[Op, Model],
     scores: Optional[list[Union[Callable, Scorer]]] = None,
-    preprocess_model_input: Optional[Callable] = None,
+    preprocess_model_input: Optional[PreprocessModelInput] = None,
 ) -> dict:
     eval = Evaluation(
         dataset=dataset, scorers=scores, preprocess_model_input=preprocess_model_input

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -270,7 +270,11 @@ class Evaluation(Object):
         except Exception:
             print("model_output failed")
             traceback.print_exc()
-            model_output = None
+            return {
+                self._output_key: None,
+                "scores": {},
+                "model_latency": time.time() - model_start_time,
+            }
         model_latency = time.time() - model_start_time
 
         scores = {}  # TODO: Consider moving scorer setup and checks out of `predict_and_score`

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -119,7 +119,7 @@ class Evaluation(Object):
     ```
     """
 
-    dataset: Union[Dataset, list]
+    dataset: Union[Dataset, list[dict]]
     scorers: Optional[list[Union[Callable, Op, Scorer]]] = None
     preprocess_model_input: Optional[Callable] = None
     trials: int = 1
@@ -140,7 +140,7 @@ class Evaluation(Object):
         return self
 
     def model_post_init(self, __context: Any) -> None:
-        scorers: list[Union[Callable, Scorer, Op]] = []
+        scorers: list[Union[Op, Scorer]] = []
         for scorer in self.scorers or []:
             if isinstance(scorer, Scorer):
                 pass
@@ -151,7 +151,7 @@ class Evaluation(Object):
             elif callable(scorer) and not is_op(scorer):
                 scorer = weave.op()(scorer)
             elif is_op(scorer):
-                pass
+                scorer = as_op(scorer)
             else:
                 raise ValueError(f"Invalid scorer: {scorer}")
 
@@ -166,7 +166,11 @@ class Evaluation(Object):
                 logger,
                 "Using 'model_output' key for compatibility with older scorers. Please update scorers to use 'output' parameter.",
             )
-        self.scorers = scorers
+
+        # I don't understand why we need a type ignore here, error:
+        # Incompatible types in assignment (expression has type "list[Op | Scorer]", variable has type "list[Callable[..., Any] | Op | Scorer] | None")
+        # This seems to be a bug in the type checker as the assignment is a valid subset of the type.
+        self.scorers = scorers  # type: ignore
 
         if isinstance(self.dataset, list):
             self.dataset = Dataset(rows=self.dataset)
@@ -174,62 +178,66 @@ class Evaluation(Object):
         if self.name is None and self.dataset.name is not None:
             self.name = self.dataset.name + "-evaluation"  # type: ignore
 
+    @property
+    def _post_init_dataset(self) -> Dataset:
+        if not weave_isinstance(self.dataset, Dataset):
+            raise TypeError(
+                "Expected self.dataset to be converted to a Dataset in `model_post_init`. Found "
+                + str(type(self.dataset))
+            )
+        return self.dataset
+
+    @property
+    def _post_init_scorers(self) -> list[Union[Op, Scorer]]:
+        if not isinstance(self.scorers, list):
+            raise TypeError(
+                "Expected self.scorers to be a list in `model_post_init`. Found "
+                + str(type(self.scorers))
+            )
+        for scorer in self.scorers:
+            if not weave_isinstance(scorer, (Op, Scorer)) and not is_op(scorer):
+                raise TypeError(
+                    "Expected all elements in self.scorers to be an instance of Op or Scorer in `model_post_init`. Found "
+                    + str(type(scorer))
+                )
+        return cast(list[Union[Op, Scorer]], self.scorers)
+
     @weave.op()
-    async def predict_and_score(
-        self, model: Union[Callable, Model], example: dict
-    ) -> dict:
+    async def predict_and_score(self, model: Union[Op, Model], example: dict) -> dict:
         if self.preprocess_model_input is None:
             model_input = example
         else:
             model_input = self.preprocess_model_input(example)  # type: ignore
 
         model_self = None
-        model_predict: Union[Callable, Model]
-        if callable(model):
-            model_predict = model
-        else:
+        model_predict_op: Op
+        if is_op(model):
+            model_predict_op = as_op(model)
+        elif weave_isinstance(model, Model):
             model_self = model
-            model_predict = get_infer_method(model)
+            model_predict_op = get_infer_method(model)
+        else:
+            raise ValueError(f"Unknown model type: {model}")
 
-        model_predict_fn_name = (
-            as_op(model_predict).name
-            if is_op(model_predict)
-            else model_predict.__name__
-        )
+        model_predict_fn_name = model_predict_op.name
 
-        predict_signature = inspect.signature(model_predict)
+        predict_signature = inspect.signature(model_predict_op)
         model_predict_arg_names = list(predict_signature.parameters.keys())
 
-        if isinstance(model_input, dict):
-            model_predict_args = {
-                k: v for k, v in model_input.items() if k in model_predict_arg_names
-            }
-        else:
-            if len(model_predict_arg_names) == 1:
-                model_predict_args = {model_predict_arg_names[0]: model_input}
-            else:
-                raise ValueError(
-                    f"{model_predict} expects arguments: {model_predict_arg_names}, provide a preprocess_model_input function that returns a dict with those keys."
-                )
+        model_predict_args = {
+            k: v for k, v in model_input.items() if k in model_predict_arg_names
+        }
         try:
             model_start_time = time.time()
-            model_call = None
-            if is_op(model_predict):
-                # I would expect this path to always be hit, but keeping the other
-                # path for backwards compatibility / safety
-                model_predict = as_op(model_predict)
-                if model_self is not None:
-                    model_predict_args = {
-                        **model_predict_args,
-                        "self": model_self,
-                    }
-                model_output, model_call = await async_call_op(
-                    model_predict, **model_predict_args
-                )
-            else:
-                # I would not expect this path to be hit, but keeping it for
-                # backwards compatibility / safety
-                model_output = await async_call(model_predict, **model_predict_args)
+            model_predict_op = as_op(model_predict_op)
+            if model_self is not None:
+                model_predict_args = {
+                    **model_predict_args,
+                    "self": model_self,
+                }
+            model_output, model_call = await async_call_op(
+                model_predict_op, **model_predict_args
+            )
         except OpCallError as e:
             dataset_column_names = list(example.keys())
             dataset_column_names_str = ", ".join(dataset_column_names[:3])
@@ -252,21 +260,21 @@ class Evaluation(Object):
                 """
             )
             raise OpCallError(message)
-        except Exception as e:
+        except Exception:
             print("model_output failed")
             traceback.print_exc()
             model_output = None
         model_latency = time.time() - model_start_time
 
         scores = {}  # TODO: Consider moving scorer setup and checks out of `predict_and_score`
-        scorers = cast(list[Union[Op, Scorer]], self.scorers or [])
+        scorers = self._post_init_scorers
 
         for scorer in scorers:
             scorer_self = None
             if weave_isinstance(scorer, Scorer):
                 scorer_self = scorer
-            scorer_name, score_fn, _ = get_scorer_attributes(scorer)
-            score_signature = inspect.signature(score_fn)
+            scorer_name, score_op, _ = get_scorer_attributes(scorer)
+            score_signature = inspect.signature(score_op)
             score_arg_names = list(score_signature.parameters.keys())
 
             # the actual kwarg name depends on the scorer
@@ -283,122 +291,102 @@ class Evaluation(Object):
                 )
                 raise OpCallError(message)
 
-            if isinstance(example, dict):
-                # The keys of `score_args` must match the argument names of the scorer's `score` method.
-                # If scorer.column_map is set, then user is indicating that the dataset column(s)
-                # being passed to the scorer have different names to the `score` functions' argument names.
-                # So we need to remap the dataset columns to the expected argument names in the scorer,
-                #
-                # column_map k:v pairs must be structured as `scorer param name : dataset column name`
-                #
-                # For instance, if the scorer expects "input" and "ground_truth" and we have a dataset
-                # with columns "question" and "answer", column_map should be defined as follows:
-                # {"input": "question", "ground_truth": "answer"}
-                #
-                # input: is the full row, we have access to it via example
-                # output: is the model output, we have access to it via model_output
-                score_arg_names = [
-                    param for param in score_arg_names if (param != "self")
-                ]
-                score_args = {}
+            # The keys of `score_args` must match the argument names of the scorer's `score` method.
+            # If scorer.column_map is set, then user is indicating that the dataset column(s)
+            # being passed to the scorer have different names to the `score` functions' argument names.
+            # So we need to remap the dataset columns to the expected argument names in the scorer,
+            #
+            # column_map k:v pairs must be structured as `scorer param name : dataset column name`
+            #
+            # For instance, if the scorer expects "input" and "ground_truth" and we have a dataset
+            # with columns "question" and "answer", column_map should be defined as follows:
+            # {"input": "question", "ground_truth": "answer"}
+            #
+            # input: is the full row, we have access to it via example
+            # output: is the model output, we have access to it via model_output
+            score_arg_names = [param for param in score_arg_names if (param != "self")]
+            score_args = {}
 
-                if isinstance(scorer, Scorer) and scorer.column_map is not None:
-                    # Ensure that all keys in column_map are in score_arg_names
-                    for key in scorer.column_map.keys():
-                        if key not in score_arg_names:
-                            message = textwrap.dedent(
-                                f"""
-                                    You have created `{scorer_name}(column_map={scorer.column_map}, ...)`.
+            if isinstance(scorer, Scorer) and scorer.column_map is not None:
+                # Ensure that all keys in column_map are in score_arg_names
+                for key in scorer.column_map.keys():
+                    if key not in score_arg_names:
+                        message = textwrap.dedent(
+                            f"""
+                                You have created `{scorer_name}(column_map={scorer.column_map}, ...)`.
 
-                                    The `column_map` contains a key, `{key}`, which is not in the `score` methods' argument names.
-                                    `score` methods' argument names: {score_arg_names}
+                                The `column_map` contains a key, `{key}`, which is not in the `score` methods' argument names.
+                                `score` methods' argument names: {score_arg_names}
 
-                                    Hint:
-                                    - Ensure that the keys in `column_map` match the scorer's argument names.
-                                    """
-                            )
-                            raise ValueError(message)
+                                Hint:
+                                - Ensure that the keys in `column_map` match the scorer's argument names.
+                                """
+                        )
+                        raise ValueError(message)
 
-                    for arg in score_arg_names:
-                        if arg == "output" or arg == "model_output":
-                            continue
-                        if arg in example:
-                            score_args[arg] = example[arg]
-                        elif arg in scorer.column_map:
-                            dataset_column_name = scorer.column_map[arg]
-                            if dataset_column_name in example:
-                                score_args[arg] = example[dataset_column_name]
-                            else:
-                                message = textwrap.dedent(
-                                    f"""
-                                        You have created `{scorer_name}(column_map={scorer.column_map}, ...)`.
-
-                                        You are mapping `{arg}` to `{dataset_column_name}`, but `{dataset_column_name}`
-                                        was not found in the dataset columns.
-
-                                        Available dataset columns: {list(example.keys())}
-
-                                        Hint:
-                                        - Ensure that `column_map` maps the `score` methods' argument names to existing dataset column names.
-                                        """
-                                )
-                                raise ValueError(message)
+                for arg in score_arg_names:
+                    if arg == "output" or arg == "model_output":
+                        continue
+                    if arg in example:
+                        score_args[arg] = example[arg]
+                    elif arg in scorer.column_map:
+                        dataset_column_name = scorer.column_map[arg]
+                        if dataset_column_name in example:
+                            score_args[arg] = example[dataset_column_name]
                         else:
                             message = textwrap.dedent(
                                 f"""
                                     You have created `{scorer_name}(column_map={scorer.column_map}, ...)`.
 
-                                    `score` method argument `{arg}` is not found in the dataset columns and is not mapped in `column_map`.
+                                    You are mapping `{arg}` to `{dataset_column_name}`, but `{dataset_column_name}`
+                                    was not found in the dataset columns.
 
                                     Available dataset columns: {list(example.keys())}
-                                    `column_map`: {scorer.column_map}
 
                                     Hint:
-                                    Either:
-                                    - map the argument name to the dataset column using the scorers `column_map` attribute, in the form {{score_arg_name : dataset_column_name}} or
-                                    - rename a column in the dataset to `{arg}` or
-                                    - re-name the `{arg}` argument in your `score` method to match a dataset column name
+                                    - Ensure that `column_map` maps the `score` methods' argument names to existing dataset column names.
                                     """
                             )
                             raise ValueError(message)
-                else:
-                    score_args = {
-                        k: v for k, v in example.items() if k in score_arg_names
-                    }
+                    else:
+                        message = textwrap.dedent(
+                            f"""
+                                You have created `{scorer_name}(column_map={scorer.column_map}, ...)`.
 
+                                `score` method argument `{arg}` is not found in the dataset columns and is not mapped in `column_map`.
+
+                                Available dataset columns: {list(example.keys())}
+                                `column_map`: {scorer.column_map}
+
+                                Hint:
+                                Either:
+                                - map the argument name to the dataset column using the scorers `column_map` attribute, in the form {{score_arg_name : dataset_column_name}} or
+                                - rename a column in the dataset to `{arg}` or
+                                - re-name the `{arg}` argument in your `score` method to match a dataset column name
+                                """
+                        )
+                        raise ValueError(message)
             else:
-                if len(score_arg_names) == 2:
-                    score_args = {score_arg_names[0]: example}
-                else:
-                    raise ValueError(
-                        f"{score_fn} expects arguments: {score_arg_names}, provide a preprocess_model_input function that returns a dict with those keys."
-                    )
+                score_args = {k: v for k, v in example.items() if k in score_arg_names}
+
             score_args[score_output_name] = model_output
 
             try:
-                if is_op(score_fn) and model_call:
-                    # I would expect this path to always be hit, but keeping the other
-                    # path for backwards compatibility / safety
-                    score_fn = as_op(score_fn)
-                    if scorer_self is not None:
-                        score_args = {
-                            **score_args,
-                            "self": scorer_self,
-                        }
-                    result, score_call = await async_call_op(score_fn, **score_args)
-                    wc = get_weave_client()
-                    if wc:
-                        # Very important: if the score is generated from a Scorer subclass,
-                        # then scorer_ref_uri will be None, and we will use the op_name from
-                        # the score_call instead.
-                        scorer_ref = get_ref(scorer_self) if scorer_self else None
-                        scorer_ref_uri = scorer_ref.uri() if scorer_ref else None
-                        wc._send_score_call(model_call, score_call, scorer_ref_uri)
-
-                else:
-                    # I would not expect this path to be hit, but keeping it for
-                    # backwards compatibility / safety
-                    result = await async_call(score_fn, **score_args)
+                score_op = as_op(score_op)
+                if scorer_self is not None:
+                    score_args = {
+                        **score_args,
+                        "self": scorer_self,
+                    }
+                result, score_call = await async_call_op(score_op, **score_args)
+                wc = get_weave_client()
+                if wc:
+                    # Very important: if the score is generated from a Scorer subclass,
+                    # then scorer_ref_uri will be None, and we will use the op_name from
+                    # the score_call instead.
+                    scorer_ref = get_ref(scorer_self) if scorer_self else None
+                    scorer_ref_uri = scorer_ref.uri() if scorer_ref else None
+                    wc._send_score_call(model_call, score_call, scorer_ref_uri)
             except OpCallError as e:
                 dataset_column_names = list(example.keys())
                 dataset_column_names_str = ", ".join(dataset_column_names[:3])
@@ -449,7 +437,7 @@ class Evaluation(Object):
 
         for name, vals in cols.items():
             if name == "scores":
-                scorers = self.scorers or []
+                scorers = self._post_init_scorers
                 for scorer in scorers:
                     scorer_name, _, summarize_fn = get_scorer_attributes(scorer)
                     scorer_stats = transpose(vals)
@@ -462,9 +450,7 @@ class Evaluation(Object):
                     summary[name] = model_output_summary
         return summary
 
-    async def get_eval_results(
-        self, model: Union[Callable, Model]
-    ) -> EvaluationResults:
+    async def get_eval_results(self, model: Union[Op, Model]) -> EvaluationResults:
         if not is_valid_model(model):
             raise ValueError(INVALID_MODEL_ERROR)
         eval_rows = []
@@ -476,7 +462,7 @@ class Evaluation(Object):
                 eval_row = await self.predict_and_score(model, example)
             except OpCallError as e:
                 raise e
-            except Exception as e:
+            except Exception:
                 print("Predict and score failed")
                 traceback.print_exc()
                 return {self._output_key: None, "scores": {}}
@@ -484,7 +470,7 @@ class Evaluation(Object):
 
         n_complete = 0
         # with console.status("Evaluating...") as status:
-        dataset = cast(Dataset, self.dataset)
+        dataset = self._post_init_dataset
         _rows = dataset.rows
         trial_rows = list(_rows) * self.trials
         async for example, eval_row in util.async_foreach(
@@ -499,7 +485,7 @@ class Evaluation(Object):
                 eval_row = {self._output_key: None, "scores": {}}
             else:
                 eval_row["scores"] = eval_row.get("scores", {})
-            for scorer in self.scorers or []:
+            for scorer in self._post_init_scorers:
                 scorer_name, _, _ = get_scorer_attributes(scorer)
                 if scorer_name not in eval_row["scores"]:
                     eval_row["scores"][scorer_name] = {}
@@ -507,7 +493,7 @@ class Evaluation(Object):
         return EvaluationResults(rows=weave.Table(eval_rows))
 
     @weave.op(call_display_name=default_evaluation_display_name)
-    async def evaluate(self, model: Union[Callable, Model]) -> dict:
+    async def evaluate(self, model: Union[Op, Model]) -> dict:
         # The need for this pattern is quite unfortunate and highlights a gap in our
         # data model. As a user, I just want to pass a list of data `eval_rows` to
         # summarize. Under the hood, Weave should choose the appropriate storage
@@ -528,7 +514,7 @@ class Evaluation(Object):
 
 def evaluate(
     dataset: Union[Dataset, list],
-    model: Union[Callable, Model],
+    model: Union[Op, Model],
     scores: Optional[list[Union[Callable, Scorer]]] = None,
     preprocess_model_input: Optional[Callable] = None,
 ) -> dict:

--- a/weave/flow/model.py
+++ b/weave/flow/model.py
@@ -1,7 +1,18 @@
-from typing import Callable
+import inspect
+import textwrap
+import time
+import traceback
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Union
+
+from rich import print
 
 from weave.flow.obj import Object
-from weave.trace.op import Op, is_op
+from weave.trace.errors import OpCallError
+from weave.trace.isinstance import weave_isinstance
+from weave.trace.op import Op, as_op, is_op
+from weave.trace.op_caller import async_call_op
+from weave.trace.weave_client import Call
 
 INFER_METHOD_NAMES = {"predict", "infer", "forward", "invoke"}
 
@@ -56,4 +67,111 @@ def get_infer_method(model: Model) -> Op:
             return infer_method
     raise MissingInferenceMethodError(
         f"Missing a method with name in ({INFER_METHOD_NAMES})"
+    )
+
+
+# Using `dataclass` because pydantic does not like `Call` as a property
+@dataclass
+class ApplyModelSuccess:
+    model_output: Any
+    model_call: Call
+    model_latency: float
+
+
+@dataclass
+class ApplyModelError:
+    model_latency: float
+
+
+ApplyModelResult = Union[ApplyModelSuccess, ApplyModelError]
+PreprocessModelInput = Callable[[dict], dict]
+
+
+async def apply_model_async(
+    model: Union[Op, Model],
+    example: dict,
+    preprocess_model_input: Optional[PreprocessModelInput] = None,
+) -> ApplyModelResult:
+    """Asynchronously applies a model (class or operation) to a given example.
+
+    This function handles the execution of a model against input data with proper type checking
+    and client context management. It supports both class-based models and operation-based models.
+
+    Args:
+        model: The model to apply, can be either a class type or a Weave Operation (Op)
+        example: The input data to process through the model
+        preprocess_model_input: A function that preprocesses the example before passing it to the model
+
+    Returns:
+        Any: The result of applying the model to the example
+
+    Raises:
+        TypeError: If the model is neither a class type nor an Op
+        ValueError: If type checking fails between model input requirements and example
+    """
+    if preprocess_model_input is None:
+        model_input = example
+    else:
+        model_input = preprocess_model_input(example)  # type: ignore
+
+    model_self = None
+    model_predict_op: Op
+    if is_op(model):
+        model_predict_op = as_op(model)
+    elif weave_isinstance(model, Model):
+        model_self = model
+        model_predict_op = get_infer_method(model)
+    else:
+        raise ValueError(f"Unknown model type: {model}")
+
+    model_predict_fn_name = model_predict_op.name
+
+    predict_signature = inspect.signature(model_predict_op)
+    model_predict_arg_names = list(predict_signature.parameters.keys())
+
+    model_predict_args = {
+        k: v for k, v in model_input.items() if k in model_predict_arg_names
+    }
+    try:
+        model_predict_op = as_op(model_predict_op)
+        if model_self is not None:
+            model_predict_args = {
+                **model_predict_args,
+                "self": model_self,
+            }
+        model_start_time = time.time()
+        model_output, model_call = await async_call_op(
+            model_predict_op, **model_predict_args
+        )
+    except OpCallError as e:
+        dataset_column_names = list(example.keys())
+        dataset_column_names_str = ", ".join(dataset_column_names[:3])
+        if len(dataset_column_names) > 3:
+            dataset_column_names_str += ", ..."
+        required_arg_names = [
+            param.name
+            for param in predict_signature.parameters.values()
+            if param.default == inspect.Parameter.empty
+        ]
+
+        message = textwrap.dedent(
+            f"""
+            Call error: {e}
+
+            Options for resolving:
+            a. change {model_predict_fn_name} argument names to match a subset of dataset column names: {dataset_column_names_str}
+            b. change dataset column names to match expected {model_predict_fn_name} argument names: {required_arg_names}
+            c. construct Evaluation with a preprocess_model_input function that accepts a dataset example and returns a dict with keys expected by {model_predict_fn_name}
+            """
+        )
+        raise OpCallError(message)
+    except Exception:
+        print("model_output failed")
+        traceback.print_exc()
+        return ApplyModelError(model_latency=time.time() - model_start_time)
+
+    return ApplyModelSuccess(
+        model_output=model_output,
+        model_call=model_call,
+        model_latency=time.time() - model_start_time,
     )

--- a/weave/flow/model.py
+++ b/weave/flow/model.py
@@ -1,6 +1,7 @@
 from typing import Callable
 
 from weave.flow.obj import Object
+from weave.trace.op import Op, is_op
 
 INFER_METHOD_NAMES = {"predict", "infer", "forward", "invoke"}
 
@@ -45,9 +46,13 @@ class Model(Object):
         )
 
 
-def get_infer_method(model: Model) -> Callable:
+def get_infer_method(model: Model) -> Op:
     for name in INFER_METHOD_NAMES:
         if (infer_method := getattr(model, name, None)) is not None:
+            if not is_op(infer_method):
+                raise ValueError(
+                    f"Model {model} must implement `{name}` as a weave.op() decorated function."
+                )
             return infer_method
     raise MissingInferenceMethodError(
         f"Missing a method with name in ({INFER_METHOD_NAMES})"

--- a/weave/scorers/base_scorer.py
+++ b/weave/scorers/base_scorer.py
@@ -1,6 +1,7 @@
 import inspect
 import textwrap
 from collections.abc import Sequence
+from dataclasses import dataclass
 from numbers import Number
 from typing import Any, Callable, Optional, Union
 
@@ -9,9 +10,11 @@ from pydantic import BaseModel, Field
 
 import weave
 from weave.flow.obj import Object
+from weave.trace.errors import OpCallError
 from weave.trace.isinstance import weave_isinstance
 from weave.trace.op import Op, as_op, is_op
-from weave.trace.weave_client import sanitize_object_name
+from weave.trace.op_caller import async_call_op
+from weave.trace.weave_client import Call, sanitize_object_name
 
 
 class Scorer(Object):
@@ -157,3 +160,194 @@ def _has_oldstyle_scorers(scorers: list[Union[Op, Scorer]]) -> bool:
         if "model_output" in score_signature.parameters:
             return True
     return False
+
+
+# Using `dataclass` because pydantic does not like `Call` as a property
+@dataclass
+class ApplyScorerSuccess:
+    result: Any
+    score_call: Call
+
+
+ApplyScorerResult = ApplyScorerSuccess
+
+
+async def apply_scorer_async(
+    scorer: Union[Op, Scorer], example: dict, model_output: dict
+) -> ApplyScorerResult:
+    """Apply a scoring function to model output and example data asynchronously.
+
+    This function handles the application of a scoring function to evaluate model outputs.
+    It supports both function-based scorers (Op) and class-based scorers (Scorer),
+    managing argument mapping and validation.
+
+    Args:
+        scorer: Either an Op (function) or Scorer (class) that implements scoring logic
+        example: Dictionary containing the input example data with features to score against
+        model_output: Dictionary containing the model's output to be scored
+
+    Returns:
+        ApplyScorerResult: Contains the scoring result and the Call object representing
+            the scoring operation
+
+    Raises:
+        OpCallError: If there are issues with argument mapping or scorer execution
+        ValueError: If the column mapping configuration is invalid
+    """
+    # For class-based scorers, we need to keep track of the instance
+    scorer_self = None
+    if weave_isinstance(scorer, Scorer):
+        scorer_self = scorer
+
+    # Extract the core components of the scorer
+    scorer_name, score_op, _ = get_scorer_attributes(scorer)
+    score_signature = inspect.signature(score_op)
+    score_arg_names = list(score_signature.parameters.keys())
+
+    # Determine which parameter name is used for model output
+    # Scorers must have either 'output' or 'model_output' (deprecated) parameter
+    if "output" in score_arg_names:
+        score_output_name = "output"
+    elif "model_output" in score_arg_names:
+        score_output_name = "model_output"
+    else:
+        message = textwrap.dedent(
+            f"""
+            Scorer {scorer_name} must have an `output` or `model_output` argument, to receive the
+            output of the model function.
+            """
+        )
+        raise OpCallError(message)
+
+    # The keys of `score_args` must match the argument names of the scorer's `score` method.
+    # If scorer.column_map is set, then user is indicating that the dataset column(s)
+    # being passed to the scorer have different names to the `score` functions' argument names.
+    # So we need to remap the dataset columns to the expected argument names in the scorer,
+    #
+    # column_map k:v pairs must be structured as `scorer param name : dataset column name`
+    #
+    # For instance, if the scorer expects "input" and "ground_truth" and we have a dataset
+    # with columns "question" and "answer", column_map should be defined as follows:
+    # {"input": "question", "ground_truth": "answer"}
+    #
+    # input: is the full row, we have access to it via example
+    # output: is the model output, we have access to it via model_output
+    # Remove 'self' from argument names if present (for class-based scorers)
+    score_arg_names = [param for param in score_arg_names if (param != "self")]
+    score_args = {}
+
+    # Handle column mapping if provided
+    # This allows dataset columns to be mapped to scorer argument names
+    if isinstance(scorer, Scorer) and scorer.column_map is not None:
+        # Validate that all mapped columns exist in scorer signature
+        for key in scorer.column_map.keys():
+            if key not in score_arg_names:
+                message = textwrap.dedent(
+                    f"""
+                        You have created `{scorer_name}(column_map={scorer.column_map}, ...)`.
+
+                        The `column_map` contains a key, `{key}`, which is not in the `score` methods' argument names.
+                        `score` methods' argument names: {score_arg_names}
+
+                        Hint:
+                        - Ensure that the keys in `column_map` match the scorer's argument names.
+                        """
+                )
+                raise ValueError(message)
+
+        # Build arguments dictionary using column mapping
+        for arg in score_arg_names:
+            if arg == "output" or arg == "model_output":
+                continue
+            if arg in example:
+                score_args[arg] = example[arg]
+            elif arg in scorer.column_map:
+                dataset_column_name = scorer.column_map[arg]
+                if dataset_column_name in example:
+                    score_args[arg] = example[dataset_column_name]
+                else:
+                    message = textwrap.dedent(
+                        f"""
+                            You have created `{scorer_name}(column_map={scorer.column_map}, ...)`.
+
+                            You are mapping `{arg}` to `{dataset_column_name}`, but `{dataset_column_name}`
+                            was not found in the dataset columns.
+
+                            Available dataset columns: {list(example.keys())}
+
+                            Hint:
+                            - Ensure that `column_map` maps the `score` methods' argument names to existing dataset column names.
+                            """
+                    )
+                    raise ValueError(message)
+            else:
+                message = textwrap.dedent(
+                    f"""
+                        You have created `{scorer_name}(column_map={scorer.column_map}, ...)`.
+
+                        `score` method argument `{arg}` is not found in the dataset columns and is not mapped in `column_map`.
+
+                        Available dataset columns: {list(example.keys())}
+                        `column_map`: {scorer.column_map}
+
+                        Hint:
+                        Either:
+                        - map the argument name to the dataset column using the scorers `column_map` attribute, in the form {{score_arg_name : dataset_column_name}} or
+                        - rename a column in the dataset to `{arg}` or
+                        - re-name the `{arg}` argument in your `score` method to match a dataset column name
+                        """
+                )
+                raise ValueError(message)
+    else:
+        # Without column mapping, directly match scorer arguments to example keys
+        score_args = {k: v for k, v in example.items() if k in score_arg_names}
+
+    # Add the model output to the arguments
+    score_args[score_output_name] = model_output
+
+    try:
+        # Execute the scoring operation
+        score_op = as_op(score_op)
+        if scorer_self is not None:
+            score_args = {
+                **score_args,
+                "self": scorer_self,
+            }
+        result, score_call = await async_call_op(score_op, **score_args)
+    except OpCallError as e:
+        # Provide detailed error message if scoring fails
+        dataset_column_names = list(example.keys())
+        dataset_column_names_str = ", ".join(dataset_column_names[:3])
+        if len(dataset_column_names) > 10:
+            dataset_column_names_str += ", ..."
+        required_arg_names = [
+            param.name
+            for param in score_signature.parameters.values()
+            if param.default == inspect.Parameter.empty
+        ]
+        required_arg_names.remove(score_output_name)
+
+        message = textwrap.dedent(
+            f"""
+            Call error: {e}
+
+                                If using the `Scorer` weave class, you can set the `scorer.column_map`
+            attribute to map scorer argument names to dataset columns.
+
+            For example, if the `score` expects "output", "input" and "ground_truth" and we have a dataset
+            with columns "question" and "answer", `column_map` can be used to map the non-output parameter like so:
+            {{"input": "question", "ground_truth": "answer"}}
+
+            scorer argument names: {score_arg_names}
+            dataset keys: {example.keys()}
+            scorer.column_map: {getattr(scorer, 'column_map', '{}')}
+
+            Options for resolving:
+            a. if using the `Scorer` weave class, you can set the `scorer.column_map` attribute to map scorer argument names to dataset column names or
+            b. change the argument names the in the scoring function of {scorer_name} to match a subset of dataset column names: ({dataset_column_names_str}) or
+            c. change dataset column names to match expected {scorer_name} argument names: {required_arg_names}
+            """
+        )
+        raise OpCallError(message)
+
+    return ApplyScorerSuccess(result=result, score_call=score_call)

--- a/weave/trace/isinstance.py
+++ b/weave/trace/isinstance.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, TypeVar
 
 from typing_extensions import TypeGuard

--- a/weave/trace/isinstance.py
+++ b/weave/trace/isinstance.py
@@ -8,7 +8,9 @@ from weave.trace.vals import WeaveObject
 C = TypeVar("C")
 
 
-def weave_isinstance(obj: Any, cls: type[C]) -> TypeGuard[C]:
+def weave_isinstance(obj: Any, cls: type[C] | tuple[type[C], ...]) -> TypeGuard[C]:
+    if isinstance(cls, tuple):
+        return any(weave_isinstance(obj, c) for c in cls)
     if isinstance(obj, cls):  # type: ignore
         return True
     if isinstance(obj, ObjectRecord):

--- a/weave/trace/op_caller.py
+++ b/weave/trace/op_caller.py
@@ -1,0 +1,50 @@
+import asyncio
+import inspect
+from collections.abc import Coroutine
+from typing import Any, Callable, Union
+
+from weave.trace.op import Op, as_op, is_op
+from weave.trace.weave_client import Call
+
+
+def async_call(func: Union[Callable, Op], *args: Any, **kwargs: Any) -> Coroutine:
+    """For async functions, calls them directly. For sync functions, runs them in a thread.
+    This provides a common async interface for both sync and async functions.
+
+    Args:
+        func: The callable or Op to wrap
+        *args: Positional arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function
+
+    Returns:
+        A coroutine that will execute the function
+    """
+    is_async = False
+    if is_op(func):
+        func = as_op(func)
+        is_async = inspect.iscoroutinefunction(func.resolve_fn)
+    else:
+        is_async = inspect.iscoroutinefunction(func)
+    if is_async:
+        return func(*args, **kwargs)  # type: ignore
+    return asyncio.to_thread(func, *args, **kwargs)
+
+
+def async_call_op(
+    func: Op, *args: Any, **kwargs: Any
+) -> Coroutine[Any, Any, tuple[Any, "Call"]]:
+    """Similar to async_call but specifically for Ops, handling the Weave tracing
+    functionality. For sync Ops, runs them in a thread.
+
+    Args:
+        func: The Op to wrap
+        *args: Positional arguments to pass to the Op
+        **kwargs: Keyword arguments to pass to the Op
+
+    Returns:
+        A coroutine that will execute the Op and return a tuple of (result, Call)
+    """
+    call_res = func.call(*args, __should_raise=True, **kwargs)
+    if inspect.iscoroutine(call_res):
+        return call_res
+    return asyncio.to_thread(lambda: call_res)


### PR DESCRIPTION
This is a pure refactor PR and should not change user experience. I am working on a larger refactor of this part of the code base but wanted to extract this portion as an incremental change. Specifically:
1. More strictly defines the dataset list to be a list of dicts (already enforced in application logic) allowing 2 branches to be removed.
2. Expose `_post_init_dataset` and `_post_init_scorers` properties in order to have more tightly defined symbols during execution.
3. Remove unreachable code due to the above.

_Note: Recommend hiding whitespace when reviewing due to indentation changes_


Now includes changes from https://github.com/wandb/weave/pull/3328