### PR TITLE
chore(weave): Fixes dedicates instance connection issues with traces API

### DIFF
--- a/sdks/node/src/urls.ts
+++ b/sdks/node/src/urls.ts
@@ -9,7 +9,7 @@ export function getUrls(host?: string) {
     baseUrl: isDefault ? `https://api.wandb.ai` : `https://${resolvedHost}`,
     traceBaseUrl: isDefault
       ? `https://trace.wandb.ai`
-      : `https://${resolvedHost}`,
+      : `https://${resolvedHost}/traces`,
     domain: isDefault ? defaultDomain : resolvedHost,
     host: isDefault ? defaultHost : resolvedHost,
   };


### PR DESCRIPTION
## Description

The URL generation logic correctly handles default `https://api.wandb.ai` url by changing trace url to `https://trace.wandb.ai`, but for non default hosts it fails to define traces url correctly (just uses `https://${resolvedHost}`).

Fix is to append `/traces` to the url for non default hosts.