### PR TITLE
chore(weave): add annotation spec name to feedback grid

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGrid.tsx
@@ -43,6 +43,9 @@ export const FeedbackGrid = ({
     return getTsClient().registerOnFeedbackListener(weaveRef, query.refetch);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+  const hasAnnotationFeedback = query.result?.some(f =>
+    f.feedback_type.startsWith(ANNOTATION_PREFIX)
+  );
 
   // Group by feedback on this object vs. descendent objects
   const grouped = useMemo(() => {
@@ -127,6 +130,7 @@ export const FeedbackGrid = ({
             <FeedbackGridInner
               feedback={grouped[path]}
               currentViewerId={currentViewerId}
+              showAnnotationName={hasAnnotationFeedback}
             />
           </div>
         );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -21,7 +21,7 @@ import {
 type FeedbackGridInnerProps = {
   feedback: Feedback[];
   currentViewerId: string | null;
-  showAnnotationName: boolean | undefined;
+  showAnnotationName?: boolean;
 };
 
 export const FeedbackGridInner = ({

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -89,8 +89,8 @@ export const FeedbackGridInner = ({
     {
       field: 'created_at',
       headerName: 'Timestamp',
-      minWidth: 120,
-      width: 120,
+      minWidth: 105,
+      width: 105,
       renderCell: params => (
         <Timestamp value={params.row.created_at} format="relative" />
       ),
@@ -98,7 +98,8 @@ export const FeedbackGridInner = ({
     {
       field: 'id',
       headerName: 'ID',
-      width: 50,
+      width: 48,
+      minWidth: 48,
       display: 'flex',
       renderCell: params => <CopyableId id={params.row.id} type="Feedback" />,
     },
@@ -126,7 +127,8 @@ export const FeedbackGridInner = ({
     {
       field: 'actions',
       headerName: '',
-      width: 50,
+      width: 36,
+      minWidth: 36,
       filterable: false,
       sortable: false,
       resizable: false,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/FeedbackGridInner.tsx
@@ -1,4 +1,8 @@
-import {GridColDef, GridRowHeightParams} from '@mui/x-data-grid-pro';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridRowHeightParams,
+} from '@mui/x-data-grid-pro';
 import React from 'react';
 
 import {Timestamp} from '../../../../Timestamp';
@@ -9,16 +13,21 @@ import {Feedback} from '../pages/wfReactInterface/traceServerClientTypes';
 import {StyledDataGrid} from '../StyledDataGrid';
 import {FeedbackGridActions} from './FeedbackGridActions';
 import {FeedbackTypeChip} from './FeedbackTypeChip';
-import {isHumanAnnotationType} from './StructuredFeedback/humanAnnotationTypes';
+import {
+  getHumanAnnotationNameFromFeedbackType,
+  isHumanAnnotationType,
+} from './StructuredFeedback/humanAnnotationTypes';
 
 type FeedbackGridInnerProps = {
   feedback: Feedback[];
   currentViewerId: string | null;
+  showAnnotationName: boolean | undefined;
 };
 
 export const FeedbackGridInner = ({
   feedback,
   currentViewerId,
+  showAnnotationName,
 }: FeedbackGridInnerProps) => {
   const columns: GridColDef[] = [
     {
@@ -31,6 +40,25 @@ export const FeedbackGridInner = ({
         </div>
       ),
     },
+    ...(showAnnotationName
+      ? [
+          {
+            field: 'annotation_name',
+            headerName: 'Name',
+            flex: 1,
+            renderCell: (params: GridRenderCellParams) => {
+              const feedbackType = params.row.feedback_type;
+              const annotationName = isHumanAnnotationType(feedbackType)
+                ? getHumanAnnotationNameFromFeedbackType(feedbackType)
+                : null;
+              if (!annotationName) {
+                return null;
+              }
+              return <CellValueString value={annotationName} />;
+            },
+          },
+        ]
+      : []),
     {
       field: 'payload',
       headerName: 'Feedback',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/humanAnnotationTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/StructuredFeedback/humanAnnotationTypes.ts
@@ -26,3 +26,6 @@ export type HumanAnnotation = Feedback & {};
 
 export const isHumanAnnotationType = (feedbackType: string) =>
   feedbackType.startsWith(HUMAN_ANNOTATION_BASE_TYPE);
+
+export const getHumanAnnotationNameFromFeedbackType = (feedbackType: string) =>
+  feedbackType.split('.').pop();


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22624](https://wandb.atlassian.net/browse/WB-22624)

Add an annotation type name to the feedback table when there are annotation types in the table. Also tidy up a bit of spacing to squeeze out more real estate.

## Testing

Prod:
<img width="631" alt="Screenshot 2025-01-06 at 3 36 01 PM" src="https://github.com/user-attachments/assets/df5ef8ec-5b74-470d-9146-f4e44f953c76" />


Branch:
<img width="643" alt="Screenshot 2025-01-06 at 3 36 07 PM" src="https://github.com/user-attachments/assets/a3c9000e-2f1b-4934-89fe-9a93a668d959" />


[WB-22624]: https://wandb.atlassian.net/browse/WB-22624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ