### PR TITLE
chore(weave): make annotation values in the traces table clickable

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -373,7 +373,10 @@ function buildCallsTableColumns(
             if (typeof params.value === 'boolean') {
               return <div>{params.value ? 'true' : 'false'}</div>;
             }
-            return <CellValueString value={params.value} />;
+            if (typeof params.value === 'string') {
+              return <CellValueString value={params.value} />;
+            }
+            return <div>{params.value}</div>;
           },
         };
       });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -18,6 +18,7 @@ import {monthRoundedTime} from '../../../../../../common/util/time';
 import {isWeaveObjectRef, parseRef} from '../../../../../../react';
 import {makeRefCall} from '../../../../../../util/refs';
 import {Timestamp} from '../../../../../Timestamp';
+import {CellValueString} from '../../../Browse2/CellValueString';
 import {
   convertFeedbackFieldToBackendFilter,
   parseFeedbackType,
@@ -372,7 +373,7 @@ function buildCallsTableColumns(
             if (typeof params.value === 'boolean') {
               return <div>{params.value ? 'true' : 'false'}</div>;
             }
-            return <div>{params.value}</div>;
+            return <CellValueString value={params.value} />;
           },
         };
       });


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22621](https://wandb.atlassian.net/browse/WB-22621)

Make the calls table annotation values clickable 

## Testing

<img width="679" alt="Screenshot 2025-01-06 at 3 29 58 PM" src="https://github.com/user-attachments/assets/5f24a453-010c-4eb0-83a8-292b4a5e481f" />



[WB-22621]: https://wandb.atlassian.net/browse/WB-22621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ