### PR TITLE
chore(weave): refs read batch handles deleted objs silently

### DIFF
--- a/tests/trace/test_obj_delete.py
+++ b/tests/trace/test_obj_delete.py
@@ -193,14 +193,15 @@ def test_read_deleted_object(client: WeaveClient):
             )
         )
 
-    with pytest.raises(weave.trace_server.errors.NotFoundError):
-        client.server.refs_read_batch(
-            tsi.RefsReadBatchReq(
-                project_id=client._project_id(),
-                object_ids=["obj_1"],
-                refs=[obj1_v2.uri()],
-            )
+    ref_res = client.server.refs_read_batch(
+        tsi.RefsReadBatchReq(
+            project_id=client._project_id(),
+            object_ids=["obj_1"],
+            refs=[obj1_v2.uri()],
         )
+    )
+    assert len(ref_res.vals) == 1
+    assert ref_res.vals[0] is None
 
 
 def test_op_versions(client: WeaveClient):

--- a/tests/trace/test_obj_delete.py
+++ b/tests/trace/test_obj_delete.py
@@ -250,11 +250,12 @@ def test_read_deleted_op(client: WeaveClient):
             )
         )
 
-    with pytest.raises(weave.trace_server.errors.NotFoundError):
-        client.server.refs_read_batch(
-            tsi.RefsReadBatchReq(
-                project_id=client._project_id(),
-                object_ids=["my_op"],
-                refs=[op_ref.uri()],
-            )
+    ref_res = client.server.refs_read_batch(
+        tsi.RefsReadBatchReq(
+            project_id=client._project_id(),
+            object_ids=["my_op"],
+            refs=[op_ref.uri()],
         )
+    )
+    assert len(ref_res.vals) == 1
+    assert ref_res.vals[0] is None

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1040,6 +1040,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     conditions=conditions,
                     object_id_conditions=object_id_conditions,
                     parameters=parameters,
+                    include_deleted=True,
                 )
                 objs = self._select_objs_query(object_query_builder)
                 found_digests = {obj.digest for obj in objs}
@@ -1047,7 +1048,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     raise NotFoundError(
                         f"Ref read contains {len(ref_digests)} digests, but found {len(found_digests)} objects. Diff digests: {ref_digests - found_digests}"
                     )
-                for obj in objs:
+                # filter out deleted objects
+                valid_objects = [obj for obj in objs if obj.deleted_at is None]
+                for obj in valid_objects:
                     root_val_cache[make_obj_cache_key(obj)] = json.loads(obj.val_dump)
 
             return [

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1040,10 +1040,13 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             objs = self._select_objs_query(
                 r.project_id,
                 conditions=conds,
+                include_deleted=True,
             )
             if len(objs) == 0:
                 raise NotFoundError(f"Obj {r.name}:{r.version} not found")
             obj = objs[0]
+            if obj.deleted_at is not None:
+                return None
             val = obj.val
             extra = r.extra
             for extra_index in range(0, len(extra), 2):


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Refs read batch is a bulk read action, I think we should resolve as many refs as we can, instead of erroring. 

Now, we return `null` for any refs that are deleted. For any given ref if we don't find anything (even a deleted object), we still raise an exception. 

Example:

```python
v0 = weave.publish({"i": 1}, name="obj_1")
v1 = weave.publish({"i": 2}, name="obj_1")
v2 = weave.publish({"i": 3}, name="obj_1")

v1.delete()

ref_res = client.server.refs_read_batch(
    tsi.RefsReadBatchReq(
        project_id=client._project_id(),
        object_ids=["obj_1"],
        refs=[v0.uri(), v1.uri(), v2.uri()],
    )
)

assert refs_res == [v0.digest, null, v2.digest]
```

## Testing

Changed tests to satisfy new paradigm. 
