### PR TITLE
feat(weave): Add global post-processing options

### DIFF
--- a/tests/trace/test_postprocessing.py
+++ b/tests/trace/test_postprocessing.py
@@ -1,0 +1,44 @@
+import weave
+from weave.trace import api
+
+
+def redact_keys(d: dict) -> dict:
+    print(f"Start redacting keys {d=}")
+    for k in d:
+        print(f"Looking at key {k=}")
+        if "key" in k.lower():
+            print(f"Redacting key {k=}")
+            d[k] = "REDACTED"
+    print(f"Finished redacting keys {d=}")
+    return d
+
+
+def redact_output(s: str) -> str:
+    if "key" in s.lower():
+        return "API KEY DETECTED IN STRING; REDACTED."
+    return s
+
+
+api._global_postprocess_inputs = redact_keys
+api._global_postprocess_output = redact_output
+
+
+def test_global_postprocessing(client) -> None:
+    @weave.op
+    def func(api_key: str, secret_key: str, name: str, age: int) -> str:
+        return (
+            f"Hello, {name}! You are {age} years old.  Also your api_key is {api_key}."
+        )
+
+    res = func(api_key="123", secret_key="456", name="John", age=30)
+
+    calls = list(client.get_calls())
+    call = calls[0]
+
+    assert call.inputs == {
+        "api_key": "REDACTED",
+        "secret_key": "REDACTED",
+        "name": "John",
+        "age": 30,
+    }
+    assert call.output == "API KEY DETECTED IN STRING; REDACTED."

--- a/tests/trace/test_postprocessing.py
+++ b/tests/trace/test_postprocessing.py
@@ -3,13 +3,9 @@ from weave.trace import api
 
 
 def redact_keys(d: dict) -> dict:
-    print(f"Start redacting keys {d=}")
     for k in d:
-        print(f"Looking at key {k=}")
         if "key" in k.lower():
-            print(f"Redacting key {k=}")
             d[k] = "REDACTED"
-    print(f"Finished redacting keys {d=}")
     return d
 
 

--- a/tests/trace/test_postprocessing.py
+++ b/tests/trace/test_postprocessing.py
@@ -19,6 +19,7 @@ def redact_output(s: str) -> str:
     return s
 
 
+# These globals are directly set here because we don't have a great way to test weave.init
 api._global_postprocess_inputs = redact_keys
 api._global_postprocess_output = redact_output
 

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -7,7 +7,7 @@ import os
 import threading
 import time
 from collections.abc import Iterator
-from typing import Any, Callable
+from typing import Any
 
 # TODO: type_handlers is imported here to trigger registration of the image serializer.
 # There is probably a better place for this, but including here for now to get the fix in.
@@ -18,7 +18,7 @@ from weave.trace.constants import TRACE_OBJECT_EMOJI
 from weave.trace.context import call_context
 from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace.context.call_context import get_current_call, require_current_call
-from weave.trace.op import as_op, op
+from weave.trace.op import PostprocessInputsFunc, PostprocessOutputFunc, as_op, op
 from weave.trace.refs import ObjectRef, parse_uri
 from weave.trace.settings import (
     UserSettings,
@@ -28,8 +28,8 @@ from weave.trace.settings import (
 from weave.trace.table import Table
 from weave.trace_server.interface.builtin_object_classes import leaderboard
 
-_global_postprocess_inputs: Callable[[Any], Any] | None = None
-_global_postprocess_output: Callable[[Any], Any] | None = None
+_global_postprocess_inputs: PostprocessInputsFunc | None = None
+_global_postprocess_output: PostprocessOutputFunc | None = None
 
 
 def init(
@@ -37,8 +37,8 @@ def init(
     *,
     settings: UserSettings | dict[str, Any] | None = None,
     autopatch_settings: AutopatchSettings | None = None,
-    global_postprocess_inputs: Callable[[Any], Any] | None = None,
-    global_postprocess_output: Callable[[Any], Any] | None = None,
+    global_postprocess_inputs: PostprocessInputsFunc | None = None,
+    global_postprocess_output: PostprocessOutputFunc | None = None,
 ) -> weave_client.WeaveClient:
     """Initialize weave tracking, logging to a wandb project.
 

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -50,6 +50,15 @@ def init(
 
     Args:
         project_name: The name of the Weights & Biases project to log to.
+        settings: Configuration for the Weave client generally.
+        autopatch_settings: Configuration for autopatch integrations, e.g. openai
+        global_postprocess_inputs: A function that will be applied to all inputs of all ops.
+        global_postprocess_output: A function that will be applied to all outputs of all ops.
+
+    NOTE: Global postprocessing settings are applied to all ops after each op's own
+    postprocessing.  The order is always:
+    1. Op-specific postprocessing
+    2. Global postprocessing
 
     Returns:
         A Weave client.

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -7,7 +7,7 @@ import os
 import threading
 import time
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, Callable
 
 # TODO: type_handlers is imported here to trigger registration of the image serializer.
 # There is probably a better place for this, but including here for now to get the fix in.
@@ -28,12 +28,17 @@ from weave.trace.settings import (
 from weave.trace.table import Table
 from weave.trace_server.interface.builtin_object_classes import leaderboard
 
+_global_postprocess_inputs: Callable[[Any], Any] | None = None
+_global_postprocess_output: Callable[[Any], Any] | None = None
+
 
 def init(
     project_name: str,
     *,
     settings: UserSettings | dict[str, Any] | None = None,
     autopatch_settings: AutopatchSettings | None = None,
+    global_postprocess_inputs: Callable[[Any], Any] | None = None,
+    global_postprocess_output: Callable[[Any], Any] | None = None,
 ) -> weave_client.WeaveClient:
     """Initialize weave tracking, logging to a wandb project.
 
@@ -50,6 +55,12 @@ def init(
         A Weave client.
     """
     parse_and_apply_settings(settings)
+
+    global _global_postprocess_inputs
+    global _global_postprocess_output
+
+    _global_postprocess_inputs = global_postprocess_inputs
+    _global_postprocess_output = global_postprocess_output
 
     if should_disable_weave():
         return weave_init.init_weave_disabled().client

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -755,6 +755,8 @@ class WeaveClient:
         Returns:
             The created Call object.
         """
+        from weave.trace.api import _global_postprocess_inputs
+
         if isinstance(op, str):
             if op not in self._anonymous_ops:
                 self._anonymous_ops[op] = _build_anonymous_op(op)
@@ -768,6 +770,9 @@ class WeaveClient:
             inputs_postprocessed = op.postprocess_inputs(inputs_redacted)
         else:
             inputs_postprocessed = inputs_redacted
+
+        if _global_postprocess_inputs:
+            inputs_postprocessed = _global_postprocess_inputs(inputs_postprocessed)
 
         self._save_nested_objects(inputs_postprocessed)
         inputs_with_refs = map_to_refs(inputs_postprocessed)
@@ -855,6 +860,8 @@ class WeaveClient:
         *,
         op: Op | None = None,
     ) -> None:
+        from weave.trace.api import _global_postprocess_output
+
         ended_at = datetime.datetime.now(tz=datetime.timezone.utc)
         call.ended_at = ended_at
         original_output = output
@@ -863,6 +870,10 @@ class WeaveClient:
             postprocessed_output = op.postprocess_output(original_output)
         else:
             postprocessed_output = original_output
+
+        if _global_postprocess_output:
+            postprocessed_output = _global_postprocess_output(postprocessed_output)
+
         self._save_nested_objects(postprocessed_output)
 
         call.output = map_to_refs(postprocessed_output)


### PR DESCRIPTION
Resolves: https://wandb.atlassian.net/browse/WB-22599

This allows users to configure custom post-processing functions to be applied globally and is intended to be give users fine-grain control over what data they actually want to log to weave.

For example, you can define a custom `redact_keys` function to hide anything with "key" in the name:
```py
import weave


def redact_keys(d: dict) -> dict:
    for k in d:
        if "key" in k.lower():
            d[k] = "REDACTED"
    return d


client = weave.init("testing306", global_postprocess_inputs=redact_keys)


@weave.op
def func(api_key: str, key_secret: str, name: str) -> int:
    return f"Hi {name}!"


func("123", "456", "John")
```

![image](https://github.com/user-attachments/assets/ad3f0a89-9a5d-4ea7-a631-2d3c1a235b72)
