### PR TITLE
chore(ui): add a loading state var to avoid "no results" on load

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
@@ -152,10 +152,14 @@ export const WeaveCHTable: FC<{
   );
 
   const [loadedRows, setLoadedRows] = useState<Array<{[key: string]: any}>>([]);
+  const [fetchQueryLoaded, setFetchQueryLoaded] = useState(false);
 
   useEffect(() => {
-    if (!fetchQuery.loading && fetchQuery.result) {
-      setLoadedRows(fetchQuery.result.rows);
+    if (!fetchQuery.loading) {
+      if (fetchQuery.result) {
+        setLoadedRows(fetchQuery.result.rows);
+      }
+      setFetchQueryLoaded(true);
     }
   }, [fetchQuery.loading, fetchQuery.result]);
 
@@ -224,7 +228,7 @@ export const WeaveCHTable: FC<{
       }}>
       <DataTableView
         data={pagedRows}
-        loading={fetchQuery.loading}
+        loading={!fetchQueryLoaded}
         displayKey="val"
         onLinkClick={onClickEnabled ? onClick : undefined}
         fullHeight={props.fullHeight}


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22420](https://wandb.atlassian.net/browse/WB-22420)

The following screenshot shows the issues, where there is at least one screen render where the query returns as "loaded" but the data does not exist in the object we pass to the table yet. This results in flashing the "no results found". Solution: set another loaded var at the same time we set the data.

![Screenshot 2025-01-07 at 12 39 39 PM](https://github.com/user-attachments/assets/06b078bf-98b8-40e4-a3b2-1fbc442555ac)



## Testing

prod:
![object-viewer-no-results-2](https://github.com/user-attachments/assets/276a2e09-f0d8-492b-99cb-d6dc6124a567)

branch:
![object-viewer-no-no-results-2](https://github.com/user-attachments/assets/8dc12d3d-324f-44ff-958a-c5c63a3de1ec)


[WB-22420]: https://wandb.atlassian.net/browse/WB-22420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ