### PR TITLE
fix(weave_query): prevent full panel crashes if a row contains an unresolved artifact

### DIFF
--- a/weave_query/weave_query/artifact_wandb.py
+++ b/weave_query/weave_query/artifact_wandb.py
@@ -163,6 +163,8 @@ def _convert_client_id_to_server_id(art_id: str) -> str:
                 "clientID": art_id,
             },
         )
+    if not (res and res['clientIDMapping']):
+        raise errors.WeaveArtifactCollectionNotFound
     return b64_to_hex_id(res["clientIDMapping"]["serverID"])
 
 


### PR DESCRIPTION
## Description

- Fixes [WB-22356](https://wandb.atlassian.net/browse/WB-22356)
- Raise a `WeaveArtifactCollectionNotFound` error whenever the artifact is unresolved. This error is already handled during op execution when we attempt to download the artifact, see: https://github.com/wandb/weave/blob/master/weave_query/weave_query/derive_op.py#L256-L269

## Testing

Able to load the user's panel when running locally with the `invoker_weave_prod.ini` profile

[WB-22356]: https://wandb.atlassian.net/browse/WB-22356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ