### PR TITLE
chore(weave): Keep programming language selection state in URL

### DIFF
--- a/docs/docs/guides/core-types/datasets.md
+++ b/docs/docs/guides/core-types/datasets.md
@@ -13,7 +13,7 @@ This guide will show you how to:
 
 ## Sample code
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     import weave

--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -9,7 +9,7 @@ Weave supports logging and displaying multiple first class media types. Log imag
 
 Logging type: `PIL.Image.Image`. Here is an example of logging an image with the OpenAI DALL-E API:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
   
     ```python
@@ -83,7 +83,7 @@ This image will be logged to weave and automatically displayed in the UI. The fo
 
 Logging type: `wave.Wave_read`. Here is an example of logging an audio file using openai's speech generation API.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
   
     ```python

--- a/docs/docs/guides/core-types/models.md
+++ b/docs/docs/guides/core-types/models.md
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # Models
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     A `Model` is a combination of data (which can include configuration, trained model weights, or other information) and code that defines how the model operates. By structuring your code to be compatible with this API, you benefit from a structured way to version your application so you can more systematically keep track of your experiments.
 

--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics. They take the AI's output, analyze it, and return a dictionary of results. Scorers can use your input data as reference if needed and can also output extra information, such as explanations or reasonings from the evaluation.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     Scorers are passed to a `weave.Evaluation` object during evaluation. There are two types of Scorers in weave:
 
@@ -26,7 +26,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
 
 ### Function-based Scorers
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     These are functions decorated with `@weave.op` that return a dictionary. They're great for simple evaluations like:
 
@@ -68,7 +68,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
 
 ### Class-based Scorers
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     For more advanced evaluations, especially when you need to keep track of additional scorer metadata, try different prompts for your LLM-evaluators, or make multiple function calls, you can use the `Scorer` class.
 
@@ -139,7 +139,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
 
 ### Scorer Keyword Arguments
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     Scorers can access both the output from your AI system and the input data from the dataset row.
 
@@ -256,7 +256,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
 
 ### Final summarization of the scorer
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     During evaluation, the scorer will be computed for each row of your dataset. To provide a final score for the evaluation we provide an `auto_summarize` depending on the returning type of the output.
     - Averages are computed for numerical columns
@@ -305,7 +305,7 @@ In Weave, Scorers are used to evaluate AI outputs and return evaluation metrics.
 
 ## Predefined Scorers
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     **Installation**
 

--- a/docs/docs/guides/integrations/nvidia_nim.md
+++ b/docs/docs/guides/integrations/nvidia_nim.md
@@ -9,7 +9,7 @@ Weave automatically tracks and logs LLM calls made via the [ChatNVIDIA](https://
 
 It’s important to store traces of LLM applications in a central database, both during development and in production. You’ll use these traces for debugging and to help build a dataset of tricky examples to evaluate against while improving your application.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     Weave can automatically capture traces for the [ChatNVIDIA python library](https://python.langchain.com/docs/integrations/chat/nvidia_ai_endpoints/).
 
@@ -43,7 +43,7 @@ It’s important to store traces of LLM applications in a central database, both
 
 ## Track your own ops
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
 Wrapping a function with `@weave.op` starts capturing inputs, outputs and app logic so you can debug how data flows through your app. You can deeply nest ops and build a tree of functions that you want to track. This also starts automatically versioning code as you experiment to capture ad-hoc details that haven't been committed to git.
 
@@ -119,7 +119,7 @@ Navigate to Weave and you can click `get_pokemon_data` in the UI to see the inpu
 
 ## Create a `Model` for easier experimentation
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     Organizing experimentation is difficult when there are many moving pieces. By using the [`Model`](/guides/core-types/models) class, you can capture and organize the experimental details of your app like your system prompt or the model you're using. This helps organize and compare different iterations of your app.
 

--- a/docs/docs/guides/integrations/openai.md
+++ b/docs/docs/guides/integrations/openai.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 It’s important to store traces of LLM applications in a central database, both during development and in production. You’ll use these traces for debugging and to help build a dataset of tricky examples to evaluate against while improving your application.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     Weave can automatically capture traces for the [openai python library](https://platform.openai.com/docs/libraries/python-library).
 
@@ -79,7 +79,7 @@ It’s important to store traces of LLM applications in a central database, both
 
 ## Track your own ops
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
 Wrapping a function with `@weave.op` starts capturing inputs, outputs and app logic so you can debug how data flows through your app. You can deeply nest ops and build a tree of functions that you want to track. This also starts automatically versioning code as you experiment to capture ad-hoc details that haven't been committed to git.
 
@@ -249,7 +249,7 @@ Wrapping a function with `weave.op` starts capturing inputs, outputs and app log
 
 ## Create a `Model` for easier experimentation
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     Organizing experimentation is difficult when there are many moving pieces. By using the [`Model`](/guides/core-types/models) class, you can capture and organize the experimental details of your app like your system prompt or the model you're using. This helps organize and compare different iterations of your app.
 

--- a/docs/docs/guides/tracking/costs.md
+++ b/docs/docs/guides/tracking/costs.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 
 ## Adding a custom cost
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     You can add a custom cost by using the [`add_cost`](/reference/python-sdk/weave/trace/weave.trace.weave_client#method-add_cost) method.
     The three required fields are `llm_id`, `prompt_token_cost`, and `completion_token_cost`.
@@ -45,7 +45,7 @@ import TabItem from '@theme/TabItem';
 
 ## Querying for costs
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     You can query for costs by using the [`query_costs`](/reference/python-sdk/weave/trace/weave.trace.weave_client#method-query_costs) method.
     There are a few ways to query for costs, you can pass in a singular cost id, or a list of LLM model names.
@@ -72,7 +72,7 @@ import TabItem from '@theme/TabItem';
 
 ## Purging a custom cost
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     You can purge a custom cost by using the [`purge_costs`](/reference/python-sdk/weave/trace/weave.trace.weave_client#method-purge_costs) method. You pass in a list of cost ids, and the costs with those ids are purged.
 
@@ -95,7 +95,7 @@ import TabItem from '@theme/TabItem';
 
 ## Calculating costs for a Project
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     You can calculate costs for a project by using our `calls_query` and adding `include_costs=True` with a little bit of setup.
 

--- a/docs/docs/guides/tracking/feedback.md
+++ b/docs/docs/guides/tracking/feedback.md
@@ -75,7 +75,7 @@ You can also get additional information for each feedback object in `client.get_
 - `feedback_type`: The type of feedback (reaction, note, custom).
 - `payload`: The feedback payload
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     import weave
@@ -115,7 +115,7 @@ You can add feedback to a call using the call's UUID. To use the UUID to get a p
 - `call.feedback.add_note("<note>")`: Add a note.
 - `call.feedback.add("<label>", <object>)`: Add a custom feedback `<object>` specified by `<label>`.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     import weave
@@ -154,7 +154,7 @@ For scenarios where you need to add feedback immediately after a call, you can r
 
 To retrieve the UUID during call execution, get the current call, and return the ID.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
 
@@ -183,7 +183,7 @@ To retrieve the UUID during call execution, get the current call, and return the
 
 Alternatively, you can use `call()` method to execute the operation and retrieve the ID after call execution:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     import weave
@@ -210,7 +210,7 @@ Alternatively, you can use `call()` method to execute the operation and retrieve
 
 You can delete feedback from a particular call by specifying a UUID.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     call.feedback.purge("<feedback_uuid>")
@@ -275,7 +275,7 @@ Human annotation scorers can also be created through the API.  Each scorer is it
 
 In the following example, two scorers are created. The first scorer, `Temperature`, is used to score the perceived temperature of the LLM call. The second scorer, `Tone`, is used to score the tone of the LLM response. Each scorer is created using `save` with an associated object ID (`temperature-scorer` and `tone-scorer`).
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     import weave
@@ -318,7 +318,7 @@ Expanding on [creating a human annotation scorer using the API](#create-a-human-
 
 > You can view human annotation scorer object history in the **Scorers** tab under **Human annotations**.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     import weave

--- a/docs/docs/guides/tracking/objects.md
+++ b/docs/docs/guides/tracking/objects.md
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 Weave's serialization layer saves and versions objects.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
 
     ```python
@@ -39,7 +39,7 @@ Saving an object with a name will create the first version of that object if it 
 
 ## Getting an object back
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     `weave.publish` returns a Ref. You can call `.get()` on any Ref to get the object back.
 

--- a/docs/docs/guides/tracking/ops.md
+++ b/docs/docs/guides/tracking/ops.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 
 A Weave op is a versioned function that automatically logs all calls.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     To create an op, decorate a python function with `weave.op()`
 
@@ -53,7 +53,7 @@ A Weave op is a versioned function that automatically logs all calls.
 
 ## Customize display names
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     You can customize the op's display name by setting the `name` parameter in the `@weave.op` decorator:
 
@@ -73,7 +73,7 @@ A Weave op is a versioned function that automatically logs all calls.
 
 ## Customize logged inputs and outputs
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     If you want to change the data that is logged to weave without modifying the original function (e.g. to hide sensitive data), you can pass `postprocess_inputs` and `postprocess_output` to the op decorator.
 
@@ -118,7 +118,7 @@ A Weave op is a versioned function that automatically logs all calls.
 
 ## Control sampling rate
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     You can control how frequently an op's calls are traced by setting the `tracing_sample_rate` parameter in the `@weave.op` decorator. This is useful for high-frequency ops where you only need to trace a subset of calls.
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -13,7 +13,7 @@ Follow these steps to track your first call or <a class="vertical-align-colab-bu
 
 First install the weave library:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```bash
     pip install weave
@@ -43,7 +43,7 @@ To get started with tracking your first project with Weave:
 
 _In this example, we're using openai so you will need to add an OpenAI [API key](https://platform.openai.com/docs/quickstart/step-2-setup-your-api-key)._
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     # highlight-next-line

--- a/docs/docs/tutorial-eval.md
+++ b/docs/docs/tutorial-eval.md
@@ -9,7 +9,7 @@ To iterate on an application, we need a way to evaluate if it's improving. To do
 
 ## 1. Build a `Model`
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
 
 `Model`s store and version information about your system, such as prompts, temperatures, and more.
@@ -99,7 +99,7 @@ Checkout the [Models](/guides/core-types/models) guide to learn more.
 
 ## 2. Collect some examples
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
 
     ```python
@@ -149,7 +149,7 @@ Checkout the [Models](/guides/core-types/models) guide to learn more.
 
 ## 3. Evaluate a `Model`
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
 
 `Evaluation`s assess a `Model`s performance on a set of examples using a list of specified scoring functions or `weave.scorer.Scorer` classes.
@@ -224,7 +224,7 @@ In some applications we want to create custom `Scorer` classes - where for examp
 
 ## 4. Pulling it all together
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
   
     ```python

--- a/docs/docs/tutorial-rag.md
+++ b/docs/docs/tutorial-rag.md
@@ -22,7 +22,7 @@ Check out the [RAG++ course](https://www.wandb.courses/courses/rag-in-production
 
 First, we compute the embeddings for our articles. You would typically do this once with your articles and put the embeddings & metadata in a database, but here we're doing it every time we run our script for simplicity.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     from openai import OpenAI
@@ -69,7 +69,7 @@ First, we compute the embeddings for our articles. You would typically do this o
 
 Next, we wrap our retrieval function `get_most_relevant_document` with a `weave.op()` decorator and we create our `Model` class. We call `weave.init('rag-qa')` to begin tracking all the inputs and outputs of our functions for later inspection.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     from openai import OpenAI
@@ -149,7 +149,7 @@ When there aren't simple ways to evaluate your application, one approach is to u
 
 As we did in the [Build an Evaluation pipeline tutorial](/tutorial-eval), we'll define a set of example rows to test our app against and a scoring function. Our scoring function will take one row and evaluate it. The input arguments should match with the corresponding keys in our row, so `question` here will be taken from the row dictionary. `output` is the output of the model. The input to the model will be taken from the example based on its input argument, so `question` here too. We're using `async` functions so they run fast in parallel. If you need a quick introduction to async, you can find one [here](https://docs.python.org/3/library/asyncio.html).
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     from openai import OpenAI
@@ -221,7 +221,7 @@ On a high-level the steps to create custom Scorer are quite simple:
 3. _Optional:_ Overwrite the `summarize` function to customize the calculation of the aggregate score. By default Weave uses the `weave.flow.scorer.auto_summarize` function if you don't define a custom function.
    - this function has to have a `@weave.op()` decorator.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     from weave.scorers import Scorer
@@ -301,7 +301,7 @@ On a high-level the steps to create custom Scorer are quite simple:
 
 To use this as a scorer, you would initialize it and pass it to `scorers` argument in your `Evaluation like this:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     evaluation = weave.Evaluation(dataset=questions, scorers=[CorrectnessLLMJudge()])
@@ -328,7 +328,7 @@ To get the same result for your RAG apps:
 
 Here, we show the code in it's entirety.
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     from openai import OpenAI

--- a/docs/docs/tutorial-tracing_2.md
+++ b/docs/docs/tutorial-tracing_2.md
@@ -16,7 +16,7 @@ LLM-powered applications can contain multiple LLMs calls and additional data pro
 
 Building on our [basic tracing example](/quickstart), we will now add additional logic to count the returned items from our LLM and wrap them all in a higher level function. We'll then add `weave.op()` to trace every function, its call order and its parent-child relationship:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
 
     ```python
@@ -147,7 +147,7 @@ Tracking metadata can be done easily by using the `weave.attributes` context man
 
 Continuing our example from above:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     import weave

--- a/docs/docs/tutorial-weave_models.md
+++ b/docs/docs/tutorial-weave_models.md
@@ -30,7 +30,7 @@ When you change the class attributes or the code that defines your model, **thes
 
 In the example below, the **model name, temperature and system prompt will be tracked and versioned**:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     import json
@@ -84,7 +84,7 @@ In the example below, the **model name, temperature and system prompt will be tr
 
 Now you can instantiate and call the model with `invoke`:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     weave.init('jurassic-park')
@@ -138,7 +138,7 @@ In the Weave UI you can get the Model ref for a particular version
 **Using the Model**
 Once you have the URI of the Model object, you can export and re-use it. Note that the exported model is already initialised and ready to use:
 
-<Tabs groupId="programming-language">
+<Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
     ```python
     # the exported weave model is already initialised and ready to be called


### PR DESCRIPTION
## Description

Change is find+replace. This keeps the programming-language selection state in the URL, allowing us to link people to pages with TypeScript examples selected.

Internal Slack: https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1736373512488929
Ref: https://docusaurus.io/docs/next/markdown-features/tabs#query-string

Command: `find . -type f -name "*.md" -exec sed -i '' -e 's|<Tabs groupId="programming-language">|<Tabs groupId="programming-language" queryString>|g' {} +`

## Testing

How was this PR tested?
