### PR TITLE
chore(ui): using internal icons

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
@@ -1,4 +1,3 @@
-import {ExpandMore, KeyboardArrowRight} from '@mui/icons-material';
 import {ButtonProps} from '@mui/material';
 import Box from '@mui/material/Box';
 import MuiButton from '@mui/material/Button';
@@ -8,7 +7,7 @@ import React, {FC, MouseEvent, useMemo} from 'react';
 import styled from 'styled-components';
 
 import {MOON_250, MOON_500} from '../../../../../../common/css/color.styles';
-import {IconParentBackUp} from '../../../../../Icon';
+import {Icon, IconParentBackUp} from '../../../../../Icon';
 import {Tooltip} from '../../../../../Tooltip';
 import {opNiceName} from '../common/Links';
 import {StatusChip} from '../common/StatusChip';
@@ -157,7 +156,9 @@ export const CustomGridTreeDataGroupingCell: FC<
               color: TREE_COLOR,
               marginTop: '8px',
             }}>
-            {rowNode.childrenExpanded ? <ExpandMore /> : <KeyboardArrowRight />}
+            <Icon
+              name={rowNode.childrenExpanded ? 'chevron-down' : 'chevron-next'}
+            />
           </MuiButton>
         ) : (
           <Box


### PR DESCRIPTION
## Description

Continuing effort to only use our own icon library for consistency.

Before:
<img width="359" alt="Screenshot 2025-01-09 at 12 00 15 AM" src="https://github.com/user-attachments/assets/f53d2c0c-1755-4698-8f74-6d42ab94fd9d" />

After:
<img width="289" alt="Screenshot 2025-01-09 at 12 00 33 AM" src="https://github.com/user-attachments/assets/180bd6c7-03b3-4192-a92f-cd3143d016b1" />

## Testing

How was this PR tested?
