### PR TITLE
chore(dev): Use uuid v4 instead of v7 in error boundary

### DIFF
--- a/weave-js/src/components/ErrorBoundary.tsx
+++ b/weave-js/src/components/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import {datadogRum} from '@datadog/browser-rum';
 import * as Sentry from '@sentry/react';
 import React, {Component, ErrorInfo, ReactNode} from 'react';
-import {v7 as uuidv7} from 'uuid';
+import {v4 as uuidv4} from 'uuid';
 
 import {weaveErrorToDDPayload} from '../errors';
 import {ErrorPanel} from './ErrorPanel';
@@ -18,7 +18,7 @@ type State = {
 
 export class ErrorBoundary extends Component<Props, State> {
   public static getDerivedStateFromError(error: Error): State {
-    return {uuid: uuidv7(), timestamp: new Date(), error};
+    return {uuid: uuidv4(), timestamp: new Date(), error};
   }
   public state: State = {
     uuid: undefined,


### PR DESCRIPTION
## Description

I'm not sure why, but in development an older version of the uuid library is sometimes referenced instead of the ^11.0.3 version our package.json specifies. The older version doesn't support v7. Since we don't really need v7 for the React Error Boundary use case I'm switching it to use v4.

Before:
![image](https://github.com/user-attachments/assets/fb0f3369-29f7-48f0-b41a-3ef6b2400d9a)

After:
![image](https://github.com/user-attachments/assets/e62857f9-84eb-4d51-a811-60ae75b9c2d7)

## Testing

How was this PR tested?
