### PR TITLE
chore(weave): add deleted_at to weave object deleted error

### DIFF
--- a/tests/trace/test_obj_delete.py
+++ b/tests/trace/test_obj_delete.py
@@ -184,7 +184,7 @@ def test_read_deleted_object(client: WeaveClient):
 
     _obj_delete(client, "obj_1", [obj1_v2.digest])
 
-    with pytest.raises(weave.trace_server.errors.ObjectDeletedError):
+    with pytest.raises(weave.trace_server.errors.ObjectDeletedError) as e:
         client.server.obj_read(
             tsi.ObjReadReq(
                 project_id=client._project_id(),
@@ -192,6 +192,7 @@ def test_read_deleted_object(client: WeaveClient):
                 digest=obj1_v2.digest,
             )
         )
+    assert e.value.deleted_at is not None
 
     ref_res = client.server.refs_read_batch(
         tsi.RefsReadBatchReq(
@@ -242,7 +243,7 @@ def test_read_deleted_op(client: WeaveClient):
 
     _obj_delete(client, "my_op", [op_ref.digest])
 
-    with pytest.raises(weave.trace_server.errors.ObjectDeletedError):
+    with pytest.raises(weave.trace_server.errors.ObjectDeletedError) as e:
         client.server.obj_read(
             tsi.ObjReadReq(
                 project_id=client._project_id(),
@@ -250,6 +251,7 @@ def test_read_deleted_op(client: WeaveClient):
                 digest=op_ref.digest,
             )
         )
+    assert e.value.deleted_at is not None
 
     ref_res = client.server.refs_read_batch(
         tsi.RefsReadBatchReq(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -541,7 +541,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         op = objs[0]
         if op.deleted_at is not None:
             raise ObjectDeletedError(
-                f"Op {req.name}:v{op.version_index} was deleted at {op.deleted_at}"
+                f"Op {req.name}:v{op.version_index} was deleted at {op.deleted_at}",
+                deleted_at=op.deleted_at,
             )
 
         return tsi.OpReadRes(op_obj=_ch_obj_to_obj_schema(op))
@@ -599,7 +600,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         obj = objs[0]
         if obj.deleted_at is not None:
             raise ObjectDeletedError(
-                f"{req.object_id}:v{obj.version_index} was deleted at {obj.deleted_at}"
+                f"{req.object_id}:v{obj.version_index} was deleted at {obj.deleted_at}",
+                deleted_at=obj.deleted_at,
             )
 
         return tsi.ObjReadRes(obj=_ch_obj_to_obj_schema(obj))

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -1,3 +1,6 @@
+import datetime
+
+
 class Error(Exception):
     """Base class for exceptions in this module."""
 
@@ -45,4 +48,6 @@ class NotFoundError(Error):
 class ObjectDeletedError(Error):
     """Raised when an object has been deleted."""
 
-    pass
+    def __init__(self, message: str, deleted_at: datetime.datetime):
+        self.deleted_at = deleted_at
+        super().__init__(message)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -730,7 +730,8 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             raise NotFoundError(f"Obj {req.object_id}:{req.digest} not found")
         if objs[0].deleted_at is not None:
             raise ObjectDeletedError(
-                f"{req.object_id}:v{objs[0].version_index} was deleted at {objs[0].deleted_at}"
+                f"{req.object_id}:v{objs[0].version_index} was deleted at {objs[0].deleted_at}",
+                deleted_at=objs[0].deleted_at,
             )
         return tsi.ObjReadRes(obj=objs[0])
 


### PR DESCRIPTION
Add the `deleted_at` time to the objectDeletedError so clients can handle these errors better