### PR TITLE
docs(weave): Document adjusting number of trials in Playground

### DIFF
--- a/docs/docs/guides/tools/playground.md
+++ b/docs/docs/guides/tools/playground.md
@@ -24,6 +24,7 @@ Get started with the Playground to optimize your LLM interactions and streamline
 - [Retry, edit, and delete messages](#retry-edit-and-delete-messages)
 - [Add a new message](#add-a-new-message)
 - [Compare LLMs](#compare-llms)
+- [Adjust the number of trials](#adjust-the-number-of-trials)
 
 ## Prerequisites
 
@@ -222,3 +223,10 @@ Playground allows you to compare LLMs. To perform a comparison, do the following
    - [Adjust parameters](#adjust-llm-parameters)
    - [Add functions](#add-a-function)
 3. In the message box, enter a message that you want to test with both models and press **Send**.
+
+## Adjust the number of trials
+
+Playground allows you to generate multiple outputs for the same input by setting the number of trials. The default setting is `1`. To adjust the number of trials, do the following:
+
+1. In the Playground UI, open the settings sidebar if it is not already open.
+2. Adjust the **Number of trials**.


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/DOCS-1141

Adds subsection to https://weave-docs.wandb.ai/guides/tools/playground describing how to adjust number of trials per https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1734390374060869?thread_ts=1734390374.060869&cid=C01T8BLDHKP

## Testing

- [x] Viewed and confirmed locally by @J2-D2-3PO 
