### PR TITLE
feat(ui): Saved Views

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -661,13 +661,17 @@ const CallPageBinding = () => {
   );
 };
 
-type CallsPageLastViewProps = {
+type RedirectToLastViewProps = {
   entity: string;
   project: string;
   tab: string;
 };
 
-const CallsPageLastView = ({entity, project, tab}: CallsPageLastViewProps) => {
+const RedirectToLastView = ({
+  entity,
+  project,
+  tab,
+}: RedirectToLastViewProps) => {
   const location = useLocation();
   const {loading: loadingProjectInfo, projectInfo} = useProjectInfo(
     entity,
@@ -1023,7 +1027,7 @@ const CallsPageBinding = () => {
   const query = useURLSearchParamsDict();
   const loadLastView = Object.keys(query).length === 0;
   if (loadLastView) {
-    return <CallsPageLastView entity={entity} project={project} tab={tab} />;
+    return <RedirectToLastView entity={entity} project={project} tab={tab} />;
   }
   return (
     <CallsPageLoadView

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -5,16 +5,36 @@ import {
   GridPinnedColumnFields,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
-import React, {FC, useMemo} from 'react';
+import _ from 'lodash';
+import React, {FC, useCallback, useState} from 'react';
+import {useHistory} from 'react-router-dom';
 
+import {toast} from '../../../../../../common/components/elements/Toast';
+import {Tailwind} from '../../../../../Tailwind';
 import {
   WeaveHeaderExtrasContext,
   WeaveHeaderExtrasProvider,
 } from '../../context';
 import {opNiceName} from '../common/opNiceName';
-import {SimplePageLayout} from '../common/SimplePageLayout';
+import {
+  SimplePageLayout,
+  SimplePageLayoutContext,
+} from '../common/SimplePageLayout';
+import {SavedViewPrefix} from '../SavedViews/SavedViewPrefix';
+import {SavedViewSuffix} from '../SavedViews/SavedViewSuffix';
+import {
+  getDefaultViewId,
+  getNewViewId,
+  SAVED_PARAM_KEYS,
+  SavedViewsInfo,
+  useCurrentViewDefinition,
+} from '../SavedViews/savedViewUtil';
+import {ViewName} from '../SavedViews/ViewName';
+import {ViewNameEditing} from '../SavedViews/ViewNameEditing';
 import {useControllableState} from '../util';
-import {opVersionRefOpName} from '../wfReactInterface/utilities';
+import {useGetTraceServerClientContext} from '../wfReactInterface/traceServerClientContext';
+import {TraceObjSchema} from '../wfReactInterface/traceServerClientTypes';
+import {projectIdFromParts} from '../wfReactInterface/tsDataModelHooks';
 import {CallsTable} from './CallsTable';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {useCurrentFilterIsEvaluationsFilter} from './evaluationsFilter';
@@ -25,8 +45,17 @@ const HeaderExtras = () => {
 };
 
 export const CallsPage: FC<{
+  currentViewerId: string | null;
+  isReadonly: boolean;
+
   entity: string;
   project: string;
+
+  baseView: TraceObjSchema;
+  views: TraceObjSchema[];
+  onRecordLastView: (view: string) => void;
+  fetchViews: () => void;
+
   initialFilter?: WFHighLevelCallFilter;
   // Setting this will make the component a controlled component. The parent
   // is responsible for updating the filter.
@@ -47,6 +76,7 @@ export const CallsPage: FC<{
   paginationModel: GridPaginationModel;
   setPaginationModel: (newModel: GridPaginationModel) => void;
 }> = props => {
+  const {entity, project, baseView, views, fetchViews} = props;
   const [filter, setFilter] = useControllableState(
     props.initialFilter ?? {},
     props.onFilterUpdate
@@ -54,61 +84,230 @@ export const CallsPage: FC<{
 
   const isEvaluationTable = useCurrentFilterIsEvaluationsFilter(
     filter,
-    props.entity,
-    props.project
+    entity,
+    project
+  );
+  // table is the internal id stored in the object.
+  const table = isEvaluationTable ? 'evaluations' : 'traces';
+
+  const getTsClient = useGetTraceServerClientContext();
+
+  const tsClient = getTsClient();
+  const view = baseView.object_id;
+
+  const currentViewDefinition = useCurrentViewDefinition(baseView);
+
+  const history = useHistory();
+  const onLoadView = (viewToLoad: TraceObjSchema) => {
+    // We want to preserve any params that are not part of view definition,
+    // e.g. peek drawer state.
+    const newQuery = new URLSearchParams(history.location.search);
+
+    // Clear out any params related to saved views
+    for (const key of SAVED_PARAM_KEYS) {
+      newQuery.delete(key);
+    }
+
+    // Update with params from the view definition
+    for (const [key, value] of Object.entries(viewToLoad.val.definition)) {
+      newQuery.set(key, JSON.stringify(value));
+    }
+
+    newQuery.set('view', viewToLoad.object_id);
+    history.push({search: newQuery.toString()});
+    props.onRecordLastView(viewToLoad.object_id);
+  };
+  const onResetView = () => {
+    let viewToLoad = views?.find(v => v.object_id === view);
+    if (!viewToLoad) {
+      const defaultViewId = getDefaultViewId(table);
+      viewToLoad = views?.find(v => v.object_id === defaultViewId);
+    }
+    if (viewToLoad) {
+      onLoadView(viewToLoad);
+    } else {
+      console.error('could not find view to reset to');
+    }
+  };
+
+  const {onRecordLastView} = props;
+
+  const onUpsertView = useCallback(
+    (objectId: string, label: string | null, successMessage: string) => {
+      if (objectId === getDefaultViewId(table)) {
+        objectId = getNewViewId(table);
+      }
+      if (label === null) {
+        // If caller doesn't provide a new label, use the existing one.
+        label = baseView.val.label;
+      }
+      const className = 'SavedView';
+      tsClient
+        .objCreate({
+          obj: {
+            project_id: projectIdFromParts({entity, project}),
+            object_id: objectId,
+            val: {
+              _type: className,
+              table,
+              // name,
+              _class_name: className,
+              _bases: ['SavedView', 'Object', 'BaseModel'],
+              label,
+              definition: currentViewDefinition,
+            },
+          },
+        })
+        .then(res => {
+          const newQuery = new URLSearchParams(history.location.search);
+          newQuery.set('view', objectId);
+          history.push({search: newQuery.toString()});
+          fetchViews();
+          toast(successMessage);
+          onRecordLastView(objectId);
+        });
+    },
+    [
+      entity,
+      fetchViews,
+      history,
+      project,
+      table,
+      onRecordLastView,
+      baseView.val.label,
+      tsClient,
+      currentViewDefinition,
+    ]
   );
 
-  const title = useMemo(() => {
-    if (isEvaluationTable) {
-      return 'Evaluations';
-    }
-    if (filter.opVersionRefs?.length === 1) {
-      const opName = opVersionRefOpName(filter.opVersionRefs[0]);
-      if (opName) {
-        return opNiceName(opName) + ' Traces';
-      }
-    }
-    return 'Traces';
-  }, [filter.opVersionRefs, isEvaluationTable]);
+  const onSaveNewView = () => {
+    // TODO: Could we set the title into edit mode and give it keyboard focus?
+    const objectId = getNewViewId(table);
+    onUpsertView(objectId, 'Untitled view', 'Successfully created new view.');
+  };
+
+  const onSaveView = () => {
+    onUpsertView(view, null, 'Successfully saved view.');
+  };
+
+  const onRenameView = (newName: string) => {
+    onUpsertView(view, newName, 'Successfully renamed view.');
+  };
+
+  const onDeleteView = () => {
+    tsClient
+      .objDelete({
+        project_id: projectIdFromParts({entity, project}),
+        object_id: view,
+      })
+      .then(res => {
+        // Don't need to fetch views again as we will reload the page.
+        // Using history replace instead of push because can't navigate back to deleted view.
+        toast('Successfully deleted view.');
+        onRecordLastView(getDefaultViewId(table));
+        const newQuery = new URLSearchParams();
+        history.replace({search: newQuery.toString()});
+      });
+  };
+
+  const savedViewsInfo: SavedViewsInfo = {
+    currentViewerId: props.currentViewerId,
+    currentViewId: view,
+    currentViewDefinition,
+    isDefault: view === getDefaultViewId(table),
+    isModified: !_.isEqual(currentViewDefinition, baseView.val.definition),
+    views,
+    baseView,
+    onLoadView,
+    onSaveView,
+    onSaveNewView,
+    onResetView,
+    onDeleteView,
+  };
+
+  const onNameChanged = (newName: string) => {
+    // Update the local state with the new name
+    baseView.val.label = newName;
+    // Update the server with the new name
+    onRenameView(newName);
+  };
+  const activeName = baseView.val.label ?? 'Untitled view';
+  const [isEditingName, setIsEditingName] = useState(false);
+  const title = (
+    <Tailwind>
+      {isEditingName ? (
+        <ViewNameEditing
+          value={activeName}
+          onChanged={onNameChanged}
+          onExit={() => setIsEditingName(false)}
+        />
+      ) : (
+        <ViewName
+          value={activeName}
+          onEditNameStart={() => setIsEditingName(true)}
+          tooltip="Click to rename view"
+        />
+      )}
+    </Tailwind>
+  );
 
   return (
     <WeaveHeaderExtrasProvider>
-      <SimplePageLayout
-        title={title}
-        hideTabsIfSingle
-        tabs={[
-          {
-            label: 'All',
-            content: (
-              <CallsTable
-                {...props}
-                // CPR (Tim): Applying "hide controls" when the filter is frozen is pretty crude.
-                // We will likely need finer-grained control over the filter enablement states
-                // rather than just a boolean flag. Note: "frozen === hideControls" at the moment.
-                // In fact, it probably should be used to determine if the filter should be applied
-                // to the frozenFilter prop. Furthermore, "frozen" is only used when showing the
-                // evaluations table. So, in this case, I think we should really just remove the
-                // `frozen` property completely and have a top-level evaluations tab that hides controls.
-                hideControls={filter.frozen && !isEvaluationTable}
-                hideOpSelector={isEvaluationTable}
-                initialFilter={filter}
-                onFilterUpdate={setFilter}
-                columnVisibilityModel={props.columnVisibilityModel}
-                setColumnVisibilityModel={props.setColumnVisibilityModel}
-                pinModel={props.pinModel}
-                setPinModel={props.setPinModel}
-                filterModel={props.filterModel}
-                setFilterModel={props.setFilterModel}
-                sortModel={props.sortModel}
-                setSortModel={props.setSortModel}
-                paginationModel={props.paginationModel}
-                setPaginationModel={props.setPaginationModel}
-              />
-            ),
-          },
-        ]}
-        headerExtra={<HeaderExtras />}
-      />
+      <SimplePageLayoutContext.Provider
+        value={{
+          headerPrefix: (
+            <Tailwind>
+              <SavedViewPrefix savedViewsInfo={savedViewsInfo} />
+            </Tailwind>
+          ),
+          headerSuffix:
+            views !== null ? (
+              <Tailwind>
+                <SavedViewSuffix
+                  savedViewsInfo={savedViewsInfo}
+                  isReadonly={props.isReadonly}
+                />
+              </Tailwind>
+            ) : undefined,
+        }}>
+        <SimplePageLayout
+          title={title}
+          hideTabsIfSingle
+          tabs={[
+            {
+              label: 'All',
+              content: (
+                <CallsTable
+                  entity={entity}
+                  project={project}
+                  // CPR (Tim): Applying "hide controls" when the filter is frozen is pretty crude.
+                  // We will likely need finer-grained control over the filter enablement states
+                  // rather than just a boolean flag. Note: "frozen === hideControls" at the moment.
+                  // In fact, it probably should be used to determine if the filter should be applied
+                  // to the frozenFilter prop. Furthermore, "frozen" is only used when showing the
+                  // evaluations table. So, in this case, I think we should really just remove the
+                  // `frozen` property completely and have a top-level evaluations tab that hides controls.
+                  hideControls={filter.frozen && !isEvaluationTable}
+                  hideOpSelector={isEvaluationTable}
+                  initialFilter={filter}
+                  onFilterUpdate={setFilter}
+                  columnVisibilityModel={props.columnVisibilityModel}
+                  setColumnVisibilityModel={props.setColumnVisibilityModel}
+                  pinModel={props.pinModel}
+                  setPinModel={props.setPinModel}
+                  filterModel={props.filterModel}
+                  setFilterModel={props.setFilterModel}
+                  sortModel={props.sortModel}
+                  setSortModel={props.setSortModel}
+                  paginationModel={props.paginationModel}
+                  setPaginationModel={props.setPaginationModel}
+                />
+              ),
+            },
+          ]}
+          headerExtra={<HeaderExtras />}
+        />
+      </SimplePageLayoutContext.Provider>
     </WeaveHeaderExtrasProvider>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -15,7 +15,6 @@ import {
   WeaveHeaderExtrasContext,
   WeaveHeaderExtrasProvider,
 } from '../../context';
-import {opNiceName} from '../common/opNiceName';
 import {
   SimplePageLayout,
   SimplePageLayoutContext,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/ConfirmDeleteDialog.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/ConfirmDeleteDialog.tsx
@@ -1,0 +1,92 @@
+import {
+  Dialog,
+  DialogActions as MaterialDialogActions,
+  DialogContent as MaterialDialogContent,
+  DialogTitle as MaterialDialogTitle,
+} from '@material-ui/core';
+import {Button} from '@wandb/weave/components/Button';
+import React, {useState} from 'react';
+import styled from 'styled-components';
+
+// TODO: Need to cleanup duplication with CallPage OverflowMenu
+const DialogContent = styled(MaterialDialogContent)`
+  padding: 0 32px !important;
+`;
+DialogContent.displayName = 'S.DialogContent';
+
+const DialogTitle = styled(MaterialDialogTitle)`
+  padding: 32px 32px 16px 32px !important;
+
+  h2 {
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 30px;
+  }
+`;
+DialogTitle.displayName = 'S.DialogTitle';
+
+const DialogActions = styled(MaterialDialogActions)<{$align: string}>`
+  justify-content: ${({$align}) =>
+    $align === 'left' ? 'flex-start' : 'flex-end'} !important;
+  padding: 32px 32px 32px 32px !important;
+`;
+DialogActions.displayName = 'S.DialogActions';
+
+type ConfirmDeleteDialogProps = {
+  setConfirmDelete: (confirmDelete: boolean) => void;
+  onDeleteCallback: () => void;
+};
+
+export const ConfirmDeleteDialog = ({
+  setConfirmDelete,
+  onDeleteCallback,
+}: ConfirmDeleteDialogProps) => {
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onDelete = () => {
+    setDeleteLoading(true);
+    onDeleteCallback();
+    setDeleteLoading(false);
+    setConfirmDelete(false);
+  };
+  return (
+    <Dialog
+      open={true}
+      onClose={() => {
+        setConfirmDelete(false);
+        setError(null);
+      }}
+      maxWidth="xs"
+      fullWidth>
+      <DialogTitle>Delete this view?</DialogTitle>
+      <DialogContent style={{overflow: 'hidden'}}>
+        {error != null ? (
+          <p style={{color: 'red'}}>{error}</p>
+        ) : (
+          <p>
+            You can delete this view if you believe it is no longer useful to
+            you and your team. This cannot be undone.
+          </p>
+        )}
+      </DialogContent>
+      <DialogActions $align="left">
+        <Button
+          variant="destructive"
+          disabled={error != null || deleteLoading}
+          onClick={onDelete}>
+          Delete view
+        </Button>
+        <Button
+          variant="ghost"
+          disabled={deleteLoading}
+          onClick={() => {
+            setConfirmDelete(false);
+            setError(null);
+          }}>
+          Cancel
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/DropdownSwitchView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/DropdownSwitchView.tsx
@@ -1,0 +1,38 @@
+import {Button} from '@wandb/weave/components/Button';
+import * as DropdownMenu from '@wandb/weave/components/DropdownMenu';
+import React, {useState} from 'react';
+
+import {TraceObjSchema} from '../wfReactInterface/traceServerClientTypes';
+import {PanelSwitchView} from './PanelSwitchView';
+import {SavedViewsInfo} from './savedViewUtil';
+
+type DropdownSwitchViewProps = {
+  savedViewsInfo: SavedViewsInfo;
+};
+
+export const DropdownSwitchView = ({
+  savedViewsInfo,
+}: DropdownSwitchViewProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const onLoadView = (view: TraceObjSchema) => {
+    setIsOpen(false);
+    savedViewsInfo.onLoadView(view);
+  };
+
+  return (
+    <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenu.Trigger>
+        <Button active={isOpen} variant="ghost" icon="menu" />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content align="start">
+          <PanelSwitchView
+            savedViewsInfo={savedViewsInfo}
+            onLoadView={onLoadView}
+          />
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/DropdownViewActions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/DropdownViewActions.tsx
@@ -1,0 +1,51 @@
+import {Button} from '@wandb/weave/components/Button';
+import * as DropdownMenu from '@wandb/weave/components/DropdownMenu';
+import {Icon} from '@wandb/weave/components/Icon';
+import React, {useState} from 'react';
+
+import {ConfirmDeleteDialog} from './ConfirmDeleteDialog';
+import {SavedViewsInfo} from './savedViewUtil';
+
+type DropdownViewActionsProps = {
+  savedViewsInfo: SavedViewsInfo;
+};
+
+export const DropdownViewActions = ({
+  savedViewsInfo,
+}: DropdownViewActionsProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const onClickDelete = () => {
+    setConfirmDelete(true);
+  };
+
+  return (
+    <>
+      <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenu.Trigger>
+          <Button active={isOpen} variant="ghost" icon="overflow-horizontal" />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content align="end">
+            <DropdownMenu.Item onClick={savedViewsInfo.onSaveNewView}>
+              <Icon name="add-new" /> Save as new view
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item
+              disabled={savedViewsInfo.isDefault}
+              onClick={onClickDelete}>
+              <Icon name="delete" /> Delete view
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+      {confirmDelete && (
+        <ConfirmDeleteDialog
+          setConfirmDelete={setConfirmDelete}
+          onDeleteCallback={savedViewsInfo.onDeleteView}
+        />
+      )}
+    </>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/PanelSwitchView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/PanelSwitchView.tsx
@@ -1,0 +1,87 @@
+import _ from 'lodash';
+import React, {useState} from 'react';
+
+import {TargetBlank} from '../../../../../../common/util/links';
+import {Button} from '../../../../../Button';
+import {Icon} from '../../../../../Icon';
+import {TraceObjSchema} from '../wfReactInterface/traceServerClientTypes';
+import {PanelView} from './PanelView';
+import {SavedViewsInfo} from './savedViewUtil';
+
+type PanelSwitchViewProps = {
+  savedViewsInfo: SavedViewsInfo;
+
+  onLoadView: (view: TraceObjSchema) => void;
+};
+
+export const PanelSwitchView = ({
+  savedViewsInfo,
+  onLoadView,
+}: PanelSwitchViewProps) => {
+  const [isShowingInfo, setIsShowingInfo] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const onInfoClick = () => setIsShowingInfo(!isShowingInfo);
+
+  const {views} = savedViewsInfo;
+  // Filter views based on search term
+  const filteredViews = views.filter(
+    view =>
+      view.val.label?.toLowerCase().includes(searchTerm.toLowerCase()) ?? false
+  );
+  // Sort filtered views by creation date
+  // TODO: should we sort currentViewId to top? That wouldn't match Workspaces
+  // but seems potentially useful to me.
+  const sortedViews = _.orderBy(filteredViews, 'created_at', 'desc');
+
+  return (
+    <div className="w-[400px]">
+      <div className="relative">
+        <Icon
+          name="search"
+          className="absolute left-16 top-[10px] text-moon-400"
+          size="sm"
+        />
+        <input
+          type="text"
+          placeholder="Search saved views..."
+          value={searchTerm}
+          onChange={e => setSearchTerm(e.target.value)}
+          className="w-full border-b border-moon-200 pb-12 pl-[44px] pr-16 pt-8 focus:outline-none"
+        />
+      </div>
+      <div className="flex items-center rounded-[4px] px-16 py-8">
+        <div className="font-semibold">Saved views</div>
+        <div className="ml-8 bg-oblivion/[0.05] px-6">{views.length}</div>
+        <div className="flex-auto"></div>
+        <Button
+          variant="ghost"
+          size="small"
+          icon="info"
+          onClick={onInfoClick}
+          tooltip="Toggle help information"
+        />
+      </div>
+      {isShowingInfo && (
+        <div className="rounded-8 mx-16 mb-8 bg-moon-100 px-12 py-8 text-sm text-moon-500">
+          Save your custom column configurations, filters, and sorts as Views
+          for quick access to your preferred data setups.{' '}
+          <TargetBlank href="http://wandb.me/weave_saved_views">
+            Learn more about saved views
+          </TargetBlank>{' '}
+          in Docs.
+        </div>
+      )}
+      <div className="max-h-[calc(100vh-24rem)] overflow-auto">
+        {sortedViews.map(view => (
+          <PanelView
+            key={view.object_id}
+            view={view}
+            onLoadView={onLoadView}
+            isChecked={view.object_id === savedViewsInfo.currentViewId}
+            currentViewerId={savedViewsInfo.currentViewerId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/PanelView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/PanelView.tsx
@@ -41,7 +41,9 @@ export const PanelView = ({
   const onClick = () => onLoadView(view);
 
   let by = null;
-  if (creatorUserId === currentViewerId) {
+  if (!creatorUserId) {
+    // creatorUserId will be the empty string for our synthetic default view
+  } else if (creatorUserId === currentViewerId) {
     by = 'by you';
   } else {
     by = <UserName prefix="by " userId={creatorUserId} field="username" />;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/PanelView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/PanelView.tsx
@@ -1,0 +1,64 @@
+/**
+ * UI panel for one view that can be loaded.
+ */
+import React from 'react';
+
+import {IconCheckmark} from '../../../../../Icon';
+import {UserName} from '../../../../../UserName';
+import {TraceObjSchema} from '../wfReactInterface/traceServerClientTypes';
+
+type PanelViewProps = {
+  view: TraceObjSchema;
+  onLoadView: (view: TraceObjSchema) => void;
+  isChecked: boolean;
+  currentViewerId: string | null;
+};
+
+export const PanelView = ({
+  view,
+  onLoadView,
+  isChecked,
+  currentViewerId,
+}: PanelViewProps) => {
+  const {wb_user_id, val} = view;
+  const creatorUserId = wb_user_id ?? null;
+  const {label} = val;
+  const resolvedName = label ?? 'Untitled view';
+
+  const saveTime = view.created_at
+    ? new Date(view.created_at)
+        .toLocaleString('en-US', {
+          month: 'numeric',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+          hour12: true,
+        })
+        .toLowerCase()
+        .replace(', ', ' at ')
+    : null;
+
+  const onClick = () => onLoadView(view);
+
+  let by = null;
+  if (creatorUserId === currentViewerId) {
+    by = 'by you';
+  } else {
+    by = <UserName prefix="by " userId={creatorUserId} field="username" />;
+  }
+
+  return (
+    <div
+      className="flex w-full cursor-pointer gap-10 px-16 py-8 hover:bg-moon-100"
+      onClick={onClick}>
+      <div className="flex-auto">
+        <div>{resolvedName}</div>
+        <div className="text-sm text-moon-500">
+          {saveTime && <>Saved on {saveTime} </>}
+          {by}
+        </div>
+      </div>
+      <div className="w-[30px] flex-none">{isChecked && <IconCheckmark />}</div>
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/SavedViewPrefix.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/SavedViewPrefix.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import {DropdownSwitchView} from './DropdownSwitchView';
+import {SavedViewsInfo} from './savedViewUtil';
+
+type SavedViewPrefixProps = {
+  savedViewsInfo: SavedViewsInfo;
+};
+
+export const SavedViewPrefix = ({savedViewsInfo}: SavedViewPrefixProps) => {
+  return (
+    <div className="ml-[-8px]">
+      <DropdownSwitchView savedViewsInfo={savedViewsInfo} />
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/SavedViewSuffix.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/SavedViewSuffix.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import {Button} from '../../../../../Button';
+import {Tooltip} from '../../../../../Tooltip';
+import {A} from '../common/Links';
+import {DropdownViewActions} from './DropdownViewActions';
+import {SavedViewSuffixTimestamp} from './SavedViewSuffixTimestamp';
+import {SavedViewsInfo} from './savedViewUtil';
+
+type SavedViewSuffixProps = {
+  savedViewsInfo: SavedViewsInfo;
+  isReadonly: boolean;
+};
+
+export const SavedViewSuffix = ({
+  savedViewsInfo,
+  isReadonly,
+}: SavedViewSuffixProps) => {
+  const {isModified, onResetView, baseView} = savedViewsInfo;
+  const {created_at} = baseView;
+  return (
+    <div className="flex items-center gap-8">
+      {isModified ? (
+        <Tooltip
+          content="Clears column actions, filters, and sorting"
+          trigger={
+            <A $variant="primary" onClick={onResetView}>
+              Reset view
+            </A>
+          }
+        />
+      ) : created_at ? (
+        <div className="mr-8 text-moon-500">
+          Saved on  <SavedViewSuffixTimestamp createdAt={created_at} />
+        </div>
+      ) : null}
+      {!isReadonly && (
+        <>
+          <DropdownViewActions savedViewsInfo={savedViewsInfo} />
+          <Button
+            disabled={!savedViewsInfo.isModified}
+            onClick={() => savedViewsInfo.onSaveView()}>
+            Save view
+          </Button>
+        </>
+      )}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/SavedViewSuffixTimestamp.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/SavedViewSuffixTimestamp.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+type SavedViewSuffixTimestampProps = {
+  createdAt: string;
+};
+
+export const SavedViewSuffixTimestamp = ({
+  createdAt,
+}: SavedViewSuffixTimestampProps) => {
+  // Jul 25 at 5:22pm
+  const saveTime = new Date(createdAt)
+    .toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    })
+    .replace(', ', ' at ')
+    .replace(/AM|PM/, match => match.toLowerCase());
+
+  return <>{saveTime}</>;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/ViewName.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/ViewName.tsx
@@ -1,0 +1,32 @@
+import {Icon} from '@wandb/weave/components/Icon';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
+import React from 'react';
+
+type ViewNameProps = {
+  value: string;
+  onEditNameStart: () => void;
+  tooltip?: string;
+};
+
+export const ViewName = ({value, onEditNameStart, tooltip}: ViewNameProps) => {
+  const onClick = () => {
+    onEditNameStart();
+  };
+  const body = (
+    <div
+      className="group flex w-max cursor-pointer items-center rounded-md px-8 py-4 hover:bg-moon-100"
+      onClick={onClick}>
+      {value}
+      <Icon
+        name="pencil-edit"
+        width={16}
+        height={16}
+        className="ml-8 min-w-[16px] text-moon-500 opacity-0 group-hover:opacity-100"
+      />
+    </div>
+  );
+  if (tooltip) {
+    return <Tooltip content={tooltip} trigger={body} noTriggerWrap />;
+  }
+  return body;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/ViewNameEditing.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/ViewNameEditing.tsx
@@ -1,0 +1,61 @@
+import React, {useEffect, useRef, useState} from 'react';
+
+type ViewNameEditingProps = {
+  value: string;
+
+  onChanged: (value: string) => void;
+  onExit: () => void;
+};
+
+export const ViewNameEditing = ({
+  value,
+  onChanged,
+  onExit,
+}: ViewNameEditingProps) => {
+  const [activeValue, setActiveValue] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Select all of the text
+  // TODO: Make this behavior optional?
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.select();
+    }
+  }, []);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.currentTarget.value;
+    setActiveValue(newValue);
+  };
+  const onBlur = () => {
+    // TODO: Trim? Disallow whitespace only?
+    if (activeValue !== value) {
+      onChanged(activeValue);
+    }
+    onExit();
+  };
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      onExit();
+    } else if (e.key === 'Enter') {
+      onBlur();
+    }
+  };
+  const placeholder = value;
+  return (
+    <div className="flex w-max items-center gap-8">
+      <input
+        ref={inputRef}
+        className="min-w-[100px] rounded-md border-2 border-transparent px-6 py-4 focus:border-teal-400 focus:outline-none dark:focus:border-teal-600"
+        value={activeValue}
+        placeholder={placeholder}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+        autoFocus
+        style={{width: `${activeValue.length}ch`}}
+      />
+      <p className="rounded bg-moon-100 px-6 text-sm text-moon-500 ">Enter</p>
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/savedViewUtil.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/savedViewUtil.ts
@@ -1,0 +1,117 @@
+import _ from 'lodash';
+import {useMemo} from 'react';
+import {useParams} from 'react-router-dom';
+
+import {capitalizeFirst} from '../../../../../../core/util/string';
+import {useURLSearchParamsDict} from '../util';
+import {TraceObjSchema} from '../wfReactInterface/traceServerClientTypes';
+
+// Copied from Browse3
+export const useParamsDecoded = <T extends object>() => {
+  // Handle the case where entity/project (old) have spaces
+  const params = useParams<T>();
+  return useMemo(() => {
+    return Object.fromEntries(
+      Object.entries(params).map(([key, value]) => [
+        key,
+        decodeURIComponent(value),
+      ])
+    );
+  }, [params]);
+};
+
+// Not page - always load first page
+export const SAVED_PARAM_KEYS = [
+  'cols',
+  'filter',
+  'filters',
+  'sort',
+  'pin',
+  'pageSize',
+];
+
+// Value of the object
+type ViewDefinition = Record<string, any>;
+
+// Get the current view definition from the query params
+export const useCurrentViewDefinition = (
+  baseView: TraceObjSchema
+): ViewDefinition => {
+  const query = useURLSearchParamsDict();
+  const picked = _.pick(query, SAVED_PARAM_KEYS);
+  const parsed = _.mapValues(picked, v => {
+    try {
+      return JSON.parse(v);
+    } catch (e) {
+      return null;
+    }
+  });
+  const filtered = _.pickBy(parsed, v => v !== null);
+  return {
+    ...baseView.val.definition,
+    ...filtered,
+  };
+};
+
+export const getDefaultViewDefinition = (table: string): ViewDefinition => {
+  const label = capitalizeFirst(table);
+  return {
+    table,
+    label,
+    definition: {},
+  };
+};
+
+export const getDefaultViewId = (table: string): string => {
+  return `${table}_default`;
+};
+
+// Get a new view id based on the current time
+// e.g. traces_2025-01-31_02-54-12-003
+export const getNewViewId = (table: string): string => {
+  const now = new Date();
+  return `${table}_${now
+    .toISOString()
+    .replace('T', '_')
+    .replace(/[:.]/g, '-')
+    .slice(0, -1)}`; // Trim trailing 'Z'
+};
+
+export const getDefaultView = (
+  projectId: string,
+  table: string
+): TraceObjSchema => {
+  const objectId = getDefaultViewId(table);
+  const val = getDefaultViewDefinition(table);
+  return {
+    base_object_class: 'SavedView',
+    project_id: projectId,
+    object_id: objectId,
+    created_at: '',
+    deleted_at: null,
+    digest: '',
+    version_index: 0,
+    is_latest: 1,
+    kind: 'object',
+    val,
+    wb_user_id: '',
+  };
+};
+
+export type SavedViewsInfo = {
+  currentViewerId: string | null; // user id of viewer, null if not logged in
+
+  currentViewId: string;
+  views: TraceObjSchema[]; // Only the latest version of each view
+
+  baseView: TraceObjSchema;
+  currentViewDefinition: ViewDefinition;
+  isDefault: boolean; // Whether current view is the default view
+  isModified: boolean; // Whether current view is not same as base view
+
+  onLoadView: (view: TraceObjSchema) => void;
+  onSaveView: () => void;
+  onSaveNewView: () => void;
+  onResetView: () => void;
+  onDeleteView: () => void;
+};


### PR DESCRIPTION
## Description

Internal Jira: https://wandb.atlassian.net/browse/WB-21701

Adds "Saved Views" to the UI. Views are saved as Weave objects. Table settings on the Traces and Evaluations pages like filters, sorting, page size, column visibility, and column pinning are stored in the view object.

New views can be saved, views can be updated, renamed, and deleted.

Some  screenshots:

<img width="1047" alt="Screenshot 2025-02-03 at 4 12 51 PM" src="https://github.com/user-attachments/assets/3cd0b0e2-6441-4d5b-9846-0f2cedaa4688" />
<img width="418" alt="Screenshot 2025-02-03 at 4 14 07 PM" src="https://github.com/user-attachments/assets/b608b3cb-b714-44b8-b34e-74533383932d" />
<img width="257" alt="Screenshot 2025-02-03 at 4 12 56 PM" src="https://github.com/user-attachments/assets/f07716dd-0a49-4c93-a37f-c93911deef3a" />
