### PR TITLE
chore(weave): removing quiet button variant

### DIFF
--- a/weave-js/src/components/Button/Button.tsx
+++ b/weave-js/src/components/Button/Button.tsx
@@ -66,7 +66,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     const isPrimary = variant === 'primary';
     const isSecondary = variant === 'secondary';
     const isGhost = variant === 'ghost';
-    const isQuiet = variant === 'quiet';
     const isDestructive = variant === 'destructive';
     const isOutline = variant === 'outline';
 
@@ -129,14 +128,6 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
               // secondary or ghost
               'bg-teal-300/[0.48] text-teal-600 dark:bg-teal-700/[0.48] dark:text-teal-400':
                 (isSecondary || isGhost) && active,
-
-              /** @deprecated, use ghost instead */
-              // quiet
-              'text-moon-500': isQuiet,
-              'bg-oblivion/[0.05] text-moon-800 dark:bg-moonbeam/[0.05] dark:text-moon-200':
-                isQuiet && active,
-              'hover:text-moon-800 dark:hover:text-moon-200': isQuiet,
-              'hover:bg-oblivion/[0.05] dark:hover:bg-moonbeam/[0.05]': isQuiet,
 
               // destructive
               'bg-red-500 text-white hover:bg-red-450': isDestructive,

--- a/weave-js/src/components/Button/types.ts
+++ b/weave-js/src/components/Button/types.ts
@@ -9,7 +9,6 @@ export const ButtonVariants = {
   Primary: 'primary',
   Secondary: 'secondary',
   Ghost: 'ghost',
-  Quiet: 'quiet',
   Destructive: 'destructive',
   Outline: 'outline',
 } as const;


### PR DESCRIPTION
## Description

Cloned #3361 for CI problems.

https://wandb.atlassian.net/browse/WB-22661

Removes "quiet" button variant now that we're deprecating it in favor of the "ghost" variant.