### PR TITLE
chore(ui): rename objectDelete for consistency

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -144,8 +144,8 @@ export class TraceServerClient extends CachingTraceServerClient {
     return res;
   }
 
-  public objectDelete(req: TraceObjDeleteReq): Promise<TraceObjDeleteRes> {
-    const res = super.objectDelete(req).then(r => {
+  public objDelete(req: TraceObjDeleteReq): Promise<TraceObjDeleteRes> {
+    const res = super.objDelete(req).then(r => {
       this.onObjectListeners.forEach(listener => listener());
       return r;
     });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
@@ -234,7 +234,7 @@ export class DirectTraceServerClient {
     return this.makeRequest<TraceObjReadReq, TraceObjReadRes>('/obj/read', req);
   }
 
-  public objectDelete(req: TraceObjDeleteReq): Promise<TraceObjDeleteRes> {
+  public objDelete(req: TraceObjDeleteReq): Promise<TraceObjDeleteRes> {
     return this.makeRequest<TraceObjDeleteReq, TraceObjDeleteRes>(
       '/obj/delete',
       req

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -1151,7 +1151,7 @@ const useObjectDeleteFunc = () => {
           path: '',
         });
       });
-      return getTsClient().objectDelete({
+      return getTsClient().objDelete({
         project_id: projectIdFromParts({
           entity,
           project,
@@ -1166,7 +1166,7 @@ const useObjectDeleteFunc = () => {
   const objectDeleteAllVersions = useCallback(
     (key: ObjectVersionKey) => {
       updateObjectCaches(key);
-      return getTsClient().objectDelete({
+      return getTsClient().objDelete({
         project_id: projectIdFromParts({
           entity: key.entity,
           project: key.project,
@@ -1188,7 +1188,7 @@ const useObjectDeleteFunc = () => {
           versionHash: digest,
         });
       });
-      return getTsClient().objectDelete({
+      return getTsClient().objDelete({
         project_id: projectIdFromParts({
           entity,
           project,
@@ -1203,7 +1203,7 @@ const useObjectDeleteFunc = () => {
   const opDeleteAllVersions = useCallback(
     (key: OpVersionKey) => {
       updateOpCaches(key);
-      return getTsClient().objectDelete({
+      return getTsClient().objDelete({
         project_id: projectIdFromParts({
           entity: key.entity,
           project: key.project,


### PR DESCRIPTION
## Description

`objectDelete` is a clearer name but `objDelete` is more consistent naming with existing `objCreate` and `objRead` methods.

## Testing

How was this PR tested?
