### PR TITLE
chore(weave): increase CI test timeout

### DIFF
--- a/tests/trace/test_import.py
+++ b/tests/trace/test_import.py
@@ -9,5 +9,5 @@ def test_import_not_slow(monkeypatch):
 
     import_time = run_single_import()
 
-    # Ideally the import takes < 1s, but in CI it can take up to 4s.
-    assert import_time < 4, f"Import time was {import_time} seconds"
+    # Ideally the import takes < 1s, but in CI it can take up to 5s.
+    assert import_time < 5, f"Import time was {import_time} seconds"


### PR DESCRIPTION
## Description

We bumped from 3s to 4s in https://github.com/wandb/weave/pull/3272 but it flaked again for me:
```
E       AssertionError: Import time was 4.160144319999972 seconds
E       assert 4.160144319999972 < 4
```

Internal slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1734388464060729