### PR TITLE
fix(weave): don't check non-string dict keys for sensitive key redaction

### DIFF
--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -148,7 +148,7 @@ def dictify(
     elif isinstance(obj, dict):
         dict_result = {}
         for k, v in obj.items():
-            if should_redact(k):
+            if isinstance(k, str) and should_redact(k):
                 dict_result[k] = REDACTED_VALUE
             else:
                 dict_result[k] = dictify(v, maxdepth, depth + 1, seen)
@@ -160,7 +160,7 @@ def dictify(
             if isinstance(as_dict, dict):
                 to_dict_result = {}
                 for k, v in as_dict.items():
-                    if should_redact(k):
+                    if isinstance(k, str) and should_redact(k):
                         to_dict_result[k] = REDACTED_VALUE
                     elif maxdepth == 0 or depth < maxdepth:
                         to_dict_result[k] = dictify(v, maxdepth, depth + 1)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1711,7 +1711,7 @@ def redact_sensitive_keys(obj: Any) -> Any:
     if isinstance(obj, dict):
         dict_res = {}
         for k, v in obj.items():
-            if should_redact(k):
+            if isinstance(k, str) and should_redact(k):
                 dict_res[k] = REDACTED_VALUE
             else:
                 dict_res[k] = redact_sensitive_keys(v)


### PR DESCRIPTION
## Description

See https://github.com/wandb/weave/issues/3379 - we were getting an AttributeError: `object has no attribute 'lower'` when attempting sensitive key redaction on dicts with non-str keys.

```
from weave.trace.weave_client import redact_sensitive_keys
d = {1: 2}
redact_sensitive_keys(d)
```
