### PR TITLE
fix(weave_query): Handle stale file handle os errors on table load

### DIFF
--- a/weave_query/weave_query/ops_domain/table.py
+++ b/weave_query/weave_query/ops_domain/table.py
@@ -863,6 +863,8 @@ def file_table(file: artifact_fs.FilesystemArtifactFile) -> typing.Optional[Tabl
         import errno
         if e.errno == errno.ESTALE:
             return None
+        else:
+            raise e
 
 
 @op(name="file-partitionedTable")

--- a/weave_query/weave_query/ops_domain/table.py
+++ b/weave_query/weave_query/ops_domain/table.py
@@ -863,8 +863,7 @@ def file_table(file: artifact_fs.FilesystemArtifactFile) -> typing.Optional[Tabl
         import errno
         if e.errno == errno.ESTALE:
             return None
-        else:
-            raise e
+        raise
 
 
 @op(name="file-partitionedTable")

--- a/weave_query/weave_query/ops_domain/table.py
+++ b/weave_query/weave_query/ops_domain/table.py
@@ -856,6 +856,13 @@ def file_table(file: artifact_fs.FilesystemArtifactFile) -> typing.Optional[Tabl
         return Table(_get_table_like_awl_from_file(file).awl)
     except FileNotFoundError as e:
         return None
+    # Prevent a panel crash from stale file handle errors
+    # There are rare stale file handle errors that cause panel crashes as noted:
+    # https://wandb.atlassian.net/browse/WB-22355
+    except OSError as e:
+        import errno
+        if e.errno == errno.ESTALE:
+            return None
 
 
 @op(name="file-partitionedTable")


### PR DESCRIPTION
## Description
Fixes the panel crash reported in [WB-22355](https://wandb.atlassian.net/browse/WB-22355)

The panel crash happens due to an unhandled 'stale file handle' error when query engine is executing `file-table.` See screenshot below from [this trace](https://us5.datadoghq.com/apm/trace/5279186285891044226?graphType=flamegraph&highlight=gorilla&panel_tab=flamegraph&shouldShowLegend=true&sort=time&spanID=10465109557340666463&spanViewType=errors&timeHint=1734124764441).

This panel crash happens very rarely as it took almost a week for repro & trace capture. We're unsure to what causes this, but we're handling the error by returning a None value for the file-table op which is consistent with how we handle pulling files from run summary.


![image](https://github.com/user-attachments/assets/932ec0d3-335b-42cc-baf9-576f1c8a1c38)



## Testing
Using the `invoker.ini` dev environment.

I simulated a stale file handle error by raising an `OSError` exception with `errno.ESTALE` in the [opening of the json table](https://github.com/wandb/weave/blob/6c559b71e2d3fe32d8f13568d1a1c57046746f63/weave_query/weave_query/ops_domain/table.py#L679-L681) and confirmed that the panel on the frontend no longer crashes.

[WB-22355]: https://wandb.atlassian.net/browse/WB-22355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ