### PR TITLE
chore(ui): add user to ops and objects tables when present

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionPage.tsx
@@ -1,5 +1,6 @@
 import Box from '@mui/material/Box';
 import {Button} from '@wandb/weave/components/Button';
+import {UserLink} from '@wandb/weave/components/UserLink';
 import {useObjectViewEvent} from '@wandb/weave/integrations/analytics/useViewEvents';
 import React, {useMemo, useState} from 'react';
 
@@ -184,6 +185,7 @@ const ObjectVersionPageInner: React.FC<{
   }, [data.loading, data.result]);
 
   const showDeleteButton = useShowDeleteButton();
+  const objectVersionUserId = objectVersion.userId;
 
   const viewerDataAsObject = useMemo(() => {
     const dataIsPrimitive =
@@ -265,6 +267,12 @@ const ObjectVersionPageInner: React.FC<{
               <p className="text-moon-500">Version</p>
               <p>{objectVersionIndex}</p>
             </div>
+            {objectVersionUserId && (
+              <div className="block">
+                <p className="text-moon-500">Created by</p>
+                <UserLink userId={objectVersionUserId} includeName />
+              </div>
+            )}
             {refExtra && (
               <div className="block">
                 <p className="text-moon-500">Subpath</p>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectVersionsPage.tsx
@@ -18,6 +18,7 @@ import {
 import {useViewerInfo} from '@wandb/weave/common/hooks/useViewerInfo';
 import {Checkbox} from '@wandb/weave/components/Checkbox';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
+import {UserLink} from '@wandb/weave/components/UserLink';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
 import _ from 'lodash';
 import React, {useEffect, useMemo, useState} from 'react';
@@ -305,6 +306,7 @@ export const ObjectVersionsTable: React.FC<{
   hidePeerVersionsColumn?: boolean;
   hideCategoryColumn?: boolean;
   hideCreatedAtColumn?: boolean;
+  hideUserColumn?: boolean;
   hideVersionSuffix?: boolean;
   onRowClick?: (objectVersion: ObjectVersionSchema) => void;
   selectedVersions?: string[];
@@ -336,6 +338,8 @@ export const ObjectVersionsTable: React.FC<{
       };
     });
   }, [props.objectVersions]);
+
+  const showUserColumn = rows.some(row => row.obj.userId != null);
 
   // TODO: We should make this page very robust similar to the CallsTable page.
   // We will want to do nearly all the same things: URL state management,
@@ -500,6 +504,26 @@ export const ObjectVersionsTable: React.FC<{
       );
     }
 
+    if (!props.hideUserColumn || !showUserColumn) {
+      cols.push(
+        basicField('userId', 'User', {
+          width: 150,
+          filterable: false,
+          sortable: false,
+          valueGetter: (unused: any, row: any) => {
+            return row.obj.userId;
+          },
+          renderCell: (params: any) => {
+            const userId = params.value;
+            if (userId == null) {
+              return <div></div>;
+            }
+            return <UserLink userId={userId} includeName />;
+          },
+        })
+      );
+    }
+
     if (!props.hideCreatedAtColumn) {
       cols.push(
         basicField('createdAtMs', 'Created', {
@@ -530,7 +554,14 @@ export const ObjectVersionsTable: React.FC<{
     }
 
     return {cols, groups};
-  }, [props, showPropsAsColumns, rows, selectedVersions, setSelectedVersions]);
+  }, [
+    props,
+    showPropsAsColumns,
+    rows,
+    selectedVersions,
+    setSelectedVersions,
+    showUserColumn,
+  ]);
 
   // Highlight table row if it matches peek drawer.
   const query = useURLSearchParamsDict();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpVersionsPage.tsx
@@ -4,6 +4,7 @@ import {
   GridRowSelectionModel,
   GridRowsProp,
 } from '@mui/x-data-grid-pro';
+import {UserLink} from '@wandb/weave/components/UserLink';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {TEAL_600} from '../../../../../common/css/color.styles';
@@ -108,6 +109,10 @@ export const FilterableOpVersionsTable: React.FC<{
       };
     });
   }, [filteredOpVersions.result]);
+
+  // only show user column if there are any columns with a user id
+  const showUserColumn = rows.some(row => row.obj.userId != null);
+
   const columns: GridColDef[] = [
     basicField('op', 'Op', {
       hideable: false,
@@ -137,6 +142,26 @@ export const FilterableOpVersionsTable: React.FC<{
         return <OpCallsLink obj={obj} />;
       },
     }),
+
+    ...(showUserColumn
+      ? [
+          basicField('userId', 'User', {
+            width: 150,
+            filterable: false,
+            sortable: false,
+            valueGetter: (unused: any, row: any) => {
+              return row.obj.userId;
+            },
+            renderCell: (params: any) => {
+              const userId = params.value;
+              if (userId == null) {
+                return <div></div>;
+              }
+              return <UserLink userId={userId} includeName />;
+            },
+          }),
+        ]
+      : []),
 
     basicField('createdAtMs', 'Created', {
       width: 100,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -223,6 +223,7 @@ export interface TraceObjSchema<
   kind: 'op' | 'object';
   base_object_class?: OBC;
   val: T;
+  wb_user_id?: string;
 }
 
 export type TraceObjQueryRes<T extends any = any> = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -1010,6 +1010,7 @@ export const convertTraceServerObjectVersionToSchema = <
     baseObjectClass: obj.base_object_class ?? null,
     versionIndex: obj.version_index,
     val: obj.val,
+    userId: obj.wb_user_id,
   };
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -112,6 +112,7 @@ export type ObjectVersionSchema<T extends any = any> = ObjectVersionKey & {
   baseObjectClass: string | null;
   createdAtMs: number;
   val: T;
+  userId?: string;
 };
 
 export type ObjectVersionFilter = {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22663](https://wandb.atlassian.net/browse/WB-22663)

Frontend for displaying user id in the objects and ops flow when present. 

## Testing

<img width="1728" alt="Screenshot 2025-01-14 at 4 56 55 PM" src="https://github.com/user-attachments/assets/369cfc42-4318-464f-978c-5efa5094e31e" />
