### PR TITLE
feat(app): expose disabled property through icon

### DIFF
--- a/weave-js/src/common/components/elements/LegacyWBIcon.tsx
+++ b/weave-js/src/common/components/elements/LegacyWBIcon.tsx
@@ -73,7 +73,7 @@ const LegacyWBIconComp = React.forwardRef<HTMLElement, LegacyWBIconProps>(
       title,
       'aria-hidden': ariaHidden,
       'aria-label': ariaLabel,
-      disabled: disabled,
+      disabled,
     };
     if (ref == null) {
       return <Icon {...passProps} className={className} />;

--- a/weave-js/src/common/components/elements/LegacyWBIcon.tsx
+++ b/weave-js/src/common/components/elements/LegacyWBIcon.tsx
@@ -24,6 +24,7 @@ export interface LegacyWBIconProps {
   onMouseEnter?: any;
   onMouseLeave?: any;
   style?: any;
+  disabled?: boolean;
 
   'data-test'?: any;
 
@@ -50,6 +51,7 @@ const LegacyWBIconComp = React.forwardRef<HTMLElement, LegacyWBIconProps>(
       title,
       ariaHidden,
       ariaLabel,
+      disabled = false,
     },
     ref
   ) => {
@@ -71,6 +73,7 @@ const LegacyWBIconComp = React.forwardRef<HTMLElement, LegacyWBIconProps>(
       title,
       'aria-hidden': ariaHidden,
       'aria-label': ariaLabel,
+      disabled: disabled,
     };
     if (ref == null) {
       return <Icon {...passProps} className={className} />;


### PR DESCRIPTION
## Description

- Part of implementation for https://wandb.atlassian.net/browse/WB-9465

Exposes a `disabled` property to allow for controlling that attribute from parent components.
Underlying `Icon` component already handled the property, but the containing `LegacyWBIcon` didn't expose it.

## Testing

Tested locally, verified proper addition of value-less attribute. 