### PR TITLE
fix(ui): object viewer crash when json/hidden selected and change trace

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -174,6 +174,9 @@ const ObjectViewerSectionNonEmpty = ({
 
   // On first render and when data changes, recompute expansion state
   useEffect(() => {
+    if (mode === 'hidden' || mode === 'json') {
+      return;
+    }
     const isSimple = isSimpleData(data);
     const newMode = isSimple || isExpanded ? 'expanded' : 'collapsed';
     if (newMode === 'expanded') {


### PR DESCRIPTION
If you hide an input/output section in the call details or set it to JSON mode, and then change the selected call in the trace tree, you would get a crash. This is because we simulate clicking on the tree expand or collapse buttons, but `apiRef.current` is null.