### PR TITLE
chore(weave): Make PIL images threadsafe

### DIFF
--- a/tests/trace/test_image_thread_safety.py
+++ b/tests/trace/test_image_thread_safety.py
@@ -1,0 +1,56 @@
+import os
+import random
+from concurrent.futures import ThreadPoolExecutor
+
+import PIL
+import pytest
+
+
+@pytest.fixture()
+def deferred_cleanup():
+    files_to_cleanup = []
+
+    def add_file(name: str):
+        files_to_cleanup.append(name)
+
+    def cleanup():
+        for name in files_to_cleanup:
+            os.remove(name)
+
+    try:
+        yield add_file
+    finally:
+        cleanup()
+
+
+# Repeat 5 times since we are trying to test for thread safety
+@pytest.mark.parametrize("i", range(5))
+def test_image_thread_safety(deferred_cleanup, i):
+    file_name = f"temp_test_{i}.png"
+
+    # 1. Create a random in-memory image
+    image = PIL.Image.new("RGB", (1024, 1024))
+    image.putdata(
+        [
+            (
+                int(255 * random.random()),
+                int(255 * random.random()),
+                int(255 * random.random()),
+            )
+            for _ in range(1024 * 1024)
+        ]
+    )
+
+    # 2. Save the image to a file
+    deferred_cleanup(file_name)  # Cleanup the file on exit
+    image.save(file_name)
+
+    # 3. Open the image in multiple threads and load it
+    # This simulates what can happen when users are working
+    # with images across threads.
+    image = PIL.Image.open(file_name)
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        jobs = [executor.submit(image.load) for i in range(10)]
+
+    # Wait for all the threads to finish
+    res = [job.result() for job in jobs]

--- a/tests/trace/test_image_thread_safety.py
+++ b/tests/trace/test_image_thread_safety.py
@@ -1,56 +1,38 @@
-import os
 import random
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 
 import PIL
 import pytest
 
 
-@pytest.fixture()
-def deferred_cleanup():
-    files_to_cleanup = []
-
-    def add_file(name: str):
-        files_to_cleanup.append(name)
-
-    def cleanup():
-        for name in files_to_cleanup:
-            os.remove(name)
-
-    try:
-        yield add_file
-    finally:
-        cleanup()
-
-
 # Repeat 5 times since we are trying to test for thread safety
 @pytest.mark.parametrize("i", range(5))
-def test_image_thread_safety(deferred_cleanup, i):
-    file_name = f"temp_test_{i}.png"
+def test_image_thread_safety(i):
+    # Create a temporary file that will be automatically cleaned up
+    with tempfile.NamedTemporaryFile(suffix=".png") as temp_file:
+        # 1. Create a random in-memory image
+        image = PIL.Image.new("RGB", (1024, 1024))
+        image.putdata(
+            [
+                (
+                    int(255 * random.random()),
+                    int(255 * random.random()),
+                    int(255 * random.random()),
+                )
+                for _ in range(1024 * 1024)
+            ]
+        )
 
-    # 1. Create a random in-memory image
-    image = PIL.Image.new("RGB", (1024, 1024))
-    image.putdata(
-        [
-            (
-                int(255 * random.random()),
-                int(255 * random.random()),
-                int(255 * random.random()),
-            )
-            for _ in range(1024 * 1024)
-        ]
-    )
+        # 2. Save the image to a file
+        image.save(temp_file.name)
 
-    # 2. Save the image to a file
-    deferred_cleanup(file_name)  # Cleanup the file on exit
-    image.save(file_name)
+        # 3. Open the image in multiple threads and load it
+        # This simulates what can happen when users are working
+        # with images across threads.
+        image = PIL.Image.open(temp_file.name)
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            jobs = [executor.submit(image.load) for i in range(10)]
 
-    # 3. Open the image in multiple threads and load it
-    # This simulates what can happen when users are working
-    # with images across threads.
-    image = PIL.Image.open(file_name)
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        jobs = [executor.submit(image.load) for i in range(10)]
-
-    # Wait for all the threads to finish
-    res = [job.result() for job in jobs]
+        # Wait for all the threads to finish
+        res = [job.result() for job in jobs]

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -14,13 +14,9 @@ from weave.flow.eval import Evaluation, Scorer
 from weave.flow.model import Model
 from weave.flow.obj import Object
 from weave.flow.prompt.prompt import EasyPrompt, MessagesPrompt, Prompt, StringPrompt
-from weave.initialization.pil_image_thread_safety import (
-    apply_threadsafe_patch_to_pil_image,
-)
+from weave.initialization import *
 from weave.trace.util import Thread as Thread
 from weave.trace.util import ThreadPoolExecutor as ThreadPoolExecutor
-
-apply_threadsafe_patch_to_pil_image()
 
 # Alias for succinct code
 P = EasyPrompt

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -15,12 +15,12 @@ from weave.flow.model import Model
 from weave.flow.obj import Object
 from weave.flow.prompt.prompt import EasyPrompt, MessagesPrompt, Prompt, StringPrompt
 from weave.initialization.pil_image_thread_safety import (
-    make_image_file_thread_safe as make_image_file_thread_safe,
+    apply_threadsafe_patch_to_pil_image,
 )
 from weave.trace.util import Thread as Thread
 from weave.trace.util import ThreadPoolExecutor as ThreadPoolExecutor
 
-make_image_file_thread_safe()
+apply_threadsafe_patch_to_pil_image()
 
 # Alias for succinct code
 P = EasyPrompt

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -14,8 +14,13 @@ from weave.flow.eval import Evaluation, Scorer
 from weave.flow.model import Model
 from weave.flow.obj import Object
 from weave.flow.prompt.prompt import EasyPrompt, MessagesPrompt, Prompt, StringPrompt
+from weave.initialization.pil_image_thread_safety import (
+    make_image_file_thread_safe as make_image_file_thread_safe,
+)
 from weave.trace.util import Thread as Thread
 from weave.trace.util import ThreadPoolExecutor as ThreadPoolExecutor
+
+make_image_file_thread_safe()
 
 # Alias for succinct code
 P = EasyPrompt

--- a/weave/initialization/__init__.py
+++ b/weave/initialization/__init__.py
@@ -1,4 +1,3 @@
-
 from .pil_image_thread_safety import apply_threadsafe_patch_to_pil_image
 
 apply_threadsafe_patch_to_pil_image()

--- a/weave/initialization/__init__.py
+++ b/weave/initialization/__init__.py
@@ -1,0 +1,6 @@
+
+from .pil_image_thread_safety import apply_threadsafe_patch_to_pil_image
+
+apply_threadsafe_patch_to_pil_image()
+
+__all__: list[str] = []

--- a/weave/initialization/pil_image_thread_safety.py
+++ b/weave/initialization/pil_image_thread_safety.py
@@ -16,8 +16,6 @@ We call `make_image_file_thread_safe` in the `__init__.py` file to ensure that t
 import threading
 from functools import wraps
 
-from PIL.ImageFile import ImageFile
-
 _patch_lock = threading.Lock()
 _patched = False
 
@@ -28,6 +26,14 @@ def make_image_file_thread_safe() -> None:
         if _patched:
             return
         _patched = True
+    try:
+        _make_image_file_thread_safe()
+    except Exception as e:
+        print(f"Failed to patch PIL.ImageFile.ImageFile: {e}.")
+
+
+def _make_image_file_thread_safe() -> None:
+    from PIL.ImageFile import ImageFile
 
     old_load = ImageFile.load
     old_init = ImageFile.__init__

--- a/weave/initialization/pil_image_thread_safety.py
+++ b/weave/initialization/pil_image_thread_safety.py
@@ -1,7 +1,7 @@
 """
 This file exposes functions to make the PIL ImageFile thread-safe and revert those changes:
-- `apply_threadsafety_patch_to_pil_image`
-- `undo_threadsafety_patch_to_pil_image`
+- `apply_threadsafe_patch_to_pil_image`
+- `undo_threadsafe_patch_to_pil_image`
 
 There is a discussion here: https://github.com/python-pillow/Pillow/issues/4848#issuecomment-671339193 in which
 the author claims that the Pillow library is thread-safe. However, my reasoning leads me to a different conclusion.
@@ -12,18 +12,18 @@ the underlying image data). Inside of Weave we use threads to parallelize work w
 has presented itself not only in our own persistence layer, but also in user code where they are consuming loaded
 images across threads.
 
-We call `apply_threadsafety_patch_to_pil_image` in the `__init__.py` file to ensure that the ImageFile class is thread-safe.
+We call `apply_threadsafe_patch_to_pil_image` in the `__init__.py` file to ensure that the ImageFile class is thread-safe.
 """
 
 import threading
 from functools import wraps
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 _patched = False
-_original_methods: dict[str, Optional[callable]] = {"init": None, "load": None}
+_original_methods: dict[str, Optional[Callable]] = {"init": None, "load": None}
 
 
-def apply_threadsafety_patch_to_pil_image() -> None:
+def apply_threadsafe_patch_to_pil_image() -> None:
     """Apply thread-safety patch to PIL ImageFile class."""
     global _patched
 
@@ -31,7 +31,7 @@ def apply_threadsafety_patch_to_pil_image() -> None:
         return
 
     try:
-        _apply_threadsafety_patch()
+        _apply_threadsafe_patch()
     except ImportError:
         pass
     except Exception as e:
@@ -40,7 +40,7 @@ def apply_threadsafety_patch_to_pil_image() -> None:
         _patched = True
 
 
-def _apply_threadsafety_patch() -> None:
+def _apply_threadsafe_patch() -> None:
     from PIL.ImageFile import ImageFile
 
     global _original_methods
@@ -54,40 +54,49 @@ def _apply_threadsafety_patch() -> None:
 
     @wraps(old_init)
     def new_init(self: ImageFile, *args: Any, **kwargs: Any) -> None:
-        self._weave_load_lock = threading.Lock()
+        self._weave_load_lock = threading.Lock()  # type: ignore
         return old_init(self, *args, **kwargs)
 
     @wraps(old_load)
-    def new_load(self: ImageFile, *args: Any, **kwargs: Any) -> None:
-        with self._weave_load_lock:
+    def new_load(self: ImageFile, *args: Any, **kwargs: Any) -> Any:
+        with self._weave_load_lock:  # type: ignore
             return old_load(self, *args, **kwargs)
 
     ImageFile.__init__ = new_init  # type: ignore
     ImageFile.load = new_load  # type: ignore
 
 
-def undo_threadsafety_patch_to_pil_image() -> None:
+def undo_threadsafe_patch_to_pil_image() -> None:
     """Revert the thread-safety patch applied to PIL ImageFile class.
 
     If the patch hasn't been applied, this function does nothing.
     If the patch has been applied but can't be reverted, an error message is printed.
     """
-    from PIL.ImageFile import ImageFile
-
-    global _patched, _original_methods
+    global _patched
 
     if not _patched:
         return
 
     try:
-        if _original_methods["init"] is not None:
-            ImageFile.__init__ = _original_methods["init"]  # type: ignore
-        if _original_methods["load"] is not None:
-            ImageFile.load = _original_methods["load"]  # type: ignore
-
-        _original_methods = {"init": None, "load": None}
-        _patched = False
+        _undo_threadsafe_patch()
+    except ImportError:
+        pass
     except Exception as e:
         print(
             f"Failed to unpatch PIL.ImageFile.ImageFile: Unable to restore original methods - {e}"
         )
+    else:
+        _patched = False
+
+
+def _undo_threadsafe_patch() -> None:
+    from PIL.ImageFile import ImageFile
+
+    global _original_methods
+
+    if _original_methods["init"] is not None:
+        ImageFile.__init__ = _original_methods["init"]  # type: ignore
+    if _original_methods["load"] is not None:
+        ImageFile.load = _original_methods["load"]  # type: ignore
+
+    _original_methods = {"init": None, "load": None}

--- a/weave/initialization/pil_image_thread_safety.py
+++ b/weave/initialization/pil_image_thread_safety.py
@@ -1,5 +1,7 @@
 """
-This file exposes a function that makes the PIL ImageFile thread-safe: `make_image_file_thread_safe`.
+This file exposes functions to make the PIL ImageFile thread-safe and revert those changes:
+- `apply_threadsafety_patch_to_pil_image`
+- `undo_threadsafety_patch_to_pil_image`
 
 There is a discussion here: https://github.com/python-pillow/Pillow/issues/4848#issuecomment-671339193 in which
 the author claims that the Pillow library is thread-safe. However, my reasoning leads me to a different conclusion.
@@ -10,40 +12,82 @@ the underlying image data). Inside of Weave we use threads to parallelize work w
 has presented itself not only in our own persistence layer, but also in user code where they are consuming loaded
 images across threads.
 
-We call `make_image_file_thread_safe` in the `__init__.py` file to ensure that the ImageFile class is thread-safe.
+We call `apply_threadsafety_patch_to_pil_image` in the `__init__.py` file to ensure that the ImageFile class is thread-safe.
 """
 
 import threading
 from functools import wraps
+from typing import Any, Optional
 
 _patched = False
+_original_methods: dict[str, Optional[callable]] = {"init": None, "load": None}
 
 
-def make_image_file_thread_safe() -> None:
+def apply_threadsafety_patch_to_pil_image() -> None:
+    """Apply thread-safety patch to PIL ImageFile class."""
     global _patched
+
+    if _patched:
+        return
+
     try:
-        _make_image_file_thread_safe()
+        _apply_threadsafety_patch()
+    except ImportError:
+        pass
     except Exception as e:
-        print(f"Failed to patch PIL.ImageFile.ImageFile: {e}.")
+        print(f"Failed to patch PIL.ImageFile.ImageFile: Unexpected error - {e}")
     else:
         _patched = True
 
 
-def _make_image_file_thread_safe() -> None:
+def _apply_threadsafety_patch() -> None:
     from PIL.ImageFile import ImageFile
+
+    global _original_methods
+
+    # Store original methods
+    _original_methods["init"] = ImageFile.__init__
+    _original_methods["load"] = ImageFile.load
 
     old_load = ImageFile.load
     old_init = ImageFile.__init__
 
     @wraps(old_init)
-    def new_init(self, *args, **kwargs):  # type: ignore
+    def new_init(self: ImageFile, *args: Any, **kwargs: Any) -> None:
         self._weave_load_lock = threading.Lock()
         return old_init(self, *args, **kwargs)
 
     @wraps(old_load)
-    def new_load(self, *args, **kwargs):  # type: ignore
+    def new_load(self: ImageFile, *args: Any, **kwargs: Any) -> None:
         with self._weave_load_lock:
             return old_load(self, *args, **kwargs)
 
     ImageFile.__init__ = new_init  # type: ignore
     ImageFile.load = new_load  # type: ignore
+
+
+def undo_threadsafety_patch_to_pil_image() -> None:
+    """Revert the thread-safety patch applied to PIL ImageFile class.
+
+    If the patch hasn't been applied, this function does nothing.
+    If the patch has been applied but can't be reverted, an error message is printed.
+    """
+    from PIL.ImageFile import ImageFile
+
+    global _patched, _original_methods
+
+    if not _patched:
+        return
+
+    try:
+        if _original_methods["init"] is not None:
+            ImageFile.__init__ = _original_methods["init"]  # type: ignore
+        if _original_methods["load"] is not None:
+            ImageFile.load = _original_methods["load"]  # type: ignore
+
+        _original_methods = {"init": None, "load": None}
+        _patched = False
+    except Exception as e:
+        print(
+            f"Failed to unpatch PIL.ImageFile.ImageFile: Unable to restore original methods - {e}"
+        )

--- a/weave/initialization/pil_image_thread_safety.py
+++ b/weave/initialization/pil_image_thread_safety.py
@@ -1,0 +1,46 @@
+"""
+This file exposes a function that makes the PIL ImageFile thread-safe: `make_image_file_thread_safe`.
+
+There is a discussion here: https://github.com/python-pillow/Pillow/issues/4848#issuecomment-671339193 in which
+the author claims that the Pillow library is thread-safe. However, my reasoning leads me to a different conclusion.
+
+Specifically, the `ImageFile.load` method is not thread-safe. This is because `load` will both close and delete
+an open file handler as well as modify properties of the ImageFile object (namely the `im` property which contains
+the underlying image data). Inside of Weave we use threads to parallelize work which may involve Images. This bug
+has presented itself not only in our own persistence layer, but also in user code where they are consuming loaded
+images across threads.
+
+We call `make_image_file_thread_safe` in the `__init__.py` file to ensure that the ImageFile class is thread-safe.
+"""
+
+import threading
+from functools import wraps
+
+from PIL.ImageFile import ImageFile
+
+_patch_lock = threading.Lock()
+_patched = False
+
+
+def make_image_file_thread_safe() -> None:
+    global _patched
+    with _patch_lock:
+        if _patched:
+            return
+        _patched = True
+
+    old_load = ImageFile.load
+    old_init = ImageFile.__init__
+
+    @wraps(old_init)
+    def new_init(self, *args, **kwargs):  # type: ignore
+        self._load_lock = threading.Lock()
+        return old_init(self, *args, **kwargs)
+
+    @wraps(old_load)
+    def new_load(self, *args, **kwargs):  # type: ignore
+        with self._load_lock:
+            return old_load(self, *args, **kwargs)
+
+    ImageFile.__init__ = new_init  # type: ignore
+    ImageFile.load = new_load  # type: ignore


### PR DESCRIPTION
See comments in code:

```
This file exposes a function that makes the PIL ImageFile thread-safe: `make_image_file_thread_safe`.
There is a discussion here: https://github.com/python-pillow/Pillow/issues/4848#issuecomment-671339193 in which
the author claims that the Pillow library is thread-safe. However, my reasoning leads me to a different conclusion.
Specifically, the `ImageFile.load` method is not thread-safe. This is because `load` will both close and delete
an open file handler as well as modify properties of the ImageFile object (namely the `im` property which contains
the underlying image data). Inside of Weave we use threads to parallelize work which may involve Images. This bug
has presented itself not only in our own persistence layer, but also in user code where they are consuming loaded
images across threads.
We call `make_image_file_thread_safe` in the `__init__.py` file to ensure that the ImageFile class is thread-safe.
```