### PR TITLE
feat(ui): allow specifying page size in grid

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pagination.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/pagination.ts
@@ -1,7 +1,7 @@
 import {GridPaginationModel} from '@mui/x-data-grid-pro';
 
 const MAX_PAGE_SIZE = 100;
-export const DEFAULT_PAGE_SIZE = 100;
+export const DEFAULT_PAGE_SIZE = 50;
 
 export const getValidPaginationModel = (
   queryPage: string | undefined,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -189,6 +189,7 @@ export const CallDetails: FC<{
               entity={call.entity}
               project={call.project}
               allowedColumnPatterns={ALLOWED_COLUMN_PATTERNS}
+              paginationModel={isPeeking ? {page: 0, pageSize: 10} : undefined}
             />
           );
           if (isPeeking) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -941,7 +941,6 @@ export const CallsTable: FC<{
         paginationMode="server"
         paginationModel={paginationModel}
         onPaginationModelChange={onPaginationModelChange}
-        pageSizeOptions={[DEFAULT_PAGE_SIZE]}
         // PAGINATION SECTION END
         rowHeight={38}
         columns={muiColumns}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -948,6 +948,7 @@ export const CallsTable: FC<{
         rowSelectionModel={rowSelectionModel}
         // columnGroupingModel={groupingModel}
         columnGroupingModel={columns.colGroupingModel}
+        hideFooter={!callsLoading && callsTotal === 0}
         hideFooterSelectedRowCount
         onColumnWidthChange={newCol => {
           setUserDefinedColumnWidths(curr => {
@@ -1021,7 +1022,7 @@ export const CallsTable: FC<{
             );
           },
           columnMenu: CallsCustomColumnMenu,
-          pagination: PaginationButtons,
+          pagination: () => <PaginationButtons hideControls={hideControls} />,
           columnMenuSortDescendingIcon: IconSortDescending,
           columnMenuSortAscendingIcon: IconSortAscending,
           columnMenuHideIcon: IconNotVisible,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -26,6 +26,7 @@ import classNames from 'classnames';
 import React, {Dispatch, FC, SetStateAction, useRef, useState} from 'react';
 
 import * as userEvents from '../../../../../../integrations/analytics/userEvents';
+import {Select} from '../../../../../Form/Select';
 import {useWFHooks} from '../wfReactInterface/context';
 import {Query} from '../wfReactInterface/traceServerClientInterface/query';
 import {
@@ -642,6 +643,11 @@ curl '${baseUrl}/calls/stream_query' \\
   return baseCurl;
 }
 
+type PageSizeOption = {
+  readonly value: number;
+  readonly label: string;
+};
+
 export const PaginationButtons = () => {
   const apiRef = useGridApiContext();
   const page = useGridSelector(apiRef, gridPageSelector);
@@ -661,35 +667,77 @@ export const PaginationButtons = () => {
   const start = rowCount > 0 ? page * pageSize + 1 : 0;
   const end = Math.min(rowCount, (page + 1) * pageSize);
 
+  const pageSizes = [10, 25, 50, 100];
+  if (!pageSizes.includes(pageSize)) {
+    pageSizes.push(pageSize);
+    pageSizes.sort((a, b) => a - b);
+  }
+  const pageSizeOptions = pageSizes.map(sz => ({
+    value: sz,
+    label: sz.toString(),
+  }));
+  const pageSizeValue = pageSizeOptions.find(o => o.value === pageSize);
+  const onPageSizeChange = (option: PageSizeOption | null) => {
+    if (option) {
+      apiRef.current.setPageSize(option.value);
+    }
+  };
+
   return (
-    <Box display="flex" alignItems="center" justifyContent="center" padding={1}>
-      <Button
-        variant="ghost"
-        size="medium"
-        onClick={handlePrevPage}
-        disabled={page === 0}
-        icon="chevron-back"
-      />
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="space-between"
+      width="100%"
+      padding={1}>
+      <Box display="flex" alignItems="center">
+        <Button
+          variant="ghost"
+          size="medium"
+          onClick={handlePrevPage}
+          disabled={page === 0}
+          icon="chevron-back"
+        />
+        <Box
+          mx={1}
+          sx={{
+            fontSize: '14px',
+            fontWeight: '400',
+            color: MOON_500,
+            // This is so that when we go from 1-100 -> 101-200, the buttons don't jump
+            minWidth: '90px',
+            display: 'flex',
+            justifyContent: 'center',
+          }}>
+          {start}-{end} of {rowCount}
+        </Box>
+        <Button
+          variant="ghost"
+          size="medium"
+          onClick={handleNextPage}
+          disabled={page >= pageCount - 1}
+          icon="chevron-next"
+        />
+      </Box>
       <Box
-        mx={1}
         sx={{
           fontSize: '14px',
           fontWeight: '400',
           color: MOON_500,
-          // This is so that when we go from 1-100 -> 101-200, the buttons dont jump
-          minWidth: '90px',
           display: 'flex',
-          justifyContent: 'center',
+          alignItems: 'center',
+          gap: '8px',
         }}>
-        {start}-{end} of {rowCount}
+        Per page:
+        <Select<PageSizeOption>
+          size="small"
+          menuPlacement="top"
+          options={pageSizeOptions}
+          value={pageSizeValue}
+          isSearchable={false}
+          onChange={onPageSizeChange}
+        />
       </Box>
-      <Button
-        variant="ghost"
-        size="medium"
-        onClick={handleNextPage}
-        disabled={page >= pageCount - 1}
-        icon="chevron-next"
-      />
     </Box>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -648,7 +648,11 @@ type PageSizeOption = {
   readonly label: string;
 };
 
-export const PaginationButtons = () => {
+type PaginationButtonsProps = {
+  hideControls?: boolean;
+};
+
+export const PaginationButtons = ({hideControls}: PaginationButtonsProps) => {
   const apiRef = useGridApiContext();
   const page = useGridSelector(apiRef, gridPageSelector);
   const pageCount = useGridSelector(apiRef, gridPageCountSelector);
@@ -719,25 +723,29 @@ export const PaginationButtons = () => {
           icon="chevron-next"
         />
       </Box>
-      <Box
-        sx={{
-          fontSize: '14px',
-          fontWeight: '400',
-          color: MOON_500,
-          display: 'flex',
-          alignItems: 'center',
-          gap: '8px',
-        }}>
-        Per page:
-        <Select<PageSizeOption>
-          size="small"
-          menuPlacement="top"
-          options={pageSizeOptions}
-          value={pageSizeValue}
-          isSearchable={false}
-          onChange={onPageSizeChange}
-        />
-      </Box>
+      {hideControls ? null : (
+        <Box
+          sx={{
+            fontSize: '14px',
+            fontWeight: '400',
+            color: MOON_500,
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            // Regrettable hack to appear over Material scrollbar's z-index of 6.
+            zIndex: 7,
+          }}>
+          Per page:
+          <Select<PageSizeOption>
+            size="small"
+            menuPlacement="top"
+            options={pageSizeOptions}
+            value={pageSizeValue}
+            isSearchable={false}
+            onChange={onPageSizeChange}
+          />
+        </Box>
+      )}
     </Box>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/views/Leaderboard/LeaderboardGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/views/Leaderboard/LeaderboardGrid.tsx
@@ -400,7 +400,7 @@ export const LeaderboardGrid: React.FC<LeaderboardGridProps> = ({
           },
         }}
         slots={{
-          pagination: PaginationButtons,
+          pagination: () => <PaginationButtons />,
         }}
       />
     </Box>


### PR DESCRIPTION
## Description

Currently we have no UI for setting pageSize and default to 100 rows, though we respect other values in query parameters.
This PR adds a small control to allow the user to set. (Does not persist yet, but should in a saved view.)
The motivation is that some users with huge traces get poor performance or failures if they try to load 100 traces at once.

<img width="174" alt="Screenshot 2025-01-16 at 10 48 52 PM" src="https://github.com/user-attachments/assets/5f315dd1-30f4-4a68-beba-0d79f1009247" />

This PR also changes the default page size to 50 and reduces the number of rows loaded in the peek drawer "table preview button" from 100 to 10.

Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1737131400397869
## Testing

How was this PR tested?
