### PR TITLE
fix(ui): all strings are clickable in object viewer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewString.tsx
@@ -86,26 +86,24 @@ const getDefaultFormat = (value: string): Format => {
 
 export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
   const trimmed = value.trim();
-  const hasScrolling = trimmed.indexOf('\n') !== -1 || value.length > 100;
   const [hasFull, setHasFull] = useState(false);
+  const defaultScrolling = trimmed.indexOf('\n') !== -1 || value.length > 100;
 
   const [format, setFormat] = useState(getDefaultFormat(value));
   useEffect(() => {
     setFormat(getDefaultFormat(value));
   }, [value]);
 
-  const [mode, setMode] = useState(hasScrolling ? (isExpanded ? 1 : 0) : 0);
+  const [mode, setMode] = useState(defaultScrolling ? (isExpanded ? 1 : 0) : 0);
 
   useEffect(() => {
-    setMode(hasScrolling ? (isExpanded ? 1 : 0) : 0);
-  }, [hasScrolling, isExpanded]);
+    setMode(defaultScrolling ? (isExpanded ? 1 : 0) : 0);
+  }, [defaultScrolling, isExpanded]);
 
-  const onClick = hasScrolling
-    ? () => {
-        const numModes = hasFull ? 3 : 2;
-        setMode((mode + 1) % numModes);
-      }
-    : undefined;
+  const onClick = () => {
+    const numModes = hasFull ? 3 : 2;
+    setMode((mode + 1) % numModes);
+  };
   const copy = useCallback(() => {
     copyToClipboard(value);
     toast('Copied to clipboard');
@@ -210,7 +208,7 @@ export const ValueViewString = ({value, isExpanded}: ValueViewStringProps) => {
     );
   }
   return (
-    <Collapsed hasScrolling={hasScrolling} onClick={onClick}>
+    <Collapsed hasScrolling={isExpanded} onClick={onClick}>
       {content}
     </Collapsed>
   );


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
https://wandb.atlassian.net/browse/WB-19941

Makes all strings clickable, so even truncated strings can be clicked on. 

## Testing


