### PR TITLE
chore(weave): Re-enable to_dict support in serialization layer

### DIFF
--- a/weave/trace/serialization/dictifiable.py
+++ b/weave/trace/serialization/dictifiable.py
@@ -1,4 +1,4 @@
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -9,14 +9,14 @@ class Dictifiable(Protocol):
         """Convert the object to a dictionary representation."""
         ...
 
-T = TypeVar('T')
-def try_to_dict(obj: T) -> dict[str, Any] | None:
+
+def try_to_dict(obj: Any) -> dict[str, Any] | None:
     """
     Attempt to convert an object to a dictionary using the Dictifiable protocol.
-    
+
     Args:
         obj: Object to attempt to convert to dictionary
-        
+
     Returns:
         Dictionary representation if object implements Dictifiable protocol, None otherwise
     """

--- a/weave/trace/serialization/dictifiable.py
+++ b/weave/trace/serialization/dictifiable.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Protocol, runtime_checkable
 
 

--- a/weave/trace/serialization/dictifiable.py
+++ b/weave/trace/serialization/dictifiable.py
@@ -1,0 +1,30 @@
+from typing import Any, Protocol, TypeVar, runtime_checkable
+
+
+@runtime_checkable
+class Dictifiable(Protocol):
+    """Protocol for objects that can be converted to a dictionary representation."""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the object to a dictionary representation."""
+        ...
+
+T = TypeVar('T')
+def try_to_dict(obj: T) -> dict[str, Any] | None:
+    """
+    Attempt to convert an object to a dictionary using the Dictifiable protocol.
+    
+    Args:
+        obj: Object to attempt to convert to dictionary
+        
+    Returns:
+        Dictionary representation if object implements Dictifiable protocol, None otherwise
+    """
+    if isinstance(obj, Dictifiable):
+        try:
+            res = obj.to_dict()
+            if isinstance(res, dict):
+                return res
+        except Exception:
+            return None
+    return None

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -9,6 +9,7 @@ from weave.trace import custom_objs
 from weave.trace.object_record import ObjectRecord
 from weave.trace.refs import ObjectRef, TableRef, parse_uri
 from weave.trace.sanitize import REDACTED_VALUE, should_redact
+from weave.trace.serialization.dictifiable import try_to_dict
 from weave.trace_server.interface.builtin_object_classes.builtin_object_registry import (
     BUILTIN_OBJECT_REGISTRY,
 )
@@ -57,6 +58,14 @@ def to_json(
             and not has_custom_repr(obj)
         ):
             return dictify(obj)
+
+        # TODO: I would prefer to only have this once in dictify? Maybe dictify and to_json need to be merged?
+        # However, even if dictify is false, i still want to try to convert to dict
+        elif as_dict := try_to_dict(obj):
+            return {
+                k: to_json(v, project_id, client, use_dictify)
+                for k, v in as_dict.items()
+            }
         return fallback_encode(obj)
     result = _build_result_from_encoded(encoded, project_id, client)
 


### PR DESCRIPTION
With dictify=false on inputs and outputs, we lost the ability to respect to_dict. This patches in a little hack to put that back