### PR TITLE
feat(weave): allow disabling autopatch

### DIFF
--- a/scripts/benchmark_init.py
+++ b/scripts/benchmark_init.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+import argparse
+import statistics
+import subprocess
+import sys
+from datetime import datetime
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
+from rich.table import Table
+
+from weave.trace.autopatch import AutopatchSettings
+
+
+def today() -> str:
+    return datetime.today().date().strftime("%Y-%m-%d")
+
+
+def run_single_init(disable_autopatch: bool = False):
+    projname = today() + "_benchmark_init"
+    cmd = rf"""
+import time
+import weave
+start = time.perf_counter()
+weave.init("{projname}", autopatch_settings={{"disable_autopatch": {disable_autopatch}}})
+end = time.perf_counter()
+print(end - start)
+"""
+    result = subprocess.run([sys.executable, "-c", cmd], capture_output=True, text=True)
+    # Get the last line of output (Skipping "Logged in as Weights & Biases user...")
+    output = result.stdout.strip().split("\n")[-1]
+    print(output)
+    return float(output)
+
+
+def benchmark(iterations: int = 10, disable_autopatch: bool = False):
+    projname = today() + "_benchmark_init"
+    # Ensure project exists
+    import weave
+
+    weave.init(projname, autopatch_settings=AutopatchSettings(disable_autopatch=True))
+
+    console = Console()
+    times = []
+
+    with Progress(
+        SpinnerColumn(),
+        *Progress.get_default_columns(),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
+        task = progress.add_task("[cyan]Running init tests...", total=iterations)
+
+        for _ in range(iterations):
+            times.append(run_single_init(disable_autopatch))
+            progress.advance(task)
+
+    # Display results in a nice table
+    table = Table(title="Init Time Benchmark Results")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Value", style="green")
+
+    table.add_row("Mean init time", f"{statistics.mean(times):.4f}s")
+    table.add_row("Median init time", f"{statistics.median(times):.4f}s")
+    table.add_row("Std dev", f"{statistics.stdev(times):.4f}s")
+    table.add_row("Min time", f"{min(times):.4f}s")
+    table.add_row("Max time", f"{max(times):.4f}s")
+
+    console.print("\n")
+    console.print(table)
+
+    # Show individual times
+    times_table = Table(title="Individual Init Times")
+    times_table.add_column("Run #", style="cyan")
+    times_table.add_column("Time (seconds)", style="green")
+
+    for i, t in enumerate(times, 1):
+        times_table.add_row(str(i), f"{t:.4f}")
+
+    console.print("\n")
+    console.print(times_table)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark weave.init performance")
+    parser.add_argument(
+        "--disable-autopatch", action="store_true", help="Disable autopatching"
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=10,
+        help="Number of iterations to run (default: 10)",
+    )
+    args = parser.parse_args()
+
+    benchmark(iterations=args.iterations, disable_autopatch=args.disable_autopatch)

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -54,7 +54,7 @@ class AutopatchSettings(BaseModel):
 def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     if settings is None:
         settings = AutopatchSettings()
-    elif settings.disable_autopatch:
+    if settings.disable_autopatch:
         return
 
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -32,7 +32,8 @@ class IntegrationSettings(BaseModel):
 class AutopatchSettings(BaseModel):
     """Settings for auto-patching integrations."""
 
-    # These will be uncommented as we add support for more integrations.  Note that
+    # If True, other autopatch settings are ignored.
+    disable_autopatch: bool = False
 
     anthropic: IntegrationSettings = Field(default_factory=IntegrationSettings)
     cerebras: IntegrationSettings = Field(default_factory=IntegrationSettings)
@@ -51,6 +52,11 @@ class AutopatchSettings(BaseModel):
 
 @validate_call
 def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
+    if settings is None:
+        settings = AutopatchSettings()
+    elif settings.disable_autopatch:
+        return
+
     from weave.integrations.anthropic.anthropic_sdk import get_anthropic_patcher
     from weave.integrations.cerebras.cerebras_sdk import get_cerebras_patcher
     from weave.integrations.cohere.cohere_sdk import get_cohere_patcher
@@ -70,9 +76,6 @@ def autopatch(settings: Optional[AutopatchSettings] = None) -> None:
     from weave.integrations.notdiamond.tracing import get_notdiamond_patcher
     from weave.integrations.openai.openai_sdk import get_openai_patcher
     from weave.integrations.vertexai.vertexai_sdk import get_vertexai_patcher
-
-    if settings is None:
-        settings = AutopatchSettings()
 
     get_openai_patcher(settings.openai).attempt_patch()
     get_mistral_patcher(settings.mistral).attempt_patch()


### PR DESCRIPTION
## Description

Gives users the ability to disable autopatching, giving improved `weave.init` performance by almost a second if the user does not need integrations. An example use: a script that doesn't need to log any traces, like the benchmarking script included here.

For discussion related to https://github.com/wandb/weave/issues/3441

Before: Can disable individual integrations

After: Can also easily disable all integrations

Future?: Can selectively enable integrations

Integrations enabled:
```
python benchmark_init.py 
Logged in as Weights & Biases user: jamie-rasmussen.
View Weave data at https://wandb.ai/jamie-rasmussen/2025-01-20_benchmark_init/weave
1.981088749999799
1.254892750000181
1.242289083000287
1.322170541999185
1.3297177079994071
1.2651509999996051
1.3684602919993267
1.268961792000482
1.3221507079997536
1.3851784170001338
  Running init tests... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:36


 Init Time Benchmark Results  
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Metric           ┃ Value   ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ Mean init time   │ 1.3740s │
│ Median init time │ 1.3222s │
│ Std dev          │ 0.2187s │
│ Min time         │ 1.2423s │
│ Max time         │ 1.9811s │
└──────────────────┴─────────┘


  Individual Init Times   
┏━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Run # ┃ Time (seconds) ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ 1     │ 1.9811         │
│ 2     │ 1.2549         │
│ 3     │ 1.2423         │
│ 4     │ 1.3222         │
│ 5     │ 1.3297         │
│ 6     │ 1.2652         │
│ 7     │ 1.3685         │
│ 8     │ 1.2690         │
│ 9     │ 1.3222         │
│ 10    │ 1.3852         │
└───────┴────────────────┘
```

Integrations disabled:
```
python benchmark_init.py --disable-autopatch
Logged in as Weights & Biases user: jamie-rasmussen.
View Weave data at https://wandb.ai/jamie-rasmussen/2025-01-20_benchmark_init/weave
0.45323512499999197
0.48261237500082643
0.467393875000198
0.540551707999839
0.4925498749998951
0.44786283299981733
0.4837395419999666
0.4726712920000864
0.38254491699990467
0.5333322499991482
  Running init tests... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00 0:00:25


 Init Time Benchmark Results  
┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ Metric           ┃ Value   ┃
┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ Mean init time   │ 0.4756s │
│ Median init time │ 0.4776s │
│ Std dev          │ 0.0447s │
│ Min time         │ 0.3825s │
│ Max time         │ 0.5406s │
└──────────────────┴─────────┘


  Individual Init Times   
┏━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ Run # ┃ Time (seconds) ┃
┡━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ 1     │ 0.4532         │
│ 2     │ 0.4826         │
│ 3     │ 0.4674         │
│ 4     │ 0.5406         │
│ 5     │ 0.4925         │
│ 6     │ 0.4479         │
│ 7     │ 0.4837         │
│ 8     │ 0.4727         │
│ 9     │ 0.3825         │
│ 10    │ 0.5333         │
└───────┴────────────────┘

```
