### PR TITLE
chore(dev): run testci during weave-js test step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -180,6 +180,7 @@ jobs:
           yarn tslint
           yarn prettier
           yarn run tsc
+          yarn testci
 
   # ==== Trace Jobs ====
   lint:

--- a/weave-js/src/components/TooltipDeprecated.tsx
+++ b/weave-js/src/components/TooltipDeprecated.tsx
@@ -14,7 +14,7 @@ import {
 
 export const TooltipDeprecated = styled(Popup).attrs({
   basic: true, // This removes the pointing arrow.
-  mouseEnterDelay: 501,
+  mouseEnterDelay: 500,
   popperModifiers: {
     preventOverflow: {
       // Prevent popper from erroneously constraining the popup.

--- a/weave-js/src/components/TooltipDeprecated.tsx
+++ b/weave-js/src/components/TooltipDeprecated.tsx
@@ -14,7 +14,7 @@ import {
 
 export const TooltipDeprecated = styled(Popup).attrs({
   basic: true, // This removes the pointing arrow.
-  mouseEnterDelay: 500,
+  mouseEnterDelay: 501,
   popperModifiers: {
     preventOverflow: {
       // Prevent popper from erroneously constraining the popup.


### PR DESCRIPTION
## Description

Runs testci during weave-js test step. This will let us not run it in core, as there are no core dependencies

## Testing

run ci. see commit history for example change to actually trigger js tests
https://github.com/wandb/weave/actions/runs/12891921201/job/35945037394