### PR TITLE
chore(ui): add tooltip to Op version delete button

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
@@ -201,6 +201,7 @@ const DeleteOpButtonWithModal: React.FC<{
         icon="delete"
         variant="ghost"
         onClick={() => setDeleteModalOpen(true)}
+        tooltip="Delete this Op version"
       />
       <DeleteModal
         open={deleteModalOpen}


### PR DESCRIPTION
## Description

Wasn't immediately obvious to me if this button only deleted the version or all versions of the Op - added a tooltip.
<img width="500" alt="Screenshot 2025-01-21 at 11 38 03 AM" src="https://github.com/user-attachments/assets/da24543c-27be-47fe-b9d5-50597f55ed1b" />


