### PR TITLE
perf(weave): Speed up json object parsing

### DIFF
--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -232,7 +232,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         r = self._generic_request_executor(url, req, stream=True)
         for line in r.iter_lines():
             if line:
-                yield res_model.model_validate(json.loads(line))
+                yield res_model.model_validate_json(line)
 
     @tenacity.retry(
         stop=tenacity.stop_after_delay(REMOTE_REQUEST_RETRY_DURATION),


### PR DESCRIPTION
Speed up object parsing by using `model_validate_json` instead of `model_validate(json.loads(...))`


Perf example is for 1 Call object
![image](https://github.com/user-attachments/assets/e0ffa2a8-76bc-4df2-90e8-14ff8e9188eb)
