### PR TITLE
docs(weave): add .delete() to object doc page

### DIFF
--- a/docs/docs/guides/tracking/objects.md
+++ b/docs/docs/guides/tracking/objects.md
@@ -62,7 +62,7 @@ Saving an object with a name will create the first version of that object if it 
 
 <Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
-    You can call `.delete()` on any object Ref to delete that version of the object.
+    To delete a version of an object, call `.delete()` on the object ref.
 
     ```python
     weave.init('intro-example')

--- a/docs/docs/guides/tracking/objects.md
+++ b/docs/docs/guides/tracking/objects.md
@@ -58,6 +58,28 @@ Saving an object with a name will create the first version of that object if it 
   </TabItem>
 </Tabs>
 
+### Deletion
+
+<Tabs groupId="programming-language" queryString>
+  <TabItem value="python" label="Python" default>
+    You can call `.delete()` on any object Ref to delete the object.
+
+    ```python
+    weave.init('intro-example')
+    cat_names_ref = weave.ref('cat-names')
+    cat_names_ref.delete()
+    ```
+
+    Trying to access a deleted object will result in an error. Resolving an object that has a reference to a deleted object will return a `DeletedRef` object in place of the deleted object.
+
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+    ```plaintext
+    This feature is not available in TypeScript yet.  Stay tuned!
+    ```
+  </TabItem>
+</Tabs>
+
 ## Ref styles
 
 A fully qualified weave object ref uri looks like this:

--- a/docs/docs/guides/tracking/objects.md
+++ b/docs/docs/guides/tracking/objects.md
@@ -58,7 +58,7 @@ Saving an object with a name will create the first version of that object if it 
   </TabItem>
 </Tabs>
 
-### Deletion
+### Deleting an object
 
 <Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>

--- a/docs/docs/guides/tracking/objects.md
+++ b/docs/docs/guides/tracking/objects.md
@@ -62,11 +62,11 @@ Saving an object with a name will create the first version of that object if it 
 
 <Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
-    You can call `.delete()` on any object Ref to delete the object.
+    You can call `.delete()` on any object Ref to delete that version of the object.
 
     ```python
     weave.init('intro-example')
-    cat_names_ref = weave.ref('cat-names')
+    cat_names_ref = weave.ref('cat-names:v1')
     cat_names_ref.delete()
     ```
 

--- a/docs/docs/guides/tracking/objects.md
+++ b/docs/docs/guides/tracking/objects.md
@@ -58,7 +58,7 @@ Saving an object with a name will create the first version of that object if it 
   </TabItem>
 </Tabs>
 
-### Deleting an object
+## Deleting an object
 
 <Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>

--- a/docs/docs/guides/tracking/ops.md
+++ b/docs/docs/guides/tracking/ops.md
@@ -161,11 +161,11 @@ export WEAVE_PRINT_CALL_LINK=false
 
 <Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
-    You can call `.delete()` on any op Ref to delete the op.
+    You can call `.delete()` on any op Ref to delete that version of the op.
 
     ```python
     weave.init('intro-example')
-    my_op_ref = weave.ref('track_me')
+    my_op_ref = weave.ref('track_me:v1')
     my_op_ref.delete()
     ```
 

--- a/docs/docs/guides/tracking/ops.md
+++ b/docs/docs/guides/tracking/ops.md
@@ -157,7 +157,7 @@ If you want to suppress the printing of call links during logging, you can set t
 export WEAVE_PRINT_CALL_LINK=false
 ```
 
-### Deleting an op
+## Deleting an op
 
 <Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>

--- a/docs/docs/guides/tracking/ops.md
+++ b/docs/docs/guides/tracking/ops.md
@@ -161,7 +161,7 @@ export WEAVE_PRINT_CALL_LINK=false
 
 <Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
-    You can call `.delete()` on any op Ref to delete that version of the op.
+    To delete a version of an op, call `.delete()` on the op ref.
 
     ```python
     weave.init('intro-example')

--- a/docs/docs/guides/tracking/ops.md
+++ b/docs/docs/guides/tracking/ops.md
@@ -156,3 +156,25 @@ If you want to suppress the printing of call links during logging, you can set t
 ```bash
 export WEAVE_PRINT_CALL_LINK=false
 ```
+
+### Deleting an op
+
+<Tabs groupId="programming-language" queryString>
+  <TabItem value="python" label="Python" default>
+    You can call `.delete()` on any op Ref to delete the op.
+
+    ```python
+    weave.init('intro-example')
+    my_op_ref = weave.ref('track_me')
+    my_op_ref.delete()
+    ```
+
+    Trying to access a deleted op will result in an error.
+
+  </TabItem>
+  <TabItem value="typescript" label="TypeScript">
+    ```plaintext
+    This feature is not available in TypeScript yet.  Stay tuned!
+    ```
+  </TabItem>
+</Tabs>


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Minimal docs for sdk object and op deletion 

## Testing

<img width="992" alt="Screenshot 2025-01-21 at 3 22 04 PM" src="https://github.com/user-attachments/assets/456c9ac6-c7bb-4916-bace-d0efdcc3eed2" />

<img width="1021" alt="Screenshot 2025-01-21 at 3 21 54 PM" src="https://github.com/user-attachments/assets/775175fd-3685-47cf-b67f-042c44cbe637" />

