### PR TITLE
chore(weave): Improve Weave patch to support pre-constructed images

### DIFF
--- a/tests/trace/image_patch_test.py
+++ b/tests/trace/image_patch_test.py
@@ -18,4 +18,5 @@ def test_patching_import_order():
 
     pil_image_thread_safety.apply_threadsafe_patch_to_pil_image()
     assert pil_image_thread_safety._patched
+
     image.crop((0, 0, 10, 10))

--- a/tests/trace/image_patch_test.py
+++ b/tests/trace/image_patch_test.py
@@ -1,0 +1,21 @@
+from tempfile import NamedTemporaryFile
+
+from weave.initialization import pil_image_thread_safety
+
+
+def test_patching_import_order():
+    # This test verifies the correct behavior if patching occurs after the construction
+    # of an image
+    assert pil_image_thread_safety._patched
+    pil_image_thread_safety.undo_threadsafe_patch_to_pil_image()
+    assert not pil_image_thread_safety._patched
+    import PIL
+
+    image = PIL.Image.new("RGB", (10, 10))
+    with NamedTemporaryFile(suffix=".png") as f:
+        image.save(f.name)
+        image = PIL.Image.open(f.name)
+
+    pil_image_thread_safety.apply_threadsafe_patch_to_pil_image()
+    assert pil_image_thread_safety._patched
+    image.crop((0, 0, 10, 10))

--- a/tests/trace/type_handlers/Image/image_test.py
+++ b/tests/trace/type_handlers/Image/image_test.py
@@ -149,20 +149,19 @@ def test_image_as_file(client: WeaveClient) -> None:
         file_path.unlink()
 
 
+def make_random_image(image_size: tuple[int, int] = (1024, 1024)):
+    random_colour = (
+        random.randint(0, 255),
+        random.randint(0, 255),
+        random.randint(0, 255),
+    )
+    return Image.new("RGB", image_size, random_colour)
+
+
 @pytest.fixture
 def dataset_ref(client):
     # This fixture represents a saved dataset containing images
-    IMAGE_SIZE = (1024, 1024)
     N_ROWS = 50
-
-    def make_random_image():
-        random_colour = (
-            random.randint(0, 255),
-            random.randint(0, 255),
-            random.randint(0, 255),
-        )
-        return Image.new("RGB", IMAGE_SIZE, random_colour)
-
     rows = [{"img": make_random_image()} for _ in range(N_ROWS)]
     dataset = weave.Dataset(rows=rows)
     ref = weave.publish(dataset)
@@ -202,3 +201,18 @@ async def test_many_images_will_consistently_log():
 
     # But if there's an issue, the stderr will contain `Task failed:`
     assert "Task failed" not in res.stderr
+
+
+def test_images_in_load_of_dataset(client):
+    N_ROWS = 50
+    rows = [{"img": make_random_image()} for _ in range(N_ROWS)]
+    dataset = weave.Dataset(rows=rows)
+    ref = weave.publish(dataset)
+
+    dataset = ref.get()
+    for gotten_row, local_row in zip(dataset, rows):
+        assert isinstance(gotten_row["img"], Image.Image)
+        assert gotten_row["img"].size == local_row["img"].size
+        assert gotten_row["img"].tobytes() == local_row["img"].tobytes()
+
+    return ref

--- a/weave/initialization/pil_image_thread_safety.py
+++ b/weave/initialization/pil_image_thread_safety.py
@@ -20,10 +20,14 @@ import threading
 from functools import wraps
 from typing import Any, Callable, Optional
 
+# Global state
+# `_patched` is a boolean that indicates whether the thread-safety patch has been applied
+# `_original_methods` is a dictionary that stores the original methods of the ImageFile class
+# `_new_lock_lock` is a lock that is used to create a new lock for each ImageFile instance
+# `_fallback_load_lock` is a global lock that is used to ensure thread-safe image loading when per-instance locking fails
 _patched = False
 _original_methods: dict[str, Optional[Callable]] = {"load": None}
 _new_lock_lock = threading.Lock()
-# Global fallback lock for thread-safe image loading when per-instance locking fails
 _fallback_load_lock = threading.Lock()
 
 


### PR DESCRIPTION
Modifies the patching logic such that order of construction is irrelevant. Currently this will fail:

```python
import PIL
image = PIL.Image.new("RGB", (10, 10))
with NamedTemporaryFile(suffix=".png") as f:
    image.save(f.name)
    image = PIL.Image.open(f.name)
image.crop((0, 0, 10, 10)) # <---- Attribute error on `_weave_load_lock`
```

This modified implementation uses a `TheadSafeLockLookup` to ensure that the `_weave_load_lock` is always available for any object requesting it and only minted once per object.