### PR TITLE
feat(app): Runs History Tables Scrubber

### DIFF
--- a/weave-js/src/common/types/file.ts
+++ b/weave-js/src/common/types/file.ts
@@ -1,0 +1,4 @@
+export const TABLE_FILE_TYPE = {
+  type: 'file' as const,
+  wbObjectType: {type: 'table' as const, columnTypes: {}},
+};

--- a/weave-js/src/common/types/run.ts
+++ b/weave-js/src/common/types/run.ts
@@ -1,0 +1,7 @@
+export const LIST_RUNS_TYPE = {
+  type: 'list' as const,
+  objectType: {
+    type: 'union' as const,
+    members: ['none' as const, 'run' as const],
+  },
+};

--- a/weave-js/src/common/util/table.ts
+++ b/weave-js/src/common/util/table.ts
@@ -1,0 +1,36 @@
+import {
+  isAssignableTo,
+  list,
+  listObjectType,
+  maybe,
+  Type,
+  typedDict,
+  typedDictPropertyTypes,
+} from '@wandb/weave/core';
+
+import {TABLE_FILE_TYPE} from '../types/file';
+
+export const getTableKeysFromNodeType = (
+  inputNodeType: Type,
+  defaultKey: string | null = null
+) => {
+  if (
+    inputNodeType != null &&
+    isAssignableTo(inputNodeType, list(typedDict({})))
+  ) {
+    const typeMap = typedDictPropertyTypes(listObjectType(inputNodeType));
+    const tableKeys = Object.keys(typeMap)
+      .filter(key => {
+        return isAssignableTo(typeMap[key], maybe(TABLE_FILE_TYPE));
+      })
+      .sort();
+    const value =
+      tableKeys.length > 0 &&
+      defaultKey != null &&
+      tableKeys.indexOf(defaultKey) !== -1
+        ? defaultKey
+        : tableKeys?.[0] ?? '';
+    return {tableKeys, value};
+  }
+  return {tableKeys: [], value: ''};
+};

--- a/weave-js/src/components/Panel2/PanelExpression/hooks.ts
+++ b/weave-js/src/components/Panel2/PanelExpression/hooks.ts
@@ -610,6 +610,14 @@ export function usePanelExpressionState(props: PanelExpressionProps) {
         ...results,
       ];
     }
+
+    // Only paginated tables are supported for run history tables stepper
+    results = results.filter(r => {
+      if (r.key.startsWith('run-history-tables-stepper')) {
+        return r.key === 'run-history-tables-stepper.row.table';
+      }
+      return true;
+    });
     return results;
   }, [handler, stackIds, weavePlotEnabled]);
 

--- a/weave-js/src/components/Panel2/PanelRegistry.tsx
+++ b/weave-js/src/components/Panel2/PanelRegistry.tsx
@@ -45,6 +45,7 @@ import {weavePythonPanelSpecs} from './PanelRegistryWeavePython';
 // converters
 import {Spec as RowSpec} from './PanelRow';
 import {Spec as RunColorSpec} from './PanelRunColor';
+import {Spec as PanelRunHistoryTablesStepperSpec} from './PanelRunHistoryTablesStepper';
 import {Spec as RunOverviewSpec} from './PanelRunOverview';
 import {Spec as PanelRunsTableSpec} from './PanelRunsTable';
 import {Spec as SavedModelSpec} from './PanelSavedModel';
@@ -237,4 +238,5 @@ export const ConverterSpecs = (): ConverterSpecArray =>
         Panel.toConvertSpec(MultiTableSpec2),
         Panel.toConvertSpec(ProjectionSpec),
         Panel.toConvertSpec(PanelRunsTableSpec),
+        Panel.toConvertSpec(PanelRunHistoryTablesStepperSpec),
       ]);

--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -113,12 +113,12 @@ const PanelRunHistoryTablesStepper: React.FC<
       const nonNullTables = tablesWithStepsNodeResult.filter(
         (row: any) => row.table != null
       );
-      const steps = nonNullTables.map((row: any) => row._step);
-      const tables = nonNullTables.map((row: any) => row.table);
-      setSteps(steps);
-      setCurrentStep(steps[0]);
+      const newSteps = nonNullTables.map((row: any) => row._step);
+      const newTables = nonNullTables.map((row: any) => row.table);
+      setSteps(newSteps);
+      setCurrentStep(newSteps[0]);
       setCurrentTableHistoryKey(value);
-      setTables(tables);
+      setTables(newTables);
     }
   }, [tablesWithStepsNodeResult, tablesWithStepsNodeLoading, value]);
 

--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -5,10 +5,6 @@ import {
   constNumber,
   constString,
   file,
-  isAssignableTo,
-  list,
-  listObjectType,
-  maybe,
   NodeOrVoidNode,
   opDict,
   opFileTable,
@@ -17,9 +13,6 @@ import {
   opPick,
   opRunHistory,
   opTableRows,
-  Type,
-  typedDict,
-  typedDictPropertyTypes,
   voidNode,
 } from '@wandb/weave/core';
 import React, {useEffect, useState} from 'react';
@@ -95,12 +88,12 @@ const PanelRunHistoryTablesStepper: React.FC<
     config?.tableHistoryKey
   );
   const tableWithStepsNode = opMap({
-    arr: runHistoryRefined.result,
+    arr: runHistoryRefined.result as any,
     mapFn: constFunction({row: runHistoryRefined.result.type}, ({row}) =>
       opDict({
         _step: opPick({obj: row, key: constString('_step')}),
         table: opPick({obj: row, key: constString(value ?? '')}),
-      })
+      } as any)
     ) as any,
   });
 
@@ -117,8 +110,8 @@ const PanelRunHistoryTablesStepper: React.FC<
     }
 
     if (tablesWithStepsNodeResult != null) {
-      const steps = tablesWithStepsNodeResult.map(row => row._step);
-      const tables = tablesWithStepsNodeResult.map(row => row.table);
+      const steps = tablesWithStepsNodeResult.map((row: any) => row._step);
+      const tables = tablesWithStepsNodeResult.map((row: any) => row.table);
       setSteps(steps);
       setCurrentStep(steps[0]);
       setCurrentTableHistoryKey(value);

--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -26,7 +26,6 @@ import React, {useEffect, useState} from 'react';
 
 import {useNodeValue, useNodeWithServerType} from '../../../react';
 import * as ConfigPanel from '../ConfigPanel';
-import * as ControlPageStyles from '../ControlPage.styles';
 import * as Panel2 from '../panel';
 import {PanelComp2} from '../PanelComp';
 import {TableSpec} from '../PanelTable/PanelTable';
@@ -183,6 +182,7 @@ const PanelRunHistoryTablesStepper: React.FC<
             width: '100%',
             height: '100%',
             padding: '2px',
+            overflowY: 'auto',
           }}>
           <PanelComp2
             input={defaultNode}
@@ -197,7 +197,16 @@ const PanelRunHistoryTablesStepper: React.FC<
             updateInput={props.updateInput}
           />
           {steps.length > 0 && (
-            <ControlPageStyles.ControlBar>
+            <div
+              style={{
+                padding: '2px',
+                height: '1.7em',
+                borderTop: '1px solid #ddd',
+                backgroundColor: '#f8f8f8',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}>
               <SliderInput
                 min={steps[0]}
                 max={steps[steps.length - 1]}
@@ -209,7 +218,7 @@ const PanelRunHistoryTablesStepper: React.FC<
                 ticks={steps}
                 onChange={setCurrentStep}
               />
-            </ControlPageStyles.ControlBar>
+            </div>
           )}
         </div>
       )}

--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -110,8 +110,11 @@ const PanelRunHistoryTablesStepper: React.FC<
     }
 
     if (tablesWithStepsNodeResult != null) {
-      const steps = tablesWithStepsNodeResult.map((row: any) => row._step);
-      const tables = tablesWithStepsNodeResult.map((row: any) => row.table);
+      const nonNullTables = tablesWithStepsNodeResult.filter(
+        (row: any) => row.table != null
+      );
+      const steps = nonNullTables.map((row: any) => row._step);
+      const tables = nonNullTables.map((row: any) => row.table);
       setSteps(steps);
       setCurrentStep(steps[0]);
       setCurrentTableHistoryKey(value);
@@ -121,7 +124,7 @@ const PanelRunHistoryTablesStepper: React.FC<
 
   const tableIndex = steps.indexOf(currentStep);
   let defaultNode: NodeOrVoidNode = voidNode();
-  if (tableIndex !== -1) {
+  if (tableIndex !== -1 && tables[tableIndex] != null) {
     defaultNode = opTableRows({
       table: opFileTable({
         file: constNodeUnsafe(

--- a/weave-js/src/components/Panel2/panellib/libpanel.ts
+++ b/weave-js/src/components/Panel2/panellib/libpanel.ts
@@ -198,6 +198,11 @@ export function getStackIdAndName<X, C, T extends Type>(
     ) {
       displayName = 'Run Tables  ▸  Combined';
     } else if (
+      ourDisplayName === 'Run History Tables Stepper' &&
+      childDisplayName === 'Paginated Tables'
+    ) {
+      displayName = 'Run History Tables Stepper';
+    } else if (
       ourDisplayName === 'Combined Table' &&
       childDisplayName === 'Table'
     ) {


### PR DESCRIPTION
## Description

- Addresses [WB-23061](https://wandb.atlassian.net/browse/WB-23061) ([Story ticket](https://wandb.atlassian.net/browse/WB-22173))
- Introduces new panel to display a paginated table of the history tables for a given table name 
- The pagination is controlled by a slider and respects the `_step` value associated to each table version

## Testing
Local FE

#### Happy Case

https://github.com/user-attachments/assets/a0b22b97-adbf-4399-97cf-eed0659079d4


#### Multiple tables

https://github.com/user-attachments/assets/1c16fbfe-4376-43f9-8d22-fb5880ec6d11


#### Irregular Steps

https://github.com/user-attachments/assets/1682ba51-aad0-4d55-a450-6c77ef8c3bb0






[WB-22173]: https://wandb.atlassian.net/browse/WB-22173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




[WB-23061]: https://wandb.atlassian.net/browse/WB-23061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ