### PR TITLE
chore(weave): add metadata_only to obj_read

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1608,6 +1608,19 @@ def test_object_version_read(client):
         assert obj_res.obj.val == {"a": i}
         assert obj_res.obj.version_index == i
 
+    # read each object one at a time, check the version, metadata only
+    for i in range(10):
+        obj_res = client.server.obj_read(
+            tsi.ObjReadReq(
+                project_id=client._project_id(),
+                object_id=refs[i].name,
+                digest=refs[i].digest,
+                metadata_only=True,
+            )
+        )
+        assert obj_res.obj.val == {}
+        assert obj_res.obj.version_index == i
+
     # now grab the latest version of the object
     obj_res = client.server.obj_read(
         tsi.ObjReadReq(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -593,8 +593,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         object_query_builder.add_digests_conditions(req.digest)
         object_query_builder.add_object_ids_condition([req.object_id])
         object_query_builder.set_include_deleted(include_deleted=True)
+        metadata_only = req.metadata_only or False
 
-        objs = self._select_objs_query(object_query_builder)
+        objs = self._select_objs_query(object_query_builder, metadata_only)
         if len(objs) == 0:
             raise NotFoundError(f"Obj {req.object_id}:{req.digest} not found")
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -732,6 +732,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             req.project_id,
             conditions=conds,
             include_deleted=True,
+            metadata_only=req.metadata_only,
         )
         if len(objs) == 0:
             raise NotFoundError(f"Obj {req.object_id}:{req.digest} not found")

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -421,6 +421,12 @@ class ObjReadReq(BaseModel):
     object_id: str
     digest: str
 
+    metadata_only: Optional[bool] = Field(
+        default=False,
+        description="If true, the `val` column is not read from the database and is empty."
+        "All other fields are returned.",
+    )
+
 
 class ObjReadRes(BaseModel):
     obj: ObjSchema


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22880](https://wandb.atlassian.net/browse/WB-22880)

Adds a `metadata_only` field to the `obj_read` request. 

## Testing

add to existing test

[WB-22880]: https://wandb.atlassian.net/browse/WB-22880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ