### PR TITLE
chore(ui): move smallref onto metadata_only obj_read

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -124,8 +124,8 @@ export const SmallRef: FC<{
       };
     }
   }
-  const objectVersion = useObjectVersion(objVersionKey);
-  const opVersion = useOpVersion(opVersionKey);
+  const objectVersion = useObjectVersion(objVersionKey, true);
+  const opVersion = useOpVersion(opVersionKey, true);
 
   const isDeleted =
     isObjDeleteError(objectVersion?.error) ||

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -234,6 +234,7 @@ export type TraceObjReadReq = {
   project_id: string;
   object_id: string;
   digest: string;
+  metadata_only?: boolean;
 };
 
 export type TraceObjReadRes = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -676,7 +676,8 @@ const useFeedback = (
 
 const useOpVersion = (
   // Null value skips
-  key: OpVersionKey | null
+  key: OpVersionKey | null,
+  metadataOnly?: boolean
 ): LoadableWithError<OpVersionSchema | null> => {
   const getTsClient = useGetTraceServerClientContext();
   const loadingRef = useRef(false);
@@ -697,11 +698,12 @@ const useOpVersion = (
           }),
           object_id: deepKey?.opId ?? '',
           digest: deepKey?.versionHash ?? '',
+          metadata_only: metadataOnly ?? false,
         })
         .then(res => {
           loadingRef.current = false;
           setOpVersionRes(res);
-          if (res.obj == null) {
+          if (res.obj == null && !metadataOnly) {
             setError(new Error(JSON.stringify(res)));
             // be conservative and unset the cache when there's an error
             if (deepKey) {
@@ -710,7 +712,7 @@ const useOpVersion = (
           }
         });
     }
-  }, [deepKey, getTsClient]);
+  }, [deepKey, getTsClient, metadataOnly]);
 
   return useMemo(() => {
     if (key == null) {
@@ -765,13 +767,22 @@ const useOpVersion = (
       ...returnedResult,
     };
 
+    // Skip setting the cache if metadata only
+    if (metadataOnly) {
+      return {
+        loading: false,
+        result: cacheableResult,
+        error,
+      };
+    }
+
     opVersionCache.set(key, cacheableResult);
     return {
       loading: false,
       result: cacheableResult,
       error,
     };
-  }, [cachedOpVersion, key, opVersionRes, error]);
+  }, [cachedOpVersion, key, opVersionRes, error, metadataOnly]);
 };
 
 const useOpVersions = (
@@ -891,7 +902,8 @@ const useFileContent = makeTraceServerEndpointHook<
 
 const useObjectVersion = (
   // Null value skips
-  key: ObjectVersionKey | null
+  key: ObjectVersionKey | null,
+  metadataOnly?: boolean
 ): LoadableWithError<ObjectVersionSchema | null> => {
   const getTsClient = useGetTraceServerClientContext();
   const loadingRef = useRef(false);
@@ -912,6 +924,7 @@ const useObjectVersion = (
           }),
           object_id: deepKey?.objectId ?? '',
           digest: deepKey?.versionHash ?? '',
+          metadata_only: metadataOnly ?? false,
         })
         .then(res => {
           loadingRef.current = false;
@@ -929,7 +942,7 @@ const useObjectVersion = (
           setError(new Error(JSON.stringify(err)));
         });
     }
-  }, [deepKey, getTsClient]);
+  }, [deepKey, getTsClient, metadataOnly]);
 
   return useMemo(() => {
     if (key == null) {
@@ -983,13 +996,22 @@ const useObjectVersion = (
       ...returnedResult,
     };
 
+    // Skip setting the cache if metadata only
+    if (metadataOnly) {
+      return {
+        loading: false,
+        result: cacheableResult,
+        error,
+      };
+    }
+
     objectVersionCache.set(key, cacheableResult);
     return {
       loading: false,
       result: cacheableResult,
       error,
     };
-  }, [cachedObjectVersion, key, objectVersionRes, error]);
+  }, [cachedObjectVersion, key, objectVersionRes, error, metadataOnly]);
 };
 
 export const convertTraceServerObjectVersionToSchema = <

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -222,7 +222,8 @@ export type WFDataModelHooksInterface = {
     baseObjectClass?: string
   ) => Promise<string>;
   useOpVersion: (
-    key: OpVersionKey | null
+    key: OpVersionKey | null,
+    metadataOnly?: boolean
   ) => LoadableWithError<OpVersionSchema | null>;
   useOpVersions: (
     entity: string,
@@ -233,7 +234,8 @@ export type WFDataModelHooksInterface = {
     opts?: {skip?: boolean}
   ) => LoadableWithError<OpVersionSchema[]>;
   useObjectVersion: (
-    key: ObjectVersionKey | null
+    key: ObjectVersionKey | null,
+    metadataOnly?: boolean
   ) => LoadableWithError<ObjectVersionSchema | null>;
   useTableRowsQuery: (
     entity: string,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22881](https://wandb.atlassian.net/browse/WB-22881)

When rendering object refs, no need to load the actual object value. Make sure not to cache when getting metadata_only.

Depends on:
- https://github.com/wandb/weave/pull/3462 

## Testing

👀 


[WB-22881]: https://wandb.atlassian.net/browse/WB-22881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ