### PR TITLE
chore(ui): show object version timestamp in header metadata

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetVersionPage.tsx
@@ -5,6 +5,7 @@ import React, {useMemo} from 'react';
 import {Icon} from '../../../../Icon';
 import {LoadingDots} from '../../../../LoadingDots';
 import {Tailwind} from '../../../../Tailwind';
+import {Timestamp} from '../../../../Timestamp';
 import {WeaveCHTableSourceRefContext} from '../pages/CallPage/DataTableView';
 import {ObjectViewerSection} from '../pages/CallPage/ObjectViewerSection';
 import {objectVersionText} from '../pages/common/Links';
@@ -30,6 +31,7 @@ export const DatasetVersionPage: React.FC<{
   const projectName = objectVersion.project;
   const objectName = objectVersion.objectId;
   const objectVersionIndex = objectVersion.versionIndex;
+  const {createdAtMs} = objectVersion;
 
   const objectVersions = useRootObjectVersions(
     entityName,
@@ -76,7 +78,7 @@ export const DatasetVersionPage: React.FC<{
       }
       headerContent={
         <Tailwind>
-          <div className="grid w-full grid-flow-col grid-cols-[auto_auto_1fr] gap-[16px] text-[14px]">
+          <div className="grid w-full grid-flow-col grid-cols-[auto_auto_auto_1fr] gap-[16px] text-[14px]">
             <div className="block">
               <p className="text-moon-500">Name</p>
               <ObjectVersionsLink
@@ -108,6 +110,12 @@ export const DatasetVersionPage: React.FC<{
             <div className="block">
               <p className="text-moon-500">Version</p>
               <p>{objectVersionIndex}</p>
+            </div>
+            <div className="block">
+              <p className="text-moon-500">Created</p>
+              <p>
+                <Timestamp value={createdAtMs / 1000} format="relative" />
+              </p>
             </div>
             {objectVersion.userId && (
               <div className="block">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
@@ -7,6 +7,7 @@ import {maybePluralizeWord} from '../../../../../../core/util/string';
 import {Icon, IconName} from '../../../../../Icon';
 import {LoadingDots} from '../../../../../LoadingDots';
 import {Tailwind} from '../../../../../Tailwind';
+import {Timestamp} from '../../../../../Timestamp';
 import {Tooltip} from '../../../../../Tooltip';
 import {DatasetVersionPage} from '../../datasets/DatasetVersionPage';
 import {NotFoundPanel} from '../../NotFoundPanel';
@@ -121,7 +122,7 @@ const ObjectVersionPageInner: React.FC<{
   const projectName = objectVersion.project;
   const objectName = objectVersion.objectId;
   const objectVersionIndex = objectVersion.versionIndex;
-  const refExtra = objectVersion.refExtra;
+  const {refExtra, createdAtMs} = objectVersion;
   const objectVersions = useRootObjectVersions(
     entityName,
     projectName,
@@ -231,7 +232,7 @@ const ObjectVersionPageInner: React.FC<{
       }
       headerContent={
         <Tailwind>
-          <div className="grid w-full grid-flow-col grid-cols-[auto_auto_1fr] gap-[16px] text-[14px]">
+          <div className="grid w-full grid-flow-col grid-cols-[auto_auto_auto_1fr] gap-[16px] text-[14px]">
             <div className="block">
               <p className="text-moon-500">Name</p>
               <div className="flex items-center">
@@ -265,6 +266,12 @@ const ObjectVersionPageInner: React.FC<{
             <div className="block">
               <p className="text-moon-500">Version</p>
               <p>{objectVersionIndex}</p>
+            </div>
+            <div className="block">
+              <p className="text-moon-500">Created</p>
+              <p>
+                <Timestamp value={createdAtMs / 1000} format="relative" />
+              </p>
             </div>
             {objectVersion.userId && (
               <div className="block">


### PR DESCRIPTION
## Description

Adds the created timestamp to the metadata displayed for an object version.

Before:
<img width="369" alt="Screenshot 2025-01-22 at 1 32 19 PM" src="https://github.com/user-attachments/assets/e7ce882e-3f84-44e6-adf6-ac5d5503dc66" />

After:
<img width="478" alt="Screenshot 2025-01-22 at 1 32 09 PM" src="https://github.com/user-attachments/assets/d95eb3d8-c6e9-4f0f-80a5-4042c2c2789f" />

