### PR TITLE
fix(weave): navigate properly when deleting obj/op version fullscreen

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectDeleteButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectDeleteButtons.tsx
@@ -1,8 +1,13 @@
 import {Button} from '@wandb/weave/components/Button';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
-import React, {useState} from 'react';
+import React, {useContext, useState} from 'react';
+import {useHistory} from 'react-router-dom';
 
-import {useClosePeek} from '../../context';
+import {
+  useClosePeek,
+  useWeaveflowCurrentRouteContext,
+  WeaveflowPeekContext,
+} from '../../context';
 import {DeleteModal} from '../common/DeleteModal';
 import {useWFHooks} from '../wfReactInterface/context';
 import {ObjectVersionSchema} from '../wfReactInterface/wfDataModelHooksInterface';
@@ -13,12 +18,31 @@ export const DeleteObjectButtonWithModal: React.FC<{
 }> = ({objVersionSchema, overrideDisplayStr}) => {
   const {useObjectDeleteFunc} = useWFHooks();
   const closePeek = useClosePeek();
+  const {isPeeking} = useContext(WeaveflowPeekContext);
+  const routerContext = useWeaveflowCurrentRouteContext();
+  const history = useHistory();
   const {objectVersionsDelete} = useObjectDeleteFunc();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   const deleteStr =
     overrideDisplayStr ??
     `${objVersionSchema.objectId}:v${objVersionSchema.versionIndex}`;
+
+  const onSuccess = () => {
+    if (isPeeking) {
+      closePeek();
+    } else {
+      history.push(
+        routerContext.objectVersionsUIUrl(
+          objVersionSchema.entity,
+          objVersionSchema.project,
+          {
+            objectName: objVersionSchema.objectId,
+          }
+        )
+      );
+    }
+  };
 
   return (
     <>
@@ -39,7 +63,7 @@ export const DeleteObjectButtonWithModal: React.FC<{
             [objVersionSchema.versionHash]
           )
         }
-        onSuccess={closePeek}
+        onSuccess={onSuccess}
       />
     </>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
@@ -1,10 +1,15 @@
 import {Button} from '@wandb/weave/components/Button';
-import React, {useMemo, useState} from 'react';
+import React, {useContext, useMemo, useState} from 'react';
+import {useHistory} from 'react-router-dom';
 
 import {Icon} from '../../../../../Icon';
 import {LoadingDots} from '../../../../../LoadingDots';
 import {Tailwind} from '../../../../../Tailwind';
-import {useClosePeek} from '../../context';
+import {
+  useClosePeek,
+  useWeaveflowCurrentRouteContext,
+  WeaveflowPeekContext,
+} from '../../context';
 import {NotFoundPanel} from '../../NotFoundPanel';
 import {OpCodeViewer} from '../../OpCodeViewer';
 import {DeleteModal, useShowDeleteButton} from '../common/DeleteModal';
@@ -188,12 +193,31 @@ const DeleteOpButtonWithModal: React.FC<{
 }> = ({opVersionSchema, overrideDisplayStr}) => {
   const {useObjectDeleteFunc} = useWFHooks();
   const closePeek = useClosePeek();
+  const {isPeeking} = useContext(WeaveflowPeekContext);
+  const routerContext = useWeaveflowCurrentRouteContext();
+  const history = useHistory();
   const {opVersionsDelete} = useObjectDeleteFunc();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
 
   const deleteStr =
     overrideDisplayStr ??
     `${opVersionSchema.opId}:v${opVersionSchema.versionIndex}`;
+
+  const onSuccess = () => {
+    if (isPeeking) {
+      closePeek();
+    } else {
+      history.push(
+        routerContext.opVersionsUIUrl(
+          opVersionSchema.entity,
+          opVersionSchema.project,
+          {
+            opName: opVersionSchema.opId,
+          }
+        )
+      );
+    }
+  };
 
   return (
     <>
@@ -215,7 +239,7 @@ const DeleteOpButtonWithModal: React.FC<{
             [opVersionSchema.versionHash]
           )
         }
-        onSuccess={closePeek}
+        onSuccess={onSuccess}
       />
     </>
   );


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
[WB-22873](https://wandb.atlassian.net/browse/WB-22873)

When in fullscreen mode, deleting an op or object does not redirect properly. Now, check if we are fullscreen, and navigate to the "versions" page. 

## Testing

![op-delete](https://github.com/user-attachments/assets/60fa4413-0dbe-41bd-bfcf-391542038bb2)


[WB-22873]: https://wandb.atlassian.net/browse/WB-22873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ