### PR TITLE
chore(ui): show op version timestamp in header metadata

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
@@ -5,6 +5,7 @@ import {useHistory} from 'react-router-dom';
 import {Icon} from '../../../../../Icon';
 import {LoadingDots} from '../../../../../LoadingDots';
 import {Tailwind} from '../../../../../Tailwind';
+import {Timestamp} from '../../../../../Timestamp';
 import {
   useClosePeek,
   useWeaveflowCurrentRouteContext,
@@ -56,7 +57,7 @@ const OpVersionPageInner: React.FC<{
 }> = ({opVersion}) => {
   const {useOpVersions, useCallsStats} = useWFHooks();
   const uri = opVersionKeyToRefUri(opVersion);
-  const {entity, project, opId, versionIndex} = opVersion;
+  const {entity, project, opId, versionIndex, createdAtMs} = opVersion;
 
   const opVersions = useOpVersions(
     entity,
@@ -85,7 +86,7 @@ const OpVersionPageInner: React.FC<{
       title={opVersionText(opId, versionIndex)}
       headerContent={
         <Tailwind>
-          <div className="grid w-full grid-flow-col grid-cols-[auto_auto_1fr] gap-[16px] text-[14px]">
+          <div className="grid w-full grid-flow-col grid-cols-[auto_auto_auto_1fr] gap-[16px] text-[14px]">
             <div className="block">
               <p className="text-moon-500">Name</p>
               <div className="flex items-center">
@@ -121,6 +122,12 @@ const OpVersionPageInner: React.FC<{
             <div className="block">
               <p className="text-moon-500">Version</p>
               <p>{versionIndex}</p>
+            </div>
+            <div className="block">
+              <p className="text-moon-500">Created</p>
+              <p>
+                <Timestamp value={createdAtMs / 1000} format="relative" />
+              </p>
             </div>
             <div className="block">
               <p className="text-moon-500">Calls:</p>


### PR DESCRIPTION
## Description
Follow up to https://github.com/wandb/weave/pull/3464 adding timestamp to op page metadata.

Before:
<img width="399" alt="Screenshot 2025-01-22 at 2 35 30 PM" src="https://github.com/user-attachments/assets/a735b608-c2c7-4a4f-98cd-44a7bf5766b4" />


After:
<img width="507" alt="Screenshot 2025-01-22 at 2 35 23 PM" src="https://github.com/user-attachments/assets/54a46c8f-d05b-4c09-85b4-341bb4f984f2" />

