### PR TITLE
docs(weave): Add troubleshooting page

### DIFF
--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -1,0 +1,11 @@
+# Troubleshooting 
+
+This page provides solutions and guidance for common issues you may encounter. As we continue to expand this guide, more troubleshooting topics will be added to address a broader range of scenarios.
+
+:::tip
+Do you have Weave troubleshooting advice to share with the community?  Click **Edit this page** at the bottom of this guide to contribute directly by submitting a pull request.
+:::
+
+## Reduce the number of trace table rows
+
+To reduce the number of trace table rows retrieved by a query, set the `pageSize` query parameter to a value less than the default value of `100`. 

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -8,12 +8,12 @@ Do you have Weave troubleshooting advice to share with the community? Click **Ed
 
 ## Trace pages load slowly
 
-If trace pages are loading slowly, reduce the number of rows displayed to improve load time. You can either reduce the number of rows via the UI, or using query parameters.
+If trace pages are loading slowly, reduce the number of rows displayed to improve load time. The default value is `50`. You can either reduce the number of rows via the UI, or using query parameters.
 
 ### Adjust via the UI (recommended)
 
-Use the **Per page** control at the bottom-right of the Traces page to adjust the number of rows displayed. The default value is `50`, but you can also set to `10`, `25`, or `100`.
+Use the **Per page** control at the bottom-right of the Traces page to adjust the number of rows displayed. In addition to the default of `50`, you can also set to `10`, `25`, or `100`.
 
 ### Use query parameters 
 
-If you prefer a manual approach, you can modify the `pageSize` query parameter in your query URL to a value less than the default of `50`.
+If you prefer a manual approach, you can modify the `pageSize` query parameter in your query URL to a value less than the maximum of `100`.

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -6,6 +6,14 @@ This page provides solutions and guidance for common issues you may encounter. A
 Do you have Weave troubleshooting advice to share with the community?  Click **Edit this page** at the bottom of this guide to contribute directly by submitting a pull request.
 :::
 
-## Reduce the number of trace table rows
+## Trace pages load slowly
 
-To reduce the number of trace table rows retrieved by a query, set the `pageSize` query parameter to a value less than the default value of `100`. 
+If trace pages are loading slowly,  reduce the number of rows displayed to improve load time. You can either reduce the number of rows via the UI, or using query parameters.
+
+### Adjust via the UI (recommended)
+
+Use the **Per page** control at the bottom-right of the Traces page to adjust the number of rows displayed. The default value is `50`, but you can also set to `10`, `25`, or `100`.
+
+### Use query parameters 
+
+If you prefer a manual approach, you can modify the `pageSize` query parameter in your query URL to a value less than the default of `50`.

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -3,12 +3,12 @@
 This page provides solutions and guidance for common issues you may encounter. As we continue to expand this guide, more troubleshooting topics will be added to address a broader range of scenarios.
 
 :::tip
-Do you have Weave troubleshooting advice to share with the community?  Click **Edit this page** at the bottom of this guide to contribute directly by submitting a pull request.
+Do you have Weave troubleshooting advice to share with the community? Click **Edit this page** at the bottom of this guide to contribute directly by submitting a pull request.
 :::
 
 ## Trace pages load slowly
 
-If trace pages are loading slowly,  reduce the number of rows displayed to improve load time. You can either reduce the number of rows via the UI, or using query parameters.
+If trace pages are loading slowly, reduce the number of rows displayed to improve load time. You can either reduce the number of rows via the UI, or using query parameters.
 
 ### Adjust via the UI (recommended)
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -71,6 +71,7 @@ const sidebars: SidebarsConfig = {
         "guides/tools/playground",
         "guides/core-types/media",
         "guides/core-types/env-vars",
+        "guides/troubleshooting",
         {
           type: "category",
           collapsible: true,


### PR DESCRIPTION
## Description

- https://wandb.atlassian.net/browse/DOCS-1186

Adds Troubleshooting page to the docs, with first tip from [this slack convo](https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1736846808980349).

We don't currently have a great place to put this page without a larger menu reorg, so slotting into Product Walkthrough for now

## Testing

- `yarn start` on local
