### PR TITLE
chore(ui): dont do the cost query if no calls found

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -97,6 +97,7 @@ export const useCallsForQuery = (
   );
 
   const costCols = useMemo(() => ['id'], []);
+  const noCalls = calls.result == null || calls.result.length === 0;
   const costs = useCalls(
     entity,
     project,
@@ -108,7 +109,7 @@ export const useCallsForQuery = (
     costCols,
     expandedColumns,
     {
-      skip: calls.loading,
+      skip: calls.loading || noCalls,
       includeCosts: true,
     }
   );


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Micro perf improvement by not querying for costs when we have no calls to display.

in prod we actually query for costs twice even when there are no calls. 

## Testing

Prod:
<img width="1620" alt="Screenshot 2025-01-22 at 1 57 10 PM" src="https://github.com/user-attachments/assets/ff539c56-15d0-4ee8-82ed-b42e6ebf6758" />

Branch:
<img width="1673" alt="Screenshot 2025-01-22 at 1 57 42 PM" src="https://github.com/user-attachments/assets/7257e8f3-c64a-42e6-a1aa-0c0af3531f38" />

