### PR TITLE
fix: filter out LiteLLM GenericAPILogger enterprise feature debug message

### DIFF
--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -7,8 +7,20 @@ from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace_server import sqlite_trace_server
 from weave.trace_server_bindings import remote_http_trace_server
 
-# Suppress LiteLLM's debug message about GenericAPILogger
-logging.getLogger("LiteLLM").setLevel(logging.INFO)
+
+class LiteLLMFilter(logging.Filter):
+    """Filter to suppress specific LiteLLM debug messages."""
+    def filter(self, record: logging.LogRecord) -> bool:
+        # Only filter debug messages about GenericAPILogger enterprise feature
+        return not (
+            record.levelno == logging.DEBUG
+            and "Unable to import GenericAPILogger - LiteLLM Enterprise Feature" in record.getMessage()
+        )
+
+
+# Add filter to suppress specific LiteLLM debug message
+litellm_logger = logging.getLogger("LiteLLM")
+litellm_logger.addFilter(LiteLLMFilter())
 
 
 class InitializedClient:

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import logging
+
 from weave.trace import autopatch, errors, init_message, trace_sentry, weave_client
 from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace_server import sqlite_trace_server
 from weave.trace_server_bindings import remote_http_trace_server
+
+# Suppress LiteLLM's debug message about GenericAPILogger
+logging.getLogger("LiteLLM").setLevel(logging.INFO)
 
 
 class InitializedClient:


### PR DESCRIPTION
The LiteLLM library outputs a debug message about being unable to import GenericAPILogger when it's imported. This is an expected message for non-enterprise users and doesn't indicate any issues, but it can be confusing for users who see it in their logs.

This change adds a custom filter to the LiteLLM logger that suppresses only this specific debug message about the enterprise feature while allowing all other debug messages to be shown.

Test Plan:
1. Set logging level to DEBUG
2. Call weave.init()
3. Verify that the LiteLLM debug message about GenericAPILogger enterprise feature is suppressed
4. Verify that other debug messages are still shown