### PR TITLE
Update "Open App" link to actually open Weave

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -185,7 +185,7 @@ const config: Config = {
           position: "right",
         },
         {
-          to: "https://wandb.ai/home",
+          to: "https://wandb.ai/quickstart?product=weave",
           label: "Open App",
           position: "right",
           className: "button button--secondary button--med margin-right--sm",


### PR DESCRIPTION
## Description

Maybe there's a better dashboard link that gets you right into the Weave UI, but the generic dashboard link doesn't feel specific enough. Is there a better idea?
