### PR TITLE
docs(weave): Partner team request - add links in Integrations to partner pages

### DIFF
--- a/docs/docs/guides/integrations/azure.md
+++ b/docs/docs/guides/integrations/azure.md
@@ -2,6 +2,10 @@
 
 Weights & Biases integrates with Microsoft Azure OpenAI services, helping teams to manage, debug, and optimize their Azure AI workflows at scale. This guide introduces the W&B integration, what it means for Weave users, its key features, and how to get started.
 
+:::tip
+For the latest tutorials, visit [Weights & Biases on Microsoft Azure](https://wandb.ai/site/partners/azure).
+:::
+
 ## Key features
 
 - **LLM evaluations**: Evaluate and monitor LLM-powered applications using Weave, optimized for Azure infrastructure.  

--- a/docs/docs/guides/integrations/bedrock.md
+++ b/docs/docs/guides/integrations/bedrock.md
@@ -2,6 +2,10 @@
 
 Weave automatically tracks and logs LLM calls made via Amazon Bedrock, AWS's fully managed service that offers foundation models from leading AI companies through a unified API.
 
+:::tip
+For the latest tutorials, visit [Weights & Biases on Amazon Web Services](https://wandb.ai/site/partners/aws/).
+:::
+
 ## Traces
 
 Weave will automatically capture traces for Bedrock API calls. You can use the Bedrock client as usual after initializing Weave and patching the client:

--- a/docs/docs/guides/integrations/google-gemini.md
+++ b/docs/docs/guides/integrations/google-gemini.md
@@ -1,5 +1,9 @@
 # Google Gemini
 
+:::tip
+For the latest tutorials, visit [Weights & Biases on Google Cloud](https://wandb.ai/site/partners/googlecloud/).
+:::
+
 Google offers two ways of calling Gemini via API:
 
 1. Via the [Vertex APIs](https://cloud.google.com/vertex-ai/docs).

--- a/docs/docs/guides/integrations/nvidia_nim.md
+++ b/docs/docs/guides/integrations/nvidia_nim.md
@@ -5,6 +5,10 @@ import TabItem from '@theme/TabItem';
 
 Weave automatically tracks and logs LLM calls made via the [ChatNVIDIA](https://python.langchain.com/docs/integrations/chat/nvidia_ai_endpoints/) library, after `weave.init()` is called.
 
+:::tip
+For the latest tutorials, visit [Weights & Biases on NVIDIA](https://wandb.ai/site/partners/nvidia).
+:::
+
 ## Tracing
 
 It’s important to store traces of LLM applications in a central database, both during development and in production. You’ll use these traces for debugging and to help build a dataset of tricky examples to evaluate against while improving your application.


### PR DESCRIPTION
https://wandb.atlassian.net/browse/DOCS-1224

Requested by partner team as part of larger marketing strategy. For the following Integrations pages, adds appropriate links to partner pages with text similar to “For latest tutorials, click [here](https://wandb.ai/site/partners/nvidia)”:
- AWS
- Azure
- Gemini
- NVIDIA NIM
