### PR TITLE
chore(weave): Streaming Evals Pt1: lazy `async_foreach`

### DIFF
--- a/tests/trace/test_flow_util.py
+++ b/tests/trace/test_flow_util.py
@@ -1,0 +1,155 @@
+import asyncio
+
+import pytest
+
+from weave.flow.util import async_foreach
+
+
+@pytest.mark.asyncio
+async def test_async_foreach_basic():
+    """Test basic functionality of async_foreach."""
+    input_data = range(5)
+    results = []
+
+    async def process(x: int) -> int:
+        await asyncio.sleep(0.1)  # Simulate async work
+        return x * 2
+
+    async for item, result in async_foreach(
+        input_data, process, max_concurrent_tasks=2
+    ):
+        results.append((item, result))
+
+    assert len(results) == 5
+    assert all(result == item * 2 for item, result in results)
+    assert [item for item, _ in results] == list(range(5))
+
+
+@pytest.mark.asyncio
+async def test_async_foreach_concurrency():
+    """Test that max_concurrent_tasks is respected."""
+    currently_running = 0
+    max_running = 0
+    input_data = range(10)
+
+    async def process(x: int) -> int:
+        nonlocal currently_running, max_running
+        currently_running += 1
+        max_running = max(max_running, currently_running)
+        await asyncio.sleep(0.1)  # Simulate async work
+        currently_running -= 1
+        return x
+
+    max_concurrent = 3
+    async for _, _ in async_foreach(
+        input_data, process, max_concurrent_tasks=max_concurrent
+    ):
+        pass
+
+    assert max_running == max_concurrent
+
+
+@pytest.mark.asyncio
+async def test_async_foreach_lazy_loading():
+    """Test that items are loaded lazily from the iterator."""
+    items_loaded = 0
+
+    def lazy_range(n: int):
+        nonlocal items_loaded
+        for i in range(n):
+            items_loaded += 1
+            yield i
+
+    async def process(x: int) -> int:
+        await asyncio.sleep(0.1)
+        return x
+
+    # Process first 3 items then break
+    async for _, _ in async_foreach(lazy_range(100), process, max_concurrent_tasks=2):
+        if items_loaded >= 3:
+            break
+
+    # Should have loaded at most 4 items (3 + 1 for concurrency)
+    assert items_loaded <= 4
+
+
+@pytest.mark.asyncio
+async def test_async_foreach_error_handling():
+    """Test error handling in async_foreach."""
+    input_data = range(5)
+
+    async def process(x: int) -> int:
+        if x == 3:
+            raise ValueError("Test error")
+        return x
+
+    with pytest.raises(ValueError, match="Test error"):
+        async for _, _ in async_foreach(input_data, process, max_concurrent_tasks=2):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_async_foreach_empty_input():
+    """Test behavior with empty input sequence."""
+    results = []
+
+    async def process(x: int) -> int:
+        return x
+
+    async for item, result in async_foreach([], process, max_concurrent_tasks=2):
+        results.append((item, result))
+
+    assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_async_foreach_cancellation():
+    """Test that tasks are properly cleaned up on cancellation."""
+    input_data = range(100)
+    results = []
+
+    async def slow_process(x: int) -> int:
+        await asyncio.sleep(0.5)  # Longer delay to ensure tasks are running
+        return x
+
+    # Create a task we can cancel
+    async def run_foreach():
+        async for item, result in async_foreach(
+            input_data, slow_process, max_concurrent_tasks=3
+        ):
+            results.append((item, result))
+            if len(results) >= 2:  # Cancel after 2 results
+                raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_foreach()
+
+    # Give a moment for any lingering tasks to complete if cleanup failed
+    await asyncio.sleep(0.1)
+
+    # Check that we got the expected number of results before cancellation
+    assert len(results) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_foreach_execution_order():
+    """Test that results are yielded in input sequence order regardless of completion order."""
+    # Create input data with deliberately varying processing times
+    input_data = [(0, 0.3), (1, 0.1), (2, 0.2)]  # (value, delay) pairs
+    calls = []
+    results = []
+
+    async def process(item: tuple[int, float]) -> int:
+        calls.append(item)
+        value, delay = item
+        await asyncio.sleep(delay)  # Different delays to force out-of-order completion
+        return value * 2
+
+    async for item, result in async_foreach(
+        input_data, process, max_concurrent_tasks=3
+    ):
+        results.append((item[0], result))  # Store (original_value, processed_result)
+
+    # Verify results are in original sequence order
+    assert results == [(0, 0), (1, 2), (2, 4)]
+    assert calls == [(0, 0.3), (1, 0.1), (2, 0.2)]

--- a/weave/flow/util.py
+++ b/weave/flow/util.py
@@ -16,18 +16,83 @@ async def async_foreach(
     func: Callable[[T], Awaitable[U]],
     max_concurrent_tasks: int,
 ) -> AsyncIterator[tuple[T, U]]:
+    """Process items from a sequence concurrently with a maximum number of parallel tasks.
+
+    This function loads items from the input sequence lazily to support large or infinite
+    sequences. Items are processed and yielded in the same order as the input sequence.
+
+    Args:
+        sequence: An iterable of items to process. Items are loaded lazily.
+        func: An async function that processes each item from the sequence.
+        max_concurrent_tasks: Maximum number of items to process concurrently.
+
+    Yields:
+        Tuples of (original_item, processed_result) in the same order as the input sequence.
+
+    Example:
+        ```python
+        async def process(x: int) -> str:
+            await asyncio.sleep(1)  # Simulate async work
+            return str(x * 2)
+
+        async for item, result in async_foreach(range(10), process, max_concurrent_tasks=3):
+            print(f"Processed {item} -> {result}")
+        ```
+
+    Notes:
+        - If func raises an exception, it will be propagated to the caller
+        - Memory usage is bounded by max_concurrent_tasks
+        - All pending tasks are properly cleaned up on error or cancellation
+        - Results are yielded in the same order as the input sequence
+    """
     semaphore = asyncio.Semaphore(max_concurrent_tasks)
+    active_tasks: list[asyncio.Task] = []
 
     async def process_item(item: T) -> tuple[T, U]:
+        """Process a single item using the provided function with semaphore control."""
         async with semaphore:
             result = await func(item)
             return item, result
 
-    tasks = [asyncio.create_task(process_item(item)) for item in sequence]
+    def maybe_queue_next_task() -> None:
+        """Attempt to queue the next task from the iterator if available."""
+        try:
+            item = next(iterator)
+            task = asyncio.create_task(process_item(item))
+            active_tasks.append(task)
+        except StopIteration:
+            pass
 
-    for task in asyncio.as_completed(tasks):
-        item, result = await task
-        yield item, result
+    iterator = iter(sequence)
+
+    try:
+        # Prime the initial set of tasks
+        for _ in range(max_concurrent_tasks):
+            maybe_queue_next_task()
+
+        while active_tasks:
+            # Always wait for the first task in the list to complete
+            # This ensures we yield results in order
+            task = active_tasks.pop(0)  # Remove completed task from front of list
+            try:
+                item, result = await task
+                yield item, result
+
+                # Add a new task if there are more items
+                maybe_queue_next_task()
+            except Exception:
+                # Clean up remaining tasks before re-raising
+                for t in active_tasks:
+                    t.cancel()
+                await asyncio.gather(*active_tasks, return_exceptions=True)
+                raise
+
+    except asyncio.CancelledError:
+        # Clean up tasks if the caller cancels this coroutine
+        for task in active_tasks:
+            task.cancel()
+        await asyncio.gather(*active_tasks, return_exceptions=True)
+        raise
 
 
 def _subproc(


### PR DESCRIPTION
Context:

Currently the `async_foreach` method used in eval loop eagerly exhausts the passed in iterable which makes streaming datasets not possible. 

This is part 1 of a few PRs that build up to streaming support in evals & support for huggingface datasets.

---

Summary:

This pull request includes significant improvements to the `async_foreach` function in `weave/flow/util.py` and adds comprehensive tests for this functionality in `tests/trace/test_flow_util.py`. The changes enhance the documentation, error handling, and concurrency control of the `async_foreach` function.

Enhancements to `async_foreach`:

* [`weave/flow/util.py`](diffhunk://#diff-4ea0910967848b60c0a39eef3ba931abba8016263740bba2b083a94bf26ebf87R19-R96): Added detailed docstring to `async_foreach` explaining its functionality, arguments, and usage examples. Improved concurrency control by adding a semaphore and task management to ensure tasks are processed in order and cleaned up on errors or cancellation.

Comprehensive tests added:

* [`tests/trace/test_flow_util.py`](diffhunk://#diff-75763b33c284c3dd83fa28f8aaabbe7b5877444afa17531b9451a517a6dfbbb6R1-R155): Added multiple tests for `async_foreach` to cover basic functionality, concurrency limits, lazy loading, error handling, empty input, task cancellation, and execution order. These tests ensure that the function behaves as expected under various conditions.