### PR TITLE
chore(app): Update ToggleButtonGroup to allow icon only buttons

### DIFF
--- a/weave-js/src/components/ToggleButtonGroup.tsx
+++ b/weave-js/src/components/ToggleButtonGroup.tsx
@@ -10,6 +10,7 @@ export type ToggleOption = {
   value: string;
   icon?: IconName;
   isDisabled?: boolean;
+  iconOnly?: boolean;
 };
 
 export type ToggleButtonGroupProps = {
@@ -54,7 +55,12 @@ export const ToggleButtonGroup = React.forwardRef<
         className="flex gap-px"
         ref={ref}>
         {options.map(
-          ({value: optionValue, icon, isDisabled: optionIsDisabled}) => (
+          ({
+            value: optionValue,
+            icon,
+            isDisabled: optionIsDisabled,
+            iconOnly = false,
+          }) => (
             <ToggleGroup.Item
               key={optionValue}
               value={optionValue}
@@ -81,7 +87,7 @@ export const ToggleButtonGroup = React.forwardRef<
                   'first:rounded-l-sm', // First button rounded left
                   'last:rounded-r-sm' // Last button rounded right
                 )}>
-                {optionValue}
+                {!iconOnly ? optionValue : <></>}
               </Button>
             </ToggleGroup.Item>
           )


### PR DESCRIPTION
## Description

Since the value of each item has to be a unique string for Radix https://www.radix-ui.com/primitives/docs/components/toggle-group, we can't just omit the value from the option. This adds an optional option field that lets you decide whether to show the value string or just the icon.

## Testing

How was this PR tested?

Tested on https://github.com/wandb/core/pull/26984
