### PR TITLE
feat(ui): artifact ref links

### DIFF
--- a/wb_schema.gql
+++ b/wb_schema.gql
@@ -299,6 +299,7 @@ type Entity implements Node {
   id: ID!
   name: String!
   isTeam: Boolean!
+  project(name: String): Project
   projects(
     before: String
     after: String

--- a/weave-js/src/common/hooks/useArtifactWeaveReference.ts
+++ b/weave-js/src/common/hooks/useArtifactWeaveReference.ts
@@ -1,0 +1,121 @@
+import {ApolloClient, gql, useApolloClient} from '@apollo/client';
+import {useEffect, useState} from 'react';
+
+import {isOrgRegistryProjectName} from '../util/artifacts';
+import {useIsMounted} from './useIsMounted';
+
+export const ARTIFACT_WEAVE_REF_QUERY = gql`
+  query entity(
+    $entityName: String!
+    $projectName: String!
+    $artifactName: String!
+  ) {
+    entity(name: $entityName) {
+      id
+      project(name: $projectName) {
+        id
+        artifact(name: $artifactName) {
+          id
+          artifactType {
+            id
+            name
+          }
+        }
+      }
+      organization {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export type ArtifactWeaveReferenceInfo = {
+  orgName: string;
+  artifactType: string;
+};
+
+const fetchArtifactWeaveReference = async (
+  apolloClient: ApolloClient<any>,
+  variables: {
+    entityName: string;
+    projectName: string;
+    artifactName: string;
+  }
+): Promise<ArtifactWeaveReferenceInfo | undefined> => {
+  const result = await apolloClient.query({
+    query: ARTIFACT_WEAVE_REF_QUERY as any,
+    variables,
+  });
+
+  const organization = result?.data?.entity?.organization?.name;
+  const artifactType =
+    result?.data?.entity?.project?.artifact?.artifactType?.name;
+
+  // Early returns for invalid cases
+  if (!artifactType) {
+    return undefined;
+  }
+
+  if (!organization && isOrgRegistryProjectName(variables.projectName)) {
+    return undefined;
+  }
+
+  return {
+    orgName: organization,
+    artifactType,
+  };
+};
+
+export const useArtifactWeaveReference = ({
+  entityName,
+  projectName,
+  artifactName,
+  skip = false,
+}: {
+  entityName: string;
+  projectName: string;
+  artifactName: string;
+  skip?: boolean;
+}) => {
+  const [loading, setLoading] = useState(!skip);
+  const [artInfo, setArtInfo] = useState<ArtifactWeaveReferenceInfo | null>(
+    null
+  );
+  const isMounted = useIsMounted();
+  const apolloClient = useApolloClient();
+
+  useEffect(() => {
+    if (skip) {
+      return;
+    }
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const info = await fetchArtifactWeaveReference(apolloClient, {
+          entityName,
+          projectName,
+          artifactName,
+        });
+
+        if (isMounted()) {
+          setArtInfo(info ?? null);
+        }
+      } catch (err) {
+        console.error('Error fetching artifact weave reference:', err);
+        if (isMounted()) {
+          setArtInfo(null);
+        }
+      } finally {
+        if (isMounted()) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchData();
+  }, [skip, entityName, projectName, artifactName, isMounted, apolloClient]);
+
+  return {loading, artInfo};
+};

--- a/weave-js/src/common/util/artifacts.ts
+++ b/weave-js/src/common/util/artifacts.ts
@@ -103,3 +103,26 @@ export function isVersionAlias(alias: {alias: string}): boolean {
 export function getDescriptionSummary(artifactDescription: string) {
   return artifactDescription.split('\n')[0];
 }
+
+// Maintain same as https://github.com/wandb/core/blob/master/frontends/app/src/components/Registries/common/utils.ts
+export const REGISTRY_PROJECT_PREFIX = 'wandb-registry-';
+
+export type registryProject = {
+  isRegistryProject: boolean;
+  registryName?: string;
+};
+
+export const isOrgRegistryProjectName = (projectName: string) => {
+  const {isRegistryProject} = checkRegistryProject(projectName);
+  return isRegistryProject;
+};
+
+export const checkRegistryProject = (projectName?: string): registryProject => {
+  if (!projectName || !projectName.startsWith(REGISTRY_PROJECT_PREFIX)) {
+    return {isRegistryProject: false, registryName: undefined};
+  }
+  return {
+    isRegistryProject: true,
+    registryName: projectName.substring(REGISTRY_PROJECT_PREFIX.length),
+  };
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import {parseRef} from '../../../../react';
-import {isWeaveRef} from '../Browse3/filters/common';
+import {isArtifactRef, isWeaveRef} from '../Browse3/filters/common';
 import {ValueViewNumber} from '../Browse3/pages/CallPage/ValueViewNumber';
 import {
   isProbablyTimestamp,
@@ -38,7 +38,7 @@ export const CellValue = ({value}: CellValueProps) => {
   if (value === null) {
     return <ValueViewPrimitive>null</ValueViewPrimitive>;
   }
-  if (isWeaveRef(value)) {
+  if (isWeaveRef(value) || isArtifactRef(value)) {
     return <SmallRef objRef={parseRef(value)} />;
   }
   if (typeof value === 'boolean') {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/SmallRef.tsx
@@ -1,10 +1,14 @@
 import {Box} from '@mui/material';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import {useArtifactWeaveReference} from '@wandb/weave/common/hooks/useArtifactWeaveReference';
 import {getTypeName, Type} from '@wandb/weave/core';
 import {
   isWandbArtifactRef,
   isWeaveObjectRef,
   ObjectRef,
   refUri,
+  WandbArtifactRef,
+  WeaveObjectRef,
 } from '@wandb/weave/react';
 import React, {FC} from 'react';
 
@@ -18,6 +22,7 @@ import {
   ObjectVersionKey,
   OpVersionKey,
 } from '../Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
+import {fetchArtifactRefPageUrl} from './url';
 
 const getRootType = (t: Type): Type => {
   if (
@@ -76,8 +81,139 @@ export const objectRefDisplayName = (
   throw new Error('Unknown ref type');
 };
 
-export const SmallRef: FC<{
-  objRef: ObjectRef;
+export const SmallRefBox: FC<{
+  iconName: IconName;
+  text: string;
+  iconOnly?: boolean;
+  isDeleted?: boolean;
+}> = ({iconName, text, iconOnly = false, isDeleted = false}) => (
+  <Box display="flex" alignItems="center">
+    <Box
+      mr="4px"
+      bgcolor={hexToRGB(MOON_300, 0.48)}
+      sx={{
+        height: '22px',
+        width: '22px',
+        borderRadius: '16px',
+        display: 'flex',
+        flex: '0 0 22px',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}>
+      <Icon name={iconName} width={14} height={14} />
+    </Box>
+    {!iconOnly && (
+      <Box
+        sx={{
+          height: '22px',
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          textDecoration: isDeleted ? 'line-through' : 'none',
+        }}>
+        {text}
+      </Box>
+    )}
+  </Box>
+);
+
+export const SmallArtifactRef: FC<{
+  objRef: WandbArtifactRef;
+  iconOnly?: boolean;
+}> = ({objRef}) => {
+  const {loading, artInfo} = useArtifactWeaveReference({
+    entityName: objRef.entityName,
+    projectName: objRef.projectName,
+    artifactName: objRef.artifactName + ':' + objRef.artifactVersion,
+  });
+  if (loading) {
+    return (
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          minHeight: '38px',
+          display: 'flex',
+          alignItems: 'center',
+        }}>
+        <SmallRefBox iconName={IconNames.Loading} text="Loading..." />
+      </Box>
+    );
+  }
+
+  const artifactUrl = artInfo
+    ? fetchArtifactRefPageUrl({
+        entityName: objRef.entityName,
+        projectName: objRef.projectName,
+        artifactName: objRef.artifactName,
+        artifactVersion: objRef.artifactVersion,
+        artifactType: artInfo?.artifactType,
+        orgName: artInfo?.orgName,
+      })
+    : null;
+
+  const Content = (
+    <Tooltip.Provider delayDuration={150} skipDelayDuration={50}>
+      <Tooltip.Root>
+        <Box
+          sx={{
+            width: '100%',
+            height: '100%',
+            minHeight: '38px',
+            display: 'flex',
+            alignItems: 'center',
+            cursor: artifactUrl ? 'pointer' : 'not-allowed',
+          }}>
+          <Tooltip.Trigger asChild>
+            <Box sx={{display: 'flex', alignItems: 'center'}}>
+              <SmallRefBox
+                iconName={IconNames.Registries}
+                text={`${objRef.artifactName}:${objRef.artifactVersion}`}
+              />
+            </Box>
+          </Tooltip.Trigger>
+        </Box>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            side="top"
+            sideOffset={8}
+            className="rounded bg-moon-900 px-3 py-2 text-sm text-moon-200"
+            style={{
+              zIndex: 9999,
+              position: 'relative',
+              backgroundColor: '#1a1a1a',
+              color: '#e0e0e0',
+              padding: '8px 12px',
+              borderRadius: '4px',
+            }}>
+            {artifactUrl
+              ? objRef.artifactPath
+              : 'No link detected for this wandb artifact reference: ' +
+                objRef.artifactPath}
+            <Tooltip.Arrow style={{fill: '#1a1a1a'}} />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+
+  return artifactUrl ? (
+    <Link
+      $variant="secondary"
+      style={{width: '100%', height: '100%'}}
+      as="a"
+      href={artifactUrl}>
+      {Content}
+    </Link>
+  ) : (
+    Content
+  );
+};
+
+export const SmallWeaveRef: FC<{
+  objRef: WeaveObjectRef;
   wfTable?: WFDBTableType;
   iconOnly?: boolean;
 }> = ({objRef, wfTable, iconOnly = false}) => {
@@ -90,47 +226,31 @@ export const SmallRef: FC<{
   let objVersionKey: ObjectVersionKey | null = null;
   let opVersionKey: OpVersionKey | null = null;
 
-  const isArtifactRef = isWandbArtifactRef(objRef);
-  const isWeaveObjRef = isWeaveObjectRef(objRef);
-
-  if (isArtifactRef) {
-    objVersionKey = {
-      scheme: 'wandb-artifact',
+  if (objRef.weaveKind === 'op') {
+    opVersionKey = {
       entity: objRef.entityName,
       project: objRef.projectName,
+      opId: objRef.artifactName,
+      versionHash: objRef.artifactVersion,
+    };
+  } else {
+    objVersionKey = {
+      scheme: 'weave',
+      entity: objRef.entityName,
+      project: objRef.projectName,
+      weaveKind: objRef.weaveKind,
       objectId: objRef.artifactName,
       versionHash: objRef.artifactVersion,
-      path: objRef.artifactPath,
+      path: '',
       refExtra: objRef.artifactRefExtra,
     };
-  } else if (isWeaveObjRef) {
-    if (objRef.weaveKind === 'op') {
-      opVersionKey = {
-        entity: objRef.entityName,
-        project: objRef.projectName,
-        opId: objRef.artifactName,
-        versionHash: objRef.artifactVersion,
-      };
-    } else {
-      objVersionKey = {
-        scheme: 'weave',
-        entity: objRef.entityName,
-        project: objRef.projectName,
-        weaveKind: objRef.weaveKind,
-        objectId: objRef.artifactName,
-        versionHash: objRef.artifactVersion,
-        path: '',
-        refExtra: objRef.artifactRefExtra,
-      };
-    }
   }
+
   const objectVersion = useObjectVersion(objVersionKey, true);
   const opVersion = useOpVersion(opVersionKey, true);
-
   const isDeleted =
     isObjDeleteError(objectVersion?.error) ||
     isObjDeleteError(opVersion?.error);
-
   const versionIndex =
     objectVersion.result?.versionIndex ?? opVersion.result?.versionIndex;
 
@@ -159,42 +279,16 @@ export const SmallRef: FC<{
     icon = IconNames.JobProgramCode;
   }
   const Item = (
-    <Box display="flex" alignItems="center">
-      <Box
-        mr="4px"
-        bgcolor={hexToRGB(MOON_300, 0.48)}
-        sx={{
-          height: '22px',
-          width: '22px',
-          borderRadius: '16px',
-          display: 'flex',
-          flex: '0 0 22px',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}>
-        <Icon name={icon} width={14} height={14} />
-      </Box>
-      {!iconOnly && (
-        <Box
-          sx={{
-            height: '22px',
-            flex: 1,
-            minWidth: 0,
-            overflow: 'hidden',
-            whiteSpace: 'nowrap',
-            textOverflow: 'ellipsis',
-            textDecoration: isDeleted ? 'line-through' : 'none',
-          }}>
-          {label}
-        </Box>
-      )}
-    </Box>
+    <SmallRefBox
+      iconName={icon}
+      text={label}
+      iconOnly={iconOnly}
+      isDeleted={isDeleted}
+    />
   );
+
   if (refTypeQuery.loading || isDeleted) {
     return Item;
-  }
-  if (!isArtifactRef && !isWeaveObjRef) {
-    return <div>[Error: non wandb ref]</div>;
   }
   return (
     <Link
@@ -206,4 +300,20 @@ export const SmallRef: FC<{
       {Item}
     </Link>
   );
+};
+
+export const SmallRef: FC<{
+  objRef: ObjectRef;
+  wfTable?: WFDBTableType;
+  iconOnly?: boolean;
+}> = ({objRef, wfTable, iconOnly = false}) => {
+  if (isWeaveObjectRef(objRef)) {
+    return (
+      <SmallWeaveRef objRef={objRef} wfTable={wfTable} iconOnly={iconOnly} />
+    );
+  }
+  if (isWandbArtifactRef(objRef)) {
+    return <SmallArtifactRef objRef={objRef} />;
+  }
+  return <div>[Error: non wandb ref]</div>;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/url.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/url.ts
@@ -1,3 +1,4 @@
+import {checkRegistryProject} from '@wandb/weave/common/util/artifacts';
 import {isWandbArtifactRef, parseRef} from '@wandb/weave/react';
 
 import {useWeaveflowRouteContext} from '../Browse3/context';
@@ -21,3 +22,76 @@ export const useRefPageUrl = () => {
   };
   return refPageUrl;
 };
+
+export type ArtifactRefURLInfo = {
+  entityName: string;
+  projectName: string;
+  artifactName: string;
+  artifactVersion: string;
+  artifactType: string;
+  orgName: string;
+};
+
+// Keep somewhat in sync with
+// https://github.com/wandb/core/blob/master/frontends/app/src/util/urls/paths.ts
+export function fetchArtifactRefPageUrl(ref: ArtifactRefURLInfo): string {
+  // Handle registry artifact
+  const {isRegistryProject, registryName} = checkRegistryProject(
+    ref.projectName
+  );
+  if (isRegistryProject && registryName) {
+    return buildRegistryArtifactUrl(ref, registryName);
+  }
+
+  // Handle old team level model registry artifact
+  if (isModelRegistryArtifact(ref)) {
+    return buildTeamModelRegistryUrl(ref);
+  }
+
+  // Handle regular artifact
+  return buildRegularArtifactUrl(ref);
+}
+
+function isModelRegistryArtifact(ref: ArtifactRefURLInfo): boolean {
+  return (
+    ref.artifactType.toLowerCase().includes('model') &&
+    ref.projectName === 'model-registry'
+  );
+}
+
+function buildRegistryArtifactUrl(
+  ref: ArtifactRefURLInfo,
+  registryName: string
+): string {
+  const path = `orgs/${ref.orgName}/registry/${registryName}`;
+  const params = new URLSearchParams({
+    selectionPath: `${ref.entityName}/${ref.projectName}/${encodeURIComponent(
+      ref.artifactName
+    )}`,
+    view: 'membership',
+    version: ref.artifactVersion,
+  });
+
+  return `${window.location.origin}/${path}?${params.toString()}`;
+}
+
+function buildRegularArtifactUrl(ref: ArtifactRefURLInfo): string {
+  return `${window.location.origin}/${ref.entityName}/${
+    ref.projectName
+  }/artifacts/${encodeURIComponent(ref.artifactType)}/${encodeURIComponent(
+    ref.artifactName
+  )}/${ref.artifactVersion}`;
+}
+
+function buildTeamModelRegistryUrl(ref: ArtifactRefURLInfo): string {
+  const path = `${ref.entityName}/registry/model`;
+  const params = new URLSearchParams({
+    selectionPath: `${ref.entityName}/model-registry/${encodeURIComponent(
+      ref.artifactName
+    )}`,
+    view: 'membership',
+    version: ref.artifactVersion,
+  });
+
+  return `${window.location.origin}/${path}?${params.toString()}`;
+}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -8,7 +8,11 @@ import {
   GridFilterItem,
   GridFilterModel,
 } from '@mui/x-data-grid-pro';
-import {isWeaveObjectRef, parseRefMaybe} from '@wandb/weave/react';
+import {
+  isWandbArtifactRef,
+  isWeaveObjectRef,
+  parseRefMaybe,
+} from '@wandb/weave/react';
 import _ from 'lodash';
 
 import {parseFeedbackType} from '../feedback/HumanFeedback/tsHumanFeedback';
@@ -16,7 +20,10 @@ import {
   parseScorerFeedbackField,
   RUNNABLE_FEEDBACK_IN_SUMMARY_PREFIX,
 } from '../feedback/HumanFeedback/tsScorerFeedback';
-import {WEAVE_REF_PREFIX} from '../pages/wfReactInterface/constants';
+import {
+  WANDB_ARTIFACT_REF_PREFIX,
+  WEAVE_REF_PREFIX,
+} from '../pages/wfReactInterface/constants';
 import {TraceCallSchema} from '../pages/wfReactInterface/traceServerClientTypes';
 
 export type FilterId = number | string | undefined;
@@ -294,15 +301,20 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = {
 
 // Create a unique symbol for RefString
 const WeaveRefStringSymbol = Symbol('WeaveRefString');
+const ArtifactRefStringSymbol = Symbol('ArtifactRefString');
 
 // Define RefString type using the unique symbol
 export type WeaveRefString = string & {[WeaveRefStringSymbol]: never};
+export type ArtifactRefString = string & {[ArtifactRefStringSymbol]: never};
 
 const isRefPrefixedString = (value: any): boolean => {
   if (typeof value !== 'string') {
     return false;
   }
-  if (value.startsWith(WEAVE_REF_PREFIX)) {
+  if (
+    value.startsWith(WEAVE_REF_PREFIX) ||
+    value.startsWith(WANDB_ARTIFACT_REF_PREFIX)
+  ) {
     return true;
   }
   return false;
@@ -321,6 +333,14 @@ export const isWeaveRef = (value: any): value is WeaveRefString => {
   }
   const parsed = parseRefMaybe(value);
   return parsed ? isWeaveObjectRef(parsed) : false;
+};
+
+export const isArtifactRef = (value: any): value is ArtifactRefString => {
+  if (!isRefPrefixedString(value)) {
+    return false;
+  }
+  const parsed = parseRefMaybe(value);
+  return parsed ? isWandbArtifactRef(parsed) : false;
 };
 
 export const getStringList = (value: any): string[] => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueView.tsx
@@ -6,7 +6,7 @@ import {
   parseRefMaybe,
 } from '../../../../../../react';
 import {SmallRef} from '../../../Browse2/SmallRef';
-import {isWeaveRef} from '../../filters/common';
+import {isArtifactRef, isWeaveRef} from '../../filters/common';
 import {isCustomWeaveTypePayload} from '../../typeViews/customWeaveType.types';
 import {CustomWeaveTypeDispatcher} from '../../typeViews/CustomWeaveTypeDispatcher';
 import {
@@ -76,6 +76,9 @@ export const ValueView = ({data, isExpanded}: ValueViewProps) => {
     ) {
       return <WeaveCHTable tableRefUri={data.value} />;
     }
+    return <SmallRef objRef={parseRef(data.value)} />;
+  }
+  if (isArtifactRef(data.value)) {
     return <SmallRef objRef={parseRef(data.value)} />;
   }
 

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -561,15 +561,15 @@ export const parseRefMaybe = (s: string): ObjectRef | null => {
 
 export const parseRef = (ref: string): ObjectRef => {
   const url = new URL(ref);
-  let splitLimit: number;
+  let maxSplitsToMake: number;
 
   const isWandbArtifact = url.protocol.startsWith('wandb-artifact');
   const isLocalArtifact = url.protocol.startsWith('local-artifact');
   const isWeaveRef = url.protocol.startsWith('weave');
   if (isWandbArtifact) {
-    splitLimit = 4;
+    maxSplitsToMake = 3;
   } else if (isLocalArtifact) {
-    splitLimit = 2;
+    maxSplitsToMake = 2;
   } else if (isWeaveRef) {
     return parseWeaveRef(ref);
   } else {
@@ -579,22 +579,22 @@ export const parseRef = (ref: string): ObjectRef => {
   // Decode the URI pathname to handle URL-encoded characters, required
   // in some browsers (safari)
   const decodedUri = decodeURIComponent(url.pathname);
-  const splitUri = decodedUri.replace(/^\/+/, '').split('/', splitLimit);
+  const splitUri = decodedUri.replace(/^\/+/, '').split('/', maxSplitsToMake);
 
-  if (splitUri.length !== splitLimit) {
+  if (maxSplitsToMake !== splitUri.length) {
     throw new Error(`Invalid Artifact URI: ${url}`);
   }
 
   if (isWandbArtifact) {
-    const [entityName, projectName, artifactId, artifactPathPart] = splitUri;
-    const [artifactNamePart, artifactVersion] = artifactId.split(':', 2);
+    const [entityName, projectName, artifactName] = splitUri;
+    const [artifactCollection, artifactVersion] = artifactName.split(':', 2);
     return {
       scheme: 'wandb-artifact',
       entityName,
       projectName,
-      artifactName: artifactNamePart,
+      artifactName: artifactCollection,
       artifactVersion,
-      artifactPath: artifactPathPart,
+      artifactPath: ref,
       artifactRefExtra: url.hash ? url.hash.slice(1) : undefined,
     };
   }


### PR DESCRIPTION
## Description

Pulling frontend changes out of https://github.com/wandb/weave/pull/2920/ and updating them to resolve merge conflicts 

Before:
<img width="492" alt="Screenshot 2025-01-27 at 4 51 11 PM" src="https://github.com/user-attachments/assets/aa06554b-a10f-406f-a8ac-1e6545fa16c3" />

After:

<img width="476" alt="Screenshot 2025-01-27 at 4 51 53 PM" src="https://github.com/user-attachments/assets/79507e23-2c2f-41bd-8adc-560cf613ce73" />

## Testing

Now that the changes in https://github.com/wandb/weave/pull/3484 have been deployed, these changes can be tested against the prod trace server backend. I used a tweaked version of the script from the original PR.

```
from typing import List
import weave

import wandb

# Configuration Constants
PROJECT = "2025-01-23_artref"
TEAM_ENTITY = "jamie-team"  # MAKE SURE THIS IS NOT A PERSONAL ENTITY
PERSONAL_ENTITY = "jamie-rasmussen" # Most likely your username
ORG_ENTITY = "wandb-jamie"  # Fetch this from the UI banner {BASE_URL}/orgs/wandb/registry/model

artifact_name = "test"

# log an empty personal entity artifact
run = wandb.init(project=PROJECT, entity=PERSONAL_ENTITY)
model_artifact = wandb.Artifact(name=artifact_name, type="model")
run.log_artifact(model_artifact).wait()
ARTIFACT = f"wandb-artifact:///{model_artifact.qualified_name}"
print(f"Logged personal entity artifact: {ARTIFACT}")

# link to model registry artifact
run.link_artifact(model_artifact, f"model-registry/{artifact_name}")
MODEL_REG_URL = f"wandb-artifact:///{PERSONAL_ENTITY}/model-registry/{artifact_name}:latest"
run.finish()

# Log a team entity artifact
run = wandb.init(project=PROJECT, entity=TEAM_ENTITY)
model_artifact = wandb.Artifact(name=artifact_name, type="model")
run.log_artifact(model_artifact).wait()
ARTIFACT = f"wandb-artifact:///{model_artifact.qualified_name}"
print(f"Logged team entity artifact: {ARTIFACT}")


# link to global registry
run.link_artifact(model_artifact, f"wandb-registry-model/{artifact_name}")
GLOBAL_REGISTRY_URL = (
    f"wandb-artifact:///{ORG_ENTITY}/wandb-registry-model/{artifact_name}:latest"
)
print(f"Linked team entity artifact to global registry: {GLOBAL_REGISTRY_URL}")
run.finish()


NON_EXISTENT_ARTIFACT = "wandb-artifact:///im-not-valid/im-not-real/testArtifact:v1"


class UnslothLoRAChatModel(weave.Model):
    """
    ChatModel class to store and version additional parameters beyond just the model name.
    Especially useful for fine-tuning scenarios.
    """

    model_registry: str
    wandb_registry_model: str
    regular_artifact: str
    invalid_artifact: str
    cm_temperature: float
    device: str

    @weave.op()
    def predict(self, query: List[str]) -> str:
        return "Berlin"


def main():
    # Instantiate the Chat Model
    new_chat_model = UnslothLoRAChatModel(
        name="UnslothLoRAChatModelRag",
        model_registry=MODEL_REG_URL,
        wandb_registry_model=GLOBAL_REGISTRY_URL,
        regular_artifact=ARTIFACT,
        invalid_artifact=NON_EXISTENT_ARTIFACT,
        cm_temperature=1.0,
        device="cpu",
    )
    print(new_chat_model)

    weave.init(f"{PERSONAL_ENTITY}/{PROJECT}")

    result = new_chat_model.predict(["What is the capital of Germany?"])
    print(result)


if __name__ == "__main__":
    main()

```
