### PR TITLE
feat(ui): lightbox for images

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
@@ -409,7 +409,7 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
       renderCell: (params: GridRenderCellParams) => {
         if (!isEditing) {
           return (
-            <Box sx={{marginLeft: '8px'}}>
+            <Box sx={{marginLeft: '8px', height: '100%'}}>
               <CellValue value={params.value} />
             </Box>
           );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/PIL.Image.Image/PILImageImage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/PIL.Image.Image/PILImageImage.tsx
@@ -196,11 +196,13 @@ const PILImageImageLoaded = ({
             maxWidth: previewWidth,
             maxHeight: previewHeight,
             margin: 'auto',
+            overflow: 'hidden',
           }}>
           <img
             style={{
               maxWidth: '100%',
               maxHeight: '100%',
+              objectFit: 'contain',
             }}
             src={url}
             alt="Custom"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/PIL.Image.Image/PILImageImage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/PIL.Image.Image/PILImageImage.tsx
@@ -1,5 +1,10 @@
-import React from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
+import {AutoSizer} from 'react-virtualized';
+import Lightbox from 'yet-another-react-lightbox';
+import Fullscreen from 'yet-another-react-lightbox/plugins/fullscreen';
+import Zoom from 'yet-another-react-lightbox/plugins/zoom';
 
+import {StyledTooltip, TooltipHint} from '../../../../../DraggablePopups';
 import {LoadingDots} from '../../../../../LoadingDots';
 import {NotApplicable} from '../../NotApplicable';
 import {useWFHooks} from '../../pages/wfReactInterface/context';
@@ -10,57 +15,236 @@ type PILImageImageTypePayload = CustomWeaveTypePayload<
   {'image.jpg': string} | {'image.png': string}
 >;
 
-export const PILImageImage: React.FC<{
+type PILImageImageProps = {
   entity: string;
   project: string;
   data: PILImageImageTypePayload;
-}> = props => {
-  const {useFileContent} = useWFHooks();
+};
 
+export const PILImageImage = (props: PILImageImageProps) => (
+  <AutoSizer style={{height: '100%', width: '100%'}}>
+    {({width, height}) => {
+      if (width === 0 || height === 0) {
+        return null;
+      }
+      return (
+        <PILImageImageWithSize
+          {...props}
+          containerWidth={width}
+          containerHeight={height}
+        />
+      );
+    }}
+  </AutoSizer>
+);
+
+type PILImageImageWithSizeProps = PILImageImageProps & {
+  containerWidth: number;
+  containerHeight: number;
+};
+
+const PILImageImageWithSize = ({
+  entity,
+  project,
+  data,
+  containerWidth,
+  containerHeight,
+}: PILImageImageWithSizeProps) => {
+  const {useFileContent} = useWFHooks();
   const imageTypes = {
     'image.jpg': 'jpg',
     'image.png': 'png',
   } as const;
 
-  const imageKey = Object.keys(props.data.files).find(
-    key => key in imageTypes
-  ) as keyof PILImageImageTypePayload['files'] | undefined;
+  const imageKey = Object.keys(data.files).find(key => key in imageTypes) as
+    | keyof PILImageImageTypePayload['files']
+    | undefined;
   const imageBinary = useFileContent(
-    props.entity,
-    props.project,
-    imageKey ? props.data.files[imageKey] : '',
+    entity,
+    project,
+    imageKey ? data.files[imageKey] : '',
     {skip: !imageKey}
   );
-
   if (!imageKey) {
     return <NotApplicable />;
-  }
-  const imageFileExt = imageTypes[imageKey as keyof typeof imageTypes];
-
-  if (imageBinary.loading) {
+  } else if (imageBinary.loading) {
     return <LoadingDots />;
   } else if (imageBinary.result == null) {
     return <span></span>;
   }
+  const fileExt = imageTypes[imageKey as keyof typeof imageTypes];
 
-  const arrayBuffer = imageBinary.result as any as ArrayBuffer;
-  const blob = new Blob([arrayBuffer], {
-    type: `image/${imageFileExt}`,
-  });
-  const url = URL.createObjectURL(blob);
-
-  // TODO: It would be nice to have a more general image render - similar to the
-  // ValueViewImage that does things like light box, general scaling,
-  // downloading, etc..
   return (
+    <PILImageImageWithData
+      fileExt={fileExt}
+      buffer={imageBinary.result}
+      containerWidth={containerWidth}
+      containerHeight={containerHeight}
+    />
+  );
+};
+
+const loadImage = (setImageDim: any, imageUrl: string) => {
+  const img = new Image();
+  img.src = imageUrl;
+
+  img.onload = () => {
+    setImageDim({
+      height: img.height,
+      width: img.width,
+    });
+  };
+  img.onerror = err => {
+    console.log('img error');
+    console.error(err);
+  };
+};
+
+type PILImageImageWithDataProps = {
+  fileExt: 'jpg' | 'png';
+  buffer: ArrayBuffer;
+  containerWidth: number;
+  containerHeight: number;
+};
+
+const PILImageImageWithData = ({
+  fileExt,
+  buffer,
+  containerWidth,
+  containerHeight,
+}: PILImageImageWithDataProps) => {
+  const url = useMemo(() => {
+    const blob = new Blob([buffer], {
+      type: `image/${fileExt}`,
+    });
+    return URL.createObjectURL(blob);
+  }, [buffer, fileExt]);
+
+  const [imageDim, setImageDim] = useState({
+    width: -1,
+    height: -1,
+  });
+  useEffect(() => {
+    setImageDim({width: -1, height: -1});
+    loadImage(setImageDim, url);
+  }, [url]);
+
+  if (imageDim.width === -1 || imageDim.height === -1) {
+    return <LoadingDots />;
+  }
+  return (
+    <PILImageImageLoaded
+      url={url}
+      fileExt={fileExt}
+      imageWidth={imageDim.width}
+      imageHeight={imageDim.height}
+      containerWidth={containerWidth}
+      containerHeight={containerHeight}
+    />
+  );
+};
+
+type PILImageImageLoadedProps = {
+  url: string;
+  fileExt: 'jpg' | 'png';
+  imageWidth: number;
+  imageHeight: number;
+  containerWidth: number;
+  containerHeight: number;
+};
+
+const previewWidth = 300;
+const previewHeight = 300;
+
+const PILImageImageLoaded = ({
+  url,
+  fileExt,
+  imageWidth,
+  imageHeight,
+  containerWidth,
+  containerHeight,
+}: PILImageImageLoadedProps) => {
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const onClick = () => setLightboxOpen(true);
+
+  let image = (
     <img
+      style={{
+        maxWidth: '100%',
+        maxHeight: '100%',
+        cursor: 'pointer',
+      }}
       src={url}
       alt="Custom"
-      style={{
-        width: '100%',
-        height: '100%',
-        objectFit: 'contain',
-      }}
+      onClick={onClick}
     />
+  );
+
+  const hasPreview =
+    containerWidth < previewWidth || containerHeight < previewHeight;
+
+  if (hasPreview) {
+    const preview = (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          cursor: 'pointer',
+        }}>
+        <div
+          style={{
+            maxWidth: previewWidth,
+            maxHeight: previewHeight,
+            margin: 'auto',
+          }}>
+          <img
+            style={{
+              maxWidth: '100%',
+              maxHeight: '100%',
+            }}
+            src={url}
+            alt="Custom"
+            onClick={onClick}
+          />
+        </div>
+        <TooltipHint>
+          {imageWidth}x{imageHeight}, {fileExt} - Click for more details
+        </TooltipHint>
+      </div>
+    );
+    image = (
+      <StyledTooltip enterDelay={500} title={preview}>
+        {image}
+      </StyledTooltip>
+    );
+  }
+
+  return (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+        }}>
+        {image}
+      </div>
+      <Lightbox
+        plugins={[Fullscreen, Zoom]}
+        open={lightboxOpen}
+        close={() => setLightboxOpen(false)}
+        controller={{
+          closeOnBackdropClick: true,
+        }}
+        slides={[{src: url}]}
+        render={{
+          // Hide previous and next buttons because we only have one image.
+          buttonPrev: () => null,
+          buttonNext: () => null,
+        }}
+        carousel={{finite: true}}
+      />
+    </>
   );
 };


### PR DESCRIPTION
## Description

Partial fix for https://wandb.atlassian.net/browse/WB-21609

Brings back a lightbox viewer for logged images, also with a preview on hover, which we didn't have before.

Tested with new `wf` example, Image-Eval which creates a Weave dataset and evaluation from a W&B artifact that contains 100 image generation prompts and the dall-e output for them.

Before:
<img width="857" alt="Screenshot 2025-01-27 at 10 12 44 PM" src="https://github.com/user-attachments/assets/701198e3-6e80-429d-af78-ff565edf0f7a" />


After:
<img width="851" alt="Screenshot 2025-01-27 at 10 13 39 PM" src="https://github.com/user-attachments/assets/8341db6a-fff9-403b-b3d6-c6d4bcd6b597" />
<img width="342" alt="Screenshot 2025-01-27 at 10 13 45 PM" src="https://github.com/user-attachments/assets/2363112a-6a74-43d3-bbfe-3bed06e15460" />
![image](https://github.com/user-attachments/assets/cfc78865-a28b-4b38-9e23-c18d604c5131)
