### PR TITLE
chore(ui): allow non-string title in SimplePageLayout

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -28,7 +28,7 @@ export const SimplePageLayoutContext =
   createContext<SimplePageLayoutContextType>({});
 
 export const SimplePageLayout: FC<{
-  title: string;
+  title: React.ReactNode;
   tabs: Array<{
     label: string;
     content: ReactNode;


### PR DESCRIPTION
## Description

Loosen the typing of the SimplePageLayout title - in SavedViews this will be a component allowing you to rename the page instead of a simple string.
