### PR TITLE
refactor(ui): move header components out of Browse2

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/CollapseHeader.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/CollapseHeader.tsx
@@ -4,8 +4,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import {Button} from '../../../Button';
-import {Tooltip} from '../../../Tooltip';
+import {Button} from '../../../../../../Button';
+import {Tooltip} from '../../../../../../Tooltip';
 
 type CollapseHeaderProps = {
   headerName: string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/ExpandHeader.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/ExpandHeader.tsx
@@ -4,8 +4,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import {Button} from '../../../Button';
-import {Tooltip} from '../../../Tooltip';
+import {Button} from '../../../../../../Button';
+import {Tooltip} from '../../../../../../Tooltip';
 
 type ExpandHeaderProps = {
   headerName: string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
@@ -11,8 +11,6 @@ import {isWeaveObjectRef, parseRef} from '../../../../../../../react';
 import {ErrorBoundary} from '../../../../../../ErrorBoundary';
 import {flattenObjectPreservingWeaveTypes} from '../../../../Browse2/browse2Util';
 import {CellValue} from '../../../../Browse2/CellValue';
-import {CollapseHeader} from '../../../../Browse2/CollapseHeader';
-import {ExpandHeader} from '../../../../Browse2/ExpandHeader';
 import {SmallRef} from '../../../../Browse2/SmallRef';
 import {
   CellFilterWrapper,
@@ -36,6 +34,8 @@ import {
   makeRefExpandedPayload,
 } from '../../wfReactInterface/tsDataModelHooksCallRefExpansion';
 import {buildTree} from './buildTree';
+import {CollapseHeader} from './CollapseHeader';
+import {ExpandHeader} from './ExpandHeader';
 
 /**
  * This function is responsible for taking the raw data and flattening it


### PR DESCRIPTION
## Description

Move some components out of Browse2 and closer to only use in Browse3.
