### PR TITLE
chore(weave): fix pytest warning

### DIFF
--- a/tests/trace/type_handlers/Image/image_test.py
+++ b/tests/trace/type_handlers/Image/image_test.py
@@ -214,5 +214,3 @@ def test_images_in_load_of_dataset(client):
         assert isinstance(gotten_row["img"], Image.Image)
         assert gotten_row["img"].size == local_row["img"].size
         assert gotten_row["img"].tobytes() == local_row["img"].tobytes()
-
-    return ref


### PR DESCRIPTION
## Description

Fix this warning in tests:
```
tests/trace/type_handlers/Image/image_test.py::test_images_in_load_of_dataset
  /home/runner/work/weave/weave/.nox/tests-3-9-shard-trace/lib/python3.9/site-packages/_pytest/python.py:163: PytestReturnNotNoneWarning: Expected None, but tests/trace/type_handlers/Image/image_test.py::test_images_in_load_of_dataset returned ObjectRef(entity='shawn', project='test-project', name='Dataset', _digest='PJ3hsmfcP6fkaYlocbpAzkZpo5tKeYJFWBAWa8zk5cE', _extra=()), which will be an error in a future version of pytest.
```
