### PR TITLE
feat(weave): add call(s) to dataset in the app

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
@@ -18,9 +18,10 @@ import {CellValueString} from './CellValueString';
 
 type CellValueProps = {
   value: any;
+  noLink?: boolean;
 };
 
-export const CellValue = ({value}: CellValueProps) => {
+export const CellValue = ({value, noLink}: CellValueProps) => {
   if (value === undefined) {
     return null;
   }
@@ -28,7 +29,7 @@ export const CellValue = ({value}: CellValueProps) => {
     return <ValueViewPrimitive>null</ValueViewPrimitive>;
   }
   if (isWeaveRef(value) || isArtifactRef(value)) {
-    return <SmallRef objRef={parseRef(value)} />;
+    return <SmallRef objRef={parseRef(value)} noLink={noLink} />;
   }
   if (typeof value === 'boolean') {
     return (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/AddToDatasetDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/AddToDatasetDrawer.tsx
@@ -1,0 +1,453 @@
+import {Box, Typography} from '@mui/material';
+import React, {useCallback, useEffect, useState} from 'react';
+import {toast} from 'react-toastify';
+
+import {maybePluralize} from '../../../../../core/util/string';
+import {Button} from '../../../../Button';
+import {WaveLoader} from '../../../../Loaders/WaveLoader';
+import {useWeaveflowRouteContext} from '../context';
+import {ResizableDrawer} from '../pages/common/ResizableDrawer';
+import {useWFHooks} from '../pages/wfReactInterface/context';
+import {ObjectVersionSchema} from '../pages/wfReactInterface/wfDataModelHooksInterface';
+import {
+  DatasetEditProvider,
+  useDatasetEditContext,
+} from './DatasetEditorContext';
+import {createNewDataset, updateExistingDataset} from './datasetOperations';
+import {DatasetPublishToast} from './DatasetPublishToast';
+import {EditAndConfirmStep} from './EditAndConfirmStep';
+import {FieldConfig, NewDatasetSchemaStep} from './NewDatasetSchemaStep';
+import {SchemaMappingStep} from './SchemaMappingStep';
+import {CallData, FieldMapping} from './schemaUtils';
+import {SelectDatasetStep} from './SelectDatasetStep';
+
+interface AddToDatasetDrawerProps {
+  entity: string;
+  project: string;
+  open: boolean;
+  onClose: () => void;
+  selectedCalls: CallData[];
+}
+
+const typographyStyle = {fontFamily: 'Source Sans Pro'};
+
+export const AddToDatasetDrawer: React.FC<AddToDatasetDrawerProps> = props => {
+  return (
+    <DatasetEditProvider>
+      <AddToDatasetDrawerInner {...props} />
+    </DatasetEditProvider>
+  );
+};
+
+export const AddToDatasetDrawerInner: React.FC<AddToDatasetDrawerProps> = ({
+  open,
+  onClose,
+  entity,
+  project,
+  selectedCalls,
+}) => {
+  const [currentStep, setCurrentStep] = useState(1);
+  const [selectedDataset, setSelectedDataset] =
+    useState<ObjectVersionSchema | null>(null);
+  const [datasets, setDatasets] = useState<ObjectVersionSchema[]>([]);
+  const [fieldMappings, setFieldMappings] = useState<FieldMapping[]>([]);
+  const [datasetObject, setDatasetObject] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [drawerWidth, setDrawerWidth] = useState(800);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [newDatasetName, setNewDatasetName] = useState<string | null>(null);
+  const [fieldConfigs, setFieldConfigs] = useState<FieldConfig[]>([]);
+  const [isNameValid, setIsNameValid] = useState(false);
+  const [datasetKey, setDatasetKey] = useState<string>('');
+
+  const {peekingRouter} = useWeaveflowRouteContext();
+  const {useRootObjectVersions, useTableUpdate, useObjCreate, useTableCreate} =
+    useWFHooks();
+  const tableUpdate = useTableUpdate();
+  const objCreate = useObjCreate();
+  const tableCreate = useTableCreate();
+  const {getRowsNoMeta, convertEditsToTableUpdateSpec, resetEditState} =
+    useDatasetEditContext();
+
+  // Update dataset key when the underlying dataset selection or mappings change
+  useEffect(() => {
+    if (currentStep === 1) {
+      // Only update key when on the selection/mapping step
+      setDatasetKey(
+        selectedDataset
+          ? `${selectedDataset.objectId}-${
+              selectedDataset.versionHash
+            }-${JSON.stringify(fieldMappings)}`
+          : `new-dataset-${newDatasetName}-${JSON.stringify(fieldMappings)}`
+      );
+    }
+  }, [currentStep, selectedDataset, newDatasetName, fieldMappings]);
+
+  // Reset edit state only when the dataset key changes
+  useEffect(() => {
+    if (datasetKey) {
+      resetEditState();
+    }
+  }, [datasetKey, resetEditState]);
+
+  const objectVersions = useRootObjectVersions(
+    entity,
+    project,
+    {
+      baseObjectClasses: ['Dataset'],
+    },
+    undefined,
+    true
+  );
+
+  useEffect(() => {
+    if (objectVersions.result) {
+      setDatasets(objectVersions.result);
+    }
+  }, [objectVersions.result]);
+
+  const handleNext = () => {
+    const isNewDataset = selectedDataset === null;
+    if (isNewDataset) {
+      if (!newDatasetName?.trim()) {
+        setError('Please enter a dataset name');
+        return;
+      }
+      if (!fieldConfigs.some(config => config.included)) {
+        setError('Please select at least one field to include');
+        return;
+      }
+
+      // Create field mappings from field configs
+      const newMappings = fieldConfigs
+        .filter(config => config.included)
+        .map(config => ({
+          sourceField: config.sourceField,
+          targetField: config.targetField,
+        }));
+      setFieldMappings(newMappings);
+
+      // Create an empty dataset object structure
+      const newDatasetObject = {
+        rows: [],
+        schema: fieldConfigs
+          .filter(config => config.included)
+          .map(config => ({
+            name: config.targetField,
+            type: 'string', // You might want to infer the type from the source data
+          })),
+      };
+      setDatasetObject(newDatasetObject);
+    }
+    setCurrentStep(prev => Math.min(prev + 1, 2));
+  };
+
+  const handleBack = () => {
+    setCurrentStep(prev => Math.max(prev - 1, 1));
+  };
+
+  const handleDatasetSelect = (dataset: ObjectVersionSchema | null) => {
+    if (dataset?.objectId !== selectedDataset?.objectId) {
+      resetEditState();
+      setSelectedDataset(dataset);
+    } else {
+      setSelectedDataset(dataset);
+    }
+  };
+
+  const handleMappingChange = (newMappings: FieldMapping[]) => {
+    if (JSON.stringify(newMappings) !== JSON.stringify(fieldMappings)) {
+      resetEditState();
+      setFieldMappings(newMappings);
+    } else {
+      setFieldMappings(newMappings);
+    }
+  };
+
+  const projectId = `${entity}/${project}`;
+
+  const resetDrawerState = useCallback(() => {
+    setCurrentStep(1);
+    setSelectedDataset(null);
+    setFieldMappings([]);
+    setDatasetObject(null);
+    setError(null);
+  }, []);
+
+  const handleCreate = async () => {
+    if (!datasetObject) {
+      return;
+    }
+
+    setError(null);
+    setIsCreating(true);
+    try {
+      let result: any;
+      const isNewDataset = selectedDataset === null;
+
+      if (isNewDataset) {
+        // Create new dataset flow
+        if (!newDatasetName) {
+          throw new Error('Dataset name is required');
+        }
+        result = await createNewDataset({
+          projectId,
+          entity,
+          project,
+          datasetName: newDatasetName,
+          rows: getRowsNoMeta(),
+          tableCreate,
+          objCreate,
+          router: peekingRouter,
+        });
+      } else {
+        // Update existing dataset flow
+        if (!selectedDataset) {
+          throw new Error('No dataset selected');
+        }
+        result = await updateExistingDataset({
+          projectId,
+          entity,
+          project,
+          selectedDataset,
+          datasetObject,
+          updateSpecs: convertEditsToTableUpdateSpec(),
+          tableUpdate,
+          objCreate,
+          router: peekingRouter,
+        });
+      }
+
+      toast(
+        <DatasetPublishToast
+          message={`${maybePluralize(
+            selectedCalls.length,
+            'example'
+          )} added to dataset`}
+          url={result.url}
+        />,
+        {
+          autoClose: 5000,
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+        }
+      );
+
+      resetDrawerState();
+      onClose();
+    } catch (error) {
+      console.error('Failed to create dataset version:', error);
+      setError(
+        error instanceof Error ? error.message : 'An unexpected error occurred'
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const isNextDisabled =
+    currentStep === 1 &&
+    ((selectedDataset === null && (!newDatasetName?.trim() || !isNameValid)) ||
+      (selectedDataset === null &&
+        !fieldConfigs.some(config => config.included)));
+
+  const renderStepContent = () => {
+    const isNewDataset = selectedDataset === null;
+
+    switch (currentStep) {
+      case 1:
+        return (
+          <div>
+            <SelectDatasetStep
+              selectedDataset={selectedDataset}
+              setSelectedDataset={handleDatasetSelect}
+              datasets={datasets}
+              newDatasetName={newDatasetName}
+              setNewDatasetName={setNewDatasetName}
+              onValidationChange={setIsNameValid}
+              entity={entity}
+              project={project}
+            />
+            {!isNewDataset && selectedDataset && (
+              <SchemaMappingStep
+                selectedDataset={selectedDataset}
+                selectedCalls={selectedCalls}
+                entity={entity}
+                project={project}
+                fieldMappings={fieldMappings}
+                datasetObject={datasetObject}
+                onMappingChange={handleMappingChange}
+                onDatasetObjectLoaded={setDatasetObject}
+              />
+            )}
+            {isNewDataset && (
+              <NewDatasetSchemaStep
+                selectedCalls={selectedCalls}
+                fieldConfigs={fieldConfigs}
+                onFieldConfigsChange={setFieldConfigs}
+              />
+            )}
+          </div>
+        );
+      case 2:
+        return (
+          <EditAndConfirmStep
+            selectedCalls={selectedCalls}
+            fieldMappings={fieldMappings}
+            datasetObject={datasetObject}
+            isNewDataset={isNewDataset}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <ResizableDrawer
+      open={open}
+      onClose={onClose}
+      defaultWidth={isFullscreen ? window.innerWidth - 73 : drawerWidth}
+      setWidth={width => !isFullscreen && setDrawerWidth(width)}>
+      {isCreating ? (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: '100%',
+          }}>
+          <WaveLoader size="huge" />
+        </Box>
+      ) : (
+        <>
+          <Box
+            sx={{
+              position: 'sticky',
+              top: 0,
+              zIndex: 20,
+              pl: '16px',
+              pr: '8px',
+              height: 44,
+              width: '100%',
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              backgroundColor: 'white',
+            }}>
+            <Box
+              sx={{
+                height: 44,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+              }}>
+              {currentStep === 2 ? (
+                <Button
+                  onClick={handleBack}
+                  variant="ghost"
+                  icon="back"
+                  tooltip="Back"
+                  size="medium"
+                />
+              ) : null}
+              <Typography
+                sx={{
+                  ...typographyStyle,
+                  fontWeight: 600,
+                  fontSize: '1.25rem',
+                }}>
+                Add example{selectedCalls.length !== 1 ? 's' : ''} to dataset
+              </Typography>
+            </Box>
+            <Box sx={{display: 'flex', gap: 1}}>
+              {currentStep === 2 && (
+                <Button
+                  onClick={() => setIsFullscreen(!isFullscreen)}
+                  variant="ghost"
+                  icon="full-screen-mode-expand"
+                  tooltip={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                  size="medium"
+                />
+              )}
+              {currentStep === 1 && (
+                <Button
+                  size="medium"
+                  variant="ghost"
+                  icon="close"
+                  onClick={onClose}
+                  tooltip="Close"
+                />
+              )}
+            </Box>
+          </Box>
+          <Box
+            sx={{
+              flex: 1,
+              overflow: 'auto',
+              px: currentStep === 1 ? 2 : 0,
+              display: 'flex',
+              flexDirection: 'column',
+            }}>
+            {error && (
+              <Box sx={{mb: 2, p: 2, bgcolor: 'error.light', borderRadius: 1}}>
+                <Typography sx={typographyStyle} color="error.dark">
+                  {error}
+                </Typography>
+              </Box>
+            )}
+            {renderStepContent()}
+          </Box>
+          <Box
+            sx={{
+              p: 2,
+              borderTop: '1px solid',
+              borderColor: 'divider',
+              display: 'flex',
+              justifyContent: 'space-between',
+              gap: 1,
+              bgcolor: 'background.paper',
+            }}>
+            {currentStep === 1 ? (
+              <Button
+                onClick={handleNext}
+                color="primary"
+                variant="primary"
+                disabled={isNextDisabled}
+                style={{width: '100%'}}
+                twWrapperStyles={{width: '100%'}}>
+                Next
+              </Button>
+            ) : (
+              <>
+                <Button
+                  onClick={handleBack}
+                  color="primary"
+                  variant="secondary"
+                  style={{width: '100%'}}
+                  twWrapperStyles={{width: '100%'}}>
+                  Back
+                </Button>
+                <Button
+                  onClick={handleCreate}
+                  color="primary"
+                  variant="primary"
+                  style={{width: '100%'}}
+                  twWrapperStyles={{width: '100%'}}>
+                  {selectedDataset === null
+                    ? 'Create dataset'
+                    : 'Add to dataset'}
+                </Button>
+              </>
+            )}
+          </Box>
+        </>
+      )}
+    </ResizableDrawer>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CellRenderers.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CellRenderers.tsx
@@ -9,6 +9,7 @@ import set from 'lodash/set';
 import React, {useCallback, useState} from 'react';
 
 import {CellValue} from '../../Browse2/CellValue';
+import {isRefPrefixedString} from '../filters/common';
 import {DatasetRow, useDatasetEditContext} from './DatasetEditorContext';
 import {CodeEditor} from './editors/CodeEditor';
 import {DiffEditor} from './editors/DiffEditor';
@@ -30,12 +31,10 @@ export const DELETED_CELL_STYLES = {
 const cellViewingStyles = {
   height: '100%',
   width: '100%',
-  fontFamily: '"Source Sans Pro", sans-serif',
-  fontSize: '14px',
-  lineHeight: '1.5',
-  padding: '8px 12px',
   display: 'flex',
+  padding: '8px 12px',
   alignItems: 'center',
+  justifyContent: 'center',
   transition: 'background-color 0.2s ease',
 };
 
@@ -61,9 +60,11 @@ export const CellViewingRenderer: React.FC<
   serverValue,
 }) => {
   const [isHovered, setIsHovered] = useState(false);
-  const {setEditedRows} = useDatasetEditContext();
+  const {setEditedRows, setAddedRows} = useDatasetEditContext();
 
-  const isEditable = typeof value !== 'object' && typeof value !== 'boolean';
+  const isWeaveUrl = isRefPrefixedString(value);
+  const isEditable =
+    !isWeaveUrl && typeof value !== 'object' && typeof value !== 'boolean';
 
   const handleEditClick = (event: React.MouseEvent) => {
     event.stopPropagation();
@@ -106,11 +107,19 @@ export const CellViewingRenderer: React.FC<
       const existingRow = api.getRow(id);
       const updatedRow = {...existingRow, [field]: !value};
       api.updateRows([{id, ...updatedRow}]);
-      setEditedRows(prev => {
-        const newMap = new Map(prev);
-        newMap.set(existingRow.___weave?.index, updatedRow);
-        return newMap;
-      });
+      if (existingRow.___weave?.isNew) {
+        setAddedRows(prev => {
+          const newMap = new Map(prev);
+          newMap.set(existingRow.___weave?.id, updatedRow);
+          return newMap;
+        });
+      } else {
+        setEditedRows(prev => {
+          const newMap = new Map(prev);
+          newMap.set(existingRow.___weave?.index, updatedRow);
+          return newMap;
+        });
+      }
     };
 
     return (
@@ -180,18 +189,21 @@ export const CellViewingRenderer: React.FC<
             },
           },
         }}>
-        <Box
+        <div
           onClick={e => e.stopPropagation()}
           onDoubleClick={e => e.stopPropagation()}
-          sx={{
+          style={{
+            height: '100%',
             backgroundColor: getBackgroundColor(),
             opacity: isDeleted ? DELETED_CELL_STYLES.opacity : 1,
             textDecoration: isDeleted
               ? DELETED_CELL_STYLES.textDecoration
               : 'none',
+            alignContent: 'center',
+            paddingLeft: '8px',
           }}>
-          <CellValue value={value} />
-        </Box>
+          <CellValue value={value} noLink={true} />
+        </div>
       </Tooltip>
     );
   }
@@ -565,23 +577,44 @@ export const CellEditingRenderer: React.FC<
   );
 };
 
-interface ControlCellProps {
+export interface ControlCellProps {
   params: GridRenderCellParams;
-  deleteRow: (absoluteIndex: number) => void;
-  restoreRow: (absoluteIndex: number) => void;
-  deleteAddedRow: (rowId: string) => void;
+  deleteRow: (index: number) => void;
+  deleteAddedRow: (id: string) => void;
+  restoreRow: (index: number) => void;
   isDeleted: boolean;
   isNew: boolean;
+  hideRemoveForAddedRows?: boolean;
 }
 
 export const ControlCell: React.FC<ControlCellProps> = ({
   params,
   deleteRow,
-  restoreRow,
   deleteAddedRow,
+  restoreRow,
   isDeleted,
   isNew,
+  hideRemoveForAddedRows,
 }) => {
+  const rowId = params.id as string;
+  const rowIndex = params.row.___weave?.index;
+
+  // Hide remove button for added rows if requested
+  if (isNew && hideRemoveForAddedRows) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          height: '100%',
+          width: '100%',
+          backgroundColor: CELL_COLORS.NEW,
+        }}
+      />
+    );
+  }
+
   return (
     <Box
       sx={{
@@ -609,28 +642,21 @@ export const ControlCell: React.FC<ControlCellProps> = ({
             opacity: 0,
           },
           zIndex: 1000,
+          backgroundColor: 'transparent',
         }}>
-        {isNew && (
+        {isDeleted ? (
           <Button
-            onClick={() => deleteAddedRow(params.row.___weave?.id)}
-            tooltip="Remove"
-            icon="close"
-            size="small"
-            variant="secondary"
-          />
-        )}
-        {isDeleted && (
-          <Button
-            onClick={() => restoreRow(params.row.___weave?.index)}
+            onClick={() => restoreRow(rowIndex)}
             tooltip="Restore"
             icon="undo"
             size="small"
             variant="secondary"
           />
-        )}
-        {!isNew && !isDeleted && (
+        ) : (
           <Button
-            onClick={() => deleteRow(params.row.___weave?.index)}
+            onClick={() =>
+              isNew ? deleteAddedRow(rowId) : deleteRow(rowIndex)
+            }
             tooltip="Delete"
             icon="delete"
             size="small"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DataPreviewTooltip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DataPreviewTooltip.tsx
@@ -1,0 +1,214 @@
+import {Box, Paper, Tooltip, TooltipProps} from '@mui/material';
+import React from 'react';
+
+import {WaveLoader} from '../../../../Loaders/WaveLoader';
+import {CellValue} from '../../Browse2/CellValue';
+
+interface DataPreviewTooltipProps {
+  rows?: Array<Record<string, any>>;
+  maxRows?: number;
+  maxColumns?: number;
+  children: React.ReactElement;
+  tooltipProps?: Partial<TooltipProps>;
+  isLoading?: boolean;
+}
+
+export const DataPreviewTooltip: React.FC<DataPreviewTooltipProps> = ({
+  rows,
+  maxRows = 5,
+  maxColumns = 3,
+  children,
+  tooltipProps,
+  isLoading = false,
+}) => {
+  if (isLoading) {
+    return (
+      <Tooltip
+        title={
+          <Box sx={{display: 'flex', justifyContent: 'center'}}>
+            <WaveLoader size="small" />
+          </Box>
+        }
+        placement="right"
+        enterDelay={600}
+        enterNextDelay={200}
+        leaveDelay={0}
+        slotProps={{
+          tooltip: {
+            sx: {
+              bgcolor: 'white',
+              color: 'inherit',
+              boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.15)',
+              p: 0,
+            },
+          },
+        }}
+        {...tooltipProps}>
+        {children}
+      </Tooltip>
+    );
+  }
+
+  if (!rows?.length) {
+    return <>{children}</>;
+  }
+
+  const previewRows = rows.slice(0, maxRows);
+  const allColumns = Array.from(
+    new Set(previewRows.flatMap(row => Object.keys(row)))
+  );
+  const previewColumns = allColumns.slice(0, maxColumns);
+  const hasMoreColumns = allColumns.length > maxColumns;
+  const hasMoreRows = rows.length > maxRows;
+
+  const tooltipContent = (
+    <Paper
+      elevation={0}
+      sx={{
+        maxWidth: '800px',
+        maxHeight: '400px',
+        fontFamily: 'Source Sans Pro',
+        fontSize: '14px',
+        borderRadius: 1,
+        overflow: 'hidden',
+      }}>
+      <Box
+        sx={{
+          overflowX: 'auto',
+          overflowY: 'auto',
+          maxHeight: '400px',
+        }}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${
+              previewColumns.length + (hasMoreColumns ? 1 : 0)
+            }, minmax(120px, 1fr))`,
+            minWidth: 'fit-content',
+            gap: 0,
+            border: '1px solid rgba(224, 224, 224, 1)',
+            borderRadius: 1,
+          }}>
+          {/* Header row */}
+          {previewColumns.map((column, colIndex) => (
+            <Box
+              key={column}
+              sx={{
+                color: 'text.secondary',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                p: 1,
+                borderBottom: '1px solid rgba(224, 224, 224, 1)',
+                borderRight:
+                  colIndex < previewColumns.length - 1 || hasMoreColumns
+                    ? '1px solid rgba(224, 224, 224, 1)'
+                    : 'none',
+                bgcolor: '#fafafa',
+                position: 'sticky',
+                top: 0,
+                zIndex: 1,
+              }}>
+              {column}
+            </Box>
+          ))}
+          {hasMoreColumns && (
+            <Box
+              sx={{
+                color: 'text.secondary',
+                fontStyle: 'italic',
+                p: 1,
+                borderBottom: '1px solid rgba(224, 224, 224, 1)',
+                bgcolor: '#fafafa',
+                position: 'sticky',
+                top: 0,
+                zIndex: 1,
+              }}>
+              +{allColumns.length - maxColumns} more
+            </Box>
+          )}
+
+          {/* Data rows */}
+          {previewRows.map((row, rowIndex) => (
+            <React.Fragment key={rowIndex}>
+              {previewColumns.map((column, colIndex) => (
+                <Box
+                  key={column}
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    p: 1,
+                    borderBottom:
+                      rowIndex < previewRows.length - 1
+                        ? '1px solid rgba(224, 224, 224, 1)'
+                        : 'none',
+                    borderRight:
+                      colIndex < previewColumns.length - 1 || hasMoreColumns
+                        ? '1px solid rgba(224, 224, 224, 1)'
+                        : 'none',
+                    maxWidth: '300px',
+                  }}>
+                  <Box
+                    onClick={e => e.stopPropagation()}
+                    onMouseEnter={e => e.stopPropagation()}
+                    onMouseLeave={e => e.stopPropagation()}>
+                    <CellValue value={row[column]} noLink />
+                  </Box>
+                </Box>
+              ))}
+              {hasMoreColumns && (
+                <Box
+                  sx={{
+                    color: 'text.secondary',
+                    fontStyle: 'italic',
+                    p: 1,
+                    borderBottom:
+                      rowIndex < previewRows.length - 1
+                        ? '1px solid rgba(224, 224, 224, 1)'
+                        : 'none',
+                  }}>
+                  ...
+                </Box>
+              )}
+            </React.Fragment>
+          ))}
+        </Box>
+      </Box>
+
+      {hasMoreRows && (
+        <Box
+          sx={{
+            mt: 1,
+            color: 'text.secondary',
+            fontStyle: 'italic',
+            textAlign: 'center',
+          }}>
+          {rows.length - maxRows} more rows...
+        </Box>
+      )}
+    </Paper>
+  );
+
+  return (
+    <Tooltip
+      title={tooltipContent}
+      placement="right"
+      enterDelay={600}
+      enterNextDelay={200}
+      leaveDelay={0}
+      slotProps={{
+        tooltip: {
+          sx: {
+            bgcolor: 'white',
+            color: 'inherit',
+            boxShadow: '0px 2px 8px rgba(0, 0, 0, 0.15)',
+            p: 0,
+          },
+        },
+      }}
+      {...tooltipProps}>
+      {children}
+    </Tooltip>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetPreview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetPreview.tsx
@@ -1,0 +1,41 @@
+import React, {useEffect} from 'react';
+
+import {useDatasetEditContext} from './DatasetEditorContext';
+import {EditableDatasetView} from './EditableDatasetView';
+
+export interface DatasetPreviewProps {
+  mappedRows: Array<{___weave: {id: string; isNew: boolean}}>;
+  datasetObject: any;
+}
+
+export const DatasetPreview: React.FC<DatasetPreviewProps> = ({
+  mappedRows,
+  datasetObject,
+}) => {
+  const {setAddedRows, addedRows} = useDatasetEditContext();
+
+  // Only set rows if they don't exist or if they're different
+  useEffect(() => {
+    const rowsMap = new Map(
+      mappedRows.map(row => [
+        row.___weave.id,
+        {...row, ___weave: {...row.___weave, serverValue: row}},
+      ])
+    );
+
+    // Check if we need to initialize
+    const needsInitialization = addedRows.size === 0;
+
+    if (needsInitialization) {
+      setAddedRows(rowsMap);
+    }
+  }, [mappedRows, setAddedRows, addedRows]);
+
+  return (
+    <EditableDatasetView
+      datasetObject={datasetObject}
+      isEditing={true}
+      hideRemoveForAddedRows={true}
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetPublishToast.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetPublishToast.tsx
@@ -1,0 +1,36 @@
+import {Box, Typography} from '@mui/material';
+import {TEAL_500} from '@wandb/weave/common/css/color.styles';
+import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {Icon} from '../../../../Icon';
+
+const VIEW_DATASET_LINK_STYLES = {
+  color: TEAL_500,
+  textDecoration: 'none',
+  fontSize: '16px',
+  fontFamily: 'Source Sans Pro',
+} as const;
+
+interface DatasetPublishToastProps {
+  url: string;
+  message: string;
+}
+
+export const DatasetPublishToast: React.FC<DatasetPublishToastProps> = ({
+  url,
+  message,
+}) => (
+  <Box sx={{display: 'flex', flexDirection: 'column', gap: 1}}>
+    <Box sx={{display: 'flex', alignItems: 'center', gap: 1.5}}>
+      <Icon name="checkmark-circle" width={24} height={24} color={TEAL_500} />
+      <Typography
+        sx={{color: 'white', fontSize: '16px', fontFamily: 'Source Sans Pro'}}>
+        {message}
+      </Typography>
+    </Box>
+    <Link to={url} style={VIEW_DATASET_LINK_STYLES}>
+      View the dataset
+    </Link>
+  </Box>
+);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditAndConfirmStep.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditAndConfirmStep.tsx
@@ -1,0 +1,51 @@
+import {Box} from '@mui/material';
+import React, {useMemo} from 'react';
+
+import {DatasetPreview} from './DatasetPreview';
+import {CallData, FieldMapping, mapCallsToDatasetRows} from './schemaUtils';
+
+export interface EditAndConfirmStepProps {
+  selectedCalls: CallData[];
+  fieldMappings: FieldMapping[];
+  datasetObject: any;
+  isNewDataset?: boolean;
+}
+
+interface WeaveRow {
+  ___weave: {id: string; isNew: boolean};
+  [key: string]: any;
+}
+
+export const EditAndConfirmStep: React.FC<EditAndConfirmStepProps> = ({
+  selectedCalls,
+  fieldMappings,
+  datasetObject,
+  isNewDataset,
+}) => {
+  const mappedRows = useMemo(() => {
+    const rows = mapCallsToDatasetRows(selectedCalls, fieldMappings);
+
+    // For new datasets, only include the fields that were mapped
+    if (isNewDataset) {
+      const targetFields = new Set(fieldMappings.map(m => m.targetField));
+      return rows.map(row => {
+        const {___weave, ...rest} = row;
+        const filteredData = Object.fromEntries(
+          Object.entries(rest).filter(([key]) => targetFields.has(key))
+        );
+        return {
+          ___weave,
+          ...filteredData,
+        } as WeaveRow;
+      });
+    }
+
+    return rows;
+  }, [selectedCalls, fieldMappings, isNewDataset]);
+
+  return (
+    <Box sx={{height: '100%', width: '100%'}}>
+      <DatasetPreview mappedRows={mappedRows} datasetObject={datasetObject} />
+    </Box>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
@@ -16,7 +16,6 @@ import {RowId} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pa
 import {Tooltip} from '@wandb/weave/components/Tooltip';
 import get from 'lodash/get';
 import React, {
-  FC,
   useCallback,
   useContext,
   useEffect,
@@ -56,9 +55,10 @@ interface DatasetObjectVal {
   _bases: ['Object', 'BaseModel'];
 }
 
-interface EditableDataTableViewProps {
+export interface EditableDatasetViewProps {
   datasetObject: DatasetObjectVal;
-  isEditing: boolean;
+  isEditing?: boolean;
+  hideRemoveForAddedRows?: boolean;
 }
 
 interface OrderedRow {
@@ -66,9 +66,10 @@ interface OrderedRow {
   [key: string]: any;
 }
 
-export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
+export const EditableDatasetView: React.FC<EditableDatasetViewProps> = ({
   datasetObject,
-  isEditing,
+  isEditing = false,
+  hideRemoveForAddedRows = false,
 }) => {
   const {useTableRowsQuery, useTableQueryStats} = useWFHooks();
   const [sortBy, setSortBy] = useState<SortBy[]>([]);
@@ -379,6 +380,7 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
                   restoreRow={restoreRow}
                   isDeleted={deletedRows.includes(params.row.___weave?.index)}
                   isNew={params.row.___weave?.isNew}
+                  hideRemoveForAddedRows={hideRemoveForAddedRows}
                 />
               ),
             },
@@ -398,9 +400,14 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
       renderCell: (params: GridRenderCellParams) => {
         if (!isEditing) {
           return (
-            <Box sx={{marginLeft: '8px', height: '100%'}}>
+            <div
+              style={{
+                marginLeft: '8px',
+                height: '100%',
+                alignContent: 'center',
+              }}>
               <CellValue value={params.value} />
-            </Box>
+            </div>
           );
         }
         const rowIndex = params.row.___weave?.index;
@@ -453,6 +460,7 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
     loadedRows,
     columnWidths,
     preserveFieldOrder,
+    hideRemoveForAddedRows,
   ]);
 
   const handleColumnWidthChange = useCallback((params: any) => {
@@ -548,6 +556,7 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
                 height: '34px',
               },
             },
+            lineHeight: '20px',
           },
           // Removed default MUI blue from editing cell
           '.MuiDataGrid-cell.MuiDataGrid-cell--editing': {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/NewDatasetSchemaStep.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/NewDatasetSchemaStep.tsx
@@ -1,0 +1,271 @@
+import {Box, Stack, Typography} from '@mui/material';
+import {MOON_100, TEAL_500} from '@wandb/weave/common/css/color.styles';
+import React, {useEffect, useMemo} from 'react';
+
+import {TextField} from '../../../../Form/TextField';
+import {Icon} from '../../../../Icon';
+import {DataPreviewTooltip} from './DataPreviewTooltip';
+import {useDatasetEditContext} from './DatasetEditorContext';
+import {CallData, extractSourceSchema} from './schemaUtils';
+
+const typographyStyle = {fontFamily: 'Source Sans Pro'};
+
+export interface FieldConfig {
+  sourceField: string;
+  targetField: string;
+  included: boolean;
+}
+
+interface NewDatasetSchemaStepProps {
+  selectedCalls: CallData[];
+  fieldConfigs: FieldConfig[];
+  onFieldConfigsChange: (configs: FieldConfig[]) => void;
+}
+
+export const NewDatasetSchemaStep: React.FC<NewDatasetSchemaStepProps> = ({
+  selectedCalls,
+  fieldConfigs,
+  onFieldConfigsChange,
+}) => {
+  const {resetEditState} = useDatasetEditContext();
+  const sourceSchema = useMemo(() => {
+    return selectedCalls.length > 0 ? extractSourceSchema(selectedCalls) : [];
+  }, [selectedCalls]);
+
+  // Initialize field configs when source schema changes
+  useEffect(() => {
+    if (sourceSchema.length > 0 && fieldConfigs.length === 0) {
+      const initialConfigs = sourceSchema.map(field => ({
+        sourceField: field.name,
+        targetField: field.name.replace(/^(inputs\.|output\.)/, ''),
+        included: true,
+      }));
+      onFieldConfigsChange(initialConfigs);
+    }
+  }, [sourceSchema, fieldConfigs.length, onFieldConfigsChange]);
+
+  // Extract preview data for each source field
+  const fieldPreviews = useMemo(() => {
+    const previews = new Map<string, Array<Record<string, any>>>();
+
+    const getNestedValue = (obj: any, path: string[]): any => {
+      let current = obj;
+      for (const part of path) {
+        if (current == null) {
+          return undefined;
+        }
+        if (typeof current === 'object' && '__val__' in current) {
+          current = current.__val__;
+        }
+        if (typeof current !== 'object') {
+          return current;
+        }
+        current = current[part];
+      }
+      return current;
+    };
+
+    sourceSchema.forEach(field => {
+      const fieldData = selectedCalls.map(call => {
+        let value: any;
+        if (field.name.startsWith('inputs.')) {
+          const path = field.name.slice(7).split('.');
+          value = getNestedValue(call.val.inputs, path);
+        } else if (field.name.startsWith('output.')) {
+          if (typeof call.val.output === 'object' && call.val.output !== null) {
+            const path = field.name.slice(7).split('.');
+            value = getNestedValue(call.val.output, path);
+          } else {
+            value = call.val.output;
+          }
+        } else {
+          const path = field.name.split('.');
+          value = getNestedValue(call.val, path);
+        }
+        return {[field.name]: value};
+      });
+      previews.set(field.name, fieldData);
+    });
+    return previews;
+  }, [sourceSchema, selectedCalls]);
+
+  const handleTargetFieldChange = (
+    sourceField: string,
+    newTargetField: string
+  ) => {
+    const newConfigs = fieldConfigs.map(config =>
+      config.sourceField === sourceField
+        ? {...config, targetField: newTargetField}
+        : config
+    );
+    onFieldConfigsChange(newConfigs);
+  };
+
+  const handleIncludedChange = (sourceField: string) => {
+    const newConfigs = fieldConfigs.map(config =>
+      config.sourceField === sourceField
+        ? {...config, included: !config.included}
+        : config
+    );
+    onFieldConfigsChange(newConfigs);
+    resetEditState();
+  };
+
+  if (!selectedCalls.length) {
+    return (
+      <Stack spacing={1} sx={{mt: 2}}>
+        <Typography sx={typographyStyle}>
+          No data available to extract schema from.
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (!sourceSchema.length) {
+    return (
+      <Stack spacing={1} sx={{mt: 2}}>
+        <Typography sx={typographyStyle}>
+          No schema could be extracted from the data.
+        </Typography>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={1} sx={{mt: 4}}>
+      <Typography sx={{...typographyStyle, fontWeight: 600}}>
+        Configure dataset fields
+      </Typography>
+      <Typography
+        sx={{
+          ...typographyStyle,
+          color: 'text.secondary',
+          fontSize: '0.875rem',
+        }}>
+        Select which fields from your calls to include in the dataset. For each
+        included field, you can customize the column name that will appear in
+        the resulting dataset.
+      </Typography>
+      <Box sx={{height: 16}} />
+      <Box sx={{bgcolor: '#F8F8F8', p: 2, borderRadius: 1}}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 40px 1fr',
+            gap: 2,
+            mb: 2,
+          }}>
+          <Typography
+            sx={{
+              ...typographyStyle,
+              color: 'text.secondary',
+              fontSize: '0.875rem',
+              pl: 6, // Align with field name accounting for toggle width
+            }}>
+            Call Fields
+          </Typography>
+          <Box /> {/* Spacer for arrow */}
+          <Typography
+            sx={{
+              ...typographyStyle,
+              color: 'text.secondary',
+              fontSize: '0.875rem',
+            }}>
+            Dataset Columns
+          </Typography>
+        </Box>
+        <Stack spacing={2}>
+          {fieldConfigs.map(config => (
+            <Box
+              key={config.sourceField}
+              sx={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 40px 1fr',
+                alignItems: 'center',
+                gap: 2,
+              }}>
+              <Box
+                onClick={() => handleIncludedChange(config.sourceField)}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  cursor: 'pointer',
+                  userSelect: 'none',
+                  '&:hover': {
+                    opacity: 0.8,
+                  },
+                }}>
+                <Box
+                  sx={{
+                    width: 32,
+                    height: 16,
+                    borderRadius: 8,
+                    bgcolor: config.included ? TEAL_500 : MOON_100,
+                    position: 'relative',
+                    transition: 'background-color 0.2s',
+                  }}>
+                  <Box
+                    sx={{
+                      width: 12,
+                      height: 12,
+                      borderRadius: '50%',
+                      bgcolor: 'white',
+                      position: 'absolute',
+                      top: 2,
+                      left: config.included ? 18 : 2,
+                      transition: 'left 0.2s',
+                    }}
+                  />
+                </Box>
+                <DataPreviewTooltip
+                  rows={fieldPreviews.get(config.sourceField)}
+                  tooltipProps={{
+                    placement: 'right-start',
+                    componentsProps: {
+                      popper: {
+                        modifiers: [
+                          {
+                            name: 'offset',
+                            options: {
+                              offset: [0, 2],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  }}>
+                  <Typography
+                    sx={{
+                      ...typographyStyle,
+                      color: config.included ? 'inherit' : 'text.disabled',
+                    }}>
+                    {config.sourceField}
+                  </Typography>
+                </DataPreviewTooltip>
+              </Box>
+              <Box sx={{display: 'flex', justifyContent: 'center'}}>
+                <Icon
+                  name="forward-next"
+                  style={{
+                    color: config.included ? 'inherit' : 'text.disabled',
+                  }}
+                />
+              </Box>
+              <Box>
+                <TextField
+                  value={config.targetField}
+                  onChange={value =>
+                    handleTargetFieldChange(config.sourceField, value)
+                  }
+                  placeholder="Enter field name"
+                  disabled={!config.included}
+                />
+              </Box>
+            </Box>
+          ))}
+        </Stack>
+      </Box>
+    </Stack>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/SchemaMappingStep.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/SchemaMappingStep.tsx
@@ -1,0 +1,429 @@
+import {Box, Paper, Stack, Typography} from '@mui/material';
+import React, {useCallback, useEffect, useMemo} from 'react';
+
+import {Select} from '../../../../Form/Select';
+import {Icon} from '../../../../Icon';
+import {LoadingDots} from '../../../../LoadingDots';
+import {useWFHooks} from '../pages/wfReactInterface/context';
+import {ObjectVersionSchema} from '../pages/wfReactInterface/wfDataModelHooksInterface';
+import {DataPreviewTooltip} from './DataPreviewTooltip';
+import {
+  CallData,
+  extractSourceSchema,
+  FieldMapping,
+  inferSchema,
+  suggestMappings,
+} from './schemaUtils';
+
+export interface SchemaMappingStepProps {
+  selectedDataset: ObjectVersionSchema;
+  selectedCalls: CallData[];
+  entity: string;
+  project: string;
+  onMappingChange: (mappings: FieldMapping[]) => void;
+  onDatasetObjectLoaded: (obj: any) => void;
+  fieldMappings?: FieldMapping[];
+  datasetObject?: any;
+}
+
+const typographyStyle = {fontFamily: 'Source Sans Pro'};
+
+export const SchemaMappingStep: React.FC<SchemaMappingStepProps> = ({
+  selectedDataset,
+  selectedCalls,
+  entity,
+  project,
+  onMappingChange,
+  onDatasetObjectLoaded,
+  fieldMappings,
+}) => {
+  const {useObjectVersion, useTableRowsQuery} = useWFHooks();
+  const prevDatasetRef = React.useRef<string | null>(null);
+
+  const sourceSchema = useMemo(() => {
+    return selectedCalls.length > 0 ? extractSourceSchema(selectedCalls) : [];
+  }, [selectedCalls]);
+
+  const selectedDatasetObjectVersion = useObjectVersion(
+    selectedDataset
+      ? {
+          scheme: 'weave',
+          weaveKind: 'object',
+          entity: selectedDataset.entity,
+          project: selectedDataset.project,
+          objectId: selectedDataset.objectId,
+          versionHash: selectedDataset.versionHash,
+          path: selectedDataset.path,
+        }
+      : null,
+    undefined
+  );
+
+  useEffect(() => {
+    if (selectedDatasetObjectVersion.result?.val) {
+      onDatasetObjectLoaded(selectedDatasetObjectVersion.result.val);
+    }
+  }, [selectedDatasetObjectVersion.result, onDatasetObjectLoaded]);
+
+  const tableDigest = selectedDatasetObjectVersion.result?.val?.rows
+    ?.split('/')
+    ?.pop();
+
+  const tableRowsQuery = useTableRowsQuery(
+    entity || '',
+    project || '',
+    tableDigest || '',
+    undefined,
+    10 // This is an arbitrary limit to prevent loading too much data.
+  );
+
+  const targetSchema = useMemo(() => {
+    if (!tableRowsQuery.result) {
+      return [];
+    }
+    return inferSchema(tableRowsQuery.result.rows.map(row => row.val));
+  }, [tableRowsQuery.result]);
+
+  const currentDatasetKey =
+    selectedDataset?.objectId + selectedDataset?.versionHash;
+
+  useEffect(() => {
+    if (
+      prevDatasetRef.current !== currentDatasetKey &&
+      tableRowsQuery.result &&
+      targetSchema.length > 0
+    ) {
+      prevDatasetRef.current = currentDatasetKey;
+      const suggestedMappings = suggestMappings(sourceSchema, targetSchema, []);
+      onMappingChange(suggestedMappings);
+    }
+  }, [
+    currentDatasetKey,
+    tableRowsQuery.result,
+    targetSchema,
+    sourceSchema,
+    onMappingChange,
+  ]);
+
+  const localFieldMappings = useMemo(() => {
+    if (!tableRowsQuery.result || !targetSchema.length) {
+      return fieldMappings || [];
+    }
+    return fieldMappings || [];
+  }, [fieldMappings, tableRowsQuery.result, targetSchema.length]);
+
+  useEffect(() => {
+    if (JSON.stringify(localFieldMappings) !== JSON.stringify(fieldMappings)) {
+      onMappingChange(localFieldMappings);
+    }
+  }, [localFieldMappings, fieldMappings, onMappingChange]);
+
+  const handleMappingChange = useCallback(
+    (targetField: string, sourceField: string | null) => {
+      const existingMappings = fieldMappings || [];
+      const newMappings = existingMappings.filter(
+        m => m.targetField !== targetField
+      );
+
+      if (sourceField !== null && sourceField !== '') {
+        newMappings.push({sourceField, targetField});
+      }
+      onMappingChange(newMappings);
+    },
+    [fieldMappings, onMappingChange]
+  );
+
+  const fieldPreviews = useMemo(() => {
+    const previews = new Map<string, Array<Record<string, any>>>();
+
+    const getNestedValue = (obj: any, path: string[]): any => {
+      let current = obj;
+      for (const part of path) {
+        if (current == null) {
+          return undefined;
+        }
+        if (typeof current === 'object' && '__val__' in current) {
+          current = current.__val__;
+        }
+        if (typeof current !== 'object') {
+          return current;
+        }
+        current = current[part];
+      }
+      return current;
+    };
+
+    sourceSchema.forEach(field => {
+      const fieldData = selectedCalls.map(call => {
+        let value: any;
+        if (field.name.startsWith('inputs.')) {
+          const path = field.name.slice(7).split('.');
+          value = getNestedValue(call.val.inputs, path);
+        } else if (field.name.startsWith('output.')) {
+          if (typeof call.val.output === 'object' && call.val.output !== null) {
+            const path = field.name.slice(7).split('.');
+            value = getNestedValue(call.val.output, path);
+          } else {
+            value = call.val.output;
+          }
+        } else {
+          const path = field.name.split('.');
+          value = getNestedValue(call.val, path);
+        }
+        return {[field.name]: value};
+      });
+      previews.set(field.name, fieldData);
+    });
+    return previews;
+  }, [sourceSchema, selectedCalls]);
+
+  const formatOptionLabel = useCallback(
+    (option: {label: string; value: string}) => {
+      if (option.value === '') {
+        return option.label;
+      }
+      const previewData = fieldPreviews.get(option.value);
+      return (
+        <DataPreviewTooltip
+          rows={previewData}
+          tooltipProps={{
+            placement: 'left-start',
+            sx: {
+              maxWidth: '800px',
+            },
+          }}>
+          <div>{option.label}</div>
+        </DataPreviewTooltip>
+      );
+    },
+    [fieldPreviews]
+  );
+
+  const renderTargetField = useCallback(
+    (fieldName: string) => {
+      const previewData = tableRowsQuery.result?.rows.slice(0, 5).map(row => ({
+        [fieldName]: row.val[fieldName],
+      }));
+
+      return (
+        <DataPreviewTooltip
+          rows={previewData}
+          tooltipProps={{
+            placement: 'bottom-start',
+            sx: {
+              maxWidth: '800px',
+            },
+            componentsProps: {
+              popper: {
+                modifiers: [
+                  {
+                    name: 'offset',
+                    options: {
+                      offset: [0, 8],
+                    },
+                  },
+                ],
+              },
+            },
+          }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              padding: '4px 8px',
+              borderRadius: 1,
+              transition: 'all 0.2s ease',
+              '&:hover': {
+                backgroundColor: 'rgba(0, 0, 0, 0.04)',
+              },
+            }}>
+            <Typography
+              sx={{
+                fontFamily: 'Monospace',
+                fontWeight: 500,
+                color: 'text.primary',
+                fontSize: '14px',
+              }}>
+              {fieldName}
+            </Typography>
+          </Box>
+        </DataPreviewTooltip>
+      );
+    },
+    [tableRowsQuery.result]
+  );
+
+  if (
+    tableRowsQuery.loading ||
+    selectedDatasetObjectVersion.loading ||
+    !targetSchema.length
+  ) {
+    return (
+      <Stack spacing={1} sx={{mt: 2}}>
+        <Typography sx={{...typographyStyle, fontWeight: 600}}>
+          Field Mapping
+        </Typography>
+        <Paper
+          variant="outlined"
+          sx={{
+            p: 2,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            minHeight: '56px',
+          }}>
+          <LoadingDots />
+        </Paper>
+      </Stack>
+    );
+  }
+
+  if (!selectedCalls.length || !tableRowsQuery.result?.rows?.length) {
+    return (
+      <Stack spacing={1} sx={{mt: 2}}>
+        <Typography sx={typographyStyle}>
+          No data available to extract schema from.
+        </Typography>
+      </Stack>
+    );
+  }
+
+  if (!sourceSchema.length || !targetSchema.length) {
+    return (
+      <Stack spacing={1} sx={{mt: 2}}>
+        <Typography sx={typographyStyle}>
+          No schema could be extracted from the data.
+        </Typography>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={1} sx={{mt: 4}}>
+      <Typography sx={{...typographyStyle, fontWeight: 600}}>
+        Configure field mapping
+      </Typography>
+      <Typography
+        sx={{
+          ...typographyStyle,
+          color: 'text.secondary',
+          fontSize: '0.875rem',
+        }}>
+        Map fields from your calls to the corresponding dataset columns.
+      </Typography>
+      <Box sx={{height: 16}} />
+      <Box sx={{bgcolor: '#F8F8F8', p: 2, borderRadius: 1}}>
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 40px 1fr',
+            gap: 2,
+            mb: 2,
+          }}>
+          <Typography
+            sx={{
+              ...typographyStyle,
+              color: 'text.secondary',
+              fontSize: '0.875rem',
+              pl: 1,
+            }}>
+            Call Fields
+          </Typography>
+          <Box /> {/* Spacer for arrow */}
+          <Typography
+            sx={{
+              ...typographyStyle,
+              color: 'text.secondary',
+              fontSize: '0.875rem',
+            }}>
+            Dataset Columns
+          </Typography>
+        </Box>
+        <Stack spacing={2}>
+          {targetSchema.map(targetField => {
+            const currentMapping = localFieldMappings.find(
+              m => m.targetField === targetField.name
+            );
+
+            return (
+              <Box
+                key={targetField.name}
+                sx={{
+                  display: 'grid',
+                  gridTemplateColumns: '1fr 40px 1fr',
+                  alignItems: 'center',
+                  gap: 2,
+                }}>
+                <Box sx={{flex: 1, minWidth: '100px'}}>
+                  <Box sx={{position: 'relative'}}>
+                    {currentMapping && (
+                      <DataPreviewTooltip
+                        rows={fieldPreviews.get(currentMapping.sourceField)}
+                        tooltipProps={{
+                          placement: 'right-start',
+                          componentsProps: {
+                            popper: {
+                              modifiers: [
+                                {
+                                  name: 'offset',
+                                  options: {
+                                    offset: [0, 2],
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                        }}>
+                        <Box
+                          sx={{
+                            position: 'absolute',
+                            inset: 0,
+                            zIndex: 1,
+                            pointerEvents: 'none',
+                          }}
+                        />
+                      </DataPreviewTooltip>
+                    )}
+                    <Select
+                      placeholder="Select column"
+                      value={
+                        currentMapping
+                          ? {
+                              label: currentMapping.sourceField,
+                              value: currentMapping.sourceField,
+                            }
+                          : null
+                      }
+                      options={[
+                        {label: '-- None --', value: ''},
+                        ...sourceSchema.map(field => ({
+                          label: field.name,
+                          value: field.name,
+                        })),
+                      ]}
+                      onChange={option => {
+                        handleMappingChange(
+                          targetField.name,
+                          option === null ? null : option.value
+                        );
+                      }}
+                      formatOptionLabel={formatOptionLabel}
+                      isSearchable={true}
+                      isClearable={true}
+                    />
+                  </Box>
+                </Box>
+                <Box sx={{display: 'flex', justifyContent: 'center'}}>
+                  <Icon name="forward-next" />
+                </Box>
+                <Box sx={{flex: 1, minWidth: '100px'}}>
+                  {renderTargetField(targetField.name)}
+                </Box>
+              </Box>
+            );
+          })}
+        </Stack>
+      </Box>
+    </Stack>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/SelectDatasetStep.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/SelectDatasetStep.tsx
@@ -1,0 +1,382 @@
+import {Box, Stack, Typography} from '@mui/material';
+import React, {useCallback, useMemo, useState} from 'react';
+import {components, GroupBase, MenuListProps} from 'react-select';
+
+import {Checkbox} from '../../../../Checkbox';
+import {Select} from '../../../../Form/Select';
+import {TextField} from '../../../../Form/TextField';
+import {Icon} from '../../../../Icon';
+import {useWFHooks} from '../pages/wfReactInterface/context';
+import {ObjectVersionSchema} from '../pages/wfReactInterface/wfDataModelHooksInterface';
+import {SmallRef} from '../smallRef/SmallRef';
+import {DataPreviewTooltip} from './DataPreviewTooltip';
+import {useDatasetEditContext} from './DatasetEditorContext';
+
+const typographyStyle = {fontFamily: 'Source Sans Pro'};
+
+export interface SelectDatasetStepProps {
+  selectedDataset: ObjectVersionSchema | null;
+  setSelectedDataset: (dataset: ObjectVersionSchema | null) => void;
+  datasets: ObjectVersionSchema[];
+  onCreateNewDataset?: (name: string) => void;
+  newDatasetName?: string | null;
+  setNewDatasetName?: (name: string) => void;
+  onValidationChange?: (isValid: boolean) => void;
+  entity: string;
+  project: string;
+}
+
+interface DatasetOptionProps {
+  dataset: ObjectVersionSchema;
+  entity: string;
+  project: string;
+}
+
+const CREATE_NEW_OPTION_VALUE = '__create_new__';
+
+const DatasetOption: React.FC<DatasetOptionProps> = ({
+  dataset,
+  entity,
+  project,
+}) => {
+  const {useObjectVersion, useTableRowsQuery} = useWFHooks();
+
+  const datasetObjectVersion = useObjectVersion(
+    dataset
+      ? {
+          scheme: 'weave',
+          weaveKind: 'object',
+          entity: dataset.entity,
+          project: dataset.project,
+          objectId: dataset.objectId,
+          versionHash: dataset.versionHash,
+          path: dataset.path,
+        }
+      : null,
+    undefined
+  );
+
+  const tableDigest = datasetObjectVersion.result?.val?.rows?.split('/')?.pop();
+  const tableRowsQuery = useTableRowsQuery(
+    entity || '',
+    project || '',
+    tableDigest || '',
+    undefined,
+    5 // Limit to 5 rows for preview
+  );
+
+  const previewRows = tableRowsQuery?.result?.rows.map(row => row.val) || [];
+  const isLoading = datasetObjectVersion.loading || tableRowsQuery?.loading;
+
+  return (
+    <DataPreviewTooltip
+      rows={previewRows}
+      isLoading={isLoading}
+      tooltipProps={{
+        placement: 'right-start',
+        componentsProps: {
+          popper: {
+            modifiers: [
+              {
+                name: 'offset',
+                options: {
+                  offset: [0, 2],
+                },
+              },
+            ],
+          },
+        },
+      }}>
+      <Box sx={{display: 'flex', alignItems: 'center'}}>
+        <SmallRef
+          objRef={{
+            scheme: 'weave',
+            weaveKind: 'object',
+            entityName: dataset.entity,
+            projectName: dataset.project,
+            artifactName: dataset.objectId,
+            artifactVersion: dataset.versionHash,
+          }}
+          noLink
+        />
+      </Box>
+    </DataPreviewTooltip>
+  );
+};
+
+const CreateNewOption = () => (
+  <Box
+    sx={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 1,
+      '&:hover': {
+        backgroundColor: 'transparent',
+      },
+    }}>
+    <Icon name="add-new" size="small" />
+    <Box
+      component="span"
+      sx={{
+        fontSize: '16px',
+        fontFamily: 'Source Sans Pro',
+        fontWeight: 600,
+      }}>
+      Create new
+    </Box>
+  </Box>
+);
+
+type DatasetSelectOption =
+  | {
+      label: JSX.Element;
+      value: ObjectVersionSchema;
+      searchText: string;
+    }
+  | {
+      label: JSX.Element;
+      value: string;
+      searchText: string;
+    };
+
+const DatasetSelectMenu = (
+  props: MenuListProps<
+    DatasetSelectOption,
+    false,
+    GroupBase<DatasetSelectOption>
+  >
+) => {
+  const createNewOption = React.Children.toArray(props.children).find(
+    (child: any) => child?.props?.data?.value === CREATE_NEW_OPTION_VALUE
+  );
+  const otherOptions = React.Children.toArray(props.children).filter(
+    (child: any) => child?.props?.data?.value !== CREATE_NEW_OPTION_VALUE
+  );
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateRows: 'minmax(0, 1fr) auto',
+        height: '100%',
+        minHeight: 0,
+      }}>
+      <Box sx={{minHeight: 0, overflowY: 'auto'}}>
+        <components.MenuList {...props} children={otherOptions} />
+      </Box>
+      <Box
+        sx={{
+          borderTop: '1px solid',
+          borderColor: 'divider',
+          bgcolor: 'rgba(0, 0, 0, 0.02)',
+          py: 1,
+        }}>
+        {createNewOption}
+      </Box>
+    </Box>
+  );
+};
+
+export const SelectDatasetStep: React.FC<SelectDatasetStepProps> = ({
+  selectedDataset,
+  setSelectedDataset,
+  datasets,
+  newDatasetName = '',
+  setNewDatasetName = () => {},
+  onValidationChange = () => {},
+  entity,
+  project,
+}) => {
+  const [error, setError] = useState<string | null>(null);
+  const [showLatestOnly, setShowLatestOnly] = useState(true);
+  const [isCreatingNew, setIsCreatingNew] = useState(false);
+  const {resetEditState} = useDatasetEditContext();
+
+  const handleNameChange = (value: string) => {
+    setNewDatasetName(value);
+    if (!value.trim()) {
+      setError(null);
+      onValidationChange(false);
+      return;
+    }
+
+    try {
+      // First check if it starts with a letter or number
+      if (!/^[a-zA-Z0-9]/.test(value)) {
+        setError('Dataset name must start with a letter or number');
+        onValidationChange(false);
+        return;
+      }
+
+      // Then check if it only contains allowed characters
+      if (!/^[a-zA-Z0-9\-_]+$/.test(value)) {
+        const invalidChars = [
+          ...new Set(
+            value
+              .split('')
+              .filter(c => !/[a-zA-Z0-9\-_]/.test(c))
+              .map(c => (c === ' ' ? '<space>' : c))
+          ),
+        ].join(', ');
+        setError(`Invalid characters found: ${invalidChars}`);
+        onValidationChange(false);
+        return;
+      }
+
+      setError(null);
+      onValidationChange(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Invalid dataset name');
+      onValidationChange(false);
+    }
+  };
+
+  const filteredDatasets = useMemo(() => {
+    if (!showLatestOnly) {
+      return datasets;
+    }
+
+    // Group datasets by objectId and find the latest version for each
+    const latestVersions = new Map<string, ObjectVersionSchema>();
+    datasets.forEach(dataset => {
+      const existing = latestVersions.get(dataset.objectId);
+      if (!existing || dataset.versionIndex > existing.versionIndex) {
+        latestVersions.set(dataset.objectId, dataset);
+      }
+    });
+    return Array.from(latestVersions.values());
+  }, [datasets, showLatestOnly]);
+
+  const dropdownOptions = useMemo(() => {
+    const datasetOptions = filteredDatasets.map(dataset => ({
+      label: (
+        <DatasetOption dataset={dataset} entity={entity} project={project} />
+      ),
+      value: dataset,
+      searchText: dataset.objectId,
+    }));
+
+    return [
+      ...datasetOptions,
+      {
+        label: <CreateNewOption />,
+        value: CREATE_NEW_OPTION_VALUE,
+        searchText: 'create new dataset',
+      },
+    ];
+  }, [filteredDatasets, entity, project]);
+
+  const filterOption = useCallback((option: any, inputValue: string) => {
+    return (
+      option.data.value === CREATE_NEW_OPTION_VALUE ||
+      option.data.searchText.toLowerCase().includes(inputValue.toLowerCase())
+    );
+  }, []);
+
+  const handleDatasetChange = (option: any) => {
+    if (option?.value === CREATE_NEW_OPTION_VALUE) {
+      setSelectedDataset(null);
+      setIsCreatingNew(true);
+      resetEditState();
+    } else {
+      setSelectedDataset(option?.value ?? null);
+      setIsCreatingNew(false);
+    }
+  };
+
+  return (
+    <Stack spacing={1} sx={{mt: 2}}>
+      <Typography sx={{...typographyStyle, fontWeight: 600, mb: 2}}>
+        Choose a dataset
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 3,
+        }}>
+        <Box sx={{flex: '0 1 400px', minWidth: 0}}>
+          <Select
+            placeholder="Select Dataset"
+            value={
+              selectedDataset
+                ? dropdownOptions.find(opt => opt.value === selectedDataset)
+                : isCreatingNew
+                ? dropdownOptions.find(
+                    opt => opt.value === CREATE_NEW_OPTION_VALUE
+                  )
+                : null
+            }
+            options={dropdownOptions}
+            onChange={handleDatasetChange}
+            isSearchable={true}
+            isClearable={false}
+            filterOption={filterOption}
+            components={{MenuList: DatasetSelectMenu}}
+            maxMenuHeight={300}
+          />
+        </Box>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            cursor: 'pointer',
+            whiteSpace: 'nowrap',
+            mt: 1,
+          }}>
+          <Typography
+            onClick={() => setShowLatestOnly(!showLatestOnly)}
+            sx={{...typographyStyle, userSelect: 'none', cursor: 'pointer'}}>
+            Show latest versions only
+          </Typography>
+          <Checkbox
+            style={{
+              marginRight: 4,
+            }}
+            checked={showLatestOnly}
+            onCheckedChange={checked => setShowLatestOnly(checked === true)}
+            size="small"
+          />
+        </Box>
+      </Box>
+
+      {isCreatingNew && (
+        <Box sx={{mt: 4}}>
+          <Typography sx={{...typographyStyle, fontWeight: 600, mb: 2}}>
+            Dataset name
+          </Typography>
+          <TextField
+            value={newDatasetName ?? ''}
+            onChange={value => {
+              handleNameChange(value);
+            }}
+            placeholder="Enter a name for your new dataset"
+            errorState={error != null}
+          />
+          {error && (
+            <Typography
+              sx={{
+                color: 'error.main',
+                fontFamily: 'Source Sans Pro',
+                fontSize: '0.875rem',
+                mt: 1,
+              }}>
+              {error}
+            </Typography>
+          )}
+          <Typography
+            sx={{
+              color: 'text.secondary',
+              fontFamily: 'Source Sans Pro',
+              fontSize: '0.875rem',
+              mt: 1,
+            }}>
+            Valid dataset names must start with a letter or number and can only
+            contain letters, numbers, hyphens, and underscores.
+          </Typography>
+        </Box>
+      )}
+    </Stack>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.test.ts
@@ -1,0 +1,112 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {ObjectVersionSchema} from '../pages/wfReactInterface/wfDataModelHooksInterface';
+import {createNewDataset, updateExistingDataset} from './datasetOperations';
+
+const mockTableUpdate = vi.fn();
+const mockTableCreate = vi.fn();
+const mockObjCreate = vi.fn();
+const mockRouter = {
+  objectVersionUIUrl: vi.fn().mockReturnValue('/mock-url'),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockTableUpdate.mockReset();
+  mockTableCreate.mockReset();
+  mockObjCreate.mockReset();
+});
+
+describe('createNewDataset', () => {
+  const createOptions = {
+    projectId: 'test-project',
+    entity: 'test-entity',
+    project: 'test-project',
+    datasetName: 'new-dataset',
+    rows: [{row: 'data'}],
+    tableCreate: mockTableCreate,
+    objCreate: mockObjCreate,
+    router: mockRouter,
+  };
+
+  it('should create a new dataset with initial data', async () => {
+    mockTableCreate.mockResolvedValue({digest: 'new-digest'});
+    mockObjCreate.mockResolvedValue({version: 'v1'});
+
+    const result = await createNewDataset(createOptions);
+
+    expect(result).toEqual({
+      url: '/mock-url',
+      objectId: 'new-dataset',
+    });
+
+    expect(mockTableCreate).toHaveBeenCalledWith({
+      table: {
+        project_id: 'test-project',
+        rows: [{row: 'data'}],
+      },
+    });
+
+    expect(mockObjCreate).toHaveBeenCalledWith('test-project', 'new-dataset', {
+      _type: 'Dataset',
+      name: 'new-dataset',
+      description: null,
+      ref: null,
+      _class_name: 'Dataset',
+      _bases: ['Object', 'BaseModel'],
+      rows: 'weave:///test-entity/test-project/table/new-digest',
+    });
+  });
+
+  it('should throw error on invalid table create response', async () => {
+    mockTableCreate.mockResolvedValue({});
+    await expect(createNewDataset(createOptions)).rejects.toThrow(
+      'Invalid response from table create'
+    );
+  });
+});
+
+describe('updateExistingDataset', () => {
+  const updateOptions = {
+    projectId: 'test-project',
+    entity: 'test-entity',
+    project: 'test-project',
+    selectedDataset: {
+      objectId: 'dataset-123',
+      versionHash: 'abc',
+    } as ObjectVersionSchema,
+    datasetObject: {rows: 'weave:///old-project/table/old-digest'},
+    updateSpecs: [{pop: {index: 0}}, {insert: {index: 0, row: {data: 'new'}}}],
+    tableUpdate: mockTableUpdate,
+    objCreate: mockObjCreate,
+    router: mockRouter,
+  };
+
+  it('should update existing dataset with new version', async () => {
+    mockTableUpdate.mockResolvedValue({digest: 'updated-digest'});
+    mockObjCreate.mockResolvedValue({version: 'v2'});
+
+    const result = await updateExistingDataset(updateOptions);
+
+    expect(result).toEqual({
+      url: '/mock-url',
+      objectId: 'dataset-123',
+    });
+
+    expect(mockTableUpdate).toHaveBeenCalledWith('test-project', 'old-digest', [
+      {pop: {index: 0}},
+      {insert: {index: 0, row: {data: 'new'}}},
+    ]);
+
+    expect(mockObjCreate).toHaveBeenCalledWith('test-project', 'dataset-123', {
+      rows: 'weave:///test-entity/test-project/table/updated-digest',
+    });
+  });
+
+  it('should throw error on invalid table update response', async () => {
+    mockTableUpdate.mockResolvedValue({});
+    await expect(updateExistingDataset(updateOptions)).rejects.toThrow(
+      'Invalid response from table update'
+    );
+  });
+});

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.ts
@@ -1,0 +1,141 @@
+import {createWeaveTableRef} from '../../../../../react';
+import {
+  TableCreateReq,
+  TableCreateRes,
+} from '../pages/wfReactInterface/traceServerClientTypes';
+import {ObjectVersionSchema} from '../pages/wfReactInterface/wfDataModelHooksInterface';
+
+export interface CreateNewDatasetOptions {
+  projectId: string;
+  entity: string;
+  project: string;
+  datasetName: string;
+  rows: Array<Record<string, any>>;
+  tableCreate: (table: TableCreateReq) => Promise<TableCreateRes>;
+  objCreate: (projectId: string, objectId: string, obj: any) => Promise<any>;
+  router: any;
+}
+
+export interface UpdateDatasetOptions {
+  projectId: string;
+  entity: string;
+  project: string;
+  selectedDataset: ObjectVersionSchema;
+  datasetObject: any;
+  updateSpecs: Array<
+    {pop: {index: number}} | {insert: {index: number; row: Record<string, any>}}
+  >;
+  tableUpdate: (
+    projectId: string,
+    tableDigest: string,
+    specs: any
+  ) => Promise<any>;
+  objCreate: (projectId: string, objectId: string, obj: any) => Promise<any>;
+  router: any;
+}
+
+export const createNewDataset = async ({
+  projectId,
+  entity,
+  project,
+  datasetName,
+  rows,
+  tableCreate,
+  objCreate,
+  router,
+}: CreateNewDatasetOptions) => {
+  const newTableResult = await tableCreate({
+    table: {
+      project_id: projectId,
+      rows,
+    },
+  });
+
+  if (!newTableResult?.digest) {
+    console.error('Invalid response from table create', newTableResult);
+    throw new Error('Invalid response from table create');
+  }
+
+  const newTableRef = createWeaveTableRef(
+    entity,
+    project,
+    newTableResult.digest
+  );
+
+  const newDatasetResp = await objCreate(projectId, datasetName, {
+    _type: 'Dataset',
+    name: datasetName,
+    description: null,
+    ref: null,
+    _class_name: 'Dataset',
+    _bases: ['Object', 'BaseModel'],
+    rows: newTableRef,
+  });
+
+  const newDatasetUrl = router.objectVersionUIUrl(
+    entity,
+    project,
+    datasetName,
+    newDatasetResp,
+    undefined,
+    undefined
+  );
+
+  return {
+    url: newDatasetUrl,
+    objectId: datasetName,
+  };
+};
+
+export const updateExistingDataset = async ({
+  projectId,
+  entity,
+  project,
+  selectedDataset,
+  datasetObject,
+  updateSpecs,
+  tableUpdate,
+  objCreate,
+  router,
+}: UpdateDatasetOptions) => {
+  const existingTableDigest = datasetObject.rows.split('/').pop();
+
+  const updatedTableResult = await tableUpdate(
+    projectId,
+    existingTableDigest,
+    updateSpecs
+  );
+
+  if (!updatedTableResult?.digest) {
+    throw new Error('Invalid response from table update');
+  }
+
+  const updatedTableRef = createWeaveTableRef(
+    entity,
+    project,
+    updatedTableResult.digest
+  );
+
+  const updatedDatasetResp = await objCreate(
+    projectId,
+    selectedDataset.objectId,
+    {
+      ...datasetObject,
+      rows: updatedTableRef,
+    }
+  );
+
+  const updatedDatasetUrl = router.objectVersionUIUrl(
+    entity,
+    project,
+    selectedDataset.objectId,
+    updatedDatasetResp,
+    undefined,
+    undefined
+  );
+
+  return {
+    url: updatedDatasetUrl,
+    objectId: selectedDataset.objectId,
+  };
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
@@ -1,0 +1,116 @@
+import {flattenObject, inferSchema, inferType} from './schemaUtils';
+
+describe('inferType', () => {
+  test('identifies null type', () => {
+    expect(inferType(null)).toBe('null');
+  });
+
+  test('identifies array type', () => {
+    expect(inferType([])).toBe('array');
+    expect(inferType([1, 2, 3])).toBe('array');
+  });
+
+  test('identifies date type', () => {
+    expect(inferType(new Date())).toBe('date');
+  });
+
+  test('identifies object type', () => {
+    expect(inferType({})).toBe('object');
+    expect(inferType({key: 'value'})).toBe('object');
+  });
+
+  test('identifies primitive types', () => {
+    expect(inferType('string')).toBe('string');
+    expect(inferType(42)).toBe('number');
+    expect(inferType(true)).toBe('boolean');
+    expect(inferType(undefined)).toBe('undefined');
+  });
+});
+
+describe('flattenObject', () => {
+  test('flattens simple object', () => {
+    const result = flattenObject({a: 1, b: 'test'});
+    expect(result).toEqual([
+      {name: 'a', type: 'number'},
+      {name: 'b', type: 'string'},
+    ]);
+  });
+
+  test('flattens nested objects', () => {
+    const obj = {
+      user: {
+        name: 'Alice',
+        address: {
+          city: 'Paris',
+        },
+      },
+      age: 30,
+    };
+
+    expect(flattenObject(obj)).toEqual([
+      {name: 'user.name', type: 'string'},
+      {name: 'user.address.city', type: 'string'},
+      {name: 'age', type: 'number'},
+    ]);
+  });
+
+  test('handles arrays as leaf nodes', () => {
+    const obj = {tags: ['a', 'b', 'c']};
+    expect(flattenObject(obj)).toEqual([{name: 'tags', type: 'array'}]);
+  });
+
+  test('handles date objects', () => {
+    const date = new Date();
+    const obj = {created: date};
+    expect(flattenObject(obj)).toEqual([{name: 'created', type: 'date'}]);
+  });
+});
+
+describe('inferSchema', () => {
+  test('infers schema from single object', () => {
+    const data = {name: 'Alice', age: 30};
+    expect(inferSchema(data)).toEqual([
+      {name: 'name', type: 'string'},
+      {name: 'age', type: 'number'},
+    ]);
+  });
+
+  test('merges types from multiple objects', () => {
+    const data = [
+      {name: 'Alice', age: 30},
+      {name: 'Bob', age: 'thirty'},
+    ];
+
+    expect(inferSchema(data)).toEqual([
+      {name: 'name', type: 'string'},
+      {name: 'age', type: 'number | string'},
+    ]);
+  });
+
+  test('handles nested structures', () => {
+    const data = [{user: {name: 'Alice'}}, {user: {age: 30}}];
+
+    expect(inferSchema(data)).toEqual([
+      {name: 'user.name', type: 'string'},
+      {name: 'user.age', type: 'number'},
+    ]);
+  });
+
+  test('handles empty input', () => {
+    expect(inferSchema([])).toEqual([]);
+    expect(inferSchema({})).toEqual([]);
+  });
+
+  test('handles mixed types including null/undefined', () => {
+    const data = [
+      {value: 42},
+      {value: null},
+      {value: 'text'},
+      {value: undefined},
+    ];
+
+    expect(inferSchema(data)).toEqual([
+      {name: 'value', type: 'number | null | string | undefined'},
+    ]);
+  });
+});

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
@@ -1,0 +1,257 @@
+import {v4 as uuidv4} from 'uuid';
+
+import {TraceCallSchema} from '../pages/wfReactInterface/traceServerClientTypes';
+
+export interface SchemaField {
+  name: string;
+  type: string;
+}
+
+export const inferType = (value: any): string => {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  if (value instanceof Date) {
+    return 'date';
+  }
+  if (value !== null && typeof value === 'object') {
+    return 'object';
+  }
+  return typeof value;
+};
+
+export const flattenObject = (obj: any, prefix = ''): SchemaField[] => {
+  let fields: SchemaField[] = [];
+
+  // Special handling for __ref__ and __val__ pattern
+  if (
+    obj != null &&
+    typeof obj === 'object' &&
+    '__ref__' in obj &&
+    '__val__' in obj
+  ) {
+    return flattenObject(obj.__val__, prefix);
+  }
+
+  for (const [key, value] of Object.entries(obj)) {
+    const newKey = prefix ? `${prefix}.${key}` : key;
+
+    if (
+      value !== null &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      !(value instanceof Date)
+    ) {
+      fields = [...fields, ...flattenObject(value, newKey)];
+    } else {
+      fields.push({
+        name: newKey,
+        type: inferType(value),
+      });
+    }
+  }
+
+  return fields;
+};
+
+export const inferSchema = (data: any): SchemaField[] => {
+  const schemaMap = new Map<string, Set<string>>();
+
+  const addToSchema = (obj: any) => {
+    const flatFields = flattenObject(obj);
+    flatFields.forEach(field => {
+      if (!schemaMap.has(field.name)) {
+        schemaMap.set(field.name, new Set());
+      }
+      schemaMap.get(field.name)?.add(field.type);
+    });
+  };
+
+  if (Array.isArray(data)) {
+    data.forEach(item => addToSchema(item));
+  } else {
+    addToSchema(data);
+  }
+
+  return Array.from(schemaMap.entries()).map(([name, types]) => ({
+    name,
+    type: Array.from(types).join(' | '),
+  }));
+};
+
+export interface CallData {
+  digest: string;
+  val: TraceCallSchema;
+}
+
+export interface FieldMapping {
+  sourceField: string;
+  targetField: string;
+}
+
+export const extractSourceSchema = (calls: CallData[]): SchemaField[] => {
+  const allFields: SchemaField[] = [];
+
+  calls.forEach(call => {
+    if (call.val.inputs) {
+      allFields.push(...flattenObject(call.val.inputs, 'inputs'));
+    }
+
+    const output = call.val.output;
+    if (output !== undefined) {
+      if (typeof output === 'string') {
+        allFields.push({name: 'output', type: 'string'});
+      } else {
+        allFields.push(...flattenObject(output, 'output'));
+      }
+    }
+  });
+
+  return allFields.reduce((acc, field) => {
+    if (!acc.some(f => f.name === field.name)) {
+      acc.push(field);
+    }
+    return acc;
+  }, [] as SchemaField[]);
+};
+
+/**
+ * Suggests field mappings between a source schema and target schema, with support for nested paths
+ * and existing mappings.
+ *
+ * The function follows this priority order for suggesting mappings:
+ * 1. Keeps all valid existing mappings
+ * 2. Exact matches between source and target field names
+ * 3. Matches based on the last segment of nested paths (e.g. "inputs.examples.question" matches "question")
+ * 4. Falls back to mapping remaining fields to "output" if available
+ *
+ * For nested path matching:
+ * - Source field "inputs.examples.question" will match target field "question"
+ * - Only the first source field ending in a given name is mapped (e.g. if both
+ *   "inputs.question" and "inputs.examples.question" exist, first one is used)
+ *
+ * @param sourceSchema - Array of fields available in the source data
+ * @param targetSchema - Array of fields required by the target schema
+ * @param existingMappings - Array of existing field mappings to preserve if still valid
+ * @returns Array of suggested field mappings, including preserved valid existing mappings
+ */
+export const suggestMappings = (
+  sourceSchema: SchemaField[],
+  targetSchema: SchemaField[],
+  existingMappings: FieldMapping[]
+): FieldMapping[] => {
+  const sourceNames = new Set(sourceSchema.map(s => s.name));
+  const targetNames = new Set(targetSchema.map(t => t.name));
+  const sourcePathMap = new Map<string, string>();
+  sourceSchema.forEach(source => {
+    const parts = source.name.split('.');
+    const lastPart = parts[parts.length - 1];
+    if (!sourcePathMap.has(lastPart)) {
+      sourcePathMap.set(lastPart, source.name);
+    }
+  });
+  const suggested: FieldMapping[] = existingMappings.filter(
+    m => targetNames.has(m.targetField) && sourceNames.has(m.sourceField)
+  );
+  const mappedTargets = new Set(suggested.map(m => m.targetField));
+  const remainingTargets = targetSchema.filter(
+    target => !mappedTargets.has(target.name)
+  );
+  remainingTargets.forEach(target => {
+    if (sourceNames.has(target.name)) {
+      suggested.push({sourceField: target.name, targetField: target.name});
+      mappedTargets.add(target.name);
+    }
+  });
+  remainingTargets.forEach(target => {
+    if (!mappedTargets.has(target.name)) {
+      const sourcePath = sourcePathMap.get(target.name);
+      if (sourcePath) {
+        suggested.push({sourceField: sourcePath, targetField: target.name});
+        mappedTargets.add(target.name);
+      }
+    }
+  });
+  if (sourceNames.has('output')) {
+    remainingTargets.forEach(target => {
+      if (!mappedTargets.has(target.name)) {
+        suggested.push({sourceField: 'output', targetField: target.name});
+      }
+    });
+  }
+  return suggested;
+};
+
+/**
+ * Maps an array of call data to dataset rows formatted for MUI DataGrid consumption.
+ *
+ * @param selectedCalls - Array of call data containing inputs and outputs
+ * @param fieldMappings - Array of mappings that define how call data fields map to dataset columns
+ * @returns An array of rows compatible with MUI DataGrid, each containing mapped fields and Weave metadata
+ *
+ * Each returned row will:
+ * - Be formatted for use in MUI DataGrid components
+ * - Include a ___weave namespace containing metadata used by Weave's custom hooks and callbacks:
+ *   - id: A unique identifier prefixed with "new-"
+ *   - isNew: Flag indicating this is a newly created row
+ * - Include mapped values from the call's inputs/outputs based on fieldMappings
+ * - Only include fields where the source value is defined
+ */
+export const mapCallsToDatasetRows = (
+  selectedCalls: CallData[],
+  fieldMappings: FieldMapping[]
+) => {
+  const resolveValue = (obj: any, path: string): any => {
+    const parts = path.split('.');
+    let current = obj;
+
+    for (const part of parts) {
+      if (current == null) {
+        return undefined;
+      }
+
+      // Handle __ref__/__val__ pattern during value resolution
+      if (
+        typeof current === 'object' &&
+        '__ref__' in current &&
+        '__val__' in current
+      ) {
+        current = current.__val__;
+      }
+
+      current = current[part];
+    }
+    return current;
+  };
+
+  return selectedCalls.map(call => {
+    const row: Record<string, any> = {};
+
+    fieldMappings.forEach(mapping => {
+      const inputs = call.val.inputs || {};
+      const output = call.val.output;
+
+      let sourceValue: any;
+      if (mapping.sourceField === 'output' && typeof output === 'string') {
+        sourceValue = output;
+      } else {
+        sourceValue = resolveValue({inputs, output}, mapping.sourceField);
+      }
+
+      if (sourceValue !== undefined) {
+        row[mapping.targetField] = sourceValue;
+      }
+    });
+
+    return {
+      ___weave: {
+        id: `new-${uuidv4()}`,
+        isNew: true,
+      },
+      ...row,
+    };
+  });
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -307,7 +307,7 @@ const ArtifactRefStringSymbol = Symbol('ArtifactRefString');
 export type WeaveRefString = string & {[WeaveRefStringSymbol]: never};
 export type ArtifactRefString = string & {[ArtifactRefStringSymbol]: never};
 
-const isRefPrefixedString = (value: any): boolean => {
+export const isRefPrefixedString = (value: any): boolean => {
   if (typeof value !== 'string') {
     return false;
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OverflowMenu.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OverflowMenu.tsx
@@ -8,13 +8,18 @@ import {PopupDropdown} from '@wandb/weave/common/components/PopupDropdown';
 import {useOrgName} from '@wandb/weave/common/hooks/useOrganization';
 import {useViewerUserInfo2} from '@wandb/weave/common/hooks/useViewerUserInfo';
 import {Button} from '@wandb/weave/components/Button';
-import {IconDelete, IconPencilEdit} from '@wandb/weave/components/Icon';
+import {
+  IconDelete,
+  IconPencilEdit,
+  IconTable,
+} from '@wandb/weave/components/Icon';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
 import React, {FC, useState} from 'react';
 import styled from 'styled-components';
 
 import * as userEvents from '../../../../../../integrations/analytics/userEvents';
 import {useClosePeek} from '../../context';
+import {AddToDatasetDrawer} from '../../datasets/AddToDatasetDrawer';
 import {isEvaluateOp} from '../common/heuristics';
 import {CopyableId} from '../common/Id';
 import {useWFHooks} from '../wfReactInterface/context';
@@ -25,6 +30,7 @@ export const OverflowMenu: FC<{
   setIsRenaming: (isEditing: boolean) => void;
 }> = ({selectedCalls, setIsRenaming}) => {
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [addToDatasetModalOpen, setAddToDatasetModalOpen] = useState(false);
 
   const menuOptions = [
     [
@@ -34,6 +40,15 @@ export const OverflowMenu: FC<{
         icon: <IconPencilEdit style={{marginRight: '4px'}} />,
         onClick: () => setIsRenaming(true),
         disabled: selectedCalls.length !== 1,
+      },
+    ],
+    [
+      {
+        key: 'addToDataset',
+        text: 'Add to dataset',
+        icon: <IconTable style={{marginRight: '4px'}} />,
+        onClick: () => setAddToDatasetModalOpen(true),
+        disabled: selectedCalls.length === 0,
       },
     ],
     [
@@ -56,6 +71,16 @@ export const OverflowMenu: FC<{
           setConfirmDelete={setConfirmDelete}
         />
       )}
+      <AddToDatasetDrawer
+        entity={selectedCalls[0]?.entity ?? ''}
+        project={selectedCalls[0]?.project ?? ''}
+        open={addToDatasetModalOpen}
+        onClose={() => setAddToDatasetModalOpen(false)}
+        selectedCalls={selectedCalls.map(call => ({
+          digest: call.callId,
+          val: call.traceCall!,
+        }))}
+      />
       <PopupDropdown
         sections={menuOptions}
         trigger={
@@ -67,7 +92,7 @@ export const OverflowMenu: FC<{
             style={{marginLeft: '4px'}}
           />
         }
-        offset="-78px, -16px"
+        offset="-178px, -16px"
       />
     </>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -55,6 +55,7 @@ import {
   useWeaveflowCurrentRouteContext,
   WeaveflowPeekContext,
 } from '../../context';
+import {AddToDatasetDrawer} from '../../datasets/AddToDatasetDrawer';
 import {
   convertFeedbackFieldToBackendFilter,
   parseFeedbackType,
@@ -92,6 +93,7 @@ import {
 import {CallsCharts} from './CallsCharts';
 import {CallsCustomColumnMenu} from './CallsCustomColumnMenu';
 import {
+  BulkAddToDatasetButton,
   BulkDeleteButton,
   CompareEvaluationsTableButton,
   CompareTracesTableButton,
@@ -665,6 +667,24 @@ export const CallsTable: FC<{
   }, [allRowKeys, columnVisibilityModel, tableData]);
 
   const [deleteConfirmModalOpen, setDeleteConfirmModalOpen] = useState(false);
+  const [addToDatasetModalOpen, setAddToDatasetModalOpen] = useState(false);
+
+  // Replace the state and effect with a single memo
+  const selectedCallObjects = useMemo(() => {
+    if (!callsResult) {
+      return [];
+    }
+    return callsResult
+      .filter(
+        call =>
+          call?.traceCall?.id != null &&
+          selectedCalls.includes(call.traceCall.id)
+      )
+      .map(call => ({
+        digest: call.traceCall!.id,
+        val: call.traceCall!,
+      }));
+  }, [callsResult, selectedCalls]);
 
   // Called in reaction to Hide column menu
   const onColumnVisibilityModelChange = setColumnVisibilityModel
@@ -844,6 +864,20 @@ export const CallsTable: FC<{
                   onDeleteCallback={() => {
                     setSelectedCalls([]);
                   }}
+                />
+              </div>
+              <ButtonDivider />
+              <div className="flex-none">
+                <BulkAddToDatasetButton
+                  onClick={() => setAddToDatasetModalOpen(true)}
+                  disabled={selectedCalls.length === 0}
+                />
+                <AddToDatasetDrawer
+                  entity={entity}
+                  project={project}
+                  open={addToDatasetModalOpen}
+                  onClose={() => setAddToDatasetModalOpen(false)}
+                  selectedCalls={selectedCallObjects}
                 />
               </div>
               <ButtonDivider />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -468,6 +468,31 @@ export const BulkDeleteButton: FC<{
   );
 };
 
+export const BulkAddToDatasetButton: FC<{
+  onClick: () => void;
+  disabled?: boolean;
+}> = ({onClick, disabled}) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const handleClick = () => {
+    // Force tooltip to close by blurring the button
+    buttonRef.current?.blur();
+    onClick();
+  };
+
+  return (
+    <Button
+      ref={buttonRef}
+      variant="ghost"
+      size="medium"
+      onClick={handleClick}
+      disabled={disabled}
+      tooltip="Add selected rows to a dataset"
+      icon="table"
+    />
+  );
+};
+
 export const RefreshButton: FC<{
   onClick: () => void;
   disabled?: boolean;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/ResizableDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/ResizableDrawer.tsx
@@ -99,7 +99,9 @@ export const ResizableDrawer: React.FC<ResizableDrawerProps> = ({
           width: `${internalWidth}px`,
           position: 'fixed',
           maxWidth: `${maxAllowedWidth}px`,
-          minWidth: '120px',
+          minWidth: '500px',
+          maxHeight: 'calc(100vh - 60px)',
+          height: 'calc(100vh - 60px)',
         },
       }}>
       <Box

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClient.ts
@@ -8,6 +8,8 @@ import {
   FeedbackCreateRes,
   FeedbackPurgeReq,
   FeedbackPurgeRes,
+  TableCreateReq,
+  TableCreateRes,
   TableUpdateReq,
   TableUpdateRes,
   TraceCallsDeleteReq,
@@ -121,6 +123,10 @@ export class TraceServerClient extends CachingTraceServerClient {
 
   public tableUpdate(req: TableUpdateReq): Promise<TableUpdateRes> {
     return super.tableUpdate(req);
+  }
+
+  public tableCreate(req: TableCreateReq): Promise<TableCreateRes> {
+    return super.tableCreate(req);
   }
 
   public feedbackCreate(req: FeedbackCreateReq): Promise<FeedbackCreateRes> {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -394,3 +394,17 @@ export type TableUpdateRes = {
   digest: string;
   updated_row_digests: string[];
 };
+
+export type TableCreateReq = {
+  table: TableSchemaForInsert;
+};
+
+export type TableSchemaForInsert = {
+  project_id: string;
+  rows: Array<Record<string, any>>;
+};
+
+export type TableCreateRes = {
+  digest: string;
+  row_digests: string[];
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
@@ -27,6 +27,8 @@ import {
   FeedbackPurgeRes,
   FeedbackQueryReq,
   FeedbackQueryRes,
+  TableCreateReq,
+  TableCreateRes,
   TableUpdateReq,
   TableUpdateRes,
   TraceCallReadReq,
@@ -267,6 +269,13 @@ export class DirectTraceServerClient {
   public tableUpdate(req: TableUpdateReq): Promise<TableUpdateRes> {
     return this.makeRequest<TableUpdateReq, TableUpdateRes>(
       '/table/update',
+      req
+    );
+  }
+
+  public tableCreate(req: TableCreateReq): Promise<TableCreateRes> {
+    return this.makeRequest<TableCreateReq, TableCreateRes>(
+      '/table/create',
       req
     );
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -2002,6 +2002,19 @@ export const useTableUpdate = (): ((
   );
 };
 
+export const useTableCreate = (): ((
+  table: traceServerTypes.TableCreateReq
+) => Promise<traceServerTypes.TableCreateRes>) => {
+  const getTsClient = useGetTraceServerClientContext();
+
+  return useCallback(
+    (table: traceServerTypes.TableCreateReq) => {
+      return getTsClient().tableCreate(table);
+    },
+    [getTsClient]
+  );
+};
+
 /// Utility Functions ///
 
 export const convertISOToDate = (iso: string): Date => {
@@ -2028,6 +2041,7 @@ export const tsWFDataModelHooks: WFDataModelHooksInterface = {
   useTableRowsQuery,
   useTableQueryStats,
   useTableUpdate,
+  useTableCreate,
   derived: {
     useChildCallsForCompare,
     useGetRefsType,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -307,6 +307,9 @@ export type WFDataModelHooksInterface = {
     baseDigest: string,
     updates: traceServerClientTypes.TableUpdateSpec[]
   ) => Promise<traceServerClientTypes.TableUpdateRes>;
+  useTableCreate: () => (
+    table: traceServerClientTypes.TableCreateReq
+  ) => Promise<traceServerClientTypes.TableCreateRes>;
   derived: {
     useChildCallsForCompare: (
       entity: string,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRef.tsx
@@ -13,10 +13,16 @@ export const SmallRef: FC<{
   objRef: ObjectRef;
   wfTable?: WFDBTableType;
   iconOnly?: boolean;
-}> = ({objRef, wfTable, iconOnly = false}) => {
+  noLink?: boolean;
+}> = ({objRef, wfTable, iconOnly = false, noLink = false}) => {
   if (isWeaveObjectRef(objRef)) {
     return (
-      <SmallWeaveRef objRef={objRef} wfTable={wfTable} iconOnly={iconOnly} />
+      <SmallWeaveRef
+        objRef={objRef}
+        wfTable={wfTable}
+        iconOnly={iconOnly}
+        noLink={noLink}
+      />
     );
   }
   if (isWandbArtifactRef(objRef)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRefLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRefLoaded.tsx
@@ -16,6 +16,7 @@ type SmallRefLoadedProps = {
   url: string;
   label?: string;
   error: Error | null;
+  noLink?: boolean;
 };
 
 export const SmallRefLoaded = ({
@@ -23,13 +24,18 @@ export const SmallRefLoaded = ({
   url,
   label,
   error,
+  noLink = false,
 }: SmallRefLoadedProps) => {
   const content = (
     <div
-      className={classNames('flex items-center gap-4 text-moon-700', {
-        'hover:text-teal-500': !error,
-        'line-through': error,
-      })}>
+      className={classNames(
+        'flex items-center gap-4 font-semibold text-moon-700',
+        {
+          'cursor-pointer hover:text-teal-500': !error && !noLink,
+          'line-through': error,
+          'cursor-default': noLink,
+        }
+      )}>
       <SmallRefIcon icon={icon} />
       {label && (
         <div className="h-[22px] min-w-0 flex-1 overflow-hidden overflow-ellipsis whitespace-nowrap">
@@ -47,6 +53,9 @@ export const SmallRefLoaded = ({
         content={reason}
       />
     );
+  }
+  if (noLink) {
+    return <div className="w-full cursor-default">{content}</div>;
   }
   return (
     <Link $variant="secondary" to={url} className="w-full">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallWeaveRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallWeaveRef.tsx
@@ -89,12 +89,14 @@ type SmallWeaveRefProps = {
   objRef: WeaveObjectRef;
   wfTable?: WFDBTableType;
   iconOnly?: boolean;
+  noLink?: boolean;
 };
 
 export const SmallWeaveRef = ({
   objRef,
   wfTable,
   iconOnly = false,
+  noLink = false,
 }: SmallWeaveRefProps) => {
   const {peekingRouter} = useWeaveflowRouteContext();
   const {useObjectVersion} = useWFHooks();
@@ -134,7 +136,13 @@ export const SmallWeaveRef = ({
     : getObjectVersionLabel(objRef, versionIndex);
   return (
     <TailwindContents>
-      <SmallRefLoaded icon={icon} label={label} url={url} error={error} />
+      <SmallRefLoaded
+        icon={icon}
+        label={label}
+        url={url}
+        error={error}
+        noLink={noLink}
+      />
     </TailwindContents>
   );
 };

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -710,6 +710,15 @@ export const refUri = (ref: ObjectRef): string => {
   }
 };
 
+export const createWeaveTableRef = (
+  entity: string,
+  project: string,
+  tableDigest: string
+): string => {
+  const projectId = `${entity}/${project}`;
+  return `weave:///${projectId}/table/${tableDigest}`;
+};
+
 export const absoluteTargetMutation = (absoluteTarget: NodeOrVoidNode) => {
   const rootConstructorNode = getChainRootConstructor(absoluteTarget);
   const rootArgsInner: {[key: string]: any} = {};


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-23106

Add call(s) to datasets in the app through a drawer that can be opened for a single call or a set of calls selected from the trace table.

The drawer can be opened from two places:
1. When call are bulk selected in the trace table, a button with a dataset icon appears next to the delete button in the table controls. Clicking this button opens the drawer.
2. The overflow menu in the call page controls has an add to dataset options with a dataset icon. Clicking this option opens the drawer.

The add to dataset drawer walks the user through a three step process.
1. Select a dataset to add your call(s) to
2. Adjust and confirm a mapping from call fields to dataset columns
3. Adjust the final dataset version in the dataset editor and publish a new dataset version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the `AddToDatasetDrawer` component for adding examples to datasets.
  - Added the `DatasetPreview`, `EditAndConfirmStep`, and `SchemaMappingStep` components for enhanced dataset editing.
  - Implemented the `BulkAddToDatasetButton` for bulk actions on selected calls.
  - Added the `SelectDatasetStep` component for selecting datasets.
  - Introduced the `DatasetPublishToast` component to confirm dataset publishing.
  - Enhanced the `OverflowMenu` to include an option for adding selected calls to a dataset.
  - Added the `DataPreviewTooltip` component for displaying data previews in tooltips.
  - Introduced a new method for creating tables in the trace server client.
  - Added new `noLink` property to various components for flexible rendering options.

- **Style**
  - Adjusted the layout and styling of the drawer and grid components for improved usability.
  - Updated the minimum width of the `ResizableDrawer` for better layout.

- **Tests**
  - Expanded unit tests for dataset creation and schema inference functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->