### PR TITLE
feat(weave): allow disabling capture of context

### DIFF
--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -61,6 +61,12 @@ class UserSettings(BaseModel):
     may lead to unexpected behaviour.  Make sure this is only set once at the start!
     """
 
+    capture_client_info: bool = True
+    """Toggles capture of client information (Python version, SDK version) for ops."""
+
+    capture_system_info: bool = True
+    """Toggles capture of system information (OS name and version) for ops."""
+
     client_parallelism: Optional[int] = None
     """
     Sets the number of workers to use for background operations.
@@ -101,6 +107,14 @@ def should_print_call_link() -> bool:
 
 def should_capture_code() -> bool:
     return _should("capture_code")
+
+
+def should_capture_client_info() -> bool:
+    return _should("capture_client_info")
+
+
+def should_capture_system_info() -> bool:
+    return _should("capture_system_info")
 
 
 def client_parallelism() -> Optional[int]:

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -53,7 +53,11 @@ from weave.trace.refs import (
 from weave.trace.sanitize import REDACTED_VALUE, should_redact
 from weave.trace.serialize import from_json, isinstance_namedtuple, to_json
 from weave.trace.serializer import get_serializer_for_obj
-from weave.trace.settings import client_parallelism
+from weave.trace.settings import (
+    client_parallelism,
+    should_capture_client_info,
+    should_capture_system_info,
+)
 from weave.trace.table import Table
 from weave.trace.util import deprecated, log_once
 from weave.trace.vals import WeaveObject, WeaveTable, make_trace_obj
@@ -987,12 +991,14 @@ class WeaveClient:
             attributes = {}
 
         attributes = AttributesDict(**attributes)
-        attributes._set_weave_item("client_version", version.VERSION)
-        attributes._set_weave_item("source", "python-sdk")
-        attributes._set_weave_item("os_name", platform.system())
-        attributes._set_weave_item("os_version", platform.version())
-        attributes._set_weave_item("os_release", platform.release())
-        attributes._set_weave_item("sys_version", sys.version)
+        if should_capture_client_info():
+            attributes._set_weave_item("client_version", version.VERSION)
+            attributes._set_weave_item("source", "python-sdk")
+            attributes._set_weave_item("sys_version", sys.version)
+        if should_capture_system_info():
+            attributes._set_weave_item("os_name", platform.system())
+            attributes._set_weave_item("os_version", platform.version())
+            attributes._set_weave_item("os_release", platform.release())
 
         op_name_future = self.future_executor.defer(lambda: op_def_ref.uri())
 


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C072S236A75/p1738168167702489

Adds the ability to disable capture of contextual information such as Weave client version and operating system.
