### PR TITLE
chore(weave): Subtle docs style adjustments

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -190,27 +190,15 @@ const config: Config = {
           position: "right",
           className: "button button--secondary button--med margin-right--sm",
         },
-      ],
-    },
-    footer: {
-      style: "dark",
-      links: [
         {
-          title: "Learning",
+          position: "left",
+          label: "Community",
+          type: "dropdown",
           items: [
-            {
-              label: "Documentation",
-              to: "/quickstart",
-            },
             {
               label: "LLM Courses",
               href: "https://www.wandb.courses/",
             },
-          ],
-        },
-        {
-          title: "Community",
-          items: [
             {
               label: "Forum",
               href: "https://community.wandb.ai",
@@ -221,16 +209,9 @@ const config: Config = {
             },
           ],
         },
-        {
-          title: "Github",
-          items: [
-            {
-              label: "Weave",
-              href: "https://github.com/wandb/weave",
-            },
-          ],
-        },
       ],
+    },
+    footer: {
       copyright: `Made with ❤️ by Weights & Biases`,
     },
     prism: {

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -6,14 +6,6 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  
-  /* --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e; */
   --ifm-color-primary: #0096ad;
   --ifm-color-primary-dark: #29784c;
   --ifm-color-primary-darker: #277148;
@@ -27,11 +19,7 @@
   /* Defaults to 0/0. This makes the expansion toggles rotate cleanly */
   --ifm-transition-fast: 100ms;
   --ifm-transition-slow: 100ms;
-
 }
-
-h1 { font-size: 2rem !important; }
-h2 { font-size: 1.5rem !important; }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
 [data-theme='dark'] {
@@ -44,69 +32,53 @@ h2 { font-size: 1.5rem !important; }
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.1);
 }
-/* Custom styles for Homepage */
-.hero--primary {
-  background-color: transparent; /* Removes green background */
-}
 
-.hero__title,
-.hero__subtitle {
-  color: #000; /* Changes text color to black */
-}
+/* Sidebar styling */
+.theme-doc-sidebar-container {
+  /* This customizes "section headers". */
+  li.sidebar-section-title {
+    > div.menu__list-item-collapsible {
+        font-weight: bold; 
+        color: var(--ifm-color-primary-contrast-foreground);
 
-.padding-top--md {
-  padding-top: 2rem !important;
-}
-
-.pagination-nav {
-  display: none;
-}
-
-.vertical-align-colab-button {
-  vertical-align: middle;
-  line-height: 16px;
-}
-
-/* This customizes "section headers". */
-li.sidebar-section-title {
-  > div.menu__list-item-collapsible {
-      font-weight: bold; 
-      color: var(--ifm-color-primary-contrast-foreground);
-
-      /* We don't want any click interaction effects here */
-      &:hover {
-        background-color: transparent;
-      }
+        /* We don't want any click interaction effects here */
+        &:hover {
+          background-color: transparent;
+        }
+    }
+    &:first-child > div.menu__list-item-collapsible {
+      margin-top: 0.5em;
+    }
+    &:not(:first-child) > div.menu__list-item-collapsible {
+      margin-top: 1em;
+    }
   }
-  &:first-child > div.menu__list-item-collapsible {
-    margin-top: 0.5em;
-  }
-  &:not(:first-child) > div.menu__list-item-collapsible {
-    margin-top: 1em;
-  }
-}
 
-nav.menu {
-  /* Adds equal padding on all sides (right side missing in default) */
-  padding: 0.5em;
-}
-
-.clean-btn.menu__caret {
-  &:hover {
-    /* eliminates the double hover effect causing ugly carets */
-    background-color: transparent;
+  nav.menu {
+    /* Adds equal padding on all sides (right side missing in default) */
+    padding: 0.5em;
   }
-  &:before {
+
+  .clean-btn.menu__caret {
+    &:hover {
+      /* eliminates the double hover effect causing ugly carets */
+      background-color: transparent;
+    }
+    &:before {
+      /* reduces the default caret size to be less invasive */
+      background: var(--ifm-menu-link-sublist-icon) 50% / 1.6rem 1.6rem
+    }
+  }
+
+  .menu__link--sublist-caret:after {
     /* reduces the default caret size to be less invasive */
     background: var(--ifm-menu-link-sublist-icon) 50% / 1.6rem 1.6rem
   }
 }
 
-.menu__link--sublist-caret:after {
-  /* reduces the default caret size to be less invasive */
-  background: var(--ifm-menu-link-sublist-icon) 50% / 1.6rem 1.6rem
-}
+/* Specific element styling */
 
+/* Custom styling for the Notebook CTA button */
 .notebook-cta-button {
   text-decoration: none;
 
@@ -115,4 +87,10 @@ nav.menu {
       gap: 7px;
       align-items: center;
   }
+}
+
+/* Custom styling for colab button */
+.vertical-align-colab-button {
+  vertical-align: middle;
+  line-height: 16px;
 }

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -35,11 +35,11 @@
 
 /* Typography Scale */
 h1 { font-size: 2rem !important; }
-h2 { font-size: 1.5rem !important; }
-h3 { font-size: 1.25rem !important; }
-h4 { font-size: 1.125rem !important; }
-h5 { font-size: 1rem !important; }
-h6 { font-size: 0.875rem !important; }
+h2 { font-size: 1.8rem !important; }
+h3 { font-size: 1.6rem !important; }
+h4 { font-size: 1.4rem !important; }
+h5 { font-size: 1.2rem !important; }
+h6 { font-size: 1rem !important; }
 
 /* Sidebar styling */
 .theme-doc-sidebar-container {

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -20,6 +20,7 @@
   --ifm-transition-fast: 100ms;
   --ifm-transition-slow: 100ms;
 
+
   /* Footer */
   --ifm-footer-padding-vertical: 1.125rem;
 }
@@ -46,30 +47,45 @@ h6 { font-size: 1rem !important; }
 
 /* Sidebar styling */
 .theme-doc-sidebar-container {
-  /* This customizes "section headers". */
+  /* Section Headers */
   li.sidebar-section-title {
     > div.menu__list-item-collapsible {
-        font-weight: bold; 
-        color: var(--ifm-color-primary-contrast-foreground);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      padding: 0.5rem 0.75rem;
 
-        /* We don't want any click interaction effects here */
-        &:hover {
-          background-color: transparent;
-        }
+      &:hover {
+        background-color: transparent;
+      }
     }
+
     &:first-child > div.menu__list-item-collapsible {
-      margin-top: 0.5em;
-    }
-    &:not(:first-child) > div.menu__list-item-collapsible {
-      margin-top: 1em;
+      margin-top: 0;
     }
   }
 
+  /* Menu Items */
   nav.menu {
-    /* Adds equal padding on all sides (right side missing in default) */
-    padding: 0.5em;
+    .menu__link {
+      font-size: 0.9375rem;
+      margin: 0.125rem 0;
+    }
   }
 
+  /* Nested Items */
+  .menu__list-item {
+    .menu__list {
+      margin: 0.125rem 0 0.125rem 0.5rem;
+
+      .menu__link {
+        font-size: 0.875rem;
+      }
+    }
+  }
+
+
+  /* Carets */
   .clean-btn.menu__caret {
     &:hover {
       /* eliminates the double hover effect causing ugly carets */

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -93,13 +93,13 @@ h6 { font-size: 1rem !important; }
     }
     &:before {
       /* reduces the default caret size to be less invasive */
-      background: var(--ifm-menu-link-sublist-icon) 50% / 1.6rem 1.6rem
+      background: var(--ifm-menu-link-sublist-icon) 50% / 1.4rem 1.4rem
     }
   }
 
   .menu__link--sublist-caret:after {
     /* reduces the default caret size to be less invasive */
-    background: var(--ifm-menu-link-sublist-icon) 50% / 1.6rem 1.6rem
+    background: var(--ifm-menu-link-sublist-icon) 50% / 1.4rem 1.4rem
   }
 }
 

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -33,6 +33,14 @@
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.1);
 }
 
+/* Typography Scale */
+h1 { font-size: 2rem !important; }
+h2 { font-size: 1.5rem !important; }
+h3 { font-size: 1.25rem !important; }
+h4 { font-size: 1.125rem !important; }
+h5 { font-size: 1rem !important; }
+h6 { font-size: 0.875rem !important; }
+
 /* Sidebar styling */
 .theme-doc-sidebar-container {
   /* This customizes "section headers". */
@@ -93,4 +101,20 @@
 .vertical-align-colab-button {
   vertical-align: middle;
   line-height: 16px;
+}
+
+/* Table of Contents */
+.table-of-contents {
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  position: sticky;
+  top: var(--wb-space-4);
+
+  &__link {
+    display: block;
+    padding: var(--wb-space-1) 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -19,6 +19,9 @@
   /* Defaults to 0/0. This makes the expansion toggles rotate cleanly */
   --ifm-transition-fast: 100ms;
   --ifm-transition-slow: 100ms;
+
+  /* Footer */
+  --ifm-footer-padding-vertical: 1.125rem;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
1. Remove unused styles
2. Defined a clear header size scale (previously bottomed out at h2)
3. Reduced footer size and moved links into header
4. Slight refresh of sidebar for a cleaner look

After (left) Before (Right)
![Screenshot 2025-01-29 at 12 45 55](https://github.com/user-attachments/assets/fc84ab6d-9f5f-43db-bab5-77b40f01800b)
