### PR TITLE
chore(ui): add className prop to ToggleButtonGroup component

### DIFF
--- a/weave-js/src/components/ToggleButtonGroup.tsx
+++ b/weave-js/src/components/ToggleButtonGroup.tsx
@@ -19,6 +19,7 @@ export type ToggleButtonGroupProps = {
   size: ButtonSize;
   isDisabled?: boolean;
   onValueChange: (value: string) => void;
+  className?: string;
 };
 
 /**
@@ -27,74 +28,80 @@ export type ToggleButtonGroupProps = {
 export const ToggleButtonGroup = React.forwardRef<
   HTMLDivElement,
   ToggleButtonGroupProps
->(({options, value, size, isDisabled = false, onValueChange}, ref) => {
-  if (options.length < 2) {
-    return null; // Do not render if there are fewer than two options
-  }
+>(
+  (
+    {options, value, size, isDisabled = false, onValueChange, className},
+    ref
+  ) => {
+    if (options.length < 2) {
+      return null; // Do not render if there are fewer than two options
+    }
 
-  if (!options.some(option => option.value === value)) {
-    console.warn(
-      `Warning: The provided value "${value}" is not one of the options.`
+    if (!options.some(option => option.value === value)) {
+      console.warn(
+        `Warning: The provided value "${value}" is not one of the options.`
+      );
+    }
+
+    const handleValueChange = (newValue: string) => {
+      if (
+        newValue !== value &&
+        options.find(option => option.value === newValue)?.isDisabled !== true
+      ) {
+        onValueChange(newValue);
+      }
+    };
+    return (
+      <Tailwind>
+        <ToggleGroup.Root
+          type="single" // supports single selection only
+          value={value}
+          onValueChange={handleValueChange}
+          className={twMerge('flex gap-px', className)}
+          ref={ref}>
+          {options.map(
+            ({
+              value: optionValue,
+              icon,
+              isDisabled: optionIsDisabled,
+              iconOnly = false,
+            }) => (
+              <ToggleGroup.Item
+                key={optionValue}
+                value={optionValue}
+                disabled={isDisabled}
+                asChild>
+                <Button
+                  icon={icon}
+                  size={size}
+                  className={twMerge(
+                    size === 'small' &&
+                      (icon ? 'gap-4 px-4 py-3 text-sm' : 'px-8 py-3 text-sm'),
+                    size === 'medium' &&
+                      (icon
+                        ? 'gap-5 px-7 py-4 text-base'
+                        : 'px-10 py-4 text-base'),
+                    size === 'large' &&
+                      (icon
+                        ? 'gap-6 px-10 py-8 text-base'
+                        : 'px-12 py-8 text-base'),
+                    (isDisabled || optionIsDisabled) &&
+                      'cursor-auto opacity-35',
+                    value === optionValue
+                      ? 'bg-teal-300/[0.48] text-teal-600 hover:bg-teal-300/[0.48]'
+                      : 'hover:bg-oblivion/7 bg-oblivion/5 text-moon-600 hover:text-moon-800',
+                    'first:rounded-l-sm', // First button rounded left
+                    'last:rounded-r-sm' // Last button rounded right
+                  )}>
+                  {!iconOnly ? optionValue : <></>}
+                </Button>
+              </ToggleGroup.Item>
+            )
+          )}
+        </ToggleGroup.Root>
+      </Tailwind>
     );
   }
-
-  const handleValueChange = (newValue: string) => {
-    if (
-      newValue !== value &&
-      options.find(option => option.value === newValue)?.isDisabled !== true
-    ) {
-      onValueChange(newValue);
-    }
-  };
-  return (
-    <Tailwind>
-      <ToggleGroup.Root
-        type="single" // supports single selection only
-        value={value}
-        onValueChange={handleValueChange}
-        className="flex gap-px"
-        ref={ref}>
-        {options.map(
-          ({
-            value: optionValue,
-            icon,
-            isDisabled: optionIsDisabled,
-            iconOnly = false,
-          }) => (
-            <ToggleGroup.Item
-              key={optionValue}
-              value={optionValue}
-              disabled={isDisabled}
-              asChild>
-              <Button
-                icon={icon}
-                size={size}
-                className={twMerge(
-                  size === 'small' &&
-                    (icon ? 'gap-4 px-4 py-3 text-sm' : 'px-8 py-3 text-sm'),
-                  size === 'medium' &&
-                    (icon
-                      ? 'gap-5 px-7 py-4 text-base'
-                      : 'px-10 py-4 text-base'),
-                  size === 'large' &&
-                    (icon
-                      ? 'gap-6 px-10 py-8 text-base'
-                      : 'px-12 py-8 text-base'),
-                  (isDisabled || optionIsDisabled) && 'cursor-auto opacity-35',
-                  value === optionValue
-                    ? 'bg-teal-300/[0.48] text-teal-600 hover:bg-teal-300/[0.48]'
-                    : 'hover:bg-oblivion/7 bg-oblivion/5 text-moon-600 hover:text-moon-800',
-                  'first:rounded-l-sm', // First button rounded left
-                  'last:rounded-r-sm' // Last button rounded right
-                )}>
-                {!iconOnly ? optionValue : <></>}
-              </Button>
-            </ToggleGroup.Item>
-          )
-        )}
-      </ToggleGroup.Root>
-    </Tailwind>
-  );
-});
+);
 
 ToggleButtonGroup.displayName = 'ToggleButtonGroup';


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Follow up to https://github.com/wandb/core/pull/25697#discussion_r1933003640 - adds `className` as a prop to `ToggleButtonGroup` common component.

## Testing

Adding the `className` prop to the Storybook example successfully changes styling:
<img width="267" alt="Screenshot 2025-01-29 at 2 53 41 PM" src="https://github.com/user-attachments/assets/36544afb-462a-4664-867f-f9b250c2a542" />

<img width="813" alt="Screenshot 2025-01-29 at 2 51 30 PM" src="https://github.com/user-attachments/assets/0ee799d4-2375-4765-8de6-d0655bb3a254" />


How was this PR tested?
