### PR TITLE
fix(ui): additional filters lookup the proper operator

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -3,7 +3,7 @@
  */
 
 import {GridFilterItem} from '@mui/x-data-grid-pro';
-import React, {useCallback, useMemo} from 'react';
+import React, {useMemo} from 'react';
 
 import {Button} from '../../../../Button';
 import {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -3,7 +3,7 @@
  */
 
 import {GridFilterItem} from '@mui/x-data-grid-pro';
-import React, {useMemo} from 'react';
+import React, {useCallback, useMemo} from 'react';
 
 import {Button} from '../../../../Button';
 import {
@@ -35,8 +35,11 @@ export const FilterRow = ({
     if (item.id == null) {
       onAddFilter(field);
     } else {
-      // TODO: May need to get new operator or value?
-      onUpdateFilter({...item, field});
+      // If this is an additional filter, we need to get new operator
+      // because the default is string
+      const newOperatorOptions = getGroupedOperatorOptions(field);
+      const operator = newOperatorOptions[0].options[0].value;
+      onUpdateFilter({...item, field, operator});
     }
   };
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22869](https://wandb.atlassian.net/browse/WB-22869)

While the first filter always works, additional filters have a string operator by default, no matter the type. This pr fixes that by looking up a smart default (that should match the dropdown).


## Testing

prod:

![filter-double-prod](https://github.com/user-attachments/assets/e0ad6d54-b3cb-4ce6-89d0-9a79a4222e45)

branch:
![filter-double-branch](https://github.com/user-attachments/assets/0d69e868-9a71-4340-8115-102f86f866bc)


[WB-22869]: https://wandb.atlassian.net/browse/WB-22869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ