### PR TITLE
fix(weave_query): Unescape nested dictionary keys before GQL retrieval and during typedDict-pick

### DIFF
--- a/weave_query/weave_query/graph.py
+++ b/weave_query/weave_query/graph.py
@@ -4,7 +4,7 @@ import typing
 
 from weave_query import weave_types
 from weave_query import uris, errors, storage
-
+from weave_query._dict_utils import unescape_dots
 if typing.TYPE_CHECKING:
     from weave_query import weave_inspector
 
@@ -193,7 +193,10 @@ class ConstNode(Node):
         if isinstance(val, dict) and "nodeType" in val:
             val = Node.node_from_json(val)
         else:
-            val = storage.from_python({"_type": obj["type"], "_val": obj["val"]})  # type: ignore
+            _val = obj["val"]
+            if isinstance(_val, str):
+                _val = unescape_dots(_val)
+            val = storage.from_python({"_type": obj["type"], "_val": _val})  # type: ignore
         t = weave_types.TypeRegistry.type_from_dict(obj["type"])
         if isinstance(t, weave_types.Function):
             cls = dispatch.RuntimeConstNode

--- a/weave_query/weave_query/ops_primitives/_dict_utils.py
+++ b/weave_query/weave_query/ops_primitives/_dict_utils.py
@@ -22,7 +22,12 @@ def tag_aware_dict_val_for_escaped_key(
 ) -> typing.Any:
     if key == None:
         return None
-    return _any_val_for_path(obj, [unescape_dots(key)]) or _any_val_for_path(obj, split_escaped_string(key))
+
+    obj_at_full_path = _any_val_for_path(obj, [unescape_dots(key)])
+    if box.is_none(obj_at_full_path):
+        return _any_val_for_path(obj, split_escaped_string(key))
+    else:
+        return obj_at_full_path
 
 
 class MergeInputTypes(typing.TypedDict):

--- a/weave_query/weave_query/ops_primitives/_dict_utils.py
+++ b/weave_query/weave_query/ops_primitives/_dict_utils.py
@@ -22,7 +22,7 @@ def tag_aware_dict_val_for_escaped_key(
 ) -> typing.Any:
     if key == None:
         return None
-    return _any_val_for_path(obj, split_escaped_string(key))
+    return _any_val_for_path(obj, [unescape_dots(key)]) or _any_val_for_path(obj, split_escaped_string(key))
 
 
 class MergeInputTypes(typing.TypedDict):


### PR DESCRIPTION
## Description

Fixes [WB-22947](https://wandb.atlassian.net/browse/WB-22947), which was occurring due to 2 related issues:
1. The history columns are unescaped, so the value inside the node needs to also be the unescaped key. (This is the change in `weave_query/weave_query/graph.py`)
2. The history data returned to us is already flattened. So we can access it directly with the nested key instead of walking the history data. (This is the change in `weave_query/weave_query/ops_primitives/_dict_utils.py`)
    * i.e. When the data is in this shape: `{ 'key_1': { 'key_1_1': 0 }}`, the `_any_val_for_path` function will attempt to walk the dictionary, looking for `key_1`, then `key_1_1`. However, the history data is being returned as `{ 'key_1.key_1_1': 0 }`, so we can access the data directly with the nested key `key_1.key_1_1`. 

## Testing

Ran `invoker_weave_prod` locally and added end to end test

Old Behaviour:
<img width="1419" alt="Screenshot 2025-01-29 at 5 58 51 PM" src="https://github.com/user-attachments/assets/9c9ada8b-068a-45de-ac2c-162af64c5c77" />


New Behaviour:
<img width="765" alt="Screenshot 2025-01-30 at 3 50 39 PM" src="https://github.com/user-attachments/assets/cd7c44d6-ebe6-4baa-9564-6f2856039b8f" />


[WB-22947]: https://wandb.atlassian.net/browse/WB-22947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ