### PR TITLE
chore(weave): Add grok2 and gemini flash 2

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
@@ -196,6 +196,16 @@ export const LLM_MAX_TOKENS = {
     max_tokens: 8192,
     supports_function_calling: true,
   },
+  'gemini/gemini-2.0-flash-exp': {
+    provider: 'gemini',
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
+  'gemini/gemini-2.0-flash-thinking-exp': {
+    provider: 'gemini',
+    max_tokens: 8192,
+    supports_function_calling: true,
+  },
 
   // Groq models
   'groq/gemma-7b-it': {
@@ -383,6 +393,21 @@ export const LLM_MAX_TOKENS = {
 
   // xAI models
   'xai/grok-beta': {
+    max_tokens: 131072,
+    provider: 'xai',
+    supports_function_calling: true,
+  },
+  'xai/grok-2-1212': {
+    max_tokens: 131072,
+    provider: 'xai',
+    supports_function_calling: true,
+  },
+  'xai/grok-2': {
+    max_tokens: 131072,
+    provider: 'xai',
+    supports_function_calling: true,
+  },
+  'xai/grok-2-latest': {
     max_tokens: 131072,
     provider: 'xai',
     supports_function_calling: true,


### PR DESCRIPTION
## Description

Adds grok 2 and gemini flash 2 to playground models

![Screenshot 2025-01-30 at 8 12 29 AM](https://github.com/user-attachments/assets/3a77c77c-7036-48a0-8daa-49e069d5589c)
![Screenshot 2025-01-30 at 8 12 25 AM](https://github.com/user-attachments/assets/be614ee4-611b-4474-95db-3337ba39e1b6)

