### PR TITLE
chore(ui): add missing field to TraceObjSchema

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/objectClassQuery.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/objectClassQuery.test.ts
@@ -51,6 +51,7 @@ describe('Type Tests', () => {
           project_id: '',
           object_id: '',
           created_at: '',
+          deleted_at: null,
           digest: '',
           version_index: 0,
           is_latest: 0,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -217,6 +217,7 @@ export interface TraceObjSchema<
   project_id: string;
   object_id: string;
   created_at: string;
+  deleted_at: string | null;
   digest: string;
   version_index: number;
   is_latest: number;


### PR DESCRIPTION
## Description

Adding `deleted_at` field to TypeScript side to match Python declaration.
https://github.com/wandb/weave/blob/master/weave/trace_server/trace_server_interface.py#L181

I think the field has to always exist because of the default value, so `| null` seemed more correct than the `?` we have for `base_object_class` and `wb_user_id`.