### PR TITLE
chore(ui): Add useProjectInfo hook

### DIFF
--- a/wb_schema.gql
+++ b/wb_schema.gql
@@ -202,6 +202,7 @@ type Project implements Node {
   createdAt: DateTime!
   updatedAt: DateTime
   id: ID!
+  internalId: ID!
   name: String!
   runs(filters: JSONString, order: String, first: Int): RunConnection
   entity: Entity!

--- a/weave-js/src/common/hooks/useProjectInfo.ts
+++ b/weave-js/src/common/hooks/useProjectInfo.ts
@@ -1,0 +1,84 @@
+/**
+ * This is a GraphQL approach to querying project information.
+ */
+
+import {gql, useApolloClient} from '@apollo/client';
+import {useEffect, useState} from 'react';
+
+// Note: id is the "external" ID, which changes when a project is renamed.
+//       internalId does not change.
+const PROJECT_QUERY = gql`
+  query Project($entityName: String!, $projectName: String!) {
+    project(name: $projectName, entityName: $entityName) {
+      id
+      internalId
+    }
+  }
+`;
+
+export type ProjectInfo = {
+  externalIdEncoded: string;
+  internalIdEncoded: string;
+};
+type ProjectInfoResponseLoading = {
+  loading: true;
+  projectInfo: {};
+};
+export type MaybeProjectInfo = ProjectInfo | null;
+type ProjectInfoResponseSuccess = {
+  loading: false;
+  projectInfo: MaybeProjectInfo;
+};
+type ProjectInfoResponse =
+  | ProjectInfoResponseLoading
+  | ProjectInfoResponseSuccess;
+
+export const useProjectInfo = (
+  entityName: string,
+  projectName: string
+): ProjectInfoResponse => {
+  const [response, setResponse] = useState<ProjectInfoResponse>({
+    loading: true,
+    projectInfo: {},
+  });
+
+  const apolloClient = useApolloClient();
+
+  useEffect(() => {
+    let mounted = true;
+    apolloClient
+      .query({
+        query: PROJECT_QUERY as any,
+        variables: {
+          entityName,
+          projectName,
+        },
+      })
+      .then(result => {
+        if (!mounted) {
+          return;
+        }
+        const projectInfo = result.data.project;
+        if (!projectInfo) {
+          // Invalid project
+          setResponse({
+            loading: false,
+            projectInfo: null,
+          });
+          return;
+        }
+        setResponse({
+          loading: false,
+          projectInfo: {
+            externalIdEncoded: projectInfo.id,
+            internalIdEncoded: projectInfo.internalId,
+          },
+        });
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [apolloClient, entityName, projectName]);
+
+  return response;
+};


### PR DESCRIPTION
## Description

A project like `jamie-rasmussen/2025-01-30_wf` has both an "id" and an "internalId". If you decode them they look like:
id: `Project:v1:2025-01-30_wf:jamie-rasmussen`
internalId: `ProjectInternalId:40869716`
So somewhat unexpectedly, the "id" value changes when you rename the project. The "internalId" does not change.

In the upcoming Saved Views work, we use local storage to remember the last view you used, on a per-project (and per-page, traces or evaluations) basis. This hook allows us to query for the "internalId" of the project, so that we can use it as part of the key.

