### PR TITLE
fix(ui): more specific icons shown in SmallRef

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
@@ -298,6 +298,15 @@ export const isObjDeleteError = (error: Error | null): boolean => {
   return false;
 };
 
+export const getErrorReason = (error: Error): string | null => {
+  try {
+    const parsed = JSON.parse(error.message);
+    return parsed.reason ?? null;
+  } catch (e) {
+    return null;
+  }
+};
+
 /// Hooks ///
 
 export const useParentCall = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRefIcon.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRefIcon.tsx
@@ -1,0 +1,18 @@
+/**
+ * Small circle with icon.
+ */
+import React from 'react';
+
+import {Icon, IconName} from '../../../../Icon';
+
+type SmallRefIconProps = {
+  icon: IconName;
+};
+
+export const SmallRefIcon = ({icon}: SmallRefIconProps) => {
+  return (
+    <div className="flex h-[22px] w-[22px] flex-none items-center justify-center rounded-full bg-moon-300/[0.48]">
+      <Icon role="presentation" className="h-[14px] w-[14px]" name={icon} />
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRefLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRefLoaded.tsx
@@ -1,0 +1,56 @@
+/**
+ * Render a SmallRef after we have all of the necessary data.
+ */
+
+import classNames from 'classnames';
+import React from 'react';
+
+import {IconName} from '../../../../Icon';
+import {Tooltip} from '../../../../Tooltip';
+import {Link} from '../pages/common/Links';
+import {getErrorReason} from '../pages/wfReactInterface/utilities';
+import {SmallRefIcon} from './SmallRefIcon';
+
+type SmallRefLoadedProps = {
+  icon: IconName;
+  url: string;
+  label?: string;
+  error: Error | null;
+};
+
+export const SmallRefLoaded = ({
+  icon,
+  url,
+  label,
+  error,
+}: SmallRefLoadedProps) => {
+  const content = (
+    <div
+      className={classNames('flex items-center gap-4 text-moon-700', {
+        'hover:text-teal-500': !error,
+        'line-through': error,
+      })}>
+      <SmallRefIcon icon={icon} />
+      {label && (
+        <div className="h-[22px] min-w-0 flex-1 overflow-hidden overflow-ellipsis whitespace-nowrap">
+          {label}
+        </div>
+      )}
+    </div>
+  );
+  if (error) {
+    const reason = getErrorReason(error);
+    return (
+      <Tooltip
+        trigger={<div className="w-full">{content}</div>}
+        noTriggerWrap
+        content={reason}
+      />
+    );
+  }
+  return (
+    <Link $variant="secondary" to={url} className="w-full">
+      {content}
+    </Link>
+  );
+};


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-21887

This improves a number of things about SmallRef.
* Currently, the component renders once with a version hash, then with the version number, and again but in a bolder font. I change it to show a loading dots indicator, and then the final form.
* We were showing a generic icon instead of a more specific one for prompts, models, datasets, etc.
* Deleted refs now have a tooltip with more information.

Before:
<img width="1086" alt="Screenshot 2025-01-31 at 10 05 46 AM" src="https://github.com/user-attachments/assets/06875998-8145-4053-9dc0-8101082c0fa2" />

After:
<img width="890" alt="Screenshot 2025-01-31 at 10 06 31 AM" src="https://github.com/user-attachments/assets/4c35c68a-c441-43a9-ba34-41b4566e85ff" />


