### PR TITLE
Griffin/calls query no aggregation

### DIFF
--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -672,10 +672,11 @@ class CallsQuery(BaseModel):
         )
 
         where_filter_sql = combine_conditions(
-            having_conditions_sql
-            + [c.as_sql(pb, table_alias, no_agg=True) for c in self.query_conditions],
+            [c.as_sql(pb, table_alias, no_agg=True) for c in self.query_conditions],
             "AND",
         )
+        if where_filter_sql:
+            where_filter_sql = "AND " + where_filter_sql
 
         order_by_sql_no_agg = ""
         if len(self.order_fields) > 0:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -288,6 +288,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
         pb = ParamBuilder()
         inner_query = cq.as_sql(pb)
+        print(">>>>> STATS SQL <<<<<\n")
+        print(inner_query)
+        print("\n\n")
         raw_res = self._query(
             f"SELECT count() FROM ({inner_query})",
             pb.get_params(),
@@ -1947,8 +1950,8 @@ def _ch_call_dict_to_call_schema_dict(ch_call_dict: dict) -> dict:
         "op_name": ch_call_dict.get("op_name"),
         "started_at": started_at,
         "ended_at": ended_at,
-        "attributes": _dict_dump_to_dict(ch_call_dict.get("attributes_dump") or {}),
-        "inputs": _dict_dump_to_dict(ch_call_dict.get("inputs_dump") or {}),
+        "attributes": _dict_dump_to_dict(ch_call_dict.get("attributes_dump") or "{}"),
+        "inputs": _dict_dump_to_dict(ch_call_dict.get("inputs_dump") or "{}"),
         "output": _nullable_any_dump_to_any(ch_call_dict.get("output_dump")),
         "summary": make_derived_summary_fields(
             summary=summary or {},

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1947,8 +1947,8 @@ def _ch_call_dict_to_call_schema_dict(ch_call_dict: dict) -> dict:
         "op_name": ch_call_dict.get("op_name"),
         "started_at": started_at,
         "ended_at": ended_at,
-        "attributes": _dict_dump_to_dict(ch_call_dict.get("attributes_dump", "{}")),
-        "inputs": _dict_dump_to_dict(ch_call_dict.get("inputs_dump", "{}")),
+        "attributes": _dict_dump_to_dict(ch_call_dict.get("attributes_dump") or {}),
+        "inputs": _dict_dump_to_dict(ch_call_dict.get("inputs_dump") or {}),
         "output": _nullable_any_dump_to_any(ch_call_dict.get("output_dump")),
         "summary": make_derived_summary_fields(
             summary=summary or {},

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -342,6 +342,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             cq.set_offset(req.offset)
 
         pb = ParamBuilder()
+        print(">>>>> SQL <<<<<\n")
+        print(cq.as_sql(pb))
+        print("\n\n")
+        logger.info("nooooooooooooooooooooooo aggggg", extra={"sql": cq.as_sql(pb)})
+
         raw_res = self._query_stream(
             cq.as_sql(pb),
             pb.get_params(),

--- a/weave/trace_server/migrations/011_display_name_simple.down.sql
+++ b/weave/trace_server/migrations/011_display_name_simple.down.sql
@@ -1,0 +1,34 @@
+ALTER TABLE calls_merged
+    DROP COLUMN display_name;
+
+ALTER TABLE calls_merged
+    ADD COLUMN display_name AggregateFunction(argMax, Nullable(String), DateTime64(3));
+
+ALTER TABLE calls_merged_stats
+    DROP COLUMN display_name;
+
+ALTER TABLE calls_merged_stats
+    ADD COLUMN display_name AggregateFunction(argMax, Nullable(String), DateTime64(3));
+
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name
+    FROM call_parts
+    GROUP BY project_id,
+        id;

--- a/weave/trace_server/migrations/011_display_name_simple.down.sql
+++ b/weave/trace_server/migrations/011_display_name_simple.down.sql
@@ -1,14 +1,8 @@
 ALTER TABLE calls_merged
-    DROP COLUMN display_name;
-
-ALTER TABLE calls_merged
-    ADD COLUMN display_name AggregateFunction(argMax, Nullable(String), DateTime64(3));
+    MODIFY COLUMN display_name AggregateFunction(argMax, Nullable(String), DateTime64(3));
 
 ALTER TABLE calls_merged_stats
-    DROP COLUMN display_name;
-
-ALTER TABLE calls_merged_stats
-    ADD COLUMN display_name AggregateFunction(argMax, Nullable(String), DateTime64(3));
+    MODIFY COLUMN display_name AggregateFunction(argMax, Nullable(String), DateTime64(3));
 
 ALTER TABLE calls_merged_view MODIFY QUERY
     SELECT project_id,

--- a/weave/trace_server/migrations/011_display_name_simple.up.sql
+++ b/weave/trace_server/migrations/011_display_name_simple.up.sql
@@ -1,14 +1,4 @@
-ALTER TABLE calls_merged
-    DROP COLUMN display_name;
-
-ALTER TABLE calls_merged
-    ADD COLUMN display_name SimpleAggregateFunction(any, Nullable(String));
-
-ALTER TABLE calls_merged_stats
-    DROP COLUMN display_name;
-
-ALTER TABLE calls_merged_stats
-    ADD COLUMN display_name SimpleAggregateFunction(any, Nullable(String));
+ALTER TABLE calls_merged MODIFY COLUMN display_name SimpleAggregateFunction(any, Nullable(String));
 
 ALTER TABLE calls_merged_view MODIFY QUERY
     SELECT project_id,

--- a/weave/trace_server/migrations/011_display_name_simple.up.sql
+++ b/weave/trace_server/migrations/011_display_name_simple.up.sql
@@ -1,0 +1,34 @@
+ALTER TABLE calls_merged
+    DROP COLUMN display_name;
+
+ALTER TABLE calls_merged
+    ADD COLUMN display_name SimpleAggregateFunction(any, Nullable(String));
+
+ALTER TABLE calls_merged_stats
+    DROP COLUMN display_name;
+
+ALTER TABLE calls_merged_stats
+    ADD COLUMN display_name SimpleAggregateFunction(any, Nullable(String));
+
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        anySimpleState(display_name) as display_name
+    FROM call_parts
+    GROUP BY project_id,
+        id;

--- a/weave/trace_server/migrations/012_migrate_to_simple_calls_query.down.sql
+++ b/weave/trace_server/migrations/012_migrate_to_simple_calls_query.down.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE calls_merged MODIFY SETTING min_bytes_for_wide_part = 10485760, min_age_to_force_merge_seconds = 0;

--- a/weave/trace_server/migrations/012_migrate_to_simple_calls_query.up.sql
+++ b/weave/trace_server/migrations/012_migrate_to_simple_calls_query.up.sql
@@ -1,0 +1,5 @@
+
+ALTER TABLE calls_merged 
+MODIFY SETTING min_bytes_for_wide_part = 0, min_age_to_force_merge_seconds = 10;
+
+OPTIMIZE TABLE calls_merged FINAL;

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -70,7 +70,7 @@ def hydrate_calls_with_feedback(
 
 def make_derived_summary_fields(
     summary: dict[str, Any],
-    op_name: str,
+    op_name: Optional[str],
     started_at: Optional[datetime.datetime] = None,
     ended_at: Optional[datetime.datetime] = None,
     exception: Optional[str] = None,
@@ -101,7 +101,7 @@ def make_derived_summary_fields(
 
     if display_name:
         weave_summary["display_name"] = display_name
-    else:
+    elif op_name:
         if ri.string_will_be_interpreted_as_ref(op_name):
             op = ri.parse_internal_uri(op_name)
             if isinstance(op, ri.InternalObjectRef):


### PR DESCRIPTION
wow does that optimize final take a while, even on my local dev setup (~20gbs) it took like 45seconds to run the `optimize final`

Note: 
- without aggregation, clickhouse connect doesn't know how to serialize the non `simple` aggregation functions. We only have one of those, `display_name`. I think this will be an issue... this pr migrates the table to just turn it into a simple `any` aggregation, but this will not work in prod (renaming a call is not not guaranteed to work). 
- also the down migration now doesn't work, even though looking at it, it should. might be possible to get around with with a cheeky `cast` but that is uncomfortable...