### PR TITLE
feat(app): pass derived columns as new variables onto the stack in panel plots

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -83,6 +83,7 @@ import * as TableType from './tableType';
 import {
   BaseTableDataType,
   getColumnCellFormats,
+  getColumnVariables,
   getTableMeasurements,
   nodeIsValidList,
   tableIsPanelVariable,
@@ -228,19 +229,7 @@ const PanelTableInnerConfigSetter: React.FC<
   }, [config, tableState, autoTable]);
 
   const columnVariables: {[key: string]: NodeOrVoidNode} = useMemo(() => {
-    const defineColumnVariables = (currentTableState: Table.TableState) => {
-      return Object.keys(currentTableState.columns).reduce(
-        (acc: {[key: string]: NodeOrVoidNode}, colId) => {
-          const columnName =
-            currentTableState.columnNames[colId] || colId.replace(/-/g, '');
-          acc[columnName] = currentTableState.columnSelectFunctions[colId];
-          return acc;
-        },
-        {}
-      );
-    };
-
-    return defineColumnVariables(config.tableState ?? tableState ?? autoTable);
+    return getColumnVariables(config.tableState ?? tableState ?? autoTable);
   }, [config.tableState, tableState, autoTable]);
 
   const [showColumnSelect, setShowColumnSelect] = React.useState(false);

--- a/weave-js/src/components/Panel2/PanelTable/util.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.ts
@@ -458,3 +458,15 @@ export const useBaseTableData = (
 export const tableIsPanelVariable = (stack: Stack) => {
   return stack && stack.find(node => node.name === 'input') !== undefined;
 };
+
+export const getColumnVariables = (currentTableState: Table.TableState) => {
+  return Object.keys(currentTableState.columns).reduce(
+    (acc: {[key: string]: NodeOrVoidNode}, colId) => {
+      const columnName =
+        currentTableState.columnNames[colId] || colId.replace(/-/g, '');
+      acc[columnName] = currentTableState.columnSelectFunctions[colId];
+      return acc;
+    },
+    {}
+  );
+};


### PR DESCRIPTION

## Description

- Fixes [WB-23058](https://wandb.atlassian.net/browse/WB-23058)
- Followup to https://github.com/wandb/weave/pull/3518. Allows users to use their derived columns as plot dimensions by passing the columns from table state onto the stack during `PanelPlot` render.

## Testing

Local FE

https://github.com/user-attachments/assets/7d119569-976b-4737-9a70-aadf463a6d43




[WB-23058]: https://wandb.atlassian.net/browse/WB-23058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ