### PR TITLE
fix(ui): new tooltip broke table row size

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -882,6 +882,7 @@ const PanelTableInner: React.FC<
                 <Tooltip
                   key={rowSize}
                   content={rowSizeTooltipContent[RowSize[rowSize]]}
+                  noTriggerWrap
                   trigger={
                     <Button
                       startIcon={rowSizeIconName[RowSize[rowSize]]}


### PR DESCRIPTION
## Description

Fix table row size controls. See internal Slack:
https://weightsandbiases.slack.com/archives/C02U6LLHP9S/p1738347523801469
https://weightsandbiases.slack.com/archives/C06CCH5PH3L/p1738629213010689

Before:
<img width="146" alt="Screenshot 2025-02-03 at 7 16 27 PM" src="https://github.com/user-attachments/assets/6ee846ae-f232-4f0f-9405-963bc51c4083" />


After:
<img width="126" alt="Screenshot 2025-02-03 at 7 16 31 PM" src="https://github.com/user-attachments/assets/0ccb4427-0706-47e3-88d9-5977ae3882b8" />




## Testing

How was this PR tested?
