### PR TITLE
fix(ui): Paginated rows don't consistently have the same sort order

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -231,6 +231,9 @@ export const CallsTable: FC<{
     new Set<string>().add('inputs.example')
   );
 
+  // Keep track of the display sort model separately from the actual sort model
+  const [displaySortModel, setDisplaySortModel] = useState<GridSortModel>([]);
+
   // Helpers to handle expansion
   const onExpand = (col: string) => {
     setExpandedRefCols(prevState => new Set(prevState).add(col));
@@ -708,18 +711,35 @@ export const CallsTable: FC<{
       }
 
       // handle feedback conversion from weave summary to backend filter
-      for (const sort of newModel) {
+      const processedModel = newModel.map(sort => {
         if (sort.field.startsWith('summary.weave.feedback')) {
           const parsed = parseFeedbackType(sort.field);
           if (parsed) {
-            const backendFilter = convertFeedbackFieldToBackendFilter(
-              parsed.field
-            );
-            sort.field = backendFilter;
+            return {
+              ...sort,
+              field: convertFeedbackFieldToBackendFilter(parsed.field),
+            };
           }
         }
+        return sort;
+      });
+
+      // Update the display sort model
+      setDisplaySortModel(processedModel);
+
+      // If there's no sort specified, use started_at desc only
+      if (processedModel.length === 0) {
+        setSortModel([{ field: 'started_at', sort: 'desc' }]);
+        return;
       }
-      setSortModel(newModel);
+
+      // Only append started_at as secondary sort if it's not already present
+      const hasStartedAt = processedModel.some(sort => sort.field === 'started_at');
+      if (!hasStartedAt) {
+        setSortModel([...processedModel, { field: 'started_at', sort: 'desc' }]);
+      } else {
+        setSortModel(processedModel);
+      }
     },
     [callsLoading, setSortModel, muiColumns]
   );
@@ -932,7 +952,7 @@ export const CallsTable: FC<{
         columnVisibilityModel={columnVisibilityModel}
         // SORT SECTION START
         sortingMode="server"
-        sortModel={sortModel}
+        sortModel={displaySortModel}
         onSortModelChange={onSortModelChange}
         // SORT SECTION END
         // PAGINATION SECTION START


### PR DESCRIPTION
## Description

**To replicate:**
- Sort on a row with a lot of the same values (enough for > 1 page).
- Select all.
- Paginate to page 2.
- Paginate back to page 1.
- Some there will be some number of new rows on page 1 which aren't selected.

This is because the database does not return a stable order when multiple rows have the same sort value.

**Fix:**
Appending a `started_at` sort as a secondary sort when needed.