### PR TITLE
feat(weave): Pydantic Scorer's output

### DIFF
--- a/tests/scorers/test_json_scorer.py
+++ b/tests/scorers/test_json_scorer.py
@@ -18,4 +18,4 @@ from weave.scorers import ValidJSONScorer
 def test_json_scorer(output, expected_result):
     scorer = ValidJSONScorer()
     result = scorer.score(output)
-    assert result["json_valid"] is expected_result
+    assert result.json_valid == expected_result

--- a/tests/scorers/test_pydantic_scorer.py
+++ b/tests/scorers/test_pydantic_scorer.py
@@ -27,4 +27,6 @@ def user_scorer():
     ],
 )
 def test_pydantic_scorer(user_scorer, input_data, expected_result):
-    assert user_scorer.score(input_data) == expected_result
+    result = user_scorer.score(input_data)
+    # Assert the result is a pydantic model with the attribute 'valid_pydantic'
+    assert result.valid_pydantic == expected_result["valid_pydantic"]

--- a/tests/scorers/test_ragas_scorer.py
+++ b/tests/scorers/test_ragas_scorer.py
@@ -6,8 +6,8 @@ from weave.scorers import (
     ContextRelevancyScorer,
 )
 from weave.scorers.ragas_scorer import (
-    EntityExtractionResponse,
-    RelevancyResponse,
+    ContextEntityRecallScorerOutput,
+    ContextRelevancyScorerOutput,
 )
 
 
@@ -17,10 +17,10 @@ def mock_create(monkeypatch):
     def _mock_create(*args, **kwargs):
         # Retrieve the response_model to return appropriate mock responses
         response_model = kwargs.get("response_model")
-        if response_model is EntityExtractionResponse:
-            return EntityExtractionResponse(entities=["Paris"])
-        elif response_model is RelevancyResponse:
-            return RelevancyResponse(
+        if response_model is ContextEntityRecallScorerOutput:
+            return ContextEntityRecallScorerOutput(recall=1.0)
+        elif response_model is ContextRelevancyScorerOutput:
+            return ContextRelevancyScorerOutput(
                 reasoning="The context directly answers the question.",
                 relevancy_score=1,
             )
@@ -52,15 +52,13 @@ def test_context_entity_recall_scorer_score(context_entity_recall_scorer):
     output = "Paris is the capital of France."
     context = "The capital city of France is Paris."
     result = context_entity_recall_scorer.score(output, context)
-    assert isinstance(result, dict)
-    assert "recall" in result
-    assert result["recall"] == 1.0  # Assuming full recall in mock response
+    assert isinstance(result, ContextEntityRecallScorerOutput)
+    assert result.recall == 1.0  # Assuming full recall in mock response
 
 
 def test_context_relevancy_scorer_score(context_relevancy_scorer):
     output = "What is the capital of France?"
     context = "Paris is the capital city of France."
     result = context_relevancy_scorer.score(output, context)
-    assert isinstance(result, dict)
-    assert "relevancy_score" in result
-    assert result["relevancy_score"] == 1  # Assuming relevancy in mock response
+    assert isinstance(result, ContextRelevancyScorerOutput)
+    assert result.relevancy_score == 1  # Assuming relevancy in mock response

--- a/tests/scorers/test_string_scorer.py
+++ b/tests/scorers/test_string_scorer.py
@@ -16,7 +16,7 @@ from weave.scorers import (
 def test_string_match_scorer(output, target, expected_result):
     scorer = StringMatchScorer()
     result = scorer.score(output, target)
-    assert result["string_in_input"] is expected_result
+    assert result.string_in_input is expected_result
 
 
 @pytest.mark.parametrize(
@@ -30,4 +30,4 @@ def test_string_match_scorer(output, target, expected_result):
 def test_levenshtein_scorer(output, target, expected_distance):
     scorer = LevenshteinScorer()
     result = scorer.score(output, target)
-    assert result["levenshtein_distance"] == expected_distance
+    assert result.levenshtein_distance == expected_distance

--- a/weave/scorers/json_scorer.py
+++ b/weave/scorers/json_scorer.py
@@ -1,8 +1,14 @@
 import json
 from typing import Any
 
+from pydantic import BaseModel, Field
+
 import weave
 from weave.scorers.base_scorer import Scorer
+
+
+class ValidJSONScorerOutput(BaseModel):
+    json_valid: bool = Field(description="Whether the model output is valid JSON")
 
 
 class ValidJSONScorer(Scorer):
@@ -13,6 +19,6 @@ class ValidJSONScorer(Scorer):
         try:
             _ = json.loads(output)
         except json.JSONDecodeError:
-            return {"json_valid": False}
+            return ValidJSONScorerOutput(json_valid=False)
         else:
-            return {"json_valid": True}
+            return ValidJSONScorerOutput(json_valid=True)

--- a/weave/scorers/pydantic_scorer.py
+++ b/weave/scorers/pydantic_scorer.py
@@ -1,9 +1,15 @@
 from typing import Any
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 import weave
 from weave.scorers.base_scorer import Scorer
+
+
+class PydanticScorerOutput(BaseModel):
+    valid_pydantic: bool = Field(
+        description="Whether the model output is valid against the pydantic model"
+    )
 
 
 class PydanticScorer(Scorer):
@@ -17,13 +23,13 @@ class PydanticScorer(Scorer):
             try:
                 self.model.model_validate_json(output)
             except ValidationError:
-                return {"valid_pydantic": False}
+                return PydanticScorerOutput(valid_pydantic=False)
             else:
-                return {"valid_pydantic": True}
+                return PydanticScorerOutput(valid_pydantic=True)
         else:
             try:
                 self.model.model_validate(output)
             except ValidationError:
-                return {"valid_pydantic": False}
+                return PydanticScorerOutput(valid_pydantic=False)
             else:
-                return {"valid_pydantic": True}
+                return PydanticScorerOutput(valid_pydantic=True)

--- a/weave/scorers/string_scorer.py
+++ b/weave/scorers/string_scorer.py
@@ -1,18 +1,34 @@
 from typing import Callable
 
-from pydantic import Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 import weave
 from weave.scorers.base_scorer import Scorer
+
+
+class StringMatchScorerOutput(BaseModel):
+    """Output type for StringMatchScorer."""
+
+    string_in_input: bool = Field(
+        description="Whether the output string is found in the target string"
+    )
+
+
+class LevenshteinScorerOutput(BaseModel):
+    """Output type for LevenshteinScorer."""
+
+    levenshtein_distance: int = Field(
+        description="The Levenshtein distance between the output and the target"
+    )
 
 
 class StringMatchScorer(Scorer):
     """Scorer that checks if the model output string is found in the search columns of the dataset row."""
 
     @weave.op
-    def score(self, output: str, target: str) -> dict:
+    def score(self, output: str, target: str) -> StringMatchScorerOutput:
         string_in_input = output.lower() in target.lower()
-        return {"string_in_input": string_in_input}
+        return StringMatchScorerOutput(string_in_input=string_in_input)
 
 
 class LevenshteinScorer(Scorer):
@@ -34,6 +50,6 @@ class LevenshteinScorer(Scorer):
             return self
 
     @weave.op
-    def score(self, output: str, target: str) -> dict:
+    def score(self, output: str, target: str) -> LevenshteinScorerOutput:
         distance = self.distance(output, target)
-        return {"levenshtein_distance": distance}
+        return LevenshteinScorerOutput(levenshtein_distance=distance)

--- a/weave/scorers/xml_scorer.py
+++ b/weave/scorers/xml_scorer.py
@@ -1,15 +1,23 @@
 import xml.etree.ElementTree as ET
 from typing import Union
 
+from pydantic import BaseModel, Field
+
 import weave
 from weave.scorers.base_scorer import Scorer
+
+
+class ValidXMLScorerOutput(BaseModel):
+    """Output type for ValidXMLScorer."""
+
+    xml_valid: bool = Field(description="Whether the XML is valid")
 
 
 class ValidXMLScorer(Scorer):
     """Score an XML string."""
 
     @weave.op
-    def score(self, output: Union[str, dict]) -> dict:
+    def score(self, output: Union[str, dict]) -> ValidXMLScorerOutput:
         if isinstance(output, dict):
             xml_string = output.get("output", "")
         else:
@@ -18,6 +26,6 @@ class ValidXMLScorer(Scorer):
         try:
             ET.fromstring(xml_string)
         except ET.ParseError:
-            return {"xml_valid": False}
+            return ValidXMLScorerOutput(xml_valid=False)
         else:
-            return {"xml_valid": True}
+            return ValidXMLScorerOutput(xml_valid=True)


### PR DESCRIPTION
Make Scorer's return Pydantic BaseModel outputs to align with the outputs of LLM-sdks.
(Also remove this from https://github.com/wandb/weave/pull/3576 as suggested by @andrewtruong )