### PR TITLE
fix(weave): AttributeError with OpenAIModerationScorer

### DIFF
--- a/weave/scorers/llm_utils.py
+++ b/weave/scorers/llm_utils.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 OPENAI_DEFAULT_MODEL = "gpt-4o"
 OPENAI_DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
-OPENAI_DEFAULT_MODERATION_MODEL = "text-moderation-latest"
+OPENAI_DEFAULT_MODERATION_MODEL = "omni-moderation-latest"
 
 ANTHROPIC_DEFAULT_MODEL = "claude-3-5-sonnet"
 

--- a/weave/scorers/moderation_scorer.py
+++ b/weave/scorers/moderation_scorer.py
@@ -37,5 +37,5 @@ class OpenAIModerationScorer(LLMScorer):
             model=self.model_id,
             input=output,
         ).results[0]
-        categories = {k: v for k, v in response.categories.items() if v}
+        categories = {k: v for k, v in response.categories.to_dict().items() if v}
         return {"flagged": response.flagged, "categories": categories}


### PR DESCRIPTION
## Description

Two unrelated changes.
1. Per [OpenAI docs](https://platform.openai.com/docs/guides/moderation) `text-moderation-latest` is now legacy and `omni-moderation-latest` is recommended. (Among other things it adds an "illicit" category.)
2. `response.categories` is a `openai.types.moderation.Categories` object and not a dict, so we were getting `AttributeError: 'Categories' object has no attribute 'items'`