### PR TITLE
feat(app): extend runs history step slider to include history tables from all runs

### DIFF
--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -167,6 +167,8 @@ const PanelRunHistoryTablesStepper: React.FC<
   const exampleRowRefined = useNodeWithServerType(exampleRow);
   let defaultNode: NodeOrVoidNode = voidNode();
   if (currentStep) {
+    // This performs the following weave expression:
+    // runs.history.concat.filter((row) => row._step == <current-step>)[<table-history-key>].concat
     defaultNode = opConcat({
       arr: opTableRows({
         table: opFileTable({

--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -1,24 +1,31 @@
 import SliderInput from '@wandb/weave/common/components/elements/SliderInput';
+import {TABLE_FILE_TYPE} from '@wandb/weave/common/types/file';
 import {
   constFunction,
-  constNodeUnsafe,
   constNumber,
   constString,
-  file,
+  isAssignableTo,
+  isUnion,
+  listObjectType,
+  maybe,
   NodeOrVoidNode,
-  opDict,
+  nullableTaggableValue,
+  opConcat,
   opFileTable,
+  opFilter,
   opIndex,
-  opMap,
+  opNumberEqual,
   opPick,
   opRunHistory,
   opTableRows,
+  Type,
+  typedDictPropertyTypes,
+  Union,
   voidNode,
 } from '@wandb/weave/core';
 import React, {useEffect, useState} from 'react';
 
 import {LIST_RUNS_TYPE} from '../../../common/types/run';
-import {getTableKeysFromNodeType} from '../../../common/util/table';
 import {useNodeValue, useNodeWithServerType} from '../../../react';
 import * as ConfigPanel from '../ConfigPanel';
 import * as Panel2 from '../panel';
@@ -34,19 +41,62 @@ type PanelRunHistoryTablesStepperProps = Panel2.PanelProps<
   PanelRunsHistoryTablesConfigType
 >;
 
+const getTableKeysFromRunsHistoryPropertyType = (
+  runsHistoryPropertyType: Type | undefined
+) => {
+  if (
+    runsHistoryPropertyType &&
+    isUnion(nullableTaggableValue(listObjectType(runsHistoryPropertyType)))
+  ) {
+    const runsPropertyType: Union = nullableTaggableValue(
+      listObjectType(runsHistoryPropertyType)
+    ) as Union;
+    const tableKeys = runsPropertyType.members.reduce(
+      (acc: string[], member: Type) => {
+        const typeMap = typedDictPropertyTypes(member);
+        const runTableKeys = Object.keys(typeMap).filter(key => {
+          return isAssignableTo(typeMap[key], maybe(TABLE_FILE_TYPE));
+        });
+
+        return [...acc, ...runTableKeys];
+      },
+      []
+    );
+    return [...new Set(tableKeys)].sort();
+  }
+  return [];
+};
+
+const getCurrentTableHistoryKey = (
+  tableKeys: string[],
+  configKey: string | undefined
+) => {
+  if (configKey && tableKeys.indexOf(configKey) !== -1) {
+    return configKey;
+  } else if (tableKeys.length > 0) {
+    return tableKeys[0];
+  }
+  return '';
+};
+
 const PanelRunHistoryTablesStepperConfig: React.FC<
   PanelRunHistoryTablesStepperProps
 > = props => {
-  const firstRun = opIndex({arr: props.input, index: constNumber(0)});
-  const runHistoryNode = opRunHistory({run: firstRun as any});
-  const runHistoryRefined = useNodeWithServerType(runHistoryNode);
-  const {tableKeys, value} = getTableKeysFromNodeType(
-    runHistoryRefined.result?.type,
+  const runsHistoryNode = opConcat({
+    arr: opRunHistory({run: props.input as any}),
+  });
+  const runsHistoryRefined = useNodeWithServerType(runsHistoryNode);
+  const tableKeys = getTableKeysFromRunsHistoryPropertyType(
+    runsHistoryRefined.result?.type
+  );
+    const tableHistoryKey = getCurrentTableHistoryKey(
+    tableKeys,
     props.config?.tableHistoryKey
   );
+
   const options = tableKeys.map(key => ({text: key, value: key}));
   const updateConfig = props.updateConfig;
-  const setSummaryKey = React.useCallback(
+  const setTableHistoryKey = React.useCallback(
     val => {
       updateConfig({tableHistoryKey: val});
     },
@@ -61,9 +111,9 @@ const PanelRunHistoryTablesStepperConfig: React.FC<
         scrolling
         multiple={false}
         options={options}
-        value={value}
+        value={tableHistoryKey}
         onChange={(e, data) => {
-          setSummaryKey(data.value as any);
+          setTableHistoryKey(data.value as any);
         }}
       />
     </ConfigPanel.ConfigOption>
@@ -74,63 +124,67 @@ const PanelRunHistoryTablesStepper: React.FC<
   PanelRunHistoryTablesStepperProps
 > = props => {
   const [currentStep, setCurrentStep] = useState(0);
-  const [currentTableHistoryKey, setCurrentTableHistoryKey] =
-    useState<any>(null);
   const [steps, setSteps] = useState<number[]>([]);
-  const [tables, setTables] = useState<any[]>([]);
+  const {input} = props;
 
-  const {input, config} = props;
-  const firstRun = opIndex({arr: input, index: constNumber(0)});
-  const runHistoryNode = opRunHistory({run: firstRun as any});
-  const runHistoryRefined = useNodeWithServerType(runHistoryNode);
-  const {value} = getTableKeysFromNodeType(
-    runHistoryRefined.result?.type,
-    config?.tableHistoryKey
+  const runsHistoryNode = opConcat({
+    arr: opRunHistory({run: input as any}),
+  });
+  const runsHistoryRefined = useNodeWithServerType(runsHistoryNode);
+  const tableKeys = getTableKeysFromRunsHistoryPropertyType(
+    runsHistoryRefined.result?.type
   );
-  const tableWithStepsNode = opMap({
-    arr: runHistoryRefined.result as any,
-    mapFn: constFunction({row: runHistoryRefined.result.type}, ({row}) =>
-      opDict({
-        _step: opPick({obj: row, key: constString('_step')}),
-        table: opPick({obj: row, key: constString(value ?? '')}),
-      } as any)
-    ) as any,
-  });
+  const tableHistoryKey = getCurrentTableHistoryKey(
+    tableKeys,
+    props.config?.tableHistoryKey
+  );
 
-  const {
-    result: tablesWithStepsNodeResult,
-    loading: tablesWithStepsNodeLoading,
-  } = useNodeValue(tableWithStepsNode, {
-    skip: !value || currentTableHistoryKey === value,
+  const stepsNode = opPick({
+    obj: runsHistoryNode,
+    key: constString('_step'),
   });
+  const {result: stepsNodeResult, loading: stepsNodeLoading} =
+    useNodeValue(stepsNode);
 
   useEffect(() => {
-    if (tablesWithStepsNodeLoading) {
+    if (stepsNodeLoading) {
       return;
     }
 
-    if (tablesWithStepsNodeResult != null) {
-      const nonNullTables = tablesWithStepsNodeResult.filter(
-        (row: any) => row.table != null
+    if (stepsNodeResult != null) {
+      const newSteps: number[] = [...new Set<number>(stepsNodeResult)].sort(
+        (a, b) => a - b
       );
-      const newSteps = nonNullTables.map((row: any) => row._step);
-      const newTables = nonNullTables.map((row: any) => row.table);
       setSteps(newSteps);
       setCurrentStep(newSteps[0]);
-      setCurrentTableHistoryKey(value);
-      setTables(newTables);
     }
-  }, [tablesWithStepsNodeResult, tablesWithStepsNodeLoading, value]);
+  }, [stepsNodeResult, stepsNodeLoading]);
 
-  const tableIndex = steps.indexOf(currentStep);
+  const exampleRow = opIndex({
+    arr: runsHistoryNode,
+    index: constNumber(0),
+  });
+  const exampleRowRefined = useNodeWithServerType(exampleRow);
   let defaultNode: NodeOrVoidNode = voidNode();
-  if (tableIndex !== -1 && tables[tableIndex] != null) {
-    defaultNode = opTableRows({
-      table: opFileTable({
-        file: constNodeUnsafe(
-          file('json', {type: 'table', columnTypes: {}}),
-          tables[tableIndex]
-        ),
+  if (currentStep) {
+    defaultNode = opConcat({
+      arr: opTableRows({
+        table: opFileTable({
+          file: opPick({
+            obj: opFilter({
+              arr: runsHistoryNode,
+              filterFn: constFunction(
+                {row: exampleRowRefined.result.type},
+                ({row}) =>
+                  opNumberEqual({
+                    lhs: opPick({obj: row, key: constString('_step')}),
+                    rhs: constNumber(currentStep),
+                  })
+              ),
+            }),
+            key: constString(tableHistoryKey),
+          }),
+        }),
       }),
     });
   }
@@ -153,7 +207,7 @@ const PanelRunHistoryTablesStepper: React.FC<
             loading={props.loading}
             panelSpec={TableSpec}
             configMode={false}
-            config={config}
+            config={props.config}
             context={props.context}
             updateConfig={props.updateConfig}
             updateContext={props.updateContext}

--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -89,7 +89,7 @@ const PanelRunHistoryTablesStepperConfig: React.FC<
   const tableKeys = getTableKeysFromRunsHistoryPropertyType(
     runsHistoryRefined.result?.type
   );
-    const tableHistoryKey = getCurrentTableHistoryKey(
+  const tableHistoryKey = getCurrentTableHistoryKey(
     tableKeys,
     props.config?.tableHistoryKey
   );


### PR DESCRIPTION

## Description

- Implements [WB-23062](https://wandb.atlassian.net/browse/WB-23062)
- Followup to https://github.com/wandb/weave/pull/3459
- The panel now retrieves history data from all runs (instead of just the latest) and performs the following query:
    ```
    runs.history.concat.filter((row) => row['step'] == <step>)[<table>]
    ```
    for the specified `<step>` (given by the slider on the bottom) and `<table>` (selected in the config)

## Testing

Local FE

https://github.com/user-attachments/assets/9e39f2b9-6465-46ee-9d6b-c2735e297dae



[WB-23062]: https://wandb.atlassian.net/browse/WB-23062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ