### PR TITLE
fix(weave): show hidden sibling count

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
@@ -89,10 +89,6 @@ export const CustomGridTreeDataGroupingCell: FC<
 
   const isHiddenCount = id === 'HIDDEN_SIBLING_COUNT';
 
-  if (call == null) {
-    return <div />;
-  }
-
   const box = (
     <CursorBox
       $isClickable={!isHiddenCount}
@@ -184,7 +180,7 @@ export const CustomGridTreeDataGroupingCell: FC<
       <CallOrCountRow>
         {isHiddenCount ? (
           <Box>{row.count.toLocaleString()} hidden calls</Box>
-        ) : (
+        ) : call != null ? (
           <>
             <Box
               sx={{
@@ -217,6 +213,8 @@ export const CustomGridTreeDataGroupingCell: FC<
               />
             )}
           </>
+        ) : (
+          <Box />
         )}
         {rowTypeIndicator && <Box>{rowTypeIndicator}</Box>}
       </CallOrCountRow>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
@@ -216,10 +216,14 @@ export const CustomGridTreeDataGroupingCell: FC<
         ) : (
           <Box />
         )}
-        {rowTypeIndicator && <Box>{rowTypeIndicator}</Box>}
       </CallOrCountRow>
+      {rowTypeIndicator && <Box>{rowTypeIndicator}</Box>}
     </CursorBox>
   );
 
-  return tooltip ? <Tooltip content={tooltip} trigger={box} /> : box;
+  return tooltip ? (
+    <Tooltip content={tooltip} noTriggerWrap trigger={box} />
+  ) : (
+    box
+  );
 };


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Adds back hidden siblings, errantly removed in this pr: https://github.com/wandb/weave/pull/2945

## Testing

<img width="787" alt="Screenshot 2025-02-05 at 11 39 23 AM" src="https://github.com/user-attachments/assets/21293e27-5583-4966-9023-8059f25dda21" />
