### PR TITLE
chore(ui): fix scorer grid props naming

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/ScorerFeedbackGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/ScorerFeedbackGrid.tsx
@@ -13,7 +13,7 @@ import {useGetTraceServerClientContext} from '../pages/wfReactInterface/traceSer
 import {ScoresFeedbackGridInner} from './ScoresFeedbackGridInner';
 import {RUNNABLE_FEEDBACK_TYPE_PREFIX} from './StructuredFeedback/runnableFeedbackTypes';
 
-type FeedbackGridProps = {
+type ScorerFeedbackGridProps = {
   entity: string;
   project: string;
   weaveRef: string;
@@ -25,7 +25,7 @@ export const ScorerFeedbackGrid = ({
   project,
   weaveRef,
   objectType,
-}: FeedbackGridProps) => {
+}: ScorerFeedbackGridProps) => {
   /**
    * This component is very similar to `FeedbackGrid`, but it only shows scores.
    * While some of the code is duplicated, it is kept separate to make it easier

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/ScoresFeedbackGridInner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/ScoresFeedbackGridInner.tsx
@@ -12,17 +12,15 @@ import {SmallRef} from '../smallRef/SmallRef';
 import {StyledDataGrid} from '../StyledDataGrid';
 import {FeedbackGridActions} from './FeedbackGridActions';
 
-type FeedbackGridInnerProps = {
+type ScoresFeedbackGridInnerProps = {
   feedback: Feedback[];
   currentViewerId: string | null;
-  showAnnotationName?: boolean;
 };
 
 export const ScoresFeedbackGridInner = ({
   feedback,
   currentViewerId,
-  showAnnotationName,
-}: FeedbackGridInnerProps) => {
+}: ScoresFeedbackGridInnerProps) => {
   /**
    * This component is very similar to `FeedbackGridInner`, but it only shows scores.
    * While some of the code is duplicated, it is kept separate to make it easier


### PR DESCRIPTION
## Description

Fix naming of props type in ScorerFeedbackGrid. Removed an unused prop. Also wondering if the inner component naming of "Scores" was intentional instead of "Scorer".