### PR TITLE
fix(app): handle singular embedding columns in combined 2D projection panel

### DIFF
--- a/weave-js/src/components/Panel2/PanelProjectionConverter/util.ts
+++ b/weave-js/src/components/Panel2/PanelProjectionConverter/util.ts
@@ -51,13 +51,19 @@ export const processConfig: <U extends Type>(
   let inputColumnNames = config?.inputColumnNames ?? [];
   if (inputCardinality === 'single') {
     if (
+      _.isArray(inputColumnNames) &&
       inputColumnNames.length >= 1 &&
-      validEmbeddingColumns.indexOf(inputColumnNames[0]) === -1
+      validEmbeddingColumns.indexOf(inputColumnNames[0]) !== -1
     ) {
-      inputColumnNames = [];
-    }
-    if (inputColumnNames.length === 0 && validEmbeddingColumns.length > 0) {
-      inputColumnNames = [validEmbeddingColumns[0]];
+      inputColumnNames = [inputColumnNames[0]];
+    } else if (
+      _.isString(inputColumnNames) &&
+      validEmbeddingColumns.indexOf(inputColumnNames) !== -1
+    ) {
+      inputColumnNames = [inputColumnNames];
+    } else {
+      inputColumnNames =
+        validEmbeddingColumns.length > 0 ? [validEmbeddingColumns[0]] : [];
     }
   } else {
     if (


### PR DESCRIPTION
## Description
JIRA: [WB-23076](https://wandb.atlassian.net/browse/WB-23076)

**Issue**: The incoming `inputColumnNames` from the config could be either a string (when the config is single select) or an array (when the config is multi-select) and since `.length` is defined on either, we would run through the same logic for either type.

**Fix**
In the single select case, there is an added case to handle incoming strings. There is a bit of refactoring of the logic, which should be equivalent to what we had before:
* The default is the first element of `validEmbeddingColumns`, if it exists, and an empty array otherwise
* When the incoming `inputColumnNames` is an array, we take the first element, if it exists in `validEmbeddingColumns`
* When the incoming `inputColumnNames` is a string, we use it if it exists in `validEmbeddingColumns`

## Testing

Local FE

https://github.com/user-attachments/assets/5668cd2e-1248-4dee-94cb-3a11c5c290c4



[WB-23076]: https://wandb.atlassian.net/browse/WB-23076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ