### PR TITLE
feat(app): add apply button to column header popup

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
@@ -180,7 +180,10 @@ export const ColumnHeader: React.FC<{
       workingSelectFunction.type !== 'invalid'
     ) {
       let panelUpdated = false;
-      if (workingSelectFunction !== propsSelectFunction) {
+      if (
+        weave.expToString(workingSelectFunction) !==
+        weave.expToString(propsSelectFunction)
+      ) {
         newState = Table.updateColumnSelect(
           newState,
           colId,
@@ -657,6 +660,28 @@ export const ColumnHeader: React.FC<{
                         </PanelContextProvider>
                       </S.PanelSettings>
                     )}
+                </S.ColumnEditorSection>
+                <S.ColumnEditorSection>
+                  <Button
+                    data-test="column-header-apply"
+                    size="small"
+                    disabled={
+                      weave.expToString(workingSelectFunction) ===
+                        weave.expToString(propsSelectFunction) &&
+                      workingColumnName === propsColumnName &&
+                      workingPanelId === propsPanelId &&
+                      workingPanelConfig === propsPanelConfig
+                    }
+                    twWrapperStyles={{
+                      display: 'flex',
+                      justifyContent: 'flex-end',
+                    }}
+                    onClick={() => {
+                      applyWorkingState();
+                      setColumnSettingsOpen(false);
+                    }}>
+                    Apply
+                  </Button>
                 </S.ColumnEditorSection>
               </div>
             )

--- a/weave-js/src/panel/WeaveExpression/state.ts
+++ b/weave-js/src/panel/WeaveExpression/state.ts
@@ -321,7 +321,6 @@ export class WeaveExpressionState {
         this.trace(`...live updating expression`);
         this.setExpression(newExpr as NodeOrVoidNode);
       }
-      return;
     }
 
     if (ReactEditor.isFocused(this.editor)) {


### PR DESCRIPTION
## Description

* Add `Apply` button to address [WB-23056](https://wandb.atlassian.net/browse/WB-23056) 
    * Related: We want to compare the text of `workingSelectFunction` and `propsSelectFunction`, since `workingSelectFunction` is an `EditingNode` and `propsSelectFunction` is a `NodeOrVoidNode`.
* Remove the early return to fix [WB-23159](https://wandb.atlassian.net/browse/WB-23159). We always want to set `pendingExpr`, which is initialized to the original expression. Our current logic is the following
```js
// newExpr is the incoming change
if (pendingExpr == newExpr) {
  return;
} else {
  // fire off setExpression hook
  return;
}

// update pendingExpr = newExpr
```
Incoming `newExpr`s will fire off the `setExpression` hook but never update `pendingExpr` so if we revert `newExpr` back to the original expression, the equality `pendingExpr == newExpr` evaluates to true and whatever's using `setExpression` (such as our `ColumnHeader`) will not receive the latest update.


## Testing

Local FE


https://github.com/user-attachments/assets/9bc83c8d-64a3-457a-bfe2-168515833aea




[WB-23056]: https://wandb.atlassian.net/browse/WB-23056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-23159]: https://wandb.atlassian.net/browse/WB-23159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ