### PR TITLE
chore(ui): break import cycle

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts
@@ -16,11 +16,8 @@ import {
   WEAVE_REF_PREFIX,
   WEAVE_REF_SCHEME,
 } from './constants';
-import {useWFHooks} from './context';
 import {
-  CallSchema,
   KnownBaseObjectClassType,
-  Loadable,
   ObjectVersionKey,
   ObjectVersionSchema,
   OpCategory,
@@ -305,21 +302,4 @@ export const getErrorReason = (error: Error): string | null => {
   } catch (e) {
     return null;
   }
-};
-
-/// Hooks ///
-
-export const useParentCall = (
-  call: CallSchema | null
-): Loadable<CallSchema | null> => {
-  const {useCall} = useWFHooks();
-  let parentCall = null;
-  if (call && call.parentId) {
-    parentCall = {
-      entity: call.entity,
-      project: call.project,
-      callId: call.parentId,
-    };
-  }
-  return useCall(parentCall);
 };


### PR DESCRIPTION
## Description

Deletes the unused `useParentCall` function. More importantly, this allows us to break an import cycle that causes an infinite reloading problem in development.

Cycle: context.tsx > tsDataModelHooks.ts > utilities.ts > context.tsx

## Testing

`npx madge --circular src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities.ts`