### PR TITLE
chore(ui): break opNiceName cycle

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CustomGridTreeDataGroupingCell.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import {MOON_250, MOON_500} from '../../../../../../common/css/color.styles';
 import {Icon, IconParentBackUp} from '../../../../../Icon';
 import {Tooltip} from '../../../../../Tooltip';
-import {opNiceName} from '../common/Links';
+import {opNiceName} from '../common/opNiceName';
 import {StatusChip} from '../common/StatusChip';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {TraceCostStats} from './cost/TraceCostStats';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OpVersionText.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OpVersionText.tsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import {opNiceName} from '../common/Links';
+import {opNiceName} from '../common/opNiceName';
 import {useWFHooks} from '../wfReactInterface/context';
 import {refUriToOpVersionKey} from '../wfReactInterface/utilities';
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -11,7 +11,7 @@ import {
   WeaveHeaderExtrasContext,
   WeaveHeaderExtrasProvider,
 } from '../../context';
-import {opNiceName} from '../common/Links';
+import {opNiceName} from '../common/opNiceName';
 import {SimplePageLayout} from '../common/SimplePageLayout';
 import {useControllableState} from '../util';
 import {opVersionRefOpName} from '../wfReactInterface/utilities';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableFilter.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableFilter.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {useMemo} from 'react';
 
-import {opNiceName} from '../common/Links';
+import {opNiceName} from '../common/opNiceName';
 import {useWFHooks} from '../wfReactInterface/context';
 import {
   opVersionKeyToRefUri,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
@@ -12,7 +12,7 @@ import {
 import {useCallsForQuery} from '../../../CallsPage/callsTableQuery';
 import {useEvaluationsFilter} from '../../../CallsPage/evaluationsFilter';
 import {Id} from '../../../common/Id';
-import {opNiceName} from '../../../common/Links';
+import {opNiceName} from '../../../common/opNiceName';
 import {useWFHooks} from '../../../wfReactInterface/context';
 import {
   CallSchema,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
@@ -14,13 +14,9 @@ import {
 import {NotFoundPanel} from '../../NotFoundPanel';
 import {OpCodeViewer} from '../../OpCodeViewer';
 import {DeleteModal, useShowDeleteButton} from '../common/DeleteModal';
-import {
-  CallsLink,
-  opNiceName,
-  OpVersionsLink,
-  opVersionText,
-} from '../common/Links';
+import {CallsLink, OpVersionsLink, opVersionText} from '../common/Links';
 import {CenteredAnimatedLoader} from '../common/Loader';
+import {opNiceName} from '../common/opNiceName';
 import {
   ScrollableTabContent,
   SimplePageLayoutWithHeader,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionsPage.tsx
@@ -16,12 +16,8 @@ import {StyledDataGrid} from '../../StyledDataGrid';
 import {basicField} from '../common/DataTable';
 import {Empty} from '../common/Empty';
 import {EMPTY_PROPS_OPERATIONS} from '../common/EmptyContent';
-import {
-  CallsLink,
-  opNiceName,
-  OpVersionLink,
-  OpVersionsLink,
-} from '../common/Links';
+import {CallsLink, OpVersionLink, OpVersionsLink} from '../common/Links';
+import {opNiceName} from '../common/opNiceName';
 import {SimplePageLayout} from '../common/SimplePageLayout';
 import {useControllableState, useURLSearchParamsDict} from '../util';
 import {useWFHooks} from '../wfReactInterface/context';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
@@ -5,7 +5,7 @@ import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {StyledTextArea} from '../../StyledTextarea';
 import {useWFHooks} from '../wfReactInterface/context';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
-import {opNiceName} from './Links';
+import {opNiceName} from './opNiceName';
 
 export const EditableCallName: React.FC<{
   call: CallSchema;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -23,6 +23,7 @@ import {WFHighLevelCallFilter} from '../CallsPage/callsTableFilter';
 import {WFHighLevelObjectVersionFilter} from '../ObjectsPage/objectsPageTypes';
 import {WFHighLevelOpVersionFilter} from '../OpsPage/opsPageTypes';
 import {Id} from './Id';
+import {opNiceName} from './opNiceName';
 
 type LinkVariant = 'primary' | 'secondary';
 
@@ -212,14 +213,6 @@ export const OpLink: React.FC<{
       {props.opName}
     </Link>
   );
-};
-
-export const opNiceName = (opName: string) => {
-  let text = opName;
-  if (text.startsWith('op-')) {
-    text = text.slice(3);
-  }
-  return text;
 };
 
 export const opVersionText = (opName: string, versionIndex: number) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/opNiceName.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/opNiceName.ts
@@ -1,0 +1,8 @@
+// Originally was in Links.tsx but that caused a circular dependency
+export const opNiceName = (opName: string) => {
+  let text = opName;
+  if (text.startsWith('op-')) {
+    text = text.slice(3);
+  }
+  return text;
+};


### PR DESCRIPTION
## Description

Breaking another import cycle causing infinite reloading problem in development.

Cycle was Links.tsx > context.tsx > callsTableFilter.ts > Links.tsx

## Testing

`npx madge --circular src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx`
