### PR TITLE
security(weave_query): Upgrade Pyarrow to 17.0.0

### DIFF
--- a/weave-js/src/core/ops/primitives/list.ts
+++ b/weave-js/src/core/ops/primitives/list.ts
@@ -678,7 +678,7 @@ export const opGroupby = makeListOp({
     engine
   ) => {
     const tableRows: any[] = inputs.arr;
-    // console.log('OP GROUP BY RESOLVER', tableRows.length);
+    // console.log('OP GROUP BY RESOLVER', tableRows.length, "");
     const groupByFn = inputs.groupByFn;
     const groupSafeKeyFn =
       groupByFn.nodeType === 'void' ? groupByFn : toSafeCall(groupByFn);

--- a/weave-js/src/core/ops/primitives/list.ts
+++ b/weave-js/src/core/ops/primitives/list.ts
@@ -678,7 +678,7 @@ export const opGroupby = makeListOp({
     engine
   ) => {
     const tableRows: any[] = inputs.arr;
-    // console.log('OP GROUP BY RESOLVER', tableRows.length, "");
+    // console.log('OP GROUP BY RESOLVER', tableRows.length);
     const groupByFn = inputs.groupByFn;
     const groupSafeKeyFn =
       groupByFn.nodeType === 'void' ? groupByFn : toSafeCall(groupByFn);

--- a/weave_query/requirements.legacy.txt
+++ b/weave_query/requirements.legacy.txt
@@ -6,8 +6,7 @@ typing_extensions>=4.0.0
 
 # Definitely need arrow
 # TODO: Colab has 9.0.0, can we support?
-# TODO: 17.0.0 breaks a bunch of tests - can we move this requirement to just the engine?
-pyarrow>=14.0.1,<17.0.0
+pyarrow==17.0.0
 
 # pydantic integration, and required by openai anyway
 openai>=1.0.0

--- a/weave_query/weave_query/arrow/arrow.py
+++ b/weave_query/weave_query/arrow/arrow.py
@@ -347,8 +347,7 @@ def rewrite_weavelist_refs(arrow_data, object_type, source_artifact, target_arti
                 object_type.object_type,
                 source_artifact,
                 target_artifact,
-            ),
-            mask=pa.compute.is_null(data),
+            )
         )
     else:
         # We have a column of refs

--- a/weave_query/weave_query/arrow/arrow_tags.py
+++ b/weave_query/weave_query/arrow/arrow_tags.py
@@ -30,11 +30,11 @@ def recursively_encode_pyarrow_strings_as_dictionaries(array: pa.Array) -> pa.Ar
             mask=pa.compute.invert(array.is_valid()),
         )
     elif pa.types.is_list(array.type):
-        return pa.ListArray.from_arrays(
+        result_array = pa.ListArray.from_arrays(
             offsets_starting_at_zero(array),
-            recursively_encode_pyarrow_strings_as_dictionaries(array.flatten()),
-            mask=pa.compute.invert(array.is_valid()),
+            recursively_encode_pyarrow_strings_as_dictionaries(array.flatten())
         )
+        return pc.if_else(pa.compute.invert(array.is_valid()), None, result_array)
     elif array.type == pa.string():
         return pc.dictionary_encode(array)
     else:

--- a/weave_query/weave_query/arrow/arrow_tags.py
+++ b/weave_query/weave_query/arrow/arrow_tags.py
@@ -5,7 +5,10 @@ from pyarrow import compute as pc
 
 from weave_query import weave_types as types
 from weave_query.arrow import convert
-from weave_query.arrow.arrow import offsets_starting_at_zero
+from weave_query.arrow.arrow import (
+    offsets_starting_at_zero,
+    safe_list_array_from_arrays
+)
 from weave_query.language_features.tagging import (
     process_opdef_output_type,
     tag_store,
@@ -30,11 +33,12 @@ def recursively_encode_pyarrow_strings_as_dictionaries(array: pa.Array) -> pa.Ar
             mask=pa.compute.invert(array.is_valid()),
         )
     elif pa.types.is_list(array.type):
-        result_array = pa.ListArray.from_arrays(
-            offsets_starting_at_zero(array),
-            recursively_encode_pyarrow_strings_as_dictionaries(array.flatten())
+        new_offsets = offsets_starting_at_zero(array)
+        return safe_list_array_from_arrays(
+            new_offsets,
+            recursively_encode_pyarrow_strings_as_dictionaries(array.flatten()),
+            mask=pa.compute.invert(array.is_valid())
         )
-        return pc.if_else(pa.compute.invert(array.is_valid()), None, result_array)
     elif array.type == pa.string():
         return pc.dictionary_encode(array)
     else:

--- a/weave_query/weave_query/arrow/convert.py
+++ b/weave_query/weave_query/arrow/convert.py
@@ -307,9 +307,9 @@ def recursively_build_pyarrow_array(
             mapper._object_type,
             py_objs_already_mapped,
         )
-        return pa.ListArray.from_arrays(
-            offsets, new_objs, mask=pa.array(mask, type=pa.bool_())
-        )
+        result_array = pa.ListArray.from_arrays(offsets, new_objs)
+
+        return pc.if_else(pa.array(mask, type=pa.bool_()), None, result_array)
     elif pa.types.is_temporal(pyarrow_type):
         if py_objs_already_mapped:
             return pa.array(py_objs, type=pyarrow_type)

--- a/weave_query/weave_query/arrow/convert.py
+++ b/weave_query/weave_query/arrow/convert.py
@@ -21,6 +21,7 @@ from weave_query.arrow.list_ import (
     ArrowWeaveList,
     PathType,
     unsafe_awl_construction,
+    safe_list_array_from_arrays
 )
 from weave_query.language_features.tagging import tag_store, tagged_value_type
 
@@ -307,9 +308,9 @@ def recursively_build_pyarrow_array(
             mapper._object_type,
             py_objs_already_mapped,
         )
-        result_array = pa.ListArray.from_arrays(offsets, new_objs)
-
-        return pc.if_else(pa.array(mask, type=pa.bool_()), None, result_array)
+        return safe_list_array_from_arrays(
+            offsets, new_objs, mask=pa.array(mask, type=pa.bool_())
+        )
     elif pa.types.is_temporal(pyarrow_type):
         if py_objs_already_mapped:
             return pa.array(py_objs, type=pyarrow_type)

--- a/weave_query/weave_query/arrow/list_.py
+++ b/weave_query/weave_query/arrow/list_.py
@@ -802,12 +802,14 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
             )._map_column(fn, pre_fn, path + (PathItemList(),))
             # print("SELF OBJECT TYPE", self.object_type)
             # print("SELF ARROW DATA TYPE", self._arrow_data.type)
+            result_array = pa.ListArray.from_arrays(
+                offsets_starting_at_zero(self._arrow_data),
+                items._arrow_data
+            )
+
+            result_array = pc.if_else(pa.compute.is_null(arr), None, result_array)
             with_mapped_children = ArrowWeaveList(
-                pa.ListArray.from_arrays(
-                    offsets_starting_at_zero(self._arrow_data),
-                    items._arrow_data,
-                    mask=pa.compute.is_null(arr),
-                ),
+                result_array,
                 self.object_type.__class__(items.object_type),
                 self._artifact,
                 invalid_reason=items._invalid_reason,

--- a/weave_query/weave_query/arrow/list_.py
+++ b/weave_query/weave_query/arrow/list_.py
@@ -801,8 +801,6 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
             items: ArrowWeaveList = ArrowWeaveList(
                 arr.flatten(), self.object_type.object_type, self._artifact
             )._map_column(fn, pre_fn, path + (PathItemList(),))
-            # print("SELF OBJECT TYPE", self.object_type)
-            # print("SELF ARROW DATA TYPE", self._arrow_data.type)
 
             new_offsets = offsets_starting_at_zero(self._arrow_data)
             result_array = safe_list_array_from_arrays(

--- a/weave_query/weave_query/ops_arrow/arraylist_ops.py
+++ b/weave_query/weave_query/ops_arrow/arraylist_ops.py
@@ -350,9 +350,9 @@ def dropna(self):
     cumulative_non_null_counts = pa.compute.cumulative_sum(non_null)
     new_offsets = cumulative_non_null_counts.take(pa.compute.subtract(end_indexes, 1))
     new_offsets = pa.concat_arrays([start_indexes[:1], new_offsets])
-    unflattened = pa.ListArray.from_arrays(
-        new_offsets, new_data, mask=pa.compute.is_null(a)
-    )
+    unflattened = pa.ListArray.from_arrays(new_offsets, new_data)
+    unflattened = pa.compute.if_else(pa.compute.is_null(a), None, unflattened)
+
 
     return ArrowWeaveList(
         unflattened,


### PR DESCRIPTION
## Description

[WB-22924](https://wandb.atlassian.net/jira/software/c/projects/WB/boards/138?selectedIssue=WB-22924)

This PR upgrades and pins pyarrow to 17.0.0.

### 16.1.0 -> 17.0.0 Upgrade Issues

This [change in pyarrow](https://github.com/apache/arrow/pull/13894) introduced stricter checks when using `pa.ListArray.from_arrays().` Specifically, we cannot use both a null mask with an offset that has nulls.

```cpp
  if (null_bitmap != nullptr && offsets.null_count() > 0) {
    return Status::Invalid(
        "Ambiguous to specify both validity map and offsets with nulls");
  }
```


This new strictness caused many of our unit tests to fail:
![image](https://github.com/user-attachments/assets/5636bb98-bb67-483f-a1a6-8b2066db0e36)

**A strange observation**
I stumbled upon this accidentally, but just checking the null count in the offsets like `new_offsets.null_count` makes all the unit tests pass. 

My theory:
It looks like when we're getting new offsets during concatenation, we use compute functions (which are lazy), so when the offset is checked for nulls on the cpp side, it's possible that it's in an intermediate state with nulls. When evaluating the null_count in python, this forces the compute functions to evaluate, resulting in offsets without nulls.

### Solution
I created a new function called `safe_list_array_from_arrays` that handles the strictness. It checks the `null_count` of the offsets:
*  if there are nulls, it calls `pa.ListArray.from_arrays()` without a mask, then uses `pc.if_else` to set nulls.
* if there are no nulls, it calls `pa.ListArray.from_arrays()` with the mask.

**The outcome:**
`offset.null_count` is called which triggers evaluation of the offset array
a. If there are no nulls in the offset array, the mask is used, and the behavior is the same as before the upgrade
b. If there are nulls in the offset array, then a mask isn't used, but `pc.if_else` handles nulling values in the resulting array.

## Testing

I used the unit test failures to test my changes.


[WB-22924]: https://wandb.atlassian.net/browse/WB-22924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the key dependency to enforce version 17.0.0 for improved compatibility with current tests.
- **New Features**
  - Introduced an enhanced mechanism for constructing list arrays, ensuring more robust handling of null values and better data consistency during array operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->