### PR TITLE
fix(ui): Only update monaco editor value if value has changed

### DIFF
--- a/weave-js/src/common/components/Monaco/Editor.tsx
+++ b/weave-js/src/common/components/Monaco/Editor.tsx
@@ -44,7 +44,9 @@ const Editor = (
 
   const [value, setValue] = useState(props.value || '');
   useEffect(() => {
-    setValue(props.value || '');
+    if (props.value !== value) {
+      setValue(props.value || '');
+    }
   }, [props.value]);
 
   return (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

-[ Fixes WB-23196](http://wandb.atlassian.net/browse/WB-23196)

Modifies the code in MonacoEditor to only update the value passed to the editor if it changes. This fixes an issue where the carat would jump to the end of the editor on the CreateSweepPage. 

## Testing

On Beta and locally on dev on CreateSweepPage
