### PR TITLE
chore(ui): remove (avg) from total tokens label in eval compare

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooksEvaluationComparison.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooksEvaluationComparison.ts
@@ -781,7 +781,7 @@ const modelLatencyMetricDimension: MetricDefinition = {
 const totalTokensMetricDimension: MetricDefinition = {
   source: 'derived',
   scoreType: 'continuous',
-  metricSubPath: ['Total Tokens (avg)'],
+  metricSubPath: ['Total Tokens'],
   shouldMinimize: true,
   unit: '',
 };


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

We show the label as `Total Tokens (avg)`, but it's clearly a sum. Now: `Total Tokens`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style  
   - Updated the displayed metric label for tokens by removing the average indicator. Users will now see "Total Tokens" instead of "Total Tokens (avg)", providing a clearer and more direct representation of the data without any change to the underlying calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->