### PR TITLE
chore(ui): add error state and refetch to useBaseObjectInstances

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/objectClassQuery.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/objectClassQuery.test.ts
@@ -13,7 +13,7 @@ import {
   TraceObjCreateRes,
   TraceObjSchema,
 } from './traceServerClientTypes';
-import {Loadable} from './wfDataModelHooksInterface';
+import {LoadableWithError} from './wfDataModelHooksInterface';
 
 type TypesAreEqual<T, U> = [T] extends [U]
   ? [U] extends [T]
@@ -28,9 +28,11 @@ describe('Type Tests', () => {
     >;
 
     // Define the expected type structure
-    type ExpectedType = Loadable<
+    type ExpectedType = LoadableWithError<
       Array<TraceObjSchema<TestOnlyExample, 'TestOnlyExample'>>
-    >;
+    > & {
+      refetch: () => void;
+    };
 
     // Type assertion tests
     type AssertTypesAreEqual = TypesAreEqual<
@@ -46,6 +48,7 @@ describe('Type Tests', () => {
     // Additional runtime sample for documentation
     const sampleResult: CollectionObjectsReturn = {
       loading: false,
+      error: null,
       result: [
         {
           project_id: '',
@@ -68,6 +71,7 @@ describe('Type Tests', () => {
           }),
         },
       ],
+      refetch: () => {},
     };
 
     expectType<ExpectedType>(sampleResult);


### PR DESCRIPTION
## Description

Address a few issues with `useBaseObjectInstances`
* Add support for an error case
* Add support for a refetch function
* It could get into a state where loading was still true even though the results array had changed, which was confusing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a built-in mechanism to refresh data, enabling users to re-trigger data fetching as needed.
- **Refactor**
	- Enhanced error management and state tracking for asynchronous data operations, ensuring a smoother and more reliable data retrieval experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->