### PR TITLE
chore(weave): allow unlimited selection in calls table, avoid confusion

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -111,7 +111,7 @@ import {
 import {useCallsForQuery} from './callsTableQuery';
 import {useCurrentFilterIsEvaluationsFilter} from './evaluationsFilter';
 import {ManageColumnsButton} from './ManageColumnsButton';
-const MAX_EVAL_COMPARISONS = 5;
+
 const MAX_SELECT = 100;
 
 export const DEFAULT_HIDDEN_COLUMN_PREFIXES = [
@@ -590,17 +590,14 @@ export const CallsTable: FC<{
                   : 'indeterminate'
               }
               onCheckedChange={() => {
-                const maxForTable = isEvaluateTable
-                  ? MAX_EVAL_COMPARISONS
-                  : MAX_SELECT;
                 if (
                   selectedCalls.length ===
-                  Math.min(tableData.length, maxForTable)
+                  Math.min(tableData.length, MAX_SELECT)
                 ) {
                   setSelectedCalls([]);
                 } else {
                   setSelectedCalls(
-                    tableData.map(row => row.id).slice(0, maxForTable)
+                    tableData.map(row => row.id).slice(0, MAX_SELECT)
                   );
                 }
               }}
@@ -610,19 +607,11 @@ export const CallsTable: FC<{
         renderCell: (params: any) => {
           const rowId = params.id as string;
           const isSelected = selectedCalls.includes(rowId);
-          const disabled =
-            !isSelected &&
-            (isEvaluateTable
-              ? selectedCalls.length >= MAX_EVAL_COMPARISONS
-              : selectedCalls.length >= MAX_SELECT);
-          let tooltipText = '';
-          if (isEvaluateTable) {
-            if (selectedCalls.length >= MAX_EVAL_COMPARISONS && !isSelected) {
-              tooltipText = `Comparison limited to ${MAX_EVAL_COMPARISONS} evaluations`;
-            }
-          } else if (selectedCalls.length >= MAX_SELECT && !isSelected) {
-            tooltipText = `Selection limited to ${MAX_SELECT} items`;
-          }
+          const disabled = !isSelected && selectedCalls.length >= MAX_SELECT;
+          const tooltipText =
+            selectedCalls.length >= MAX_SELECT && !isSelected
+              ? `Selection limited to ${MAX_SELECT} items`
+              : '';
 
           return (
             <Tooltip title={tooltipText} placement="right" arrow>
@@ -652,7 +641,7 @@ export const CallsTable: FC<{
       ...columns.cols,
     ];
     return cols;
-  }, [columns.cols, selectedCalls, tableData, isEvaluateTable]);
+  }, [columns.cols, selectedCalls, tableData]);
 
   // Register Compare Evaluations Button
   const history = useHistory();


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This was initially due to the comparison view being limited, but now with the broken up plots and metric selection and horizontal scrolling, uncapped is more viable. 

## Testing

<img width="608" alt="Screenshot 2025-02-07 at 10 22 45 AM" src="https://github.com/user-attachments/assets/cf8518a5-b34f-4339-9085-bdb99643606d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the Calls page selection mechanics by unifying the maximum selectable items to 100.
	- Updated interface messages and behavior to consistently reflect this limit, enhancing clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->