### PR TITLE
docs(weave): Add Python-only callout to Prompts page

### DIFF
--- a/docs/docs/guides/core-types/prompts.md
+++ b/docs/docs/guides/core-types/prompts.md
@@ -1,5 +1,9 @@
 # Prompts
 
+:::important
+Curremtly, this feature is only accessible through the Python SDK. All code examples on this page are provided in Python.
+:::
+
 Creating, evaluating, and refining prompts is a core activity for AI engineers.
 Small changes to a prompt can have big impacts on your application's behavior.
 Weave lets you create prompts, save and retrieve them, and evolve them over time.


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1257

Add callout to Prompts page that feature is only Python for now. 

## Testing

yarn start on local
