### PR TITLE
docs(dev): fix useCreateBuiltinObjectInstance method name

### DIFF
--- a/dev_docs/BuiltinObjectClasses.md
+++ b/dev_docs/BuiltinObjectClasses.md
@@ -19,7 +19,7 @@ These can then be retrieved using `weave.ref().get()`:
 config = weave.ref("my_model_config").get()
 ```
 
-Sometimes users are working with standard structured classes like `dataclasses` or `pydantic.BaseModel`. 
+Sometimes users are working with standard structured classes like `dataclasses` or `pydantic.BaseModel`.
 In such cases, we have special serialization and deserialization logic that allows for cleaner serialization patterns.
 For example, let's say the user does:
 
@@ -40,11 +40,11 @@ This will result in an on-disk payload that looks like:
 
 ```json
 {
-    "model_name": "my_model",
-    "model_version": "1.0",
-    "_type": "ModelConfig",
-    "_class_name": "ModelConfig",
-    "_bases": ["Object", "BaseModel"]
+  "model_name": "my_model",
+  "model_version": "1.0",
+  "_type": "ModelConfig",
+  "_class_name": "ModelConfig",
+  "_bases": ["Object", "BaseModel"]
 }
 ```
 
@@ -53,10 +53,11 @@ Effectively, this is like creating a virtual table for that class.
 
 **Terminology**: We use the term "weave Object" (capital "O") to refer to instances of classes that subclass `weave.Object`.
 
-**Technical note**: the "base_object_class" is the first subtype of "Object", not the _class_name. 
+**Technical note**: the "base_object_class" is the first subtype of "Object", not the \_class_name.
 For example, let's say the class hierarchy is:
-* `A -> Object -> BaseModel`, then the `base_object_class` filter will be "A".
-* `B -> A -> Object -> BaseModel`, then the `base_object_class` filter will still be "A"!
+
+- `A -> Object -> BaseModel`, then the `base_object_class` filter will be "A".
+- `B -> A -> Object -> BaseModel`, then the `base_object_class` filter will still be "A"!
 
 Finally, the Weave library itself utilizes this mechanism for common objects like `Model`, `Dataset`, `Evaluation`, etc...
 This allows the user to subclass these objects to add additional metadata or functionality, while categorizing them in the same virtual table.
@@ -97,6 +98,7 @@ __all__ = ["MyConfig"]
 ```
 
 2. **Use in Python**:
+
 ```python
 # Publishing
 ref = weave.publish(MyConfig(...))
@@ -107,6 +109,7 @@ assert isinstance(config, MyConfig)
 ```
 
 3. **Use via HTTP API**:
+
 ```bash
 # Creating
 curl -X POST 'https://trace.wandb.ai/obj/create' \
@@ -131,12 +134,13 @@ curl -X POST 'https://trace.wandb.ai/objs/query' \
 ```
 
 4. **Use in React**:
+
 ```typescript
 // Read with type safety
 const result = useBaseObjectInstances("MyConfig", ...);
 
 // Write with validation
-const createFn = useCreateBaseObjectInstance("MyConfig");
+const createFn = useCreateBuiltinObjectInstance("MyConfig");
 createFn({...}); // TypeScript enforced schema
 ```
 
@@ -157,15 +161,16 @@ Run `make synchronize-base-object-schemas` to ensure the frontend TypeScript typ
 1. Define your schema in a python file in the `weave/trace_server/interface/builtin_object_classes/test_only_example.py` directory. See `weave/trace_server/interface/builtin_object_classes/test_only_example.py` as an example.
 2. Make sure to register your schemas in `weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py` by calling `register_base_object`.
 3. Run `make synchronize-base-object-schemas` to generate the frontend types.
-    * The first step (`make generate_base_object_schemas`) will run `weave/scripts/generate_base_object_schemas.py` to generate a JSON schema in `weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json`.
-    * The second step (yarn `generate-schemas`) will read this file and use it to generate the frontend types located in `weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBuiltinObjectClasses.zod.ts`.
+   - The first step (`make generate_base_object_schemas`) will run `weave/scripts/generate_base_object_schemas.py` to generate a JSON schema in `weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json`.
+   - The second step (yarn `generate-schemas`) will read this file and use it to generate the frontend types located in `weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBuiltinObjectClasses.zod.ts`.
 4. Now, each use case uses different parts:
-    1. `Python Writing`. Users can directly import these classes and use them as normal Pydantic models, which get published with `weave.publish`. The python client correct builds the requisite payload.
-    2. `Python Reading`. Users can `weave.ref().get()` and the weave python SDK will return the instance with the correct type. Note: we do some special handling such that the returned object is not a WeaveObject, but literally the exact pydantic class.
-    3. `HTTP Writing`. In cases where the client/user does not want to add the special type information, users can publish builtin objects (set of weave.Objects provided by Weave) by setting the `builtin_object_class` setting on `POST obj/create` to the name of the class. The weave server will validate the object against the schema, update the metadata fields, and store the object.
-    4. `HTTP Reading`. When querying for objects, the server will return the object with the correct type if the `base_object_class` metadata field is set.
-    5. `Frontend`. The frontend will read the zod schema from `weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBuiltinObjectClasses.zod.ts` and use that to provide compile time type safety when using `useBaseObjectInstances` and runtime type safety when using `useCreateBaseObjectInstance`.
-* Note: it is critical that all techniques produce the same digest for the same data - which is tested in the tests. This way versions are not thrashed by different clients/users.
+   1. `Python Writing`. Users can directly import these classes and use them as normal Pydantic models, which get published with `weave.publish`. The python client correct builds the requisite payload.
+   2. `Python Reading`. Users can `weave.ref().get()` and the weave python SDK will return the instance with the correct type. Note: we do some special handling such that the returned object is not a WeaveObject, but literally the exact pydantic class.
+   3. `HTTP Writing`. In cases where the client/user does not want to add the special type information, users can publish builtin objects (set of weave.Objects provided by Weave) by setting the `builtin_object_class` setting on `POST obj/create` to the name of the class. The weave server will validate the object against the schema, update the metadata fields, and store the object.
+   4. `HTTP Reading`. When querying for objects, the server will return the object with the correct type if the `base_object_class` metadata field is set.
+   5. `Frontend`. The frontend will read the zod schema from `weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBuiltinObjectClasses.zod.ts` and use that to provide compile time type safety when using `useBaseObjectInstances` and runtime type safety when using `useCreateBuiltinObjectInstance`.
+
+- Note: it is critical that all techniques produce the same digest for the same data - which is tested in the tests. This way versions are not thrashed by different clients/users.
 
 ```mermaid
 graph TD
@@ -201,7 +206,7 @@ graph TD
 
     subgraph "Frontend"
         Z --> |import| UBI["useBaseObjectInstances"]
-        Z --> |import| UCI["useCreateBaseObjectInstance"]
+        Z --> |import| UCI["useCreateBuiltinObjectInstance"]
         UBI --> |Filters base_object_class| HR
         UCI --> |object_class| HW
         UI[React UI] --> UBI


### PR DESCRIPTION
## Description

The only actual change I made is changing the name `useCreateBaseObjectInstance` to `useCreateBuiltinObjectInstance`, the rest is autoformatting.
