### PR TITLE
chore(weave): add query to calls_query_stats in `get_calls`

### DIFF
--- a/tests/trace/test_scored_calls_query.py
+++ b/tests/trace/test_scored_calls_query.py
@@ -126,6 +126,7 @@ async def perform_scorer_tests(
     calls_high_level = client.get_calls(scored_by=[s0_name])
     assert call_ids(calls_low_level) == expected_ids
     assert call_ids(calls_high_level) == expected_ids
+    assert len(calls_high_level) == len(calls_low_level)
 
     # 2. Query for calls that have been scored by s0:v0
     expected_ids = call_ids([call_scored_by_s0_v0, call_scored_by_s0_v0_and_s1_v0])
@@ -138,6 +139,7 @@ async def perform_scorer_tests(
     calls_high_level = client.get_calls(scored_by=[s0_v0_uri])
     assert call_ids(calls_low_level) == expected_ids
     assert call_ids(calls_high_level) == expected_ids
+    assert len(calls_high_level) == len(calls_low_level)
 
     # 3. Query for calls that have been scored by s0:v1
     expected_ids = call_ids([call_scored_by_s0_v1])
@@ -150,6 +152,7 @@ async def perform_scorer_tests(
     calls_high_level = client.get_calls(scored_by=[s0_v1_uri])
     assert call_ids(calls_low_level) == expected_ids
     assert call_ids(calls_high_level) == expected_ids
+    assert len(calls_high_level) == len(calls_low_level)
 
     # 4. Query for calls that have been scored by s1:*
     expected_ids = call_ids([call_scored_by_s1_v0, call_scored_by_s0_v0_and_s1_v0])
@@ -162,6 +165,7 @@ async def perform_scorer_tests(
     calls_high_level = client.get_calls(scored_by=[s1_name])
     assert call_ids(calls_low_level) == expected_ids
     assert call_ids(calls_high_level) == expected_ids
+    assert len(calls_high_level) == len(calls_low_level)
 
     # 5. Query for calls that have been scored by s1:v0
     expected_ids = call_ids([call_scored_by_s1_v0, call_scored_by_s0_v0_and_s1_v0])
@@ -174,6 +178,7 @@ async def perform_scorer_tests(
     calls_high_level = client.get_calls(scored_by=[s1_v0_uri])
     assert call_ids(calls_low_level) == expected_ids
     assert call_ids(calls_high_level) == expected_ids
+    assert len(calls_high_level) == len(calls_low_level)
 
 
 @pytest.mark.asyncio

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -292,7 +292,7 @@ def _make_calls_iterator(
 
     def size_func() -> int:
         response = server.calls_query_stats(
-            CallsQueryStatsReq(project_id=project_id, filter=filter)
+            CallsQueryStatsReq(project_id=project_id, filter=filter, query=query)
         )
         if limit_override is not None:
             offset = offset_override or 0

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -310,6 +310,40 @@ def _make_calls_iterator(
     )
 
 
+def _add_scored_by_to_calls_query(
+    scored_by: list[str] | str | None, query: Query | None
+) -> Query | None:
+    # This logic might be pushed down to the server soon, but for now it lives here:
+    if not scored_by:
+        return query
+
+    if isinstance(scored_by, str):
+        scored_by = [scored_by]
+    exprs = []
+    if query is not None:
+        exprs.append(query["$expr"])
+    for name in scored_by:
+        ref = maybe_parse_uri(name)
+        if ref and isinstance(ref, ObjectRef):
+            uri = name
+            scorer_name = ref.name
+            exprs.append(
+                {
+                    "$eq": (
+                        get_field_expr(
+                            runnable_feedback_runnable_ref_selector(scorer_name)
+                        ),
+                        literal_expr(uri),
+                    )
+                }
+            )
+        else:
+            exprs.append(
+                exists_expr(get_field_expr(runnable_feedback_output_selector(name)))
+            )
+    return Query.model_validate({"$expr": {"$and": exprs}})
+
+
 class OpNameError(ValueError):
     """Raised when an op name is invalid."""
 
@@ -881,35 +915,7 @@ class WeaveClient:
         if filter is None:
             filter = CallsFilter()
 
-        # This logic might be pushed down to the server soon, but for now it lives here:
-        if scored_by:
-            if isinstance(scored_by, str):
-                scored_by = [scored_by]
-            exprs = []
-            if query is not None:
-                exprs.append(query["$expr"])
-            for name in scored_by:
-                ref = maybe_parse_uri(name)
-                if ref and isinstance(ref, ObjectRef):
-                    uri = name
-                    scorer_name = ref.name
-                    exprs.append(
-                        {
-                            "$eq": (
-                                get_field_expr(
-                                    runnable_feedback_runnable_ref_selector(scorer_name)
-                                ),
-                                literal_expr(uri),
-                            )
-                        }
-                    )
-                else:
-                    exprs.append(
-                        exists_expr(
-                            get_field_expr(runnable_feedback_output_selector(name))
-                        )
-                    )
-            query = Query.model_validate({"$expr": {"$and": exprs}})
+        query = _add_scored_by_to_calls_query(scored_by, query)
 
         return _make_calls_iterator(
             self.server,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-23221](https://wandb.atlassian.net/browse/WB-23221)

The query parameter can limit results, it must be passed to the calls stats function to get the length as well as the main streaming endpoint. 

Also move the query construction code to where the other helper is, for clarity on main client endpoint. 

## Testing

add test


[WB-23221]: https://wandb.atlassian.net/browse/WB-23221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ