### PR TITLE
fix(app): prevent column from being removed when it is used in a filter

### DIFF
--- a/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
@@ -484,7 +484,11 @@ export const ColumnHeader: React.FC<{
           name: 'Remove all right',
           icon: 'next',
           onSelect: () => {
-            const newTableState = Table.removeColumnsToRight(tableState, colId, stack);
+            const newTableState = Table.removeColumnsToRight(
+              tableState,
+              colId,
+              stack
+            );
             recordEvent('REMOVE_COLUMNS_TO_RIGHT');
             updateTableState(newTableState);
           },
@@ -494,7 +498,11 @@ export const ColumnHeader: React.FC<{
           name: 'Remove all left',
           icon: 'previous',
           onSelect: () => {
-            const newTableState = Table.removeColumnsToLeft(tableState, colId, stack);
+            const newTableState = Table.removeColumnsToLeft(
+              tableState,
+              colId,
+              stack
+            );
             recordEvent('REMOVE_COLUMNS_TO_LEFT');
             updateTableState(newTableState);
           },

--- a/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx
@@ -484,7 +484,7 @@ export const ColumnHeader: React.FC<{
           name: 'Remove all right',
           icon: 'next',
           onSelect: () => {
-            const newTableState = Table.removeColumnsToRight(tableState, colId);
+            const newTableState = Table.removeColumnsToRight(tableState, colId, stack);
             recordEvent('REMOVE_COLUMNS_TO_RIGHT');
             updateTableState(newTableState);
           },
@@ -494,7 +494,7 @@ export const ColumnHeader: React.FC<{
           name: 'Remove all left',
           icon: 'previous',
           onSelect: () => {
-            const newTableState = Table.removeColumnsToLeft(tableState, colId);
+            const newTableState = Table.removeColumnsToLeft(tableState, colId, stack);
             recordEvent('REMOVE_COLUMNS_TO_LEFT');
             updateTableState(newTableState);
           },

--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -841,11 +841,7 @@ export function insertColumnLeft(
   });
 }
 
-export function removeColumn(
-  ts: TableState,
-  colId: string,
-  stack: Stack | undefined = undefined
-) {
+export function removeColumn(ts: TableState, colId: string, stack?: Stack) {
   if (ts.groupBy.includes(colId)) {
     // We don't allow removing the group by column. The UI
     // removeColumnsToLeft and removeColumnsToRight from

--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -903,7 +903,7 @@ export function removeColumnsToLeft(
   if (colIndex === -1) {
     throw new Error('invalid remove col id' + colId);
   }
-  for (let i = colIndex - 1; i > 0; i--) {
+  for (let i = colIndex - 1; i >= 0; i--) {
     ts = removeColumn(ts, ts.order[i], stack);
   }
   return ts;

--- a/weave-js/src/components/Panel2/PanelTable/tableState.ts
+++ b/weave-js/src/components/Panel2/PanelTable/tableState.ts
@@ -15,6 +15,7 @@ import {
   isList,
   isListLike,
   isSimpleTypeShape,
+  isVoidNode,
   listObjectType,
   maybe,
   Node,
@@ -57,6 +58,8 @@ import {
 } from '@wandb/weave/core';
 import {produce} from 'immer';
 import _ from 'lodash';
+
+import {defineColumnName} from './util';
 
 export type ColumnId = string;
 
@@ -838,7 +841,11 @@ export function insertColumnLeft(
   });
 }
 
-export function removeColumn(ts: TableState, colId: string) {
+export function removeColumn(
+  ts: TableState,
+  colId: string,
+  stack: Stack | undefined = undefined
+) {
   if (ts.groupBy.includes(colId)) {
     // We don't allow removing the group by column. The UI
     // removeColumnsToLeft and removeColumnsToRight from
@@ -846,6 +853,18 @@ export function removeColumn(ts: TableState, colId: string) {
     // state.
     return ts;
   }
+
+  if (stack) {
+    // If the column is used in the current filter, don't remove it.
+    const currentFilter = ts.preFilterFunction;
+    if (!isVoidNode(currentFilter)) {
+      const {usedStack} = dereferenceAllVars(currentFilter, stack);
+      if (usedStack.find(d => d.name === defineColumnName(ts, colId))) {
+        return ts;
+      }
+    }
+  }
+
   const colIndex = ts.order.indexOf(colId);
   if (colIndex === -1) {
     throw new Error('invalid remove col id' + colId);
@@ -860,24 +879,32 @@ export function removeColumn(ts: TableState, colId: string) {
   });
 }
 
-export function removeColumnsToRight(ts: TableState, colId: string) {
+export function removeColumnsToRight(
+  ts: TableState,
+  colId: string,
+  stack: Stack
+) {
   const colIndex = ts.order.indexOf(colId);
   if (colIndex === -1) {
     throw new Error('invalid remove col id' + colId);
   }
   for (let i = ts.order.length - 1; i > colIndex; i--) {
-    ts = removeColumn(ts, ts.order[i]);
+    ts = removeColumn(ts, ts.order[i], stack);
   }
   return ts;
 }
 
-export function removeColumnsToLeft(ts: TableState, colId: string) {
+export function removeColumnsToLeft(
+  ts: TableState,
+  colId: string,
+  stack: Stack
+) {
   const colIndex = ts.order.indexOf(colId);
   if (colIndex === -1) {
     throw new Error('invalid remove col id' + colId);
   }
   for (let i = colIndex - 1; i > 0; i--) {
-    ts = removeColumn(ts, ts.order[i]);
+    ts = removeColumn(ts, ts.order[i], stack);
   }
   return ts;
 }

--- a/weave-js/src/components/Panel2/PanelTable/util.ts
+++ b/weave-js/src/components/Panel2/PanelTable/util.ts
@@ -459,11 +459,17 @@ export const tableIsPanelVariable = (stack: Stack) => {
   return stack && stack.find(node => node.name === 'input') !== undefined;
 };
 
+export const defineColumnName = (
+  currentTableState: Table.TableState,
+  colId: string
+) => {
+  return currentTableState.columnNames[colId] || colId.replace(/-/g, '');
+};
+
 export const getColumnVariables = (currentTableState: Table.TableState) => {
   return Object.keys(currentTableState.columns).reduce(
     (acc: {[key: string]: NodeOrVoidNode}, colId) => {
-      const columnName =
-        currentTableState.columnNames[colId] || colId.replace(/-/g, '');
+      const columnName = defineColumnName(currentTableState, colId);
       acc[columnName] = currentTableState.columnSelectFunctions[colId];
       return acc;
     },


### PR DESCRIPTION
## Description

- Fixes [WB-23205](https://wandb.atlassian.net/browse/WB-23205)
- Disable the `Remove` button in column settings if the column is being used as a variable in the filter expression. Also prevent the column from being removed if the user selects `Remove all right` or `Remove all left` 
- We check if the column is used as a variable by dereferencing all variables in the filter expression and checking for existence in the used stack.

## Testing

Local FE

Remove button is disabled:

https://github.com/user-attachments/assets/bda50405-6050-404b-b414-06e29e1f6b97

Remove all right does not remove the column:

https://github.com/user-attachments/assets/7ddbcd96-a0e9-466f-be18-e21f415b380d

Remove all left does not remove the column:

https://github.com/user-attachments/assets/f6371a5f-44e6-4fe6-a3c1-21443a71e174

[WB-23205]: https://wandb.atlassian.net/browse/WB-23205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced table column management: Columns actively used in filters can no longer be removed. The removal option is now disabled and accompanied by an explanatory message, ensuring the table’s filtering remains intact.
  - Updated interactions for column removal improve robustness when modifying table layouts.

- **Refactor**
  - Consolidated column naming logic for consistency in display and streamlined future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->