### PR TITLE
feat(weave): sort datasets while editing

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
@@ -100,15 +100,6 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
     pageSize: 50,
   });
 
-  // Reset sort model and pagination if we enter edit mode with sorting applied.
-  useEffect(() => {
-    if (isEditing && sortModel.length > 0) {
-      setPaginationModel({page: 0, pageSize: 50});
-      setSortModel([]);
-      setSortBy([]);
-    }
-  }, [isEditing, sortModel]);
-
   const sharedRef = useContext(WeaveCHTableSourceRefContext);
 
   const history = useHistory();
@@ -269,16 +260,14 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
 
   const rows = useMemo(() => {
     if (fetchQueryLoaded) {
-      return loadedRows.map((row, i) => {
+      return loadedRows.map(row => {
         const digest = row.digest;
-        const absoluteIndex =
-          i + paginationModel.pageSize * paginationModel.page;
         const value = flattenObjectPreservingWeaveTypes(row.val);
-        const editedRow = editedRows.get(absoluteIndex);
+        const editedRow = editedRows.get(row.original_index);
         return {
           ___weave: {
-            id: `${digest}_${absoluteIndex}`,
-            index: absoluteIndex,
+            id: `${digest}_${row.original_index}`,
+            index: row.original_index,
             isNew: false,
             serverValue: value,
           },
@@ -287,7 +276,7 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
       });
     }
     return [];
-  }, [loadedRows, fetchQueryLoaded, editedRows, paginationModel]);
+  }, [loadedRows, fetchQueryLoaded, editedRows]);
 
   const combinedRows = useMemo(() => {
     if (
@@ -404,7 +393,7 @@ export const EditableDatasetView: FC<EditableDataTableViewProps> = ({
       flex: columnWidths[field as string] ? undefined : 1,
       minWidth: 100,
       editable: isEditing,
-      sortable: !isEditing,
+      sortable: true,
       filterable: false,
       renderCell: (params: GridRenderCellParams) => {
         if (!isEditing) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -297,6 +297,7 @@ export type TraceTableQueryRes = {
   rows: Array<{
     digest: string;
     val: any;
+    original_index?: number;
   }>;
 };
 


### PR DESCRIPTION
## Description

Make datasets sortable in edit mode and preserve row indices during sorting operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The dataset view now preserves its sorting order when switching to edit mode.
	- Sorting remains enabled during editing, enhancing data interaction.
	- Row handling has been streamlined for a more consistent and simplified display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->