### PR TITLE
fix(weave): start timestamp applied when actually starting

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1076,10 +1076,10 @@ class WeaveClient:
         current_wb_run_id = safe_current_wb_run_id()
         check_wandb_run_matches(current_wb_run_id, self.entity, self.project)
 
-        started_at = datetime.datetime.now(tz=datetime.timezone.utc)
         project_id = self._project_id()
 
         def send_start_call() -> None:
+            started_at = datetime.datetime.now(tz=datetime.timezone.utc)
             inputs_json = to_json(inputs_with_refs, project_id, self, use_dictify=False)
             self.server.call_start(
                 CallStartReq(


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

We moved the start call execution to a scheduled background process, but the starttime happens before we begin work on it, which leads to very weird timestamps in the UI, like: 

<img width="388" alt="Screenshot 2025-02-10 at 4 51 01 PM" src="https://github.com/user-attachments/assets/00349f65-8559-49d3-b8d4-0c542f8b7d4d" />

where every call looks like its taking longer than the previous, instead of all being around 5s. 

## Testing

Now: 
