### PR TITLE
fix(weave): run sync eval predict functions in parallel

### DIFF
--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 import pytest
 
@@ -286,3 +287,40 @@ def test_scorer_name_sanitization(scorer_name):
 
     result = asyncio.run(evaluation.evaluate(model))
     assert result["my-scorer"] == {"true_count": 1, "true_fraction": 0.5}
+
+
+def test_sync_eval_parallelism(client):
+    @weave.op()
+    def sync_op(a):
+        time.sleep(1)
+        return a
+
+    @weave.op()
+    def score(output):
+        return 1
+
+    dataset = [
+        {"a": 1},
+        {"a": 2},
+        {"a": 3},
+        {"a": 4},
+        {"a": 5},
+        {"a": 6},
+        {"a": 7},
+        {"a": 8},
+        {"a": 9},
+        {"a": 10},
+    ]
+
+    # 10 rows, should complete in <5 seconds. if sync, 10+
+
+    now = time.time()
+
+    evaluation = Evaluation(dataset=dataset, scorers=[score])
+    result = asyncio.run(evaluation.evaluate(sync_op))
+    assert result == {
+        "output": {"mean": 5.5},
+        "score": {"mean": 1.0},
+        "model_latency": {"mean": pytest.approx(1, abs=1)},
+    }
+    assert time.time() - now < 5

--- a/weave/trace/op_caller.py
+++ b/weave/trace/op_caller.py
@@ -44,7 +44,10 @@ def async_call_op(
     Returns:
         A coroutine that will execute the Op and return a tuple of (result, Call)
     """
-    call_res = func.call(*args, __should_raise=True, **kwargs)
-    if inspect.iscoroutine(call_res):
-        return call_res
-    return asyncio.to_thread(lambda: call_res)
+    is_async = inspect.iscoroutinefunction(func.resolve_fn)
+    if is_async:
+        return func.call(*args, __should_raise=True, **kwargs)
+    else:
+        return asyncio.to_thread(
+            lambda: func.call(*args, __should_raise=True, **kwargs)
+        )


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Once again allow sync functions to execute in parallel, respecting `WEAVE_PARALLELISM` in evaluations. 

Broken by [this](https://github.com/wandb/weave/pull/3325/files#diff-6d28dd17dfc8f677f389cf6cd48c8842b00294dc8f5c1f0f03ce835bf487ae9d) refactor

## Testing

Branch:
<img width="463" alt="Screenshot 2025-02-10 at 5 31 10 PM" src="https://github.com/user-attachments/assets/e86b9462-ca9d-4527-b96f-406e2be1a930" />

Master:
<img width="462" alt="Screenshot 2025-02-10 at 5 31 22 PM" src="https://github.com/user-attachments/assets/31f4bb2a-85a6-4dd8-a994-5370daa8c36f" />
