### PR TITLE
docs(weave): Full stop is a must 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Our goal is to bring rigor, best-practices, and composability to the inherently 
 
 ## Documentation
 
-Our documentation site can be found [here](https://wandb.me/weave)
+Our documentation site can be found [here](https://wandb.me/weave).
 
 ## Installation
 ```


### PR DESCRIPTION
There was a missing full stop in the README. MY minor OCD couldn't look past it. 