### PR TITLE
style(weave): fix tool call show more

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,75 @@
+language: en-US
+# CodeRabbit configuration
+reviews:
+  # High-level configuration
+  poem: true
+  review_status: false
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: true
+
+  # Language-specific instructions
+  path_instructions:
+    - path: "**/*.{js,jsx,ts,tsx}"
+      instructions: |
+        Focus on architectural and logical issues rather than style (assuming ESLint is in place).
+        Flag potential memory leaks and performance bottlenecks.
+        Check for proper error handling and async/await usage.
+        Avoid strict enforcement of try/catch blocks - accept Promise chains, early returns, and other clear error handling patterns. These are acceptable as long as they maintain clarity and predictability.
+        Ensure proper type usage in TypeScript files.
+        Look for security vulnerabilities in data handling.
+        Don't comment on formatting if prettier is configured.
+        Verify proper React hooks usage and component lifecycle.
+        Check for proper state management patterns.
+
+    - path: "**/*.py"
+      instructions: |
+        Focus on pythonic code patterns.
+        Check for proper exception handling.
+        Verify type hints usage where applicable.
+        Look for potential performance improvements.
+        Don't comment on formatting if black/isort is configured.
+        Check for proper dependency injection patterns.
+        Verify proper async handling if applicable.
+
+    - path: "**/*.go"
+      instructions: |
+        Focus on idiomatic Go patterns.
+        Check for proper error handling.
+        Look for concurrent programming issues.
+        Verify interface implementations.
+        Don't comment on formatting (assuming gofmt is used).
+        Check for proper resource cleanup.
+        Verify proper package organization.
+
+    - path: "**/*.{yaml,yml,json,tf}"
+      instructions: |
+        Check for security best practices.
+        Verify environment-specific configurations.
+        Look for hardcoded credentials or sensitive data.
+        Ensure proper resource limits and requests.
+        Verify proper versioning of dependencies.
+        Check for infrastructure best practices.
+
+    - path: "Dockerfile*"
+      instructions: |
+        Check for security best practices.
+        Verify proper base image usage.
+        Look for efficient layer caching.
+        Check for proper cleanup of temporary files.
+        Verify environment variables usage.
+
+    - path: "**/*.{md,mdx}"
+      instructions: |
+        Focus on technical accuracy.
+        Check for broken links.
+        Verify code examples are up-to-date.
+        Look for clarity and completeness.
+        Don't focus on grammar/spelling unless significant.
+
+# General settings
+chat:
+  auto_reply: true

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanel.tsx
@@ -93,7 +93,7 @@ export const MessagePanel = ({
           className={classNames('relative w-full overflow-visible', {
             'rounded-lg': !isNested,
             'border-t border-moon-250': isTool,
-            'bg-moon-100': isSystemPrompt || hasToolCalls,
+            'bg-moon-100': isSystemPrompt || isTool,
             'bg-cactus-300/[0.24]': isUser,
             'max-w-full': !isUser,
             'max-w-[768px]': isUser,
@@ -102,7 +102,9 @@ export const MessagePanel = ({
             'py-[16px]': hasContent,
             'pb-[4px] pt-[8px]': !isUser && !isTool && !isSystemPrompt,
           })}>
-          <div>
+          <div className={classNames({
+            'pb-[16px]': hasToolCalls && hasContent
+          })}>
             {isSystemPrompt && (
               <div className="flex justify-between px-[16px]">
                 <div className="text-sm text-moon-500">
@@ -123,8 +125,8 @@ export const MessagePanel = ({
               ref={contentRef}
               className={classNames('w-full overflow-y-hidden', {
                 'max-h-[400px]':
-                  !isShowingMore && !editorHeight && !hasToolCalls,
-                'max-h-full': isShowingMore || editorHeight || hasToolCalls,
+                  !isShowingMore && !editorHeight,
+                'max-h-full': isShowingMore || editorHeight,
               })}>
               {messageHeader}
               {isPlayground && editorHeight ? (
@@ -156,19 +158,12 @@ export const MessagePanel = ({
                       )}
                     </div>
                   )}
-                  {hasToolCalls && (
-                    <div
-                      className={classNames({
-                        'border-t border-moon-250 pt-8': hasContent,
-                      })}>
-                      <ToolCalls toolCalls={message.tool_calls!} />
-                    </div>
-                  )}
+                  
                 </>
               )}
             </div>
 
-            {isOverflowing && !hasToolCalls && !editorHeight && (
+            {isOverflowing && !editorHeight && (
               <ShowMoreButton
                 isUser={isUser}
                 isSystemPrompt={isSystemPrompt}
@@ -178,6 +173,14 @@ export const MessagePanel = ({
               />
             )}
           </div>
+          {hasToolCalls && (
+            <div
+              className={classNames({
+                'border-t border-moon-250 pt-8': hasContent,
+              })}>
+              <ToolCalls toolCalls={message.tool_calls!} />
+            </div>
+          )}
         </div>
       </div>
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanel.tsx
@@ -123,9 +123,8 @@ export const MessagePanel = ({
               ref={contentRef}
               className={classNames('w-full overflow-y-hidden', {
                 'max-h-[400px]':
-                  !isShowingMore && !editorHeight && !isNested && !hasToolCalls,
-                'max-h-full':
-                  isShowingMore || editorHeight || isNested || hasToolCalls,
+                  !isShowingMore && !editorHeight && !hasToolCalls,
+                'max-h-full': isShowingMore || editorHeight || hasToolCalls,
               })}>
               {messageHeader}
               {isPlayground && editorHeight ? (
@@ -173,6 +172,7 @@ export const MessagePanel = ({
               <ShowMoreButton
                 isUser={isUser}
                 isSystemPrompt={isSystemPrompt}
+                isNested={isNested}
                 isShowingMore={isShowingMore}
                 setIsShowingMore={setIsShowingMore}
               />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanel.tsx
@@ -102,9 +102,10 @@ export const MessagePanel = ({
             'py-[16px]': hasContent,
             'pb-[4px] pt-[8px]': !isUser && !isTool && !isSystemPrompt,
           })}>
-          <div className={classNames({
-            'pb-[16px]': hasToolCalls && hasContent
-          })}>
+          <div
+            className={classNames({
+              'pb-[16px]': hasToolCalls && hasContent,
+            })}>
             {isSystemPrompt && (
               <div className="flex justify-between px-[16px]">
                 <div className="text-sm text-moon-500">
@@ -124,8 +125,7 @@ export const MessagePanel = ({
             <div
               ref={contentRef}
               className={classNames('w-full overflow-y-hidden', {
-                'max-h-[400px]':
-                  !isShowingMore && !editorHeight,
+                'max-h-[400px]': !isShowingMore && !editorHeight,
                 'max-h-full': isShowingMore || editorHeight,
               })}>
               {messageHeader}
@@ -158,7 +158,6 @@ export const MessagePanel = ({
                       )}
                     </div>
                   )}
-                  
                 </>
               )}
             </div>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ShowMoreButton.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ShowMoreButton.tsx
@@ -5,6 +5,7 @@ import React, {Dispatch, SetStateAction} from 'react';
 type ShowMoreButtonProps = {
   isShowingMore: boolean;
   setIsShowingMore: Dispatch<SetStateAction<boolean>>;
+  isNested?: boolean;
   isUser?: boolean;
   isSystemPrompt?: boolean;
 };
@@ -12,6 +13,7 @@ type ShowMoreButtonProps = {
 export const ShowMoreButton = ({
   isShowingMore,
   setIsShowingMore,
+  isNested,
   isUser,
   isSystemPrompt,
 }: ShowMoreButtonProps) => {
@@ -23,7 +25,7 @@ export const ShowMoreButton = ({
           ${
             isUser
               ? 'from-[#f4fbe8]'
-              : isSystemPrompt
+              : isSystemPrompt || isNested
               ? 'from-[#f8f8f8]'
               : 'from-white'
           } 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ToolCalls.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ToolCalls.tsx
@@ -58,7 +58,7 @@ const OneToolCall = ({toolCall}: OneToolCallProps) => {
 
   const copyText = `${name}(${parsedArgs})`;
   return (
-    <div className="bg-moon-100 py-8">
+    <div className="bg-moon-100 py-8 rounded-lg">
       {/* The tool call header has a copy button */}
       <div className="pb-8">
         <div className="flex justify-between px-16">
@@ -111,7 +111,7 @@ type ToolCallsProps = {
 
 export const ToolCalls = ({toolCalls}: ToolCallsProps) => {
   return (
-    <div>
+    <div className="flex flex-col gap-8">
       {toolCalls.map(tc => (
         <OneToolCall key={tc.id} toolCall={tc} />
       ))}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ToolCalls.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ToolCalls.tsx
@@ -58,7 +58,7 @@ const OneToolCall = ({toolCall}: OneToolCallProps) => {
 
   const copyText = `${name}(${parsedArgs})`;
   return (
-    <div className="bg-moon-100 py-8 rounded-lg">
+    <div className="rounded-lg bg-moon-100 py-8">
       {/* The tool call header has a copy button */}
       <div className="pb-8">
         <div className="flex justify-between px-16">


### PR DESCRIPTION
## Description
color for show more was off as well as it just didnt work

before

https://github.com/user-attachments/assets/f57a9479-674b-4ffe-b366-9780dd379348

after

https://github.com/user-attachments/assets/c2814e6a-9920-4a4c-942f-fb87116f98c6

## Testing

How was this PR tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Refined the chat view’s content display logic for improved handling of extended messages.
  - Updated the "Show More" button behavior to appear in additional contexts, including when viewing nested messages, for a smoother user experience.
  - Enhanced visual styling of tool call components for better presentation, including updated layouts and styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->