### PR TITLE
fix(weave_query): Handle joinAll and groupBy scenario panel crashes

### DIFF
--- a/weave-js/src/components/Panel2/panellib/libcolors.ts
+++ b/weave-js/src/components/Panel2/panellib/libcolors.ts
@@ -2,6 +2,7 @@ import {
   constFunction,
   isAssignableTo,
   isListLike,
+  isOutputNode,
   isVoidNode,
   listObjectTypePassTags,
   Node,
@@ -36,6 +37,18 @@ export const useColorNode = (inputNode: Node): NodeOrVoidNode => {
     ) {
       return voidNode();
     }
+
+    // Don't add a runColor onto an input node from the op tag-joinObj
+    // because it comes from a joinAll + groupby operation.
+    // This causes a panel crash because it attempts to map a run color
+    // from a type that does not have the run tag.
+    //
+    // There is a difference in the output type of tag-joinObj on the client (this)
+    // and the query engine service.
+    if (isOutputNode(inputNode) && inputNode.fromOp.name === 'tag-joinObj') {
+      return voidNode();
+    }
+
     return opMapEach({
       obj: inputNode,
       mapFn: constFunction({row: withNamedTag('run', 'run', 'any')}, ({row}) =>

--- a/weave_query/weave_query/arrow/list_.py
+++ b/weave_query/weave_query/arrow/list_.py
@@ -1311,16 +1311,21 @@ class ArrowWeaveList(typing.Generic[ArrowWeaveListObjectTypeVar]):
     ):
         if index == None:
             return None
+
         indexes: pa.Array
+        
+        arr = self._arrow_data
+        length = len(arr)
+
         if isinstance(index, int):
+            if index >= length or index < -length:
+                return None
             indexes = [index]
         elif isinstance(index, ArrowWeaveList):
             indexes = index._arrow_data
         else:
             indexes = index
 
-        arr = self._arrow_data
-        length = len(arr)
         neg_cond = pc.less(indexes, 0)
         indexes_neg = pc.add(indexes, length)
         indexes = pc.choose(neg_cond, indexes, indexes_neg)


### PR DESCRIPTION
## Description

Fixes [WB-23251](https://wandb.atlassian.net/browse/WB-23251)

## Bug Description

When users join a table and then perform a groupby, they experience a panel crash and our query service backend produces a pyarrow MakeBuilder error.

There are two backend errors:
1. `"Error while dispatching: tag-run. This is most likely a client error"`
2. `'MakeBuilder: cannot construct builder for dictionaries with value type struct<id: string, name: string, summaryMetrics: string, summaryMetricsSubset: string, project: struct<id: string, name: string, entity: struct<id: string, name: string>>>`

This PR addresses both.

### tag-run error
The reason this error occurs is because the "Joined On" column which is a list of strings after the joinAll and groupby operation is used as an inputNode to `useRunColors.` The client expects the inputNode to have the type:
```
{
        "type": "tagged",
        "tag": {
            "type": "tagged",
            "tag": {
                "type": "tagged",
                "tag": {
                    "type": "typedDict",
                    "propertyTypes": {
                        "project": "project"
                    }
                },
                "value": {
                    "type": "typedDict",
                    "propertyTypes": {
                        "project": "project"
                    }
                }
            },
            "value": {
                "type": "typedDict",
                "propertyTypes": {
                    "run": "run"
                }
            }
        },
        "value": {
            "type": "union",
            "members": [
                "none",
                "string"
            ]
        }
    }
```

Which it does, but when the query engine service performs the ArrowWeaveList-joinAll op, it uses an untagged `join_key_col`, to allow for safe comparisons using `pa.compute.equal.` So the resulting type for the joined on column is an AWL<String>. This is the correct behavior on a table that's joined only because the "joined on" col will not have the option for a StringHistogram to be displayed.

When we perform a groupby, the "Joined On" column becomes an AWL<List<String>> which will render as a StringHistogram, which adds a colorNode on a column type that's not tagged with a run, resulting in the `tag-run` error.

**Solution**
This is solved by checking whether or not the colorNode is being added to an OutputNode that's `from_op.name === "tag-joinObj"` and returning a VoidNode if it is.

## MakeBuilder Error
This error happens because we try to access an out-of-bounds array element. When groupby is used, the `countValue` in [react.tsx::useEach](https://github.com/wandb/weave/blob/4ebd314b81ebe4dddd03fcbdf4deda3a85621bdd/weave-js/src/react.tsx#L1050-L1057) is undefined, so it'll default to whatever the user sets, or what our defined defaults are.

During the `ArrowWeaveList-__getitem__` operation:
1. We perform a series of pyarrow compute functions to handle negative indexes and out of bound indexes to get back an ArrowWeaveList
2. That AWL's data is a `pa.ListArray<StructArray>` with a null_count of 1 because of the out of bounds access
3. We then call `awl.to_pylist_tagged()[0]`which maps the `separate_awls` function to the AWL
4. `awl._map_columns()` enters a codepath to handle the AWL: 

    - https://github.com/wandb/weave/blob/4ebd314b81ebe4dddd03fcbdf4deda3a85621bdd/weave_query/weave_query/arrow/list_.py#L802
5. Calling `arr.flatten()` on a ListArray where the StructArray is null results in the MakeBuilder error.

**Solution**
Add some logic to `_index` that handles out of bound indexes by returning None early.

## Testing

Local dev

Before:

https://github.com/user-attachments/assets/98d33a65-e327-4ee5-aed5-e78be16394de

After:

https://github.com/user-attachments/assets/4dfa688e-5631-4632-8b91-921db82a33a0







[WB-23251]: https://wandb.atlassian.net/browse/WB-23251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved panel stability by refining color processing logic to avoid potential crashes related to input nodes.
  - Enhanced list indexing error handling to gracefully manage out-of-bound accesses and invalid indices without disrupting the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->