### PR TITLE
fix(weave_query): Use correct types to prevent col header panel crash

### DIFF
--- a/weave_query/tests/test_arrow.py
+++ b/weave_query/tests/test_arrow.py
@@ -1792,6 +1792,13 @@ def test_flatten_handles_tagged_lists():
         for i in expected
     ]
 
+def test_flatten_handles_union_return_type():
+    data = [None, [{"a": 1}, {"b": 2}, {"c": 3}]]
+    awl = arrow.to_arrow(data)
+    node = weave.save(awl)
+    flattened = node.flatten()
+    assert weave.use(flattened).object_type == awl.object_type
+
 
 def test_keys_ops():
     awl = arrow.to_arrow([{"a": 1}, {"a": 1, "b": 2, "c": 2}, {"c": 3}])

--- a/weave_query/weave_query/ops_arrow/list_ops.py
+++ b/weave_query/weave_query/ops_arrow/list_ops.py
@@ -922,6 +922,7 @@ def flatten(arr):
     #   - handle N levels instead of 1
 
     arrow_data = arr._arrow_data
+    arr_was_flattened = False
     if is_list_arrowweavelist(arr) or (
         is_taggedvalue_arrowweavelist(arr)
         and is_list_arrowweavelist(arr.tagged_value_value())
@@ -943,6 +944,7 @@ def flatten(arr):
 
         assert isinstance(values, pa.ListArray)
         flattened_values = values.flatten()
+        arr_was_flattened = True
 
         if tags is not None:
             list_parent_indices = pc.list_parent_indices(values)
@@ -955,7 +957,7 @@ def flatten(arr):
 
     return ArrowWeaveList(
         arrow_data,
-        flatten_return_object_type(arr.object_type),
+        flatten_return_object_type(arr.object_type) if arr_was_flattened else arr.object_type,
         arr._artifact,
     )
 


### PR DESCRIPTION
## Description

Fixes [WB-22999](https://wandb.atlassian.net/browse/WB-22999)

## Bug Description
When a user clicks on a table's column header where the column is a list of images, they experience a panel crash.

The root cause is a types mismatch between the pyarrow ListArray and the AWL's `object_type` because of different logic used to determine:
1. If the array should be flattened, **versus**
    https://github.com/wandb/weave/blob/3be274d46a0f4507fa1672dffb0b998c043c7d47/weave_query/weave_query/ops_arrow/list_ops.py#L924-L928

2. The return object_type of the AWL
    https://github.com/wandb/weave/blob/3be274d46a0f4507fa1672dffb0b998c043c7d47/weave_query/weave_query/ops_arrow/list_ops.py#L903-L912

**Solution**
This PR sets the object_type of the returned AWL based on if the array was flattened or not.

## Testing

How was this PR tested?

Local dev + added unit test

Before (my local dev can't load image artifacts for some reason):

https://github.com/user-attachments/assets/37a3f05e-d685-41e5-a49d-e857ac1ee00d

After:

https://github.com/user-attachments/assets/c35a4fa7-4d38-40a2-9bb5-d7b7b7564935



[WB-22999]: https://wandb.atlassian.net/browse/WB-22999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the list transformation functionality to accurately reflect when the data structure is modified. Users will experience more predictable results when processing collections with mixed content types.

- **Tests**
  - Added automated tests to ensure that the updated list processing consistently maintains the expected data type for collections containing optional or mixed values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->