### PR TITLE
fix(weave): call set() on user requested nested columns

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -22,7 +22,7 @@ from tests.trace.util import (
     FuzzyDateTimeMatcher,
     MaybeStringMatcher,
     client_is_sqlite,
-    get_clickhouse_loglines,
+    get_info_loglines,
 )
 from weave import Thread, ThreadPoolExecutor
 from weave.trace import weave_client
@@ -3293,9 +3293,9 @@ def test_calls_query_multiple_dupe_select_columns(client, capsys, caplog):
         for query in select_queries:
             assert query.count("output") == 1
     else:
-        select_query = get_clickhouse_loglines(
-            caplog, "clickhouse_stream_query", ["query"]
-        )[0]
+        select_query = get_info_loglines(caplog, "clickhouse_stream_query", ["query"])[
+            0
+        ]
         assert (
             select_query["query"].count("any(calls_merged.output_dump) AS output_dump")
             == 1

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3257,9 +3257,7 @@ def test_calls_len(client):
     assert len(client.get_calls()) == 2
 
 
-def test_calls_query_multiple_dupe_select_columns(
-    client, capsys
-):  # Change caplog to capsys
+def test_calls_query_multiple_dupe_select_columns(client, capsys):
     @weave.op
     def test():
         return {"a": {"b": {"c": {"d": 1}}}}

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3285,7 +3285,6 @@ def test_calls_query_multiple_dupe_select_columns(client, capsys, caplog):
 
     # now make sure we don't make duplicate selects
     if client_is_sqlite(client):
-        captured = capsys.readouterr()
         select_queries = [
             line
             for line in capsys.readouterr().out.split("\n")

--- a/tests/trace/util.py
+++ b/tests/trace/util.py
@@ -70,13 +70,21 @@ class DummyTestException(Exception):
     pass
 
 
-def get_clickhouse_loglines(
-    caplog, match_string: Optional[str] = None, getattrs: list[str] = []
+def get_info_loglines(
+    caplog, match_string: Optional[str] = None, getattrs: list[str] = ["msg"]
 ):
     """
     Get all log lines from caplog that match the given string.
 
     Match string is compared to the message, and getattrs is a list of attributes to get from the record.
+
+    Example:
+    ```python
+    logger.info("my query", query="SELECT * FROM my_table")
+    ```
+
+    >>> get_info_loglines(caplog, "my query", ["msg", "query"])
+    >>> [{"msg": "my query", "query": "SELECT * FROM my_table"}]
     """
     lines = []
     for record in caplog.records:

--- a/tests/trace/util.py
+++ b/tests/trace/util.py
@@ -67,3 +67,22 @@ class DatetimeMatcher:
 
 class DummyTestException(Exception):
     pass
+
+
+def get_clickhouse_loglines(
+    caplog, match_string: str | None = None, getattrs: list[str] = []
+):
+    """
+    Get all log lines from caplog that match the given string.
+
+    Match string is compared to the message, and getattrs is a list of attributes to get from the record.
+    """
+    lines = []
+    for record in caplog.records:
+        if match_string and record.msg != match_string:
+            continue
+        line = {}
+        for attr in getattrs:
+            line[attr] = getattr(record, attr)
+        lines.append(line)
+    return lines

--- a/tests/trace/util.py
+++ b/tests/trace/util.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from typing import Optional
 
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 
@@ -70,7 +71,7 @@ class DummyTestException(Exception):
 
 
 def get_clickhouse_loglines(
-    caplog, match_string: str | None = None, getattrs: list[str] = []
+    caplog, match_string: Optional[str] = None, getattrs: list[str] = []
 ):
     """
     Get all log lines from caplog that match the given string.

--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -698,12 +698,21 @@ def test_calls_query_multiple_select_columns() -> None:
     cq.add_field("inputs")
     cq.add_field("inputs")
     cq.add_field("inputs")
+    cq.add_field("outputs")
+    cq.add_field("outputs")
+    cq.add_field("outputs")
+    cq.add_field("outputs")
+    cq.add_field("outputs")
+    cq.add_field("outputs")
+    cq.add_field("outputs")
+    cq.add_field("outputs")
     assert_sql(
         cq,
         """
         SELECT
             calls_merged.id AS id,
-            any(calls_merged.inputs_dump) AS inputs_dump
+            any(calls_merged.inputs_dump) AS inputs_dump,
+            any(calls_merged.outputs_dump) AS outputs_dump
         FROM calls_merged
         WHERE calls_merged.project_id = {pb_0:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)

--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -711,7 +711,7 @@ def test_calls_query_multiple_select_columns() -> None:
         SELECT
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump,
-            any(calls_merged.outputs_dump) AS outputs_dump
+            any(calls_merged.output_dump) AS output_dump
         FROM calls_merged
         WHERE calls_merged.project_id = {pb_0:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)

--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -698,14 +698,13 @@ def test_calls_query_multiple_select_columns() -> None:
     cq.add_field("inputs")
     cq.add_field("inputs")
     cq.add_field("inputs")
-    cq.add_field("outputs")
-    cq.add_field("outputs")
-    cq.add_field("outputs")
-    cq.add_field("outputs")
-    cq.add_field("outputs")
-    cq.add_field("outputs")
-    cq.add_field("outputs")
-    cq.add_field("outputs")
+    cq.add_field("output")
+    cq.add_field("output")
+    cq.add_field("output")
+    cq.add_field("output")
+    cq.add_field("output")
+    cq.add_field("output")
+    cq.add_field("output")
     assert_sql(
         cq,
         """

--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -325,7 +325,10 @@ class CallsQuery(BaseModel):
     include_costs: bool = False
 
     def add_field(self, field: str) -> "CallsQuery":
-        self.select_fields.append(get_field_by_name(field))
+        name = get_field_by_name(field)
+        if name in self.select_fields:
+            return self
+        self.select_fields.append(name)
         return self
 
     def add_condition(self, operand: "tsi_query.Operand") -> "CallsQuery":

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -305,13 +305,13 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         )
         columns = all_call_select_columns
         if req.columns:
+            # TODO: add support for json extract fields
+            # Split out any nested column requests
+            columns = [col.split(".")[0] for col in columns]
             # Set columns to user-requested columns, w/ required columns
             # These are all formatted by the CallsQuery, which prevents injection
             # and other attack vectors.
             columns = list(set(required_call_columns + req.columns))
-            # TODO: add support for json extract fields
-            # Split out any nested column requests
-            columns = [col.split(".")[0] for col in columns]
 
         # sort the columns such that similar queries are grouped together
         columns = sorted(columns)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -307,11 +307,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         if req.columns:
             # TODO: add support for json extract fields
             # Split out any nested column requests
-            columns = [col.split(".")[0] for col in columns]
+            columns = [col.split(".")[0] for col in req.columns]
             # Set columns to user-requested columns, w/ required columns
             # These are all formatted by the CallsQuery, which prevents injection
             # and other attack vectors.
-            columns = list(set(required_call_columns + req.columns))
+            columns = list(set(required_call_columns + columns))
 
         # sort the columns such that similar queries are grouped together
         columns = sorted(columns)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -389,7 +389,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         select_columns = list(tsi.CallSchema.model_fields.keys())
         if req.columns:
             # TODO(gst): allow json fields to be selected
-            simple_columns = [x.split(".")[0] for x in req.columns]
+            simple_columns = list({x.split(".")[0] for x in req.columns})
             select_columns = [x for x in simple_columns if x in select_columns]
             # add required columns, preserving requested column order
             select_columns += [


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fixes very degenerate cases when requesting many nested columns. 

This pr: 
- Split fields before calling `set`
- Add check for dupes when adding in the CallsQuery 
- add `get_clickhouse_loglines` util function for tests

## Testing

- add unit test on calls query
- add end to end test

Prod:
```python
calls = client.get_calls(columns=["inputs", "inputs.message", "inputs.message.response"])

# in the server:
"""
SELECT
        calls_merged.id AS id,
        any(calls_merged.inputs_dump) AS inputs_dump,
        any(calls_merged.inputs_dump) AS inputs_dump,
        any(calls_merged.inputs_dump) AS inputs_dump,
        ...
FROM calls_merged
....
"""
```

Branch:
```python
calls = client.get_calls(columns=["inputs", "inputs.message", "inputs.message.response"])

# in the server:
"""
SELECT
        calls_merged.id AS id,
        any(calls_merged.inputs_dump) AS inputs_dump,
        ...
FROM calls_merged
....
"""
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the processing of query columns to ensure unique selections and prevent duplicates.
  - Enhanced the integrity of query construction by refining logic for adding fields to the selection list.
  - Improved the handling of column requests in the query methods.

- **Tests**
  - Added new tests to validate behavior when multiple fields are selected and to ensure that duplicate selections in SQL queries are avoided.
  - Introduced a utility function to facilitate log retrieval during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->