### PR TITLE
refactor(weave): Rename Presidio scorer

### DIFF
--- a/tests/scorers/test_presidio_scorer.py
+++ b/tests/scorers/test_presidio_scorer.py
@@ -1,20 +1,18 @@
 import pytest
 
-from weave.scorers import PresidioEntityRecognitionGuardrail
+from weave.scorers import PresidioScorer
 
 
 @pytest.fixture
-def presidio_entity_recognition_guardrail():
-    return PresidioEntityRecognitionGuardrail()
+def presidio_scorer():
+    return PresidioScorer()
 
 
 @pytest.mark.skip(
     reason="This test depends on the spacy model `en-core-web-lg` which takes a long time to download"
 )
-def test_presidio_entity_recognition_guardrail_score(
-    presidio_entity_recognition_guardrail,
-):
+def test_presidio_scorer_score(presidio_scorer):
     input_text = "John Doe is a software engineer at XYZ company and his email is john.doe@xyz.com."
-    result = presidio_entity_recognition_guardrail.score(input_text)
+    result = presidio_scorer.score(input_text)
     assert not result.passed
     assert "john.doe@xyz.com" in result.metadata["detected_entities"]["EMAIL_ADDRESS"]

--- a/weave/scorers/__init__.py
+++ b/weave/scorers/__init__.py
@@ -13,8 +13,8 @@ from weave.scorers.moderation_scorer import (
     WeaveBiasScorerV1,
     WeaveToxicityScorerV1,
 )
-from weave.scorers.presidio_entity_recognition_guardrail import (
-    PresidioEntityRecognitionGuardrail,
+from weave.scorers.presidio_scorer import (
+    PresidioScorer,
 )
 from weave.scorers.prompt_injection_guardrail import (
     PromptInjectionLLMGuardrail,
@@ -50,7 +50,7 @@ __all__ = [
     "MultiTaskBinaryClassificationF1",
     "OpenAIModerationScorer",
     "PromptInjectionLLMGuardrail",
-    "PresidioEntityRecognitionGuardrail",
+    "PresidioScorer",
     "PydanticScorer",
     "Scorer",
     "StringMatchScorer",

--- a/weave/scorers/presidio_scorer.py
+++ b/weave/scorers/presidio_scorer.py
@@ -28,7 +28,7 @@ def get_available_entities() -> list[str]:
     ]
 
 
-class PresidioEntityRecognitionGuardrail(weave.Scorer):
+class PresidioScorer(weave.Scorer):
     """
     The `PresidioEntityRecognitionGuardrail` class is a guardrail for entity recognition and anonymization
     by leveraging Presidio's AnalyzerEngine and AnonymizerEngine to perform these tasks.


### PR DESCRIPTION
Rename `PresidioEntityRecognitionGuardrail` to `PresidioScorer` both for simplicity and that we're not pigeon-holing our scorers to only "guardrails" - Guardrails is the api that any scorer can plug into.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the scoring component to improve clarity and maintain a consistent public interface.
- **Tests**
	- Updated associated testing routines to align with the new naming, ensuring accurate verification of scoring functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->