### PR TITLE
feat(app): use custom run names in query panel

### DIFF
--- a/weave-js/src/common/hooks/useRunName.ts
+++ b/weave-js/src/common/hooks/useRunName.ts
@@ -1,0 +1,31 @@
+import {usePanelContext} from '../../components/Panel2/PanelContext';
+import {
+  constNodeUnsafe,
+  constString,
+  isVoidNode,
+  Node,
+  opPick,
+  opRunId,
+  opRunName,
+} from '../../core';
+import {useNodeValue} from '../../react';
+
+export const useRunName = (runNode: Node | null) => {
+  const {frame} = usePanelContext();
+
+  const emptyObject = constNodeUnsafe({type: 'dict', objectType: 'any'}, {});
+
+  const customRunNamesNode = runNode != null ?  opPick({
+    obj: isVoidNode(frame.customRunNames)
+      ? emptyObject
+      : frame.customRunNames,
+    key: opRunId({run: runNode}),
+  }) : constString('');
+
+  const displayNameNode = runNode != null ? opRunName({run: runNode}) : constString('');
+
+  const { result: customRunName } = useNodeValue(customRunNamesNode);
+  const { result: displayName } = useNodeValue(displayNameNode);
+
+  return customRunName ?? displayName ?? '';
+};

--- a/weave-js/src/common/hooks/useRunName.ts
+++ b/weave-js/src/common/hooks/useRunName.ts
@@ -15,17 +15,21 @@ export const useRunName = (runNode: Node | null) => {
 
   const emptyObject = constNodeUnsafe({type: 'dict', objectType: 'any'}, {});
 
-  const customRunNamesNode = runNode != null ?  opPick({
-    obj: isVoidNode(frame.customRunNames)
-      ? emptyObject
-      : frame.customRunNames,
-    key: opRunId({run: runNode}),
-  }) : constString('');
+  const customRunNamesNode =
+    runNode != null
+      ? opPick({
+          obj: isVoidNode(frame.customRunNames)
+            ? emptyObject
+            : frame.customRunNames,
+          key: opRunId({run: runNode}),
+        })
+      : constString('');
 
-  const displayNameNode = runNode != null ? opRunName({run: runNode}) : constString('');
+  const displayNameNode =
+    runNode != null ? opRunName({run: runNode}) : constString('');
 
-  const { result: customRunName } = useNodeValue(customRunNamesNode);
-  const { result: displayName } = useNodeValue(displayNameNode);
+  const customRunNameValue = useNodeValue(customRunNamesNode);
+  const displayNameValue = useNodeValue(displayNameNode);
 
-  return customRunName ?? displayName ?? '';
+  return customRunNameValue.result ?? displayNameValue.result ?? '';
 };

--- a/weave-js/src/common/hooks/useRunName.ts
+++ b/weave-js/src/common/hooks/useRunName.ts
@@ -16,7 +16,7 @@ export const useRunName = (runNode: Node | null) => {
   const emptyObject = constNodeUnsafe({type: 'dict', objectType: 'any'}, {});
 
   const customRunNamesNode =
-    runNode != null
+    runNode != null && frame.customRunNames != null
       ? opPick({
           obj: isVoidNode(frame.customRunNames)
             ? emptyObject

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1,6 +1,7 @@
 import 'react-base-table/lib/TableRow';
 
 import {MOON_500} from '@wandb/weave/common/css/color.styles';
+import {useRunName} from '@wandb/weave/common/hooks/useRunName';
 import {saveTableAsCSV} from '@wandb/weave/common/util/csv';
 import {
   callOpVeryUnsafe,
@@ -27,12 +28,8 @@ import {
   opMap,
   opPick,
   opRunId,
-  opRunName,
   Stack,
-  taggedValue,
   Type,
-  typedDict,
-  union,
   varNode,
   voidNode,
   WeaveInterface,
@@ -1227,17 +1224,9 @@ const IndexCell: React.FC<{
           }),
         })
       : constString('inherit');
-  const runNameNode =
-    props.runNode != null
-      ? opRunName({
-          run: weave.callFunction(props.runNode, {
-            row: props.rowNode as any,
-          }),
-        })
-      : constString('');
 
   const colorNodeValue = LLReact.useNodeValue(colorNode);
-  const runNameNodeValue = LLReact.useNodeValue(runNameNode);
+  const runNameNodeValue = useRunName(props.runNode);
   const index = LLReact.useNodeValue(
     opGetIndexCheckpointTag({obj: props.rowNode})
   );

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -29,7 +29,10 @@ import {
   opPick,
   opRunId,
   Stack,
+  taggedValue,
   Type,
+  typedDict,
+  union,
   varNode,
   voidNode,
   WeaveInterface,
@@ -1226,7 +1229,16 @@ const IndexCell: React.FC<{
       : constString('inherit');
 
   const colorNodeValue = LLReact.useNodeValue(colorNode);
-  const runNameNodeValue = useRunName(props.runNode);
+
+  const runNode =
+    props.runNode !== null
+      ? weave.callFunction(props.runNode, {
+          row: props.rowNode as any,
+        })
+      : null;
+
+  const runName = useRunName(runNode);
+
   const index = LLReact.useNodeValue(
     opGetIndexCheckpointTag({obj: props.rowNode})
   );
@@ -1235,7 +1247,6 @@ const IndexCell: React.FC<{
   } else {
     const isSelected =
       index.result != null && index.result === props.activeRowIndex;
-    const runName = runNameNodeValue.result ?? '';
     const basicIndexContent = (
       <span>{index.result + (useOneBasedIndex ? 1 : 0)}</span>
     );


### PR DESCRIPTION
## Description

- Implements [WB-23176](https://wandb.atlassian.net/browse/WB-23176)
- Use `customRunNames` in query panel tables and plots, if it is available in the frame, and fallback to `runName` otherwise

## Testing

Local FE

Table:

https://github.com/user-attachments/assets/b01314a4-9f78-4680-894e-cdb1cae1bdb1

Plots:

https://github.com/user-attachments/assets/c8771131-9edc-44da-9011-f761d9b54bde


[WB-23176]: https://wandb.atlassian.net/browse/WB-23176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new hook, `useRunName`, for fetching run names directly from run nodes, enhancing the consistency of run name retrieval.
	- Enhanced the `useVegaReadyTables` function to better handle custom run names and improve flexibility in determining run nodes.

- **Refactor**
	- Simplified the logic in the `PanelTable` component by removing the previous method of obtaining run names, improving clarity and potentially enhancing performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->