### PR TITLE
fix(weave): smallref produces correct link for op versions in tables

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValue.tsx
@@ -1,7 +1,7 @@
 import {Box} from '@mui/material';
 import React from 'react';
 
-import {parseRef} from '../../../../react';
+import {parseRef, parseWeaveRef} from '../../../../react';
 import {isArtifactRef, isWeaveRef} from '../Browse3/filters/common';
 import {ValueViewNumber} from '../Browse3/pages/CallPage/ValueViewNumber';
 import {
@@ -27,7 +27,13 @@ export const CellValue = ({value}: CellValueProps) => {
   if (value === null) {
     return <ValueViewPrimitive>null</ValueViewPrimitive>;
   }
-  if (isWeaveRef(value) || isArtifactRef(value)) {
+  if (isWeaveRef(value)) {
+    const parsed = parseWeaveRef(value);
+    if (parsed.weaveKind === 'op') {
+      return <SmallRef objRef={parsed} wfTable="OpVersion" />;
+    }
+    return <SmallRef objRef={parsed} />;
+  } else if (isArtifactRef(value)) {
     return <SmallRef objRef={parseRef(value)} />;
   }
   if (typeof value === 'boolean') {

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -550,6 +550,21 @@ const RE_WEAVE_CALL_REF_PATHNAME = new RegExp(
     '$', // End of the string
   ].join('')
 );
+const RE_WEAVE_OP_VERSION_REF_PATHNAME = new RegExp(
+  [
+    '^', // Start of the string
+    PATTERN_ENTITY,
+    '/',
+    PATTERN_PROJECT,
+    '/op/',
+    '([a-zA-Z0-9-_/. ]{1,128})', // Op name
+    ':',
+    '([*]|[a-zA-Z0-9]+)', // Op version, allowing '*' for any version
+    '/?', // Ref extra portion is optional
+    PATTERN_REF_EXTRA, // Optional ref extra
+    '$', // End of the string
+  ].join('')
+);
 
 export const parseRefMaybe = (s: string): ObjectRef | null => {
   try {
@@ -611,7 +626,7 @@ export const parseRef = (ref: string): ObjectRef => {
   throw new Error(`Unknown protocol: ${url.protocol}`);
 };
 
-const parseWeaveRef = (ref: string): WeaveObjectRef => {
+export const parseWeaveRef = (ref: string): WeaveObjectRef => {
   const trimmed = ref.slice(WEAVE_REF_PREFIX.length);
   const tableMatch = trimmed.match(RE_WEAVE_TABLE_REF_PATHNAME);
   if (tableMatch !== null) {
@@ -636,6 +651,20 @@ const parseWeaveRef = (ref: string): WeaveObjectRef => {
       weaveKind: 'call' as WeaveKind,
       artifactName: callId,
       artifactVersion: '',
+      artifactRefExtra: '',
+    };
+  }
+  const opVersionMatch = trimmed.match(RE_WEAVE_OP_VERSION_REF_PATHNAME);
+  if (opVersionMatch !== null) {
+    const [entityName, projectName, opName, opVersion] =
+      opVersionMatch.slice(1);
+    return {
+      scheme: 'weave',
+      entityName,
+      projectName,
+      weaveKind: 'op' as WeaveKind,
+      artifactName: opName,
+      artifactVersion: opVersion,
       artifactRefExtra: '',
     };
   }


### PR DESCRIPTION
## Description

`SmallRef` does not produce correct links when given references to `OpVersions`, unless the prop `wfTable='OpVersion` is passed.

This PR modifies the `parseWeaveRef` helper in `react.tsx` to set `op` as weavekind for appropriate refs, and modifies `CellValue` to always set `wfTable='OpVersion'` when `op` is the `weaveKind`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced support for operation version references, ensuring accurate display of related details.
  
- **Refactor**
  - Updated reference handling exposes a more nuanced prioritization and rendering of distinct reference types, leading to improved interface display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->