### PR TITLE
docs(weave): disable italics in code blocks

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -137,3 +137,10 @@ h6 { font-size: 1rem !important; }
     white-space: nowrap;
   }
 }
+
+/* Prevent keyword italicization in dark mode code blocks */
+[data-theme='dark'] .token.keyword,
+[data-theme='dark'] .token.operator,
+[data-theme='dark'] .token.builtin {
+  font-style: normal !important;
+}


### PR DESCRIPTION
## Description

Prevent italics in code blocks in the weave docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Enhanced dark mode appearance by updating the styling of code blocks to display text in a consistent, non-italic format for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->