### PR TITLE
fix(weave_query): Handle escaped dots in run-history

### DIFF
--- a/weave_query/weave_query/compile.py
+++ b/weave_query/weave_query/compile.py
@@ -30,6 +30,7 @@ from weave_query import (
 )
 from weave_query.language_features.tagging import tagged_value_type_helpers
 from weave_query.op_def import OpDef
+from weave_query._dict_utils import unescape_dots
 
 # These call_* functions must match the actual op implementations.
 # But we don't want to import the op definitions themselves here, since
@@ -464,7 +465,7 @@ def compile_apply_column_pushdown(
                 )
             if "run-history" in node.from_op.name:
                 history_cols = list(run_cols.keys())
-
+                history_cols = [unescape_dots(hc) for hc in history_cols]
                 if len(history_cols) > 0:
                     return graph.OutputNode(
                         node.type,

--- a/weave_query/weave_query/graph.py
+++ b/weave_query/weave_query/graph.py
@@ -4,7 +4,7 @@ import typing
 
 from weave_query import weave_types
 from weave_query import uris, errors, storage
-from weave_query._dict_utils import unescape_dots
+
 if typing.TYPE_CHECKING:
     from weave_query import weave_inspector
 
@@ -193,10 +193,7 @@ class ConstNode(Node):
         if isinstance(val, dict) and "nodeType" in val:
             val = Node.node_from_json(val)
         else:
-            _val = obj["val"]
-            if isinstance(_val, str):
-                _val = unescape_dots(_val)
-            val = storage.from_python({"_type": obj["type"], "_val": _val})  # type: ignore
+            val = storage.from_python({"_type": obj["type"], "_val": obj["val"]})  # type: ignore
         t = weave_types.TypeRegistry.type_from_dict(obj["type"])
         if isinstance(t, weave_types.Function):
             cls = dispatch.RuntimeConstNode

--- a/weave_query/weave_query/ops_primitives/_dict_utils.py
+++ b/weave_query/weave_query/ops_primitives/_dict_utils.py
@@ -22,12 +22,7 @@ def tag_aware_dict_val_for_escaped_key(
 ) -> typing.Any:
     if key == None:
         return None
-
-    obj_at_full_path = _any_val_for_path(obj, [unescape_dots(key)])
-    if box.is_none(obj_at_full_path):
-        return _any_val_for_path(obj, split_escaped_string(key))
-    else:
-        return obj_at_full_path
+    return _any_val_for_path(obj, split_escaped_string(key))
 
 
 class MergeInputTypes(typing.TypedDict):


### PR DESCRIPTION
## Description

Fixes [WB-23402](https://wandb.atlassian.net/browse/WB-23402)

A few weeks ago there was a bug with `run.history` not returning dictionary values correctly because nested keys were flattened. We shipped [a fix](https://github.com/wandb/weave/pull/3536) that unescaped dots in the keys from pick operations to resolve the bug.

This PR fixes a regression with pick keys that have dots. They were being unescaped and since we overload the dot to provide key path and for use as a character, this led to X/Y selectors in panel plots like "row["mAP-val-0\.5:0\.95"]" not working correctly.

Now we unescape dots during compilation specifically for `run-history` ops.


## Testing
Tested through local dev

Pic of plot working again with selected X/Y dim:
![image](https://github.com/user-attachments/assets/907c996b-0e7e-4987-a3bb-db4cc54c1009)

Pic of history working with nested dict:
![image](https://github.com/user-attachments/assets/940d7446-5e8c-4a66-8c21-a4644e900dbc)


Pic of history pick working with nested dict:
![image](https://github.com/user-attachments/assets/2db0259c-2e60-4538-a33c-a2aad4202c61)




[WB-23402]: https://wandb.atlassian.net/browse/WB-23402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected data formatting issues to ensure outputs present fully accurate column labels and values, enhancing reliability and consistency in reporting.
  - Ensured that downstream data displays now faithfully reflect the intended formatting.

- **Refactor**
  - Streamlined internal data processing routines to reduce complexity and boost performance during data transformation and retrieval.
  - Refined processes improve overall data handling efficiency for a smoother user experience.
  - Modified handling of column names to ensure proper processing of special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->