### PR TITLE
chore(ui): add dataset export to use tab

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/Tabs/TabUseDataset.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/Tabs/TabUseDataset.tsx
@@ -29,7 +29,10 @@ export const TabUseDataset = ({
   const isParentObject = !ref.artifactRefExtra;
   const isRow = ref.artifactRefExtra?.startsWith(ROW_PATH_PREFIX) ?? false;
   const label = isParentObject ? 'dataset version' : isRow ? 'row' : 'object';
-  let pythonName = isValidVarName(name) ? name : 'dataset';
+  const versionName = `${name}_v${versionIndex}`;
+  let pythonName = isValidVarName(versionName)
+    ? versionName
+    : `dataset_v${versionIndex}`;
   if (isRow) {
     pythonName += '_row';
   }
@@ -37,9 +40,13 @@ export const TabUseDataset = ({
   // TODO: Row references are not yet supported, you get:
   //       ValueError: '/' not currently supported in short-form URI
   let long = '';
+  let download = '';
+  let downloadCopyText = '';
   if (!isRow && 'projectName' in ref) {
-    long = `weave.init('${ref.projectName}')
+    long = `weave.init('${ref.entityName}/${ref.projectName}')
 ${pythonName} = weave.ref('${ref.artifactName}:v${versionIndex}').get()`;
+    download = `${pythonName}.to_pandas().to_csv("${versionName}.csv", index=False)`;
+    downloadCopyText = long + '\n' + download;
   }
 
   return (
@@ -71,6 +78,17 @@ ${pythonName} = weave.ref('${ref.artifactName}:v${versionIndex}').get()`;
             <div className="mt-8">or</div>
             <CopyableText language="python" text={long} />
           </>
+        )}
+        {download && (
+          <Box mt={2}>
+            For further analysis or export you can convert this {label} to a
+            Pandas DataFrame, for example:
+            <CopyableText
+              language="python"
+              text={download}
+              copyText={downloadCopyText}
+            />
+          </Box>
         )}
       </Box>
     </Box>


### PR DESCRIPTION
## Description

Enhance the "Use" tab for datasets.
* Include the entity in the `weave.init` call - this avoids errors if you are viewing a dataset outside your default entity.
* Include the version number in the generated variable name
* Include an example of exporting to CSV via intermediate Pandas.

Before:
<img width="792" alt="Screenshot 2025-02-19 at 10 46 53 PM" src="https://github.com/user-attachments/assets/17eed404-3b51-4734-ad96-017c1f96abfe" />

After:
<img width="1000" alt="Screenshot 2025-02-19 at 10 47 14 PM" src="https://github.com/user-attachments/assets/9f090878-ccef-452f-8fb8-063a3e4fef34" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Datasets now display versioned names for enhanced identification.
	- A new section in the interface provides a copyable command to export datasets as CSV files using Pandas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->