### PR TITLE
chore(weave): Unblock scorers CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ scorers = [
   "scikit-learn>=1.5.2",
   "transformers>=4.48.2",
   "torch>=2.4.1",
+  "sentencepiece>=0.2.0",
   "presidio-analyzer>=2.2.0",
   "presidio-anonymizer>=2.2.0",
 ]


### PR DESCRIPTION
Fix scorers CI, missing dep.

Note: This appeared because I changed some of the underlying model checkpoints to use legacy tokenizer.