### PR TITLE
chore(weave): show nested scorer output

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -435,14 +435,15 @@ function buildCallsTableColumns(
         // Add to scorer's group
         scorerGroup?.children.push({field});
         // remove the leading dot from the score path
-        const headerName = (parsed?.scorePath || colName).replace(/^\./, '');
+        const scorePath = (parsed?.scorePath || colName).replace(/^\./, '');
+        const headerName = `${scorerName}.${scorePath}`;
 
         scoreColumns.push({
           field,
           headerName,
           width: 150,
           renderHeader: () => {
-            return <div>{headerName}</div>;
+            return <div>{scorePath}</div>;
           },
           valueGetter: (unused: any, row: any) => {
             return row[colName];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -431,19 +431,34 @@ function buildCallsTableColumns(
       colNames.forEach(colName => {
         const parsed = parseScorerFeedbackField(colName);
         const field = convertScorerFeedbackFieldToBackendFilter(colName);
-
+        if (parsed === null) {
+          scoreColumns.push({
+            field,
+            headerName: colName,
+            width: 150,
+            renderHeader: () => {
+              return <div> {colName}</div>;
+            },
+            valueGetter: (unused: any, row: any) => {
+              return row[colName];
+            },
+            renderCell: (params: GridRenderCellParams<TraceCallSchema>) => {
+              return <CellValue value={params.value} />;
+            },
+          });
+          return;
+        }
         // Add to scorer's group
         scorerGroup?.children.push({field});
-        // remove the leading dot from the score path
-        const scorePath = (parsed?.scorePath || colName).replace(/^\./, '');
-        const headerName = `${scorerName}.${scorePath}`;
+
+        const scorePayloadPath = parsed.scorePath.replace(/^\./, '');
 
         scoreColumns.push({
           field,
-          headerName,
+          headerName: 'Scores.' + parsed.scorerName + parsed.scorePath,
           width: 150,
           renderHeader: () => {
-            return <div>{scorePath}</div>;
+            return <div>{scorePayloadPath}</div>;
           },
           valueGetter: (unused: any, row: any) => {
             return row[colName];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -398,7 +398,6 @@ function buildCallsTableColumns(
   if (scoreColNames.length > 0) {
     // Group scores by scorer name
     const scorerGroups = new Map<string, string[]>();
-
     scoreColNames.forEach(colName => {
       const parsed = parseScorerFeedbackField(colName);
       if (parsed) {
@@ -410,7 +409,7 @@ function buildCallsTableColumns(
       }
     });
 
-    // Create scorer groups in the grouping model
+    // Create scorer groups in the grouping model for each scorer
     const scoreGroup = {
       groupId: 'scores',
       headerName: 'Scores',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -484,7 +484,7 @@ function buildCallsTableColumns(
 
           scoreColumns.push({
             field,
-            headerName: leafName,
+            headerName: `Scores.${parsed.scorerName}${parsed.scorePath}`,
             width: 150,
             renderHeader: () => {
               return <div>{leafName}</div>;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -255,7 +255,9 @@ const getFeedbackMerged = (calls: CallSchema[]) => {
           feedback[key].payload.output = JSON.parse(
             feedback[key].payload.output
           );
-        } catch (e) {}
+        } catch (e) {
+          // pass
+        }
       }
     });
     c.traceCall = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -248,18 +248,6 @@ const getFeedbackMerged = (calls: CallSchema[]) => {
       },
       {}
     );
-    // for any scorer feedback, parse the payload as json
-    Object.keys(feedback).forEach(key => {
-      if (key.startsWith('wandb.runnable.')) {
-        try {
-          feedback[key].payload.output = JSON.parse(
-            feedback[key].payload.output
-          );
-        } catch (e) {
-          // pass
-        }
-      }
-    });
     c.traceCall = {
       ...c.traceCall,
       summary: {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -248,6 +248,16 @@ const getFeedbackMerged = (calls: CallSchema[]) => {
       },
       {}
     );
+    // for any scorer feedback, parse the payload as json
+    Object.keys(feedback).forEach(key => {
+      if (key.startsWith('wandb.runnable.')) {
+        try {
+          feedback[key].payload.output = JSON.parse(
+            feedback[key].payload.output
+          );
+        } catch (e) {}
+      }
+    });
     c.traceCall = {
       ...c.traceCall,
       summary: {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Hack to group and display runnable scorers nicely in the trace table

## Testing

Prod:
<img width="1242" alt="Screenshot 2025-02-20 at 10 04 50 AM" src="https://github.com/user-attachments/assets/c1354fc2-04d6-4f47-be1b-9f6f2507d8ed" />


Branch:
<img width="1286" alt="Screenshot 2025-02-20 at 10 50 51 AM" src="https://github.com/user-attachments/assets/999e1065-bf50-4537-afaf-69d2a33cf40c" />
<img width="442" alt="Screenshot 2025-02-20 at 10 52 13 AM" src="https://github.com/user-attachments/assets/97786b6d-fd4e-4775-8af8-5af1e23a4042" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced the calls table by grouping score columns under their respective scorer names for improved clarity and organization.
  - Added filter functionality directly within the score column rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->