### PR TITLE
feat(ui): Add delayBeforeShow and instant appearance to WaveLoader via CSSTransition

### DIFF
--- a/weave-js/src/common/components/WandbLoader.tsx
+++ b/weave-js/src/common/components/WandbLoader.tsx
@@ -113,8 +113,10 @@ export const TrackedWaveLoader = ({
   onComplete,
   onStart,
   size,
+  delayBeforeShow = 0,
 }: TrackedWandbLoaderProps & {
   size: 'small' | 'huge';
+  delayBeforeShow?: number;
 }) => {
   useLifecycleProfiling(
     name,
@@ -141,5 +143,5 @@ export const TrackedWaveLoader = ({
     onStart
   );
 
-  return <WaveLoader size={size} />;
+  return <WaveLoader size={size} delayBeforeShow={delayBeforeShow} />;
 };

--- a/weave-js/src/common/util/hooks.ts
+++ b/weave-js/src/common/util/hooks.ts
@@ -271,3 +271,14 @@ export function useIsMounted() {
   }, []);
   return useCallback(() => isMountedRef.current, []);
 }
+
+export function useTimeout(ms: number) {
+  const [isReady, setIsReady] = useState(false);
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setIsReady(true);
+    }, ms);
+    return () => clearTimeout(timeout);
+  }, [ms]);
+  return isReady;
+}

--- a/weave-js/src/components/Loaders/WaveLoader.tsx
+++ b/weave-js/src/components/Loaders/WaveLoader.tsx
@@ -22,15 +22,34 @@ const Dot = React.memo(
   }
 );
 
-export const WaveLoader = ({size}: {size: 'small' | 'huge'}) => {
+export const WaveLoader = ({
+  size,
+  delayBeforeShow,
+}: {
+  size: 'small' | 'huge';
+  delayBeforeShow?: number;
+}) => {
+  const [okToShow, setOkToShow] = React.useState(false);
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      setOkToShow(true);
+    }, delayBeforeShow);
+    return () => clearTimeout(timer);
+  }, [delayBeforeShow]);
+
   return (
     <TailwindContents>
       <div
         className="flex items-center gap-x-4"
         data-test={`wave-loader-${size}`}>
-        <Dot size={size} />
-        <Dot delay=".3s" size={size} />
-        <Dot delay=".6s" size={size} />
+        {okToShow && (
+          <>
+            <Dot size={size} />
+            <Dot delay=".3s" size={size} />
+            <Dot delay=".6s" size={size} />
+          </>
+        )}
       </div>
     </TailwindContents>
   );

--- a/weave-js/src/components/Loaders/WaveLoader.tsx
+++ b/weave-js/src/components/Loaders/WaveLoader.tsx
@@ -1,7 +1,7 @@
+import {useTimeout} from '@wandb/weave/common/util/hooks';
 import {TailwindContents} from '@wandb/weave/components/Tailwind';
 import classNames from 'classnames';
 import React, {useMemo} from 'react';
-import {CSSTransition} from 'react-transition-group';
 
 const Dot = React.memo(
   ({delay, size}: {delay?: string; size: 'small' | 'huge'}) => {
@@ -38,61 +38,19 @@ export const WaveLoader = ({
   size: 'small' | 'huge';
   delayBeforeShow?: number;
 }) => {
+  const isReady = useTimeout(delayBeforeShow ?? 0);
   return (
     <TailwindContents>
-      {/**
-        CSSTransition from react-transition-group controls how the child element 
-        (the <div> with dots) appears and disappears.
-
-        - in={true}
-          Forces the transition to run in "appear" or "enter" states immediately 
-          on mount (since it's already "in").
-        
-        - appear
-          Enables a special "appear" phase on the initial mount, as opposed to 
-          jumping straight to the "entered" state.
-
-        - mountOnEnter
-          Does not mount the child DOM node until the transition is ready to 
-          start (i.e., the "appear" or "enter" phase).
-
-        - timeout={delayBeforeShow ?? 0}
-          Defines how long the "appear" phase lasts, in milliseconds. If 
-          delayBeforeShow is undefined, it defaults to 0 (no wait). 
-          After this timeout, the component transitions from the appear classes 
-          to the enter classes.
-
-        - classNames: An object mapping transition states to class names:
-            * appear/appearActive
-              Applied during the "appear" phase. Here we use 'opacity-0' to keep 
-              the component completely invisible for the entire duration of appear.
-            
-            * enter/enterActive
-              Applied when we leave the "appear" phase and fully enter the component. 
-              In this case, 'opacity-100' is used, so it instantly becomes fully visible.
-            
-          Because there are no actual "transition-opacity" or "duration-..." 
-          classes, the element will flip from invisible to visible with no fade.
-      */}
-      <CSSTransition
-        in={true}
-        appear
-        mountOnEnter
-        timeout={delayBeforeShow ?? 0}
-        classNames={{
-          appear: 'opacity-0',
-          appearActive: 'opacity-0',
-          enter: 'opacity-100',
-          enterActive: 'opacity-100',
-        }}>
-        <div
-          className="flex items-center gap-x-4 "
-          data-test={`wave-loader-${size}`}>
-          <Dot size={size} />
-          <Dot delay=".3s" size={size} />
-          <Dot delay=".6s" size={size} />
-        </div>
-      </CSSTransition>
+      <div
+        className={classNames(
+          'flex items-center gap-x-4',
+          isReady ? 'opacity-100' : 'opacity-0'
+        )}
+        data-test={`wave-loader-${size}`}>
+        <Dot size={size} />
+        <Dot delay=".3s" size={size} />
+        <Dot delay=".6s" size={size} />
+      </div>
     </TailwindContents>
   );
 };

--- a/weave-js/src/components/Loaders/WaveLoader.tsx
+++ b/weave-js/src/components/Loaders/WaveLoader.tsx
@@ -1,6 +1,7 @@
 import {TailwindContents} from '@wandb/weave/components/Tailwind';
 import classNames from 'classnames';
 import React, {useMemo} from 'react';
+import {CSSTransition} from 'react-transition-group';
 
 const Dot = React.memo(
   ({delay, size}: {delay?: string; size: 'small' | 'huge'}) => {
@@ -22,6 +23,14 @@ const Dot = React.memo(
   }
 );
 
+/**
+ * WaveLoader displays a row of Dot elements after an optional delay,
+ * instantly switching from completely hidden to visible.
+ *
+ * @param {Object} props
+ * @param {'small' | 'huge'} props.size - The size variant for each Dot.
+ * @param {number} [props.delayBeforeShow] - Time in ms to wait before showing the dots.
+ */
 export const WaveLoader = ({
   size,
   delayBeforeShow,
@@ -29,28 +38,61 @@ export const WaveLoader = ({
   size: 'small' | 'huge';
   delayBeforeShow?: number;
 }) => {
-  const [okToShow, setOkToShow] = React.useState(false);
-
-  React.useEffect(() => {
-    const timer = setTimeout(() => {
-      setOkToShow(true);
-    }, delayBeforeShow);
-    return () => clearTimeout(timer);
-  }, [delayBeforeShow]);
-
   return (
     <TailwindContents>
-      <div
-        className="flex items-center gap-x-4"
-        data-test={`wave-loader-${size}`}>
-        {okToShow && (
-          <>
-            <Dot size={size} />
-            <Dot delay=".3s" size={size} />
-            <Dot delay=".6s" size={size} />
-          </>
-        )}
-      </div>
+      {/**
+        CSSTransition from react-transition-group controls how the child element 
+        (the <div> with dots) appears and disappears.
+
+        - in={true}
+          Forces the transition to run in "appear" or "enter" states immediately 
+          on mount (since it's already "in").
+        
+        - appear
+          Enables a special "appear" phase on the initial mount, as opposed to 
+          jumping straight to the "entered" state.
+
+        - mountOnEnter
+          Does not mount the child DOM node until the transition is ready to 
+          start (i.e., the "appear" or "enter" phase).
+
+        - timeout={delayBeforeShow ?? 0}
+          Defines how long the "appear" phase lasts, in milliseconds. If 
+          delayBeforeShow is undefined, it defaults to 0 (no wait). 
+          After this timeout, the component transitions from the appear classes 
+          to the enter classes.
+
+        - classNames: An object mapping transition states to class names:
+            * appear/appearActive
+              Applied during the "appear" phase. Here we use 'opacity-0' to keep 
+              the component completely invisible for the entire duration of appear.
+            
+            * enter/enterActive
+              Applied when we leave the "appear" phase and fully enter the component. 
+              In this case, 'opacity-100' is used, so it instantly becomes fully visible.
+            
+          Because there are no actual "transition-opacity" or "duration-..." 
+          classes, the element will flip from invisible to visible with no fade.
+      */}
+      <CSSTransition
+        in={true}
+        appear
+        mountOnEnter
+        timeout={delayBeforeShow ?? 0}
+        classNames={{
+          appear: 'opacity-0',
+          appearActive: 'opacity-0',
+          enter: 'opacity-100',
+          enterActive: 'opacity-100',
+        }}>
+        <div
+          className="flex items-center gap-x-4 "
+          data-test={`wave-loader-${size}`}>
+          <Dot size={size} />
+          <Dot delay=".3s" size={size} />
+          <Dot delay=".6s" size={size} />
+        </div>
+      </CSSTransition>
     </TailwindContents>
   );
 };


### PR DESCRIPTION
# PR Title: Add `delayBeforeShow` Support to `WaveLoader` with `useTimeout` Hook  

## Summary  
This PR introduces a `delayBeforeShow` prop to `WaveLoader`, allowing for a configurable delay before the component becomes visible. It also adds a new `useTimeout` hook to handle the delay in a declarative manner.

## Changes  

### **1. `WaveLoader` Enhancements**
- Added a `delayBeforeShow` prop to control visibility delay.
- Introduced `useTimeout` to manage the delay before the loader appears.
- Applied conditional class handling (`opacity-0` → `opacity-100`) to ensure instant visibility once the timeout expires.

### **2. `TrackedWaveLoader` Updates**
- Now accepts `delayBeforeShow` and passes it to `WaveLoader` for consistent behavior.
- Defaulted `delayBeforeShow` to `0` to maintain backward compatibility.

### **3. New `useTimeout` Hook**
- Added `useTimeout(ms: number)`, which returns `true` after the specified duration.

## Rationale  
This change improves control over when `WaveLoader` appears, preventing unnecessary initial rendering.

## Testing  
- Verified that `WaveLoader` remains hidden (`opacity-0`) until `delayBeforeShow` expires, then instantly switches to `opacity-100`.
- Ensured `TrackedWaveLoader` correctly propagates `delayBeforeShow` to `WaveLoader`.
- Confirmed no regressions in default behavior when `delayBeforeShow` is `0`.

## Backward Compatibility  
- The `delayBeforeShow` prop defaults to `0`, ensuring existing usage remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional delay for loader animations, allowing a more controlled appearance.
  - Added a new hook for managing timeouts within React components.
- **Refactor**
  - Enhanced loader components with smoother transition effects for improved visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->