### PR TITLE
fix(weave): pydantic exception when using openai integration with Azure

### DIFF
--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -244,7 +244,10 @@ def openai_accumulator(
                 choices=output_choices,
                 created=value.created,  # Each chunk has the same timestamp
                 model=value.model,
-                object=value.object,
+                # The AzureOpenAI service will return an initial chunk with object=''
+                # which causes a pydantic_core._pydantic_core.ValidationError as
+                # the OpenAI SDK requires this literal value.
+                object=value.object or "chat.completion.chunk",
                 system_fingerprint=value.system_fingerprint,
             )
             return acc


### PR DESCRIPTION
## Description

The OpenAI SDK requires the `object` field on a `ChatCompletionChunk` to be the literal value `"chat.completion.chunk"`
https://github.com/openai/openai-python/blob/2e56c8da6f163db00a4ca362020148bb391edca9/src/openai/types/chat/chat_completion_chunk.py#L128

However, the Azure OpenAI service will return an initial chunk with an empty string value, like this:
```
ChatCompletionChunk(id='', choices=[], created=0, model='', object='', service_tier=None, system_fingerprint=None, usage=None, prompt_filter_results=[{'prompt_index': 0, 'content_filter_results': {'hate': {'filtered': False, 'severity': 'safe'}, 'jailbreak': {'filtered': False, 'detected': False}, 'self_harm': {'filtered': False, 'severity': 'safe'}, 'sexual': {'filtered': False, 'severity': 'safe'}, 'violence': {'filtered': False, 'severity': 'safe'}}}])
```

This change fixes the resulting error:
```
Error capturing value from iterator, call data may be incomplete:
Traceback (most recent call last):
  File "/Users/jamie/source/jcr/suprot_2025-02-17/.venv/lib/python3.12/site-packages/weave/trace/op_extensions/accumulator.py", line 108, in __next__
    self._on_yield(value)
  File "/Users/jamie/source/jcr/suprot_2025-02-17/.venv/lib/python3.12/site-packages/weave/trace/op_extensions/accumulator.py", line 293, in on_yield
    acc.next(value)
  File "/Users/jamie/source/jcr/suprot_2025-02-17/.venv/lib/python3.12/site-packages/weave/trace/op_extensions/accumulator.py", line 320, in next
    self._state = self._accumulator(self._state, value)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jamie/source/jcr/suprot_2025-02-17/.venv/lib/python3.12/site-packages/weave/integrations/openai/openai_sdk.py", line 334, in <lambda>
    make_accumulator=lambda inputs: lambda acc, value: openai_accumulator(
                                                       ^^^^^^^^^^^^^^^^^^^
  File "/Users/jamie/source/jcr/suprot_2025-02-17/.venv/lib/python3.12/site-packages/weave/integrations/openai/openai_sdk.py", line 242, in openai_accumulator
    acc = ChatCompletionChunk(
          ^^^^^^^^^^^^^^^^^^^^
  File "/Users/jamie/source/jcr/suprot_2025-02-17/.venv/lib/python3.12/site-packages/pydantic/main.py", line 212, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for ChatCompletionChunk
object
  Input should be 'chat.completion.chunk' [type=literal_error, input_value='', input_type=str]
    For further information visit https://errors.pydantic.dev/2.9/v/literal_error
 (subsequent messages of this type will be suppressed)
```

## Testing

Create an Azure account, replicated user reported problem.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved processing of AI responses to prevent errors from unexpected incomplete data, ensuring a smoother and more reliable experience when interacting with AI services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->