### PR TITLE
fix(weave): Only print root donut link

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1120,6 +1120,7 @@ class WeaveClient:
         project_id = self._project_id()
 
         _should_print_call_link = should_print_call_link()
+        _current_call = call_context.get_current_call()
 
         def send_start_call() -> bool:
             maybe_redacted_inputs_with_refs = inputs_with_refs
@@ -1151,9 +1152,8 @@ class WeaveClient:
 
         def on_complete(f: Future) -> None:
             try:
-                if f.result() and not call_context.get_current_call():
-                    if _should_print_call_link:
-                        print_call_link(call)
+                if _should_print_call_link and f.result() and not _current_call:
+                    print_call_link(call)
             except Exception:
                 pass
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1152,7 +1152,8 @@ class WeaveClient:
 
         def on_complete(f: Future) -> None:
             try:
-                if _should_print_call_link and f.result() and not _current_call:
+                root_call_did_not_error = f.result() and not _current_call
+                if root_call_did_not_error and _should_print_call_link:
                     print_call_link(call)
             except Exception:
                 pass


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved call link display so that only a single, accurate link is printed when nested operations complete successfully.
  
- **Tests**
  - Introduced a test that validates nested operations produce the expected number of calls and correctly formatted output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->