### PR TITLE
Integrate Verdict as a Scorer

### DIFF
--- a/docs/docs/guides/evaluation/builtin_scorers.mdx
+++ b/docs/docs/guides/evaluation/builtin_scorers.mdx
@@ -318,6 +318,42 @@ import TabItem from '@theme/TabItem';
 
     ---
 
+    ## `VerdictScorer`
+
+    [Verdict](https://github.com/haizelabs/verdict) is a library for creating arbitrary execution graphs of chained LLM judge calls.
+
+    ```python
+    from weave.scorers import VerdictScorer
+
+    from verdict import Pipeline, Layer
+    from verdict.common.judge import JudgeUnit
+    from verdict.scale import BooleanScale
+    from verdict.transform import MaxPoolUnit
+
+    pipeline = Pipeline() \
+        >> Layer(
+            JudgeUnit(BooleanScale(), explanation=True).prompt("""
+                Is the <output> to the <query> consistent with the <context>?
+                <query>{source.query}</query>
+                <context>{source.context}</context>
+                <output>{source.output}</output>
+            """)
+        , repeat=3) \
+        >> MaxPoolUnit()
+
+    verdict_scorer = VerdictScorer(pipeline)
+    result = verdict_scorer.score(
+        query="What is the capital of France?",
+        context="Paris is the capital of France.",
+        output="Paris."
+    )
+    print(result)
+    ```
+
+    This will execute a Verdict pipeline that makes 3 LLM calls in parallel and then takes the majority vote of the results.
+
+    ---
+
     ## `PydanticScorer`
 
     The `PydanticScorer` validates the AI system's output against a Pydantic model to ensure it adheres to a specified schema or data structure.

--- a/docs/docs/guides/evaluation/guardrails_and_monitors.md
+++ b/docs/docs/guides/evaluation/guardrails_and_monitors.md
@@ -28,6 +28,7 @@ While this guide shows you how to create custom scorers, Weave comes with a vari
 - [Summarization quality](./builtin_scorers.mdx#summarizationscorer)
 - [Embedding similarity](./builtin_scorers.mdx#embeddingsimilarityscorer)
 - [Relevancy evaluation](./builtin_scorers.mdx#ragas---contextrelevancyscorer)
+- [Verdict Pipeline evaluation](./builtin_scorers.mdx#verdictscorer)
 - And more!
 
 

--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -27,6 +27,7 @@ While this guide shows you how to create custom scorers, Weave comes with a vari
 - [Hallucination detection](./builtin_scorers.mdx#hallucinationfreescorer)
 - [Summarization quality](./builtin_scorers.mdx#summarizationscorer)
 - [Embedding similarity](./builtin_scorers.mdx#embeddingsimilarityscorer)
+- [Verdict Pipeline evaluation](./builtin_scorers.mdx#verdictscorer)
 - [Toxicity detection (local)](./weave_local_scorers.md#weavetoxicityscorerv1)
 - [Context Relevance scoring (local)](./weave_local_scorers.md#weavecontextrelevancescorerv1)
 - And more!

--- a/noxfile.py
+++ b/noxfile.py
@@ -50,6 +50,7 @@ def lint(session):
         "mistral1",
         "notdiamond",
         "openai",
+        "verdict",
         "vertexai",
         "bedrock",
         "scorers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ scorers = [
   "pip>=20.0", # this is needed for presidio-analyzer to pull the spacy models
   "presidio-analyzer>=2.2.0",
   "presidio-anonymizer>=2.2.0",
+  "verdict>=0.2.0",
 ]
 notdiamond = ["notdiamond>=0.3.21", "litellm<=1.49.1"]
 openai = ["openai>=1.0.0"]

--- a/tests/scorers/test_verdict_scorer.py
+++ b/tests/scorers/test_verdict_scorer.py
@@ -1,0 +1,38 @@
+import pytest
+
+from weave.scorers.verdict_scorer import VerdictScorer
+
+from verdict import Pipeline, Layer
+from verdict.common.judge import JudgeUnit
+from verdict.scale import BooleanScale
+from verdict.transform import MaxPoolUnit
+
+
+@pytest.fixture
+def verdict_scorer() -> VerdictScorer:
+    """Fixture to return a VerdictScorer instance with a 3x Verdict BooleanScale judge + MaxVote."""
+    pipeline = Pipeline() \
+        >> Layer(
+            JudgeUnit(BooleanScale(), explanation=True).prompt("""
+                Is the <output> to the <query> consistent with the <context>?
+                <query>{source.query}</query>
+                <context>{source.context}</context>
+                <output>{source.output}</output>
+            """)
+        , repeat=3) \
+        >> MaxPoolUnit()
+
+    return VerdictScorer(pipeline)
+
+
+def test_verdict_scorer_score(verdict_scorer):
+    """Test score with a consistent output."""
+
+    result = verdict_scorer.score(
+        query="What is the capital of France?",
+        context="Paris is the capital of France.",
+        output="Paris."
+    )
+
+    assert result is not None
+    assert result["Pipeline_root.block.block.unit[Map MaxPool]_score"] == True

--- a/weave/scorers/__init__.py
+++ b/weave/scorers/__init__.py
@@ -41,6 +41,7 @@ from weave.scorers.string_scorer import (
 from weave.scorers.summarization_scorer import SummarizationScorer
 from weave.scorers.trust_scorer import WeaveTrustScorerV1
 from weave.scorers.xml_scorer import ValidXMLScorer
+from weave.scorers.verdict_scorer import VerdictScorer
 
 __all__ = [
     "auto_summarize",
@@ -62,6 +63,7 @@ __all__ = [
     "StringMatchScorer",
     "SummarizationScorer",
     "ValidXMLScorer",
+    "VerdictScorer",
     "WeaveBiasScorerV1",
     "WeaveToxicityScorerV1",
     "WeaveCoherenceScorerV1",

--- a/weave/scorers/verdict_scorer.py
+++ b/weave/scorers/verdict_scorer.py
@@ -1,0 +1,52 @@
+import weave
+from weave import Scorer
+from typing import Dict
+
+import verdict
+
+class VerdictScorer(Scorer):
+    """
+    A scorer that executes a passed Verdict pipeline to score an input.
+
+    Args:
+        pipeline: The Verdict pipeline to use for scoring
+
+    Note: This Scorer's `score` method will accept any number of keyword arguments. These can be referenced in the
+    Verdict prompt using the `{source.KEY}` template variable. Moreover, this Scorer will return a dictionary with
+    all Verdict leaf outputs indexed by their prefix (e.g., 'Pipeline_root.block.unit[DirectScoreJudge]_score'). To
+    return custom keys, subclass this Scorer and override the `score` method.
+
+    Returns:
+        dict: A dictionary containing each Verdict leaf node identifier as a key and the node output as a value.
+
+    Example:
+        >>> pipeline = verdict.Pipeline() \
+        ...     >> JudgeUnit(BooleanScale(), explanation=True).prompt('''
+        ...         Is the <output> to the <query> consistent with the <context>?
+        ...         <query>{source.query}</query>
+        ...         <context>{source.context}</context>
+        ...         <output>{source.output}</output>
+        ...     ''')
+        >>> scorer = VerdictScorer(pipeline)
+        >>> result = scorer.score(
+        ...     query="What is the capital of France?",
+        ...     context="Paris is the capital of France.",
+        ...     output="Paris."
+        ... )
+        >>> print(result)
+        {
+            'Pipeline_root.block.unit[DirectScoreJudge]_score': True,
+            'Pipeline_root.block.unit[DirectScoreJudge]_explanation': 'The context specifically mentions that the capital of France is Paris.'
+        }
+    """
+
+    _pipeline: verdict.Pipeline
+
+    def __init__(self, pipeline: verdict.Pipeline):
+        super().__init__()
+        self._pipeline = pipeline
+
+    @weave.op
+    def score(self, **kwargs: Dict[str, str]) -> dict:
+        response, leaf_node_prefixes = self._pipeline.run(verdict.schema.Schema.of(**kwargs))
+        return {prefix: response[prefix] for prefix in leaf_node_prefixes}


### PR DESCRIPTION
## Description
Integrate [Verdict](https://github.com/haizelabs/verdict), a library for creating arbitrary graphs of chained LLM-as-a-judge calls as a Scorer.

## Testing
We add a simple integration test that confirms the inputs are properly piped to the specified Verdict pipeline and the output contains the expected response.