### PR TITLE
fix(ui): missing space in calls link

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -426,6 +426,7 @@ export const CallsLink: React.FC<{
   if (props.callCount != null) {
     label = props.callCount.toString();
     label += props.countIsLimited ? '+' : '';
+    label += ' ';
     label += maybePluralizeWord(props.callCount, 'call');
   }
   return (


### PR DESCRIPTION
## Description

Lost a space in https://github.com/wandb/weave/pull/3556

Before:
<img width="113" alt="Screenshot 2025-02-24 at 9 26 11 AM" src="https://github.com/user-attachments/assets/663c1e84-5715-4a0a-8ce1-5b51aecdf8be" />

After:
<img width="127" alt="Screenshot 2025-02-24 at 9 26 01 AM" src="https://github.com/user-attachments/assets/a23a611a-d90f-4857-968d-c8a14da76877" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted the spacing in link labels displaying call counts for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->