### PR TITLE
chore(dev): pass silent flag to graphql-codegen to prevent ci hangs

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -14,7 +14,7 @@
     "eslint-fix": "eslint --fix --ext .js,.jsx,.ts,.tsx src",
     "tslint": "tslint --project .",
     "tslint-fix": "tslint --fix --project .",
-    "generate": "graphql-codegen",
+    "generate": "graphql-codegen --silent",
     "generate:watch": "graphql-codegen -w",
     "prettier": "prettier --config .prettierrc --check \"src/**/*.ts\" \"src/**/*.tsx\"",
     "prettier-fix": "prettier --loglevel warn --config .prettierrc --write \"src/**/*.ts\" \"src/**/*.tsx\"",


### PR DESCRIPTION
## Description

The silent flag should prevent the spinners from showing and hanging sometimes due to circleci tty environment. Hard to confirm since it doesn't happen reliably.

## Testing

Existing CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the generation process to run silently, reducing extraneous log output during execution for a cleaner overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->