### PR TITLE
chore(weave): hide schema mapping prior to dataset selection in dataset drawer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/AddToDatasetDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/AddToDatasetDrawer.tsx
@@ -255,6 +255,8 @@ export const AddToDatasetDrawerInner: React.FC<AddToDatasetDrawerProps> = ({
 
   const renderStepContent = () => {
     const isNewDataset = selectedDataset === null;
+    const hasDatasetChoice =
+      selectedDataset !== null || newDatasetName !== null;
 
     switch (currentStep) {
       case 1:
@@ -270,24 +272,28 @@ export const AddToDatasetDrawerInner: React.FC<AddToDatasetDrawerProps> = ({
               entity={entity}
               project={project}
             />
-            {!isNewDataset && selectedDataset && (
-              <SchemaMappingStep
-                selectedDataset={selectedDataset}
-                selectedCalls={selectedCalls}
-                entity={entity}
-                project={project}
-                fieldMappings={fieldMappings}
-                datasetObject={datasetObject}
-                onMappingChange={handleMappingChange}
-                onDatasetObjectLoaded={setDatasetObject}
-              />
-            )}
-            {isNewDataset && (
-              <NewDatasetSchemaStep
-                selectedCalls={selectedCalls}
-                fieldConfigs={fieldConfigs}
-                onFieldConfigsChange={setFieldConfigs}
-              />
+            {hasDatasetChoice && (
+              <>
+                {!isNewDataset && selectedDataset && (
+                  <SchemaMappingStep
+                    selectedDataset={selectedDataset}
+                    selectedCalls={selectedCalls}
+                    entity={entity}
+                    project={project}
+                    fieldMappings={fieldMappings}
+                    datasetObject={datasetObject}
+                    onMappingChange={handleMappingChange}
+                    onDatasetObjectLoaded={setDatasetObject}
+                  />
+                )}
+                {isNewDataset && (
+                  <NewDatasetSchemaStep
+                    selectedCalls={selectedCalls}
+                    fieldConfigs={fieldConfigs}
+                    onFieldConfigsChange={setFieldConfigs}
+                  />
+                )}
+              </>
             )}
           </div>
         );


### PR DESCRIPTION
## Description

Hide the schema mapping step in the `add to dataset drawer` until a dataset has been selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Refined the dataset workflow so that the next steps in adding or mapping a dataset are now displayed when you have either selected an existing dataset or provided a new dataset name, resulting in a smoother and more intuitive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->