### PR TITLE
fix(app): revert obtain mask-specific class labels from the run config

### DIFF
--- a/weave-js/src/components/Panel2/PanelImage.tsx
+++ b/weave-js/src/components/Panel2/PanelImage.tsx
@@ -1,10 +1,7 @@
 import {BoundingBoxSliderControl} from '@wandb/weave/common/components/MediaCard';
 import {BoundingBox2D, LayoutType} from '@wandb/weave/common/types/media';
 import {
-  Node,
   opAssetArtifactVersion,
-  opGetRunTag,
-  opRunConfig,
   replaceInputVariables,
   WBImage,
 } from '@wandb/weave/core';
@@ -35,42 +32,14 @@ type PanelImageProps = Panel2.PanelProps<
   PanelImageConfigType
 >;
 
-const useClassLabels = (input: Node<typeof inputType>) => {
-  const {loading: runConfigLoading} = CGReact.useNodeValue(
-    opRunConfig({run: opGetRunTag({obj: input})})
-  );
-
-  const {loading: runTagLoading, result: runTag} = CGReact.useNodeValue(
-    opGetRunTag({obj: input})
-  );
-
-  return useMemo(() => {
-    if (!(runConfigLoading || runTagLoading) && runTag != null) {
-      try {
-        const configSubset: {[key: string]: any} = JSON.parse(
-          runTag.configSubset
-        );
-        return _.get(configSubset, '_wandb.value.mask/class_labels', {});
-      } catch (error) {
-        console.error('Failed to parse config subset:', error);
-        return {};
-      }
-    }
-    return {};
-  }, [runTag, runTagLoading, runConfigLoading]);
-};
-
 const PanelImageConfig: FC<PanelImageProps> = ({
   config,
   updateConfig,
   input,
 }) => {
-  const classLabels = useClassLabels(input);
-
   const {classSets, controls} = Controls.useImageControls(
     input.type,
-    config?.overlayControls,
-    classLabels
+    config?.overlayControls
   );
   const updatedConfig = useMemo(() => {
     if (controls === config?.overlayControls) {
@@ -139,17 +108,11 @@ const PanelImage: FC<PanelImageProps> = ({config, input}) => {
 
   const image: WBImage = nodeValueQuery.result;
 
-  const classLabels = useClassLabels(inputNode);
-
   const {
     maskControls: mergedMaskControls,
     boxControls: mergedBoxControls,
     classSets,
-  } = Controls.useImageControls(
-    inputNode.type,
-    config?.overlayControls,
-    classLabels
-  );
+  } = Controls.useImageControls(inputNode.type, config?.overlayControls);
 
   const {imageBoxes, imageMasks, boxControls, maskControls} = useMemo(() => {
     const knownBoxKeys = image?.boxes != null ? _.keys(image.boxes) : [];


### PR DESCRIPTION
Reverts wandb/weave#3693

breaking integration test, see https://weightsandbiases.slack.com/archives/C080ZF68V9V/p1740422898771159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the image control interface by consolidating configuration steps and removing unused labeling features.
  - Simplified control parameters for image overlays, resulting in a smoother and more responsive experience.
  - The streamlined approach reduces complexity and optimizes performance when managing image displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->