### PR TITLE
chore(weave): fix smallref for op versions

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -69,10 +69,7 @@ export const CallSummary: React.FC<{
           data={{
             Operation:
               parseRefMaybe(span.name) != null ? (
-                <SmallRef
-                  objRef={parseRefMaybe(span.name)!}
-                  wfTable="OpVersion"
-                />
+                <SmallRef objRef={parseRefMaybe(span.name)!} />
               ) : (
                 span.name
               ),

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRef.tsx
@@ -7,22 +7,15 @@ import React, {FC} from 'react';
 
 import {SmallArtifactRef} from './SmallArtifactRef';
 import {SmallWeaveRef} from './SmallWeaveRef';
-import {WFDBTableType} from './types';
 
 export const SmallRef: FC<{
   objRef: ObjectRef;
-  wfTable?: WFDBTableType;
   iconOnly?: boolean;
   noLink?: boolean;
-}> = ({objRef, wfTable, iconOnly = false, noLink = false}) => {
+}> = ({objRef, iconOnly = false, noLink = false}) => {
   if (isWeaveObjectRef(objRef)) {
     return (
-      <SmallWeaveRef
-        objRef={objRef}
-        wfTable={wfTable}
-        iconOnly={iconOnly}
-        noLink={noLink}
-      />
+      <SmallWeaveRef objRef={objRef} iconOnly={iconOnly} noLink={noLink} />
     );
   }
   if (isWandbArtifactRef(objRef)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallWeaveRef.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallWeaveRef.tsx
@@ -16,7 +16,6 @@ import {TailwindContents} from '../../../../Tailwind';
 import {useWeaveflowRouteContext} from '../context';
 import {useWFHooks} from '../pages/wfReactInterface/context';
 import {SmallRefLoaded} from './SmallRefLoaded';
-import {WFDBTableType} from './types';
 
 export const objectRefDisplayName = (
   objRef: ObjectRef,
@@ -87,14 +86,12 @@ const getObjectVersionLabel = (
 
 type SmallWeaveRefProps = {
   objRef: WeaveObjectRef;
-  wfTable?: WFDBTableType;
   iconOnly?: boolean;
   noLink?: boolean;
 };
 
 export const SmallWeaveRef = ({
   objRef,
-  wfTable,
   iconOnly = false,
   noLink = false,
 }: SmallWeaveRefProps) => {
@@ -130,7 +127,12 @@ export const SmallWeaveRef = ({
     objRef.weaveKind === 'op' ? 'Op' : baseObjectClass ?? 'Object';
 
   const icon = ICON_MAP[rootTypeName] ?? IconNames.CubeContainer;
-  const url = peekingRouter.refUIUrl(rootTypeName, objRef, wfTable);
+
+  const url = peekingRouter.refUIUrl(
+    rootTypeName,
+    objRef,
+    objRef.weaveKind === 'op' ? 'OpVersion' : undefined
+  );
   const label = iconOnly
     ? undefined
     : getObjectVersionLabel(objRef, versionIndex);


### PR DESCRIPTION
## Description

Infer setting for `wfTable` in small ref link for op versions to be `OpVersion` - otherwise the links don't work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed the `wfTable` parameter from the `SmallWeaveRef` and `SmallRef` components, streamlining the component structure and enhancing rendering logic.
	- Updated the `CallSummary` component to reflect the removal of the `wfTable` prop in the `SmallRef` component instantiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->