### PR TITLE
test(weave): add/improve test to langchain batch fix, and set use_stack=True

### DIFF
--- a/tests/integrations/langchain/langchain_test.py
+++ b/tests/integrations/langchain/langchain_test.py
@@ -226,7 +226,7 @@ async def test_simple_chain_abatch(
 
 def assert_correct_calls_for_chain_batch_from_op(calls: list[Call]) -> None:
     flattened = flatten_calls(calls)
-    assert len(flattened) == 13
+    assert len(flattened) == 9
     assert_ends_and_errors(flattened)
 
     got = [(op_name_from_ref(c.op_name), d, c.parent_id) for (c, d) in flattened]
@@ -242,10 +242,6 @@ def assert_correct_calls_for_chain_batch_from_op(calls: list[Call]) -> None:
         ("langchain.Prompt.PromptTemplate", 2, ids[5]),
         ("langchain.Llm.ChatOpenAI", 2, ids[5]),
         ("openai.chat.completions.create", 3, ids[7]),
-        ("langchain.Chain.RunnableSequence", 1, ids[0]),
-        ("langchain.Prompt.PromptTemplate", 2, ids[9]),
-        ("langchain.Llm.ChatOpenAI", 2, ids[9]),
-        ("openai.chat.completions.create", 3, ids[11]),
     ]
     assert got == exp
 
@@ -277,7 +273,7 @@ def test_simple_chain_batch_inside_op(client: WeaveClient) -> None:
         assert parent is not None
         assert "run_batch" in parent.op_name
         assert parent.parent_id is None
-        assert len(parent.children()) == 3
+        assert len(parent.children()) == 2
         for child in parent.children():
             assert "langchain.Chain.RunnableSequence" in child.op_name
             assert child.parent_id == parent.id
@@ -289,7 +285,7 @@ def test_simple_chain_batch_inside_op(client: WeaveClient) -> None:
             assert "langchain.Llm.ChatOpenAI" in grandchildren[1].op_name
             assert grandchildren[1].parent_id == child.id
 
-    run_batch([{"number": 2}, {"number": 3}, {"number": 4}])
+    run_batch([{"number": 2}, {"number": 3}])
 
     calls = list(client.calls(filter=tsi.CallsFilter(trace_roots_only=True)))
     assert_correct_calls_for_chain_batch_from_op(calls)

--- a/weave/integrations/langchain/langchain.py
+++ b/weave/integrations/langchain/langchain.py
@@ -56,7 +56,7 @@ except ImportError:
     import_failed = True
 
 from collections.abc import Generator
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 RUNNABLE_SEQUENCE_NAME = "RunnableSequence"
 

--- a/weave/integrations/langchain/langchain.py
+++ b/weave/integrations/langchain/langchain.py
@@ -56,7 +56,7 @@ except ImportError:
     import_failed = True
 
 from collections.abc import Generator
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 RUNNABLE_SEQUENCE_NAME = "RunnableSequence"
 
@@ -180,10 +180,8 @@ if not import_failed:
                         if wv_current_run.parent_id is None:
                             use_stack = False
                         else:
-                            # Hack in memory parent call to satisfy `create_call`
-                            # Impact is the parent won't actually represent the parent call
-                            # so we do NOT want to save the parent to the stack
-                            use_stack = False
+                            # Hack in memory parent call to satisfy `create_call` without actually
+                            # getting the parent.
                             parent_run = Call(
                                 id=wv_current_run.parent_id,
                                 trace_id=wv_current_run.trace_id,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Add calls to stack when handling langchain batch flow (getting parent when parallel)
- Remove logger assertions
- Improve test to assert call stack during execution to ensure completion



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced the verification for batch processing by switching from log-based validation to structured context checks, ensuring more accurate operation tracking.
  
- **Chores**
  - Streamlined test interfaces and refined internal commentary to improve overall maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->