### PR TITLE
chore(weave): Fix migrations for create or replace views

### DIFF
--- a/weave/trace_server/migrations/002_add_deleted_at.down.sql
+++ b/weave/trace_server/migrations/002_add_deleted_at.down.sql
@@ -6,7 +6,8 @@ This migration undoes adding the `deleted_at` column to:
 
 ALTER TABLE object_versions DROP COLUMN deleted_at;
 
-CREATE OR REPLACE VIEW object_versions_deduped as
+DROP VIEW object_versions_deduped;
+CREATE VIEW object_versions_deduped as
     SELECT project_id,
         object_id,
         created_at,

--- a/weave/trace_server/migrations/002_add_deleted_at.up.sql
+++ b/weave/trace_server/migrations/002_add_deleted_at.up.sql
@@ -8,7 +8,8 @@ This migration adds:
 ALTER TABLE object_versions
     ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL;
 
-CREATE OR REPLACE VIEW object_versions_deduped as
+DROP VIEW object_versions_deduped;
+CREATE VIEW object_versions_deduped as
     SELECT project_id,
         object_id,
         created_at,


### PR DESCRIPTION
For some unknown reason, we are getting errors in dev when migrating local and using `CREATE OR REPLACE VIEW`. This change modifies these calls to a series of drop then creates. Furthermore, these views ARE NOT EVEN USED! 

It is generally bad practice to edit migrations, but these are forwards and backwards compatible changes.