### PR TITLE
chore(weave): Add o3 mini to playground

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
@@ -97,6 +97,16 @@ export const LLM_MAX_TOKENS = {
     max_tokens: 100000,
     supports_function_calling: true,
   },
+  'o3-mini': {
+    provider: 'openai',
+    max_tokens: 100000,
+    supports_function_calling: true,
+  },
+  'o3-mini-2025-01-31': {
+    provider: 'openai',
+    max_tokens: 100000,
+    supports_function_calling: true,
+  },
 
   // Anthropic models
   'claude-3-7-sonnet-20250219': {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -177,7 +177,8 @@ export const getInputFromPlaygroundState = (state: PlaygroundState) => {
     type: 'function',
     function: func,
   }));
-  return {
+
+  const inputs = {
     // Adding this to prevent the exact same call from not getting run
     // eg running the same call in parallel
     key: Math.random() * 1000,
@@ -199,6 +200,16 @@ export const getInputFromPlaygroundState = (state: PlaygroundState) => {
           },
     tools: tools.length > 0 ? tools : undefined,
   };
+
+  if (state.model.includes('o3')) {
+    const {max_tokens, ...rest} = inputs;
+    return {
+      ...rest,
+      max_completion_tokens: max_tokens,
+    };
+  }
+
+  return inputs;
 };
 
 // This is a helper function to parse the trace call output for anthropic

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -314,7 +314,6 @@ export type CompletionsCreateInputs = {
   model: string;
   messages: any[];
   temperature: number;
-  max_tokens: number;
 
   // These are optional, depending on the LLM provider some accept these some dont
   stop?: string[];
@@ -326,6 +325,9 @@ export type CompletionsCreateInputs = {
     type: string;
   };
   tools?: any[];
+  // These are optional, o3 accepts max_completion_tokens, others accept max_tokens
+  max_tokens?: number;
+  max_completion_tokens?: number;
 };
 
 export type CompletionsCreateReq = {


### PR DESCRIPTION
## Description
Adds o3 mini to playground
there is a little hack to map max_tokens -> max_completion_tokens
once we do an overhaul of the passed variables this can be removed

![Screenshot 2025-02-24 at 3 48 06 PM](https://github.com/user-attachments/assets/c36057b8-44a9-4caa-b882-e883dff045ed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded support for additional language models with enhanced token limits and function calling capabilities.
  
- **Refactor**
  - Improved input handling in the interactive playground for a more dynamic configuration experience based on the selected model type.
  - Enhanced flexibility in input structure by allowing optional token properties in the completion requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->