### PR TITLE
chore(weave): calls query supports sorting by status

### DIFF
--- a/weave/trace_server/computed_columns.py
+++ b/weave/trace_server/computed_columns.py
@@ -1,0 +1,166 @@
+"""
+Computed columns module for trace server implementations.
+
+This module provides a unified way to define and use computed columns
+that are derived from other columns rather than being direct database columns.
+These computed columns can be used in queries, filters, and order-by clauses
+across different database backends (currently SQLite and ClickHouse).
+"""
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class DbEngine(str, Enum):
+    """Supported database engines."""
+
+    SQLITE = "sqlite"
+    CLICKHOUSE = "clickhouse"
+
+
+class ComputedColumn(BaseModel):
+    """
+    Definition of a computed column that can be used in queries.
+
+    A computed column is derived from other columns using a SQL expression
+    that is specific to each database engine.
+    """
+
+    name: str = Field(..., description="Name of the computed column")
+    description: str = Field(
+        ..., description="Description of what this column represents"
+    )
+
+    # SQL snippets for each database engine - using names without leading underscores
+    sqlite_sql: Optional[str] = Field(None, description="SQL snippet for SQLite")
+    clickhouse_sql: Optional[str] = Field(
+        None, description="SQL snippet for ClickHouse"
+    )
+
+    # Optional additional configuration
+    sortable: bool = Field(
+        True, description="Whether this column can be used in ORDER BY"
+    )
+    filterable: bool = Field(
+        True, description="Whether this column can be used in WHERE/HAVING"
+    )
+
+    def get_sql(self, engine: DbEngine, table_alias: Optional[str] = None) -> str:
+        """
+        Get the SQL snippet for this computed column for the specified database engine.
+
+        Args:
+            engine: The database engine to get the SQL for
+            table_alias: Optional table alias to use in the SQL
+
+        Returns:
+            SQL snippet for the computed column
+        """
+        if engine == DbEngine.SQLITE:
+            sql = self.sqlite_sql
+        elif engine == DbEngine.CLICKHOUSE:
+            sql = self.clickhouse_sql
+        else:
+            raise ValueError(f"Unsupported database engine: {engine}")
+
+        if sql is None:
+            raise NotImplementedError(
+                f"SQL for {self.name} not implemented for {engine}"
+            )
+
+        # Apply table alias if provided and needed
+        if table_alias:
+            # Replace column references with table-qualified references
+            # This is a simple implementation that assumes columns are referenced directly
+            # A more robust implementation might use a SQL parser
+            for col in ["exception", "ended_at"]:
+                sql = sql.replace(f"{col} ", f"{table_alias}.{col} ")
+                sql = sql.replace(f"{col}\n", f"{table_alias}.{col}\n")
+
+            # For ClickHouse, we need to handle the any() function
+            if engine == DbEngine.CLICKHOUSE:
+                for col in ["exception", "ended_at"]:
+                    sql = sql.replace(f"any({col})", f"any({table_alias}.{col})")
+
+        return sql
+
+
+class ComputedColumnsRegistry:
+    """Registry of computed columns that can be used in queries."""
+
+    def __init__(self) -> None:
+        self._columns: dict[str, ComputedColumn] = {}
+        self._initialize_defaults()
+
+    def _initialize_defaults(self) -> None:
+        """Initialize the default computed columns."""
+        # Status column - computed from exception and ended_at
+        status = ComputedColumn(
+            name="status",
+            description="Status of the call (error, success, or running)",
+            sqlite_sql="""
+                CASE
+                    WHEN exception IS NOT NULL THEN 1
+                    WHEN ended_at IS NOT NULL THEN 2
+                    ELSE 3
+                END
+            """,
+            clickhouse_sql="""
+                CASE
+                    WHEN any(exception) IS NOT NULL THEN 1
+                    WHEN any(ended_at) IS NOT NULL THEN 2
+                    ELSE 3
+                END
+            """,
+        )
+        self.register(status)
+
+    def register(self, column: ComputedColumn) -> None:
+        """Register a computed column."""
+        self._columns[column.name] = column
+
+    def get(self, name: str) -> Optional[ComputedColumn]:
+        """Get a computed column by name."""
+        return self._columns.get(name)
+
+    def contains(self, name: str) -> bool:
+        """Check if a column name is a computed column."""
+        return name in self._columns
+
+    def list_columns(self) -> list[str]:
+        """List all registered computed column names."""
+        return list(self._columns.keys())
+
+
+# Global instance of the registry
+computed_columns = ComputedColumnsRegistry()
+
+
+def is_computed_column(column_name: str) -> bool:
+    """Check if a column name is a computed column."""
+    return computed_columns.contains(column_name)
+
+
+def get_computed_column_sql(
+    column_name: str, engine: DbEngine, table_alias: Optional[str] = None
+) -> str:
+    """
+    Get the SQL for a computed column.
+
+    Args:
+        column_name: Name of the column
+        engine: Database engine to get SQL for
+        table_alias: Optional table alias to use in the SQL
+
+    Returns:
+        SQL snippet for the computed column
+
+    Raises:
+        KeyError: If the column name is not a registered computed column
+    """
+    column = computed_columns.get(column_name)
+    if column is None:
+        raise KeyError(f"Unknown computed column: {column_name}")
+    return column.get_sql(engine, table_alias)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -14,6 +14,11 @@ import emoji
 
 from weave.trace_server import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.computed_columns import (
+    DbEngine,
+    get_computed_column_sql,
+    is_computed_column,
+)
 from weave.trace_server.emoji_util import detone_emojis
 from weave.trace_server.errors import (
     InvalidRequest,
@@ -414,7 +419,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             order_parts = []
             for field, direction in order_by:
                 json_path: Optional[str] = None
-                if field.startswith("inputs"):
+                if is_computed_column(field):
+                    field = get_computed_column_sql(field, DbEngine.SQLITE)
+                elif field.startswith("inputs"):
                     field = "inputs" + field[len("inputs") :]
                     if field.startswith("inputs."):
                         json_path = field[len("inputs.") :]


### PR DESCRIPTION
## Description

Add support for sorting by `status` to the calls stream query. Status is not defined anywhere in our data model, and currently the frontend infers it by checking for exceptions or an end timestamp on the call object. This PR implements the same logic in the calls query.

- `OrderField` receives a new, optional attribute `raw_sql` which can be used to forcibly inject sql for a particular order field instead.
- If `status` is the order key, we use a case statement within the order by to compute the status as either 1, 2, or 3 (failed, succeeded, running) respectively.
- Adds tests for the correctness of the generated SQL.

This has been successfully tested against a clickhouse cloud db in our qa environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced query result sorting for status. Users will now benefit from more flexible ordering options, including tailored ascending/descending orders and the ability to combine sorting with filters and limits for a more precise data display.
  - Introduction of computed columns, allowing for advanced query capabilities and improved data management.

- **Bug Fixes**
  - Adjusted SQL logic for processing the status field to ensure accurate categorization in queries.

- **Tests**
  - Improved test coverage for sorting functionality, ensuring that the status sorting behaves as expected in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->