### PR TITLE
Revert "feat(weave): to_json handling for pydantic model subclass"

### DIFF
--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -1,11 +1,4 @@
-from pydantic import BaseModel
-
-from weave.trace.serialize import (
-    dictify,
-    fallback_encode,
-    is_pydantic_model_class,
-    to_json,
-)
+from weave.trace.serialize import dictify, fallback_encode
 
 
 def test_dictify_simple() -> None:
@@ -205,55 +198,4 @@ def test_dictify_sanitizes_nested() -> None:
             },
             "api_key": "REDACTED",
         },
-    }
-
-
-def test_is_pydantic_model_class() -> None:
-    """We expect is_pydantic_model_class to return True for Pydantic model classes, and False otherwise.
-    Notably it should return False for instances of Pydantic model classes."""
-    assert not is_pydantic_model_class(int)
-    assert not is_pydantic_model_class(str)
-    assert not is_pydantic_model_class(list)
-    assert not is_pydantic_model_class(dict)
-    assert not is_pydantic_model_class(tuple)
-    assert not is_pydantic_model_class(set)
-    assert not is_pydantic_model_class(None)
-    assert not is_pydantic_model_class(42)
-    assert not is_pydantic_model_class("foo")
-    assert not is_pydantic_model_class({})
-    assert not is_pydantic_model_class([])
-
-    class CalendarEvent(BaseModel):
-        name: str
-        date: str
-        participants: list[str]
-
-    event = CalendarEvent(name="Test", date="2024-01-01", participants=["Alice", "Bob"])
-    assert not is_pydantic_model_class(event)
-    assert is_pydantic_model_class(CalendarEvent)
-
-
-def test_to_json_pydantic_class(client) -> None:
-    """We expect to_json to return the Pydantic schema for the class."""
-
-    class CalendarEvent(BaseModel):
-        name: str
-        date: str
-        participants: list[str]
-
-    project_id = "entity/project"
-    serialized = to_json(CalendarEvent, project_id, client, use_dictify=False)
-    assert serialized == {
-        "properties": {
-            "name": {"title": "Name", "type": "string"},
-            "date": {"title": "Date", "type": "string"},
-            "participants": {
-                "items": {"type": "string"},
-                "title": "Participants",
-                "type": "array",
-            },
-        },
-        "required": ["name", "date", "participants"],
-        "title": "CalendarEvent",
-        "type": "object",
     }

--- a/weave/trace/serialize.py
+++ b/weave/trace/serialize.py
@@ -5,8 +5,6 @@ from collections.abc import Sequence
 from types import CoroutineType
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel
-
 from weave.trace import custom_objs
 from weave.trace.object_record import ObjectRecord
 from weave.trace.refs import ObjectRef, TableRef, parse_uri
@@ -24,19 +22,6 @@ from weave.trace_server.trace_server_interface_util import bytes_digest
 
 if TYPE_CHECKING:
     from weave.trace.weave_client import WeaveClient
-
-
-def is_pydantic_model_class(obj: Any) -> bool:
-    """Determine if obj is a subclass of pydantic.BaseModel."""
-    try:
-        return (
-            isinstance(obj, type)
-            and issubclass(obj, BaseModel)
-            and obj is not BaseModel
-        )
-    except TypeError:
-        # Might be something like Iterable[CalendarEvent]
-        return False
 
 
 def to_json(
@@ -60,8 +45,6 @@ def to_json(
         return [to_json(v, project_id, client, use_dictify) for v in obj]
     elif isinstance(obj, dict):
         return {k: to_json(v, project_id, client, use_dictify) for k, v in obj.items()}
-    elif is_pydantic_model_class(obj):
-        return obj.model_json_schema()
 
     if isinstance(obj, (int, float, str, bool)) or obj is None:
         return obj


### PR DESCRIPTION
Reverts wandb/weave#3742


TEST

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined JSON conversion by removing legacy handling for specialized object types.
- **Tests**
	- Removed outdated tests that verified now-discontinued model-specific behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->