### PR TITLE
chore(app): UI improvements for runs history step slider

### DIFF
--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -218,14 +218,15 @@ const PanelRunHistoryTablesStepper: React.FC<
           {steps.length > 0 && (
             <div
               style={{
-                padding: '2px',
-                height: '1.7em',
+                padding: '8px',
                 borderTop: '1px solid #ddd',
                 backgroundColor: '#f8f8f8',
                 display: 'flex',
                 justifyContent: 'center',
                 alignItems: 'center',
+                marginTop: '8px',
               }}>
+              Step:{' '}
               <SliderInput
                 min={steps[0]}
                 max={steps[steps.length - 1]}

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -153,7 +153,20 @@ export const PanelTable: React.FC<
   if (typedInputNodeUse.loading) {
     return <Panel2Loader />;
   } else if (typedInputNode && isAssignableTo(typedInputNode.type, 'none')) {
-    return <div>-</div>;
+    return (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#666',
+          fontSize: '14px',
+        }}>
+        No items to display
+      </div>
+    );
   } else if (!nodeIsValidList(typedInputNode)) {
     console.warn(
       'PanelTable returning empty state because of Invalid input type: ',


### PR DESCRIPTION
## Description

- Adds padding around the slider

Old:
<img width="1728" alt="Screenshot 2025-02-25 at 4 59 12 PM" src="https://github.com/user-attachments/assets/f045d823-4aec-41ec-b9eb-ef0be4cfb81f" /> 

New: 
<img width="1728" alt="Screenshot 2025-02-25 at 4 58 49 PM" src="https://github.com/user-attachments/assets/2ab03b1c-d868-48ff-b719-09e45920862c" />

- Provide a more informative empty state

Old:
<img width="1728" alt="Screenshot 2025-02-25 at 4 59 04 PM" src="https://github.com/user-attachments/assets/397590df-7144-40cb-8e34-7f1be9f5bbef" />

New:
<img width="1728" alt="Screenshot 2025-02-25 at 4 58 40 PM" src="https://github.com/user-attachments/assets/ee25ed70-36a3-4e3e-baac-8c02813f746a" />


## Testing

Local FE (See screenshots above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the layout of the step display area with enhanced spacing and a new label for better clarity.
  - Redesigned the empty state view of data tables with centered and styled text, offering clearer feedback when there are no items to show.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->