### PR TITLE
fix(weave): use of deprecated /calls/query endpoint

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -308,20 +308,21 @@ def _make_calls_iterator(
     page_size: int = DEFAULT_CALLS_PAGE_SIZE,
 ) -> CallsIter:
     def fetch_func(offset: int, limit: int) -> list[CallSchema]:
-        response = server.calls_query(
-            CallsQueryReq(
-                project_id=project_id,
-                filter=filter,
-                offset=offset,
-                limit=limit,
-                include_costs=include_costs,
-                include_feedback=include_feedback,
-                query=query,
-                sort_by=sort_by,
-                columns=columns,
+        return list(
+            server.calls_query_stream(
+                CallsQueryReq(
+                    project_id=project_id,
+                    filter=filter,
+                    offset=offset,
+                    limit=limit,
+                    include_costs=include_costs,
+                    include_feedback=include_feedback,
+                    query=query,
+                    sort_by=sort_by,
+                    columns=columns,
+                )
             )
         )
-        return response.calls
 
     # TODO: Should be Call, not WeaveObject
     def transform_func(call: CallSchema) -> WeaveObject:
@@ -1027,18 +1028,20 @@ class WeaveClient:
         Returns:
             A call object.
         """
-        response = self.server.calls_query(
-            CallsQueryReq(
-                project_id=self._project_id(),
-                filter=CallsFilter(call_ids=[call_id]),
-                include_costs=include_costs,
-                include_feedback=include_feedback,
-                columns=columns,
+        calls = list(
+            self.server.calls_query_stream(
+                CallsQueryReq(
+                    project_id=self._project_id(),
+                    filter=CallsFilter(call_ids=[call_id]),
+                    include_costs=include_costs,
+                    include_feedback=include_feedback,
+                    columns=columns,
+                )
             )
         )
-        if not response.calls:
+        if not calls:
             raise ValueError(f"Call not found: {call_id}")
-        response_call = response.calls[0]
+        response_call = calls[0]
         return make_client_call(self.entity, self.project, response_call, self.server)
 
     @deprecated(new_name="get_call")

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -290,11 +290,12 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
     def calls_query(
         self, req: Union[tsi.CallsQueryReq, dict[str, Any]]
     ) -> tsi.CallsQueryRes:
-        return self._generic_request(
-            "/calls/query", req, tsi.CallsQueryReq, tsi.CallsQueryRes
-        )
+        # This previously called the deprecated /calls/query endpoint.
+        return tsi.CallsQueryRes(calls=list(self.calls_query_stream(req)))
 
-    def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
+    def calls_query_stream(
+        self, req: Union[tsi.CallsQueryReq, dict[str, Any]]
+    ) -> Iterator[tsi.CallSchema]:
         return self._generic_stream_request(
             "/calls/stream_query", req, tsi.CallsQueryReq, tsi.CallSchema
         )


### PR DESCRIPTION
## Description

1. Change server.calls_query to be implemented in terms of `calls_query_stream` so that it won't use the deprecated endpoint.
2. Change the higher level `client.get_call` and `client.get_calls` methods to use `calls_query_stream`

## Testing

How was this PR tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the retrieval of call data using a direct streaming approach, reducing overhead and simplifying processing for enhanced performance.
  
- **New Features**
  - Updated the server query interface to support more flexible input types.
  - Deprecated the legacy query method in favor of the improved streaming mechanism.

These updates deliver a smoother, more efficient data fetching experience for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->