### PR TITLE
chore(weave): better WEAVE_DEBUG_HTTP control

### DIFF
--- a/weave/trace_server/requests.py
+++ b/weave/trace_server/requests.py
@@ -133,6 +133,9 @@ class LoggingHTTPAdapter(HTTPAdapter):
     # Actual signature is:
     # self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None
     def send(self, request: PreparedRequest, **kwargs: Any) -> Response:  # type: ignore
+        if os.environ.get("WEAVE_DEBUG_HTTP") != "1":
+            return super().send(request, **kwargs)
+
         console.print(Text("-" * 21, style=STYLE_DIVIDER_REQUEST))
         pprint_prepared_request(request)
         start_time = time()
@@ -148,10 +151,9 @@ class LoggingHTTPAdapter(HTTPAdapter):
 
 
 session = Session()
-if os.environ.get("WEAVE_DEBUG_HTTP") == "1":
-    adapter = LoggingHTTPAdapter()
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
+adapter = LoggingHTTPAdapter()
+session.mount("http://", adapter)
+session.mount("https://", adapter)
 
 
 def get(url: str, params: Optional[dict[str, str]] = None, **kwargs: Any) -> Response:


### PR DESCRIPTION
## Description

The `WEAVE_DEBUG_HTTP` environment variable was only getting read when Weave was imported. By checking its value at HTTP request time instead we can have fine grained control over when logging happens, turning it on or off by setting
`os.environ["WEAVE_DEBUG_HTTP"] = "1"` in e.g. ipython.

This makes it a lot easier to find the requests that correspond to a particular call you are making.