### PR TITLE
fix(weave): exception field of call object not being set on get_calls

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -733,6 +733,7 @@ def make_client_call(
         id=call_id,
         inputs=from_json(server_call.inputs, server_call.project_id, server),
         output=from_json(server_call.output, server_call.project_id, server),
+        exception=server_call.exception,
         summary=dict(server_call.summary) if server_call.summary is not None else None,
         _display_name=server_call.display_name,
         attributes=server_call.attributes,


### PR DESCRIPTION
## Description

- Fixes WB-23275

Fixes exception field being lost when iterating over calls returned by python client SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling during client-server interactions by introducing an expanded mechanism to capture and relay additional error details, ensuring improved system robustness without impacting existing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->