### PR TITLE
fix(ui): prevent "auto-refresh" deleting scorer input fields

### DIFF
--- a/weave-js/src/components/Form/TextField.tsx
+++ b/weave-js/src/components/Form/TextField.tsx
@@ -24,6 +24,7 @@ type TextFieldProps = {
   onChange?: (value: string) => void;
   onKeyDown?: (key: string, e: React.KeyboardEvent<HTMLInputElement>) => void;
   onBlur?: (value: string) => void;
+  onFocus?: () => void;
   autoFocus?: boolean;
   disabled?: boolean;
   icon?: IconName;
@@ -48,6 +49,7 @@ export const TextField = ({
   onChange,
   onKeyDown,
   onBlur,
+  onFocus,
   autoFocus,
   disabled,
   icon,
@@ -133,6 +135,7 @@ export const TextField = ({
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             onBlur={handleBlur}
+            onFocus={onFocus}
             autoFocus={autoFocus}
             disabled={disabled}
             readOnly={!onChange} // It would be readonly regardless but this prevents a console warning


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-23535](https://wandb.atlassian.net/browse/WB-23535)
[WB-23052](https://wandb.atlassian.net/browse/WB-23052)

This pr:
- adds an optional `onFocus` param on TextField 
- refactors state hooks in the Zod nested component into separate hook for clarity
- adds additional checks to only update on if the field is focused

## Testing

Prod:
![scorer-input-prod](https://github.com/user-attachments/assets/00c2fdd1-28be-41f3-9662-2530c2159ced)

Branch:
![scorer-input-branch](https://github.com/user-attachments/assets/e840885a-24f0-4cee-b291-bb5a607db984)


[WB-23535]: https://wandb.atlassian.net/browse/WB-23535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-23052]: https://wandb.atlassian.net/browse/WB-23052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional property to text input components that enables custom handling when an input field gains focus, enhancing interactivity.
  - Improved nested form interactions by refining focus and state transitions, resulting in a smoother and more stable data entry experience.
  - These enhancements contribute to a more responsive and intuitive interface when interacting with forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->