### PR TITLE
chore(weave): Make object viewer load much faster

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -146,19 +146,22 @@ const ObjectViewerSectionNonEmpty = ({
   }, [apiRef]);
 
   // Re-clicking the button will reapply collapse/expand
-  const onClickCollapsed = () => {
+  const onClickCollapsed = useCallback(() => {
     if (mode === 'collapsed') {
       setTreeExpanded(false);
     }
     setMode('collapsed');
     setExpandedIds([]);
-  };
+  }, [mode, setTreeExpanded]);
 
-  const isExpandAllSmall =
-    !!apiRef?.current?.getAllRowIds &&
-    getGroupIds().length - expandedIds.length < EXPANDED_IDS_LENGTH;
+  const isExpandAllSmall = useMemo(() => {
+    return (
+      !!apiRef?.current?.getAllRowIds &&
+      getGroupIds().length - expandedIds.length < EXPANDED_IDS_LENGTH
+    );
+  }, [apiRef, expandedIds.length, getGroupIds]);
 
-  const onClickExpanded = () => {
+  const onClickExpanded = useCallback(() => {
     if (mode === 'expanded') {
       setTreeExpanded(true);
     }
@@ -170,22 +173,13 @@ const ObjectViewerSectionNonEmpty = ({
         getGroupIds().slice(0, expandedIds.length + EXPANDED_IDS_LENGTH)
       );
     }
-  };
-
-  // On first render and when data changes, recompute expansion state
-  useEffect(() => {
-    if (mode === 'hidden' || mode === 'json') {
-      return;
-    }
-    const isSimple = isSimpleData(data);
-    const newMode = isSimple || isExpanded ? 'expanded' : 'collapsed';
-    if (newMode === 'expanded') {
-      onClickExpanded();
-    } else {
-      onClickCollapsed();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, isExpanded]);
+  }, [
+    expandedIds.length,
+    getGroupIds,
+    isExpandAllSmall,
+    mode,
+    setTreeExpanded,
+  ]);
 
   return (
     <Box sx={{height: '100%', display: 'flex', flexDirection: 'column'}}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewerSection.tsx
@@ -1,13 +1,7 @@
 import Box from '@mui/material/Box';
 import {GridRowId, useGridApiRef} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, {useCallback, useContext, useMemo, useState} from 'react';
 import styled from 'styled-components';
 
 import {isWeaveObjectRef, parseRef} from '../../../../../../react';
@@ -20,7 +14,7 @@ import {CustomWeaveTypeDispatcher} from '../../typeViews/CustomWeaveTypeDispatch
 import {OBJECT_ATTR_EDGE_NAME} from '../wfReactInterface/constants';
 import {WeaveCHTable, WeaveCHTableSourceRefContext} from './DataTableView';
 import {ObjectViewer} from './ObjectViewer';
-import {getValueType, traverse} from './traverse';
+import {getValueType} from './traverse';
 import {ValueView} from './ValueView';
 
 const EXPANDED_IDS_LENGTH = 200;
@@ -51,35 +45,6 @@ const Title = styled.div`
   text-align: left;
 `;
 Title.displayName = 'S.Title';
-
-// We'll automatically expand objects if they are "simple" enough.
-// This is a heuristic for what that means.
-const isSimpleData = (data: Data): boolean => {
-  let isSimple = true;
-  traverse(data, context => {
-    if (context.depth > 3) {
-      isSimple = false;
-      return false;
-    }
-    if (isWeaveRef(context.value)) {
-      isSimple = false;
-      return false;
-    }
-    if (context.valueType === 'array' && context.value.length > 10) {
-      isSimple = false;
-      return false;
-    }
-    if (
-      context.valueType === 'object' &&
-      Object.keys(context.value).length > 10
-    ) {
-      isSimple = false;
-      return false;
-    }
-    return undefined;
-  });
-  return isSimple;
-};
 
 // Use a deep comparison to avoid re-rendering when the data object hasn't really changed.
 const ObjectViewerSectionNonEmptyMemoed = React.memo(


### PR DESCRIPTION
There is an effect which is intended to reset the expansion state when new data is loaded into the object viewer. This can result in a horrible render loop (for some examples, it can take 30s to resolve). I did not get to the bottom of exactly why, but i think it is because the MUI data grid is loading in fresh data while simultaneously we are expanding/collapsing nodes, and it seems to have more-than-linear loading time depending on the size of the old and new state. Removing this moves the load down to sub second in nearly all cases i found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved component responsiveness and efficiency through optimized state management and event handling.
	- Enhanced performance by reducing unnecessary recalculations and streamlining the control flow. 
	- Removed unnecessary complexity related to data expansion logic, leading to a cleaner implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->