### PR TITLE
fix(weave): correctly handle null case when flattening calls for dataset insertion

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
@@ -64,6 +64,16 @@ describe('flattenObject', () => {
     const obj = {created: date};
     expect(flattenObject(obj)).toEqual([{name: 'created', type: 'date'}]);
   });
+
+  test('handles null values', () => {
+    const obj = {value: null};
+    expect(flattenObject(obj)).toEqual([{name: 'value', type: 'null'}]);
+  });
+
+  test('handles undefined values', () => {
+    const obj = {value: undefined};
+    expect(flattenObject(obj)).toEqual([{name: 'value', type: 'undefined'}]);
+  });
 });
 
 describe('inferSchema', () => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
@@ -26,13 +26,13 @@ export const inferType = (value: any): string => {
 export const flattenObject = (obj: any, prefix = ''): SchemaField[] => {
   let fields: SchemaField[] = [];
 
+  // Return empty array for null or undefined inputs
+  if (obj == null) {
+    return fields;
+  }
+
   // Special handling for __ref__ and __val__ pattern
-  if (
-    obj != null &&
-    typeof obj === 'object' &&
-    '__ref__' in obj &&
-    '__val__' in obj
-  ) {
+  if (typeof obj === 'object' && '__ref__' in obj && '__val__' in obj) {
     return flattenObject(obj.__val__, prefix);
   }
 
@@ -95,7 +95,16 @@ export interface FieldMapping {
 export const extractSourceSchema = (calls: CallData[]): SchemaField[] => {
   const allFields: SchemaField[] = [];
 
+  if (!calls || !Array.isArray(calls)) {
+    return allFields;
+  }
+
   calls.forEach(call => {
+    // Skip if call or call.val is undefined
+    if (!call || !call.val) {
+      return;
+    }
+
     if (call.val.inputs) {
       allFields.push(...flattenObject(call.val.inputs, 'inputs'));
     }


### PR DESCRIPTION
## Description

Correctly handle the `null`and `undefined` case in our recursive call object flattener for the add to dataset UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling and input validation to ensure smoother data processing and reduce the risk of unexpected errors during usage.
  - Improved resilience of functions against `null` and `undefined` inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->