### PR TITLE
chore(weave): combine op filter into filter panel

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
@@ -8,6 +8,8 @@ import {AdapterMoment} from '@mui/x-date-pickers/AdapterMoment';
 import React from 'react';
 import {AutoSizer} from 'react-virtualized';
 
+import {WFHighLevelCallFilter} from '../pages/CallsPage/callsTableFilter';
+import {OpVersionSchema} from '../pages/wfReactInterface/wfDataModelHooksInterface';
 import {ColumnInfo} from '../types';
 import {FilterBar} from './FilterBar';
 
@@ -17,6 +19,21 @@ type FilterPanelProps = {
   columnInfo: ColumnInfo;
   selectedCalls: string[];
   clearSelectedCalls: () => void;
+
+  // op stuff
+  frozenFilter: WFHighLevelCallFilter | undefined;
+  filter: WFHighLevelCallFilter;
+  setFilter: (state: WFHighLevelCallFilter) => void;
+  selectedOpVersionOption: string;
+  opVersionOptions: Record<
+    string,
+    {
+      title: string;
+      ref: string;
+      group: string;
+      objectVersion?: OpVersionSchema;
+    }
+  >;
 };
 
 export const FilterPanel = (props: FilterPanelProps) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -3,12 +3,16 @@
  */
 
 import {GridFilterItem} from '@mui/x-data-grid-pro';
+import {Icon} from '@wandb/weave/components/Icon';
 import {RemoveAction} from '@wandb/weave/components/Tag';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
 import React from 'react';
 
 import {parseRef} from '../../../../../react';
 import {Timestamp} from '../../../../Timestamp';
 import {UserLink} from '../../../../UserLink';
+import {ALL_TRACES_OR_CALLS_REF_KEY} from '../pages/CallsPage/callsTableFilter';
+import {opNiceName} from '../pages/common/opNiceName';
 import {SmallRef} from '../smallRef/SmallRef';
 import {
   FilterId,
@@ -26,6 +30,7 @@ import {IdList} from './IdList';
 type FilterTagItemProps = {
   item: GridFilterItem;
   onRemoveFilter: (id: FilterId) => void;
+  className?: string;
 };
 
 const quoteValue = (valueType: string, value: string): string => {
@@ -35,16 +40,45 @@ const quoteValue = (valueType: string, value: string): string => {
   return value;
 };
 
-export const FilterTagItem = ({item, onRemoveFilter}: FilterTagItemProps) => {
+export const FilterTagItem = ({
+  item,
+  onRemoveFilter,
+  className = '',
+}: FilterTagItemProps) => {
   const field = getFieldLabel(item.field);
-
   const operator = getOperatorLabel(item.operator);
+  let label: any = `${field} ${operator}`;
   let value: React.ReactNode = '';
+
+  let disableRemove = false;
+
   const fieldType = getFieldType(item.field);
   if (fieldType === 'id') {
     value = <IdList ids={getStringList(item.value)} type="Call" />;
   } else if (fieldType === 'user') {
     value = <UserLink userId={item.value} hasPopover={false} />;
+  } else if (item.id === 'default-operation') {
+    let tooltip: React.ReactNode = null;
+    if (item.value === ALL_TRACES_OR_CALLS_REF_KEY) {
+      tooltip = (
+        <Tooltip
+          content="All traces from any op"
+          trigger={<span>All ops</span>}
+        />
+      );
+      disableRemove = true;
+    } else {
+      const opName = opNiceName(parseRef(item.value).artifactName);
+      tooltip = (
+        <Tooltip content={item.value} trigger={<span>{opName}</span>} />
+      );
+    }
+    label = (
+      <div className="flex items-center gap-2">
+        <Icon name="job-program-code" />
+        {tooltip}
+      </div>
+    );
   } else if (isWeaveRef(item.value)) {
     value = <SmallRef objRef={parseRef(item.value)} />;
   } else if (!isValuelessOperator(item.operator)) {
@@ -55,23 +89,29 @@ export const FilterTagItem = ({item, onRemoveFilter}: FilterTagItemProps) => {
       value = ' ' + quoteValue(valueType, item.value);
     }
   }
-  const label = `${field} ${operator}`;
   return (
-    <FilterTag
-      label={
-        <>
-          {label}
-          <div className="ml-4">{value}</div>
-        </>
-      }
-      removeAction={
-        <RemoveAction
-          onClick={(e: any) => {
-            e.stopPropagation();
-            onRemoveFilter(item.id);
-          }}
-        />
-      }
-    />
+    <div
+      className={`flex items-center gap-1 rounded bg-moon-100 px-2 py-1 ${className}`}>
+      <FilterTag
+        label={
+          <>
+            {label}
+            <div className="ml-4">{value}</div>
+          </>
+        }
+        removeAction={
+          disableRemove ? (
+            <></>
+          ) : (
+            <RemoveAction
+              onClick={(e: any) => {
+                e.stopPropagation();
+                onRemoveFilter(item.id);
+              }}
+            />
+          )
+        }
+      />
+    </div>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectField.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectField.tsx
@@ -27,6 +27,7 @@ type SelectFieldProps = {
   options: SelectFieldOption[];
   value: string;
   onSelectField: (name: string) => void;
+  isDisabled?: boolean;
 };
 
 const Option = (props: OptionProps<FieldOption, false, GroupedOption>) => {
@@ -58,17 +59,18 @@ export const SelectField = ({
   options,
   value,
   onSelectField,
+  isDisabled,
 }: SelectFieldProps) => {
   const internalOptions = _.cloneDeep(options);
   const allOptions: FieldOption[] = internalOptions.flatMap(
     (groupOption: SelectFieldOption) => (groupOption as GroupedOption).options
   );
-  let isDisabled = false;
+  let innerIsDisabled = isDisabled ?? false;
   let selectedOption = allOptions.find(o => o.value === value);
 
   // Handle the case of a filter that we let the user create but not edit.
   if (value && !selectedOption) {
-    isDisabled = true;
+    innerIsDisabled = true;
     selectedOption = {
       value,
       label: getFieldLabel(value),
@@ -90,7 +92,7 @@ export const SelectField = ({
       onChange={onReactSelectChange}
       components={{Option, SingleValue}}
       formatOptionLabel={OptionLabel}
-      isDisabled={isDisabled}
+      isDisabled={innerIsDisabled}
       autoFocus
     />
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -6,15 +6,7 @@
  *    * (BackendExpansion) Move Expansion to Backend, and support filter/sort
  */
 
-import {
-  Autocomplete,
-  Box,
-  Chip,
-  FormControl,
-  ListItem,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import {Box, Chip, Tooltip, Typography} from '@mui/material';
 import {
   GridColDef,
   GridColumnVisibilityModel,
@@ -26,11 +18,9 @@ import {
   GridSortModel,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
-import {MOON_200, TEAL_300} from '@wandb/weave/common/css/color.styles';
 import {Switch} from '@wandb/weave/components';
 import {Checkbox} from '@wandb/weave/components/Checkbox/Checkbox';
 import {
-  Icon,
   IconNotVisible,
   IconPinToRight,
   IconSortAscending,
@@ -65,9 +55,7 @@ import {getDefaultOperatorForValue} from '../../filters/common';
 import {FilterPanel} from '../../filters/FilterPanel';
 import {flattenObjectPreservingWeaveTypes} from '../../flattenObject';
 import {DEFAULT_PAGE_SIZE} from '../../grid/pagination';
-import {StyledPaper} from '../../StyledAutocomplete';
 import {StyledDataGrid} from '../../StyledDataGrid';
-import {StyledTextField} from '../../StyledTextField';
 import {ConfirmDeleteModal} from '../CallPage/OverflowMenu';
 import {Empty} from '../common/Empty';
 import {
@@ -86,10 +74,7 @@ import {TraceCallSchema} from '../wfReactInterface/traceServerClientTypes';
 import {traceCallToUICallSchema} from '../wfReactInterface/tsDataModelHooks';
 import {EXPANDED_REF_REF_KEY} from '../wfReactInterface/tsDataModelHooksCallRefExpansion';
 import {objectVersionNiceString} from '../wfReactInterface/utilities';
-import {
-  CallSchema,
-  OpVersionSchema,
-} from '../wfReactInterface/wfDataModelHooksInterface';
+import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CallsCharts} from './CallsCharts';
 import {CallsCustomColumnMenu} from './CallsCustomColumnMenu';
 import {
@@ -757,15 +742,6 @@ export const CallsTable: FC<{
             onClick={() => calls.refetch()}
             disabled={callsLoading}
           />
-          {!hideOpSelector && (
-            <OpSelector
-              frozenFilter={frozenFilter}
-              filter={filter}
-              setFilter={setFilter}
-              selectedOpVersionOption={selectedOpVersionOption}
-              opVersionOptions={opVersionOptions}
-            />
-          )}
           {filterModel && setFilterModel && (
             <FilterPanel
               filterModel={filterModel}
@@ -773,6 +749,12 @@ export const CallsTable: FC<{
               setFilterModel={setFilterModel}
               selectedCalls={selectedCalls}
               clearSelectedCalls={clearSelectedCalls}
+              // op stuff
+              frozenFilter={frozenFilter}
+              filter={filter}
+              setFilter={setFilter}
+              selectedOpVersionOption={selectedOpVersionOption}
+              opVersionOptions={opVersionOptions}
             />
           )}
           <div className="flex items-center gap-6">
@@ -1056,90 +1038,6 @@ export const CallsTable: FC<{
         }}
       />
     </FilterLayoutTemplate>
-  );
-};
-
-const OpSelector = ({
-  frozenFilter,
-  filter,
-  setFilter,
-  selectedOpVersionOption,
-  opVersionOptions,
-}: {
-  frozenFilter: WFHighLevelCallFilter | undefined;
-  filter: WFHighLevelCallFilter;
-  setFilter: (state: WFHighLevelCallFilter) => void;
-  selectedOpVersionOption: string;
-  opVersionOptions: Record<
-    string,
-    {
-      title: string;
-      ref: string;
-      group: string;
-      objectVersion?: OpVersionSchema;
-    }
-  >;
-}) => {
-  const frozenOpFilter = Object.keys(frozenFilter ?? {}).includes('opVersions');
-  const handleChange = useCallback(
-    (event: any, newValue: string | null) => {
-      if (newValue === ALL_TRACES_OR_CALLS_REF_KEY) {
-        setFilter({
-          ...filter,
-          opVersionRefs: [],
-        });
-      } else {
-        setFilter({
-          ...filter,
-          opVersionRefs: newValue ? [newValue] : [],
-        });
-      }
-    },
-    [filter, setFilter]
-  );
-
-  return (
-    <div className="flex-none">
-      <ListItem sx={{minWidth: 190, width: 320, height: 32, padding: 0}}>
-        <FormControl fullWidth sx={{borderColor: MOON_200}}>
-          <Autocomplete
-            PaperComponent={paperProps => <StyledPaper {...paperProps} />}
-            sx={{
-              '& .MuiOutlinedInput-root': {
-                height: '32px',
-                '& fieldset': {
-                  borderColor: MOON_200,
-                },
-                '&:hover fieldset': {
-                  borderColor: `rgba(${TEAL_300}, 0.48)`,
-                },
-              },
-              '& .MuiOutlinedInput-input': {
-                height: '32px',
-                padding: '0 14px',
-                boxSizing: 'border-box',
-              },
-            }}
-            size="small"
-            limitTags={1}
-            disabled={frozenOpFilter}
-            value={selectedOpVersionOption}
-            onChange={handleChange}
-            renderInput={renderParams => (
-              <StyledTextField {...renderParams} sx={{maxWidth: '350px'}} />
-            )}
-            getOptionLabel={option => opVersionOptions[option]?.title ?? ''}
-            disableClearable={
-              selectedOpVersionOption === ALL_TRACES_OR_CALLS_REF_KEY
-            }
-            groupBy={option => opVersionOptions[option]?.group}
-            options={Object.keys(opVersionOptions)}
-            popupIcon={<Icon name="chevron-down" />}
-            clearIcon={<Icon name="close" />}
-          />
-        </FormControl>
-      </ListItem>
-    </div>
   );
 };
 


### PR DESCRIPTION
## Description

TODO: 
- fix all the gross hacks that are making this somewhat work
- debounce the filter additions, very non-performant currently 
- fix the styling so that the default (op and in the future date) rows match the programatic filters


<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
<img width="612" alt="Screenshot 2025-02-27 at 4 28 15 PM" src="https://github.com/user-attachments/assets/1f2572b1-1820-4180-8f7f-da30940fca5d" />

## Testing
![filter-ops-3](https://github.com/user-attachments/assets/a8f5c332-2fb8-4493-b562-144610f7e5ce)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering capabilities allow users to filter operations by version with an improved user interface, including intuitive selection fields and tooltips.
- **Refactor**
  - Consolidated operation filtering controls into the main filter panel for a streamlined filter management experience.
  - Improved disabled state handling and tag display for a more refined interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->