### PR TITLE
fix(ui): dont drop new keys when on row update

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
@@ -297,15 +297,29 @@ export const EditableDatasetView: React.FC<EditableDatasetViewProps> = ({
     return [...displayedAddedRows, ...rows];
   }, [rows, addedRows, numAddedRows, paginationModel, isEditing]);
 
+  const initialFieldsSet = useMemo(
+    () => new Set(initialFields),
+    [initialFields]
+  );
+
   const preserveFieldOrder = useCallback(
     (row: OrderedRow): OrderedRow => {
       const orderedRow: OrderedRow = {___weave: row.___weave};
+      // First add all fields that are in initialFields in the correct order
       initialFields.forEach(field => {
         orderedRow[field] = row[field] !== undefined ? row[field] : '';
       });
+
+      // Then add any additional fields that weren't in initialFields
+      Object.keys(row).forEach(field => {
+        if (field !== '___weave' && !initialFieldsSet.has(field)) {
+          orderedRow[field] = row[field];
+        }
+      });
+
       return orderedRow;
     },
-    [initialFields]
+    [initialFields, initialFieldsSet]
   );
 
   const columns = useMemo(() => {


### PR DESCRIPTION
## Description

Fixes a bug that was causing edits to blank fields in new rows for the edit step in add to dataset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the dataset view so that key fields now appear in a consistent order.
  - Ensured that if a field is missing from a record, it displays with an empty value, providing a clearer and more reliable data presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->