### PR TITLE
chore(weave): filter null messages before sending in playground

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatInput.tsx
@@ -140,6 +140,7 @@ export const PlaygroundChatInput: React.FC<PlaygroundChatInputProps> = ({
               variant="secondary"
               size="medium"
               startIcon="add-new"
+              disabled={isLoading || chatText.trim() === ''}
               onClick={() => handleAdd(addMessageRole, chatText)}>
               Add
             </Button>


### PR DESCRIPTION
## Description
hide whitespace when reviewing

https://wandb.atlassian.net/browse/WB-23085
i had a pr that I did not push up :/

creates a filter null messages func
wraps state with that func before sending

prevents users from add empty text messages
on send filters null or '' messages out

https://github.com/user-attachments/assets/b6f4c07f-be79-4387-ac14-ab61f6c3be80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced chat input interactivity by disabling the send button when no valid message is entered or while processing.
  
- **Refactor**
	- Improved chat state management by filtering out empty message entries to ensure smoother overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->