### PR TITLE
fix(ui): prevent cursor and keyboard from targeting non editable cells

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CellRenderers.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CellRenderers.tsx
@@ -189,10 +189,22 @@ export const CellViewingRenderer: React.FC<
             },
           },
         }}>
-        <div
-          onClick={e => e.stopPropagation()}
-          onDoubleClick={e => e.stopPropagation()}
-          style={{
+        <Box
+          onClick={e => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          onDoubleClick={e => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          onKeyDown={e => e.preventDefault()}
+          onFocus={e => e.target.blur()}
+          onMouseDown={e => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+          sx={{
             height: '100%',
             backgroundColor: getBackgroundColor(),
             opacity: isDeleted ? DELETED_CELL_STYLES.opacity : 1,
@@ -203,7 +215,7 @@ export const CellViewingRenderer: React.FC<
             paddingLeft: '8px',
           }}>
           <CellValue value={value} noLink={true} />
-        </div>
+        </Box>
       </Tooltip>
     );
   }


### PR DESCRIPTION
## Description
Capture and dismiss keyboard and mouse interactions in non editable cells in the dataset editor. This created a bug where small ref text in ref cells could be selected and deleted, breaking the visual display of the cell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced user interaction handling to ensure a more consistent response during clicks, key presses, and focus events.
  
- **Style**
  - Updated the component's styling approach to align with modern design practices for a seamless look and feel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->