### PR TITLE
refactor(ui): datasets page does not use ObjectVersionsPage

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -65,6 +65,7 @@ import {Empty} from './Browse3/pages/common/Empty';
 import {EMPTY_NO_TRACE_SERVER} from './Browse3/pages/common/EmptyContent';
 import {SimplePageLayoutContext} from './Browse3/pages/common/SimplePageLayout';
 import {CompareEvaluationsPage} from './Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage';
+import {DatasetsPage} from './Browse3/pages/DatasetsPage/DatasetsPage';
 import {LeaderboardListingPage} from './Browse3/pages/LeaderboardPage/LeaderboardListingPage';
 import {LeaderboardPage} from './Browse3/pages/LeaderboardPage/LeaderboardPage';
 import {ModsPage} from './Browse3/pages/ModsPage';
@@ -409,10 +410,13 @@ const Browse3ProjectRoot: FC<{
         </Route>
         <Route
           path={[
-            `${projectRoot}/:tab(prompts|datasets|models|objects)`,
+            `${projectRoot}/:tab(prompts|models|objects)`,
             `${projectRoot}/object-versions`,
           ]}>
           <ObjectVersionsPageBinding />
+        </Route>
+        <Route path={`${projectRoot}/:tab(datasets)`}>
+          <DatasetsPageBinding />
         </Route>
         {/* OPS */}
         <Route path={`${projectRoot}/ops/:itemName/versions/:version?`}>
@@ -799,6 +803,41 @@ const ObjectVersionsPageBinding = () => {
   );
   return (
     <ObjectVersionsPage
+      entity={entity}
+      project={project}
+      initialFilter={filters}
+      onFilterUpdate={onFilterUpdate}
+    />
+  );
+};
+
+// New DatasetsPageBinding component for the dedicated datasets page
+const DatasetsPageBinding = () => {
+  const {entity, project} = useParamsDecoded<Browse3TabParams>();
+  const query = useURLSearchParamsDict();
+  const filters = useMemo(() => {
+    if (query.filter === undefined) {
+      return {};
+    }
+    try {
+      return JSON.parse(query.filter);
+    } catch (e) {
+      console.log(e);
+      return {};
+    }
+  }, [query.filter]);
+
+  const history = useHistory();
+  const routerContext = useWeaveflowCurrentRouteContext();
+  const onFilterUpdate = useCallback(
+    filter => {
+      history.push(routerContext.objectVersionsUIUrl(entity, project, filter));
+    },
+    [history, entity, project, routerContext]
+  );
+
+  return (
+    <DatasetsPage
       entity={entity}
       project={project}
       initialFilter={filters}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/DatasetsPage/DatasetsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/DatasetsPage/DatasetsPage.tsx
@@ -1,0 +1,152 @@
+/**
+ * This page is specifically for datasets. It shows a list of dataset objects and their versions.
+ * It is inspired by ObjectVersionsPage but tailored specifically for the dataset use case.
+ */
+import {useViewerInfo} from '@wandb/weave/common/hooks/useViewerInfo';
+import {Button} from '@wandb/weave/components/Button';
+import {Tailwind} from '@wandb/weave/components/Tailwind';
+import React, {useMemo, useState} from 'react';
+import {useHistory} from 'react-router-dom';
+
+import {Loading} from '../../../../../Loading';
+import {useWeaveflowCurrentRouteContext} from '../../context';
+import {SimplePageLayout} from '../common/SimplePageLayout';
+import {DeleteObjectVersionsButtonWithModal} from '../ObjectsPage/ObjectDeleteButtons';
+import {WFHighLevelObjectVersionFilter} from '../ObjectsPage/objectsPageTypes';
+import {FilterableObjectVersionsTable} from '../ObjectsPage/ObjectVersionsTable';
+import {useControllableState} from '../util';
+
+export type DatasetFilter = WFHighLevelObjectVersionFilter;
+
+const DATASET_TYPE = 'Dataset' as const;
+
+export const DatasetsPage: React.FC<{
+  entity: string;
+  project: string;
+  initialFilter?: DatasetFilter;
+  onFilterUpdate?: (filter: DatasetFilter) => void;
+}> = props => {
+  const history = useHistory();
+  const {loading: loadingUserInfo, userInfo} = useViewerInfo();
+  const router = useWeaveflowCurrentRouteContext();
+
+  const baseFilter = useMemo(() => {
+    return {
+      ...props.initialFilter,
+      baseObjectClass: DATASET_TYPE,
+    };
+  }, [props.initialFilter]);
+
+  const [filter, setFilter] =
+    useControllableState<WFHighLevelObjectVersionFilter>(
+      baseFilter ?? {baseObjectClass: DATASET_TYPE},
+      props.onFilterUpdate
+    );
+
+  const {entity, project} = props;
+  const [selectedVersions, setSelectedVersions] = useState<string[]>([]);
+
+  const onCompare = () => {
+    history.push(router.compareObjectsUri(entity, project, selectedVersions));
+  };
+
+  const title = useMemo(() => {
+    if (filter.objectName) {
+      return 'Versions of ' + filter.objectName;
+    }
+    return 'Datasets';
+  }, [filter.objectName]);
+
+  if (loadingUserInfo) {
+    return <Loading />;
+  }
+
+  const filteredOnObject = filter.objectName != null;
+  const hasComparison = filteredOnObject;
+  const viewer = userInfo ? userInfo.id : null;
+  const isReadonly = !viewer || !userInfo?.teams.includes(props.entity);
+  const isAdmin = userInfo?.admin;
+  const showDeleteButton = filteredOnObject && !isReadonly && isAdmin;
+
+  return (
+    <SimplePageLayout
+      title={title}
+      hideTabsIfSingle
+      headerExtra={
+        <DatasetsPageHeaderExtra
+          entity={entity}
+          project={project}
+          objectName={filter.objectName ?? null}
+          selectedVersions={selectedVersions}
+          setSelectedVersions={setSelectedVersions}
+          showDeleteButton={showDeleteButton}
+          showCompareButton={hasComparison}
+          onCompare={onCompare}
+        />
+      }
+      tabs={[
+        {
+          label: '',
+          content: (
+            <FilterableObjectVersionsTable
+              entity={entity}
+              project={project}
+              initialFilter={filter}
+              onFilterUpdate={setFilter}
+              selectedVersions={selectedVersions}
+              setSelectedVersions={
+                hasComparison ? setSelectedVersions : undefined
+              }
+            />
+          ),
+        },
+      ]}
+    />
+  );
+};
+
+const DatasetsPageHeaderExtra: React.FC<{
+  entity: string;
+  project: string;
+  objectName: string | null;
+  selectedVersions: string[];
+  setSelectedVersions: (selected: string[]) => void;
+  showDeleteButton?: boolean;
+  showCompareButton?: boolean;
+  onCompare: () => void;
+}> = ({
+  entity,
+  project,
+  objectName,
+  selectedVersions,
+  setSelectedVersions,
+  showDeleteButton,
+  showCompareButton,
+  onCompare,
+}) => {
+  const compareButton = showCompareButton ? (
+    <Button disabled={selectedVersions.length < 2} onClick={onCompare}>
+      Compare
+    </Button>
+  ) : undefined;
+
+  const deleteButton = showDeleteButton ? (
+    <DeleteObjectVersionsButtonWithModal
+      entity={entity}
+      project={project}
+      objectName={objectName ?? ''}
+      objectVersions={selectedVersions}
+      disabled={selectedVersions.length === 0 || !objectName}
+      onSuccess={() => setSelectedVersions([])}
+    />
+  ) : undefined;
+
+  return (
+    <Tailwind>
+      <div className="mr-16 flex gap-8">
+        {compareButton}
+        {deleteButton}
+      </div>
+    </Tailwind>
+  );
+};


### PR DESCRIPTION
## Description

Currently, `/weave/datasets` routes to an object versions page labeled `Datasets`- I am calling this the "datasets page".

This PR copies some of the `ObjectVersionsPage` code into `Browse3/pages/DatasetsPage/` to so we can modify the datasets page without modifying the objects page. This PR also updates the `/weave/datasets` route to render the new, dataset-specific implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated datasets page accessible via the updated navigation.
  - Introduced a user interface for managing datasets with dynamic filtering and version display.
  - Enabled conditional actions, such as comparing and deleting items, based on user permissions.
  - Enhanced routing capabilities to streamline user navigation within the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->