### PR TITLE
chore(app): Create isMediaString util

### DIFF
--- a/weave-js/src/common/types/media.ts
+++ b/weave-js/src/common/types/media.ts
@@ -226,6 +226,10 @@ export const isMediaCardType = (type: string): type is MediaCardType => {
   return _.includes(mediaCardStrings, type);
 };
 
+export const isMediaString = (type: string): type is MediaString => {
+  return _.includes(mediaStrings, type);
+};
+
 export const mediaCardTypeToKeys = (mediaType: MediaCardType) => {
   const mapping: {[k in MediaCardType]: MediaCardString[]} = {
     image: ['images', 'image-file', 'images/separated'],


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

Creates a util for checking the metric type if it's a media string.

## Testing

How was this PR tested?

See https://github.com/wandb/core/pull/27744


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced media type validation for more consistent and reliable handling of media-related information throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->