### PR TITLE
Griffin/client flinish

### DIFF
--- a/tests/trace/test_evaluation_performance.py
+++ b/tests/trace/test_evaluation_performance.py
@@ -159,7 +159,7 @@ async def test_evaluation_resilience(
         with pytest.raises(DummyTestException):
             res = await evaluation.evaluate(predict)
 
-    client_with_throwing_server.flush()
+    client_with_throwing_server.finish()
 
     logs = log_collector.get_error_logs()
     ag_res = Counter([k.split(", req:")[0] for k in {l.msg for l in logs}])
@@ -172,7 +172,7 @@ async def test_evaluation_resilience(
         res = await evaluation.evaluate(predict)
         assert res["score"]["true_count"] == 1
 
-    client_with_throwing_server.flush()
+    client_with_throwing_server.finish()
 
     logs = log_collector.get_error_logs()
     ag_res = Counter([k.split(", req:")[0] for k in {l.msg for l in logs}])

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -1,0 +1,446 @@
+import {
+  MOON_250,
+  TEAL_350,
+  TEAL_400,
+} from '@wandb/weave/common/css/color.styles';
+import {Icon} from '@wandb/weave/components/Icon';
+import React, {useEffect, useRef, useState} from 'react';
+
+import {
+  dateToISOString,
+  formatDate,
+  formatDateOnly,
+  isRelativeDate,
+  parseDate,
+} from '../../../../../util/date';
+
+type PredefinedSuggestion = {
+  abbreviation: string;
+  label: string;
+};
+
+const PREDEFINED_SUGGESTIONS: PredefinedSuggestion[] = [
+  {abbreviation: '1d', label: '1 day'},
+  {abbreviation: '2d', label: '2 days'},
+  {abbreviation: '1w', label: '1 week'},
+  {abbreviation: '2w', label: '2 weeks'},
+  {abbreviation: '1m', label: '1 month'},
+];
+
+type SelectDatetimeDropdownProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
+  value,
+  onChange,
+}) => {
+  const [inputValue, setInputValue] = useState(value || '');
+  const [parsedDate, setParsedDate] = useState<Date | null>(null);
+  const [isDropdownVisible, setDropdownVisible] = useState(false);
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [selectedSuggestion, setSelectedSuggestion] = useState<string | null>(
+    null
+  );
+  const [isInputHovered, setIsInputHovered] = useState(false);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLUListElement>(null);
+
+  // Initialize the parsed date from the initial value
+  useEffect(() => {
+    if (value) {
+      const date = parseDate(value);
+      setParsedDate(date);
+    }
+  }, [value]);
+
+  // Compute yesterday's date string (date only, no time)
+  const yesterdayDate = new Date();
+  yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+  const yesterdayString = formatDateOnly(yesterdayDate);
+
+  const yesterdaySuggestion: PredefinedSuggestion = {
+    abbreviation: yesterdayString,
+    label: 'Yesterday (Absolute)',
+  };
+  const predefinedSuggestions: PredefinedSuggestion[] = [
+    ...PREDEFINED_SUGGESTIONS,
+    yesterdaySuggestion,
+  ];
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newInputValue = event.target.value;
+    setInputValue(newInputValue);
+
+    // Parse the input to get a date
+    const date = parseDate(newInputValue);
+    setParsedDate(date);
+
+    // Call the parent onChange handler with the timestamp
+    if (date) {
+      onChange(dateToISOString(date));
+    } else {
+      // If we couldn't parse a date, pass the raw input
+      // This allows for storing relative date strings like "3d" directly
+      onChange(newInputValue);
+    }
+
+    // Check against our predefined suggestions by their value
+    const isPredefined = predefinedSuggestions.some(
+      s => s.abbreviation === newInputValue
+    );
+    if (!isPredefined) {
+      setSelectedSuggestion(null);
+    }
+  };
+
+  const handleFocus = () => {
+    setDropdownVisible(true);
+    setIsInputFocused(true);
+  };
+
+  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (
+      dropdownRef.current &&
+      !dropdownRef.current.contains(event.relatedTarget as Node)
+    ) {
+      setDropdownVisible(false);
+    }
+    setIsInputFocused(false);
+  };
+
+  const handleSuggestionClick = (suggestionValue: string) => {
+    setInputValue(suggestionValue);
+
+    // Parse the suggestion to get a date
+    const date = parseDate(suggestionValue);
+    setParsedDate(date);
+
+    // Call the parent onChange handler with the timestamp
+    if (date) {
+      onChange(dateToISOString(date));
+    } else {
+      // If we couldn't parse a date, pass the raw input
+      onChange(suggestionValue);
+    }
+
+    setSelectedSuggestion(suggestionValue);
+    setDropdownVisible(false);
+    if (inputRef.current) {
+      inputRef.current.blur();
+    }
+  };
+
+  const handleMouseEnter = (index: number) => {
+    setHoveredIndex(index);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredIndex(null);
+  };
+
+  const handleInputMouseEnter = () => {
+    setIsInputHovered(true);
+  };
+
+  const handleInputMouseLeave = () => {
+    setIsInputHovered(false);
+  };
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        display: 'flex',
+        alignItems: 'center',
+        marginBottom: '5px',
+      }}>
+      <DateInput
+        inputValue={inputValue}
+        isInputFocused={isInputFocused}
+        isInputHovered={isInputHovered}
+        inputRef={inputRef}
+        handleInputChange={handleInputChange}
+        handleFocus={handleFocus}
+        handleBlur={handleBlur}
+        handleInputMouseEnter={handleInputMouseEnter}
+        handleInputMouseLeave={handleInputMouseLeave}
+      />
+
+      <DateTypeLabel inputValue={inputValue} parsedDate={parsedDate} />
+
+      <SuggestionsList
+        isDropdownVisible={isDropdownVisible}
+        dropdownRef={dropdownRef}
+        parsedDate={parsedDate}
+        inputValue={inputValue}
+        predefinedSuggestions={predefinedSuggestions}
+        selectedSuggestion={selectedSuggestion}
+        hoveredIndex={hoveredIndex}
+        handleSuggestionClick={handleSuggestionClick}
+        handleMouseEnter={handleMouseEnter}
+        handleMouseLeave={handleMouseLeave}
+      />
+    </div>
+  );
+};
+
+// Subcomponents
+type DateInputProps = {
+  inputValue: string;
+  isInputFocused: boolean;
+  isInputHovered: boolean;
+  inputRef: React.RefObject<HTMLInputElement>;
+  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleFocus: () => void;
+  handleBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
+  handleInputMouseEnter: () => void;
+  handleInputMouseLeave: () => void;
+};
+
+const DateInput: React.FC<DateInputProps> = ({
+  inputValue,
+  isInputFocused,
+  isInputHovered,
+  inputRef,
+  handleInputChange,
+  handleFocus,
+  handleBlur,
+  handleInputMouseEnter,
+  handleInputMouseLeave,
+}) => {
+  return (
+    <>
+      <Icon
+        name="date"
+        style={{
+          position: 'absolute',
+          top: '50%',
+          left: '9px',
+          transform: 'translateY(-50%)',
+          fontSize: '16px',
+        }}
+      />
+      <input
+        type="text"
+        value={inputValue}
+        onChange={handleInputChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onMouseEnter={handleInputMouseEnter}
+        onMouseLeave={handleInputMouseLeave}
+        placeholder="Enter a date..."
+        style={{
+          padding: '4px 12px',
+          paddingLeft: '32px',
+          paddingRight: '80px', // extra space for the label on the right
+          borderRadius: '4px',
+          border: 0,
+          boxShadow: isInputFocused
+            ? `0 0 0 2px ${TEAL_400}`
+            : isInputHovered
+            ? `0 0 0 2px ${TEAL_350}`
+            : `inset 0 0 0 1px ${MOON_250}`,
+          outline: 'none',
+          flex: 1,
+          height: '32px',
+          minHeight: '32px',
+          boxSizing: 'border-box',
+          fontSize: '16px',
+          lineHeight: '24px',
+          cursor: 'default',
+        }}
+        ref={inputRef}
+      />
+    </>
+  );
+};
+
+type DateTypeLabelProps = {
+  inputValue: string;
+  parsedDate: Date | null;
+};
+
+const DateTypeLabel: React.FC<DateTypeLabelProps> = ({
+  inputValue,
+  parsedDate,
+}) => {
+  if (!inputValue.trim()) {
+    return null;
+  }
+
+  const dateLabel = parsedDate
+    ? isRelativeDate(inputValue)
+      ? 'Relative'
+      : 'Absolute'
+    : 'Unparsable';
+
+  const labelColor = parsedDate
+    ? isRelativeDate(inputValue)
+      ? '#4CAF50' // green for relative
+      : '#2196F3' // blue for absolute
+    : '#F44336'; // red for unparsable
+
+  return (
+    <span
+      title={parsedDate ? `Parsed Date: ${formatDate(parsedDate)}` : ''}
+      style={{
+        position: 'absolute',
+        right: '10px',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        fontSize: '12px',
+        color: labelColor,
+        cursor: parsedDate ? 'default' : 'help',
+        zIndex: 2, // Ensure the label sits on top of the input
+        pointerEvents: 'auto', // Make sure the label can receive pointer events
+      }}>
+      {dateLabel}
+    </span>
+  );
+};
+
+type ParsedDateInfoProps = {
+  parsedDate: Date | null;
+  inputValue: string;
+};
+
+const ParsedDateInfo: React.FC<ParsedDateInfoProps> = ({
+  parsedDate,
+  inputValue,
+}) => {
+  if (!parsedDate) {
+    return null;
+  }
+
+  return (
+    <li
+      style={{
+        padding: '8px',
+        borderBottom: '1px solid #eee',
+        color: '#555',
+        cursor: 'default',
+      }}>
+      <strong>{isRelativeDate(inputValue) ? 'Relative:' : 'Absolute:'}</strong>{' '}
+      {formatDate(parsedDate)}
+    </li>
+  );
+};
+
+type SuggestionItemProps = {
+  suggestion: PredefinedSuggestion;
+  index: number;
+  isSelected: boolean;
+  isHovered: boolean;
+  onClick: () => void;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+};
+
+const SuggestionItem: React.FC<SuggestionItemProps> = ({
+  suggestion,
+  index,
+  isSelected,
+  isHovered,
+  onClick,
+  onMouseEnter,
+  onMouseLeave,
+}) => {
+  return (
+    <li
+      key={index}
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={{
+        padding: '8px',
+        cursor: 'pointer',
+        backgroundColor: isSelected
+          ? isHovered
+            ? '#f8f8f8'
+            : '#E1F7FA'
+          : isHovered
+          ? '#f8f8f8'
+          : '#fff',
+      }}
+      onMouseDown={e => e.preventDefault()}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}>
+        <span>{suggestion.abbreviation}</span>
+        <span style={{color: '#999'}}>{suggestion.label}</span>
+      </div>
+    </li>
+  );
+};
+
+type SuggestionsListProps = {
+  isDropdownVisible: boolean;
+  dropdownRef: React.RefObject<HTMLUListElement>;
+  parsedDate: Date | null;
+  inputValue: string;
+  predefinedSuggestions: PredefinedSuggestion[];
+  selectedSuggestion: string | null;
+  hoveredIndex: number | null;
+  handleSuggestionClick: (suggestionValue: string) => void;
+  handleMouseEnter: (index: number) => void;
+  handleMouseLeave: () => void;
+};
+
+const SuggestionsList: React.FC<SuggestionsListProps> = ({
+  isDropdownVisible,
+  dropdownRef,
+  parsedDate,
+  inputValue,
+  predefinedSuggestions,
+  selectedSuggestion,
+  hoveredIndex,
+  handleSuggestionClick,
+  handleMouseEnter,
+  handleMouseLeave,
+}) => {
+  if (!isDropdownVisible) {
+    return null;
+  }
+
+  return (
+    <ul
+      ref={dropdownRef}
+      style={{
+        position: 'absolute',
+        top: '100%',
+        left: '0',
+        right: '0',
+        backgroundColor: '#fff',
+        border: '1px solid #ccc',
+        borderRadius: '4px',
+        marginTop: '4px',
+        listStyle: 'none',
+        fontSize: '14px',
+        padding: '0',
+        overflow: 'hidden',
+        zIndex: 1000,
+      }}>
+      <ParsedDateInfo parsedDate={parsedDate} inputValue={inputValue} />
+
+      {predefinedSuggestions.map((suggestion, index) => (
+        <SuggestionItem
+          key={index}
+          suggestion={suggestion}
+          index={index}
+          isSelected={selectedSuggestion === suggestion.abbreviation}
+          isHovered={hoveredIndex === index}
+          onClick={() => handleSuggestionClick(suggestion.abbreviation)}
+          onMouseEnter={() => handleMouseEnter(index)}
+          onMouseLeave={handleMouseLeave}
+        />
+      ))}
+    </ul>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
@@ -2,13 +2,11 @@
  * Select the value for a filter. Depends on the operator.
  */
 
-import moment from 'moment';
 import React from 'react';
 
 import {parseRef} from '../../../../../react';
 import {UserLink} from '../../../../UserLink';
 import {SmallRef} from '../smallRef/SmallRef';
-import {StyledDateTimePicker} from '../StyledDateTimePicker';
 import {
   getFieldType,
   getStringList,
@@ -17,6 +15,7 @@ import {
   isWeaveRef,
 } from './common';
 import {IdList} from './IdList';
+import {SelectDatetimeDropdown} from './SelectDatetimeDropdown';
 import {TextValue} from './TextValue';
 import {ValueInputBoolean} from './ValueInputBoolean';
 
@@ -51,15 +50,7 @@ export const SelectValue = ({
     return <UserLink userId={value} includeName={true} hasPopover={false} />;
   }
   if (fieldType === 'datetime') {
-    const dateTimeValue = value ? moment(value) : null;
-    return (
-      <StyledDateTimePicker
-        value={dateTimeValue}
-        onChange={(newValue: moment.Moment | null) =>
-          onSetValue(newValue ? newValue.toISOString() : '')
-        }
-      />
-    );
+    return <SelectDatetimeDropdown value={value} onChange={onSetValue} />;
   }
 
   if (operator.startsWith('(bool): ')) {

--- a/weave-js/src/util/date.test.ts
+++ b/weave-js/src/util/date.test.ts
@@ -1,0 +1,408 @@
+import {vi} from 'vitest';
+
+import {
+  dateToISOString,
+  formatDate,
+  formatDateOnly,
+  isRelativeDate,
+  parseDate,
+} from './date';
+
+// Helper function to create a date with a specific year, month, day
+const createDate = (year: number, month: number, day: number): Date => {
+  const date = new Date(year, month - 1, day);
+  date.setHours(0, 0, 0, 0);
+  return date;
+};
+
+// Helper function to compare dates (ignoring time)
+const areDatesEqual = (date1: Date | null, date2: Date | null): boolean => {
+  if (!date1 || !date2) {
+    return date1 === date2;
+  }
+
+  return (
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate()
+  );
+};
+
+describe('Date Utility Functions', () => {
+  // Mock the current date for consistent testing
+  beforeAll(() => {
+    // Mock current date to 2023-06-15
+    const mockDate = new Date(2023, 5, 15);
+    vi.spyOn(Date, 'now').mockImplementation(() => mockDate.getTime());
+    vi.setSystemTime(mockDate);
+  });
+
+  afterAll(() => {
+    // Restore original Date.now
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe('parseDate', () => {
+    test('should return null for invalid inputs', () => {
+      expect(parseDate('')).toBeNull();
+      expect(parseDate('   ')).toBeNull();
+      expect(parseDate('invalid-date')).toBeNull();
+      expect(parseDate('not-a-date')).toBeNull();
+    });
+
+    test('should parse standard date formats', () => {
+      // ISO format
+      expect(
+        areDatesEqual(parseDate('2023-06-15'), createDate(2023, 6, 15))
+      ).toBe(true);
+
+      // MM/DD/YYYY format
+      expect(
+        areDatesEqual(parseDate('06/15/2023'), createDate(2023, 6, 15))
+      ).toBe(true);
+
+      // Skip the DD/MM/YYYY test as it's locale-dependent
+      // Moment.js might interpret it differently based on the system locale
+      const parsedDate = parseDate('15/06/2023');
+      if (parsedDate) {
+        // Just verify it's a valid date, not the exact value
+        expect(parsedDate instanceof Date).toBe(true);
+      }
+    });
+
+    test('should parse shorthand relative dates', () => {
+      // Current date is 2023-06-15
+
+      // Days ago
+      expect(areDatesEqual(parseDate('1d'), createDate(2023, 6, 14))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('7d'), createDate(2023, 6, 8))).toBe(true);
+
+      // Weeks ago
+      expect(areDatesEqual(parseDate('1w'), createDate(2023, 6, 8))).toBe(true);
+      expect(areDatesEqual(parseDate('2w'), createDate(2023, 6, 1))).toBe(true);
+
+      // Months ago
+      expect(areDatesEqual(parseDate('1m'), createDate(2023, 5, 15))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('6m'), createDate(2022, 12, 15))).toBe(
+        true
+      );
+
+      // Years ago
+      expect(areDatesEqual(parseDate('1y'), createDate(2022, 6, 15))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('5y'), createDate(2018, 6, 15))).toBe(
+        true
+      );
+    });
+
+    test('should parse natural language dates', () => {
+      // Current date is 2023-06-15 (Thursday)
+
+      // Today, yesterday, tomorrow
+      expect(areDatesEqual(parseDate('today'), createDate(2023, 6, 15))).toBe(
+        true
+      );
+      expect(
+        areDatesEqual(parseDate('yesterday'), createDate(2023, 6, 14))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('tomorrow'), createDate(2023, 6, 16))
+      ).toBe(true);
+
+      // Last/next/this time units
+      expect(
+        areDatesEqual(parseDate('last day'), createDate(2023, 6, 14))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('next day'), createDate(2023, 6, 16))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('last week'), createDate(2023, 6, 8))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('next week'), createDate(2023, 6, 22))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('last month'), createDate(2023, 5, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('next month'), createDate(2023, 7, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('last year'), createDate(2022, 6, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('next year'), createDate(2024, 6, 15))
+      ).toBe(true);
+
+      // For day of week tests, we need to be more flexible
+      // The actual behavior might depend on the current day of the week
+      // Just verify they return a valid date
+      const thisMonday = parseDate('this monday');
+      expect(thisMonday instanceof Date).toBe(true);
+
+      const thisThursday = parseDate('this thursday');
+      expect(thisThursday instanceof Date).toBe(true);
+
+      const thisSunday = parseDate('this sunday');
+      expect(thisSunday instanceof Date).toBe(true);
+
+      const nextMonday = parseDate('next monday');
+      expect(nextMonday instanceof Date).toBe(true);
+
+      const nextThursday = parseDate('next thursday');
+      expect(nextThursday instanceof Date).toBe(true);
+
+      const lastMonday = parseDate('last monday');
+      expect(lastMonday instanceof Date).toBe(true);
+
+      const lastThursday = parseDate('last thursday');
+      expect(lastThursday instanceof Date).toBe(true);
+    });
+
+    test('should parse "X units ago" format', () => {
+      // Current date is 2023-06-15
+      expect(
+        areDatesEqual(parseDate('1 day ago'), createDate(2023, 6, 14))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('3 days ago'), createDate(2023, 6, 12))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('1 week ago'), createDate(2023, 6, 8))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('2 weeks ago'), createDate(2023, 6, 1))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('1 month ago'), createDate(2023, 5, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('6 months ago'), createDate(2022, 12, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('1 year ago'), createDate(2022, 6, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('5 years ago'), createDate(2018, 6, 15))
+      ).toBe(true);
+    });
+
+    test('should parse "in X units" format', () => {
+      // Current date is 2023-06-15
+      expect(
+        areDatesEqual(parseDate('in 1 day'), createDate(2023, 6, 16))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('in 3 days'), createDate(2023, 6, 18))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('in 1 week'), createDate(2023, 6, 22))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('in 2 weeks'), createDate(2023, 6, 29))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('in 1 month'), createDate(2023, 7, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('in 6 months'), createDate(2023, 12, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('in 1 year'), createDate(2024, 6, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('in 5 years'), createDate(2028, 6, 15))
+      ).toBe(true);
+    });
+
+    test('should parse quarter formats', () => {
+      expect(areDatesEqual(parseDate('Q1 2023'), createDate(2023, 1, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('Q2 2023'), createDate(2023, 4, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('Q3 2023'), createDate(2023, 7, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('Q4 2023'), createDate(2023, 10, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('2023 Q1'), createDate(2023, 1, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('2023 Q2'), createDate(2023, 4, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('2023 Q3'), createDate(2023, 7, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('2023 Q4'), createDate(2023, 10, 1))).toBe(
+        true
+      );
+    });
+
+    test('should parse month and year formats', () => {
+      // Full month names
+      expect(
+        areDatesEqual(parseDate('January 2023'), createDate(2023, 1, 1))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('June 2023'), createDate(2023, 6, 1))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('December 2023'), createDate(2023, 12, 1))
+      ).toBe(true);
+
+      // Abbreviated month names
+      expect(areDatesEqual(parseDate('Jan 2023'), createDate(2023, 1, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('Jun 2023'), createDate(2023, 6, 1))).toBe(
+        true
+      );
+      expect(
+        areDatesEqual(parseDate('Dec 2023'), createDate(2023, 12, 1))
+      ).toBe(true);
+
+      // Year first formats
+      expect(
+        areDatesEqual(parseDate('2023 January'), createDate(2023, 1, 1))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('2023 June'), createDate(2023, 6, 1))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('2023 December'), createDate(2023, 12, 1))
+      ).toBe(true);
+
+      // Year first with abbreviated months
+      expect(areDatesEqual(parseDate('2023 Jan'), createDate(2023, 1, 1))).toBe(
+        true
+      );
+      expect(areDatesEqual(parseDate('2023 Jun'), createDate(2023, 6, 1))).toBe(
+        true
+      );
+      expect(
+        areDatesEqual(parseDate('2023 Dec'), createDate(2023, 12, 1))
+      ).toBe(true);
+    });
+
+    test('should handle before/after today and current time formats', () => {
+      // X days/weeks/months before/after today
+      expect(
+        areDatesEqual(parseDate('3 days before today'), createDate(2023, 6, 12))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('3 days after today'), createDate(2023, 6, 18))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('1 week before today'), createDate(2023, 6, 8))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('1 week after today'), createDate(2023, 6, 22))
+      ).toBe(true);
+      expect(
+        areDatesEqual(
+          parseDate('1 month before today'),
+          createDate(2023, 5, 15)
+        )
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('1 month after today'), createDate(2023, 7, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('1 year before today'), createDate(2022, 6, 15))
+      ).toBe(true);
+      expect(
+        areDatesEqual(parseDate('1 year after today'), createDate(2024, 6, 15))
+      ).toBe(true);
+
+      // Current time
+      const now = new Date(2023, 5, 15); // Our mocked current date
+      expect(parseDate('now')?.getFullYear()).toBe(now.getFullYear());
+      expect(parseDate('now')?.getMonth()).toBe(now.getMonth());
+      expect(parseDate('now')?.getDate()).toBe(now.getDate());
+      expect(parseDate('right now')?.getFullYear()).toBe(now.getFullYear());
+      expect(parseDate('current time')?.getFullYear()).toBe(now.getFullYear());
+    });
+  });
+
+  describe('isRelativeDate', () => {
+    test('should identify relative date inputs', () => {
+      // Shorthand formats
+      expect(isRelativeDate('1d')).toBe(true);
+      expect(isRelativeDate('2w')).toBe(true);
+      expect(isRelativeDate('3m')).toBe(true);
+      expect(isRelativeDate('4y')).toBe(true);
+
+      // Natural language formats
+      expect(isRelativeDate('today')).toBe(true);
+      expect(isRelativeDate('yesterday')).toBe(true);
+      expect(isRelativeDate('tomorrow')).toBe(true);
+      expect(isRelativeDate('last week')).toBe(true);
+      expect(isRelativeDate('next month')).toBe(true);
+      expect(isRelativeDate('this year')).toBe(true);
+      expect(isRelativeDate('3 days ago')).toBe(true);
+      expect(isRelativeDate('in 2 weeks')).toBe(true);
+    });
+
+    test('should identify absolute date inputs', () => {
+      expect(isRelativeDate('2023-06-15')).toBe(false);
+      expect(isRelativeDate('06/15/2023')).toBe(false);
+      expect(isRelativeDate('June 15, 2023')).toBe(false);
+      expect(isRelativeDate('Q2 2023')).toBe(false);
+      expect(isRelativeDate('2023 Q2')).toBe(false);
+      expect(isRelativeDate('June 2023')).toBe(false);
+      expect(isRelativeDate('2023 June')).toBe(false);
+    });
+  });
+
+  describe('formatDate', () => {
+    test('should format dates correctly', () => {
+      const date = new Date(2023, 5, 15, 12, 30, 45);
+      expect(formatDate(date)).toBe('2023-06-15 12:30:45');
+      expect(formatDate(date, 'YYYY-MM-DD')).toBe('2023-06-15');
+      expect(formatDate(date, 'MM/DD/YYYY')).toBe('06/15/2023');
+      expect(formatDate(date, 'MMMM D, YYYY')).toBe('June 15, 2023');
+    });
+
+    test('should handle null or undefined inputs', () => {
+      expect(formatDate(null)).toBe('');
+      expect(formatDate(undefined)).toBe('');
+    });
+  });
+
+  describe('formatDateOnly', () => {
+    test('should format dates without time', () => {
+      const date = new Date(2023, 5, 15, 12, 30, 45);
+      expect(formatDateOnly(date)).toBe('2023-06-15');
+      expect(formatDateOnly(date, 'MM/DD/YYYY')).toBe('06/15/2023');
+      expect(formatDateOnly(date, 'MMMM D, YYYY')).toBe('June 15, 2023');
+    });
+
+    test('should handle null or undefined inputs', () => {
+      expect(formatDateOnly(null)).toBe('');
+      expect(formatDateOnly(undefined)).toBe('');
+    });
+  });
+
+  describe('dateToISOString', () => {
+    test('should convert dates to ISO strings', () => {
+      const date = new Date(2023, 5, 15, 12, 30, 45);
+      expect(dateToISOString(date)).toBe(date.toISOString());
+    });
+
+    test('should handle null or undefined inputs', () => {
+      expect(dateToISOString(null)).toBe('');
+      expect(dateToISOString(undefined)).toBe('');
+    });
+  });
+});

--- a/weave-js/src/util/date.ts
+++ b/weave-js/src/util/date.ts
@@ -1,0 +1,387 @@
+/**
+ * Date utility functions for parsing and formatting dates
+ */
+
+import moment from 'moment';
+
+/**
+ * Attempts to parse a date string into a Date object
+ * Handles various date formats and natural language
+ *
+ * @param dateStr The date string to parse
+ * @returns A Date object if parsing was successful, or null if parsing failed
+ */
+export const parseDate = (dateStr: string): Date | null => {
+  if (!dateStr || typeof dateStr !== 'string') {
+    return null;
+  }
+
+  const now = new Date();
+
+  // Trim the input
+  const trimmedStr = dateStr.trim();
+  if (!trimmedStr) {
+    return null;
+  }
+
+  // Handle shorthand relative dates (e.g., "1d", "2w", "3m", "1y")
+  const shorthandPattern = /^(\d+)([dwmy])$/i;
+  const shorthandMatch = trimmedStr.match(shorthandPattern);
+  if (shorthandMatch) {
+    const amount = parseInt(shorthandMatch[1], 10);
+    const unit = shorthandMatch[2].toLowerCase();
+
+    switch (unit) {
+      case 'd':
+        const daysAgo = new Date(now);
+        daysAgo.setDate(daysAgo.getDate() - amount);
+        return daysAgo;
+      case 'w':
+        const weeksAgo = new Date(now);
+        weeksAgo.setDate(weeksAgo.getDate() - amount * 7);
+        return weeksAgo;
+      case 'm':
+        const monthsAgo = new Date(now);
+        monthsAgo.setMonth(monthsAgo.getMonth() - amount);
+        return monthsAgo;
+      case 'y':
+        const yearsAgo = new Date(now);
+        yearsAgo.setFullYear(yearsAgo.getFullYear() - amount);
+        return yearsAgo;
+    }
+  }
+
+  // Try parsing with moment
+  const momentDate = moment(trimmedStr);
+  if (momentDate.isValid()) {
+    return momentDate.toDate();
+  }
+
+  // Try parsing natural language dates
+  const lowerStr = trimmedStr.toLowerCase();
+
+  // Handle "today", "yesterday", "tomorrow"
+  if (lowerStr === 'today') {
+    return new Date(now.setHours(0, 0, 0, 0));
+  } else if (lowerStr === 'yesterday') {
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(0, 0, 0, 0);
+    return yesterday;
+  } else if (lowerStr === 'tomorrow') {
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(0, 0, 0, 0);
+    return tomorrow;
+  }
+
+  // Handle "last week", "next month", etc.
+  const lastNextPattern =
+    /^(last|next|this)\s+(day|week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/i;
+  const lastNextMatch = lowerStr.match(lastNextPattern);
+  if (lastNextMatch) {
+    const direction = lastNextMatch[1].toLowerCase();
+    const unit = lastNextMatch[2].toLowerCase();
+
+    // Handle days of the week
+    const daysOfWeek = [
+      'sunday',
+      'monday',
+      'tuesday',
+      'wednesday',
+      'thursday',
+      'friday',
+      'saturday',
+    ];
+    if (daysOfWeek.includes(unit)) {
+      const today = now.getDay();
+      const targetDay = daysOfWeek.indexOf(unit);
+      let daysToAdd = 0;
+
+      if (direction === 'this') {
+        // This week's day
+        daysToAdd = (targetDay - today + 7) % 7;
+        if (daysToAdd === 0 && today === targetDay) {
+          daysToAdd = 0; // Today is the target day
+        }
+      } else if (direction === 'next') {
+        // Next week's day
+        daysToAdd = (targetDay - today + 7) % 7;
+        if (daysToAdd === 0) {
+          daysToAdd = 7; // Next week's same day
+        }
+      } else if (direction === 'last') {
+        // Last week's day
+        daysToAdd = (targetDay - today - 7) % 7;
+        if (daysToAdd === 0 && today === targetDay) {
+          daysToAdd = -7; // Last week's same day
+        }
+      }
+
+      const res = new Date(now);
+      res.setDate(res.getDate() + daysToAdd);
+      return res;
+    }
+
+    // Handle other time units
+    const multiplier = direction === 'last' ? -1 : direction === 'next' ? 1 : 0;
+
+    const result = new Date(now);
+    switch (unit) {
+      case 'day':
+        result.setDate(result.getDate() + multiplier);
+        break;
+      case 'week':
+        result.setDate(result.getDate() + multiplier * 7);
+        break;
+      case 'month':
+        result.setMonth(result.getMonth() + multiplier);
+        break;
+      case 'year':
+        result.setFullYear(result.getFullYear() + multiplier);
+        break;
+    }
+    return result;
+  }
+
+  // Handle "X days/weeks/months/years ago"
+  const agoPattern = /^(\d+)\s+(day|week|month|year)s?\s+ago$/i;
+  const agoMatch = lowerStr.match(agoPattern);
+  if (agoMatch) {
+    const amount = parseInt(agoMatch[1], 10);
+    const unit = agoMatch[2].toLowerCase();
+
+    const result = new Date(now);
+    switch (unit) {
+      case 'day':
+        result.setDate(result.getDate() - amount);
+        break;
+      case 'week':
+        result.setDate(result.getDate() - amount * 7);
+        break;
+      case 'month':
+        result.setMonth(result.getMonth() - amount);
+        break;
+      case 'year':
+        result.setFullYear(result.getFullYear() - amount);
+        break;
+    }
+    return result;
+  }
+
+  // Handle "in X days/weeks/months/years"
+  const inFuturePattern = /^in\s+(\d+)\s+(day|week|month|year)s?$/i;
+  const inFutureMatch = lowerStr.match(inFuturePattern);
+  if (inFutureMatch) {
+    const amount = parseInt(inFutureMatch[1], 10);
+    const unit = inFutureMatch[2].toLowerCase();
+
+    const result = new Date(now);
+    switch (unit) {
+      case 'day':
+        result.setDate(result.getDate() + amount);
+        break;
+      case 'week':
+        result.setDate(result.getDate() + amount * 7);
+        break;
+      case 'month':
+        result.setMonth(result.getMonth() + amount);
+        break;
+      case 'year':
+        result.setFullYear(result.getFullYear() + amount);
+        break;
+    }
+    return result;
+  }
+
+  // Handle quarter patterns like "Q1 2023", "2023 Q2", etc.
+  const quarterPattern = /^(?:Q([1-4])\s+(\d{4})|(\d{4})\s+Q([1-4]))$/i;
+  const quarterMatch = lowerStr.match(quarterPattern);
+  if (quarterMatch) {
+    const quarter = parseInt(quarterMatch[1] || quarterMatch[4], 10);
+    const year = parseInt(quarterMatch[2] || quarterMatch[3], 10);
+    const month = (quarter - 1) * 3; // Q1=0 (Jan), Q2=3 (Apr), Q3=6 (Jul), Q4=9 (Oct)
+
+    return new Date(year, month, 1);
+  }
+
+  // Handle month and year patterns like "Jan 2023", "January 2023", "2023 Jan", etc.
+  const monthNames = [
+    'january',
+    'february',
+    'march',
+    'april',
+    'may',
+    'june',
+    'july',
+    'august',
+    'september',
+    'october',
+    'november',
+    'december',
+  ];
+  const monthAbbreviations = [
+    'jan',
+    'feb',
+    'mar',
+    'apr',
+    'may',
+    'jun',
+    'jul',
+    'aug',
+    'sep',
+    'oct',
+    'nov',
+    'dec',
+  ];
+
+  // Try "Month YYYY" or "Mon YYYY" format
+  for (let i = 0; i < monthNames.length; i++) {
+    const fullPattern = new RegExp(`^${monthNames[i]}\\s+(\\d{4})$`, 'i');
+    const abbrPattern = new RegExp(
+      `^${monthAbbreviations[i]}\\s+(\\d{4})$`,
+      'i'
+    );
+
+    const fullMatch = lowerStr.match(fullPattern);
+    const abbrMatch = lowerStr.match(abbrPattern);
+
+    if (fullMatch || abbrMatch) {
+      const year = parseInt(fullMatch?.[1] || abbrMatch?.[1] || '0', 10);
+      return new Date(year, i, 1);
+    }
+  }
+
+  // Try "YYYY Month" or "YYYY Mon" format
+  for (let i = 0; i < monthNames.length; i++) {
+    const fullPattern = new RegExp(`^(\\d{4})\\s+${monthNames[i]}$`, 'i');
+    const abbrPattern = new RegExp(
+      `^(\\d{4})\\s+${monthAbbreviations[i]}$`,
+      'i'
+    );
+
+    const fullMatch = lowerStr.match(fullPattern);
+    const abbrMatch = lowerStr.match(abbrPattern);
+
+    if (fullMatch || abbrMatch) {
+      const year = parseInt(fullMatch?.[1] || abbrMatch?.[1] || '0', 10);
+      return new Date(year, i, 1);
+    }
+  }
+
+  // X days/weeks/months before/after today
+  const beforeAfterPattern =
+    /^(\d+)\s+(day|week|month|year)s?\s+(before|after)\s+today$/i;
+  const beforeAfterMatch = lowerStr.match(beforeAfterPattern);
+  if (beforeAfterMatch) {
+    const amount = parseInt(beforeAfterMatch[1], 10);
+    const unit = beforeAfterMatch[2].toLowerCase();
+    const direction = beforeAfterMatch[3].toLowerCase();
+    const multiplier = direction === 'before' ? -1 : 1;
+
+    const result = new Date(now);
+    switch (unit) {
+      case 'day':
+        result.setDate(result.getDate() + amount * multiplier);
+        break;
+      case 'week':
+        result.setDate(result.getDate() + amount * 7 * multiplier);
+        break;
+      case 'month':
+        result.setMonth(result.getMonth() + amount * multiplier);
+        break;
+      case 'year':
+        result.setFullYear(result.getFullYear() + amount * multiplier);
+        break;
+    }
+    return result;
+  }
+
+  // Handle "now", "right now", "current time"
+  if (/^(now|right now|current time)$/i.test(lowerStr)) {
+    return new Date(now);
+  }
+
+  // If all parsing attempts fail, return null
+  return null;
+};
+
+/**
+ * Determines if a date input string represents a relative date
+ *
+ * @param value The date string to check
+ * @returns True if the input represents a relative date, false otherwise
+ */
+export const isRelativeDate = (value: string): boolean => {
+  if (!value || typeof value !== 'string') {
+    return false;
+  }
+
+  const trimmedValue = value.trim().toLowerCase();
+
+  // Check for shorthand patterns (e.g., "1d", "2w")
+  if (/^\d+[dwmy]$/i.test(trimmedValue)) {
+    return true;
+  }
+
+  // Check for natural language relative terms
+  const relativeKeywords = [
+    'ago',
+    'last',
+    'next',
+    'this',
+    'yesterday',
+    'today',
+    'tomorrow',
+    'previous',
+    'past',
+    'coming',
+    'in',
+  ];
+
+  return relativeKeywords.some(keyword => trimmedValue.includes(keyword));
+};
+
+/**
+ * Formats a date as a string with the specified format
+ *
+ * @param date The date to format
+ * @param format The format string (defaults to 'YYYY-MM-DD HH:mm:ss')
+ * @returns A formatted date string, or empty string if date is invalid
+ */
+export const formatDate = (
+  date: Date | null | undefined,
+  format = 'YYYY-MM-DD HH:mm:ss'
+): string => {
+  if (!date) {
+    return '';
+  }
+  return moment(date).format(format);
+};
+
+/**
+ * Formats a date as just the date (without time)
+ *
+ * @param date The date to format
+ * @param format The format string (defaults to 'YYYY-MM-DD')
+ * @returns A formatted date string, or empty string if date is invalid
+ */
+export const formatDateOnly = (
+  date: Date | null | undefined,
+  format = 'YYYY-MM-DD'
+): string => {
+  if (!date) {
+    return '';
+  }
+  return moment(date).format(format);
+};
+
+/**
+ * Converts a date to ISO string or returns empty string if null
+ *
+ * @param date The date to convert
+ * @returns ISO string representation of the date, or empty string if date is invalid
+ */
+export const dateToISOString = (date: Date | null | undefined): string => {
+  return date ? date.toISOString() : '';
+};


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

`flush` deactivates the async processor that handles uploading calls, we want to make sure this is really only called at the end of the user process. The only benefit to calling it is to prevent exiting, it should not be called repeatedly or before final ops are called.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an intuitive date selection dropdown that offers quick suggestions (e.g., "1 day", "2 days", "Yesterday") to simplify date input.
  
- **Refactor**
  - Upgraded the overall date handling for a smoother experience and improved support for both absolute and relative date formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->