### PR TITLE
fix(app): Preserve nw url search query between workspace and runs pages

### DIFF
--- a/weave-js/src/components/FancyPage/FancyPageSidebar.tsx
+++ b/weave-js/src/components/FancyPage/FancyPageSidebar.tsx
@@ -53,6 +53,7 @@ export type FancyPageSidebarItemButton = {
   name: string;
   nameTooltip?: string;
   slug: string;
+  search?: string;
 
   // Some buttons should get active highlighting for multiple different slugs.
   additionalSlugs?: string[];

--- a/weave-js/src/components/FancyPage/FancyPageSidebarSection.tsx
+++ b/weave-js/src/components/FancyPage/FancyPageSidebarSection.tsx
@@ -156,6 +156,7 @@ const FancyPageSidebarSection = (props: FancyPageSidebarSectionProps) => {
                 pathname: item.slug
                   ? `${props.baseUrl}/${item.slug}`
                   : props.baseUrl,
+                search: item.search,
               },
         };
 

--- a/weave-js/src/components/FancyPage/useProjectSidebar.ts
+++ b/weave-js/src/components/FancyPage/useProjectSidebar.ts
@@ -1,6 +1,7 @@
 import {IconNames} from '@wandb/weave/components/Icon';
 import _ from 'lodash';
 import {useMemo} from 'react';
+import {useLocation} from 'react-router-dom';
 
 import {FancyPageSidebarItem} from './FancyPageSidebar';
 
@@ -14,6 +15,18 @@ export const useProjectSidebar = (
   isLaunchActive: boolean = false,
   isWandbAdmin: boolean = false
 ): FancyPageSidebarItem[] => {
+  // must preserve named workspace url query string
+  // when navigating between workspace & runs pages
+  let nwSearchStr: string | undefined;
+  const location = useLocation();
+  const allSearchParams = new URLSearchParams(location.search);
+  const nwId = allSearchParams.get('nw');
+  if (nwId) {
+    const nwSearchParams = new URLSearchParams();
+    nwSearchParams.append('nw', nwId);
+    nwSearchStr = nwSearchParams.toString();
+  }
+
   // Should show models sidebar items if we have models data or if we don't have a trace backend
   let showModelsSidebarItems = hasModelsData || !hasTraceBackend;
   // Should show weave sidebar items if we have weave data and we have a trace backend
@@ -62,6 +75,7 @@ export const useProjectSidebar = (
             type: 'button' as const,
             name: 'Workspace',
             slug: 'workspace',
+            search: nwSearchStr,
             isShown: !isWeaveOnly,
             isDisabled: viewingRestricted,
             iconName: IconNames.DashboardBlackboard,
@@ -70,6 +84,7 @@ export const useProjectSidebar = (
             type: 'button' as const,
             name: 'Runs',
             slug: 'table',
+            search: nwSearchStr,
             isShown: !isWeaveOnly,
             isDisabled: viewingRestricted,
             iconName: IconNames.Table,
@@ -259,13 +274,14 @@ export const useProjectSidebar = (
 
     return onlyShownItems;
   }, [
-    isLoading,
-    isShowAll,
-    isWeaveOnly,
-    viewingRestricted,
-    isModelsOnly,
-    showWeaveSidebarItems,
     isLaunchActive,
+    isLoading,
+    isModelsOnly,
+    isShowAll,
     isWandbAdmin,
+    isWeaveOnly,
+    nwSearchStr,
+    showWeaveSidebarItems,
+    viewingRestricted,
   ]);
 };


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-23455

Issue: navigating between "Workspace" and "Runs" pages removes `nw` url query, which results in loading the wrong view on refresh

https://github.com/user-attachments/assets/4ccf4be8-c45d-4777-bd76-5e139bfcc473

We need to preserve the `nw` url query when those sidebar items are clicked. This PR updates `FancyPageSidebar` items to accept optional `search` property that can be applied to the link destination

## Testing

- open saved view -> go to runs -> refresh -> correct view/runs displayed
- full screen a panel -> go to runs -> back to workspace -> workspace is shown (not full-screened panel)
- full screen a panel -> expand run selector (not from sidebar) -> collapse run selector -> full-screened panel is shown

https://github.com/user-attachments/assets/60636441-bdcf-4a93-ab9f-122d7f35fcc4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced sidebar navigation now supports additional URL search parameters.
	- Updated routing ensures that a designated query parameter is preserved when switching between key sections, providing more consistent and context-aware navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->