### PR TITLE
chore(weave): Make queue size configurable

### DIFF
--- a/docs/docs/guides/core-types/env-vars.md
+++ b/docs/docs/guides/core-types/env-vars.md
@@ -30,6 +30,7 @@ os.environ["WEAVE_PRINT_CALL_LINK"] = "false"
 | `WEAVE_USE_SERVER_CACHE` | `bool` | `false` | Enables server response caching. When enabled, responses from the server are cached to disk to improve performance for repeated queries. |
 | `WEAVE_SERVER_CACHE_SIZE_LIMIT` | `int` | `1000000000` | Sets the maximum size limit for the server cache in bytes. When the cache reaches this size, older entries are automatically removed to make space for new ones. Important: the underlying implementation uses SQLite which has a Write Ahead Log (WAL) that will grow to 4MB regardless of this setting. This WAL will be removed when the program exits. |
 | `WEAVE_SERVER_CACHE_DIR` | `str` | `None` | Specifies the directory where cache files should be stored. If not set, a temporary directory is used. |
+| `WEAVE_MAX_CALLS_QUEUE_SIZE` | `int` | `100000` | Sets the maximum size of the calls queue.  Defaults to 100_000.  Setting a value of 0 means the queue can grow unbounded. |
 
 :::note
 All boolean environment variables accept the following values (case-insensitive):

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -206,9 +206,9 @@ def scorers_dir() -> str:
 
 def max_calls_queue_size() -> int:
     max_queue_size = _optional_int("max_calls_queue_size")
-    if max_queue_size == 0:
-        return 0
-    return max_queue_size or 100_000
+    if max_queue_size is None:
+        return 100_000
+    return max_queue_size
 
 
 def parse_and_apply_settings(

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -205,7 +205,10 @@ def scorers_dir() -> str:
 
 
 def max_calls_queue_size() -> int:
-    return _optional_int("max_calls_queue_size") or 100_000
+    max_queue_size = _optional_int("max_calls_queue_size")
+    if max_queue_size == 0:
+        return 0
+    return max_queue_size or 100_000
 
 
 def parse_and_apply_settings(

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -128,6 +128,14 @@ class UserSettings(BaseModel):
     ~/.cache/wandb/weave-scorers.
 
     Can be overridden with the environment variable `WEAVE_SCORERS_DIR`
+
+    """
+    max_calls_queue_size: int = 100_000
+    """
+    Sets the maximum size of the calls queue.  Defaults to 100_000.
+    Setting a value of 0 means the queue can grow unbounded.
+
+    Can be overridden with the environment variable `WEAVE_MAX_CALLS_QUEUE_SIZE`
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -194,6 +202,10 @@ def server_cache_dir() -> Optional[str]:
 
 def scorers_dir() -> str:
     return _optional_str("scorers_dir")  # type: ignore
+
+
+def max_calls_queue_size() -> int:
+    return _optional_int("max_calls_queue_size") or 100_000
 
 
 def parse_and_apply_settings(

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -8,6 +8,7 @@ import tenacity
 from pydantic import BaseModel, ValidationError
 
 from weave.trace.env import weave_trace_server_url
+from weave.trace.settings import max_calls_queue_size
 from weave.trace_server import requests
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
@@ -102,7 +103,10 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         self.trace_server_url = trace_server_url
         self.should_batch = should_batch
         if self.should_batch:
-            self.call_processor = AsyncBatchProcessor(self._flush_calls)
+            self.call_processor = AsyncBatchProcessor(
+                self._flush_calls,
+                max_queue_size=max_calls_queue_size(),
+            )
         self._auth: Optional[tuple[str, str]] = None
         self.remote_request_bytes_limit = remote_request_bytes_limit
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable option to set the maximum size of the calls queue (default: 100,000) with the flexibility to override via an environment variable.
	- Enhanced the server’s call processing by dynamically applying this setting to better manage queue size during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->