### PR TITLE
docs(weave): Add troubleshooting guide item on OSError24

### DIFF
--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -106,3 +106,13 @@ This can also be set programmatically using the `settings` argument to `weave.in
 ```python
 client = weave.init("fast-upload", settings={"client_parallelism": 100})
 ```
+
+## OSError: [Errono 24] Too many open files
+
+This error occurs when the number of open files exceeds the limit set by your operating system. In Weave, this may happen because you're working with large image datasets and/or your system has a low limit on the number of open files. Weave uses `PIL` for image processing, which keeps the file descriptors open for the duration of the program.
+
+To resolve this issue, you can increase the limit using the following command:
+
+```bash
+ulimit -n 65536
+```

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -111,9 +111,9 @@ client = weave.init("fast-upload", settings={"client_parallelism": 100})
 
 ### `[Errono 24]: Too many open files`
 
-This error occurs when the number of open files exceeds the limit set by your operating system. In Weave, this may happen because you're working with large image datasets and/or your system has a low limit on the number of open files. Weave uses `PIL` for image processing, which keeps the file descriptors open for the duration of the program.
+This error occurs when the number of open files exceeds the limit set by your operating system. In Weave, this may happen because you're working with large image datasets. Weave uses `PIL` for image processing, which keeps file descriptors open for the duration of the program.
 
-To resolve this issue, you can increase the limit using the following command:
+To resolve this issue, increase the system limit for open files to `65,536` using `ulimit`:
 
 ```bash
 ulimit -n 65536

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -107,7 +107,9 @@ This can also be set programmatically using the `settings` argument to `weave.in
 client = weave.init("fast-upload", settings={"client_parallelism": 100})
 ```
 
-## OSError: [Errono 24] Too many open files
+## OS errors
+
+### `[Errono 24]: Too many open files`
 
 This error occurs when the number of open files exceeds the limit set by your operating system. In Weave, this may happen because you're working with large image datasets and/or your system has a low limit on the number of open files. Weave uses `PIL` for image processing, which keeps the file descriptors open for the duration of the program.
 

--- a/docs/docs/guides/troubleshooting.md
+++ b/docs/docs/guides/troubleshooting.md
@@ -109,7 +109,7 @@ client = weave.init("fast-upload", settings={"client_parallelism": 100})
 
 ## OS errors
 
-### `[Errono 24]: Too many open files`
+### `[Errno 24]: Too many open files`
 
 This error occurs when the number of open files exceeds the limit set by your operating system. In Weave, this may happen because you're working with large image datasets. Weave uses `PIL` for image processing, which keeps file descriptors open for the duration of the program.
 


### PR DESCRIPTION
Resolves: https://wandb.atlassian.net/browse/WB-23536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a new troubleshooting section to help users resolve issues related to exceeding file limits.
  - The guide explains why such errors can occur during large image processing and offers clear steps to adjust system settings for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->