### PR TITLE
chore(weave): Improve client retries to not block queue

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1995,6 +1995,7 @@ class WeaveClient:
         # Add call batch uploads if available
         if self._server_is_flushable:
             server = cast(RemoteHTTPTraceServer, self.server)
+            assert server.call_processor is not None
             total += server.call_processor.num_outstanding_jobs
         return total
 
@@ -2127,6 +2128,7 @@ class WeaveClient:
             # _server_is_flushable and only call this if we know the server is
             # flushable.
             server = cast(RemoteHTTPTraceServer, self.server)
+            assert server.call_processor is not None
             server.call_processor.stop_accepting_new_work_and_flush_queue()
 
             # Restart call processor processing thread after flushing
@@ -2149,6 +2151,7 @@ class WeaveClient:
         call_processor_jobs = 0
         if self._server_is_flushable:
             server = cast(RemoteHTTPTraceServer, self.server)
+            assert server.call_processor is not None
             call_processor_jobs = server.call_processor.num_outstanding_jobs
 
         return PendingJobCounts(

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -159,7 +159,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
 
     def _flush_calls(
         self,
-        batch: list[StartBatchItem | EndBatchItem],
+        batch: list[Union[StartBatchItem, EndBatchItem]],
         *,
         _should_update_batch_size: bool = True,
     ) -> None:
@@ -168,6 +168,8 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         This method handles the logic of splitting batches that are too large,
         but delegates the actual server communication (with retries) to _send_batch_to_server.
         """
+        # Call processor must be defined for this method
+        assert self.call_processor is not None
         if len(batch) == 0:
             return
 
@@ -306,6 +308,8 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         self, req: Union[tsi.CallStartReq, dict[str, Any]]
     ) -> tsi.CallStartRes:
         if self.should_batch:
+            assert self.call_processor is not None
+
             req_as_obj: tsi.CallStartReq
             if isinstance(req, dict):
                 req_as_obj = tsi.CallStartReq.model_validate(req)
@@ -325,6 +329,8 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
 
     def call_end(self, req: Union[tsi.CallEndReq, dict[str, Any]]) -> tsi.CallEndRes:
         if self.should_batch:
+            assert self.call_processor is not None
+
             req_as_obj: tsi.CallEndReq
             if isinstance(req, dict):
                 req_as_obj = tsi.CallEndReq.model_validate(req)

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -46,7 +46,7 @@ REMOTE_REQUEST_BYTES_LIMIT = (
 
 REMOTE_REQUEST_RETRY_DURATION = 60 * 60 * 36  # 36 hours
 REMOTE_REQUEST_RETRY_MAX_INTERVAL = 60 * 5  # 5 minutes
-REMOTE_REQUEST_MAX_ATTEMPTS = 3  # Maximum immediate retry attempts
+REMOTE_REQUEST_MAX_ATTEMPTS = 6  # Maximum immediate retry attempts
 
 
 def _is_retryable_exception(e: Exception) -> bool:


### PR DESCRIPTION
This PR pops items that have failed retrying for too long and puts them in the back of the queue as to avoid blocking other calls.

In the screenshot below, see how the trace server tries a few times, gives up, and re-queues the batch for later.


![image](https://github.com/user-attachments/assets/1085d2ca-0637-4168-9a89-86c76693afec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling and retry mechanisms for remote requests, now using a fixed maximum attempt strategy for improved stability.
  - Added safeguards to catch and handle issues with oversized requests.

- **Tests**
  - Introduced a new test to verify that failed batches are correctly requeued after exceeding retry limits.
  - Updated test assertions to broadly capture retry failure scenarios.
  - Improved error handling in the test suite for the RemoteHTTPTraceServer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->