### PR TITLE
fix(app): replace index variables in input image node before obtaining class labels

### DIFF
--- a/weave-js/src/components/Panel2/PanelImage.tsx
+++ b/weave-js/src/components/Panel2/PanelImage.tsx
@@ -79,7 +79,13 @@ const PanelImageConfig: FC<PanelImageProps> = ({
   updateConfig,
   input,
 }) => {
-  const classLabels = useClassLabels(input);
+  const weave = useWeaveContext();
+
+  const exemplarsNode = useMemo(() => {
+    return replaceInputVariables(input, weave.client.opStore);
+  }, [input, weave.client.opStore]);
+
+  const classLabels = useClassLabels(exemplarsNode as Node<typeof inputType>);
 
   const {classSets, controls} = Controls.useImageControls(
     input.type,
@@ -96,12 +102,6 @@ const PanelImageConfig: FC<PanelImageProps> = ({
       };
     }
   }, [config, controls]);
-
-  const weave = useWeaveContext();
-
-  const exemplarsNode = useMemo(() => {
-    return replaceInputVariables(input, weave.client.opStore);
-  }, [input, weave.client.opStore]);
 
   const exemplars = CGReact.useNodeValue(exemplarsNode).result;
   const boxes = useMemo(() => {


### PR DESCRIPTION
## Description

When opening the column header, the selected node is created by grabbing an example row from the current table and applying the column's select function ([relevant code](https://github.com/wandb/weave/blob/master/weave-js/src/components/Panel2/PanelTable/ColumnHeader.tsx#L296-L306)). However, the example row uses `var('n')` for the index, which we have to dereference before sending the execution graph to the backend.

## Testing

Local FE

Current Behaviour:

https://github.com/user-attachments/assets/d3758ee7-3384-4a2a-8d76-d1a95c66a552

Updated Behaviour:

https://github.com/user-attachments/assets/d93a6581-aab2-4650-b012-bc7c9038cd8c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the Image Panel’s data processing for generating labels, enhancing accuracy and consistency in how information is displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->