### PR TITLE
feat(weave): Python Saved View API

### DIFF
--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -121,7 +121,7 @@ def test_saved_view_load(client):
     uri = saved_view.ref.uri()
     loaded_view = weave.SavedView.load(uri)
     assert loaded_view.name == saved_view.name
-    assert loaded_view.table == saved_view.table
+    assert loaded_view.view_type == saved_view.view_type
     assert loaded_view.base.definition.cols["attributes.weave.client_version"] is True
 
 

--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -1,0 +1,172 @@
+import datetime
+
+import weave
+from weave.flow.saved_view import filters_to_query, to_seconds
+from weave.trace.api import ObjectRef
+from weave.trace_server.interface.builtin_object_classes.saved_view import Filters
+
+
+def test_to_seconds():
+    assert to_seconds(None) is None
+    assert to_seconds("") is None
+    assert to_seconds(1) == 1
+    assert to_seconds(5.3) == 5.3
+    assert to_seconds("5.3") == 5.3
+    assert to_seconds("2025-03-02T00:00:00Z") == 1740873600.0
+    dt = datetime.datetime(2025, 3, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    assert to_seconds(dt) == 1740873600.0
+
+
+def test_filters_to_query():
+    assert filters_to_query(None) is None
+    assert filters_to_query(Filters()) is None
+
+
+def test_saved_view_create(client):
+    view = weave.SavedView("traces", "My saved view").hide_column("feedback").save()
+    assert view.name == "My saved view"
+    assert isinstance(view.ref, ObjectRef)
+
+
+def test_saved_view_column_pinning():
+    view = weave.SavedView("traces", "My saved view")
+
+    # Pin two columns to the left and two to the right.
+    # Confirm order including default pin is as expected.
+    view.pin_column_left("output.col_a")
+    view.pin_column_left("output.col_b")
+    view.pin_column_right("output.col_c")
+    view.pin_column_right("output.col_d")
+    assert view.base.definition.pin.left == [
+        "CustomCheckbox",
+        "op_name",
+        "output.col_a",
+        "output.col_b",
+    ]
+    assert view.base.definition.pin.right == ["output.col_c", "output.col_d"]
+
+    # Unpinning columns removes them from the pin list
+    view.unpin_column("output.col_a")
+    assert view.base.definition.pin.left == [
+        "CustomCheckbox",
+        "op_name",
+        "output.col_b",
+    ]
+    view.unpin_column("output.col_c")
+    assert view.base.definition.pin.right == ["output.col_d"]
+
+    # Pin a column that is currently right to left and left to right
+    view.pin_column_left("output.col_d")
+    assert view.base.definition.pin.left == [
+        "CustomCheckbox",
+        "op_name",
+        "output.col_b",
+        "output.col_d",
+    ]
+    assert view.base.definition.pin.right == []
+    view.pin_column_right("output.col_b")
+    assert view.base.definition.pin.left == [
+        "CustomCheckbox",
+        "op_name",
+        "output.col_d",
+    ]
+    assert view.base.definition.pin.right == ["output.col_b"]
+
+
+@weave.op
+def chat_completion_create(
+    custom_id: str,
+    model: str,
+    temperature: float,
+    max_tokens: int,
+    messages: list[dict[str, str]],
+    stream: bool,
+) -> str:
+    return "Hello, world!"
+
+
+def make_calls(client):
+    chat_completion_create(
+        custom_id="1",
+        model="gpt-4o-mini",
+        temperature=0.7,
+        max_tokens=500,
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        stream=False,
+    )
+    chat_completion_create(
+        custom_id="2",
+        model="gpt-3.5-turbo",
+        temperature=0.6,
+        max_tokens=400,
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        stream=False,
+    )
+    chat_completion_create(
+        custom_id="3",
+        model="gpt-3.5-turbo",
+        temperature=0.5,
+        max_tokens=300,
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        stream=False,
+    )
+    chat_completion_create(
+        custom_id="4",
+        model="gpt-3.5-turbo",
+        temperature=0.4,
+        max_tokens=200,
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        stream=True,
+    )
+    chat_completion_create(
+        custom_id="5",
+        model="gpt-3.5-turbo",
+        temperature=0.8,
+        max_tokens=100,
+        messages=[{"role": "user", "content": "Hello, world!"}],
+        stream=True,
+    )
+
+
+def test_saved_view_column_select(client):
+    make_calls(client)
+    view = weave.SavedView("traces", "My saved view")
+    view.add_column("inputs.custom_id")
+    calls = view.get_calls()
+    assert len(calls) == 5
+    grid = view.to_grid()
+    assert grid.num_columns == 1
+    assert grid["inputs.custom_id"].to_list() == ["1", "2", "3", "4", "5"]
+
+
+def test_saved_view_repr_pretty():
+    view = weave.SavedView("traces", "My saved view")
+    # Test that _repr_pretty_ doesn't raise an exception
+    view.add_column("inputs.model")
+    view.hide_column("output")
+    view.pin_column_right("inputs.model")
+    view.add_filter("inputs.model", "equals", "gpt-3.5-turbo")
+    view.add_sort("inputs.temperature", "desc")
+    view.page_size(10)
+
+    # Create a mock printer object to test _repr_pretty_
+    class MockPrinter:
+        def __init__(self):
+            self.text_content = ""
+
+        def text(self, content):
+            self.text_content += content
+
+    p = MockPrinter()
+    view._repr_pretty_(p, False)
+
+    # Verify that the representation contains expected content
+    assert "My saved view" in p.text_content
+    assert "traces" in p.text_content
+    assert "inputs.model" in p.text_content
+    assert "gpt-3.5-turbo" in p.text_content
+
+    # Test cycle case
+    p = MockPrinter()
+    view._repr_pretty_(p, True)
+    assert p.text_content == "SavedView(...)"

--- a/tests/trace/test_traverse.py
+++ b/tests/trace/test_traverse.py
@@ -1,0 +1,161 @@
+import pytest
+
+from weave.trace.traverse import ObjectPath, escape_key, get_paths, sort_paths
+
+
+def test_escape_key() -> None:
+    assert escape_key("") == ""
+    assert escape_key("user") == "user"
+    assert escape_key("user[name]") == "user\\[name\\]"
+    assert escape_key("user.name[0]") == "user\\.name\\[0\\]"
+    assert escape_key("user.name[0].name") == "user\\.name\\[0\\]\\.name"
+
+
+class TestObjectPathToStr:
+    def test_handles_empty_path(self) -> None:
+        assert ObjectPath([]).to_str() == ""
+
+    def test_handles_simple_cases(self) -> None:
+        assert ObjectPath(["foo"]).to_str() == "foo"
+        assert ObjectPath(["foo", "bar"]).to_str() == "foo.bar"
+        assert ObjectPath(["foo", "4"]).to_str() == "foo.4"
+        assert ObjectPath(["foo", 4]).to_str() == "foo[4]"
+
+    def test_escapes_periods(self) -> None:
+        assert ObjectPath(["foo.bar.baz"]).to_str() == "foo\\.bar\\.baz"
+
+    def test_escapes_brackets(self) -> None:
+        assert ObjectPath(["foo[5]"]).to_str() == "foo\\[5\\]"
+
+    def test_str(self) -> None:
+        assert str(ObjectPath(["foo", "bar"])) == "foo.bar"
+        assert str(ObjectPath(["foo", 4])) == "foo[4]"
+
+
+class TestObjectPathParseStr:
+    def test_handles_empty_path(self) -> None:
+        assert ObjectPath.parse_str("").elements == []
+
+    def test_handles_simple_cases(self) -> None:
+        assert ObjectPath.parse_str("foo").elements == ["foo"]
+        assert ObjectPath.parse_str("foo.bar").elements == ["foo", "bar"]
+
+    def test_handles_numeric_keys(self) -> None:
+        assert ObjectPath.parse_str("0").elements == ["0"]
+        assert ObjectPath.parse_str("42").elements == ["42"]
+
+    def test_handles_punctuation_in_keys(self) -> None:
+        assert ObjectPath.parse_str("a,b!").elements == ["a,b!"]
+
+    def test_handles_key_access_errors(self) -> None:
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str(".")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("a[0].")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("a..b")
+
+    def test_handles_array_index_cases(self) -> None:
+        assert ObjectPath.parse_str("foo[2]").elements == ["foo", 2]
+        assert ObjectPath.parse_str("foo[2][3]").elements == ["foo", 2, 3]
+
+    def test_handles_array_index_errors(self) -> None:
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo[")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo[]")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo[1e3]")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo.[1]")
+
+    def test_handles_escaped_chars(self) -> None:
+        assert ObjectPath.parse_str("foo\\.bar").elements == ["foo.bar"]
+        assert ObjectPath.parse_str("foo\\[").elements == ["foo["]
+
+    def test_handles_escaping_errors(self) -> None:
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo\\")
+
+    def test_handles_complex_cases(self) -> None:
+        assert ObjectPath.parse_str("fo\\.o[1].bar.baz.bim[3][5].wat").elements == [
+            "fo.o",
+            1,
+            "bar",
+            "baz",
+            "bim",
+            3,
+            5,
+            "wat",
+        ]
+
+
+class TestObjectPathDunderMethods:
+    def test_hash(self) -> None:
+        assert isinstance(hash(ObjectPath(["foo", 42, "bar"])), int)
+
+    def test_getitem(self) -> None:
+        path = ObjectPath(["foo", 42, "bar"])
+        assert path[0] == "foo"
+        assert path[1] == 42
+        assert path[2] == "bar"
+
+    def test_add(self) -> None:
+        assert ObjectPath() + ["foo"] == ObjectPath(["foo"])
+        assert ObjectPath(["foo"]) + [0] == ObjectPath(["foo", 0])
+        assert ObjectPath(["foo"]) + [0, "bar"] == ObjectPath(["foo", 0, "bar"])
+
+    def test_len(self) -> None:
+        assert len(ObjectPath(["foo", 42, "bar"])) == 3
+
+    def test_repr(self) -> None:
+        assert repr(ObjectPath(["foo", 42, "bar"])) == "ObjectPath(['foo', 42, 'bar'])"
+
+
+class TestObjectPathComparePaths:
+    def test_simple_cases(self) -> None:
+        assert ObjectPath(["foo"]).__eq__(42) is NotImplemented
+        assert ObjectPath(["foo"]).__ne__(42) is NotImplemented
+        assert ObjectPath(["foo"]) == ObjectPath(["foo"])
+        assert ObjectPath(["foo"]) != ObjectPath(["foo", 42])
+        assert ObjectPath(["foo", 10]) == ObjectPath(["foo", 10])
+        assert ObjectPath(["foo"]) < ObjectPath(["foo", "bar"])
+        assert ObjectPath(["foo"]) <= ObjectPath(["foo", "bar"])
+        assert ObjectPath(["foo"]) <= ObjectPath(["foo"])
+        assert ObjectPath(["foo", "bar"]) > ObjectPath(["foo"])
+        assert ObjectPath(["foo", "bar"]) < ObjectPath(["foo", "baz"])
+        assert ObjectPath(["foo", 9]) < ObjectPath(["foo", 10])
+        assert ObjectPath(["foo", 11]) > ObjectPath(["foo", 1])
+        assert ObjectPath(["foo", 11]) >= ObjectPath(["foo", 11])
+        assert ObjectPath(["foo", "z"]) < ObjectPath(["foo", 0])
+        assert not (ObjectPath(["foo", 0]) < ObjectPath(["foo", "a"]))
+
+
+class TestObjectPathGetPaths:
+    def test_object_cases(self) -> None:
+        assert get_paths({}) == []
+        assert get_paths({"foo": 42}) == [ObjectPath(["foo"])]
+        assert get_paths({"foo": {"bar": 42}}) == [
+            ObjectPath(["foo"]),
+            ObjectPath(["foo", "bar"]),
+        ]
+
+    def test_list_cases(self) -> None:
+        obj = {
+            "foo": [
+                {"bar": 42},
+                {"baz": 43},
+            ]
+        }
+        assert get_paths(obj) == [
+            ObjectPath(["foo"]),
+            ObjectPath(["foo", 0]),
+            ObjectPath(["foo", 0, "bar"]),
+            ObjectPath(["foo", 1]),
+            ObjectPath(["foo", 1, "baz"]),
+        ]
+
+
+class TestObjectPathSortPaths:
+    def test_sorting(self) -> None:
+        assert sort_paths([]) == []

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -14,6 +14,7 @@ from weave.flow.eval import Evaluation
 from weave.flow.model import Model
 from weave.flow.obj import Object
 from weave.flow.prompt.prompt import EasyPrompt, MessagesPrompt, Prompt, StringPrompt
+from weave.flow.saved_view import SavedView
 from weave.flow.scorer import Scorer
 from weave.initialization import *
 from weave.trace.util import Thread as Thread
@@ -46,4 +47,5 @@ __docspec__ = [
     Scorer,
     AnnotationSpec,
     Markdown,
+    SavedView,
 ]

--- a/weave/flow/saved_view.py
+++ b/weave/flow/saved_view.py
@@ -381,12 +381,22 @@ class SavedView:
         self.base.definition.filters = None
         return self
 
+    def _check_empty_call_filter(self) -> None:
+        """If all of the call filters are None, remove it."""
+        if self.base.definition.filter:
+            # Check if all fields in the filter are None
+            filter_fields = self.base.definition.filter.model_dump()
+            all_none = all(value is None for value in filter_fields.values())
+            if all_none:
+                self.base.definition.filter = None
+
     # TODO: Support other call filters such as parent_ids, call_ids, etc.
 
     def filter_op(self, op_name: str | None) -> SavedView:
         if op_name is None:
             if self.base.definition.filter:
                 self.base.definition.filter.op_names = None
+                self._check_empty_call_filter()
         else:
             op_uri = op_name
             if not op_uri.startswith("weave:///"):
@@ -539,6 +549,10 @@ class SavedView:
     @property
     def name(self) -> str:
         return self.base.label
+
+    @property
+    def table(self) -> str:
+        return self.base.table
 
     def _repr_pretty_(self, p: Any, cycle: bool) -> None:
         """Show a nicely formatted table in ipython."""

--- a/weave/flow/saved_view.py
+++ b/weave/flow/saved_view.py
@@ -1,0 +1,713 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, TypedDict
+
+from rich.table import Table
+
+from weave.trace.api import publish as weave_publish
+from weave.trace.api import ref as weave_ref
+from weave.trace.context import weave_client_context
+from weave.trace.grid import Grid
+from weave.trace.refs import ObjectRef, parse_op_uri
+from weave.trace.rich import pydantic_util
+from weave.trace.traverse import ObjectPath, get_paths
+from weave.trace.vals import WeaveObject
+from weave.trace.weave_client import CallsIter
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.interface.builtin_object_classes.saved_view import (
+    CallsFilter,
+    Column,
+    Filter,
+    Filters,
+    Pin,
+    SortBy,
+    SortDirection,
+)
+from weave.trace_server.interface.builtin_object_classes.saved_view import (
+    SavedView as SavedViewBase,
+)
+
+KNOWN_COLUMNS = [
+    "id",
+    "display_name",
+    "op_name",
+    "inputs",
+    "output",
+    "attributes",
+    "summary",
+    "started_at",
+    "ended_at",
+    "exception",
+    "func_name",
+    "parent_id",
+    "project_id",
+    "trace_id",
+    "ui_url",
+    # TODO: feedback
+    # TODO: status
+    # TODO: wb_user_id
+    # TODO: wb_run_id
+]
+
+
+class TableColumn(TypedDict):
+    """A column in a table view."""
+
+    path: ObjectPath
+    label: str
+
+
+def to_seconds(value: Any) -> float | None:
+    """Convert a value to seconds.
+
+    This is used for constructing time based filters, but might belong
+    in a more general purpose utility module.
+
+    TODO: other date specifier strings like devtools?
+
+    Handles:
+    - None: returns None
+    - Empty string: returns None
+    - Numbers: returns the number directly
+    - Strings that can be parsed as numbers: returns the parsed number
+    - Date strings: parses as date and returns seconds since epoch
+    - datetime objects: returns seconds since epoch
+
+    Returns:
+        float | None: The value converted to seconds, or None if conversion failed
+    """
+    if value is None or value == "":
+        return None
+
+    # If it's already a number, return it directly
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    # Try to parse as a number
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        pass
+
+    # Try to parse as a date
+    try:
+        if isinstance(value, datetime):
+            dt = value
+        else:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        return dt.timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+DEFAULT_PIN = Pin(left=["CustomCheckbox", "op_name"], right=[])
+DEFAULT_FILTER = Filters(items=[], logicOperator="and")
+
+# Map from the user input operator string to a Material UI like operator string.
+OPERATOR_MAP = {
+    "contains": "(string): contains",
+    "equals": "(string): equals",
+    "in": "(string): in",
+    "=": "(number): =",
+    "≠": "(number): !=",
+    "!=": "(number): !=",
+    "<": "(number): <",
+    "≤": "(number): <=",
+    "<=": "(number): <=",
+    ">": "(number): >",
+    "≥": "(number): >=",
+    ">=": "(number): >=",
+    "is": "(bool): is",
+    "after": "(date): after",
+    "before": "(date): before",
+    "is empty": "(any): isEmpty",
+    "is not empty": "(any): isNotEmpty",
+}
+
+
+def py_to_api_filter(filter: CallsFilter | None) -> tsi.CallsFilter | None:
+    """Convert Saved View Filter to API Filter"""
+    if filter is None:
+        return None
+    return tsi.CallsFilter(
+        **filter.model_dump(exclude_none=True),
+    )
+
+
+def py_to_api_sort_by(sort_by: list[SortBy] | None) -> list[tsi.SortBy] | None:
+    """Convert Saved View SortBy to API SortBy"""
+    if sort_by is None:
+        return None
+    return [tsi.SortBy(field=s.field, direction=s.direction) for s in sort_by]
+
+
+# See operationConverter in weave-js
+def filter_to_clause(item: Filter) -> dict[str, Any]:
+    if item.operator == "(any): isEmpty":
+        return {
+            "$eq": [{"$getField": item.field}, {"$literal": ""}],
+        }
+    elif item.operator == "(any): isNotEmpty":
+        return {
+            "$not": [
+                {
+                    "$eq": [{"$getField": item.field}, {"$literal": ""}],
+                },
+            ],
+        }
+    elif item.operator == "(string): contains":
+        return {
+            "$contains": {
+                "input": {"$getField": item.field},
+                "substr": {"$literal": item.value},
+            },
+        }
+    elif item.operator == "(string): equals":
+        return {
+            "$eq": [{"$getField": item.field}, {"$literal": item.value}],
+        }
+    elif item.operator == "(string): in":
+        values = (
+            item.value
+            if isinstance(item.value, list)
+            else [s.strip() for s in item.value.split(",")]
+        )
+        clauses = [
+            {"$eq": [{"$getField": item.field}, {"$literal": v}]} for v in values
+        ]
+        return {"$or": clauses}
+    elif item.operator == "(number): =":
+        value = float(item.value)
+        return {
+            "$eq": [
+                {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
+                {"$literal": value},
+            ],
+        }
+    elif item.operator == "(number): !=":
+        value = float(item.value)
+        return {
+            "$not": [
+                {
+                    "$eq": [
+                        {
+                            "$convert": {
+                                "input": {"$getField": item.field},
+                                "to": "double",
+                            }
+                        },
+                        {"$literal": value},
+                    ],
+                },
+            ],
+        }
+    elif item.operator == "(number): >":
+        value = float(item.value)
+        return {
+            "$gt": [
+                {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
+                {"$literal": value},
+            ],
+        }
+    elif item.operator == "(number): >=":
+        value = float(item.value)
+        return {
+            "$gte": [
+                {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
+                {"$literal": value},
+            ],
+        }
+    elif item.operator == "(number): <":
+        value = float(item.value)
+        return {
+            "$not": [
+                {
+                    "$gte": [
+                        {
+                            "$convert": {
+                                "input": {"$getField": item.field},
+                                "to": "double",
+                            }
+                        },
+                        {"$literal": value},
+                    ],
+                }
+            ],
+        }
+    elif item.operator == "(number): <=":
+        value = float(item.value)
+        return {
+            "$not": [
+                {
+                    "$gt": [
+                        {
+                            "$convert": {
+                                "input": {"$getField": item.field},
+                                "to": "double",
+                            }
+                        },
+                        {"$literal": value},
+                    ],
+                }
+            ],
+        }
+    elif item.operator == "(bool): is":
+        return {
+            "$eq": [{"$getField": item.field}, {"$literal": str(item.value)}],
+        }
+    elif item.operator == "(date): after":
+        seconds = to_seconds(item.value)
+        if seconds is None:
+            raise ValueError(f"Invalid date value: {item.value}")
+        return {
+            "$gt": [{"$getField": item.field}, {"$literal": seconds}],
+        }
+    elif item.operator == "(date): before":
+        seconds = to_seconds(item.value)
+        if seconds is None:
+            raise ValueError(f"Invalid date value: {item.value}")
+        return {
+            "$not": [
+                {
+                    "$gt": [{"$getField": item.field}, {"$literal": seconds}],
+                },
+            ],
+        }
+    else:
+        raise ValueError(f"Unsupported operator: {item.operator}")
+
+
+def filters_to_query(filters: Filters | None) -> tsi.Query | None:
+    """Convert Saved View Filters to API Filters"""
+    if filters is None or not filters.items:
+        return None
+
+    # TODO: Handle additional logicOperator's
+    filter_clauses = [filter_to_clause(f) for f in filters.items]
+    expr = {"$and": filter_clauses}
+    return tsi.Query(**{"$expr": expr})
+
+
+def get_object_path(obj: WeaveObject, path: str | ObjectPath) -> Any:
+    """Given a path and an object, return what is pointed to."""
+    if isinstance(path, str):
+        path = ObjectPath.parse_str(path)
+    if not isinstance(path[0], str):
+        raise TypeError(f"Path must start with a string, got {path[0]}")
+    result = getattr(obj, path[0])
+    for element in path[1:]:
+        if result is None:
+            return None
+        if isinstance(result, dict):
+            result = result.get(element, None)
+        else:
+            try:
+                result = result[element]
+            except (IndexError, KeyError):
+                return None
+    return result
+
+
+def render_cell(path: ObjectPath, value: Any) -> str:
+    if path.elements[0] == "op_name":
+        op_ref = parse_op_uri(value)
+        return op_ref.name
+    return value
+
+
+class SavedView:
+    """A fluent-style class for working with SavedView objects."""
+
+    base: SavedViewBase
+    ref: ObjectRef | None = None
+
+    def __init__(self, table: str = "traces", label: str = "SavedView") -> None:
+        self.base = SavedViewBase(
+            table=table,
+            label=label,
+            definition={},
+        )
+
+    @property
+    def entity(self) -> str | None:
+        if self.ref:
+            return self.ref.entity
+        client = weave_client_context.get_weave_client()
+        return client.entity if client else None
+
+    @property
+    def project(self) -> str | None:
+        if self.ref:
+            return self.ref.project
+        client = weave_client_context.get_weave_client()
+        return client.project if client else None
+
+    def rename(self, label: str) -> SavedView:
+        self.base.label = label
+        return self
+
+    def add_filter(self, field: str, operator: str, value: Any) -> SavedView:
+        if ObjectPath.parse_str(field).elements[0] not in KNOWN_COLUMNS:
+            raise ValueError(f'Column "{field}" is not known')
+        op = OPERATOR_MAP.get(operator)
+        if not op:
+            raise ValueError(f"Operator {operator} not supported")
+        if not self.base.definition.filters:
+            self.base.definition.filters = DEFAULT_FILTER.model_copy()
+        assert self.base.definition.filters is not None
+        next_id = len(self.base.definition.filters.items)
+        filter = Filter(id=next_id, field=field, operator=op, value=value)
+        self.base.definition.filters.items.append(filter)
+        return self
+
+    def remove_filter(self, index_or_field: int | str) -> SavedView:
+        if not self.base.definition.filters or not self.base.definition.filters.items:
+            return self
+        if isinstance(index_or_field, int):
+            self.base.definition.filters.items.pop(index_or_field)
+        else:
+            self.base.definition.filters.items = [
+                f
+                for f in self.base.definition.filters.items
+                if f.field != index_or_field
+            ]
+        if not self.base.definition.filters.items:
+            self.base.definition.filters = None
+        return self
+
+    def remove_filters(self) -> SavedView:
+        """Remove all filters from the saved view."""
+        self.base.definition.filters = None
+        return self
+
+    # TODO: Support other call filters such as parent_ids, call_ids, etc.
+
+    def filter_op(self, op_name: str | None) -> SavedView:
+        if op_name is None:
+            if self.base.definition.filter:
+                self.base.definition.filter.op_names = None
+        else:
+            op_uri = op_name
+            if not op_uri.startswith("weave:///"):
+                if not self.entity:
+                    raise ValueError(
+                        "Must specify Op URI if entity/project is not known"
+                    )
+                op_uri = f"weave:///{self.entity}/{self.project}/op/{op_name}"
+                if ":" not in op_name:
+                    op_uri += ":*"
+            if not self.base.definition.filter:
+                self.base.definition.filter = CallsFilter()
+            self.base.definition.filter.op_names = [op_uri]
+        return self
+
+    def add_sort(self, field: str, direction: SortDirection) -> SavedView:
+        if self.base.definition.sort is None:
+            self.base.definition.sort = []
+        clause = SortBy(field=field, direction=direction)
+        self.base.definition.sort.append(clause)
+        return self
+
+    def sort_by(self, field: str, direction: SortDirection) -> SavedView:
+        self.base.definition.sort = []
+        return self.add_sort(field, direction)
+
+    # Showing and hiding columns this way is not preferred.
+    # Instead try specifying exactly which columns to include.
+    def show_column(self, col_name: str) -> SavedView:
+        if not self.base.definition.cols:
+            self.base.definition.cols = {}
+        self.base.definition.cols[col_name] = True
+        return self
+
+    def hide_column(self, col_name: str) -> SavedView:
+        if not self.base.definition.cols:
+            self.base.definition.cols = {}
+        self.base.definition.cols[col_name] = False
+        return self
+
+    def add_column(self, path: str | ObjectPath, label: str | None = None) -> SavedView:
+        idx = len(self.base.definition.columns) if self.base.definition.columns else 0
+        return self.insert_column(idx, path, label)
+
+    def add_columns(self, *columns: str) -> SavedView:
+        """Convenience method for adding multiple columns to the grid."""
+        for column in columns:
+            self.add_column(column)
+        return self
+
+    def insert_column(
+        self, idx: int, path: str | ObjectPath, label: str | None = None
+    ) -> SavedView:
+        if isinstance(path, str):
+            path = ObjectPath.parse_str(path)
+        # We only check the first element in case the user knows better than us
+        # what columns are possible (e.g. an input that doesn't appear in first page of calls)
+        if path[0] not in KNOWN_COLUMNS:
+            raise ValueError(f'Column "{path}" is not known')
+        # Note: Currently allowing adding the same column multiple times, maybe we shouldn't.
+        if not self.base.definition.columns:
+            self.base.definition.columns = []
+        self.base.definition.columns.insert(idx, Column(path=path, label=label))
+        return self
+
+    def set_columns(self, *columns: str) -> SavedView:
+        """Set the columns to be displayed in the grid."""
+        self.base.definition.columns = []
+        self.add_columns(*columns)
+        return self
+
+    def column_index(self, path: int | str | ObjectPath) -> int:
+        if isinstance(path, str):
+            path = ObjectPath.parse_str(path)
+        for i, col in enumerate(self.get_table_columns()):
+            if col["path"] == path:
+                return i
+        if isinstance(path, int):
+            if path < 0 or path >= len(self.get_table_columns()):
+                raise ValueError(f'Column index "{path}" out of bounds')
+            return path
+        raise ValueError(f'Column "{path}" not found')
+
+    def rename_column(self, path: int | str | ObjectPath, label: str) -> SavedView:
+        index = self.column_index(path)
+        assert self.base.definition.columns is not None
+        self.base.definition.columns[index].label = label
+        return self
+
+    def remove_column(self, path: int | str | ObjectPath) -> SavedView:
+        if isinstance(path, str):
+            path = ObjectPath.parse_str(path)
+        if not self.base.definition.columns:
+            return self
+        if isinstance(path, int):
+            self.base.definition.columns.pop(path)
+            return self
+        self.base.definition.columns = [
+            col
+            for col in self.base.definition.columns
+            if not col.path or col.path != path.elements
+        ]
+        if not self.base.definition.columns:
+            self.base.definition.columns = None
+        return self
+
+    def remove_columns(self, *columns: str) -> SavedView:
+        """Remove columns from the saved view."""
+        if not columns:
+            self.base.definition.columns = None
+            return self
+        for col in columns:
+            self.remove_column(col)
+        return self
+
+    def pin_column_left(self, col_name: str) -> SavedView:
+        if not self.base.definition.pin:
+            self.base.definition.pin = DEFAULT_PIN.model_copy()
+        assert self.base.definition.pin is not None
+        if col_name in self.base.definition.pin.right:
+            self.base.definition.pin.right.remove(col_name)
+        if col_name not in self.base.definition.pin.left:
+            self.base.definition.pin.left.append(col_name)
+        return self
+
+    def pin_column_right(self, col_name: str) -> SavedView:
+        if not self.base.definition.pin:
+            self.base.definition.pin = DEFAULT_PIN.model_copy()
+        assert self.base.definition.pin is not None
+        if col_name in self.base.definition.pin.left:
+            self.base.definition.pin.left.remove(col_name)
+        if col_name not in self.base.definition.pin.right:
+            self.base.definition.pin.right.append(col_name)
+        return self
+
+    def unpin_column(self, col_name: str) -> SavedView:
+        if not self.base.definition.pin:
+            self.base.definition.pin = DEFAULT_PIN.copy()
+        assert self.base.definition.pin is not None
+        if col_name in self.base.definition.pin.left:
+            self.base.definition.pin.left.remove(col_name)
+        elif col_name in self.base.definition.pin.right:
+            self.base.definition.pin.right.remove(col_name)
+        return self
+
+    def page_size(self, page_size: int) -> SavedView:
+        self.base.definition.page_size = page_size
+        return self
+
+    @property
+    def name(self) -> str:
+        return self.base.label
+
+    def _repr_pretty_(self, p: Any, cycle: bool) -> None:
+        """Show a nicely formatted table in ipython."""
+        if cycle:
+            p.text("SavedView(...)")
+        else:
+            p.text(self.to_rich_table_str())
+
+    def to_rich_table_str(self) -> str:
+        table = Table(show_header=False)
+        table.add_column("Key", justify="right", style="bold cyan")
+        table.add_column("Value")
+        table.add_row("Name", self.name)
+        if self.base.description is not None:
+            table.add_row("Description", self.base.description)
+        if self.ref:
+            table.add_row("Ref", self.ref.uri())
+        table.add_row("Table", self.base.table)
+        if self.base.definition.filter is not None:
+            table.add_row(
+                "Call Filter",
+                pydantic_util.model_to_table(
+                    self.base.definition.filter, filter_none_values=True
+                ),
+            )
+        if self.base.definition.filters is not None:
+            filters_table = Table()
+            filters_table.add_column("Field")
+            filters_table.add_column("Operator")
+            filters_table.add_column("Value")
+            for filter in self.base.definition.filters.items:
+                filters_table.add_row(filter.field, filter.operator, str(filter.value))
+            table.add_row("Filters", filters_table)
+        if self.base.definition.columns is not None:
+            columns_table = Table()
+            columns_table.add_column("Column")
+            columns_table.add_column("Label")
+            for col in self.base.definition.columns:
+                columns_table.add_row(ObjectPath(col.path).to_str(), col.label)
+            table.add_row("Columns", columns_table)
+        if self.base.definition.cols:
+            # Create a nested table for column visibility
+            # TODO: Maybe color the boolean value?
+            cols_table = Table()
+            cols_table.add_column("Column")
+            cols_table.add_column("Show")
+            for col_id, visible in self.base.definition.cols.items():
+                cols_table.add_row(col_id, str(visible))
+            table.add_row("Column Visibility", cols_table)
+        if self.base.definition.pin is not None:
+            value = pydantic_util.model_to_table(self.base.definition.pin)
+            table.add_row("Pin", value)
+        if self.base.definition.sort is not None:
+            values = [f"{s.field} {s.direction}" for s in self.base.definition.sort]
+            table.add_row("Sort", ", ".join(values))
+        if self.base.definition.page_size is not None:
+            table.add_row("Page Size", str(self.base.definition.page_size))
+        return pydantic_util.table_to_str(table)
+
+    def __str__(self) -> str:
+        return self.to_rich_table_str()
+
+    def save(self) -> SavedView:
+        """Publish the saved view to the server."""
+        name = self.base.name
+        if name is None:
+            formatted_now = (
+                datetime.now()
+                .isoformat()
+                .replace("T", "_")
+                .replace(":", "-")
+                .replace(".", "-")[:-1]
+            )
+            name = f"{self.base.table}_{formatted_now}"
+        self.ref = weave_publish(self.base, name)
+        return self
+
+    def get_calls(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
+        include_costs: bool = False,
+        include_feedback: bool = False,
+        all_columns: bool = False,
+    ) -> CallsIter:
+        """Get calls matching this saved view's filters and settings."""
+        entity = self.ref.entity if self.ref else None
+        project = self.ref.project if self.ref else None
+        with weave_client_context.with_weave_client(
+            entity=entity, project=project
+        ) as client:
+            assert client is not None  # with_weave_client would have raised
+            # This method is also used internally, we allow forcing all columns.
+            table_columns = None if all_columns else self.get_table_columns()
+            if table_columns:
+                columns = [c["path"].to_str() for c in table_columns]
+            else:
+                columns = None
+            query = filters_to_query(self.base.definition.filters)
+            filter = py_to_api_filter(self.base.definition.filter)
+            sort_by = py_to_api_sort_by(self.base.definition.sort)
+            return client.get_calls(
+                columns=columns,
+                query=query,
+                filter=filter,
+                sort_by=sort_by,
+                limit=limit,
+                offset=offset,
+                include_costs=include_costs,
+                include_feedback=include_feedback,
+            )
+
+    def to_grid(self, limit: int | None = None) -> Grid:
+        calls = list(self.get_calls(limit=limit))
+        columns = self.get_table_columns()
+        grid = Grid()
+        for col in columns:
+            # TODO: Should we have a sort indictor in the column header?
+            grid.add_column(col["label"])
+        for call in calls:
+            row = []
+            for col in columns:
+                # TODO: Custom rendering for some columns
+                value = get_object_path(call, col["path"])
+                value = render_cell(col["path"], value)
+                row.append(value)
+            grid.add_row(row)
+        return grid
+
+    def get_known_columns(self, *, num_calls_to_query: int | None = None) -> list[str]:
+        """Get the set of columns that are known to exist."""
+        # TODO: Would be nice if we had a more efficient way to query server for this.
+        limit = num_calls_to_query or 10
+        seen = set(KNOWN_COLUMNS)
+        if weave_client_context.get_weave_client() is not None:
+            for call in self.get_calls(limit=limit, all_columns=True):
+                seen.update(p.to_str() for p in get_paths(call.to_dict()))
+        return sorted(seen)
+
+    def get_table_columns(self) -> list[TableColumn]:
+        # If columns are defined in the saved view definition, use those directly
+        if self.base.definition.columns:
+            return [
+                {
+                    "path": ObjectPath(col.path),
+                    "label": col.label
+                    or (ObjectPath(col.path).to_str() if col.path else ""),
+                }
+                for col in self.base.definition.columns
+            ]
+        default_columns: list[TableColumn] = [
+            {
+                "path": ObjectPath(["id"]),
+                "label": "ID",
+            },
+        ]
+        # TODO: Handle inputs, output, attributes
+        # TODO: Handle visibility
+        # TODO: Handle pinning
+        return default_columns
+
+    @classmethod
+    def load(cls, ref: str) -> SavedView:
+        obj_ref = weave_ref(ref)
+        base = obj_ref.get()
+        instance = cls.__new__(cls)
+        instance.ref = obj_ref
+        instance.base = base
+        return instance
+
+    # TODO: Where should we put method to list SavedViews?
+    # TODO: View deletion

--- a/weave/trace/context/weave_client_context.py
+++ b/weave/trace/context/weave_client_context.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import threading
+from collections.abc import Generator
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -43,3 +45,36 @@ def require_weave_client() -> WeaveClient:
     if (client := get_weave_client()) is None:
         raise WeaveInitError("You must call `weave.init(<project_name>)` first")
     return client
+
+
+@contextmanager
+def with_weave_client(
+    entity: str | None, project: str | None, required: bool = True
+) -> Generator[WeaveClient | None, None, None]:
+    """Context manager that returns a WeaveClient for a given entity and project.
+
+    Restores any active WeaveClient after the context manager exits.
+
+    Args:
+        entity: Entity name or None to use the current entity if there is one
+        project: Project name or None to use the current project if there is one
+        required: If True, raises WeaveInitError when no client exists and entity/project are None
+
+    Yields:
+        A WeaveClient to use for the duration of the context manager or None if no client exists
+        and required=False
+    """
+    current_client = get_weave_client()
+    if entity is None and project is None:
+        if required and current_client is None:
+            raise WeaveInitError("You must call `weave.init(<project_name>)` first")
+        yield current_client
+    else:
+        from weave.trace.weave_init import init_weave
+
+        scoped_name = f"{entity}/{project}"
+        try:
+            initialized_client = init_weave(scoped_name, ensure_project_exists=False)
+            yield initialized_client.client
+        finally:
+            set_weave_client_global(current_client)

--- a/weave/trace/rich/pydantic_util.py
+++ b/weave/trace/rich/pydantic_util.py
@@ -9,12 +9,14 @@ from rich.table import Table
 from weave.trace import util
 
 
-def dict_to_table(d: dict[str, Any]) -> Table:
+def dict_to_table(d: dict[str, Any], *, filter_none_values: bool = False) -> Table:
     """Create a two-column table from a dictionary."""
     table = Table(show_header=False)
     table.add_column("Key", justify="right", style="bold cyan")
     table.add_column("Value")
     for k, v in d.items():
+        if filter_none_values and v is None:
+            continue
         table.add_row(k, str(v))
     return table
 
@@ -28,9 +30,9 @@ def table_to_str(table: Table) -> str:
     return capture.get().strip()
 
 
-def model_to_table(model: BaseModel) -> Table:
+def model_to_table(model: BaseModel, *, filter_none_values: bool = False) -> Table:
     """Create a two-column table from a Pydantic model."""
-    return dict_to_table(model.model_dump())
+    return dict_to_table(model.model_dump(), filter_none_values=filter_none_values)
 
 
 def model_to_str(model: BaseModel) -> Table:

--- a/weave/trace/traverse.py
+++ b/weave/trace/traverse.py
@@ -1,0 +1,215 @@
+"""Utilities for traversing objects."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterator
+from functools import cmp_to_key
+from typing import Any, Union, overload
+
+# String indicates object key access, number indicates array index access
+# This structure allows us to handle corner cases like periods or brackets
+# in object keys.
+
+PathElement = Union[str, int]
+
+
+def escape_key(key: str) -> str:
+    """Escape special characters in a key for path string representation."""
+    return key.replace(".", "\\.").replace("[", "\\[").replace("]", "\\]")
+
+
+class ObjectPath:
+    elements: list[PathElement]
+
+    def __init__(self, elements: list[PathElement] | None = None):
+        self.elements = elements if elements is not None else []
+
+    @overload
+    def __getitem__(self, index: int) -> PathElement: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[PathElement]: ...
+
+    def __getitem__(self, index: int | slice) -> PathElement | list[PathElement]:
+        return self.elements[index]
+
+    def __len__(self) -> int:
+        return len(self.elements)
+
+    def __add__(self, other: list[PathElement]) -> ObjectPath:
+        return ObjectPath(self.elements + other)
+
+    def __iter__(self) -> Iterator[PathElement]:
+        return iter(self.elements)
+
+    def __repr__(self) -> str:
+        return f"ObjectPath({self.elements})"
+
+    def __lt__(self, other: ObjectPath) -> bool:
+        return compare_paths(self, other) < 0
+
+    def __le__(self, other: ObjectPath) -> bool:
+        return compare_paths(self, other) <= 0
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ObjectPath):
+            return NotImplemented
+        return compare_paths(self, other) == 0
+
+    def __ne__(self, other: object) -> bool:
+        if not isinstance(other, ObjectPath):
+            return NotImplemented
+        return compare_paths(self, other) != 0
+
+    def __gt__(self, other: ObjectPath) -> bool:
+        return compare_paths(self, other) > 0
+
+    def __ge__(self, other: ObjectPath) -> bool:
+        return compare_paths(self, other) >= 0
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.elements))
+
+    def __str__(self) -> str:
+        return self.to_str()
+
+    def to_str(self) -> str:
+        """Convert the path to a string representation.
+
+        Returns a string with dot notation for string elements and
+        square brackets for numeric indices.
+        """
+        result = ""
+        for element in self.elements:
+            if isinstance(element, str):
+                # Escape special characters in string keys
+                escaped = escape_key(element)
+                if result:
+                    result += "."
+                result += escaped
+            else:
+                # Use bracket notation for numeric indices
+                result += f"[{element}]"
+        return result
+
+    @classmethod
+    def parse_str(cls, path_string: str) -> ObjectPath:
+        """Parse a string representation of a path into a ObjectPath object.
+
+        Handles dot notation for object access and square brackets for array indices.
+        Supports escaping with backslash.
+
+        Args:
+            path_string: String representation of a path
+
+        Returns:
+            ObjectPath object
+
+        Raises:
+            ValueError: If the path string is invalid
+        """
+        path: list[PathElement] = []
+        key = ""
+        n = len(path_string)
+        i = 0
+
+        while i < n:
+            char = path_string[i]
+            if char == "\\":
+                if i == n - 1:
+                    raise ValueError("Invalid escape sequence")
+                key += path_string[i + 1]
+                i += 2
+            elif char == ".":
+                if i == 0 or i == n - 1:
+                    raise ValueError("Invalid object access")
+                prev = path_string[i - 1]
+                next_char = path_string[i + 1]
+                if not next_char.isalnum() or not (prev.isalnum() or prev == "]"):
+                    raise ValueError("Invalid object access")
+                if key:
+                    path.append(key)
+                    key = ""
+                i += 1
+            elif char == "[":
+                if key:
+                    path.append(key)
+                    key = ""
+                j = i + 1
+                while j < n and path_string[j] != "]":
+                    j += 1
+                index_str = path_string[i + 1 : j]
+                if j == n:
+                    raise ValueError(f"Invalid array index: '{index_str}'")
+                if not index_str.isdigit():
+                    raise ValueError(f"Invalid array index: '{index_str}'")
+                path.append(int(index_str))
+                i = j + 1
+            else:
+                key += char
+                i += 1
+
+        if key:
+            path.append(key)
+
+        return cls(path)
+
+
+ObjectPaths = list[ObjectPath]
+
+
+def get_paths(obj: Any, path: ObjectPath | None = None) -> ObjectPaths:
+    """Traverse an object and return all possible key paths."""
+    if path is None:
+        path = ObjectPath([])
+    paths = [path] if path else []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            paths.extend(get_paths(value, path + [key]))
+    elif isinstance(obj, list):
+        for i, value in enumerate(obj):
+            to_add: list[PathElement] = [i]  # Making pyright happy
+            paths.extend(get_paths(value, path + to_add))
+    return paths
+
+
+def compare_paths(path1: ObjectPath, path2: ObjectPath) -> int:
+    """Compare two paths for sort ordering.
+
+    Returns:
+        -1 if path1 < path2
+        0 if path1 == path2
+        1 if path1 > path2
+    """
+    # Compare elements pairwise
+    for e1, e2 in zip(path1, path2):
+        # If elements are same type, compare directly
+        if isinstance(e1, str) and isinstance(e2, str):
+            if e1 < e2:
+                return -1
+            if e1 > e2:
+                return 1
+        elif isinstance(e1, int) and isinstance(e2, int):
+            if e1 < e2:
+                return -1
+            if e1 > e2:
+                return 1
+
+        # If different types, strings come before integers
+        if isinstance(e1, str) and isinstance(e2, int):
+            return -1
+        if isinstance(e1, int) and isinstance(e2, str):
+            return 1
+
+    # If we get here, all common elements were equal
+    # Shorter paths come before longer paths
+    if len(path1) < len(path2):
+        return -1
+    if len(path1) > len(path2):
+        return 1
+
+    return 0
+
+
+def sort_paths(paths: Collection[ObjectPath]) -> ObjectPaths:
+    return sorted(paths, key=cmp_to_key(compare_paths))

--- a/weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py
+++ b/weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py
@@ -10,6 +10,7 @@ from weave.trace_server.interface.builtin_object_classes.provider import (
     Provider,
     ProviderModel,
 )
+from weave.trace_server.interface.builtin_object_classes.saved_view import SavedView
 from weave.trace_server.interface.builtin_object_classes.test_only_example import (
     TestOnlyExample,
     TestOnlyNestedBaseObject,
@@ -35,3 +36,4 @@ register_base_object(ActionSpec)
 register_base_object(AnnotationSpec)
 register_base_object(Provider)
 register_base_object(ProviderModel)
+register_base_object(SavedView)

--- a/weave/trace_server/interface/builtin_object_classes/saved_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/saved_view.py
@@ -62,7 +62,9 @@ class SavedViewDefinition(BaseModel):
     filter: Optional[CallsFilter] = Field(default=None)
     filters: Optional[Filters] = Field(default=None)
 
-    # cols is legacy column visibility config
+    # cols is the current UI column visibility config that
+    # doesn't allow specifying column order - prefer use of
+    # explicit columns list which is what we should work towards.
     cols: Optional[dict[str, bool]] = Field(default=None)
 
     # columns is specifying exactly which columns to include
@@ -78,7 +80,7 @@ class SavedView(base_object_def.BaseObject):
     # TODO: Should we have a spec_version literal?
 
     # "traces" or "evaluations", type is str for extensibility
-    table: str
+    view_type: str
 
     # Avoiding confusion around object_id + name
     label: str

--- a/weave/trace_server/interface/builtin_object_classes/saved_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/saved_view.py
@@ -1,0 +1,89 @@
+from typing import Any, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from weave.trace.traverse import PathElement
+from weave.trace_server.interface.builtin_object_classes import base_object_def
+
+# Compare with definitions in weave/trace_server/trace_server_interface.py
+
+
+class CallsFilter(BaseModel):
+    op_names: Optional[list[str]] = None
+    input_refs: Optional[list[str]] = None
+    output_refs: Optional[list[str]] = None
+    parent_ids: Optional[list[str]] = None
+    trace_ids: Optional[list[str]] = None
+    call_ids: Optional[list[str]] = None
+    trace_roots_only: Optional[bool] = None
+    wb_user_ids: Optional[list[str]] = None
+    wb_run_ids: Optional[list[str]] = None
+
+
+class Filter(BaseModel):
+    id: int
+    field: str
+    # Type of operator could be locked down more, but this is better for extensibility
+    operator: str
+    value: Any
+
+
+class Filters(BaseModel):
+    items: list[Filter] = []
+    logicOperator: Literal["and"] = "and"
+
+
+class Pin(BaseModel):
+    # TODO: Make them optional? But one is required?
+    left: list[str]
+    right: list[str]
+
+
+SortDirection = Literal["asc", "desc"]
+
+
+# Note: This is intentionally similar to `SortBy` in `trace_server_interface.py`
+# but duplicating because logically it shouldn't need to match the API interface.
+class SortBy(BaseModel):
+    # Field should be a key of `CallSchema`. For dictionary fields
+    # (`attributes`, `inputs`, `outputs`, `summary`), the field can be
+    # dot-separated.
+    field: str
+    direction: SortDirection
+
+
+class Column(BaseModel):
+    # Optional in case we want something like computed columns in the future.
+    path: Optional[list[PathElement]] = Field(default=None)
+    label: Optional[str] = Field(default=None)
+
+
+class SavedViewDefinition(BaseModel):
+    filter: Optional[CallsFilter] = Field(default=None)
+    filters: Optional[Filters] = Field(default=None)
+
+    # cols is legacy column visibility config
+    cols: Optional[dict[str, bool]] = Field(default=None)
+
+    # columns is specifying exactly which columns to include
+    # including order.
+    columns: Optional[list[Column]] = Field(default=None)
+
+    pin: Optional[Pin] = Field(default=None)
+    sort: Optional[list[SortBy]] = Field(default=None)
+    page_size: Optional[int] = Field(default=None)
+
+
+class SavedView(base_object_def.BaseObject):
+    # TODO: Should we have a spec_version literal?
+
+    # "traces" or "evaluations", type is str for extensibility
+    table: str
+
+    # Avoiding confusion around object_id + name
+    label: str
+
+    definition: SavedViewDefinition
+
+
+__all__ = ["SavedView"]


### PR DESCRIPTION
## Description

Implements Saved Views in the SDK. Users can define a view in terms of columns, filters, sorting, etc. and persist them as built-in objects to a project. As part of this I implemented preliminary versions of some generally useful utilities, including a "Grid" class that can be used for tabular data, and "ObjectPath" which mirrors a TypeScript utility we have.

## Testing

Unit tests added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced tabular data component featuring interactive pagination, rich display, and export capabilities.
  - Added robust saved view functionality for filtering, sorting, and customizable column management including pinning options.
  - Improved navigation for complex, nested data structures with refined path utilities.
  - Implemented a streamlined client initialization process for more reliable session management.

- **Tests**
  - Expanded automated test coverage to ensure the reliability of grid operations, saved view interactions, and data traversal.
  - Added comprehensive test suites for the `Grid`, `SavedView`, and `ObjectPath` functionalities, focusing on validation and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->