### PR TITLE
fix(weave_query): correct parsing of artifact project name and name

### DIFF
--- a/weave_query/weave_query/wandb_file_manager.py
+++ b/weave_query/weave_query/wandb_file_manager.py
@@ -70,9 +70,9 @@ def _local_path_and_download_url(
             return file_path, "{}/artifactsV2/{}/{}/{}/{}/{}/{}/{}".format(
                 base_url,
                 storage_region,
-                art_uri.entity_name,
-                art_uri.project_name,
-                art_uri.name,
+                entity_name,
+                urllib.parse.quote(art_uri.project_name),
+                urllib.parse.quote(art_uri.name),
                 urllib.parse.quote(manifest_entry.get("birthArtifactID", "")),  # type: ignore
                 md5_hex,
                 urllib.parse.quote(file_name),


### PR DESCRIPTION
## Description

- Fixes [WB-23751](https://wandb.atlassian.net/browse/WB-23751)


## Testing

Verified that zlib playback of the crashing table passes


[WB-23751]: https://wandb.atlassian.net/browse/WB-23751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved artifact download reliability by ensuring all download links are properly encoded. This change helps handle special characters in project and artifact names, reducing issues when users download their artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->