### PR TITLE
docs(weave): remove Enterprise Only from https://weave-docs.wandb.ai/guides/tracki…

### DIFF
--- a/docs/docs/guides/tracking/redact-pii.md
+++ b/docs/docs/guides/tracking/redact-pii.md
@@ -1,9 +1,5 @@
 # Redact PII from Traces
 
-:::important
-This feature is only available for Enterprise users, and is only accessible via the Python SDK.
-:::
-
 Some organizations process Personally Identifiable Information (PII) such as names, phone numbers, and email addresses in their Large Language Model (LLM) workflows. Storing this data in Weights & Biases (W&B) Weave poses compliance and security risks.
 
 The _Sensitive Data Protection_ feature allows you to automatically redact Personally Identifiable Information (PII) from a [trace](../tracking/index.md) before it is sent to Weave servers. This feature integrates [Microsoft Presidio](https://microsoft.github.io/presidio/) into the Weave Python SDK, which means that you can control redaction settings at the SDK level.


### PR DESCRIPTION
…ng/redact-pii

Per convo with PM Cassie Gamm, this feature is now available to everyone

## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

What does the PR do? Include a concise description of the PR contents.

## Testing

How was this PR tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guidance on sensitive data protection by removing information that previously limited the PII redaction feature to Enterprise users with Python SDK access, while retaining key details about its integration with Microsoft Presidio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->