### PR TITLE
feat(weave): inline serializers, with two examples

### DIFF
--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -1,6 +1,25 @@
+from datetime import datetime, timezone
+
+import rich.markdown
 from PIL import Image
 
-from weave.trace.serialization.custom_objs import decode_custom_obj, encode_custom_obj
+import weave
+from weave.trace.serialization.custom_objs import (
+    KNOWN_TYPES,
+    decode_custom_obj,
+    decode_inline_obj,
+    encode_custom_obj,
+)
+
+
+def test_encode_custom_obj_unknown_type(client):
+    """No encoding should be done for unregistered types."""
+
+    class UnknownType:
+        pass
+
+    unknown = UnknownType()
+    assert encode_custom_obj(unknown) is None
 
 
 def test_decode_custom_obj_known_type(client):
@@ -14,3 +33,43 @@ def test_decode_custom_obj_known_type(client):
 
     assert isinstance(decoded, Image.Image)
     assert decoded.tobytes() == img.tobytes()
+
+
+def test_inline_custom_obj(client):
+    dt = datetime(2025, 3, 7, 0, 0, 0)
+    encoded = encode_custom_obj(dt)
+    assert encoded["_type"] == "CustomWeaveType"
+    assert encoded["weave_type"]["type"] == "datetime.datetime"
+    assert "files" not in encoded
+    assert "load_op" in encoded
+    assert encoded["val"] == "2025-03-07T00:00:00+00:00"
+
+    decoded = decode_inline_obj(encoded)
+    assert isinstance(decoded, datetime)
+    dt_with_tz = dt.replace(tzinfo=timezone.utc)
+    assert decoded == dt_with_tz
+
+
+def test_inline_custom_obj_needs_load_op(client):
+    """Test the condition that the current version of the SDK doesn't know how to load the object.
+
+    In that case we fallback to the saved load op."""
+    md = rich.markdown.Markdown("# Hello")
+
+    @weave.op
+    def return_markdown(md):
+        return md
+
+    _, call = return_markdown.call(md)
+    client.flush()
+
+    # Temporarily modify KNOWN_TYPES to remove markdown
+    global KNOWN_TYPES
+    original_known_types = KNOWN_TYPES.copy()
+    KNOWN_TYPES.remove("rich.markdown.Markdown")
+    try:
+        loaded = client.get_call(call.id)
+        loaded_markdown = loaded.inputs["md"]
+        assert isinstance(loaded_markdown, rich.markdown.Markdown)
+    finally:
+        KNOWN_TYPES = original_known_types

--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -6,8 +6,8 @@ from PIL import Image
 import weave
 from weave.trace.serialization.custom_objs import (
     KNOWN_TYPES,
-    decode_custom_obj,
-    decode_inline_obj,
+    decode_custom_files_obj,
+    decode_custom_inline_obj,
     encode_custom_obj,
 )
 
@@ -22,12 +22,12 @@ def test_encode_custom_obj_unknown_type(client):
     assert encode_custom_obj(unknown) is None
 
 
-def test_decode_custom_obj_known_type(client):
+def test_decode_custom_files_obj_known_type(client):
     img = Image.new("RGB", (100, 100))
     encoded = encode_custom_obj(img)
 
     # Even though something is wrong with the deserializer op, we can still decode
-    decoded = decode_custom_obj(
+    decoded = decode_custom_files_obj(
         encoded["weave_type"], encoded["files"], "weave:///totally/invalid/uri"
     )
 
@@ -44,7 +44,7 @@ def test_inline_custom_obj(client):
     assert "load_op" in encoded
     assert encoded["val"] == "2025-03-07T00:00:00+00:00"
 
-    decoded = decode_inline_obj(encoded)
+    decoded = decode_custom_inline_obj(encoded)
     assert isinstance(decoded, datetime)
     dt_with_tz = dt.replace(tzinfo=timezone.utc)
     assert decoded == dt_with_tz

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueMarkdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueMarkdown.tsx
@@ -1,0 +1,220 @@
+import {Popover} from '@mui/material';
+import {Tailwind} from '@wandb/weave/components/Tailwind';
+import copyToClipboard from 'copy-to-clipboard';
+import React, {ReactNode, useCallback, useRef, useState} from 'react';
+import styled from 'styled-components';
+
+import {toast} from '../../../../common/components/elements/Toast';
+import Markdown from '../../../../common/components/Markdown';
+import * as Colors from '../../../../common/css/color.styles';
+import {Button} from '../../../Button';
+import {CodeEditor} from '../../../CodeEditor';
+import {
+  DraggableGrow,
+  DraggableHandle,
+  PoppedBody,
+  StyledTooltip,
+  TooltipHint,
+} from '../../../DraggablePopups';
+import {Icon} from '../../../Icon';
+
+type CellValueMarkdownProps = {
+  value: string;
+};
+
+const Collapsed = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+`;
+Collapsed.displayName = 'S.Collapsed';
+
+const TooltipContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+TooltipContent.displayName = 'S.TooltipContent';
+
+const TooltipText = styled.div`
+  max-height: 35vh;
+  overflow: auto;
+  white-space: break-spaces;
+`;
+TooltipText.displayName = 'S.TooltipText';
+
+const Popped = styled.div`
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  word-wrap: break-word;
+  background-color: #fff;
+  color: ${Colors.MOON_700};
+  border: 1px solid ${Colors.MOON_300};
+`;
+Popped.displayName = 'S.Popped';
+
+const Toolbar = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+`;
+Toolbar.displayName = 'S.Toolbar';
+
+const Spacer = styled.div`
+  flex: 1 1 auto;
+`;
+Spacer.displayName = 'S.Spacer';
+
+const truncateText = (text: string, maxLength: number) => {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.slice(0, maxLength) + '...';
+};
+
+export const CellValueMarkdown = ({value}: CellValueMarkdownProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const onClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(anchorEl ? null : ref.current);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popper' : undefined;
+
+  const trimmed = value.trim();
+  const [format, setFormat] = useState('Markdown');
+
+  const copy = useCallback(() => {
+    copyToClipboard(value);
+    toast('Copied to clipboard');
+  }, [value]);
+
+  let content: ReactNode = <TooltipText>{trimmed}</TooltipText>;
+  if (format === 'Code') {
+    content = (
+      <CodeEditor
+        value={trimmed}
+        language="markdown"
+        readOnly
+        handleMouseWheel
+        alwaysConsumeMouseWheel={false}
+      />
+    );
+  } else if (format === 'Markdown') {
+    content = <Markdown content={trimmed} />;
+  }
+
+  const title = open ? (
+    '' // Suppress tooltip when popper is open.
+  ) : (
+    <TooltipContent onClick={onClick}>
+      <Markdown content={trimmed} />
+      <TooltipHint>Click for more details</TooltipHint>
+    </TooltipContent>
+  );
+
+  // Unfortunate but necessary to get appear on top of peek drawer.
+  const stylePopper = {zIndex: 1};
+
+  return (
+    <>
+      <StyledTooltip enterDelay={500} title={title}>
+        <Collapsed ref={ref} onClick={onClick}>
+          <Tailwind>
+            <div className="flex items-center gap-4">
+              <div className="flex h-[22px] w-[22px] flex-none items-center justify-center rounded-full bg-moon-300/[0.48]">
+                <Icon
+                  role="presentation"
+                  className="h-[14px] w-[14px]"
+                  name="markdown"
+                />
+              </div>
+              {truncateText(trimmed, 200)}
+            </div>
+          </Tailwind>
+        </Collapsed>
+      </StyledTooltip>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        style={stylePopper}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        onClose={() => setAnchorEl(null)}
+        TransitionComponent={DraggableGrow}>
+        <Popped>
+          <TooltipContent>
+            <DraggableHandle>
+              <Toolbar>
+                <Button
+                  size="small"
+                  variant="ghost"
+                  active={format === 'Markdown'}
+                  icon="markdown"
+                  tooltip="Markdown mode"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setFormat('Markdown');
+                  }}
+                />
+                <Button
+                  size="small"
+                  variant="ghost"
+                  active={format === 'Code'}
+                  icon="code-alt"
+                  tooltip="Code mode"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setFormat('Code');
+                  }}
+                />
+                <Button
+                  size="small"
+                  variant="ghost"
+                  active={format === 'Text'}
+                  icon="text-language"
+                  tooltip="Text mode"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setFormat('Text');
+                  }}
+                />
+                <Spacer />
+                <Button
+                  size="small"
+                  variant="ghost"
+                  icon="copy"
+                  tooltip="Copy to clipboard"
+                  onClick={e => {
+                    e.stopPropagation();
+                    copy();
+                  }}
+                />
+                <Button
+                  size="small"
+                  variant="ghost"
+                  icon="close"
+                  tooltip="Close preview"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setAnchorEl(null);
+                  }}
+                />
+              </Toolbar>
+            </DraggableHandle>
+            <PoppedBody>{content}</PoppedBody>
+          </TooltipContent>
+        </Popped>
+      </Popover>
+    </>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueTimestamp.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueTimestamp.tsx
@@ -1,0 +1,260 @@
+import {Popover} from '@mui/material';
+import {Tailwind} from '@wandb/weave/components/Tailwind';
+import copyToClipboard from 'copy-to-clipboard';
+import _ from 'lodash';
+import moment from 'moment';
+import React, {ReactNode, useCallback, useRef} from 'react';
+import TimeAgo, {Formatter} from 'react-timeago';
+import styled from 'styled-components';
+
+import {toast} from '../../../../common/components/elements/Toast';
+import * as Colors from '../../../../common/css/color.styles';
+import {Button} from '../../../Button';
+import {
+  DraggableGrow,
+  DraggableHandle,
+  PoppedBody,
+  StyledTooltip,
+  TooltipHint,
+} from '../../../DraggablePopups';
+import {Icon} from '../../../Icon';
+import {formatTimestamp} from '../../../Timestamp';
+
+type CellValueTimestampProps = {
+  value: string;
+};
+
+const Collapsed = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+`;
+Collapsed.displayName = 'S.Collapsed';
+
+const TooltipContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+TooltipContent.displayName = 'S.TooltipContent';
+
+const TooltipText = styled.div`
+  max-height: 35vh;
+  overflow: auto;
+  white-space: break-spaces;
+`;
+TooltipText.displayName = 'S.TooltipText';
+
+const Popped = styled.div`
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 0.8rem;
+  word-wrap: break-word;
+  background-color: #fff;
+  color: ${Colors.MOON_700};
+  border: 1px solid ${Colors.MOON_300};
+`;
+Popped.displayName = 'S.Popped';
+
+const Toolbar = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+`;
+Toolbar.displayName = 'S.Toolbar';
+
+const Spacer = styled.div`
+  flex: 1 1 auto;
+`;
+Spacer.displayName = 'S.Spacer';
+
+// See: https://www.npmjs.com/package/react-timeago#formatter-optional
+const TIMEAGO_FORMATTER: Formatter = (
+  value,
+  unit,
+  suffix,
+  epochSeconds,
+  nextFormatter
+) =>
+  unit === 'second'
+    ? 'just now'
+    : nextFormatter!(value, unit, suffix, epochSeconds);
+
+type TableRowProps = {
+  label: string;
+  value: string | ReactNode;
+  allowCopy: boolean;
+  onCopy?: (text: string) => void;
+};
+
+const TableRow = ({label, value, allowCopy, onCopy}: TableRowProps) => {
+  return (
+    <tr className="group">
+      <th className="pr-4 text-right">{label}</th>
+      <td>{value}</td>
+      {allowCopy && onCopy && _.isString(value) && (
+        <td className="pl-2">
+          <Button
+            size="small"
+            variant="ghost"
+            icon="copy"
+            tooltip="Copy to clipboard"
+            className="invisible group-hover:visible"
+            onClick={e => {
+              e.stopPropagation();
+              onCopy(value);
+            }}
+          />
+        </td>
+      )}
+    </tr>
+  );
+};
+
+type FormatsTableProps = {
+  value: string;
+  allowCopy?: boolean;
+};
+
+const FormatsTable = ({value, allowCopy = false}: FormatsTableProps) => {
+  const then = moment(value);
+  const asLong = then.format('dddd, MMMM Do YYYY [at] h:mm:ss a Z');
+  const asIso = new Date(value).toISOString();
+  const asUnix = new Date(value).getTime() / 1000;
+
+  const onCopy = useCallback((text: string) => {
+    copyToClipboard(text);
+    toast('Copied to clipboard');
+  }, []);
+
+  return (
+    <Tailwind>
+      <TooltipText>
+        <table className="w-full border-collapse">
+          <tbody>
+            <TableRow
+              label="Long"
+              value={asLong}
+              allowCopy={allowCopy}
+              onCopy={onCopy}
+            />
+            <TableRow
+              label="ISO"
+              value={asIso}
+              allowCopy={allowCopy}
+              onCopy={onCopy}
+            />
+            <TableRow
+              label="Relative"
+              value={
+                <TimeAgo
+                  title="" // Suppress the default tooltip
+                  minPeriod={10}
+                  formatter={TIMEAGO_FORMATTER}
+                  date={then.format('YYYY-MM-DDTHH:mm:ssZ')}
+                  live={true}
+                />
+              }
+              allowCopy={false}
+            />
+            <TableRow
+              label="Unix seconds"
+              value={asUnix.toString()}
+              allowCopy={allowCopy}
+              onCopy={onCopy}
+            />
+          </tbody>
+        </table>
+      </TooltipText>
+    </Tailwind>
+  );
+};
+
+export const CellValueTimestamp = ({value}: CellValueTimestampProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const onClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(anchorEl ? null : ref.current);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popper' : undefined;
+
+  const trimmed = value.trim();
+
+  const title = open ? (
+    '' // Suppress tooltip when popper is open.
+  ) : (
+    <TooltipContent onClick={onClick}>
+      <FormatsTable value={trimmed} />
+      <TooltipHint>Click for more details</TooltipHint>
+    </TooltipContent>
+  );
+
+  // Unfortunate but necessary to get appear on top of peek drawer.
+  const stylePopper = {zIndex: 1};
+
+  const formatted = formatTimestamp(trimmed);
+
+  return (
+    <>
+      <StyledTooltip enterDelay={500} title={title}>
+        <Collapsed ref={ref} onClick={onClick}>
+          <Tailwind>
+            <div className="flex items-center gap-4">
+              <div className="flex h-[22px] w-[22px] flex-none items-center justify-center rounded-full bg-moon-300/[0.48]">
+                <Icon
+                  role="presentation"
+                  className="h-[14px] w-[14px]"
+                  name="recent-clock"
+                />
+              </div>
+              {formatted.short}
+            </div>
+          </Tailwind>
+        </Collapsed>
+      </StyledTooltip>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        style={stylePopper}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        onClose={() => setAnchorEl(null)}
+        TransitionComponent={DraggableGrow}>
+        <Popped>
+          <TooltipContent>
+            <DraggableHandle>
+              <Toolbar>
+                <div>
+                  <b>Python datetime.datetime object</b>
+                </div>
+                <Spacer />
+                <Button
+                  size="small"
+                  variant="ghost"
+                  icon="close"
+                  tooltip="Close preview"
+                  onClick={e => {
+                    e.stopPropagation();
+                    setAnchorEl(null);
+                  }}
+                />
+              </Toolbar>
+            </DraggableHandle>
+            <PoppedBody>
+              <FormatsTable value={trimmed} allowCopy={true} />
+            </PoppedBody>
+          </TooltipContent>
+        </Popped>
+      </Popover>
+    </>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -136,7 +136,11 @@ export const CallDetails: FC<{
             p: 2,
           }}>
           <CustomWeaveTypeProjectContext.Provider
-            value={{entity: call.entity, project: call.project}}>
+            value={{
+              entity: call.entity,
+              project: call.project,
+              mode: 'object_viewer',
+            }}>
             <ObjectViewerSection title="Inputs" data={inputs} />
           </CustomWeaveTypeProjectContext.Provider>
         </Box>
@@ -158,7 +162,11 @@ export const CallDetails: FC<{
             </div>
           ) : (
             <CustomWeaveTypeProjectContext.Provider
-              value={{entity: call.entity, project: call.project}}>
+              value={{
+                entity: call.entity,
+                project: call.project,
+                mode: 'object_viewer',
+              }}>
               <ObjectViewerSection title="Output" data={output} isExpanded />
             </CustomWeaveTypeProjectContext.Provider>
           )}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewMarkdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewMarkdown.tsx
@@ -1,0 +1,99 @@
+import copyToClipboard from 'copy-to-clipboard';
+import React, {ReactNode, useCallback, useEffect, useState} from 'react';
+import styled from 'styled-components';
+
+import {toast} from '../../../../../../common/components/elements/Toast';
+import Markdown from '../../../../../../common/components/Markdown';
+import {MOON_150} from '../../../../../../common/css/color.styles';
+import {Button} from '../../../../../Button';
+import {CodeEditor} from '../../../../../CodeEditor';
+import {
+  Format,
+  ValueViewMarkdownFormatMenu,
+} from './ValueViewMarkdownFormatMenu';
+
+type ValueViewMarkdownProps = {
+  value: string;
+};
+
+const Column = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+`;
+Column.displayName = 'S.Column';
+
+const Toolbar = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+  border-bottom: 1px solid ${MOON_150};
+`;
+Toolbar.displayName = 'S.Toolbar';
+
+const Spacer = styled.div`
+  flex: 1 1 auto;
+`;
+Spacer.displayName = 'S.Spacer';
+
+const Full = styled.div``;
+Full.displayName = 'S.Full';
+
+const PreserveWrapping = styled.div`
+  white-space: break-spaces;
+`;
+PreserveWrapping.displayName = 'S.PreserveWrapping';
+
+export const ValueViewMarkdown = ({value}: ValueViewMarkdownProps) => {
+  const trimmed = value.trim();
+
+  const [format, setFormat] = useState<Format>('Markdown');
+  useEffect(() => {
+    setFormat('Markdown');
+  }, [value]);
+
+  const copy = useCallback(() => {
+    copyToClipboard(value);
+    toast('Copied to clipboard');
+  }, [value]);
+
+  const onSetFormat = useCallback((newFormat: Format) => {
+    setFormat(newFormat);
+  }, []);
+
+  const toolbar = (
+    <Toolbar>
+      <Button
+        style={{marginLeft: 8}}
+        size="small"
+        variant="ghost"
+        icon="copy"
+        tooltip="Copy to clipboard"
+        onClick={e => {
+          e.stopPropagation();
+          copy();
+        }}
+      />
+      <Spacer />
+      <ValueViewMarkdownFormatMenu format={format} onSetFormat={onSetFormat} />
+    </Toolbar>
+  );
+
+  let content: ReactNode = trimmed;
+  if (format === 'Markdown') {
+    content = <Markdown content={trimmed} />;
+  } else if (format === 'Code') {
+    content = <CodeEditor value={trimmed} language="markdown" readOnly />;
+  } else {
+    content = <PreserveWrapping>{content}</PreserveWrapping>;
+  }
+
+  return (
+    <Column>
+      {toolbar}
+      <Full>{content}</Full>
+    </Column>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewMarkdownFormatMenu.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewMarkdownFormatMenu.tsx
@@ -1,0 +1,45 @@
+import * as DropdownMenu from '@wandb/weave/components/DropdownMenu';
+import React, {useState} from 'react';
+
+import {Button} from '../../../../../Button';
+
+export type Format = 'Markdown' | 'Code' | 'Text';
+
+type ValueViewMarkdownFormatMenuProps = {
+  format: Format;
+  onSetFormat: (format: Format) => void;
+};
+
+// Unfortunately necessary to be visible above drawer.
+const STYLE_MENU_CONTENT = {zIndex: 1};
+
+export const ValueViewMarkdownFormatMenu = ({
+  format,
+  onSetFormat,
+}: ValueViewMarkdownFormatMenuProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div>
+      <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
+        <DropdownMenu.Trigger>
+          <Button size="small" variant="ghost" active={isOpen}>
+            {format}
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content align="end" style={STYLE_MENU_CONTENT}>
+            <DropdownMenu.Item onClick={() => onSetFormat('Markdown')}>
+              Markdown
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => onSetFormat('Code')}>
+              Code
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => onSetFormat('Text')}>
+              Text
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/CustomWeaveTypeDispatcher.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/CustomWeaveTypeDispatcher.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import {AudioPlayer} from './Audio/AudioPlayer';
 import {CustomWeaveTypePayload} from './customWeaveType.types';
+import {DateTimeView} from './datetime.datetime/DateTimeView';
+import {MarkdownView} from './Markdown/MarkdownView';
 import {PILImageImage} from './PIL.Image.Image/PILImageImage';
 
 type CustomWeaveTypeDispatcherProps = {
@@ -22,6 +24,7 @@ const customWeaveTypeRegistry: {
     component: React.FC<{
       entity: string;
       project: string;
+      mode?: string;
       data: any; // I wish this could be typed more specifically
     }>;
     preferredRowHeight?: number;
@@ -41,6 +44,13 @@ const customWeaveTypeRegistry: {
   },
   'wave.Wave_read': {
     component: AudioPlayer,
+  },
+  'datetime.datetime': {
+    component: DateTimeView,
+  },
+  'rich.markdown.Markdown': {
+    component: MarkdownView,
+    preferredRowHeight: 350,
   },
 };
 
@@ -65,12 +75,11 @@ export const getCustomWeaveTypePreferredRowHeight = (
 export const CustomWeaveTypeProjectContext = React.createContext<{
   entity: string;
   project: string;
+  mode?: string;
 } | null>(null);
 
 /**
- * This is the primary entry-point for dispatching custom weave types. Currently
- * we just have 1, but as we add more, we might want to add a more robust
- * "registry"
+ * This is the primary entry-point for dispatching custom weave types.
  */
 export const CustomWeaveTypeDispatcher: React.FC<
   CustomWeaveTypeDispatcherProps
@@ -92,6 +101,7 @@ export const CustomWeaveTypeDispatcher: React.FC<
     return React.createElement(comp, {
       entity: applicableEntity,
       project: applicableProject,
+      mode: projectContext?.mode,
       data,
     });
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/Markdown/MarkdownView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/Markdown/MarkdownView.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import {CellValueMarkdown} from '../../../Browse2/CellValueMarkdown';
+import {ValueViewMarkdown} from '../../pages/CallPage/ValueViewMarkdown';
+
+type MarkdownViewProps = {
+  mode?: string;
+  data: {
+    val: {
+      markup: string;
+    };
+  };
+};
+
+export const MarkdownView = ({mode, data}: MarkdownViewProps) => {
+  if (!data.val || !data.val.markup) {
+    return null;
+  }
+  if (mode === 'object_viewer') {
+    return <ValueViewMarkdown value={data.val.markup} />;
+  }
+  return <CellValueMarkdown value={data.val.markup} />;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/customWeaveType.types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/customWeaveType.types.ts
@@ -26,7 +26,8 @@ export const isCustomWeaveTypePayload = (
   ) {
     return false;
   }
-  if (typeof data.files !== 'object' || data.files == null) {
+  // Inline custom objects will not have a files property.
+  if (data.files != null && typeof data.files !== 'object') {
     return false;
   }
   if (data.weave_type.type === 'Op') {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/datetime.datetime/DateTimeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/datetime.datetime/DateTimeView.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import {CellValueTimestamp} from '../../../Browse2/CellValueTimestamp';
+type DateTimeViewProps = {
+  data: {
+    val: string;
+  };
+};
+
+export const DateTimeView = ({data}: DateTimeViewProps) => {
+  return <CellValueTimestamp value={data.val} />;
+};

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -18,6 +18,7 @@ from weave.flow.scorer import Scorer
 from weave.initialization import *
 from weave.trace.util import Thread as Thread
 from weave.trace.util import ThreadPoolExecutor as ThreadPoolExecutor
+from weave.type_handlers.Markdown.markdown import Markdown
 
 # Alias for succinct code
 P = EasyPrompt
@@ -44,4 +45,5 @@ __docspec__ = [
     Evaluation,
     Scorer,
     AnnotationSpec,
+    Markdown,
 ]

--- a/weave/trace/serialization/README.md
+++ b/weave/trace/serialization/README.md
@@ -78,16 +78,18 @@ Weave also ships with a set of first-class serializers for common types, defined
 - Images (`PIL.Image.Image`)
 - Audio (`wave.Wave_read`)
 - Op (`weave.Op`)
+- Datetime (`datetime.datetime`)
+- Markdown (`rich.markdown.Markdown`)
 
 These `KNOWN_TYPES` are implemented using `register_serializer`. Unlike other types, these will always be loaded using the SDK's current `load` function (instead of the one packaged with the object).
 
 #### File-based serialization
 
-Today, all custom object serialization is file-based via `MemTraceFilesArtifact`. Technicaly this supports many files per artifact, but in practice today we use just a single file (obj.py) for each artifact. Elements of this are hardcoded in both the SDK and App layers.
+Some custom object serialization is file-based via `MemTraceFilesArtifact`. Technically this supports many files per artifact, but in practice today we use just a single file (obj.py) for each artifact. Elements of this are hardcoded in both the SDK and App layers. File-based serialization is typically used for larger values, such as images.
 
 #### Inline serialization
 
-Notably, this system is missing the ability to register inline serializers for custom objects. For example, the user may have a simple type like a custom datetime. This is a known limitation and will be addressed in the future.
+Objects that have a small serialized representation, like a Python datetime object, can have that value stored "inline" with the other serialization information such as the class name and deserialization Op. This avoids needing to make a separate API request to retrieve the value.
 
 #### Other limitations
 

--- a/weave/trace/serialization/README.md
+++ b/weave/trace/serialization/README.md
@@ -56,7 +56,7 @@ The entrypoint for custom object serialization is `weave/trace/serialization/cus
 
 #### Custom Object Serialization Flow
 
-This diagram shows the flow for file-based custom objects. Inline objects are similar but simpler.
+This diagram shows the flow for file-based custom objects.
 
 ```mermaid
 flowchart TD
@@ -69,6 +69,28 @@ flowchart TD
 
         MemArtifact -->|Read from files| Deserializer["Registered Serializer (load method)"]
         Deserializer --> DecodeCustomObj["decode_custom_files_obj()"]
+    end
+
+    DecodeCustomObj --> FromJson["from_json()"]
+    FromJson --> ReconstructedObj["Reconstructed Custom Object"]
+
+    RegisterSerializer["register_serializer()"] -.->|Registers| Serializer
+    RegisterSerializer -.->|Registers| Deserializer
+```
+
+The flow for inline custom objects is similar:
+
+```mermaid
+flowchart TD
+    CustomObj["Custom Object (datetime.datetime, rich.markdown.Markdown, etc.)"] --> ToJson["to_json()"]
+    ToJson --> EncodeCustomObj["encode_custom_obj()"]
+
+    subgraph CustomSerialization["Custom Object Serialization Process"]
+        EncodeCustomObj --> Serializer["Registered Serializer (save method)"]
+        Serializer --> Inline["Write to an inline value representation, e.g. str/dict"]
+
+        Inline --> Deserializer["Registered Serializer (load method)"]
+        Deserializer --> DecodeCustomObj["decode_custom_inline_obj()"]
     end
 
     DecodeCustomObj --> FromJson["from_json()"]

--- a/weave/trace/serialization/custom_objs.py
+++ b/weave/trace/serialization/custom_objs.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import inspect
 from collections.abc import Mapping
 from typing import Any, Callable
 
 from weave.trace.context.weave_client_context import require_weave_client
 from weave.trace.op import Op, op
-from weave.trace.refs import ObjectRef, parse_uri
+from weave.trace.refs import ObjectRef, OpRef, parse_uri
 from weave.trace.serialization import (
     op_type,  # noqa: F401, Must import this to register op save/load
 )
@@ -26,6 +27,8 @@ KNOWN_TYPES = {
     "Op",
     "PIL.Image.Image",
     "wave.Wave_read",
+    "datetime.datetime",
+    "rich.markdown.Markdown",
 }
 
 
@@ -35,8 +38,6 @@ def encode_custom_obj(obj: Any) -> dict | None:
         # We silently return None right now. We could warn here. This object
         # will not be recoverable with client.get
         return None
-    art = MemTraceFilesArtifact()
-    serializer.save(obj, art, "obj")
 
     # Save the load_instance function as an op, and store a reference
     # to that op in the saved value record. We don't do this if what
@@ -47,7 +48,7 @@ def encode_custom_obj(obj: Any) -> dict | None:
         # Ensure load_instance is an op
         if not isinstance(serializer.load, Op):
             serializer.load = op(serializer.load)
-        # Save the load_intance_op
+        # Save the load_instance_op
         wc = require_weave_client()
 
         # TODO(PR): this can fail right? Or does it return None?
@@ -55,16 +56,52 @@ def encode_custom_obj(obj: Any) -> dict | None:
         load_instance_op_ref = wc._save_op(serializer.load, "load_" + serializer.id())  # type: ignore
         load_op_uri = load_instance_op_ref.uri()
 
-    encoded_path_contents = {
-        k: (v.encode("utf-8") if isinstance(v, str) else v)  # type: ignore
-        for k, v in art.path_contents.items()
-    }
-    return {
+    encoded = {
         "_type": "CustomWeaveType",
         "weave_type": {"type": serializer.id()},
-        "files": encoded_path_contents,
         "load_op": load_op_uri,
     }
+
+    # If the save method just takes one argument, it is an inline serializer
+    save_signature = inspect.signature(serializer.save)
+    param_count = len(save_signature.parameters)
+    if param_count == 1:
+        encoded["val"] = serializer.save(obj)
+    else:
+        art = MemTraceFilesArtifact()
+        serializer.save(obj, art, "obj")
+        encoded_path_contents = {
+            k: (v.encode("utf-8") if isinstance(v, str) else v)  # type: ignore
+            for k, v in art.path_contents.items()
+        }
+        encoded["files"] = encoded_path_contents
+    return encoded
+
+
+def decode_inline_obj(obj: dict) -> Any:
+    _type = obj["weave_type"]["type"]
+    if _type in KNOWN_TYPES:
+        serializer = get_serializer_by_id(_type)
+        if serializer is not None:
+            return serializer.load(obj["val"])
+
+    load_op_uri = obj.get("load_op")
+    if load_op_uri is None:
+        raise ValueError(f"No serializer found for `{_type}`")
+
+    ref = parse_uri(load_op_uri)
+    if not isinstance(ref, OpRef):
+        raise TypeError(f"Expected OpRef, got `{type(ref)}`")
+
+    wc = require_weave_client()
+    load_instance_op = wc.get(ref)
+    if load_instance_op is None:
+        raise ValueError(
+            f"Failed to load op needed to decode object of type `{_type}`. See logs above for more information."
+        )
+
+    load_instance_op._tracing_enabled = False  # type: ignore
+    return load_instance_op(obj.get("val"))
 
 
 def _decode_custom_obj(

--- a/weave/trace/serialization/custom_objs.py
+++ b/weave/trace/serialization/custom_objs.py
@@ -81,7 +81,7 @@ def encode_custom_obj(obj: Any) -> dict | None:
     return encoded
 
 
-def decode_inline_obj(obj: dict) -> Any:
+def decode_custom_inline_obj(obj: dict) -> Any:
     _type = obj["weave_type"]["type"]
     if _type in KNOWN_TYPES:
         serializer = get_serializer_by_id(_type)
@@ -107,7 +107,7 @@ def decode_inline_obj(obj: dict) -> Any:
     return load_instance_op(obj.get("val"))
 
 
-def _decode_custom_obj(
+def _decode_custom_files_obj(
     encoded_path_contents: Mapping[str, str | bytes],
     load_instance_op: Callable[..., Any],
 ) -> Any:
@@ -119,7 +119,7 @@ def _decode_custom_obj(
     return res
 
 
-def decode_custom_obj(
+def decode_custom_files_obj(
     weave_type: dict,
     encoded_path_contents: Mapping[str, str | bytes],
     load_instance_op_uri: str | None = None,
@@ -135,7 +135,7 @@ def decode_custom_obj(
             load_instance_op = serializer.load
 
             try:
-                return _decode_custom_obj(encoded_path_contents, load_instance_op)
+                return _decode_custom_files_obj(encoded_path_contents, load_instance_op)
             except Exception as e:
                 pass
 
@@ -156,7 +156,7 @@ def decode_custom_obj(
             )
 
     try:
-        return _decode_custom_obj(encoded_path_contents, load_instance_op)
+        return _decode_custom_files_obj(encoded_path_contents, load_instance_op)
     except Exception as e:
         raise DecodeCustomObjectError(
             f"Failed to decode object of type `{_type}`. See logs above for more information."

--- a/weave/trace/serialization/custom_objs.py
+++ b/weave/trace/serialization/custom_objs.py
@@ -75,7 +75,9 @@ def encode_custom_obj(obj: Any) -> dict | None:
         }
         encoded["files"] = encoded_path_contents
     else:
-        raise ValueError(f"Unknown serializer type: {type(serializer.save)}")
+        raise ValueError(
+            f"Serializer save function could not be identified as inline or file-based: {type(serializer.save)}"
+        )
     return encoded
 
 

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -412,7 +412,10 @@ def _get_code_deps(
                     import_code.append(import_line)
 
         else:
-            # _name will work for typing_extensions.NotRequired in 3.9
+            # Code saving for Ops using TypedDict and NotRequired was failing on Python 3.9
+            # because NotRequired on 3.9 requires using typing_extensions and the implementation
+            # doesn't have a __name__ attribute. We now check for _name as a fallback.
+            # This came up in the context of persisting an inline custom object deserializer.
             var_value_name = getattr(
                 var_value, "__name__", getattr(var_value, "_name", None)
             )

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -412,14 +412,18 @@ def _get_code_deps(
                     import_code.append(import_line)
 
         else:
+            # _name will work for typing_extensions.NotRequired in 3.9
+            var_value_name = getattr(
+                var_value, "__name__", getattr(var_value, "_name", None)
+            )
             if (
-                hasattr(var_value, "__name__")
+                var_value_name
                 and hasattr(var_value, "__module__")
                 and var_value.__module__ != fn.__module__
             ):
-                import_line = f"from {var_value.__module__} import {var_value.__name__}"
-                if var_value.__name__ != var_name:
-                    import_line += f"as {var_name}"
+                import_line = f"from {var_value.__module__} import {var_value_name}"
+                if var_value_name != var_name:
+                    import_line += f" as {var_name}"
                 import_code.append(import_line)
             else:
                 try:

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -299,10 +299,10 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
             )
         elif val_type == "CustomWeaveType":
             if _is_inline_custom_obj(obj):
-                return custom_objs.decode_inline_obj(obj)
+                return custom_objs.decode_custom_inline_obj(obj)
             else:
                 files = _load_custom_obj_files(project_id, server, obj["files"])
-                return custom_objs.decode_custom_obj(
+                return custom_objs.decode_custom_files_obj(
                     obj["weave_type"], files, obj.get("load_op")
                 )
         elif (

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -93,8 +93,9 @@ def to_json(
                 for k, v in as_dict.items()
             }
         return fallback_encode(obj)
+    if "val" in encoded:
+        return encoded
     result = _build_result_from_encoded(encoded, project_id, client)
-
     return result
 
 
@@ -290,10 +291,13 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
                 {k: from_json(v, project_id, server) for k, v in obj.items()}
             )
         elif val_type == "CustomWeaveType":
-            files = _load_custom_obj_files(project_id, server, obj["files"])
-            return custom_objs.decode_custom_obj(
-                obj["weave_type"], files, obj.get("load_op")
-            )
+            if "val" in obj:
+                return custom_objs.decode_inline_obj(obj)
+            else:
+                files = _load_custom_obj_files(project_id, server, obj["files"])
+                return custom_objs.decode_custom_obj(
+                    obj["weave_type"], files, obj.get("load_op")
+                )
         elif (
             isinstance(val_type, str)
             and obj.get("_class_name") == val_type

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -300,11 +300,10 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
         elif val_type == "CustomWeaveType":
             if _is_inline_custom_obj(obj):
                 return custom_objs.decode_custom_inline_obj(obj)
-            else:
-                files = _load_custom_obj_files(project_id, server, obj["files"])
-                return custom_objs.decode_custom_files_obj(
-                    obj["weave_type"], files, obj.get("load_op")
-                )
+            files = _load_custom_obj_files(project_id, server, obj["files"])
+            return custom_objs.decode_custom_files_obj(
+                obj["weave_type"], files, obj.get("load_op")
+            )
         elif (
             isinstance(val_type, str)
             and obj.get("_class_name") == val_type

--- a/weave/trace/serialization/serializer.py
+++ b/weave/trace/serialization/serializer.py
@@ -38,16 +38,18 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass
-from typing import Any, Callable, Union
+from typing import TYPE_CHECKING, Any, Callable, Union
 
 from typing_extensions import TypeGuard
 
 # Not locking down the return type for inline encoding but
 # it would be expected to be something like a str or dict.
 InlineSave = Callable[[Any], Any]
-# Second parameter should really be MemTraceFilesArtifact
-# but we are avoiding a circular import.
-FileSave = Callable[[Any, Any, str], None]
+# This is avoiding a circular import.
+if TYPE_CHECKING:
+    from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
+
+FileSave = Callable[[Any, "MemTraceFilesArtifact", str], None]
 Save = Union[InlineSave, FileSave]
 
 

--- a/weave/trace/serialization/serializer.py
+++ b/weave/trace/serialization/serializer.py
@@ -53,8 +53,8 @@ class Serializer:
     def id(self) -> str:
         ser_id = self.target_class.__module__ + "." + self.target_class.__name__
         if ser_id.startswith("weave."):
-            # Special case for weave.Op (which is current weave.trace.op.Op).
-            # The id is just Op, since we've already already stored this as
+            # Special case for weave.Op (which is currently weave.trace.op.Op).
+            # The id is just Op, since we've already stored this as
             # "Op" in the database.
             if ser_id.endswith(".Op"):
                 return "Op"

--- a/weave/trace/serialization/serializer.py
+++ b/weave/trace/serialization/serializer.py
@@ -64,10 +64,19 @@ def is_file_save(value: Callable) -> TypeGuard[FileSave]:
     params = list(signature.parameters.values())
     # Check parameter count and return type without relying on annotations
     # that would cause circular import
+    name_annotation = params[2].annotation
     return (
         len(params) == 3
-        and params[2].annotation == "str"
-        and signature.return_annotation == "None"
+        and (
+            name_annotation is str
+            or name_annotation == "str"
+            or name_annotation == inspect._empty
+        )
+        and (
+            signature.return_annotation is None
+            or signature.return_annotation == "None"
+            or signature.return_annotation == inspect._empty
+        )
     )
 
 

--- a/weave/type_handlers/DateTime/datetime.py
+++ b/weave/type_handlers/DateTime/datetime.py
@@ -1,0 +1,23 @@
+import datetime
+
+from weave.trace.serialization import serializer
+
+
+def save(obj: datetime.datetime) -> str:
+    """Serialize a datetime object to ISO format with timezone information.
+    If the datetime object is naive (has no timezone), it will be assumed to be UTC.
+
+    TODO: Should we attempt to get local timezone information and save that too?
+    """
+    if obj.tzinfo is None:
+        obj = obj.replace(tzinfo=datetime.timezone.utc)
+    return obj.isoformat()
+
+
+def load(encoded: str) -> datetime.datetime:
+    """Deserialize an ISO format string back to a datetime object with timezone."""
+    return datetime.datetime.fromisoformat(encoded)
+
+
+def register() -> None:
+    serializer.register_serializer(datetime.datetime, save, load)

--- a/weave/type_handlers/Markdown/markdown.py
+++ b/weave/type_handlers/Markdown/markdown.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from rich.markdown import Markdown
+
+from weave.trace.serialization import serializer
+
+
+def save(obj: Markdown) -> dict[str, Any]:
+    # TODO: Serialize "justify" and "hyperlinks" attributes?
+    d = {
+        "markup": obj.markup,
+    }
+    if obj.code_theme:
+        d["code_theme"] = obj.code_theme
+    return d
+
+
+def load(encoded: dict[str, Any]) -> Markdown:
+    return Markdown(**encoded)
+
+
+def register() -> None:
+    serializer.register_serializer(Markdown, save, load)

--- a/weave/type_handlers/Markdown/markdown.py
+++ b/weave/type_handlers/Markdown/markdown.py
@@ -1,13 +1,19 @@
-from typing import Any
+from typing import TypedDict
 
 from rich.markdown import Markdown
+from typing_extensions import NotRequired
 
 from weave.trace.serialization import serializer
 
 
-def save(obj: Markdown) -> dict[str, Any]:
-    # TODO: Serialize "justify" and "hyperlinks" attributes?
-    d = {
+# TODO: Serialize "justify" and "hyperlinks" attributes?
+class SerializedMarkdown(TypedDict):
+    markup: str
+    code_theme: NotRequired[str]
+
+
+def save(obj: Markdown) -> SerializedMarkdown:
+    d: SerializedMarkdown = {
         "markup": obj.markup,
     }
     if obj.code_theme:
@@ -15,7 +21,7 @@ def save(obj: Markdown) -> dict[str, Any]:
     return d
 
 
-def load(encoded: dict[str, Any]) -> Markdown:
+def load(encoded: SerializedMarkdown) -> Markdown:
     return Markdown(**encoded)
 
 

--- a/weave/type_handlers/__init__.py
+++ b/weave/type_handlers/__init__.py
@@ -1,5 +1,9 @@
 from weave.type_handlers.Audio import audio
+from weave.type_handlers.DateTime import datetime
 from weave.type_handlers.Image import image
+from weave.type_handlers.Markdown import markdown
 
 image.register()
 audio.register()
+datetime.register()
+markdown.register()


### PR DESCRIPTION
## Description

Resolves https://wandb.atlassian.net/browse/WB-23407

Takes a different approach than https://github.com/wandb/weave/pull/3702 - it adds the ability for "inline" serialization of custom objects.

PR includes two examples of this functionality, datetimes and markdown objects. A custom UI is added for each.


### Datetime
<img width="662" alt="Screenshot 2025-03-18 at 4 31 17 PM" src="https://github.com/user-attachments/assets/d2427b2b-68a8-484a-bb8d-708e6fadcb35" />
<img width="655" alt="Screenshot 2025-03-18 at 4 31 23 PM" src="https://github.com/user-attachments/assets/35146536-9564-475b-9137-73ee4923196c" />

### Markdown
<img width="660" alt="Screenshot 2025-03-18 at 4 30 46 PM" src="https://github.com/user-attachments/assets/13d2daaf-ed2a-48a3-b88f-6c95a1a63b2d" />
<img width="472" alt="Screenshot 2025-03-18 at 4 30 05 PM" src="https://github.com/user-attachments/assets/8531fe2d-b5b2-4ea2-b190-738610ce24dc" />
<img width="480" alt="Screenshot 2025-03-18 at 4 30 31 PM" src="https://github.com/user-attachments/assets/92b8597b-0173-44ff-9c3f-ff16f922120c" />


## Testing

Markdown and datetime in the `wf` values example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an interactive Markdown viewer that allows toggling between formatted Markdown, code, and plain text views, complete with a copy-to-clipboard feature.
	- Added a dynamic timestamp display that presents dates in multiple formats with easy copy functionality.
	- Expanded custom content handling with additional views for displaying date/time and rich text, enhancing the user experience.
	- Added a new format selection menu for choosing between Markdown, Code, and Text formats.
	- Introduced a new component for rendering Markdown content with customizable display options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->