### PR TITLE
chore(weave): explicitly manage clickhouse connect connection pool

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -40,6 +40,7 @@ import emoji
 from clickhouse_connect.driver.client import Client as CHClient
 from clickhouse_connect.driver.query import QueryResult
 from clickhouse_connect.driver.summary import QuerySummary
+from clickhouse_connect.driver import httputil
 
 from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
 from weave.trace_server import environment as wf_env
@@ -1688,12 +1689,15 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         return self._thread_local.ch_client
 
     def _mint_client(self) -> CHClient:
+        # Create a larger connection pool to support more concurrent requests
+        big_pool_mgr = httputil.get_pool_manager(maxsize=20, num_pools=12)
         client = clickhouse_connect.get_client(
             host=self._host,
             port=self._port,
             user=self._user,
             password=self._password,
             secure=self._port == 8443,
+            pool_mgr=big_pool_mgr,
         )
         # Safely create the database if it does not exist
         client.command(f"CREATE DATABASE IF NOT EXISTS {self._database}")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -37,10 +37,10 @@ from zoneinfo import ZoneInfo
 import clickhouse_connect
 import ddtrace
 import emoji
+from clickhouse_connect.driver import httputil
 from clickhouse_connect.driver.client import Client as CHClient
 from clickhouse_connect.driver.query import QueryResult
 from clickhouse_connect.driver.summary import QuerySummary
-from clickhouse_connect.driver import httputil
 
 from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
 from weave.trace_server import environment as wf_env


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Increase the size of the clickhouse connection pool, potentially improves performance when handling many concurrent requests. 

During periods of heavy load, we regularly see connection aborted comments as the connection pool exhausts.  In theory, these should reconnect, but there is some overhead associated with this, so increasing the size of the pool should improve perf under those conditions. 

Docs [here](https://clickhouse.com/docs/integrations/python#customizing-the-http-connection-pool)

## Testing

How was this PR tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced server connection management with an optimized connection pool. This improvement increases the number of simultaneous requests the server can handle, resulting in better performance during high load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->