### PR TITLE
fix(weave): object versions query does not confuse deletion status of versions 

### DIFF
--- a/tests/trace/test_objects_query_builder.py
+++ b/tests/trace/test_objects_query_builder.py
@@ -177,6 +177,11 @@ FROM (
         ) AS row_num,
         if (row_num = 1, 1, 0) AS is_latest
     FROM (
+        --
+        -- Object versions are uniquely identified by (kind, project_id, object_id, digest).
+        -- This subquery selects a row to represent each object version. There are multiple rows
+        -- for each object version if it has been deleted or recreated prior to a table merge.
+        --
         SELECT
             project_id,
             object_id,
@@ -193,7 +198,15 @@ FROM (
                 kind,
                 object_id,
                 digest
-                ORDER BY created_at ASC
+                --
+                -- Prefer the most recent row. If there is a tie, prefer the row
+                -- with non-null deleted_at, which represents the deletion event.
+                --
+                -- Rows for the same object version may have the same created_at
+                -- because deletion events inherit the created_at of the last
+                -- non-deleted row for the object version.
+                --
+                ORDER BY created_at DESC, (deleted_at IS NULL) ASC
             ) AS rn
         FROM object_versions"""
 
@@ -289,7 +302,7 @@ def test_make_objects_val_query_and_parameters():
     )
 
     expected_query = """
-        SELECT object_id, digest, any(val_dump)
+        SELECT object_id, digest, argMax(val_dump, created_at)
         FROM object_versions
         WHERE project_id = {project_id: String} AND
             object_id IN {object_ids: Array(String)} AND


### PR DESCRIPTION
## Description

Fixes a few bugs that occur for `object_versions` rows that represent the creation and deletion of a single object version and have yet to be merged. Sometimes our query for object versions returns the row for the creation event, and sometimes it returns the row for the deletion event. The effect is sometimes deleted object versions are returned by our query, and sometimes recreated objects are not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated tests to verify correct behavior during object deletion and re-creation scenarios.

- **Refactor**
  - Improved object data retrieval by refining sorting and aggregation logic to consistently prioritize the latest information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->