### PR TITLE
feat(weave): New trace view: design tweaks

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/components/StackBreadcrumb.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/components/StackBreadcrumb.tsx
@@ -37,45 +37,37 @@ export const StackBreadcrumb: React.FC<
 
   return (
     <BreadcrumbWrapper>
-      <BreadcrumbNavigationButtons>
-        <Tooltip
-          content={'Reveal root call'}
-          trigger={
-            <Button
-              variant={'ghost'}
-              disabled={
-                !props.traceRootCallId ||
-                props.rootCallId === props.traceRootCallId
+      {((props.traceRootCallId && props.rootCallId !== props.traceRootCallId) ||
+        (props.rootParentId && props.rootCallId !== props.rootParentId)) && (
+        <BreadcrumbNavigationButtons>
+          {props.traceRootCallId && props.rootCallId !== props.traceRootCallId && (
+            <Tooltip
+              content={'Reveal root call'}
+              trigger={
+                <Button
+                  variant={'ghost'}
+                  onClick={() => props.setRootCallId(props.traceRootCallId!)}
+                  icon={'chevron-up'}
+                  size="small"
+                />
               }
-              onClick={() => {
-                if (props.traceRootCallId) {
-                  props.setRootCallId(props.traceRootCallId);
-                }
-              }}
-              icon={'chevron-up'}
-              size="small"
             />
-          }
-        />
-        <Tooltip
-          content={'Reveal parent call'}
-          trigger={
-            <Button
-              variant={'ghost'}
-              disabled={
-                !props.rootParentId || props.rootCallId === props.rootParentId
+          )}
+          {props.rootParentId && props.rootCallId !== props.rootParentId && (
+            <Tooltip
+              content={'Reveal parent call'}
+              trigger={
+                <Button
+                  variant={'ghost'}
+                  onClick={() => props.setRootCallId(props.rootParentId!)}
+                  icon={'parent-back-up'}
+                  size="small"
+                />
               }
-              onClick={() => {
-                if (props.rootParentId) {
-                  props.setRootCallId(props.rootParentId);
-                }
-              }}
-              icon={'parent-back-up'}
-              size="small"
             />
-          }
-        />
-      </BreadcrumbNavigationButtons>
+          )}
+        </BreadcrumbNavigationButtons>
+      )}
 
       <BreadcrumbList>
         {stack.map((node, index) => (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/components/StackBreadcrumb.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/components/StackBreadcrumb.tsx
@@ -40,19 +40,20 @@ export const StackBreadcrumb: React.FC<
       {((props.traceRootCallId && props.rootCallId !== props.traceRootCallId) ||
         (props.rootParentId && props.rootCallId !== props.rootParentId)) && (
         <BreadcrumbNavigationButtons>
-          {props.traceRootCallId && props.rootCallId !== props.traceRootCallId && (
-            <Tooltip
-              content={'Reveal root call'}
-              trigger={
-                <Button
-                  variant={'ghost'}
-                  onClick={() => props.setRootCallId(props.traceRootCallId!)}
-                  icon={'chevron-up'}
-                  size="small"
-                />
-              }
-            />
-          )}
+          {props.traceRootCallId &&
+            props.rootCallId !== props.traceRootCallId && (
+              <Tooltip
+                content={'Reveal root call'}
+                trigger={
+                  <Button
+                    variant={'ghost'}
+                    onClick={() => props.setRootCallId(props.traceRootCallId!)}
+                    icon={'chevron-up'}
+                    size="small"
+                  />
+                }
+              />
+            )}
           {props.rootParentId && props.rootCallId !== props.rootParentId && (
             <Tooltip
               content={'Reveal parent call'}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
@@ -35,7 +35,7 @@ const TraceScrubber: React.FC<
   return (
     <CollapseWrapper>
       <CollapseButton onClick={() => setIsCollapsed(!isCollapsed)}>
-        <Icon name={isCollapsed ? 'chevron-up' : 'chevron-down'} size="small" />
+        <Icon name={isCollapsed ? 'chevron-up' : 'chevron-down'} size="small" className="max-w-14 max-h-14" />
       </CollapseButton>
       <Container $isCollapsed={isCollapsed}>
         {showScrubber('timeline') && <TimelineScrubber {...props} />}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
@@ -1,5 +1,5 @@
 import {Icon} from '@wandb/weave/components/Icon';
-import React, {useState} from 'react';
+import React, {useState, useMemo} from 'react';
 
 import {BaseScrubberProps} from './components/BaseScrubber';
 import {
@@ -32,16 +32,26 @@ const TraceScrubber: React.FC<
     return props.allowedScrubbers.includes(scrubber);
   };
 
+  // Count how many scrubbers are visible
+  // Only show collapse functionality if there are 4 or more scrubbers
+  const visibleScrubberCount = useMemo(() => {
+    const scrubberOptions: ScrubberOption[] = ['timeline', 'peer', 'codePath', 'sibling', 'stack'];
+    return scrubberOptions.filter(scrubber => showScrubber(scrubber)).length;
+  }, [props.allowedScrubbers]);
+  const showCollapseButton = visibleScrubberCount >= 4;
+  
   return (
     <CollapseWrapper>
-      <CollapseButton onClick={() => setIsCollapsed(!isCollapsed)}>
-        <Icon
-          name={isCollapsed ? 'chevron-up' : 'chevron-down'}
-          size="small"
-          className="max-w-14 max-h-14"
-        />
-      </CollapseButton>
-      <Container $isCollapsed={isCollapsed}>
+      {showCollapseButton && (
+        <CollapseButton onClick={() => setIsCollapsed(!isCollapsed)}>
+          <Icon
+            name={isCollapsed ? 'chevron-up' : 'chevron-down'}
+            size="small"
+            className="max-w-14 max-h-14"
+          />
+        </CollapseButton>
+      )}
+      <Container $isCollapsed={showCollapseButton ? isCollapsed : false}>
         {showScrubber('timeline') && <TimelineScrubber {...props} />}
         {showScrubber('peer') && <PeerScrubber {...props} />}
         {showScrubber('codePath') && <CodePathScrubber {...props} />}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
@@ -35,7 +35,11 @@ const TraceScrubber: React.FC<
   return (
     <CollapseWrapper>
       <CollapseButton onClick={() => setIsCollapsed(!isCollapsed)}>
-        <Icon name={isCollapsed ? 'chevron-up' : 'chevron-down'} size="small" className="max-w-14 max-h-14" />
+        <Icon
+          name={isCollapsed ? 'chevron-up' : 'chevron-down'}
+          size="small"
+          className="max-w-14 max-h-14"
+        />
       </CollapseButton>
       <Container $isCollapsed={isCollapsed}>
         {showScrubber('timeline') && <TimelineScrubber {...props} />}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
 import {Icon} from '@wandb/weave/components/Icon';
+import React, {useState} from 'react';
 
 import {BaseScrubberProps} from './components/BaseScrubber';
 import {
@@ -9,7 +9,7 @@ import {
   StackScrubber,
   TimelineScrubber,
 } from './components/scrubbers';
-import {Container, CollapseButton, CollapseWrapper} from './styles';
+import {CollapseButton, CollapseWrapper, Container} from './styles';
 
 export type ScrubberOption =
   | 'timeline'

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, {useState} from 'react';
+import {Icon} from '@wandb/weave/components/Icon';
 
 import {BaseScrubberProps} from './components/BaseScrubber';
 import {
@@ -8,7 +9,7 @@ import {
   StackScrubber,
   TimelineScrubber,
 } from './components/scrubbers';
-import {Container} from './styles';
+import {Container, CollapseButton, CollapseWrapper} from './styles';
 
 export type ScrubberOption =
   | 'timeline'
@@ -22,20 +23,28 @@ const TraceScrubber: React.FC<
     allowedScrubbers?: ScrubberOption[];
   }
 > = props => {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
   const showScrubber = (scrubber: ScrubberOption) => {
     if (!props.allowedScrubbers) {
       return true;
     }
     return props.allowedScrubbers.includes(scrubber);
   };
+
   return (
-    <Container>
-      {showScrubber('timeline') && <TimelineScrubber {...props} />}
-      {showScrubber('peer') && <PeerScrubber {...props} />}
-      {showScrubber('codePath') && <CodePathScrubber {...props} />}
-      {showScrubber('sibling') && <SiblingScrubber {...props} />}
-      {showScrubber('stack') && <StackScrubber {...props} />}
-    </Container>
+    <CollapseWrapper>
+      <CollapseButton onClick={() => setIsCollapsed(!isCollapsed)}>
+        <Icon name={isCollapsed ? 'chevron-up' : 'chevron-down'} size="small" />
+      </CollapseButton>
+      <Container $isCollapsed={isCollapsed}>
+        {showScrubber('timeline') && <TimelineScrubber {...props} />}
+        {showScrubber('peer') && <PeerScrubber {...props} />}
+        {showScrubber('codePath') && <CodePathScrubber {...props} />}
+        {showScrubber('sibling') && <SiblingScrubber {...props} />}
+        {showScrubber('stack') && <StackScrubber {...props} />}
+      </Container>
+    </CollapseWrapper>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const Container = styled.div<{$isCollapsed?: boolean}>`
   border-top: 1px solid #e2e8f0;
-  margin-bottom: ${props => (props.$isCollapsed ? '-110px' : '0px')};
+  margin-bottom: ${props => (props.$isCollapsed ? '-108px' : '0px')};
   padding: 8px 16px;
   transition: padding 0.2s ease;
   background: #fff;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
@@ -134,8 +134,8 @@ export const RangeInput = styled.input<RangeInputProps>`
   height: 8px;
   background: linear-gradient(
     to right,
-    #13A9BA 0%,
-    #13A9BA ${props => props.$progress}%,
+    #13a9ba 0%,
+    #13a9ba ${props => props.$progress}%,
     #e2e8f0 ${props => props.$progress}%,
     #e2e8f0 100%
   );
@@ -154,7 +154,7 @@ export const RangeInput = styled.input<RangeInputProps>`
     height: 16px;
     width: 16px;
     border-radius: 50%;
-    background: #13A9BA;
+    background: #13a9ba;
     border: 2px solid white;
     margin-top: -4px;
     transition: transform 0.1s;
@@ -175,7 +175,7 @@ export const RangeInput = styled.input<RangeInputProps>`
     height: 16px;
     width: 16px;
     border-radius: 50%;
-    background: #13A9BA;
+    background: #13a9ba;
     border: 2px solid white;
     transition: transform 0.1s;
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
 
-export const Container = styled.div<{ $isCollapsed?: boolean }>`
+export const Container = styled.div<{$isCollapsed?: boolean}>`
   border-top: 1px solid #e2e8f0;
-  margin-bottom: ${props => props.$isCollapsed ? '-110px' : '0px'};
+  margin-bottom: ${props => (props.$isCollapsed ? '-110px' : '0px')};
   padding: 8px 16px;
   transition: padding 0.2s ease;
   background: #fff;
@@ -17,7 +17,7 @@ export const CollapseButton = styled.button`
   height: 24px;
   border-radius: 50%;
   background: #fff;
-  border: 1px solid #D4D5D9;
+  border: 1px solid #d4d5d9;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -26,11 +26,10 @@ export const CollapseButton = styled.button`
   z-index: 1;
   box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
 
-
   &:hover {
     transform: scale(1.05);
-    border: 1px solid #B1B4B9;
-    background: #E8E8E9;
+    border: 1px solid #b1b4b9;
+    background: #e8e8e9;
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
@@ -11,7 +11,7 @@ export const Container = styled.div<{$isCollapsed?: boolean}>`
 export const CollapseButton = styled.button`
   position: absolute;
   background: #f8fafc !important;
-  left: 16px;
+  right: 6px;
   top: -12px;
   width: 24px;
   height: 24px;
@@ -28,7 +28,6 @@ export const CollapseButton = styled.button`
 
   &:hover {
     transform: scale(1.05);
-    border: 1px solid #b1b4b9;
     background: #e8e8e9;
     box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   }
@@ -135,8 +134,8 @@ export const RangeInput = styled.input<RangeInputProps>`
   height: 8px;
   background: linear-gradient(
     to right,
-    #3b82f6 0%,
-    #3b82f6 ${props => props.$progress}%,
+    #13A9BA 0%,
+    #13A9BA ${props => props.$progress}%,
     #e2e8f0 ${props => props.$progress}%,
     #e2e8f0 100%
   );
@@ -155,7 +154,7 @@ export const RangeInput = styled.input<RangeInputProps>`
     height: 16px;
     width: 16px;
     border-radius: 50%;
-    background: #3b82f6;
+    background: #13A9BA;
     border: 2px solid white;
     margin-top: -4px;
     transition: transform 0.1s;
@@ -176,7 +175,7 @@ export const RangeInput = styled.input<RangeInputProps>`
     height: 16px;
     width: 16px;
     border-radius: 50%;
-    background: #3b82f6;
+    background: #13A9BA;
     border: 2px solid white;
     transition: transform 0.1s;
   }
@@ -295,7 +294,7 @@ export const BreadcrumbItem = styled.button<{$active?: boolean}>`
       left: 4px;
       right: 4px;
       height: 2px;
-      background: #3B82F6;
+      background: #13A9BA;
       border-radius: 1px;
     }
   `}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/styles.ts
@@ -1,8 +1,46 @@
 import styled from 'styled-components';
 
-export const Container = styled.div`
+export const Container = styled.div<{ $isCollapsed?: boolean }>`
   border-top: 1px solid #e2e8f0;
+  margin-bottom: ${props => props.$isCollapsed ? '-110px' : '0px'};
   padding: 8px 16px;
+  transition: padding 0.2s ease;
+  background: #fff;
+`;
+
+export const CollapseButton = styled.button`
+  position: absolute;
+  background: #f8fafc !important;
+  left: 16px;
+  top: -12px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #fff;
+  border: 1px solid #D4D5D9;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  z-index: 1;
+  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+
+
+  &:hover {
+    transform: scale(1.05);
+    border: 1px solid #B1B4B9;
+    background: #E8E8E9;
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+`;
+
+export const CollapseWrapper = styled.div`
+  position: relative;
 `;
 
 export const ScrubberRow = styled.div`

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -79,7 +79,7 @@ const opTypeToColor = (typeName: NodeType): string => {
     // Identifiers
     case 'agent':
     case 'model':
-      return 'text-green-500 dark:text-green-400';
+      return 'text-blue-500 dark:text-blue-400';
     // Evals
     case 'tool':
     case 'llm':
@@ -87,7 +87,7 @@ const opTypeToColor = (typeName: NodeType): string => {
     // Evals
     case 'evaluation':
     case 'scorer':
-      return 'text-amber-500 dark:text-amber-400';
+      return 'text-sienna-500 dark:text-sienna-400';
     // Other, probable noise
     default:
       return 'text-moon-400 dark:text-moon-300';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -167,7 +167,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   const showDuration = true;
   const showStatusIcon = true;
   const usageIconsOnly = false;
-  const indentMultiplier = 10;
+  const indentMultiplier = 14;
 
   return (
     <div style={style}>
@@ -176,14 +176,22 @@ const TreeNode: React.FC<TreeNodeProps> = ({
         active={id === focusedCallId}
         onClick={() => setFocusedCallId(id)}
         onDoubleClick={() => setRootCallId(id)}
-        className="h-[32px] w-full justify-start px-8 text-left text-sm"
+        className="h-[32px] w-full justify-start px-8 text-left text-sm rounded-none"
         style={{
           opacity: isDeemphasized ? 0.6 : 1,
         }}>
-        <div className="flex w-full items-center justify-between gap-8">
+        <div className="flex w-full items-center justify-between gap-8 relative">
           <div className="flex min-w-0 flex-1 items-center">
-            <div style={{minWidth: level * indentMultiplier}} />
-            {hasChildren ? (
+            <div style={{marginLeft: level * indentMultiplier}}  className={`h-[32px]`} />
+            {/* Render vertical lines for each level of hierarchy */}
+            {Array.from({ length: level }).map((_, idx) => (
+              <div 
+                key={`line-${idx}`} 
+                style={{left: idx * indentMultiplier, marginLeft: 8}} 
+                className="absolute top-0 h-full w-px border-l border-moon-300" 
+              />
+            ))}
+            {hasChildren && (
               <Icon
                 name={chevronIcon}
                 size="small"
@@ -191,15 +199,13 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                   e.stopPropagation();
                   onToggleExpand(id);
                 }}
-                className="p-0.5 shrink-0 cursor-pointer rounded hover:bg-moon-200"
+                className="p-0.5 shrink-0 cursor-pointer rounded hover:bg-moon-300"
               />
-            ) : (
-              <div className="w-4" />
             )}
-
-            <div className="ml-2 truncate font-medium">
+            <div className="pl-4 truncate font-medium">
               {getCallDisplayName(call)}
             </div>
+
           </div>
 
           <div className="ml-8 flex shrink-0 items-center gap-8 text-xs text-moon-400">
@@ -254,7 +260,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                 </div>
               </>
             )}
-            
+
           <div className="flex-0 flex min-w-0 items-center">
             {showTypeIcon ? (
               <IconOnlyPill

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -3,7 +3,6 @@ import {TextField} from '@wandb/weave/components/Form/TextField';
 import {Icon, IconName} from '@wandb/weave/components/Icon';
 import {
   getTagColorClass,
-  IconOnlyPill,
   TagColorName,
 } from '@wandb/weave/components/Tag';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
@@ -72,30 +71,31 @@ const getCallTypeIcon = (type: NodeType): IconName => {
     case 'model':
       return 'model';
     case 'evaluation':
-      return 'number';
+      return 'baseline-alt';
     case 'scorer':
-      return 'checkmark-circle';
+      return 'number';
     default:
       return 'circle';
   }
 };
 
-const opTypeToColor = (typeName: NodeType): TagColorName => {
+const opTypeToColor = (typeName: NodeType): string => {
   switch (typeName) {
+    // Identifiers
     case 'agent':
-      return 'blue';
-    case 'tool':
-      return 'gold';
-    case 'llm':
-      return 'purple';
     case 'model':
-      return 'green';
+      return 'text-green-500 dark:text-green-400';
+    // Evals
+    case 'tool':
+    case 'llm':
+      return 'text-magenta-600 dark:text-magenta-500';
+    // Evals
     case 'evaluation':
-      return 'cactus';
     case 'scorer':
-      return 'magenta';
+      return 'text-amber-500 dark:text-amber-400';
+    // Other, probable noise
     default:
-      return 'moon';
+      return 'text-moon-400 dark:text-moon-300';
   }
 };
 
@@ -163,11 +163,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   if (hasDescendantErrors && statusCode === 'SUCCESS') {
     statusCode = 'DESCENDANT_ERROR';
   }
-  const showTypeIcon = true;
-  const showDuration = true;
-  const showStatusIcon = true;
-  const usageIconsOnly = false;
-  const indentMultiplier = 14;
+ const indentMultiplier = 14;
 
   return (
     <div style={style}>
@@ -208,85 +204,40 @@ const TreeNode: React.FC<TreeNodeProps> = ({
 
           </div>
 
-          <div className="ml-8 flex shrink-0 items-center gap-8 text-xs text-moon-400">
-
-            {showDuration && (
-              <>
-                {usageIconsOnly ? (
-                  <>
-                    <div className="w-20 text-right">
-                      {cost && (
-                        <TraceStat
-                          label={''}
-                          tooltip={
-                            <>
-                              {cost && costToolTipContent}
-                              <br />
-                              {tokens && tokenToolTipContent}
-                            </>
-                          }
-                          icon="credit-card-payment"
-                          className="text-xs text-moon-400"
-                        />
+          <div className="ml-8 flex shrink-0 items-center gap-4 text-xs text-moon-400">
+            <div className="text-right">
+              {cost && (
+                <TraceStat
+                  label={cost}
+                  tooltip={
+                    <div className="text-white-800">
+                      {costToolTipContent}
+                      {tokens && (
+                        <>
+                          <br />
+                          <span style={{fontWeight: 600}}>Estimated Tokens</span>
+                        </>
                       )}
+                      {tokens && tokenToolTipContent}
                     </div>
-                  </>
-                ) : (
-                  <>
-                    {cost && (
-                      <div className="w-64 text-right">
-                        <TraceStat
-                          label={cost}
-                          tooltip={costToolTipContent}
-                          icon="credit-card-payment"
-                          className="text-xs text-moon-400"
-                        />
-                      </div>
-                    )}
-                    {tokens && (
-                      <div className="w-64 text-right">
-                        <TraceStat
-                          icon="database-artifacts"
-                          label={tokens.toString()}
-                          tooltip={tokenToolTipContent}
-                          className="text-xs text-moon-400"
-                        />
-                      </div>
-                    )}
-                  </>
-                )}
-                <div className="w-32 text-right">
-                  {duration !== null ? formatDuration(duration) : ''}
-                </div>
-              </>
-            )}
+                  }
+                  className="text-xs text-moon-400"
+                />
+              )}
+            </div>
 
-          <div className="flex-0 flex min-w-0 items-center">
-            {showTypeIcon ? (
-              <IconOnlyPill
-                icon={getCallTypeIcon(typeName)}
-                color={opTypeColor}
-                isInteractive={false}
-              />
-            ) : (
-              <div
-                className={`h-8 w-8 rounded-full ${getTagColorClass(
-                  opTypeColor
-                )}`}
-              />
-            )}
+            {/* 
+              <div className="text-right">
+                {duration !== null ? formatDuration(duration) : ''}
+              </div> 
+            */}
+            <Icon
+              name={getCallTypeIcon(typeName)}
+              className={`max-w-16 max-h-16 ${opTypeColor}`}
+            />            
+            <StatusChip value={statusCode} iconOnly />
           </div>
-
-            {showStatusIcon ? (
-              <StatusChip value={statusCode} iconOnly />
-            ) : (
-              <div
-                className={`h-8 w-8 rounded-full ${getTagColorClass(
-                  STATUS_INFO[statusCode].color
-                )}`}
-              />
-            )}
-          </div>
+          
         </div>
       </Button>
     </div>
@@ -307,7 +258,7 @@ const TreeViewHeader: React.FC<TreeViewHeaderProps> = ({
       <TextField
         value={searchQuery}
         onChange={onSearchChange}
-        placeholder="Filter by op name"
+        placeholder="Filter by op name..."
         icon="filter-alt"
         extraActions={
           searchQuery !== '' && (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -5,6 +5,7 @@ import {
   getTagColorClass,
   TagColorName,
 } from '@wandb/weave/components/Tag';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {AutoSizer, List} from 'react-virtualized';
 
@@ -225,7 +226,10 @@ const TreeNode: React.FC<TreeNodeProps> = ({
               />
             )}
             <div className="pl-4 truncate font-medium">
-              {renderHighlightedText()}
+              <Tooltip
+                trigger={<div className="truncate">{renderHighlightedText()}</div>}
+                content={<span>{displayName}</span>}
+              />
             </div>
 
           </div>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -1,10 +1,6 @@
 import {Button} from '@wandb/weave/components/Button';
 import {TextField} from '@wandb/weave/components/Form/TextField';
 import {Icon, IconName} from '@wandb/weave/components/Icon';
-import {
-  getTagColorClass,
-  TagColorName,
-} from '@wandb/weave/components/Tag';
 import {Tooltip} from '@wandb/weave/components/Tooltip';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {AutoSizer, List} from 'react-virtualized';
@@ -14,11 +10,7 @@ import {
   getTokensFromUsage,
   TraceStat,
 } from '../../../pages/CallPage/cost';
-import {
-  CallStatusType,
-  STATUS_INFO,
-  StatusChip,
-} from '../../../pages/common/StatusChip';
+import {CallStatusType, StatusChip} from '../../../pages/common/StatusChip';
 import {TraceCallSchema} from '../../../pages/wfReactInterface/traceServerClientTypes';
 import {
   parseSpanName,
@@ -26,7 +18,8 @@ import {
 } from '../../../pages/wfReactInterface/tsDataModelHooks';
 import TraceScrubber, {ScrubberOption} from '../TraceScrubber';
 import {TraceTreeFlat, TraceViewProps} from './types';
-import {formatDuration, getCallDisplayName} from './utils';
+// import {formatDuration, getCallDisplayName} from './utils';
+import {getCallDisplayName} from './utils';
 
 interface FlattenedNode {
   id: string;
@@ -147,9 +140,9 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   searchQuery,
 }) => {
   const {id, call, level, isExpanded, childrenIds, hasDescendantErrors} = node;
-  const duration = call.ended_at
-    ? Date.parse(call.ended_at) - Date.parse(call.started_at)
-    : null;
+  // const duration = call.ended_at
+  //   ? Date.parse(call.ended_at) - Date.parse(call.started_at)
+  //   : null;
 
   const spanName = parseSpanName(call.op_name);
   const typeName = spanNameToTypeHeuristic(spanName);
@@ -166,7 +159,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
     const searchLower = searchQuery.toLowerCase();
     const textLower = displayName.toLowerCase();
     const index = textLower.indexOf(searchLower);
-    
+
     if (index === -1) {
       return displayName;
     }
@@ -190,7 +183,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   if (hasDescendantErrors && statusCode === 'SUCCESS') {
     statusCode = 'DESCENDANT_ERROR';
   }
- const indentMultiplier = 14;
+  const indentMultiplier = 14;
 
   return (
     <div style={style}>
@@ -199,19 +192,22 @@ const TreeNode: React.FC<TreeNodeProps> = ({
         active={id === focusedCallId}
         onClick={() => setFocusedCallId(id)}
         onDoubleClick={() => setRootCallId(id)}
-        className="h-[32px] w-full justify-start px-8 text-left text-sm rounded-none"
+        className="h-[32px] w-full justify-start rounded-none px-8 text-left text-sm"
         style={{
           opacity: isDeemphasized ? 0.7 : 1,
         }}>
-        <div className="flex w-full items-center justify-between gap-8 relative">
+        <div className="relative flex w-full items-center justify-between gap-8">
           <div className="flex min-w-0 flex-1 items-center">
-            <div style={{marginLeft: level * indentMultiplier}}  className={`h-[32px]`} />
+            <div
+              style={{marginLeft: level * indentMultiplier}}
+              className={`h-[32px]`}
+            />
             {/* Render vertical lines for each level of hierarchy */}
-            {Array.from({ length: level }).map((_, idx) => (
-              <div 
-                key={`line-${idx}`} 
-                style={{left: idx * indentMultiplier, marginLeft: 8}} 
-                className="absolute top-0 h-full w-px border-l border-moon-300" 
+            {Array.from({length: level}).map((_, idx) => (
+              <div
+                key={`line-${idx}`}
+                style={{left: idx * indentMultiplier, marginLeft: 8}}
+                className="absolute top-0 h-full w-px border-l border-moon-300"
               />
             ))}
             {hasChildren && (
@@ -225,13 +221,14 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                 className="p-0.5 shrink-0 cursor-pointer rounded hover:bg-moon-300"
               />
             )}
-            <div className="pl-4 truncate font-medium">
+            <div className="truncate pl-4 font-medium">
               <Tooltip
-                trigger={<div className="truncate">{renderHighlightedText()}</div>}
+                trigger={
+                  <div className="truncate">{renderHighlightedText()}</div>
+                }
                 content={<span>{displayName}</span>}
               />
             </div>
-
           </div>
 
           <div className="ml-8 flex shrink-0 items-center gap-4 text-xs text-moon-400">
@@ -245,7 +242,9 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                       {tokens && (
                         <>
                           <br />
-                          <span style={{fontWeight: 600}}>Estimated Tokens</span>
+                          <span style={{fontWeight: 600}}>
+                            Estimated Tokens
+                          </span>
                         </>
                       )}
                       {tokens && tokenToolTipContent}
@@ -261,10 +260,9 @@ s            */}
             <Icon
               name={getCallTypeIcon(typeName)}
               className={`max-w-16 max-h-16 ${opTypeColor}`}
-            />            
+            />
             <StatusChip value={statusCode} iconOnly />
           </div>
-          
         </div>
       </Button>
     </div>
@@ -321,15 +319,15 @@ export const FilterableTreeView: React.FC<TraceViewProps> = props => {
 
     const foundCallIds = new Set<string>(directMatches);
     const filteredCallIdsSet = new Set(directMatches);
-    
+
     // Process queue for both upward (parents) and downward (children)
     const itemsToProcess = [...directMatches];
-    
+
     while (itemsToProcess.length > 0) {
       const id = itemsToProcess.shift();
       if (id) {
         const node = props.traceTreeFlat[id];
-        
+
         // Add parents
         if (node.parentId) {
           filteredCallIdsSet.add(node.parentId);
@@ -337,7 +335,7 @@ export const FilterableTreeView: React.FC<TraceViewProps> = props => {
             itemsToProcess.push(node.parentId);
           }
         }
-        
+
         // Add all children recursively
         const addChildren = (nodeId: string) => {
           const currentNode = props.traceTreeFlat[nodeId];
@@ -350,7 +348,7 @@ export const FilterableTreeView: React.FC<TraceViewProps> = props => {
             }
           }
         };
-        
+
         addChildren(id);
       }
     }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -181,21 +181,6 @@ const TreeNode: React.FC<TreeNodeProps> = ({
           opacity: isDeemphasized ? 0.6 : 1,
         }}>
         <div className="flex w-full items-center justify-between gap-8">
-          <div className="flex-0 flex min-w-0 items-center">
-            {showTypeIcon ? (
-              <IconOnlyPill
-                icon={getCallTypeIcon(typeName)}
-                color={opTypeColor}
-                isInteractive={false}
-              />
-            ) : (
-              <div
-                className={`h-8 w-8 rounded-full ${getTagColorClass(
-                  opTypeColor
-                )}`}
-              />
-            )}
-          </div>
           <div className="flex min-w-0 flex-1 items-center">
             <div style={{minWidth: level * indentMultiplier}} />
             {hasChildren ? (
@@ -218,6 +203,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
           </div>
 
           <div className="ml-8 flex shrink-0 items-center gap-8 text-xs text-moon-400">
+
             {showDuration && (
               <>
                 {usageIconsOnly ? (
@@ -268,6 +254,22 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                 </div>
               </>
             )}
+            
+          <div className="flex-0 flex min-w-0 items-center">
+            {showTypeIcon ? (
+              <IconOnlyPill
+                icon={getCallTypeIcon(typeName)}
+                color={opTypeColor}
+                isInteractive={false}
+              />
+            ) : (
+              <div
+                className={`h-8 w-8 rounded-full ${getTagColorClass(
+                  opTypeColor
+                )}`}
+              />
+            )}
+          </div>
 
             {showStatusIcon ? (
               <StatusChip value={statusCode} iconOnly />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -61,14 +61,14 @@ const getCallTypeIcon = (type: NodeType): IconName => {
       return 'code-alt';
     case 'llm':
       return 'forum-chat-bubble';
-    case 'none':
-      return 'circle';
     case 'model':
       return 'model';
     case 'evaluation':
       return 'baseline-alt';
     case 'scorer':
       return 'number';
+    case 'none':
+      return 'circle';  
     default:
       return 'circle';
   }
@@ -90,7 +90,7 @@ const opTypeToColor = (typeName: NodeType): string => {
       return 'text-sienna-500 dark:text-sienna-400';
     // Other, probable noise
     default:
-      return 'text-moon-400 dark:text-moon-300';
+      return 'text-moon-300 dark:text-moon-200';
   }
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -381,7 +381,7 @@ export const FilterableTreeView: React.FC<TraceViewProps> = props => {
   }, [matchedCallIds, props.traceTreeFlat, searchQuery]);
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col overflow-hidden">
       <TreeViewHeader
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -351,20 +351,24 @@ export const FilterableTreeView: React.FC<TraceViewProps> = props => {
           }
         }
 
-        // Add all children recursively
-        const addChildren = (nodeId: string) => {
-          const currentNode = props.traceTreeFlat[nodeId];
-          if (currentNode && currentNode.childrenIds) {
-            for (const childId of currentNode.childrenIds) {
-              if (!filteredCallIdsSet.has(childId)) {
-                filteredCallIdsSet.add(childId);
-                addChildren(childId);
+        // Only add children of direct matches
+        // Don't add children of parent nodes that were added just to show the path
+        if (foundCallIds.has(id)) {
+          // Add all children recursively
+          const addChildren = (nodeId: string) => {
+            const currentNode = props.traceTreeFlat[nodeId];
+            if (currentNode && currentNode.childrenIds) {
+              for (const childId of currentNode.childrenIds) {
+                if (!filteredCallIdsSet.has(childId)) {
+                  filteredCallIdsSet.add(childId);
+                  addChildren(childId);
+                }
               }
             }
-          }
-        };
-
-        addChildren(id);
+          };
+          
+          addChildren(id);
+        }
       }
     }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -289,13 +289,13 @@ const TreeViewHeader: React.FC<TreeViewHeaderProps> = ({
         icon="filter-alt"
         extraActions={
           searchQuery !== '' && (
-            <div className="mr-6 cursor-pointer rounded-sm p-1 hover:bg-moon-200">
-              <Icon
-                name="close"
-                size="small"
-                onClick={() => onSearchChange('')}
-              />
-            </div>
+            <Button
+              variant="ghost"
+              size="small"
+              icon="close"
+              onClick={() => onSearchChange('')}
+              className="mr-6"
+            />
           )
         }
       />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/TraceCostStats.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/TraceCostStats.tsx
@@ -54,7 +54,7 @@ export const TokenToolTip = (metrics: TokenTotals) => (
 
 export const CostToolTip = (metrics: CostTotals) => (
   <Box>
-    <span style={{fontWeight: 600}}>Estimated Cost</span>
+    <span style={{fontWeight: 600}}>Estimated cost</span>
     {Object.keys(metrics.inputs.cost).map(model => (
       <Box key={model + 'input'} sx={tooltipRowStyles}>
         <span>{model === 'total' ? 'Input cost' : model}: </span>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/TraceCostStats.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/TraceCostStats.tsx
@@ -31,13 +31,7 @@ const tooltipRowStyles = {
 };
 
 const tooltipDivider = (
-  <Divider
-    sx={{
-      borderColor: MOON_600,
-      marginTop: '8px',
-      marginBottom: '7px',
-    }}
-  />
+  <div className="border-t border-moon-600 mt-5 mb-4" />
 );
 
 export const TokenToolTip = (metrics: TokenTotals) => (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/TraceCostStats.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/cost/TraceCostStats.tsx
@@ -1,6 +1,4 @@
-import {Divider} from '@mui/material';
 import Box from '@mui/material/Box';
-import {MOON_600} from '@wandb/weave/common/css/color.styles';
 import {IconName} from '@wandb/weave/components/Icon';
 import {LoadingDots} from '@wandb/weave/components/LoadingDots';
 import {Pill} from '@wandb/weave/components/Tag';
@@ -30,9 +28,7 @@ const tooltipRowStyles = {
   gap: '16px',
 };
 
-const tooltipDivider = (
-  <div className="border-t border-moon-600 mt-5 mb-4" />
-);
+const tooltipDivider = <div className="mb-4 mt-5 border-t border-moon-600" />;
 
 export const TokenToolTip = (metrics: TokenTotals) => (
   <Box>


### PR DESCRIPTION
Based off of:
https://github.com/wandb/weave/pull/3834

## Description
WIP: DNM

Trace tree:
- Conditionally hid parent/root call show and tell when disabled.
- Updated search to show children and parents.
  - Added highlight to searched text in nodes.
- Added line-work to help illustrate hierarchy. 
- Added tooltips to call names for truncated calls.
- Moved call category icons to right side.
  - Updated icons to make them smaller
  - Colored based on category "types" (Identifiers, Completions/Tools, Evals, Other).
- Added token count into token cost tooltip - consolidated into one column.
- Added button to swap between token cost and latency.

Scrubbers:
- Updated scrubber colors.
- Add expand and collapse to show one or many scrubbers (pushes on and off page).

Tooltip (component):
- Updated tooltip divider (general) to add padding that wasn't rendering.

## Feedback tasks

- [x] Bug: Search w/ children - don't show siblings (that are linked to parent)
- [ ] Search w/ children may show too much for some situations - add strict filtering to only show exact matches
- [x] Green category too close to success checkmark - use different color (also look at evals)
- [x] Bug: Show/hide logic on scrubbers (specifically code view being hidden)
- [x] Bug: Investigate pixel shifting scrubbers