### PR TITLE
chore(weave): separate playground chat loading states

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
@@ -1,7 +1,8 @@
 import {Box, CircularProgress, Divider} from '@mui/material';
-import {MOON_200} from '@wandb/weave/common/css/color.styles';
+import {MOON_200, WHITE} from '@wandb/weave/common/css/color.styles';
+import {hexToRGB} from '@wandb/weave/common/css/utils';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
-import React, {Dispatch, SetStateAction, useState} from 'react';
+import React, {Dispatch, SetStateAction, useMemo, useState} from 'react';
 
 import {CallChat} from '../../CallPage/CallChat';
 import {TraceCallSchema} from '../../wfReactInterface/traceServerClientTypes';
@@ -57,7 +58,10 @@ export const PlaygroundChat = ({
   };
 
   // Check if any chat is loading
-  const isAnyLoading = playgroundStates.some(state => state.loading);
+  const isAnyLoading = useMemo(
+    () => playgroundStates.some(state => state.loading),
+    [playgroundStates]
+  );
 
   return (
     <Box
@@ -105,7 +109,7 @@ export const PlaygroundChat = ({
                     left: 0,
                     right: 0,
                     bottom: 0,
-                    backgroundColor: 'rgba(255, 255, 255, 0.7)',
+                    backgroundColor: hexToRGB(WHITE, 0.7),
                     zIndex: 100,
                     display: 'flex',
                     alignItems: 'center',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
@@ -1,7 +1,7 @@
 import {Box, CircularProgress, Divider} from '@mui/material';
 import {MOON_200} from '@wandb/weave/common/css/color.styles';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
-import React, {useState} from 'react';
+import React, {Dispatch, SetStateAction, useState} from 'react';
 
 import {CallChat} from '../../CallPage/CallChat';
 import {TraceCallSchema} from '../../wfReactInterface/traceServerClientTypes';
@@ -19,7 +19,7 @@ import {
 export type PlaygroundChatProps = {
   entity: string;
   project: string;
-  setPlaygroundStates: (states: PlaygroundState[]) => void;
+  setPlaygroundStates: Dispatch<SetStateAction<PlaygroundState[]>>;
   playgroundStates: PlaygroundState[];
   setPlaygroundStateField: SetPlaygroundStateFieldFunctionType;
   setSettingsTab: (callIndex: number | null) => void;
@@ -36,11 +36,10 @@ export const PlaygroundChat = ({
   settingsTab,
 }: PlaygroundChatProps) => {
   const [chatText, setChatText] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
 
   const {handleRetry, handleSend} = useChatCompletionFunctions(
     setPlaygroundStates,
-    setIsLoading,
+    setPlaygroundStateField,
     playgroundStates,
     entity,
     project,
@@ -56,6 +55,9 @@ export const PlaygroundChat = ({
     }
     setChatText('');
   };
+
+  // Check if any chat is loading
+  const isAnyLoading = playgroundStates.some(state => state.loading);
 
   return (
     <Box
@@ -75,23 +77,6 @@ export const PlaygroundChat = ({
           display: 'flex',
           position: 'relative',
         }}>
-        {isLoading && (
-          <Box
-            sx={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              backgroundColor: 'rgba(255, 255, 255, 0.7)',
-              zIndex: 100,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}>
-            <CircularProgress />
-          </Box>
-        )}
         {playgroundStates.map((state, idx) => (
           <React.Fragment key={idx}>
             {idx > 0 && (
@@ -112,6 +97,23 @@ export const PlaygroundChat = ({
                 flexDirection: 'column',
                 position: 'relative',
               }}>
+              {state.loading && (
+                <Box
+                  sx={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    backgroundColor: 'rgba(255, 255, 255, 0.7)',
+                    zIndex: 100,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}>
+                  <CircularProgress />
+                </Box>
+              )}
               <Box
                 sx={{
                   backgroundColor: 'white',
@@ -212,7 +214,7 @@ export const PlaygroundChat = ({
       <PlaygroundChatInput
         chatText={chatText}
         setChatText={setChatText}
-        isLoading={isLoading}
+        isLoading={isAnyLoading}
         onSend={handleSend}
         onAdd={handleAddMessage}
         settingsTab={settingsTab}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
@@ -65,7 +65,7 @@ export const useChatCompletionFunctions = (
     toolCallId?: string
   ) => {
     try {
-      // Start by determining if a specific chat is being updated or all of them
+      // Start by determining which chats need to be updated
       const chatsToUpdate =
         callIndex !== undefined
           ? [callIndex]
@@ -74,21 +74,19 @@ export const useChatCompletionFunctions = (
       const newMessageContent = content || chatText;
       const newMessage = createMessage(role, newMessageContent, toolCallId);
 
-      // Update state with the new messages before starting API requests
-      setPlaygroundStates(prevState => {
-        const updatedStates = [...prevState];
-        // Update the playground states with the new message
-        chatsToUpdate.forEach(idx => {
-          const updatedState = appendChoiceToMessages(prevState[idx]);
-          updatedState.loading = true;
-          // If the new message is not empty, add it to the messages
-          if (newMessageContent && updatedState.traceCall?.inputs?.messages) {
-            updatedState.traceCall.inputs.messages.push(newMessage);
-          }
-          updatedStates[idx] = filterNullMessages(updatedState);
-        });
-        return updatedStates;
+      // Update the playground states with the new message
+      const updatedStates = [...playgroundStates];
+      chatsToUpdate.forEach(idx => {
+        const updatedState = appendChoiceToMessages(playgroundStates[idx]);
+        if (newMessageContent && updatedState.traceCall?.inputs?.messages) {
+          updatedState.traceCall.inputs.messages.push(newMessage);
+        }
+        updatedState.loading = true;
+        updatedStates[idx] = filterNullMessages(updatedState);
       });
+
+      // Update state with the new messages before starting API requests
+      setPlaygroundStates(updatedStates);
       setChatText('');
 
       // Create an array of promises to process all chats in parallel

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
@@ -65,7 +65,7 @@ export const useChatCompletionFunctions = (
     toolCallId?: string
   ) => {
     try {
-      // Start by determining which chats need to be updated
+      // Start by determining if a specific chat is being updated or all of them
       const chatsToUpdate =
         callIndex !== undefined
           ? [callIndex]
@@ -74,19 +74,21 @@ export const useChatCompletionFunctions = (
       const newMessageContent = content || chatText;
       const newMessage = createMessage(role, newMessageContent, toolCallId);
 
-      // Update the playground states with the new message
-      const updatedStates = [...playgroundStates];
-      chatsToUpdate.forEach(idx => {
-        const updatedState = appendChoiceToMessages(playgroundStates[idx]);
-        if (newMessageContent && updatedState.traceCall?.inputs?.messages) {
-          updatedState.traceCall.inputs.messages.push(newMessage);
-        }
-        updatedState.loading = true;
-        updatedStates[idx] = filterNullMessages(updatedState);
-      });
-
       // Update state with the new messages before starting API requests
-      setPlaygroundStates(updatedStates);
+      setPlaygroundStates(prevState => {
+        const updatedStates = [...prevState];
+        // Update the playground states with the new message
+        chatsToUpdate.forEach(idx => {
+          const updatedState = appendChoiceToMessages(prevState[idx]);
+          updatedState.loading = true;
+          // If the new message is not empty, add it to the messages
+          if (newMessageContent && updatedState.traceCall?.inputs?.messages) {
+            updatedState.traceCall.inputs.messages.push(newMessage);
+          }
+          updatedStates[idx] = filterNullMessages(updatedState);
+        });
+        return updatedStates;
+      });
       setChatText('');
 
       // Create an array of promises to process all chats in parallel

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
@@ -123,26 +123,27 @@ export const useChatCompletionFunctions = (
     choiceIndex?: number
   ) => {
     try {
-      // Update the chat state to prepare for retry
-      const updatedStates = [...playgroundStates];
-      let updatedState;
+      setPlaygroundStateField(callIndex, 'loading', true);
 
-      if (choiceIndex !== undefined) {
-        updatedState = appendChoiceToMessages(
-          playgroundStates[callIndex],
-          choiceIndex
-        );
-      } else {
-        updatedState = JSON.parse(JSON.stringify(playgroundStates[callIndex]));
-        if (updatedState.traceCall?.inputs?.messages) {
-          updatedState.traceCall.inputs.messages =
-            updatedState.traceCall.inputs.messages.slice(0, messageIndex + 1);
-        }
-      }
-      updatedState.loading = true;
-
-      updatedStates[callIndex] = filterNullMessages(updatedState);
-      setPlaygroundStates(updatedStates);
+      const updatedStates = filterNullMessagesFromStates(
+        playgroundStates.map((state, index) => {
+          if (index === callIndex) {
+            if (choiceIndex !== undefined) {
+              return appendChoiceToMessages(state, choiceIndex);
+            }
+            const updatedState = JSON.parse(JSON.stringify(state));
+            if (updatedState.traceCall?.inputs?.messages) {
+              updatedState.traceCall.inputs.messages =
+                updatedState.traceCall.inputs.messages.slice(
+                  0,
+                  messageIndex + 1
+                );
+            }
+            return updatedState;
+          }
+          return state;
+        })
+      );
 
       const response = await makeCompletionRequest(callIndex, updatedStates);
 


### PR DESCRIPTION
## Description
Splits the loading states between chats
allows user to observe the difference between model timings

after split loading states that finish at separate times 

https://github.com/user-attachments/assets/0ee5b7b3-dd0e-4f08-b464-3a688bae65f9

before blocks on the slower finish

https://github.com/user-attachments/assets/9fb67f42-58a1-4d47-8fe4-75d235ec6481

beta link
http://beta.wandb.ai/?betaVersion=83c57ebae74b45487a2a33ee9e62d860773edb5e

## Testing

How was this PR tested?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced chat interactions with more precise, individual loading indicators for active chat responses.

- **Refactor**
  - Streamlined state updates and error handling for chat completions, resulting in smoother and more responsive user experiences.
  - Improved management of loading states for each chat, allowing for more granular control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->