### PR TITLE
chore(weave): Add better exceptions (e.g. for KeyboardInterrupt)

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -339,7 +339,7 @@ def _execute_op(
 
     try:
         res = func(*args, **kwargs)
-    except Exception as e:
+    except BaseException as e:
         handle_exception(e)
     else:
         return process(res)

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -319,7 +319,9 @@ def _execute_op(
 
         return res, __call
 
-    def handle_exception(e: Exception) -> tuple[Any, Call]:
+    def handle_exception(
+        e: Exception | SystemExit | KeyboardInterrupt,
+    ) -> tuple[Any, Call]:
         finish(exception=e)
         if __should_raise:
             raise

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -339,7 +339,7 @@ def _execute_op(
 
     try:
         res = func(*args, **kwargs)
-    except BaseException as e:
+    except (Exception, SystemExit, KeyboardInterrupt) as e:
         handle_exception(e)
     else:
         return process(res)


### PR DESCRIPTION
Previously, a keyboard interrupt would result in a "forever running" state.  Now it correctly shows as an error.

Before
<img width="733" alt="image" src="https://github.com/user-attachments/assets/5a9b28ce-27fb-46d0-92b5-3c58a596eef5" />

After
<img width="740" alt="image" src="https://github.com/user-attachments/assets/562221b7-0887-4605-9c55-f4d4009f3a43" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced error handling to manage interruptions more gracefully, including unexpected exit signals and user-initiated terminations. This improvement aims to provide a smoother and more robust experience during occasional interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->