### PR TITLE
chore(weave): add date range filter?

### DIFF
--- a/weave-js/package.json
+++ b/weave-js/package.json
@@ -47,7 +47,7 @@
     "@mui/icons-material": "^5.14.12",
     "@mui/material": "^6.0.2",
     "@mui/x-data-grid-pro": "^7.18.0",
-    "@mui/x-date-pickers": "^6.16.0",
+    "@mui/x-date-pickers-pro": "^7.28.0",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDateRangePicker.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledDateRangePicker.tsx
@@ -1,5 +1,5 @@
 import {styled} from '@mui/material/styles';
-import {DateTimePicker, DateTimePickerProps} from '@mui/x-date-pickers-pro';
+import {DateRangePicker, DateRangePickerProps} from '@mui/x-date-pickers-pro';
 import * as Colors from '@wandb/weave/common/css/color.styles';
 import {hexToRGB} from '@wandb/weave/common/css/utils';
 import moment from 'moment';
@@ -7,13 +7,22 @@ import React from 'react';
 
 const COLOR_BORDER_OVER = hexToRGB(Colors.TEAL_500, 0.4);
 const COLOR_BG_SELECTED_TEXT = Colors.MOON_100;
+const COLOR_BORDER_DEFAULT = Colors.MOON_300;
 
-export const StyledDateTimePicker = styled(
-  (props: DateTimePickerProps<moment.Moment>) => <DateTimePicker {...props} />
+export const StyledDateRangePicker = styled(
+  (props: DateRangePickerProps<moment.Moment>) => <DateRangePicker {...props} />
 )(() => ({
+  width: 'fit-content',
+
   '& .MuiOutlinedInput-root': {
     fontFamily: 'Source Sans Pro',
     padding: 4,
+    // Set the default border color to the correct gray
+    '& fieldset': {
+      borderColor: COLOR_BORDER_DEFAULT,
+      marginLeft: 8,
+      marginBottom: 2,
+    },
     '&:hover fieldset': {
       borderColor: COLOR_BORDER_OVER,
       borderWidth: 2,
@@ -24,5 +33,13 @@ export const StyledDateTimePicker = styled(
     '& ::selection': {
       backgroundColor: COLOR_BG_SELECTED_TEXT,
     },
+  },
+
+  '& .MuiInputBase-input': {
+    marginLeft: 12,
+  },
+
+  '& .MuiTypography-root': {
+    display: 'none',
   },
 }));

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/DateRangePicker.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/DateRangePicker.tsx
@@ -1,0 +1,70 @@
+/**
+ * Component for selecting a date range for filtering
+ */
+
+import moment from 'moment';
+import React from 'react';
+
+import {StyledDateRangePicker} from '../StyledDateRangePicker';
+
+type DateRangePickerProps = {
+  value: string;
+  onSetValue: (value: string) => void;
+};
+
+export const DateRangePicker = ({value, onSetValue}: DateRangePickerProps) => {
+  // The value is stored as a JSON string containing start and end dates
+  const parsedValue = React.useMemo(() => {
+    try {
+      if (!value) {
+        return {start: null, end: null};
+      }
+      return JSON.parse(value);
+    } catch (e) {
+      return {start: null, end: null};
+    }
+  }, [value]);
+
+  const startValue = parsedValue.start ? moment(parsedValue.start) : null;
+  const endValue = parsedValue.end ? moment(parsedValue.end) : null;
+
+  const handleRangeChange = (
+    newValue: [moment.Moment | null, moment.Moment | null]
+  ) => {
+    const [newStart, newEnd] = newValue;
+    const newRangeValue = {
+      start: newStart ? newStart.toISOString() : null,
+      end: newEnd ? newEnd.toISOString() : null,
+    };
+    onSetValue(JSON.stringify(newRangeValue));
+  };
+
+  return (
+    <StyledDateRangePicker
+      value={[startValue, endValue]}
+      onChange={handleRangeChange}
+      localeText={{start: 'start', end: 'end'}}
+      calendars={1}
+      showDaysOutsideCurrentMonth={false}
+      disableHighlightToday={true}
+    />
+  );
+};
+
+export const DateRangeDisplay = ({value}: {value: string}) => {
+  try {
+    if (!value) {
+      return null;
+    }
+    const {start, end} = JSON.parse(value);
+
+    return (
+      <span>
+        {start ? moment(start).format('YYYY-MM-DD') : '(any)'} to{' '}
+        {end ? moment(end).format('YYYY-MM-DD') : '(any)'}
+      </span>
+    );
+  } catch (e) {
+    return null;
+  }
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
@@ -3,8 +3,8 @@
  */
 
 import {GridFilterModel} from '@mui/x-data-grid-pro';
-import {LocalizationProvider} from '@mui/x-date-pickers';
-import {AdapterMoment} from '@mui/x-date-pickers/AdapterMoment';
+import {LocalizationProvider} from '@mui/x-date-pickers-pro';
+import {AdapterMoment} from '@mui/x-date-pickers-pro/AdapterMoment';
 import React from 'react';
 import {AutoSizer} from 'react-virtualized';
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -48,8 +48,17 @@ export const FilterRow = ({
     [item.field]
   );
 
-  const onSelectOperator = (operator: string) => {
-    onUpdateFilter({...item, operator});
+  const onSelectOperator = (newOperator: string) => {
+    const newItem = {
+      ...item,
+      operator: newOperator,
+      // For range operator, initialize with empty JSON object
+      value:
+        newOperator === '(date): range'
+          ? JSON.stringify({start: null, end: null})
+          : item.value,
+    };
+    onUpdateFilter(newItem);
   };
 
   const onSetValue = (value: string) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -20,6 +20,7 @@ import {
   isValuelessOperator,
   isWeaveRef,
 } from './common';
+import {DateRangeDisplay} from './DateRangePicker';
 import {FilterTag} from './FilterTag';
 import {IdList} from './IdList';
 
@@ -50,7 +51,11 @@ export const FilterTagItem = ({item, onRemoveFilter}: FilterTagItemProps) => {
   } else if (!isValuelessOperator(item.operator)) {
     const valueType = getOperatorValueType(item.operator);
     if (valueType === 'date') {
-      value = <Timestamp value={item.value} />;
+      if (item.operator === '(date): range') {
+        value = <DateRangeDisplay value={item.value} />;
+      } else {
+        value = <Timestamp value={item.value} />;
+      }
     } else {
       value = ' ' + quoteValue(valueType, item.value);
     }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
@@ -16,6 +16,7 @@ import {
   isValuelessOperator,
   isWeaveRef,
 } from './common';
+import {DateRangePicker} from './DateRangePicker';
 import {IdList} from './IdList';
 import {TextValue} from './TextValue';
 import {ValueInputBoolean} from './ValueInputBoolean';
@@ -30,8 +31,8 @@ type SelectValueProps = {
 export const SelectValue = ({
   field,
   operator,
-  value,
   onSetValue,
+  value,
 }: SelectValueProps) => {
   if (isValuelessOperator(operator)) {
     return null;
@@ -51,6 +52,10 @@ export const SelectValue = ({
     return <UserLink userId={value} includeName={true} hasPopover={false} />;
   }
   if (fieldType === 'datetime') {
+    if (operator === '(date): range') {
+      return <DateRangePicker value={value} onSetValue={onSetValue} />;
+    }
+
     const dateTimeValue = value ? moment(value) : null;
     return (
       <StyledDateTimePicker

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -151,6 +151,11 @@ const allOperators: SelectOperatorOption[] = [
     group: 'date',
   },
   {
+    value: '(date): range',
+    label: 'between',
+    group: 'date',
+  },
+  {
     value: '(any): isEmpty',
     label: 'is empty',
     group: 'any',
@@ -249,6 +254,11 @@ export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
       {
         value: '(date): before',
         label: 'before',
+        group: 'date',
+      },
+      {
+        value: '(date): range',
+        label: 'between',
         group: 'date',
       },
     ];

--- a/weave-js/yarn.lock
+++ b/weave-js/yarn.lock
@@ -1401,6 +1401,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.25.7", "@babel/runtime@^7.26.0":
+  version "7.26.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
+  integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.22.15":
   version "7.22.15"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.15.tgz#09576efc3830f0430f4548ef971dde1350ef2f38"
@@ -2958,6 +2965,11 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.16.tgz#66710c691b51cd4fca95322100cd74ec230cfe30"
   integrity sha512-qI8TV3M7ShITEEc8Ih15A2vLzZGLhD+/UPNwck/hcls2gwg7dyRjNGXcQYHKLB5Q7PuTRfrTkAoPa2VV1s67Ag==
 
+"@mui/types@~7.2.24":
+  version "7.2.24"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.24.tgz#5eff63129d9c29d80bbf2d2e561bd0690314dec2"
+  integrity sha512-3c8tRt/CbWZ+pEg7QpSwbdxOk36EfmhbKf6AGZsD1EcLDLTSZoxxJ86FVtcjxvjuhdyBiWKSTGZFaXCnidO2kw==
+
 "@mui/utils@^5.14.16":
   version "5.14.18"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.14.18.tgz#d2a46df9b06230423ba6b6317748b27185a56ac3"
@@ -2979,6 +2991,18 @@
     clsx "^2.1.1"
     prop-types "^15.8.1"
     react-is "^18.3.1"
+
+"@mui/utils@^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta":
+  version "6.4.8"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-6.4.8.tgz#f80ee0c0ac47f1cd47c2031a5fb87243322b6bf3"
+  integrity sha512-C86gfiZ5BfZ51KqzqoHi1WuuM2QdSKoFhbkZeAfQRB+jCc4YNhhj11UXFVMMsqBgZ+Zy8IHNJW3M9Wj/LOwRXQ==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@mui/types" "~7.2.24"
+    "@types/prop-types" "^15.7.14"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^19.0.0"
 
 "@mui/utils@^6.0.2":
   version "6.0.2"
@@ -3019,16 +3043,17 @@
     prop-types "^15.8.1"
     reselect "^5.1.1"
 
-"@mui/x-date-pickers@^6.16.0":
-  version "6.20.2"
-  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-6.20.2.tgz#b1b1e4862daafb750496cc77a1645caeac28a739"
-  integrity sha512-x1jLg8R+WhvkmUETRfX2wC+xJreMii78EXKLl6r3G+ggcAZlPyt0myID1Amf6hvJb9CtR7CgUo8BwR+1Vx9Ggw==
+"@mui/x-date-pickers-pro@^7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers-pro/-/x-date-pickers-pro-7.28.0.tgz#d2d083b530a7223aba893d992fade6e5df7ef3e6"
+  integrity sha512-SZzABvMEVKIYHyDaARmEz0iGK1BnhAnZH89aGd2VjaDKJGCDDdc0ASuy3sQByvBhDV/hlOPXUWpkn9EyX8N1Rg==
   dependencies:
-    "@babel/runtime" "^7.23.2"
-    "@mui/base" "^5.0.0-beta.22"
-    "@mui/utils" "^5.14.16"
-    "@types/react-transition-group" "^4.4.8"
-    clsx "^2.0.0"
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+    "@mui/x-date-pickers" "7.28.0"
+    "@mui/x-internals" "7.28.0"
+    "@mui/x-license" "7.28.0"
+    clsx "^2.1.1"
     prop-types "^15.8.1"
     react-transition-group "^4.4.5"
 
@@ -3040,6 +3065,14 @@
     "@babel/runtime" "^7.25.6"
     "@mui/utils" "^5.16.6"
 
+"@mui/x-internals@7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.28.0.tgz#b0a04f4c0f53f2f91d13a46f357f731b77c832c5"
+  integrity sha512-p4GEp/09bLDumktdIMiw+OF4p+pJOOjTG0VUvzNxjbHB9GxbBKoMcHrmyrURqoBnQpWIeFnN/QAoLMFSpfwQbw==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+
 "@mui/x-license@7.18.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@mui/x-license/-/x-license-7.18.0.tgz#0f4d8feadc44a309926b03445874d31a70a2b015"
@@ -3047,6 +3080,15 @@
   dependencies:
     "@babel/runtime" "^7.25.6"
     "@mui/utils" "^5.16.6"
+
+"@mui/x-license@7.28.0":
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-license/-/x-license-7.28.0.tgz#ffd4631da266e2e7717d440f45a3e809e36375f7"
+  integrity sha512-z50lVN4KxW+KB3usEnorEarbWtBxpYQrWfkmJqwJZEaeDO870LghBuhXNt4KEE2jqUU64MQCgZRPszIyrAvXfQ==
+  dependencies:
+    "@babel/runtime" "^7.25.7"
+    "@mui/utils" "^5.16.6 || ^6.0.0 || ^7.0.0 || ^7.0.0-beta"
+    "@mui/x-internals" "7.28.0"
 
 "@ndhoule/after@^1.0.0":
   version "1.0.0"
@@ -4611,6 +4653,11 @@
   version "15.7.12"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.12.tgz#12bb1e2be27293c1406acb6af1c3f3a1481d98c6"
   integrity sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==
+
+"@types/prop-types@^15.7.14":
+  version "15.7.14"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.14.tgz#1433419d73b2a7ebfc6918dcefd2ec0d5cd698f2"
+  integrity sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==
 
 "@types/query-string@^6.3.0":
   version "6.3.0"
@@ -12460,6 +12507,11 @@ react-is@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+react-is@^19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.0.0.tgz#d6669fd389ff022a9684f708cf6fa4962d1fea7a"
+  integrity sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Adds a between operator for dates (date range) which might be useful when we have multiple dates, rather than having a before and after. This could be auto-constructed when we detect before + after. 

Maybe roll this out just to admin first

## Testing

<img width="916" alt="Screenshot 2025-03-17 at 2 25 03 PM" src="https://github.com/user-attachments/assets/a38ecd1d-3a5c-4b5d-94f1-1a69d140ba50" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced date filtering experience with a new, styled date range picker.
  - Expanded filtering options by adding a “between” date range operator for more precise selection.
  - Upgraded date picker components to a more feature-rich version, improving overall interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->