### PR TITLE
chore(weave): sane limits on delete handling

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -498,11 +498,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 )
             )
         )
-        # only need to check non-root traces
-        all_children = [call for call in all_calls if call.parent_id is not None]
         all_descendants = find_call_descendants(
             root_ids=req.call_ids,
-            all_calls=all_children + parents,
+            all_calls=all_calls,
         )
 
         deleted_at = datetime.datetime.now()


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

In the pathological case the delete path has an unbounded query (all traces in a project are children of the same parent), put a sane limit on the query. 

This is a temporary solution, the robust solution will require a trace to know about its children. Right now, traces only have pointers to parents, so we can't walk down the tree (only up). 

## Testing

👀 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced deletion operations by introducing a processing limit, ensuring improved performance and more predictable behavior during large-scale deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->