### PR TITLE
fix(weave_query): Handle null values with vectorized string split patterns

### DIFF
--- a/weave_query/tests/ops_arrow/test_string.py
+++ b/weave_query/tests/ops_arrow/test_string.py
@@ -1,0 +1,49 @@
+import pytest
+import pyarrow as pa
+from weave_query.arrow.list_ import ArrowWeaveList
+from weave_query import weave_types as types
+from weave_query.ops_arrow.string import split
+
+class TestSplitOp:
+
+    def test_basic(self):
+        arrow_data = [
+            "a,b,c", 
+            "a,,b,c", 
+            "abc",
+            "",
+            None,
+        ]
+        pattern = ","
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = split.eager_call(awl, pattern)
+        
+        expected = [["a", "b", "c"], ["a", "", "b", "c"], ["abc"], [""], None]
+        assert result.to_pylist_notags() == expected
+
+    def test_split_dictionary_array(self):
+        arrow_data = [
+            "a,b,c", 
+            "a,,b,c", 
+            "abc",
+            "def",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([5, 4, 5, 0, 2, 1]),
+            dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        pattern = ","
+        result = split.eager_call(awl, pattern)
+                
+        expected = [
+            None,
+            [""],
+            None,
+            ["a", "b", "c"],
+            ["abc"],
+            ["a", "", "b", "c"],
+        ]
+        assert result._arrow_data.to_pylist() == expected

--- a/weave_query/tests/ops_arrow/test_string.py
+++ b/weave_query/tests/ops_arrow/test_string.py
@@ -47,3 +47,13 @@ class TestSplitOp:
             ["a", "", "b", "c"],
         ]
         assert result._arrow_data.to_pylist() == expected
+    
+    def test_split_vectorized_pattern(self):
+        arrow_data = ["a:b:c", "d|e|f", None, "g-h-i"]
+        pattern_data = [":", "|", "-", "-"]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        pattern_awl = ArrowWeaveList(pa.array(pattern_data), types.String())
+        result = split.eager_call(awl, pattern_awl)
+        
+        expected = [["a", "b", "c"], ["d", "e", "f"], None, ["g", "h", "i"]]
+        assert result.to_pylist_notags() == expected

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -224,9 +224,16 @@ def split(self, pattern):
             types.optional(types.List(types.String())),
             self._artifact,
         )
+
+    if len(self._arrow_data) != len(pattern._arrow_data):
+        raise ValueError(
+            f"Length mismatch: input array length ({len(self._arrow_data)}) does not match pattern array length ({len(pattern._arrow_data)})"
+        )
+
     return ArrowWeaveList(
         pa.array(
-            self._arrow_data[i].as_py().split(pattern._arrow_data[i].as_py())
+            None if self._arrow_data[i].as_py() is None or pattern._arrow_data[i].as_py() is None
+            else self._arrow_data[i].as_py().split(pattern._arrow_data[i].as_py())
             for i in range(len(self._arrow_data))
         ),
         types.optional(types.List(types.String())),

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -213,7 +213,9 @@ def split(self, pattern):
             # If we have a dictionary array, we need to split the dictionary and
             # then re-encode it as a dictionary array.
             return ArrowWeaveList(
-                pc.split_pattern(self._arrow_data.dictionary, pattern),
+                pa.DictionaryArray.from_arrays(
+                    self._arrow_data.indices, pc.split_pattern(self._arrow_data.dictionary, pattern)
+                ),
                 types.optional(types.List(types.String())),
                 self._artifact,
             )


### PR DESCRIPTION
## Description

- Split from https://github.com/wandb/weave/pull/3900, additional fixes to the AWL-split op that I found while adding tests
- Raise an exception when the arrow data and pattern data have mismatching lengths (TODO: I need to add a test for this)
- Null values in the arrow data should evaluate to `None`

## Testing

Unit tests