### PR TITLE
fix(weave_query): Re-encode dictionary arrays on AWL string split op

### DIFF
--- a/weave_query/tests/ops_arrow/test_string.py
+++ b/weave_query/tests/ops_arrow/test_string.py
@@ -1,0 +1,49 @@
+import pytest
+import pyarrow as pa
+from weave_query.arrow.list_ import ArrowWeaveList
+from weave_query import weave_types as types
+from weave_query.ops_arrow.string import split
+
+class TestSplitOp:
+
+    def test_basic(self):
+        arrow_data = [
+            "a,b,c", 
+            "a,,b,c", 
+            "abc",
+            "",
+            None,
+        ]
+        pattern = ","
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = split.eager_call(awl, pattern)
+        
+        expected = [["a", "b", "c"], ["a", "", "b", "c"], ["abc"], [""], None]
+        assert result.to_pylist_notags() == expected
+
+    def test_split_dictionary_array(self):
+        arrow_data = [
+            "a,b,c", 
+            "a,,b,c", 
+            "abc",
+            "def",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([5, 4, 5, 0, 2, 1]),
+            dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        pattern = ","
+        result = split.eager_call(awl, pattern)
+                
+        expected = [
+            None,
+            [""],
+            None,
+            ["a", "b", "c"],
+            ["abc"],
+            ["a", "", "b", "c"],
+        ]
+        assert result._arrow_data.to_pylist() == expected

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -213,7 +213,9 @@ def split(self, pattern):
             # If we have a dictionary array, we need to split the dictionary and
             # then re-encode it as a dictionary array.
             return ArrowWeaveList(
-                pc.split_pattern(self._arrow_data.dictionary, pattern),
+                pa.DictionaryArray.from_arrays(
+                    self._arrow_data.indices, pc.split_pattern(self._arrow_data.dictionary, pattern)
+                ),
                 types.optional(types.List(types.String())),
                 self._artifact,
             )


### PR DESCRIPTION
## Description

- Fixes [WB-18258](https://wandb.atlassian.net/browse/WB-18258)
- (Actually) re-encode incoming AWL as a DictionaryArray

## Testing

Unit Tests and uploaded updated CSV with generated from local weave_query to JIRA (see file `wandb_export_2025-03-18T12_48_55.954-07_00.csv`)


[WB-18258]: https://wandb.atlassian.net/browse/WB-18258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced string splitting functionality to correctly handle structured inputs, ensuring that results now reliably preserve the intended data organization across various cases.

- **Tests**
  - Introduced a new test suite for the `split` operation, validating functionality across different input scenarios, including handling of empty strings and `None` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->