### PR TITLE
chore(weave): weave client batch delete calls

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -606,7 +606,7 @@ def test_delete_calls(client):
     call1 = my_op(2)
     call2 = my_op(3)
 
-    calls = list(client.get_calls())
+    calls = client.get_calls()
     assert len(calls) == 3
 
     call_0_id = calls[0].id
@@ -614,22 +614,27 @@ def test_delete_calls(client):
     call_2_id = calls[2].id
 
     client.delete_calls([call_0_id, call_1_id])
-    assert len(list(client.get_calls())) == 1
-    assert list(client.get_calls())[0].id == call_2_id
+    calls = client.get_calls()
+    assert len(calls) == 1
+    assert calls[0].id == call_2_id
 
+    # test idempotent
     client.delete_calls([call_0_id, call_1_id])
-    assert len(list(client.get_calls())) == 1
-    assert list(client.get_calls())[0].id == call_2_id
+    calls = client.get_calls()
+    assert len(calls) == 1
+    assert calls[0].id == call_2_id
 
     client.delete_calls([])
-    assert len(list(client.get_calls())) == 1
-    assert list(client.get_calls())[0].id == call_2_id
+    calls = client.get_calls()
+    assert len(calls) == 1
+    assert calls[0].id == call_2_id
 
     with pytest.raises(ValueError):
         client.delete_calls([1111111111111111])
 
     client.delete_calls([call_2_id])
-    assert len(list(client.get_calls())) == 0
+    calls = client.get_calls()
+    assert len(calls) == 0
 
 
 def test_call_display_name(client):

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -597,6 +597,41 @@ def test_calls_delete_cascade(client):
     assert len(result) == 0
 
 
+def test_delete_calls(client):
+    @weave.op()
+    def my_op(a: int) -> int:
+        return a + 1
+
+    call0 = my_op(1)
+    call1 = my_op(2)
+    call2 = my_op(3)
+
+    calls = list(client.get_calls())
+    assert len(calls) == 3
+
+    call_0_id = calls[0].id
+    call_1_id = calls[1].id
+    call_2_id = calls[2].id
+
+    client.delete_calls([call_0_id, call_1_id])
+    assert len(list(client.get_calls())) == 1
+    assert list(client.get_calls())[0].id == call_2_id
+
+    client.delete_calls([call_0_id, call_1_id])
+    assert len(list(client.get_calls())) == 1
+    assert list(client.get_calls())[0].id == call_2_id
+
+    client.delete_calls([])
+    assert len(list(client.get_calls())) == 1
+    assert list(client.get_calls())[0].id == call_2_id
+
+    with pytest.raises(ValueError):
+        client.delete_calls([1111111111111111])
+
+    client.delete_calls([call_2_id])
+    assert len(list(client.get_calls())) == 0
+
+
 def test_call_display_name(client):
     call0 = client.create_call("x", {"a": 5, "b": 10})
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1335,6 +1335,20 @@ class WeaveClient:
         )
 
     @trace_sentry.global_trace_sentry.watch()
+    def delete_calls(self, call_ids: list[str]) -> None:
+        """Delete calls by their IDs.
+
+        Args:
+            call_ids: A list of call IDs to delete. Ex: ["2F0193e107-8fcf-7630-b576-977cc3062e2e"]
+        """
+        self.server.calls_delete(
+            CallsDeleteReq(
+                project_id=self._project_id(),
+                call_ids=call_ids,
+            )
+        )
+
+    @trace_sentry.global_trace_sentry.watch()
     def delete_object_version(self, object: ObjectRef) -> None:
         self.server.obj_delete(
             ObjDeleteReq(

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1338,6 +1338,8 @@ class WeaveClient:
     def delete_calls(self, call_ids: list[str]) -> None:
         """Delete calls by their IDs.
 
+        Deleting a call will also delete all of its children.
+
         Args:
             call_ids: A list of call IDs to delete. Ex: ["2F0193e107-8fcf-7630-b576-977cc3062e2e"]
         """


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-23872](https://wandb.atlassian.net/browse/WB-23872)


Easily delete large batches of calls from the API with `delete_calls` by passing in a list of strings corresponding to call ids.

maximum delete size is 1000. 

deleting calls also deletes all children of that call. 

Example: 
```python
client = weave.init("my-project")

all_calls = client.get_calls()
first_1000_calls = all_calls[:1000]
first_1000_calls_ids = [c.id for c in first_1000_calls]

client.delete_calls(call_ids=first_1000_calls_ids)
# 💰
```

## Testing

Adds test


[WB-23872]: https://wandb.atlassian.net/browse/WB-23872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced call record management now lets you delete multiple entries at once.
	- The update ensures that related records are properly handled and provides clear feedback for repeated or invalid deletion attempts.
- **Tests**
	- Added a new test function to verify the behavior of the deletion functionality under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->