### PR TITLE
chore(weave_query): Handle DictionaryArray inputs for various awl string ops

### DIFF
--- a/weave_query/tests/ops_arrow/test_string.py
+++ b/weave_query/tests/ops_arrow/test_string.py
@@ -14,7 +14,36 @@ from weave_query.ops_arrow.string import (
     strip,
     lstrip,
     rstrip,
+    arrowweavelist_len,
 )
+
+
+class TestLenOp:
+    def test_basic(self):
+        arrow_data = [
+            "abc",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = arrowweavelist_len.eager_call(awl)
+        expected = [3, 0, None]
+        assert result.to_pylist_notags() == expected
+
+    def test_dictionary_array(self):
+        arrow_data = [
+            "abc",
+            "def",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([3, 2, 0, 3]), dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = arrowweavelist_len.eager_call(awl)
+        expected = [None, 0, 3, None]
+        assert result._arrow_data.to_pylist() == expected
 
 
 class TestIsAlphaOp:

--- a/weave_query/tests/ops_arrow/test_string.py
+++ b/weave_query/tests/ops_arrow/test_string.py
@@ -9,7 +9,13 @@ from weave_query.ops_arrow.string import (
     isalnum,
     lower,
     upper,
+    slice,
+    replace,
+    strip,
+    lstrip,
+    rstrip,
 )
+
 
 class TestIsAlphaOp:
     def test_basic(self):
@@ -24,7 +30,7 @@ class TestIsAlphaOp:
         result = isalpha.eager_call(awl)
         expected = [True, False, False, False, None]
         assert result.to_pylist_notags() == expected
-        
+
     def test_dictionary_array(self):
         arrow_data = [
             "abc",
@@ -35,8 +41,7 @@ class TestIsAlphaOp:
             None,
         ]
         dict_array = pa.DictionaryArray.from_arrays(
-            indices=pa.array([5, 4, 0, 5, 2, 3]),
-            dictionary=pa.array(arrow_data)
+            indices=pa.array([5, 4, 0, 5, 2, 3]), dictionary=pa.array(arrow_data)
         )
         awl = ArrowWeaveList(dict_array, types.String())
         result = isalpha.eager_call(awl)
@@ -57,7 +62,7 @@ class TestIsNumericOp:
         result = isnumeric.eager_call(awl)
         expected = [True, False, False, False, None]
         assert result.to_pylist_notags() == expected
-        
+
     def test_dictionary_array(self):
         arrow_data = [
             "123",
@@ -68,14 +73,13 @@ class TestIsNumericOp:
             None,
         ]
         dict_array = pa.DictionaryArray.from_arrays(
-            indices=pa.array([5, 4, 0, 5, 2, 3]),
-            dictionary=pa.array(arrow_data)
-        )   
+            indices=pa.array([5, 4, 0, 5, 2, 3]), dictionary=pa.array(arrow_data)
+        )
         awl = ArrowWeaveList(dict_array, types.String())
         result = isnumeric.eager_call(awl)
         expected = [None, False, True, None, False, False]
         assert result._arrow_data.to_pylist() == expected
-        
+
 
 class TestIsAlphaNumericOp:
     def test_basic(self):
@@ -92,7 +96,7 @@ class TestIsAlphaNumericOp:
         result = isalnum.eager_call(awl)
         expected = [True, True, False, True, False, False, None]
         assert result.to_pylist_notags() == expected
-        
+
     def test_dictionary_array(self):
         arrow_data = [
             "abc",
@@ -105,14 +109,13 @@ class TestIsAlphaNumericOp:
             None,
         ]
         dict_array = pa.DictionaryArray.from_arrays(
-            indices=pa.array([7, 6, 0, 7, 2, 3, 5, 4]),
-            dictionary=pa.array(arrow_data)
-        )   
+            indices=pa.array([7, 6, 0, 7, 2, 3, 5, 4]), dictionary=pa.array(arrow_data)
+        )
         awl = ArrowWeaveList(dict_array, types.String())
         result = isalnum.eager_call(awl)
         expected = [None, False, True, None, True, False, False, True]
         assert result._arrow_data.to_pylist() == expected
-    
+
 
 class TestLowerOp:
     def test_basic(self):
@@ -138,14 +141,13 @@ class TestLowerOp:
             None,
         ]
         dict_array = pa.DictionaryArray.from_arrays(
-            indices=pa.array([5, 4, 0, 5, 2, 3]),
-            dictionary=pa.array(arrow_data)
+            indices=pa.array([5, 4, 0, 5, 2, 3]), dictionary=pa.array(arrow_data)
         )
         awl = ArrowWeaveList(dict_array, types.String())
         result = lower.eager_call(awl)
         expected = [None, "", "abc", None, "123", "abc123"]
         assert result._arrow_data.to_pylist() == expected
-   
+
 
 class TestUpperOp:
     def test_basic(self):
@@ -171,20 +173,183 @@ class TestUpperOp:
             None,
         ]
         dict_array = pa.DictionaryArray.from_arrays(
-            indices=pa.array([5, 4, 0, 5, 2, 3]),
-            dictionary=pa.array(arrow_data)
+            indices=pa.array([5, 4, 0, 5, 2, 3]), dictionary=pa.array(arrow_data)
         )
         awl = ArrowWeaveList(dict_array, types.String())
         result = upper.eager_call(awl)
         expected = [None, "", "ABC", None, "123", "ABC123"]
         assert result._arrow_data.to_pylist() == expected
 
-class TestSplitOp:
 
+class TestSliceOp:
     def test_basic(self):
         arrow_data = [
-            "a,b,c", 
-            "a,,b,c", 
+            "abcdef",
+            "123456",
+            "a",
+            "ab",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = slice.eager_call(awl, 1, 4)
+        expected = ["bcd", "234", "", "b", "", None]
+        assert result.to_pylist_notags() == expected
+
+    def test_dictionary_array(self):
+        arrow_data = [
+            "abcdef",
+            "123456",
+            "a",
+            "ab",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([5, 4, 0, 5, 2, 3]), dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = slice.eager_call(awl, 1, 4)
+        expected = [None, "", "bcd", None, "", "b"]
+        assert result._arrow_data.to_pylist() == expected
+
+
+class TestReplaceOp:
+    def test_basic(self):
+        arrow_data = [
+            "hello world",
+            "hello there",
+            "goodbye",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = replace.eager_call(awl, "hello", "hi")
+        expected = ["hi world", "hi there", "goodbye", "", None]
+        assert result.to_pylist_notags() == expected
+
+    def test_dictionary_array(self):
+        arrow_data = [
+            "hello world",
+            "hello there",
+            "goodbye",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([4, 3, 0, 4, 2]), dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = replace.eager_call(awl, "hello", "hi")
+        expected = [None, "", "hi world", None, "goodbye"]
+        assert result._arrow_data.to_pylist() == expected
+
+
+class TestStripOp:
+    def test_basic(self):
+        arrow_data = [
+            "  abc  ",
+            "\t\nxyz\r\n",
+            "def",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = strip.eager_call(awl)
+        expected = ["abc", "xyz", "def", "", None]
+        assert result.to_pylist_notags() == expected
+
+    def test_dictionary_array(self):
+        arrow_data = [
+            "  abc  ",
+            "  def  ",
+            "\t\nxyz\r\n",
+            "ghi",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([5, 4, 0, 5, 2, 3]), dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = strip.eager_call(awl)
+        expected = [None, "", "abc", None, "xyz", "ghi"]
+        assert result._arrow_data.to_pylist() == expected
+
+
+class TestLStripOp:
+    def test_basic(self):
+        arrow_data = [
+            "  abc  ",
+            "\t\nxyz\r\n",
+            "def  ",
+            "ghi",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = lstrip.eager_call(awl)
+        expected = ["abc  ", "xyz\r\n", "def  ", "ghi", "", None]
+        assert result.to_pylist_notags() == expected
+
+    def test_dictionary_array(self):
+        arrow_data = [
+            "  abc  ",
+            "  def  ",
+            "\t\nxyz\r\n",
+            "ghi  ",
+            "jkl",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([6, 5, 0, 6, 2, 3, 4]), dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = lstrip.eager_call(awl)
+        expected = [None, "", "abc  ", None, "xyz\r\n", "ghi  ", "jkl"]
+        assert result._arrow_data.to_pylist() == expected
+
+
+class TestRStripOp:
+    def test_basic(self):
+        arrow_data = [
+            "  abc  ",
+            "\t\nxyz\r\n",
+            "  def",
+            "ghi",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = rstrip.eager_call(awl)
+        expected = ["  abc", "\t\nxyz", "  def", "ghi", "", None]
+        assert result.to_pylist_notags() == expected
+
+    def test_dictionary_array(self):
+        arrow_data = [
+            "  abc  ",
+            "  def  ",
+            "\t\nxyz\r\n",
+            "  ghi",
+            "jkl",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([6, 5, 0, 6, 2, 3, 4]), dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = rstrip.eager_call(awl)
+        expected = [None, "", "  abc", None, "\t\nxyz", "  ghi", "jkl"]
+        assert result._arrow_data.to_pylist() == expected
+
+
+class TestSplitOp:
+    def test_basic(self):
+        arrow_data = [
+            "a,b,c",
+            "a,,b,c",
             "abc",
             "",
             None,
@@ -192,27 +357,26 @@ class TestSplitOp:
         pattern = ","
         awl = ArrowWeaveList(pa.array(arrow_data), types.String())
         result = split.eager_call(awl, pattern)
-        
+
         expected = [["a", "b", "c"], ["a", "", "b", "c"], ["abc"], [""], None]
         assert result.to_pylist_notags() == expected
 
     def test_split_dictionary_array(self):
         arrow_data = [
-            "a,b,c", 
-            "a,,b,c", 
+            "a,b,c",
+            "a,,b,c",
             "abc",
             "def",
             "",
             None,
         ]
         dict_array = pa.DictionaryArray.from_arrays(
-            indices=pa.array([5, 4, 5, 0, 2, 1]),
-            dictionary=pa.array(arrow_data)
+            indices=pa.array([5, 4, 5, 0, 2, 1]), dictionary=pa.array(arrow_data)
         )
         awl = ArrowWeaveList(dict_array, types.String())
         pattern = ","
         result = split.eager_call(awl, pattern)
-                
+
         expected = [
             None,
             [""],

--- a/weave_query/tests/ops_arrow/test_string.py
+++ b/weave_query/tests/ops_arrow/test_string.py
@@ -2,7 +2,182 @@ import pytest
 import pyarrow as pa
 from weave_query.arrow.list_ import ArrowWeaveList
 from weave_query import weave_types as types
-from weave_query.ops_arrow.string import split
+from weave_query.ops_arrow.string import (
+    isalpha,
+    split,
+    isnumeric,
+    isalnum,
+    lower,
+    upper,
+)
+
+class TestIsAlphaOp:
+    def test_basic(self):
+        arrow_data = [
+            "abc",
+            "123",
+            "abc123",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = isalpha.eager_call(awl)
+        expected = [True, False, False, False, None]
+        assert result.to_pylist_notags() == expected
+        
+    def test_dictionary_array(self):
+        arrow_data = [
+            "abc",
+            "def",
+            "123",
+            "abc123",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([5, 4, 0, 5, 2, 3]),
+            dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = isalpha.eager_call(awl)
+        expected = [None, False, True, None, False, False]
+        assert result._arrow_data.to_pylist() == expected
+
+
+class TestIsNumericOp:
+    def test_basic(self):
+        arrow_data = [
+            "123",
+            "123.45",
+            "abc",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = isnumeric.eager_call(awl)
+        expected = [True, False, False, False, None]
+        assert result.to_pylist_notags() == expected
+        
+    def test_dictionary_array(self):
+        arrow_data = [
+            "123",
+            "456",
+            "123.45",
+            "abc",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([5, 4, 0, 5, 2, 3]),
+            dictionary=pa.array(arrow_data)
+        )   
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = isnumeric.eager_call(awl)
+        expected = [None, False, True, None, False, False]
+        assert result._arrow_data.to_pylist() == expected
+        
+
+class TestIsAlphaNumericOp:
+    def test_basic(self):
+        arrow_data = [
+            "abc",
+            "123",
+            "123.45",
+            "abc123",
+            "",
+            "abc-123",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = isalnum.eager_call(awl)
+        expected = [True, True, False, True, False, False, None]
+        assert result.to_pylist_notags() == expected
+        
+    def test_dictionary_array(self):
+        arrow_data = [
+            "abc",
+            "def",
+            "123",
+            "123.45",
+            "abc123",
+            "",
+            "abc-123",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([7, 6, 0, 7, 2, 3, 5, 4]),
+            dictionary=pa.array(arrow_data)
+        )   
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = isalnum.eager_call(awl)
+        expected = [None, False, True, None, True, False, False, True]
+        assert result._arrow_data.to_pylist() == expected
+    
+
+class TestLowerOp:
+    def test_basic(self):
+        arrow_data = [
+            "ABC",
+            "123",
+            "ABC123",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = lower.eager_call(awl)
+        expected = ["abc", "123", "abc123", "", None]
+        assert result.to_pylist_notags() == expected
+
+    def test_dictionary_array(self):
+        arrow_data = [
+            "ABC",
+            "DEF",
+            "123",
+            "ABC123",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([5, 4, 0, 5, 2, 3]),
+            dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = lower.eager_call(awl)
+        expected = [None, "", "abc", None, "123", "abc123"]
+        assert result._arrow_data.to_pylist() == expected
+   
+
+class TestUpperOp:
+    def test_basic(self):
+        arrow_data = [
+            "abc",
+            "123",
+            "abc123",
+            "",
+            None,
+        ]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        result = upper.eager_call(awl)
+        expected = ["ABC", "123", "ABC123", "", None]
+        assert result.to_pylist_notags() == expected
+
+    def test_dictionary_array(self):
+        arrow_data = [
+            "abc",
+            "def",
+            "123",
+            "abc123",
+            "",
+            None,
+        ]
+        dict_array = pa.DictionaryArray.from_arrays(
+            indices=pa.array([5, 4, 0, 5, 2, 3]),
+            dictionary=pa.array(arrow_data)
+        )
+        awl = ArrowWeaveList(dict_array, types.String())
+        result = upper.eager_call(awl)
+        expected = [None, "", "ABC", None, "123", "ABC123"]
+        assert result._arrow_data.to_pylist() == expected
 
 class TestSplitOp:
 

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -214,7 +214,8 @@ def split(self, pattern):
             # then re-encode it as a dictionary array.
             return ArrowWeaveList(
                 pa.DictionaryArray.from_arrays(
-                    self._arrow_data.indices, pc.split_pattern(self._arrow_data.dictionary, pattern)
+                    self._arrow_data.indices,
+                    pc.split_pattern(self._arrow_data.dictionary, pattern),
                 ),
                 types.optional(types.List(types.String())),
                 self._artifact,
@@ -311,11 +312,7 @@ def endswith(self, suffix):
     output_type=ARROW_WEAVE_LIST_BOOLEAN_TYPE,
 )
 def isalpha(self):
-    return util.handle_dictionary_array(
-        self,
-        pc.ascii_is_alpha,
-        types.Boolean()
-    )
+    return util.handle_dictionary_array(self, pc.ascii_is_alpha, types.Boolean())
 
 
 @arrow_op(
@@ -324,11 +321,7 @@ def isalpha(self):
     output_type=ARROW_WEAVE_LIST_BOOLEAN_TYPE,
 )
 def isnumeric(self):
-    return util.handle_dictionary_array(
-        self,
-        pc.ascii_is_decimal,
-        types.Boolean()
-    )
+    return util.handle_dictionary_array(self, pc.ascii_is_decimal, types.Boolean())
 
 
 @arrow_op(
@@ -337,11 +330,7 @@ def isnumeric(self):
     output_type=ARROW_WEAVE_LIST_BOOLEAN_TYPE,
 )
 def isalnum(self):
-    return util.handle_dictionary_array(
-        self,
-        pc.ascii_is_alnum,
-        types.Boolean()
-    )
+    return util.handle_dictionary_array(self, pc.ascii_is_alnum, types.Boolean())
 
 
 @arrow_op(
@@ -350,11 +339,7 @@ def isalnum(self):
     output_type=ArrowWeaveListType(types.String()),
 )
 def lower(self):
-    return util.handle_dictionary_array(
-        self,
-        pc.ascii_lower,
-        types.String()
-    )
+    return util.handle_dictionary_array(self, pc.ascii_lower, types.String())
 
 
 @arrow_op(
@@ -363,11 +348,7 @@ def lower(self):
     output_type=ArrowWeaveListType(types.String()),
 )
 def upper(self):
-    return util.handle_dictionary_array(
-        self,
-        pc.ascii_upper,
-        types.String()
-    )
+    return util.handle_dictionary_array(self, pc.ascii_upper, types.String())
 
 
 @arrow_op(
@@ -380,10 +361,8 @@ def upper(self):
     output_type=self_type_output_type_fn,
 )
 def slice(self, begin, end):
-    return ArrowWeaveList(
-        pc.utf8_slice_codeunits(self._arrow_data, begin, end),
-        types.String(),
-        self._artifact,
+    return util.handle_dictionary_array(
+        self, lambda arr: pc.utf8_slice_codeunits(arr, begin, end), types.String()
     )
 
 
@@ -397,10 +376,10 @@ def slice(self, begin, end):
     output_type=self_type_output_type_fn,
 )
 def replace(self, pattern, replacement):
-    return ArrowWeaveList(
-        pc.replace_substring(self._arrow_data, pattern, replacement),
+    return util.handle_dictionary_array(
+        self,
+        lambda arr: pc.replace_substring(arr, pattern, replacement),
         types.String(),
-        self._artifact,
     )
 
 
@@ -410,9 +389,7 @@ def replace(self, pattern, replacement):
     output_type=self_type_output_type_fn,
 )
 def strip(self):
-    return ArrowWeaveList(
-        pc.utf8_trim_whitespace(self._arrow_data), types.String(), self._artifact
-    )
+    return util.handle_dictionary_array(self, pc.utf8_trim_whitespace, types.String())
 
 
 @arrow_op(
@@ -421,9 +398,7 @@ def strip(self):
     output_type=self_type_output_type_fn,
 )
 def lstrip(self):
-    return ArrowWeaveList(
-        pc.utf8_ltrim_whitespace(self._arrow_data), types.String(), self._artifact
-    )
+    return util.handle_dictionary_array(self, pc.utf8_ltrim_whitespace, types.String())
 
 
 @arrow_op(
@@ -432,9 +407,7 @@ def lstrip(self):
     output_type=self_type_output_type_fn,
 )
 def rstrip(self):
-    return ArrowWeaveList(
-        pc.utf8_rtrim_whitespace(self._arrow_data), types.String(), self._artifact
-    )
+    return util.handle_dictionary_array(self, pc.utf8_rtrim_whitespace, types.String())
 
 
 @arrow_op(

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -311,8 +311,10 @@ def endswith(self, suffix):
     output_type=ARROW_WEAVE_LIST_BOOLEAN_TYPE,
 )
 def isalpha(self):
-    return ArrowWeaveList(
-        pc.ascii_is_alpha(self._arrow_data), types.Boolean(), self._artifact
+    return util.handle_dictionary_array(
+        self,
+        pc.ascii_is_alpha,
+        types.Boolean()
     )
 
 
@@ -322,8 +324,10 @@ def isalpha(self):
     output_type=ARROW_WEAVE_LIST_BOOLEAN_TYPE,
 )
 def isnumeric(self):
-    return ArrowWeaveList(
-        pc.ascii_is_decimal(self._arrow_data), types.Boolean(), self._artifact
+    return util.handle_dictionary_array(
+        self,
+        pc.ascii_is_decimal,
+        types.Boolean()
     )
 
 
@@ -333,8 +337,10 @@ def isnumeric(self):
     output_type=ARROW_WEAVE_LIST_BOOLEAN_TYPE,
 )
 def isalnum(self):
-    return ArrowWeaveList(
-        pc.ascii_is_alnum(self._arrow_data), types.Boolean(), self._artifact
+    return util.handle_dictionary_array(
+        self,
+        pc.ascii_is_alnum,
+        types.Boolean()
     )
 
 
@@ -344,8 +350,10 @@ def isalnum(self):
     output_type=ArrowWeaveListType(types.String()),
 )
 def lower(self):
-    return ArrowWeaveList(
-        pc.ascii_lower(self._arrow_data), types.String(), self._artifact
+    return util.handle_dictionary_array(
+        self,
+        pc.ascii_lower,
+        types.String()
     )
 
 
@@ -355,8 +363,10 @@ def lower(self):
     output_type=ArrowWeaveListType(types.String()),
 )
 def upper(self):
-    return ArrowWeaveList(
-        pc.ascii_upper(self._arrow_data), types.String(), self._artifact
+    return util.handle_dictionary_array(
+        self,
+        pc.ascii_upper,
+        types.String()
     )
 
 

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -146,9 +146,7 @@ def in_(self, other):
     output_type=ARROW_WEAVE_LIST_INT_TYPE,
 )
 def arrowweavelist_len(self):
-    return ArrowWeaveList(
-        pc.binary_length(self._arrow_data), types.Int(), self._artifact
-    )
+    return util.handle_dictionary_array(self, pc.binary_length, types.Int())
 
 
 @arrow_op(

--- a/weave_query/weave_query/ops_arrow/util.py
+++ b/weave_query/weave_query/ops_arrow/util.py
@@ -8,7 +8,6 @@ from weave_query import graph
 from weave_query.arrow.list_ import ArrowWeaveList
 
 
-
 # Reimplementation of Weave0 `toSafeCall` which
 # converts media to their digest
 def _to_compare_safe_call(node: graph.OutputNode) -> graph.OutputNode:
@@ -75,18 +74,19 @@ def equal(lhs: pa.Array, rhs: typing.Union[pa.Array, pa.Scalar]) -> pa.Array:
     result = pc.replace_with_mask(result, one_null, False)
     return result
 
+
 def handle_dictionary_array(
     self: ArrowWeaveList,
     operation: typing.Callable,
     output_type: types.Type,
     *args,
-    **kwargs
+    **kwargs,
 ) -> ArrowWeaveList:
     if isinstance(self._arrow_data, pa.DictionaryArray):
         return ArrowWeaveList(
             pa.DictionaryArray.from_arrays(
                 self._arrow_data.indices,
-                operation(self._arrow_data.dictionary, *args, **kwargs)
+                operation(self._arrow_data.dictionary, *args, **kwargs),
             ),
             output_type,
             self._artifact,

--- a/weave_query/weave_query/ops_arrow/util.py
+++ b/weave_query/weave_query/ops_arrow/util.py
@@ -5,6 +5,8 @@ from pyarrow import compute as pc
 
 from weave_query import weave_types as types
 from weave_query import graph
+from weave_query.arrow.list_ import ArrowWeaveList
+
 
 
 # Reimplementation of Weave0 `toSafeCall` which
@@ -72,3 +74,25 @@ def equal(lhs: pa.Array, rhs: typing.Union[pa.Array, pa.Scalar]) -> pa.Array:
     result = pc.replace_with_mask(result, both_null, True)
     result = pc.replace_with_mask(result, one_null, False)
     return result
+
+def handle_dictionary_array(
+    self: ArrowWeaveList,
+    operation: typing.Callable,
+    output_type: types.Type,
+    *args,
+    **kwargs
+) -> ArrowWeaveList:
+    if isinstance(self._arrow_data, pa.DictionaryArray):
+        return ArrowWeaveList(
+            pa.DictionaryArray.from_arrays(
+                self._arrow_data.indices,
+                operation(self._arrow_data.dictionary, *args, **kwargs)
+            ),
+            output_type,
+            self._artifact,
+        )
+    return ArrowWeaveList(
+        operation(self._arrow_data, *args, **kwargs),
+        output_type,
+        self._artifact,
+    )


### PR DESCRIPTION
JIRA: https://wandb.atlassian.net/browse/WB-23892

## Description

Follow-up to https://github.com/wandb/weave/pull/3900: Most of the other string ops don't re-encode `DictionaryArray`s. This PR abstracts the process in a helper and modifies the following ArrowWeaveList string ops:
* Accepts a unary input type (i.e. the input the string itself with argument name `self`)
    * arrowweavelist_len (op: "ArrowWeaveListString-len")
    * isalpha (op: "ArrowWeaveListString-isAlpha")
    * isnumeric (op: "ArrowWeaveListString-isNumeric")
    * isalnum (op: "ArrowWeaveListString-isAlnum")
    * lower (op: "ArrowWeaveListString-lower")
    * upper (op: "ArrowWeaveListString-upper")
    * strip (op: "ArrowWeaveListString-strip")
    * lstrip (op: "ArrowWeaveListString-lStrip")
    * rstrip (op: "ArrowWeaveListString-rStrip")
* Additional one-liners
    * slice (op: "ArrowWeaveListString-slice")
    * replace (op: "ArrowWeaveListString-replace")

The following ops still need to be modified and I'll follow up in a separate PR:
* \_\_eq\_\_
* \_\_ne\_\_
* \_\_contains\_\_
* in\_\_
* string_add
* string\_right\_add
* append
* prepend
* split (only partially corrected from https://github.com/wandb/weave/pull/3900)
* partition
* startswith
* endswith
* join\_to\_str
* to_number 

## Testing

Unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive tests for string validations, including checks for letter-only, numeric, alphanumeric, and case conversion behaviors.

- **Refactor**
  - Improved the underlying string processing approach for better consistency and maintainability, enhancing how specific data structures are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->