### PR TITLE
feat(weave): improve webp image support

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/PIL.Image.Image/PILImageImage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/PIL.Image.Image/PILImageImage.tsx
@@ -12,7 +12,7 @@ import {CustomWeaveTypePayload} from '../customWeaveType.types';
 
 type PILImageImageTypePayload = CustomWeaveTypePayload<
   'PIL.Image.Image',
-  {'image.jpg': string} | {'image.png': string}
+  {'image.jpg': string} | {'image.png': string} | {'image.webp': string}
 >;
 
 type PILImageImageProps = {
@@ -54,6 +54,7 @@ const PILImageImageWithSize = ({
   const imageTypes = {
     'image.jpg': 'jpg',
     'image.png': 'png',
+    'image.webp': 'webp',
   } as const;
 
   const imageKey = Object.keys(data.files).find(key => key in imageTypes) as
@@ -101,7 +102,7 @@ const loadImage = (setImageDim: any, imageUrl: string) => {
 };
 
 type PILImageImageWithDataProps = {
-  fileExt: 'jpg' | 'png';
+  fileExt: 'jpg' | 'png' | 'webp';
   buffer: ArrayBuffer;
   containerWidth: number;
   containerHeight: number;
@@ -146,7 +147,7 @@ const PILImageImageWithData = ({
 
 type PILImageImageLoadedProps = {
   url: string;
-  fileExt: 'jpg' | 'png';
+  fileExt: 'jpg' | 'png' | 'webp';
   imageWidth: number;
   imageHeight: number;
   containerWidth: number;

--- a/weave/type_handlers/Image/image.py
+++ b/weave/type_handlers/Image/image.py
@@ -23,6 +23,7 @@ pil_format_to_ext = InvertableDict[str, str](
     {
         "JPEG": "jpg",
         "PNG": "png",
+        "WEBP": "webp",
     }
 )
 ext_to_pil_format = pil_format_to_ext.inv


### PR DESCRIPTION
## Description

Internal slack: https://weightsandbiases.slack.com/archives/C02UKHHN83G/p1742351127929729

The PIL Image serializer will convert unknown image types to PNG. This change allows webp images to be serialized as such and for the frontend to be able to render them.

## Testing

Added webp inline and pillow to wf values example: https://github.com/wandb/wf/pull/84
