### PR TITLE
chore(app): Accept image caption property in weave panels

### DIFF
--- a/weave-js/src/components/Panel2/ImageWithOverlays.tsx
+++ b/weave-js/src/components/Panel2/ImageWithOverlays.tsx
@@ -45,6 +45,7 @@ interface CardImageProps {
     path: string;
     width: number;
     height: number;
+    caption?: string;
   };
   imageFileNode: Node;
   masks?: Array<{loadedFrom: Node; path: string}>;
@@ -77,6 +78,9 @@ export const CardImage: FC<CardImageProps> = ({
     position: 'absolute',
     height: '100%',
     width: '100%',
+    top: 0,
+    left: 0,
+    objectFit: 'contain',
   } as const;
 
   return (
@@ -84,57 +88,81 @@ export const CardImage: FC<CardImageProps> = ({
       data-test="card-image"
       style={{
         height: '100%',
-        width: '100%',
-        position: 'relative',
+        overflow: 'auto',
       }}>
       {signedUrl == null ? (
         <div />
       ) : (
         <>
           {!hideImage && (
-            <img
-              style={{...imageStyle, objectFit: 'contain'}}
-              alt={image.path}
-              src={signedUrl}
-            />
-          )}
-          {masks != null &&
-            maskControls?.map((maskControl, i) => {
-              const mask = masks[i];
-              if (maskControl != null) {
-                const classSet = (classSets ?? {})[maskControl.classSetID];
-                return (
-                  <SegmentationMaskFromCG
-                    key={i}
-                    style={imageStyle}
-                    filePath={mask}
-                    mediaSize={{width: image.width, height: image.height}}
-                    maskControls={maskControl as Controls.MaskControlState}
-                    classSet={classSet}
-                  />
-                );
-              }
-              return undefined;
-            })}
+            <>
+              <div
+                style={{
+                  position: 'relative',
+                  height: image.caption ? '80%' : '100%',
+                }}>
+                <img style={imageStyle} alt={image.path} src={signedUrl} />
+                {masks != null &&
+                  maskControls?.map((maskControl, i) => {
+                    const mask = masks[i];
+                    if (maskControl != null) {
+                      const classSet = (classSets ?? {})[
+                        maskControl.classSetID
+                      ];
+                      return (
+                        <SegmentationMaskFromCG
+                          key={i}
+                          style={imageStyle}
+                          filePath={mask}
+                          mediaSize={{
+                            width: image.width,
+                            height: image.height,
+                          }}
+                          maskControls={
+                            maskControl as Controls.MaskControlState
+                          }
+                          classSet={classSet}
+                        />
+                      );
+                    }
+                    return undefined;
+                  })}
 
-          {boundingBoxes != null &&
-            boxControls?.map((boxControl, i) => {
-              if (boxControl != null) {
-                const classSet = classSets?.[boxControl.classSetID];
-                return (
-                  <BoundingBoxes
-                    key={i}
-                    style={imageStyle}
-                    bboxControls={boxControl as Controls.BoxControlState}
-                    boxData={boundingBoxes[i]}
-                    mediaSize={{width: image.width, height: image.height}}
-                    classSet={classSet}
-                    sliderControls={boxSliders}
-                  />
-                );
-              }
-              return undefined;
-            })}
+                {boundingBoxes != null &&
+                  boxControls?.map((boxControl, i) => {
+                    if (boxControl != null) {
+                      const classSet = classSets?.[boxControl.classSetID];
+                      return (
+                        <BoundingBoxes
+                          key={i}
+                          style={imageStyle}
+                          bboxControls={boxControl as Controls.BoxControlState}
+                          boxData={boundingBoxes[i]}
+                          mediaSize={{
+                            width: image.width,
+                            height: image.height,
+                          }}
+                          classSet={classSet}
+                          sliderControls={boxSliders}
+                        />
+                      );
+                    }
+                    return undefined;
+                  })}
+              </div>
+
+              {image.caption && (
+                <div
+                  style={{
+                    textAlign: 'center',
+                    color: 'gray',
+                    padding: '8px 0',
+                  }}>
+                  {image.caption}
+                </div>
+              )}
+            </>
+          )}
         </>
       )}
     </div>

--- a/weave-js/src/components/Panel2/PanelImage.tsx
+++ b/weave-js/src/components/Panel2/PanelImage.tsx
@@ -209,6 +209,7 @@ const PanelImage: FC<PanelImageProps> = ({config, input}) => {
     loadedFrom: imageArtifact,
     width: image?.width,
     height: image?.height,
+    caption: image?.caption,
   };
 
   if (tileLayout === 'MASKS_NEXT_TO_IMAGE') {

--- a/weave-js/src/core/model/media/mediaImage.ts
+++ b/weave-js/src/core/model/media/mediaImage.ts
@@ -18,6 +18,7 @@ export interface WBImage {
   path: string;
   width: number;
   height: number;
+  caption?: string;
   boxes?: {
     [boxGroup: string]: BoundingBox2D[];
   };

--- a/weave-js/src/core/model/media/mediaTable.ts
+++ b/weave-js/src/core/model/media/mediaTable.ts
@@ -149,6 +149,7 @@ function wbTypeToMediaType(t: WBType.WBType): Types.Type {
         boxScoreKeys: t.params?.box_score_keys?.params?.val ?? [],
         maskLayers: t.params?.mask_layers?.params?.val ?? {},
         classMap: t.params?.class_map?.params?.val ?? {},
+        caption: t.params?.caption?.params?.val ?? '',
       } as Types.ImageType;
     }
   } else if (WBType.isTableWBType(t)) {

--- a/weave-js/src/core/model/media/mediaTypes.ts
+++ b/weave-js/src/core/model/media/mediaTypes.ts
@@ -145,6 +145,7 @@ export type ImageFileWBType = WBType & {
     mask_layers?: ConstWBType<{[layerName: string]: string[]}>;
     class_map?: ConstWBType<{[id: string]: string}>;
     box_score_keys?: ConstWBType<string[]>;
+    caption?: ConstWBType<string>;
   };
 };
 

--- a/weave-js/src/core/model/types.ts
+++ b/weave-js/src/core/model/types.ts
@@ -248,6 +248,7 @@ export interface ImageType {
   boxScoreKeys?: string[];
   maskLayers?: {[layerName: string]: string[]};
   classMap?: {[key: string]: string};
+  caption?: string;
 }
 
 export interface VideoType {


### PR DESCRIPTION
## Description

- Partial progress for [WB-22188](https://wandb.atlassian.net/browse/WB-22188)
- Re-merging https://github.com/wandb/weave/pull/3807. This PR only contains the FE portion of the changes 
- This PR allows the FE to accept `caption` as a property of incoming `image-file` data and adjusts the UI to display the caption.
    - There's also a small addition to keep the image at 100% height if the caption is not present and 80% otherwise. (This avoids an awkward blank area under the image)


## Testing

Tested with local FE. The changes will not yet be visible until the BE passes `caption` data, so we should not see any changes (or errors) in the UI. This is verified in the video below:

https://github.com/user-attachments/assets/1960e115-e49b-4e8f-8b11-98798371645a

With `weave0` on, we can see what the changes _should_ look like (and the panel should not crash):

https://github.com/user-attachments/assets/fe93ed59-357b-4414-bfb8-6ee88b532a1a




[WB-22188]: https://wandb.atlassian.net/browse/WB-22188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ