### PR TITLE
fix(weave): handle noncompliant chunk response from Azure

### DIFF
--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -169,6 +169,13 @@ def openai_accumulator(
             if chunk_choice.logprobs:
                 choice["logprobs"] = chunk_choice.logprobs
 
+            # See https://github.com/openai/openai-python/issues/1677
+            # Per the OpenAI SDK, delta is not Optional. However, the AzureOpenAI service
+            # will return a None delta under some conditions, including when you have enabled
+            # custom content filtering settings with the Asynchronous_filter streaming setting.
+            if chunk_choice.delta is None:
+                continue
+
             # message
             if chunk_choice.delta.content:
                 if choice["delta"]["content"] is None:


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C053FHBH73P/p1740558111134829?thread_ts=1740124248.544159&cid=C053FHBH73P

Per the OpenAI SDK, the `delta` field of a `Choice` is not `Optional`.
https://github.com/openai/openai-python/blob/3e69750d47df4f0759d4a28ddc68e4b38756d9ca/src/openai/types/chat/chat_completion_chunk.py#L88

However, the Azure implementation can return a `None` value for the delta. This issue notes one triggering condition which I was able to reproduce, which is when you have enabled custom content filtering settings with the Asynchronous_filter streaming setting.
https://github.com/openai/openai-python/issues/1677

A similar previous PR: https://github.com/wandb/weave/pull/3736
