### PR TITLE
chore(weave): fix adding and deleting filter rows

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -160,7 +160,7 @@ export const FilterBar = ({
         items: [
           ...localFilterModel.items,
           {
-            id: localFilterModel.items.length,
+            id: getNextFilterId(localFilterModel.items),
             field,
             operator: defaultOperator,
           },


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

missed a callsite when transitioning from length-based-ids to max/length. this enables more complex filter assignments.

In prod, we assign ids based on the length of the array. when you delete items, this then reassigns those ids and they can collide.  

## Testing

Prod:
![prod-filter-delete](https://github.com/user-attachments/assets/5a26be57-d13a-4be3-90a3-aed622054d70)

Branch:
![branch-filter-delete](https://github.com/user-attachments/assets/5f9a88bc-a560-401d-afbf-fb3fcffd6726)
