### PR TITLE
chore(ui): Header update (visuals only)

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledTextField.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/StyledTextField.tsx
@@ -5,7 +5,7 @@ import {hexToRGB} from '@wandb/weave/common/css/utils';
 import React from 'react';
 
 const COLOR_LABEL = Colors.TEAL_500;
-const COLOR_BORDER_OVER = hexToRGB(Colors.TEAL_500, 0.4);
+const COLOR_BORDER_OVER = hexToRGB(Colors.TEAL_400);
 const COLOR_BG_SELECTED_TEXT = Colors.MOON_100;
 
 export const StyledTextField = styled((props: TextFieldProps) => (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -266,6 +266,9 @@ export const FilterBar = ({
     f => !isFilterIncomplete(f)
   );
 
+  // Determine if we should show a border based on whether there are active filters
+  const hasBorder = completeItems.length > 0;
+
   const {combinedItems, activeEditIds} = useMemo(() => {
     const {items, activeIds} = combineRangeFilters(completeItems, activeEditId);
     return {combinedItems: items, activeEditIds: activeIds};
@@ -275,12 +278,20 @@ export const FilterBar = ({
     <>
       <div
         ref={refBar}
-        className="border-box flex h-32 cursor-pointer items-center gap-4 rounded border border-moon-200 px-8 hover:border-teal-500/40"
+        className={`border-box flex h-32 cursor-pointer items-center gap-4 rounded px-8 ${
+          hasBorder
+            ? 'border border-moon-200 hover:border-teal-400 hover:ring-1 hover:ring-teal-400 dark:border-moon-700 dark:hover:border-teal-300 dark:hover:ring-teal-300'
+            : ''
+        } ${
+          !hasBorder
+            ? 'hover:bg-teal-300/[0.48] hover:text-teal-600 dark:hover:bg-teal-700/[0.48] dark:hover:text-teal-400'
+            : ''
+        }`}
         onClick={onClick}>
         <div>
           <IconFilterAlt />
         </div>
-        <div ref={refLabel} className="select-none">
+        <div ref={refLabel} className="select-none font-semibold">
           Filter
         </div>
         <VariableChildrenDisplay width={availableWidth} gap={8}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
@@ -24,7 +24,7 @@ export const FilterPanel = (props: FilterPanelProps) => {
     <div className="min-w-90 flex-auto self-stretch">
       <LocalizationProvider dateAdapter={AdapterMoment}>
         <AutoSizer
-          className="ml-2 flex items-center"
+          className="flex items-center"
           style={{
             width: '100%',
             height: '100%',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -1105,9 +1105,24 @@ const OpSelector = ({
         <FormControl fullWidth sx={{borderColor: MOON_200}}>
           <Autocomplete
             PaperComponent={paperProps => <StyledPaper {...paperProps} />}
+            ListboxProps={{
+              sx: {
+                fontSize: '14px',
+                fontFamily: 'Source Sans Pro',
+                '& .MuiAutocomplete-option': {
+                  fontSize: '14px',
+                  fontFamily: 'Source Sans Pro',
+                },
+                '& .MuiAutocomplete-groupLabel': {
+                  fontSize: '14px',
+                  fontFamily: 'Source Sans Pro',
+                },
+              },
+            }}
             sx={{
               '& .MuiOutlinedInput-root': {
                 height: '32px',
+                fontFamily: 'Source Sans Pro',
                 '& fieldset': {
                   borderColor: MOON_200,
                 },
@@ -1116,9 +1131,15 @@ const OpSelector = ({
                 },
               },
               '& .MuiOutlinedInput-input': {
+                fontSize: '14px',
                 height: '32px',
                 padding: '0 14px',
                 boxSizing: 'border-box',
+                fontFamily: 'Source Sans Pro',
+              },
+              '& .MuiAutocomplete-clearIndicator, & .MuiAutocomplete-popupIndicator': {
+                backgroundColor: 'transparent',
+                marginBottom: '2px',
               },
             }}
             size="small"
@@ -1135,8 +1156,8 @@ const OpSelector = ({
             }
             groupBy={option => opVersionOptions[option]?.group}
             options={Object.keys(opVersionOptions)}
-            popupIcon={<Icon name="chevron-down" />}
-            clearIcon={<Icon name="close" />}
+            popupIcon={<Icon name="chevron-down" width={16} height={16} />}
+            clearIcon={<Icon name="close" width={16} height={16} />}
           />
         </FormControl>
       </ListItem>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -27,7 +27,7 @@ import {
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import {MOON_200, TEAL_300} from '@wandb/weave/common/css/color.styles';
-import {Switch} from '@wandb/weave/components';
+import {Button} from '@wandb/weave/components/Button';
 import {Checkbox} from '@wandb/weave/components/Checkbox/Checkbox';
 import {
   Icon,
@@ -113,7 +113,6 @@ import {
 import {useCallsForQuery} from './callsTableQuery';
 import {useCurrentFilterIsEvaluationsFilter} from './evaluationsFilter';
 import {ManageColumnsButton} from './ManageColumnsButton';
-import {Button} from '@wandb/weave/components/Button';
 
 const MAX_SELECT = 100;
 
@@ -1174,10 +1173,6 @@ const OpSelector = ({
     </div>
   );
 };
-
-const ButtonDivider = () => (
-  <div className="h-24 flex-none border-l-[1px] border-moon-250"></div>
-);
 
 const useParentIdOptions = (
   entity: string,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -755,96 +755,100 @@ export const CallsTable: FC<{
       }}
       filterListItems={
         <TailwindContents>
-          <RefreshButton
-            onClick={() => calls.refetch()}
-            disabled={callsLoading}
-          />
-          {columnVisibilityModel && setColumnVisibilityModel && (
-            <div className="flex-none">
-              <ManageColumnsButton
-                columnInfo={columns}
-                columnVisibilityModel={columnVisibilityModel}
-                setColumnVisibilityModel={setColumnVisibilityModel}
-              />
-            </div>
-          )}
-          {!hideOpSelector && (
-            <OpSelector
-              frozenFilter={frozenFilter}
-              filter={filter}
-              setFilter={setFilter}
-              selectedOpVersionOption={selectedOpVersionOption}
-              opVersionOptions={opVersionOptions}
-            />
-          )}
-          {filterModel && setFilterModel && (
-            <FilterPanel
-              filterModel={filterModel}
-              columnInfo={filterFriendlyColumnInfo}
-              setFilterModel={setFilterModel}
-              selectedCalls={selectedCalls}
-              clearSelectedCalls={clearSelectedCalls}
-            />
-          )}
-          {selectedCalls.length > 0 && (
-            isEvaluateTable ? (
-              <CompareEvaluationsTableButton
-                onClick={() => {
-                  history.push(
-                    router.compareEvaluationsUri(
-                      entity,
-                      project,
-                      selectedCalls,
-                      null
-                    )
-                  );
-                }}
-              />
-            ) : (
-              <CompareTracesTableButton
-                onClick={() => {
-                  history.push(
-                    router.compareCallsUri(entity, project, selectedCalls)
-                  );
-                }}
-                disabled={selectedCalls.length < 2}
-              />
-            )
-          )}
-          {!isReadonly && selectedCalls.length !== 0 && (
+          {selectedCalls.length === 0 ? (
             <>
-              <div className="flex-none">
-                <BulkAddToDatasetButton
-                  onClick={() => setAddToDatasetModalOpen(true)}
-                  disabled={selectedCalls.length === 0}
+              <RefreshButton
+                onClick={() => calls.refetch()}
+                disabled={callsLoading}
+              />
+              {columnVisibilityModel && setColumnVisibilityModel && (
+                <div className="flex-none">
+                  <ManageColumnsButton
+                    columnInfo={columns}
+                    columnVisibilityModel={columnVisibilityModel}
+                    setColumnVisibilityModel={setColumnVisibilityModel}
+                  />
+                </div>
+              )}
+              {!hideOpSelector && (
+                <OpSelector
+                  frozenFilter={frozenFilter}
+                  filter={filter}
+                  setFilter={setFilter}
+                  selectedOpVersionOption={selectedOpVersionOption}
+                  opVersionOptions={opVersionOptions}
                 />
-                <AddToDatasetDrawer
-                  entity={entity}
-                  project={project}
-                  open={addToDatasetModalOpen}
-                  onClose={() => setAddToDatasetModalOpen(false)}
-                  selectedCalls={selectedCallObjects}
+              )}
+              {filterModel && setFilterModel && (
+                <FilterPanel
+                  filterModel={filterModel}
+                  columnInfo={filterFriendlyColumnInfo}
+                  setFilterModel={setFilterModel}
+                  selectedCalls={selectedCalls}
+                  clearSelectedCalls={clearSelectedCalls}
                 />
-              </div>
-              <div className="flex-none">
-                <BulkDeleteButton
-                  onClick={() => setDeleteConfirmModalOpen(true)}
-                  disabled={selectedCalls.length === 0}
-                />
-                <ConfirmDeleteModal
-                  calls={tableData
-                    .filter(row => selectedCalls.includes(row.id))
-                    .map(traceCallToUICallSchema)}
-                  confirmDelete={deleteConfirmModalOpen}
-                  setConfirmDelete={setDeleteConfirmModalOpen}
-                  onDeleteCallback={() => {
-                    setSelectedCalls([]);
+              )}
+            </>
+          ) : (
+            <div className="flex items-center gap-8">
+              {isEvaluateTable ? (
+                <CompareEvaluationsTableButton
+                  onClick={() => {
+                    history.push(
+                      router.compareEvaluationsUri(
+                        entity,
+                        project,
+                        selectedCalls,
+                        null
+                      )
+                    );
                   }}
                 />
-              </div>
-            </>
+              ) : (
+                <CompareTracesTableButton
+                  onClick={() => {
+                    history.push(
+                      router.compareCallsUri(entity, project, selectedCalls)
+                    );
+                  }}
+                  disabled={selectedCalls.length < 2}
+                />
+              )}
+              {!isReadonly && (
+                <>
+                  <div className="flex-none">
+                    <BulkAddToDatasetButton
+                      onClick={() => setAddToDatasetModalOpen(true)}
+                      disabled={selectedCalls.length === 0}
+                    />
+                    <AddToDatasetDrawer
+                      entity={entity}
+                      project={project}
+                      open={addToDatasetModalOpen}
+                      onClose={() => setAddToDatasetModalOpen(false)}
+                      selectedCalls={selectedCallObjects}
+                    />
+                  </div>
+                  <div className="flex-none">
+                    <BulkDeleteButton
+                      onClick={() => setDeleteConfirmModalOpen(true)}
+                      disabled={selectedCalls.length === 0}
+                    />
+                    <ConfirmDeleteModal
+                      calls={tableData
+                        .filter(row => selectedCalls.includes(row.id))
+                        .map(traceCallToUICallSchema)}
+                      confirmDelete={deleteConfirmModalOpen}
+                      setConfirmDelete={setDeleteConfirmModalOpen}
+                      onDeleteCallback={() => {
+                        setSelectedCalls([]);
+                      }}
+                    />
+                  </div>
+                </>
+              )}
+            </div>
           )}
-
           <div className="flex items-center gap-8 ml-auto">
           {selectedInputObjectVersion && (
             <Chip

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -884,16 +884,13 @@ export const CallsTable: FC<{
             />
           )}
           <div className="flex items-center gap-6">
-            <Switch.Root
-              id="tracesMetricsSwitch"
-              size="small"
-              checked={isMetricsChecked}
-              onCheckedChange={setMetricsChecked}>
-              <Switch.Thumb size="small" checked={isMetricsChecked} />
-            </Switch.Root>
-            <label className="cursor-pointer" htmlFor="tracesMetricsSwitch">
-              Metrics
-            </label>
+            <Button
+              variant="ghost"
+              icon="chart-vertical-bars"
+              active={isMetricsChecked}
+              onClick={() => setMetricsChecked(!isMetricsChecked)}
+              tooltip={isMetricsChecked ? "Hide metrics" : "Show metrics"}
+            />
           </div>
           <div className="flex-none">
             <ExportSelector

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -798,7 +798,8 @@ export const CallsTable: FC<{
                 tooltip="Clear selection"
               />
               <div className="text-sm">
-                {selectedCalls.length} {isEvaluateTable ? 'evaluations' : 'traces'} selected:
+                {selectedCalls.length}{' '}
+                {isEvaluateTable ? 'evaluations' : 'traces'} selected:
               </div>
               {isEvaluateTable ? (
                 <CompareEvaluationsTableButton
@@ -858,72 +859,72 @@ export const CallsTable: FC<{
               )}
             </div>
           )}
-          <div className="flex items-center gap-8 ml-auto">
-          {selectedInputObjectVersion && (
-            <Chip
-              label={`Input: ${objectVersionNiceString(
-                selectedInputObjectVersion
-              )}`}
-              onDelete={() => {
-                setFilter({
-                  ...filter,
-                  inputObjectVersionRefs: undefined,
-                });
-              }}
-            />
-          )}
-          {selectedOutputObjectVersion && (
-            <Chip
-              label={`Output: ${objectVersionNiceString(
-                selectedOutputObjectVersion
-              )}`}
-              onDelete={() => {
-                setFilter({
-                  ...filter,
-                  outputObjectVersionRefs: undefined,
-                });
-              }}
-            />
-          )}
-          {selectedParentId && (
-            <Chip
-              label={`Parent: ${selectedParentId}`}
-              onDelete={() => {
-                setFilter({
-                  ...filter,
-                  parentId: undefined,
-                });
-              }}
-            />
-          )}
-          <div className="flex items-center gap-6">
-            <Button
-              variant="ghost"
-              icon="chart-vertical-bars"
-              active={isMetricsChecked}
-              onClick={() => setMetricsChecked(!isMetricsChecked)}
-              tooltip={isMetricsChecked ? "Hide metrics" : "Show metrics"}
-            />
-          </div>
-          <div className="flex-none">
-            <ExportSelector
-              selectedCalls={selectedCalls}
-              numTotalCalls={callsTotal}
-              disabled={callsTotal === 0}
-              visibleColumns={visibleColumns}
-              // Remove cols from expandedRefs if it's not in visibleColumns (probably just inputs.example)
-              refColumnsToExpand={Array.from(expandedRefCols).filter(col =>
-                visibleColumns.includes(col)
-              )}
-              callQueryParams={{
-                entity,
-                project,
-                filter: effectiveFilter,
-                gridFilter: filterModel ?? DEFAULT_FILTER_CALLS,
-                gridSort: sortModel,
-              }}
-            />
-          </div>
+          <div className="ml-auto flex items-center gap-8">
+            {selectedInputObjectVersion && (
+              <Chip
+                label={`Input: ${objectVersionNiceString(
+                  selectedInputObjectVersion
+                )}`}
+                onDelete={() => {
+                  setFilter({
+                    ...filter,
+                    inputObjectVersionRefs: undefined,
+                  });
+                }}
+              />
+            )}
+            {selectedOutputObjectVersion && (
+              <Chip
+                label={`Output: ${objectVersionNiceString(
+                  selectedOutputObjectVersion
+                )}`}
+                onDelete={() => {
+                  setFilter({
+                    ...filter,
+                    outputObjectVersionRefs: undefined,
+                  });
+                }}
+              />
+            )}
+            {selectedParentId && (
+              <Chip
+                label={`Parent: ${selectedParentId}`}
+                onDelete={() => {
+                  setFilter({
+                    ...filter,
+                    parentId: undefined,
+                  });
+                }}
+              />
+            )}
+            <div className="flex items-center gap-6">
+              <Button
+                variant="ghost"
+                icon="chart-vertical-bars"
+                active={isMetricsChecked}
+                onClick={() => setMetricsChecked(!isMetricsChecked)}
+                tooltip={isMetricsChecked ? 'Hide metrics' : 'Show metrics'}
+              />
+            </div>
+            <div className="flex-none">
+              <ExportSelector
+                selectedCalls={selectedCalls}
+                numTotalCalls={callsTotal}
+                disabled={callsTotal === 0}
+                visibleColumns={visibleColumns}
+                // Remove cols from expandedRefs if it's not in visibleColumns (probably just inputs.example)
+                refColumnsToExpand={Array.from(expandedRefCols).filter(col =>
+                  visibleColumns.includes(col)
+                )}
+                callQueryParams={{
+                  entity,
+                  project,
+                  filter: effectiveFilter,
+                  gridFilter: filterModel ?? DEFAULT_FILTER_CALLS,
+                  gridSort: sortModel,
+                }}
+              />
+            </div>
           </div>
         </TailwindContents>
       }>
@@ -1146,10 +1147,11 @@ const OpSelector = ({
                 boxSizing: 'border-box',
                 fontFamily: 'Source Sans Pro',
               },
-              '& .MuiAutocomplete-clearIndicator, & .MuiAutocomplete-popupIndicator': {
-                backgroundColor: 'transparent',
-                marginBottom: '2px',
-              },
+              '& .MuiAutocomplete-clearIndicator, & .MuiAutocomplete-popupIndicator':
+                {
+                  backgroundColor: 'transparent',
+                  marginBottom: '2px',
+                },
             }}
             size="small"
             limitTags={1}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -785,55 +785,6 @@ export const CallsTable: FC<{
               clearSelectedCalls={clearSelectedCalls}
             />
           )}
-          <div className="flex items-center gap-6">
-            <Switch.Root
-              id="tracesMetricsSwitch"
-              size="small"
-              checked={isMetricsChecked}
-              onCheckedChange={setMetricsChecked}>
-              <Switch.Thumb size="small" checked={isMetricsChecked} />
-            </Switch.Root>
-            <label className="cursor-pointer" htmlFor="tracesMetricsSwitch">
-              Metrics
-            </label>
-          </div>
-          {selectedInputObjectVersion && (
-            <Chip
-              label={`Input: ${objectVersionNiceString(
-                selectedInputObjectVersion
-              )}`}
-              onDelete={() => {
-                setFilter({
-                  ...filter,
-                  inputObjectVersionRefs: undefined,
-                });
-              }}
-            />
-          )}
-          {selectedOutputObjectVersion && (
-            <Chip
-              label={`Output: ${objectVersionNiceString(
-                selectedOutputObjectVersion
-              )}`}
-              onDelete={() => {
-                setFilter({
-                  ...filter,
-                  outputObjectVersionRefs: undefined,
-                });
-              }}
-            />
-          )}
-          {selectedParentId && (
-            <Chip
-              label={`Parent: ${selectedParentId}`}
-              onDelete={() => {
-                setFilter({
-                  ...filter,
-                  parentId: undefined,
-                });
-              }}
-            />
-          )}
           {isEvaluateTable ? (
             <CompareEvaluationsTableButton
               onClick={() => {
@@ -894,6 +845,56 @@ export const CallsTable: FC<{
             </>
           )}
 
+          <div className="flex items-center gap-8 ml-auto">
+          {selectedInputObjectVersion && (
+            <Chip
+              label={`Input: ${objectVersionNiceString(
+                selectedInputObjectVersion
+              )}`}
+              onDelete={() => {
+                setFilter({
+                  ...filter,
+                  inputObjectVersionRefs: undefined,
+                });
+              }}
+            />
+          )}
+          {selectedOutputObjectVersion && (
+            <Chip
+              label={`Output: ${objectVersionNiceString(
+                selectedOutputObjectVersion
+              )}`}
+              onDelete={() => {
+                setFilter({
+                  ...filter,
+                  outputObjectVersionRefs: undefined,
+                });
+              }}
+            />
+          )}
+          {selectedParentId && (
+            <Chip
+              label={`Parent: ${selectedParentId}`}
+              onDelete={() => {
+                setFilter({
+                  ...filter,
+                  parentId: undefined,
+                });
+              }}
+            />
+          )}
+          <div className="flex items-center gap-6">
+            <Switch.Root
+              id="tracesMetricsSwitch"
+              size="small"
+              checked={isMetricsChecked}
+              onCheckedChange={setMetricsChecked}>
+              <Switch.Thumb size="small" checked={isMetricsChecked} />
+            </Switch.Root>
+            <label className="cursor-pointer" htmlFor="tracesMetricsSwitch">
+              Metrics
+            </label>
+          </div>
           <div className="flex-none">
             <ExportSelector
               selectedCalls={selectedCalls}
@@ -912,6 +913,7 @@ export const CallsTable: FC<{
                 gridSort: sortModel,
               }}
             />
+          </div>
           </div>
         </TailwindContents>
       }>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -113,6 +113,7 @@ import {
 import {useCallsForQuery} from './callsTableQuery';
 import {useCurrentFilterIsEvaluationsFilter} from './evaluationsFilter';
 import {ManageColumnsButton} from './ManageColumnsButton';
+import {Button} from '@wandb/weave/components/Button';
 
 const MAX_SELECT = 100;
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -785,32 +785,46 @@ export const CallsTable: FC<{
               clearSelectedCalls={clearSelectedCalls}
             />
           )}
-          {isEvaluateTable ? (
-            <CompareEvaluationsTableButton
-              onClick={() => {
-                history.push(
-                  router.compareEvaluationsUri(
-                    entity,
-                    project,
-                    selectedCalls,
-                    null
-                  )
-                );
-              }}
-              disabled={selectedCalls.length === 0}
-            />
-          ) : (
-            <CompareTracesTableButton
-              onClick={() => {
-                history.push(
-                  router.compareCallsUri(entity, project, selectedCalls)
-                );
-              }}
-              disabled={selectedCalls.length < 2}
-            />
+          {selectedCalls.length > 0 && (
+            isEvaluateTable ? (
+              <CompareEvaluationsTableButton
+                onClick={() => {
+                  history.push(
+                    router.compareEvaluationsUri(
+                      entity,
+                      project,
+                      selectedCalls,
+                      null
+                    )
+                  );
+                }}
+              />
+            ) : (
+              <CompareTracesTableButton
+                onClick={() => {
+                  history.push(
+                    router.compareCallsUri(entity, project, selectedCalls)
+                  );
+                }}
+                disabled={selectedCalls.length < 2}
+              />
+            )
           )}
           {!isReadonly && selectedCalls.length !== 0 && (
             <>
+              <div className="flex-none">
+                <BulkAddToDatasetButton
+                  onClick={() => setAddToDatasetModalOpen(true)}
+                  disabled={selectedCalls.length === 0}
+                />
+                <AddToDatasetDrawer
+                  entity={entity}
+                  project={project}
+                  open={addToDatasetModalOpen}
+                  onClose={() => setAddToDatasetModalOpen(false)}
+                  selectedCalls={selectedCallObjects}
+                />
+              </div>
               <div className="flex-none">
                 <BulkDeleteButton
                   onClick={() => setDeleteConfirmModalOpen(true)}
@@ -827,21 +841,6 @@ export const CallsTable: FC<{
                   }}
                 />
               </div>
-              <ButtonDivider />
-              <div className="flex-none">
-                <BulkAddToDatasetButton
-                  onClick={() => setAddToDatasetModalOpen(true)}
-                  disabled={selectedCalls.length === 0}
-                />
-                <AddToDatasetDrawer
-                  entity={entity}
-                  project={project}
-                  open={addToDatasetModalOpen}
-                  onClose={() => setAddToDatasetModalOpen(false)}
-                  selectedCalls={selectedCallObjects}
-                />
-              </div>
-              <ButtonDivider />
             </>
           )}
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -791,6 +791,16 @@ export const CallsTable: FC<{
             </>
           ) : (
             <div className="flex items-center gap-8">
+              <Button
+                variant="ghost"
+                size="small"
+                icon="close"
+                onClick={() => setSelectedCalls([])}
+                tooltip="Clear selection"
+              />
+              <div className="text-sm">
+                {selectedCalls.length} {isEvaluateTable ? 'evaluations' : 'traces'} selected:
+              </div>
               {isEvaluateTable ? (
                 <CompareEvaluationsTableButton
                   onClick={() => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -758,6 +758,15 @@ export const CallsTable: FC<{
             onClick={() => calls.refetch()}
             disabled={callsLoading}
           />
+          {columnVisibilityModel && setColumnVisibilityModel && (
+            <div className="flex-none">
+              <ManageColumnsButton
+                columnInfo={columns}
+                columnVisibilityModel={columnVisibilityModel}
+                setColumnVisibilityModel={setColumnVisibilityModel}
+              />
+            </div>
+          )}
           {!hideOpSelector && (
             <OpSelector
               frozenFilter={frozenFilter}
@@ -904,18 +913,6 @@ export const CallsTable: FC<{
               }}
             />
           </div>
-          {columnVisibilityModel && setColumnVisibilityModel && (
-            <>
-              <ButtonDivider />
-              <div className="flex-none">
-                <ManageColumnsButton
-                  columnInfo={columns}
-                  columnVisibilityModel={columnVisibilityModel}
-                  setColumnVisibilityModel={setColumnVisibilityModel}
-                />
-              </div>
-            </>
-          )}
         </TailwindContents>
       }>
       {isMetricsChecked && (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -438,12 +438,12 @@ export const CompareEvaluationsTableButton: FC<{
     <Button
       className="mx-4"
       size="medium"
-      variant="primary"
+      variant="ghost"
       disabled={disabled}
       onClick={onClick}
       icon="chart-scatterplot"
       tooltip={tooltipText}>
-      Compare
+      Compare evaluations
     </Button>
   </Box>
 );
@@ -462,11 +462,12 @@ export const CompareTracesTableButton: FC<{
     <Button
       className="mx-4"
       size="medium"
-      variant="primary"
+      variant="ghost"
       disabled={disabled}
       onClick={onClick}
+      icon="chart-scatterplot"
       tooltip={tooltipText}>
-      Compare
+      Compare traces
     </Button>
   </Box>
 );
@@ -515,7 +516,9 @@ export const BulkAddToDatasetButton: FC<{
       disabled={disabled}
       tooltip="Add selected rows to a dataset"
       icon="table"
-    />
+    >
+      Add to dataset
+    </Button>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -442,7 +442,7 @@ export const CompareEvaluationsTableButton: FC<{
       onClick={onClick}
       icon="chart-scatterplot"
       tooltip={tooltipText}>
-      Compare evaluations
+      Compare
     </Button>
   </Box>
 );
@@ -465,7 +465,7 @@ export const CompareTracesTableButton: FC<{
       onClick={onClick}
       icon="chart-scatterplot"
       tooltip={tooltipText}>
-      Compare traces
+      Compare
     </Button>
   </Box>
 );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -531,7 +531,7 @@ export const RefreshButton: FC<{
         alignItems: 'center',
       }}>
       <Button
-        variant="outline"
+        variant="ghost"
         size="medium"
         onClick={onClick}
         disabled={disabled}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -436,7 +436,6 @@ export const CompareEvaluationsTableButton: FC<{
       alignItems: 'center',
     }}>
     <Button
-      className="mx-4"
       size="medium"
       variant="ghost"
       disabled={disabled}
@@ -460,7 +459,6 @@ export const CompareTracesTableButton: FC<{
       alignItems: 'center',
     }}>
     <Button
-      className="mx-4"
       size="medium"
       variant="ghost"
       disabled={disabled}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -513,8 +513,7 @@ export const BulkAddToDatasetButton: FC<{
       onClick={handleClick}
       disabled={disabled}
       tooltip="Add selected rows to a dataset"
-      icon="table"
-    >
+      icon="table">
       Add to dataset
     </Button>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/ManageColumnsButton.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/ManageColumnsButton.tsx
@@ -99,11 +99,11 @@ export const ManageColumnsButton = ({
         anchorEl={anchorEl}
         anchorOrigin={{
           vertical: 'bottom',
-          horizontal: 'center',
+          horizontal: 'left',
         }}
         transformOrigin={{
           vertical: 'top',
-          horizontal: 'center',
+          horizontal: 'left',
         }}
         slotProps={{
           paper: {


### PR DESCRIPTION
## Description

| Before | After |
| -------- | ------- |
| ![CleanShot 2025-03-22 at 19 09 21](https://github.com/user-attachments/assets/763c20a3-43c8-45d8-90d7-c08615abad18) | ![CleanShot 2025-03-22 at 19 11 03](https://github.com/user-attachments/assets/708fff86-7595-4f27-a343-9f8635f5376f) |

- Visual changes for trace / eval page header update.
- Emphasizes actions which can be taken after row selection.
  - Adds a bar which calls out how many traces are selected
- Updated default button styles to reduce line-work.
- Updated Ops selector to use the proper Source Sans Pro font.