### PR TITLE
chore(weave): change object tables copy and add user to ops

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
@@ -278,14 +278,14 @@ const ObjectVersionPageInner: React.FC<{
               <p>{objectVersionIndex}</p>
             </div>
             <div className="block">
-              <p className="text-moon-500">Created</p>
+              <p className="text-moon-500">Last updated</p>
               <p>
                 <Timestamp value={createdAtMs / 1000} format="relative" />
               </p>
             </div>
             {objectVersion.userId && (
               <div className="block">
-                <p className="text-moon-500">Created by</p>
+                <p className="text-moon-500">Last updated by</p>
                 <UserLink userId={objectVersion.userId} includeName />
               </div>
             )}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionsTable.tsx
@@ -285,8 +285,8 @@ export const ObjectVersionsTable: React.FC<{
 
     if (!props.hideCreatedAtColumn) {
       cols.push(
-        basicField('createdAtMs', 'Created', {
-          width: 100,
+        basicField('createdAtMs', 'Last updated', {
+          width: 130,
           valueGetter: (unused: any, row: any) => {
             return row.obj.createdAtMs;
           },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionPage.tsx
@@ -1,4 +1,5 @@
 import {Button} from '@wandb/weave/components/Button';
+import {UserLink} from '@wandb/weave/components/UserLink';
 import React, {useContext, useMemo, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 
@@ -120,11 +121,17 @@ const OpVersionPageInner: React.FC<{
               <p>{versionIndex}</p>
             </div>
             <div className="block">
-              <p className="text-moon-500">Created</p>
+              <p className="text-moon-500">Last updated</p>
               <p>
                 <Timestamp value={createdAtMs / 1000} format="relative" />
               </p>
             </div>
+            {opVersion.userId && (
+              <div className="block">
+                <p className="text-moon-500">Last updated by</p>
+                <UserLink userId={opVersion.userId} includeName />
+              </div>
+            )}
             <div className="block">
               <p className="text-moon-500">Calls:</p>
               {!callsStats.loading || opVersionCallCount > 0 ? (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionsPage.tsx
@@ -159,8 +159,8 @@ export const FilterableOpVersionsTable: React.FC<{
         ]
       : []),
 
-    basicField('createdAtMs', 'Created', {
-      width: 100,
+    basicField('createdAtMs', 'Last updated', {
+      width: 130,
       renderCell: cellParams => {
         const createdAtMs = cellParams.value;
         return <Timestamp value={createdAtMs / 1000} format="relative" />;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -878,6 +878,7 @@ const convertTraceServerObjectVersionToOpSchema = (
     versionHash: obj.digest,
     createdAtMs: convertISOToDate(obj.created_at).getTime(),
     versionIndex: obj.version_index,
+    userId: obj.wb_user_id,
   };
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -76,6 +76,7 @@ export type OpVersionSchema = OpVersionKey & {
   // TODO: Add more fields & FKs
   versionIndex: number;
   createdAtMs: number;
+  userId?: string;
 };
 
 export type OpVersionFilter = {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-22878](https://wandb.atlassian.net/browse/WB-22878)

This pr: 
- changes objects and ops table text from "Created" to "Last updated"
- changes object and op pages to use "Last updated by" text
- adds user information to ops table and op page

## Testing

### Prod
Op:
<img width="1728" alt="Screenshot 2025-03-24 at 12 38 57 PM" src="https://github.com/user-attachments/assets/9439e5bf-c9de-4714-bb49-cc2ec53f225c" />

Object:
<img width="1728" alt="Screenshot 2025-03-24 at 12 42 48 PM" src="https://github.com/user-attachments/assets/6ed0e964-a40e-4ec7-9acb-e775e7ea1a81" />

### Branch
Op:
<img width="1728" alt="Screenshot 2025-03-24 at 12 38 33 PM" src="https://github.com/user-attachments/assets/deadfa62-93b7-47fd-9c9f-fd6c0bc08a27" />

Object:
<img width="1728" alt="Screenshot 2025-03-24 at 12 42 37 PM" src="https://github.com/user-attachments/assets/47137f11-c62f-41aa-a83b-e5c514cf3b79" />


[WB-22878]: https://wandb.atlassian.net/browse/WB-22878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ