### PR TITLE
chore(weave_query): Handle DictionaryArray inputs for another subset of AWL string ops

### DIFF
--- a/weave_query/tests/ops_arrow/test_string.py
+++ b/weave_query/tests/ops_arrow/test_string.py
@@ -567,6 +567,41 @@ class TestSplitOp:
         expected = [["a", "b", "c"], ["a", "", "b", "c"], ["abc"], [""], None]
         assert result.to_pylist_notags() == expected
 
+    def test_vectorized_pattern(self):
+        arrow_data = [
+            "a,b,c",
+            "a|b|c",
+            "a^b^c",
+            None,
+        ]
+        pattern = [",", "|", "^", "|"]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        pattern_awl = ArrowWeaveList(pa.array(pattern), types.String())
+        result = split.eager_call(awl, pattern_awl)
+
+        expected = [["a", "b", "c"], ["a", "b", "c"], ["a", "b", "c"], None]
+        assert result.to_pylist_notags() == expected
+
+    def test_vectorized_item_ignored(self):
+        arrow_data = ["a,b,c", "a|b|c", "a^b^c", None, "foo"]
+        pattern = [",", "|", "^", "|"]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        pattern_awl = ArrowWeaveList(pa.array(pattern), types.String())
+        result = split.eager_call(awl, pattern_awl)
+
+        expected = [["a", "b", "c"], ["a", "b", "c"], ["a", "b", "c"], None]
+        assert result.to_pylist_notags() == expected
+
+    def test_vectorized_pattern_ignored(self):
+        arrow_data = ["a,b,c", "a|b|c", "a^b^c", None]
+        pattern = [",", "|", "^", "|", "/"]
+        awl = ArrowWeaveList(pa.array(arrow_data), types.String())
+        pattern_awl = ArrowWeaveList(pa.array(pattern), types.String())
+        result = split.eager_call(awl, pattern_awl)
+
+        expected = [["a", "b", "c"], ["a", "b", "c"], ["a", "b", "c"], None]
+        assert result.to_pylist_notags() == expected
+
     def test_split_dictionary_array(self):
         arrow_data = [
             "a,b,c",

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -419,14 +419,16 @@ def rstrip(self):
 def join_to_str(arr, sep):
     if isinstance(sep, ArrowWeaveList):
         sep = sep._arrow_data
-    # match Weave0 - join nulls to empty string
-    filled_arr = pa.ListArray.from_arrays(
-        offsets_starting_at_zero(arr._arrow_data),
-        arr._arrow_data.flatten().fill_null(""),
-    )
-    return ArrowWeaveList(
-        pc.binary_join(filled_arr, sep), types.String(), arr._artifact
-    )
+
+    def _join_to_str(arrow_data):
+        # match Weave0 - join nulls to empty string
+        filled_arr = pa.ListArray.from_arrays(
+            offsets_starting_at_zero(arrow_data),
+            arrow_data.flatten().fill_null(""),
+        )
+        return pc.binary_join(filled_arr, sep)
+
+    return util.handle_dictionary_array(arr, _join_to_str, types.String())
 
 
 @arrow_op(

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -432,14 +432,18 @@ def join_to_str(arr, sep):
 @arrow_op(
     name="ArrowWeaveListString-toNumber",
     input_type={"self": ArrowWeaveListType(types.String())},
-    output_type=ArrowWeaveListType(types.Number()),
+    output_type=ArrowWeaveListType(types.optional(types.Number())),
 )
 def to_number(self):
-    arrow_data = self._arrow_data
-    is_not_numeric = pc.invert(pc.utf8_is_numeric(arrow_data))
+    def _to_number(arrow_data):
+        is_not_numeric = pc.invert(pc.utf8_is_numeric(arrow_data))
 
-    # need to use kleene logic here for masking
-    mask = pc.and_kleene(is_not_numeric, pa.nulls(len(self)).cast(pa.bool_()))
+        # need to use kleene logic here for masking
+        mask = pc.and_kleene(is_not_numeric, pa.nulls(len(arrow_data)).cast(pa.bool_()))
 
-    new_data = pc.replace_with_mask(arrow_data, mask, arrow_data).cast(pa.float64())
-    return ArrowWeaveList(new_data, types.optional(types.Number()), self._artifact)
+        new_data = pc.replace_with_mask(arrow_data, mask, arrow_data).cast(pa.float64())
+        return new_data
+
+    return util.handle_dictionary_array(
+        self, _to_number, types.optional(types.Number())
+    )

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -267,18 +267,18 @@ def partition(self, sep):
     output_type=ARROW_WEAVE_LIST_BOOLEAN_TYPE,
 )
 def startswith(self, prefix):
-    if isinstance(prefix, str):
-        return ArrowWeaveList(
-            pc.starts_with(self._arrow_data, prefix), types.Boolean(), self._artifact
-        )
-    return ArrowWeaveList(
-        pa.array(
-            s.as_py().startswith(p.as_py())
-            for s, p in zip(self._arrow_data, prefix._arrow_data)
-        ),
-        types.Boolean(),
-        self._artifact,
-    )
+    def _startswith(arrow_data):
+        if isinstance(prefix, str):
+            return pc.starts_with(arrow_data, prefix)
+        else:
+            return pa.array(
+                s.as_py().startswith(p.as_py())
+                if s.as_py() is not None and p.as_py() is not None
+                else None
+                for s, p in zip(arrow_data, prefix._arrow_data)
+            )
+
+    return util.handle_dictionary_array(self, _startswith, types.Boolean())
 
 
 @arrow_op(

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -304,7 +304,7 @@ def endswith(self, suffix):
                 s.as_py().endswith(p.as_py())
                 if s.as_py() is not None and p.as_py() is not None
                 else None
-                for s, p in zip(self._arrow_data, suffix._arrow_data)
+                for s, p in zip(arrow_data, suffix._arrow_data)
             )
 
     return util.handle_dictionary_array(self, _ends_with, types.Boolean())

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -290,18 +290,18 @@ def startswith(self, prefix):
     output_type=ARROW_WEAVE_LIST_BOOLEAN_TYPE,
 )
 def endswith(self, suffix):
-    if isinstance(suffix, str):
-        return ArrowWeaveList(
-            pc.ends_with(self._arrow_data, suffix), types.Boolean(), self._artifact
-        )
-    return ArrowWeaveList(
-        pa.array(
-            s.as_py().endswith(p.as_py())
-            for s, p in zip(self._arrow_data, suffix._arrow_data)
-        ),
-        types.Boolean(),
-        self._artifact,
-    )
+    def _ends_with(arrow_data):
+        if isinstance(suffix, str):
+            return pc.ends_with(arrow_data, suffix)
+        else:
+            return pa.array(
+                s.as_py().endswith(p.as_py())
+                if s.as_py() is not None and p.as_py() is not None
+                else None
+                for s, p in zip(self._arrow_data, suffix._arrow_data)
+            )
+
+    return util.handle_dictionary_array(self, _ends_with, types.Boolean())
 
 
 @arrow_op(


### PR DESCRIPTION
## Description
JIRA: https://wandb.atlassian.net/browse/WB-23892

Follow-up to https://github.com/wandb/weave/pull/3905. This PR fixes the following ops:
* split
* partition
* startswith
* endswith
* join\_to\_str
* to_number 

A couple things to note:
* In several instances, we weren't handling null value cases (either for `arrow_data` or for the input string argument to the op). These are fixed and included in the tests.
* The `toNumber` op does not completely work correctly as floating point numbers will not be converted (e.g. 123.45) due to `utf8_is_numeric` ([docs](https://arrow.apache.org/docs/python/generated/pyarrow.compute.utf8_is_numeric.html)) considering that string to not be numeric. I tried fixing this for a bit, but it looks like most workarounds are pretty hacky. Since the focus of this PR is updating the ops to handle `DictionaryArray`s, I've opted to keep this behaviour in for this PR.

The following ops still need to be modified:
* \_\_eq\_\_
* \_\_ne\_\_
* \_\_contains\_\_
* in\_\_
* string_add
* string\_right\_add
* append
* prepend


## Testing

Unit Tests
