### PR TITLE
style(ui): Update Select component styles

### DIFF
--- a/weave-js/src/components/Form/Select.tsx
+++ b/weave-js/src/components/Form/Select.tsx
@@ -243,7 +243,7 @@ const getStyles = <
         fontSize,
         cursor: props.cursor ?? 'default',
         border: 0,
-        borderRadius: '3px',
+        borderRadius: '5px',
         outline:
           state.menuIsOpen || state.isFocused
             ? `2px solid ${colorBorderOpen}`

--- a/weave-js/src/components/Form/Select.tsx
+++ b/weave-js/src/components/Form/Select.tsx
@@ -23,6 +23,7 @@ import {
 import {Icon} from '@wandb/weave/components/Icon';
 import React from 'react';
 import ReactSelect, {
+  ClearIndicatorProps,
   components,
   DropdownIndicatorProps,
   GroupBase,
@@ -54,7 +55,7 @@ const MIN_HEIGHTS: Record<SelectSize, number | undefined> = {
   small: undefined,
   medium: undefined,
   large: undefined,
-  variable: 40,
+  variable: 32,
 } as const;
 
 const LINE_HEIGHTS: Record<SelectSize, string | undefined> = {
@@ -75,7 +76,7 @@ const PADDING: Record<SelectSize, string> = {
   small: '2px 8px',
   medium: '4px 12px',
   large: '8px 12px',
-  variable: '2px 8px',
+  variable: '4px 12px',
 } as const;
 
 const OUTWARD_MARGINS: Record<SelectSize, string> = {
@@ -99,6 +100,26 @@ export type AdditionalProps = {
   cursor?: string;
 };
 
+const ClearIndicator = <
+  Option,
+  IsMulti extends boolean = false,
+  Group extends GroupBase<Option> = GroupBase<Option>
+>(
+  props: ClearIndicatorProps<Option, IsMulti, Group>
+) => {
+  return (
+    <components.ClearIndicator {...props}>
+      <Icon
+        name="close"
+        height={16}
+        width={16}
+        role="button"
+        aria-label="Clear all"
+      />
+    </components.ClearIndicator>
+  );
+};
+
 // Toggle icon when open
 const DropdownIndicator = <
   Option,
@@ -107,6 +128,9 @@ const DropdownIndicator = <
 >(
   indicatorProps: DropdownIndicatorProps<Option, IsMulti, Group>
 ) => {
+  if (indicatorProps.isMulti) {
+    return null;
+  }
   const iconName = indicatorProps.selectProps.menuIsOpen
     ? 'chevron-up'
     : 'chevron-down';
@@ -182,7 +206,7 @@ const getStyles = <
     },
     valueContainer: baseStyles => {
       const padding = PADDING[size];
-      return {...baseStyles, padding};
+      return {...baseStyles, padding, gap: '2px'};
     },
     multiValueLabel: baseStyles => {
       const fontSize = FONT_SIZES[size];
@@ -219,16 +243,18 @@ const getStyles = <
         fontSize,
         cursor: props.cursor ?? 'default',
         border: 0,
-        boxShadow: state.menuIsOpen
-          ? `0 0 0 2px ${colorBorderOpen}`
-          : state.isFocused
-          ? `0 0 0 2px ${colorBorderOpen}`
-          : `inset 0 0 0 1px ${colorBorderDefault}`,
+        borderRadius: '3px',
+        outline:
+          state.menuIsOpen || state.isFocused
+            ? `2px solid ${colorBorderOpen}`
+            : `1px solid ${colorBorderDefault}`,
+        transition: 'none',
         '&:hover': {
-          boxShadow:
+          outline: `2px solid ${
             state.menuIsOpen || state.isFocused
-              ? `0 0 0 2px ${colorBorderOpen}`
-              : `0 0 0 2px ${colorBorderHover}`,
+              ? colorBorderOpen
+              : colorBorderHover
+          }`,
         },
       };
     },
@@ -285,6 +311,7 @@ const getStyles = <
         },
       };
     },
+    placeholder: baseStyles => ({...baseStyles, fontSize: '16px'}),
   } as StylesConfig<Option, IsMulti, Group>;
 };
 
@@ -305,7 +332,7 @@ export const Select = <
     <ReactSelect
       {...props}
       components={Object.assign(
-        {DropdownIndicator, GroupHeading},
+        {ClearIndicator, DropdownIndicator, GroupHeading},
         props.components
       )}
       styles={styles}

--- a/weave-js/src/components/Form/TextField.tsx
+++ b/weave-js/src/components/Form/TextField.tsx
@@ -93,7 +93,7 @@ export const TextField = ({
     <Tailwind style={{width: '100%'}}>
       <div
         className={classNames(
-          'relative rounded-sm',
+          'relative rounded-[5px]',
           textFieldSize === 'small'
             ? 'h-30'
             : textFieldSize === 'medium'
@@ -118,7 +118,7 @@ export const TextField = ({
             'pointer-events-none opacity-50': disabled,
           }
         )}>
-        <div className="absolute bottom-0 top-0 flex w-full items-center rounded-sm">
+        <div className="absolute bottom-0 top-0 flex w-full items-center rounded-[5px]">
           {prefix && (
             <div
               className={classNames(
@@ -130,7 +130,7 @@ export const TextField = ({
           )}
           <input
             className={classNames(
-              'h-full w-full flex-1 rounded-sm bg-inherit pr-8',
+              'h-full w-full flex-1 rounded-[5px] bg-inherit pr-8',
               'appearance-none border-none',
               'focus:outline-none',
               'placeholder-moon-500',


### PR DESCRIPTION
## Description

Pre-req for https://wandb.atlassian.net/browse/WB-23683

We're building a new UI that displays a multi-select field next to a plain text field: https://www.figma.com/design/8v53a9ldK9DcVUkILt4CIn/Scratchpad?node-id=3102-175949&m=dev

But there are some styling discrepancies between our `TextField` and `Select` comps that are especially prominent when the two are displayed right next to each other.

<img width="846" alt="Screenshot 2025-03-24 at 1 47 31 PM" src="https://github.com/user-attachments/assets/7a40a0e4-7304-460b-9fed-d4d5605c81e4" />

- height: multi-select is taller than TextField (40px vs 32px)
- placeholder text: multi-select is smaller than TextField (14px vs 16px)
- border-radius: multi-select is rounder than TextField (4px vs 2px)
  - ...these are actually both wrong, it should be 5px [per design specs](https://www.figma.com/design/01KWBdMZg5QM9SRS1pQq0z/Design-System----Robot-Styles?node-id=16374-60224&t=ARJuNYDjkamP6I9W-0)
- "border": multi-select uses `box-shadow` to simulate border while TextField uses `outline`. this results in the borders to behave _ever so slightly_ differently:

https://github.com/user-attachments/assets/b0c6f9cf-a887-49d2-aa47-e7a86b343ae5


There are also some styling issues with multi-select that are totally unrelated to TextField:

<img width="557" alt="Screenshot 2025-03-24 at 1 52 19 PM" src="https://github.com/user-attachments/assets/7ca3e807-5212-44dc-bb9b-0a23156b1b44" />

- dropdown indicator (up/down chevron) should be hidden (see [designs](https://www.figma.com/design/8v53a9ldK9DcVUkILt4CIn/Scratchpad?node-id=3222-159265&m=dev))
- clear indicator should use our "close" icon
- selected items should should have 2px gaps

This PR addresses all of the issues listed above. For the border problem, I've converted Select to use outline like TextField does. Unfortunately, neither Select nor TextField actually fully match the [design specs in figma](https://www.figma.com/design/01KWBdMZg5QM9SRS1pQq0z/Design-System----Robot-Styles?node-id=16864-85003&t=UNBecuidxuPpDLgT-0). I think there must've been some changes to the designs since we originally implemented these components. That's probably something to be addressed separately (prob as part of the common comps epic)

## Testing

Tested in core app; things generally look right/good (will link associated core PR once that's available)

https://github.com/user-attachments/assets/98962305-966e-437d-a140-cba1eff23996

