### PR TITLE
fix(weave): add a null check to prevent playground crash

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -219,7 +219,10 @@ export const parseTraceCall = (traceCall: OptionalTraceCallSchema) => {
 
   // Handles anthropic outputs
   // Anthropic has content and stop_reason as top-level fields
-  if (isAnthropicCompletionFormat(parsedTraceCall.output)) {
+  if (
+    isAnthropicCompletionFormat(parsedTraceCall.output) &&
+    parsedTraceCall.output !== null
+  ) {
     const {content, stop_reason, ...outputs} = parsedTraceCall.output as any;
     parsedTraceCall.output = {
       ...outputs,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -220,8 +220,8 @@ export const parseTraceCall = (traceCall: OptionalTraceCallSchema) => {
   // Handles anthropic outputs
   // Anthropic has content and stop_reason as top-level fields
   if (
-    isAnthropicCompletionFormat(parsedTraceCall.output) &&
-    parsedTraceCall.output !== null
+    parsedTraceCall.output !== null &&
+    isAnthropicCompletionFormat(parsedTraceCall.output)
   ) {
     const {content, stop_reason, ...outputs} = parsedTraceCall.output as any;
     parsedTraceCall.output = {


### PR DESCRIPTION
## Description
https://wandb.atlassian.net/browse/WB-23842

the link in this ticket now loads instead of a full page crash
important for failed calls that might not have output

## Testing

How was this PR tested?
