### PR TITLE
chore(weave): allow otel style ids for calls

### DIFF
--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -544,7 +544,7 @@ const RE_WEAVE_CALL_REF_PATHNAME = new RegExp(
     '/',
     PATTERN_PROJECT,
     '/call/',
-    '([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})', // Call UUID
+    '([0-9a-fA-F-]+)', // Call ID
     '/?', // Ref extra portion is optional
     PATTERN_REF_EXTRA, // Optional ref extra
     '$', // End of the string

--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -544,7 +544,7 @@ const RE_WEAVE_CALL_REF_PATHNAME = new RegExp(
     '/',
     PATTERN_PROJECT,
     '/call/',
-    '([0-9a-fA-F-]+)', // Call ID
+    '([0-9a-fA-F-]+)', // Match any ID with or without dashes to support OTEL style ID strings
     '/?', // Ref extra portion is optional
     PATTERN_REF_EXTRA, // Optional ref extra
     '$', // End of the string

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -11,11 +11,17 @@ def project_id_validator(s: str) -> str:
 
 
 def call_id_validator(s: str) -> str:
-    return validation_util.require_uuid(s)
+    try:
+        return validation_util.require_otel_span_id(s)
+    except:
+        return validation_util.require_uuid(s)
 
 
 def trace_id_validator(s: str) -> str:
-    return validation_util.require_uuid(s)
+    try:
+        return validation_util.require_otel_trace_id(s)
+    except:
+        return validation_util.require_uuid(s)
 
 
 def parent_id_validator(s: Optional[str]) -> Optional[str]:

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -13,14 +13,14 @@ def project_id_validator(s: str) -> str:
 def call_id_validator(s: str) -> str:
     try:
         return validation_util.require_otel_span_id(s)
-    except:
+    except validation_util.CHValidationError:
         return validation_util.require_uuid(s)
 
 
 def trace_id_validator(s: str) -> str:
     try:
         return validation_util.require_otel_trace_id(s)
-    except:
+    except validation_util.CHValidationError:
         return validation_util.require_uuid(s)
 
 

--- a/weave/trace_server/validation_util.py
+++ b/weave/trace_server/validation_util.py
@@ -16,7 +16,7 @@ def require_otel_trace_id(s: str) -> str:
 
     # 16 Bytes is a hex string of len 32
     if len(s) != 32:
-        raise CHValidationError(f"Invalid Trace ID: {s}. Trace ID must be 8 bytes")
+        raise CHValidationError(f"Invalid Trace ID: {s}. Trace ID must be 16 bytes")
     return s
 
 

--- a/weave/trace_server/validation_util.py
+++ b/weave/trace_server/validation_util.py
@@ -9,6 +9,28 @@ class CHValidationError(Exception):
     pass
 
 
+def require_otel_trace_id(s: str) -> str:
+    lower_s = s.lower()
+    if lower_s != s:
+        raise CHValidationError(f"Invalid Trace ID: {s}. Trace ID must be lowercase")
+
+    # 16 Bytes is a hex string of len 32
+    if len(s) != 32:
+        raise CHValidationError(f"Invalid Trace ID: {s}. Trace ID must be 8 bytes")
+    return s
+
+
+def require_otel_span_id(s: str) -> str:
+    lower_s = s.lower()
+    if lower_s != s:
+        raise CHValidationError(f"Invalid Span ID: {s}. Span ID must be lowercase")
+
+    # 8 Bytes is a hex string of len 16
+    if len(s) != 16:
+        raise CHValidationError(f"Invalid Span ID: {s}. Span ID must be 8 bytes")
+    return s
+
+
 def require_uuid(s: str) -> str:
     lower_s = s.lower()
     if lower_s != s:


### PR DESCRIPTION
## Description

- Fixes WB-23975

Modify regex matching on frontend to match any ID with or without dashes to support OTEL style ID strings. Change validation of call IDs and trace IDs to include OTEL style ID strings.
