### PR TITLE
chore(ui): Scorer page updates

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/AnnotationScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/AnnotationScorerForm.tsx
@@ -10,31 +10,36 @@ import {ScorerFormProps} from './ScorerForms';
 import {ZSForm} from './ZodSchemaForm';
 
 const AnnotationScorerFormSchema = z.object({
-  Name: z.string().min(1),
-  Description: z.string().optional(),
-  Type: z.discriminatedUnion('type', [
-    z.object({
-      type: z.literal('Boolean'),
-    }),
-    z.object({
-      type: z.literal('Integer'),
-      Minimum: z.number().optional(),
-      Maximum: z.number().optional(),
-    }),
-    z.object({
-      type: z.literal('Number'),
-      Minimum: z.number().optional(),
-      Maximum: z.number().optional(),
-    }),
-    z.object({
-      type: z.literal('String'),
-      'Maximum length': z.number().optional(),
-    }),
-    z.object({
-      type: z.literal('Select'),
-      'Select options': z.array(z.string()).min(1),
-    }),
-  ]),
+  Name: z.string().min(1).describe('Annotation name, shown in the interface.'),
+  Description: z
+    .string()
+    .optional()
+    .describe('Visible description of your annotation field in the interface.'),
+  Type: z
+    .discriminatedUnion('type', [
+      z.object({
+        type: z.literal('Boolean'),
+      }),
+      z.object({
+        type: z.literal('Integer'),
+        Minimum: z.number().optional(),
+        Maximum: z.number().optional(),
+      }),
+      z.object({
+        type: z.literal('Number'),
+        Minimum: z.number().optional(),
+        Maximum: z.number().optional(),
+      }),
+      z.object({
+        type: z.literal('String'),
+        'Maximum length': z.number().optional(),
+      }),
+      z.object({
+        type: z.literal('Select'),
+        'Select options': z.array(z.string()).min(1),
+      }),
+    ])
+    .describe('The format of the annotation input.'),
 });
 
 const DEFAULT_STATE = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
@@ -13,9 +13,9 @@ import {TEAL_600} from '../../../../../../common/css/color.styles';
 import {LoadingDots} from '../../../../../LoadingDots';
 import {Timestamp} from '../../../../../Timestamp';
 import {StyledDataGrid} from '../../StyledDataGrid';
+import {basicField} from '../common/DataTable';
 import {Empty} from '../common/Empty';
 import {EMPTY_PROPS_SCORERS} from '../common/EmptyContent';
-import {basicField} from '../common/DataTable';
 import {
   CustomLink,
   ObjectVersionLink,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
@@ -1,37 +1,42 @@
-import React, {useEffect, useMemo, useState} from 'react';
-import {useWFHooks} from '../wfReactInterface/context';
 import {
   GridColDef,
   GridColumnGroupingModel,
   GridRowSelectionModel,
   GridRowsProp,
 } from '@mui/x-data-grid-pro';
+import {Checkbox} from '@wandb/weave/components/Checkbox';
+import {Icon, IconNames} from '@wandb/weave/components/Icon';
+import {UserLink} from '@wandb/weave/components/UserLink';
+import _ from 'lodash';
+import React, {useEffect, useMemo, useState} from 'react';
+
+import {TEAL_600} from '../../../../../../common/css/color.styles';
+import {LoadingDots} from '../../../../../LoadingDots';
+import {Pill} from '../../../../../Tag';
+import {Timestamp} from '../../../../../Timestamp';
 import {StyledDataGrid} from '../../StyledDataGrid';
 import {basicField} from '../common/DataTable';
-import {CustomLink, ObjectVersionLink, objectVersionText} from '../common/Links';
+import {
+  CustomLink,
+  ObjectVersionLink,
+  objectVersionText,
+} from '../common/Links';
 import {
   buildDynamicColumns,
   prepareFlattenedDataForTable,
 } from '../common/tabularListViews/columnBuilder';
-import {Checkbox} from '@wandb/weave/components/Checkbox';
-import {UserLink} from '@wandb/weave/components/UserLink';
-import {Timestamp} from '../../../../../Timestamp';
 import {useURLSearchParamsDict} from '../util';
-import {objectVersionKeyToRefUri} from '../wfReactInterface/utilities';
-import {
-  isTableRef,
-  makeRefExpandedPayload,
-} from '../wfReactInterface/tsDataModelHooksCallRefExpansion';
 import {
   KNOWN_BASE_OBJECT_CLASSES,
   OBJECT_ATTR_EDGE_NAME,
 } from '../wfReactInterface/constants';
-import _ from 'lodash';
-import {Pill} from '../../../../../Tag';
+import {useWFHooks} from '../wfReactInterface/context';
+import {
+  isTableRef,
+  makeRefExpandedPayload,
+} from '../wfReactInterface/tsDataModelHooksCallRefExpansion';
+import {objectVersionKeyToRefUri} from '../wfReactInterface/utilities';
 import {ObjectVersionSchema} from '../wfReactInterface/wfDataModelHooksInterface';
-import {TEAL_600} from '../../../../../../common/css/color.styles';
-import {LoadingDots} from '../../../../../LoadingDots';
-import {Icon, IconNames} from '@wandb/weave/components/Icon';
 
 // Custom table component specifically for scorers with a custom category column
 const ScorerObjectVersionsTable: React.FC<{
@@ -47,7 +52,7 @@ const ScorerObjectVersionsTable: React.FC<{
 }> = props => {
   const {selectedVersions, setSelectedVersions} = props;
   const showPropsAsColumns = !props.hidePropsAsColumns;
-  
+
   const rows: GridRowsProp = useMemo(() => {
     const vals = props.objectVersions.map(ov => ov.val);
     const flat = prepareFlattenedDataForTable(vals);
@@ -116,7 +121,7 @@ const ScorerObjectVersionsTable: React.FC<{
             },
           ]
         : [];
-    
+
     const cols: GridColDef[] = [
       ...checkboxColumnArr,
 
@@ -211,14 +216,14 @@ const ScorerObjectVersionsTable: React.FC<{
           // Custom rendering based on scorer type
           if (category === 'AnnotationSpec') {
             return (
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
                 <Icon name={IconNames.UsersTeam} size="sm" />
                 <span>Human Annotation</span>
               </div>
             );
           } else if (category === 'Scorer') {
             return (
-              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
                 <Icon name={IconNames.CodeAlt} size="sm" />
                 <span>Programmatic Scorer</span>
               </div>
@@ -387,4 +392,4 @@ export const CombinedScorersTable: React.FC<{
       objectTitle="Scorer"
     />
   );
-}; 
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
@@ -13,6 +13,8 @@ import {TEAL_600} from '../../../../../../common/css/color.styles';
 import {LoadingDots} from '../../../../../LoadingDots';
 import {Timestamp} from '../../../../../Timestamp';
 import {StyledDataGrid} from '../../StyledDataGrid';
+import {Empty} from '../common/Empty';
+import {EMPTY_PROPS_SCORERS} from '../common/EmptyContent';
 import {basicField} from '../common/DataTable';
 import {
   CustomLink,
@@ -374,16 +376,20 @@ export const CombinedScorersTable: React.FC<{
   );
 
   if (objectVersions.loading) {
-    return <div>Loading...</div>;
+    return <LoadingDots />;
   }
 
   if (objectVersions.error) {
     return <div>Error loading scorers</div>;
   }
 
+  if (!objectVersions.result || objectVersions.result.length === 0) {
+    return <Empty {...EMPTY_PROPS_SCORERS} />;
+  }
+
   return (
     <ScorerObjectVersionsTable
-      objectVersions={objectVersions.result ?? []}
+      objectVersions={objectVersions.result}
       objectTitle="Scorer"
     />
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
@@ -1,0 +1,390 @@
+import React, {useEffect, useMemo, useState} from 'react';
+import {useWFHooks} from '../wfReactInterface/context';
+import {
+  GridColDef,
+  GridColumnGroupingModel,
+  GridRowSelectionModel,
+  GridRowsProp,
+} from '@mui/x-data-grid-pro';
+import {StyledDataGrid} from '../../StyledDataGrid';
+import {basicField} from '../common/DataTable';
+import {CustomLink, ObjectVersionLink, objectVersionText} from '../common/Links';
+import {
+  buildDynamicColumns,
+  prepareFlattenedDataForTable,
+} from '../common/tabularListViews/columnBuilder';
+import {Checkbox} from '@wandb/weave/components/Checkbox';
+import {UserLink} from '@wandb/weave/components/UserLink';
+import {Timestamp} from '../../../../../Timestamp';
+import {useURLSearchParamsDict} from '../util';
+import {objectVersionKeyToRefUri} from '../wfReactInterface/utilities';
+import {
+  isTableRef,
+  makeRefExpandedPayload,
+} from '../wfReactInterface/tsDataModelHooksCallRefExpansion';
+import {
+  KNOWN_BASE_OBJECT_CLASSES,
+  OBJECT_ATTR_EDGE_NAME,
+} from '../wfReactInterface/constants';
+import _ from 'lodash';
+import {Pill} from '../../../../../Tag';
+import {ObjectVersionSchema} from '../wfReactInterface/wfDataModelHooksInterface';
+import {TEAL_600} from '../../../../../../common/css/color.styles';
+import {LoadingDots} from '../../../../../LoadingDots';
+import {Icon, IconNames} from '@wandb/weave/components/Icon';
+
+// Custom table component specifically for scorers with a custom category column
+const ScorerObjectVersionsTable: React.FC<{
+  objectVersions: ObjectVersionSchema[];
+  objectTitle?: string;
+  onRowClick?: (objectVersion: ObjectVersionSchema) => void;
+  selectedVersions?: string[];
+  setSelectedVersions?: (selected: string[]) => void;
+  hidePropsAsColumns?: boolean;
+  hidePeerVersionsColumn?: boolean;
+  hideCreatedAtColumn?: boolean;
+  hideVersionSuffix?: boolean;
+}> = props => {
+  const {selectedVersions, setSelectedVersions} = props;
+  const showPropsAsColumns = !props.hidePropsAsColumns;
+  
+  const rows: GridRowsProp = useMemo(() => {
+    const vals = props.objectVersions.map(ov => ov.val);
+    const flat = prepareFlattenedDataForTable(vals);
+
+    return props.objectVersions.map((ov, i) => {
+      let val = flat[i];
+      return {
+        id: objectVersionKeyToRefUri(ov),
+        obj: {
+          ...ov,
+          val,
+        },
+      };
+    });
+  }, [props.objectVersions]);
+
+  const showUserColumn = rows.some(row => row.obj.userId != null);
+
+  const {cols: columns, groups: columnGroupingModel} = useMemo(() => {
+    let groups: GridColumnGroupingModel = [];
+    const checkboxColumnArr: GridColDef[] =
+      selectedVersions != null && setSelectedVersions
+        ? [
+            {
+              minWidth: 30,
+              width: 34,
+              field: 'CustomCheckbox',
+              sortable: false,
+              disableColumnMenu: true,
+              resizable: false,
+              disableExport: true,
+              display: 'flex',
+              renderHeader: () => null,
+              renderCell: (params: any) => {
+                const {objectId, versionIndex} = params.row.obj;
+                const objSpecifier = `${objectId}:v${versionIndex}`;
+                const isSelected = selectedVersions.includes(objSpecifier);
+                return (
+                  <Checkbox
+                    size="small"
+                    checked={isSelected}
+                    onCheckedChange={() => {
+                      if (isSelected) {
+                        setSelectedVersions(
+                          selectedVersions.filter(id => id !== objSpecifier)
+                        );
+                      } else {
+                        // Keep the objects in sorted order, regardless of the order checked.
+                        setSelectedVersions(
+                          [...selectedVersions, objSpecifier].sort((a, b) => {
+                            const [aName, aVer] = a.split(':');
+                            const [bName, bVer] = b.split(':');
+                            if (aName !== bName) {
+                              return aName.localeCompare(bName);
+                            }
+                            const aNum = parseInt(aVer.slice(1), 10);
+                            const bNum = parseInt(bVer.slice(1), 10);
+                            return aNum - bNum;
+                          })
+                        );
+                      }
+                    }}
+                  />
+                );
+              },
+            },
+          ]
+        : [];
+    
+    const cols: GridColDef[] = [
+      ...checkboxColumnArr,
+
+      // Object name column
+      basicField('weave__object_version_link', props.objectTitle ?? 'Object', {
+        hideable: false,
+        valueGetter: (unused: any, row: any) => {
+          return row.obj.objectId;
+        },
+        renderCell: cellParams => {
+          const obj: ObjectVersionSchema = cellParams.row.obj;
+          if (props.onRowClick) {
+            let text = props.hideVersionSuffix
+              ? obj.objectId
+              : objectVersionText(obj.objectId, obj.versionIndex);
+
+            if (obj.val.name) {
+              text = obj.val.name;
+            }
+
+            return (
+              <CustomLink text={text} onClick={() => props.onRowClick?.(obj)} />
+            );
+          }
+          return (
+            <ObjectVersionLink
+              entityName={obj.entity}
+              projectName={obj.project}
+              objectName={obj.objectId}
+              version={obj.versionHash}
+              versionIndex={obj.versionIndex}
+              fullWidth={true}
+              color={TEAL_600}
+              hideVersionSuffix={props.hideVersionSuffix}
+            />
+          );
+        },
+      }),
+    ];
+
+    // Add dynamic columns if needed
+    if (showPropsAsColumns) {
+      const dynamicFields: string[] = [];
+      const dynamicFieldSet = new Set<string>();
+      rows.forEach(r => {
+        Object.keys(r.obj.val).forEach(k => {
+          if (!dynamicFieldSet.has(k)) {
+            dynamicFieldSet.add(k);
+            dynamicFields.push(k);
+          }
+        });
+      });
+
+      const {cols: newCols, groupingModel} = buildDynamicColumns<{
+        obj: ObjectVersionSchema;
+      }>(
+        dynamicFields,
+        row => ({
+          entity: row.obj.entity,
+          project: row.obj.project,
+        }),
+        (row, key) => {
+          const obj: ObjectVersionSchema = row.obj;
+          const res = obj.val?.[key];
+          if (isTableRef(res)) {
+            const selfRefUri = objectVersionKeyToRefUri(obj);
+            const targetRefUri =
+              selfRefUri +
+              ('/' +
+                OBJECT_ATTR_EDGE_NAME +
+                '/' +
+                key.split('.').join(OBJECT_ATTR_EDGE_NAME + '/'));
+            return makeRefExpandedPayload(targetRefUri, res);
+          }
+          return res;
+        }
+      );
+      cols.push(...newCols);
+      groups = groupingModel;
+    }
+
+    // Custom category column for scorers
+    cols.push(
+      basicField('baseObjectClass', 'Type', {
+        width: 200,
+        display: 'flex',
+        valueGetter: (unused: any, row: any) => {
+          return row.obj.baseObjectClass;
+        },
+        renderCell: cellParams => {
+          const category = cellParams.value;
+          // Custom rendering based on scorer type
+          if (category === 'AnnotationSpec') {
+            return (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <Icon name={IconNames.UsersTeam} size="sm" />
+                <span>Human Annotation</span>
+              </div>
+            );
+          } else if (category === 'Scorer') {
+            return (
+              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <Icon name={IconNames.CodeAlt} size="sm" />
+                <span>Programmatic Scorer</span>
+              </div>
+            );
+          }
+          return null;
+        },
+      })
+    );
+
+    if (showUserColumn) {
+      cols.push(
+        basicField('userId', 'User', {
+          width: 150,
+          filterable: false,
+          sortable: false,
+          valueGetter: (unused: any, row: any) => {
+            return row.obj.userId;
+          },
+          renderCell: (params: any) => {
+            const userId = params.value;
+            if (userId == null) {
+              return <div></div>;
+            }
+            return <UserLink userId={userId} includeName />;
+          },
+        })
+      );
+    }
+
+    if (!props.hideCreatedAtColumn) {
+      cols.push(
+        basicField('createdAtMs', 'Created', {
+          width: 100,
+          valueGetter: (unused: any, row: any) => {
+            return row.obj.createdAtMs;
+          },
+          renderCell: cellParams => {
+            const createdAtMs = cellParams.value;
+            return <Timestamp value={createdAtMs / 1000} format="relative" />;
+          },
+        })
+      );
+    }
+
+    if (!props.hidePeerVersionsColumn) {
+      cols.push(
+        basicField('peerVersions', 'Versions', {
+          width: 100,
+          sortable: false,
+          filterable: false,
+          renderCell: cellParams => {
+            const obj: ObjectVersionSchema = cellParams.row.obj;
+            return <PeerVersionsLink obj={obj} />;
+          },
+        })
+      );
+    }
+
+    return {cols, groups};
+  }, [
+    props,
+    showPropsAsColumns,
+    rows,
+    selectedVersions,
+    setSelectedVersions,
+    showUserColumn,
+  ]);
+
+  // Highlight table row if it matches peek drawer.
+  const query = useURLSearchParamsDict();
+  const {peekPath} = query;
+  const peekId = peekPath ? peekPath.split('/').pop() : null;
+  const rowIds = useMemo(() => {
+    return rows.map(row => row.id);
+  }, [rows]);
+  const [rowSelectionModel, setRowSelectionModel] =
+    useState<GridRowSelectionModel>([]);
+  useEffect(() => {
+    if (rowIds.length === 0) {
+      return;
+    }
+    if (peekId == null) {
+      setRowSelectionModel([]);
+    } else {
+      if (rowIds.includes(peekId)) {
+        setRowSelectionModel([peekId]);
+      }
+    }
+  }, [rowIds, peekId]);
+
+  return (
+    <StyledDataGrid
+      disableColumnMenu={true}
+      disableColumnFilter={true}
+      disableMultipleColumnsFiltering={true}
+      disableColumnPinning={false}
+      disableColumnReorder={true}
+      disableColumnResize={false}
+      disableColumnSelector={true}
+      disableMultipleColumnsSorting={true}
+      rows={rows}
+      initialState={{
+        sorting: {
+          sortModel: [{field: 'baseObjectClass', sort: 'asc'}],
+        },
+      }}
+      columnHeaderHeight={40}
+      rowHeight={38}
+      columns={columns}
+      disableRowSelectionOnClick
+      rowSelectionModel={rowSelectionModel}
+      columnGroupingModel={columnGroupingModel}
+    />
+  );
+};
+
+// Helper component to show peer versions link (simplified for this example)
+const PeerVersionsLink: React.FC<{obj: ObjectVersionSchema}> = props => {
+  const {useRootObjectVersions} = useWFHooks();
+
+  const obj = props.obj;
+  const objectVersionsNode = useRootObjectVersions(
+    obj.entity,
+    obj.project,
+    {
+      objectIds: [obj.objectId],
+    },
+    100,
+    true
+  );
+  if (objectVersionsNode.loading) {
+    return <LoadingDots />;
+  }
+  const countValue = objectVersionsNode.result?.length ?? 0;
+  return <div>{countValue} versions</div>;
+};
+
+export const CombinedScorersTable: React.FC<{
+  entity: string;
+  project: string;
+}> = ({entity, project}) => {
+  const {useRootObjectVersions} = useWFHooks();
+  const objectVersions = useRootObjectVersions(
+    entity,
+    project,
+    {
+      baseObjectClasses: ['Scorer', 'AnnotationSpec'],
+      latestOnly: true,
+    },
+    undefined,
+    true
+  );
+
+  if (objectVersions.loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (objectVersions.error) {
+    return <div>Error loading scorers</div>;
+  }
+
+  return (
+    <ScorerObjectVersionsTable
+      objectVersions={objectVersions.result ?? []}
+      objectTitle="Scorer"
+    />
+  );
+}; 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/CombinedScorersTable.tsx
@@ -7,12 +7,10 @@ import {
 import {Checkbox} from '@wandb/weave/components/Checkbox';
 import {Icon, IconNames} from '@wandb/weave/components/Icon';
 import {UserLink} from '@wandb/weave/components/UserLink';
-import _ from 'lodash';
 import React, {useEffect, useMemo, useState} from 'react';
 
 import {TEAL_600} from '../../../../../../common/css/color.styles';
 import {LoadingDots} from '../../../../../LoadingDots';
-import {Pill} from '../../../../../Tag';
 import {Timestamp} from '../../../../../Timestamp';
 import {StyledDataGrid} from '../../StyledDataGrid';
 import {basicField} from '../common/DataTable';
@@ -26,10 +24,7 @@ import {
   prepareFlattenedDataForTable,
 } from '../common/tabularListViews/columnBuilder';
 import {useURLSearchParamsDict} from '../util';
-import {
-  KNOWN_BASE_OBJECT_CLASSES,
-  OBJECT_ATTR_EDGE_NAME,
-} from '../wfReactInterface/constants';
+import {OBJECT_ATTR_EDGE_NAME} from '../wfReactInterface/constants';
 import {useWFHooks} from '../wfReactInterface/context';
 import {
   isTableRef,
@@ -58,7 +53,7 @@ const ScorerObjectVersionsTable: React.FC<{
     const flat = prepareFlattenedDataForTable(vals);
 
     return props.objectVersions.map((ov, i) => {
-      let val = flat[i];
+      const val = flat[i];
       return {
         id: objectVersionKeyToRefUri(ov),
         obj: {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/FormComponents.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/FormComponents.tsx
@@ -3,18 +3,23 @@ import {Select} from '@wandb/weave/components/Form/Select';
 import {TextField} from '@wandb/weave/components/Form/TextField';
 import React from 'react';
 
+import {MOON_500} from '../../../../../../common/css/color.styles';
+
 export const GAP_BETWEEN_ITEMS_PX = 16;
 export const GAP_BETWEEN_LABEL_AND_FIELD_PX = 10;
+export const GAP_BETWEEN_DESCRIPTION_AND_FIELD_PX = 8;
 
 type AutocompleteWithLabelType<Option = any> = (
   props: {
     label?: string;
+    description?: string;
     style?: React.CSSProperties;
   } & React.ComponentProps<typeof Select<Option>>
 ) => React.ReactElement;
 
 export const AutocompleteWithLabel: AutocompleteWithLabelType = ({
   label,
+  description,
   style,
   ...props
 }) => (
@@ -25,9 +30,26 @@ export const AutocompleteWithLabel: AutocompleteWithLabelType = ({
       ...style,
     }}>
     {label && (
-      <InputLabel style={{marginBottom: GAP_BETWEEN_LABEL_AND_FIELD_PX + 'px'}}>
-        {label}
-      </InputLabel>
+      <>
+        <InputLabel
+          style={{
+            marginBottom: description
+              ? '0px'
+              : GAP_BETWEEN_LABEL_AND_FIELD_PX + 'px',
+          }}>
+          {label}
+        </InputLabel>
+        {description && (
+          <div
+            style={{
+              color: MOON_500,
+              fontSize: '0.875rem',
+              marginBottom: GAP_BETWEEN_DESCRIPTION_AND_FIELD_PX + 'px',
+            }}>
+            {description}
+          </div>
+        )}
+      </>
     )}
     <Select {...props} />
   </Box>
@@ -36,6 +58,7 @@ export const AutocompleteWithLabel: AutocompleteWithLabelType = ({
 type TextFieldWithLabelType = (
   props: {
     label?: string;
+    description?: string;
     style?: React.CSSProperties;
     isOptional?: boolean;
   } & React.ComponentProps<typeof TextField>
@@ -43,6 +66,7 @@ type TextFieldWithLabelType = (
 
 export const TextFieldWithLabel: TextFieldWithLabelType = ({
   label,
+  description,
   style,
   isOptional,
   ...props
@@ -54,25 +78,39 @@ export const TextFieldWithLabel: TextFieldWithLabelType = ({
       ...style,
     }}>
     {label && (
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          marginBottom: GAP_BETWEEN_LABEL_AND_FIELD_PX + 'px',
-        }}>
-        <InputLabel>{label}</InputLabel>
-        {isOptional && (
-          <span
+      <>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            marginBottom: description
+              ? '0px'
+              : GAP_BETWEEN_LABEL_AND_FIELD_PX + 'px',
+          }}>
+          <InputLabel>{label}</InputLabel>
+          {isOptional && (
+            <span
+              style={{
+                color: MOON_500,
+                marginLeft: '4px',
+                alignSelf: 'center',
+                fontSize: '14px',
+              }}>
+              (optional)
+            </span>
+          )}
+        </div>
+        {description && (
+          <div
             style={{
-              color: 'gray',
-              marginLeft: '4px',
-              alignSelf: 'center',
-              fontSize: '14px',
+              color: MOON_500,
+              fontSize: '0.875rem',
+              marginBottom: GAP_BETWEEN_DESCRIPTION_AND_FIELD_PX + 'px',
             }}>
-            (optional)
-          </span>
+            {description}
+          </div>
         )}
-      </div>
+      </>
     )}
     <TextField {...props} />
   </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
@@ -1,7 +1,8 @@
-import { Box, Typography } from '@material-ui/core';
-import { Button } from '@wandb/weave/components/Button';
-import { Icon, IconName, IconNames } from '@wandb/weave/components/Icon';
-import { MOON_200, MOON_300 } from '@wandb/weave/common/css/color.styles';
+import {Box, Typography} from '@material-ui/core';
+import {MOON_200, MOON_300} from '@wandb/weave/common/css/color.styles';
+import {Link} from '@wandb/weave/common/util/links';
+import {Button} from '@wandb/weave/components/Button';
+import {Icon, IconName, IconNames} from '@wandb/weave/components/Icon';
 import React, {
   FC,
   ReactNode,
@@ -10,15 +11,14 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { Link } from '@wandb/weave/common/util/links';
 
-import { ResizableDrawer } from '../common/ResizableDrawer';
-import { TraceServerClient } from '../wfReactInterface/traceServerClient';
-import { useGetTraceServerClientContext } from '../wfReactInterface/traceServerClientContext';
+import {ResizableDrawer} from '../common/ResizableDrawer';
+import {TraceServerClient} from '../wfReactInterface/traceServerClient';
+import {useGetTraceServerClientContext} from '../wfReactInterface/traceServerClientContext';
 import * as AnnotationScorerForm from './AnnotationScorerForm';
-import { AutocompleteWithLabel } from './FormComponents';
+import {AutocompleteWithLabel} from './FormComponents';
 import * as LLMJudgeScorerForm from './LLMJudgeScorerForm';
-import { ProgrammaticScorerForm, ScorerFormProps } from './ScorerForms';
+import {ProgrammaticScorerForm, ScorerFormProps} from './ScorerForms';
 
 const HUMAN_ANNOTATION_LABEL = 'Human annotation';
 export const HUMAN_ANNOTATION_VALUE = 'ANNOTATION';
@@ -31,7 +31,7 @@ export type ScorerType =
   | typeof HUMAN_ANNOTATION_VALUE
   | typeof LLM_JUDGE_VALUE
   | typeof PROGRAMMATIC_VALUE;
-type OptionType = { label: string; value: ScorerType; icon: IconName };
+type OptionType = {label: string; value: ScorerType; icon: IconName};
 
 interface ScorerTypeConfig<T> extends OptionType {
   Component: FC<ScorerFormProps<T>>;
@@ -71,7 +71,7 @@ export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig<any>> = {
 };
 
 const scorerTypeOptions: OptionType[] = Object.values(scorerTypeRecord).map(
-  ({ label, value, icon }) => ({ label, value, icon })
+  ({label, value, icon}) => ({label, value, icon})
 );
 
 interface NewScorerDrawerProps {
@@ -140,14 +140,16 @@ export const NewScorerDrawer: FC<NewScorerDrawerProps> = ({
             alignItems: 'center',
             height: 44,
             minHeight: 44,
-            pl: 2,
-            pr: 1,
+            pl: 4,
+            pr: 2,
             borderBottom: `1px solid ${MOON_300}`,
           }}>
-          <Typography variant="h6" style={{ fontFamily: 'Source Sans Pro', fontWeight: 600 }}>
+          <Typography
+            variant="h6"
+            style={{fontFamily: 'Source Sans Pro', fontWeight: 600}}>
             Create new scorer
           </Typography>
-          <Box sx={{ display: 'flex', marginLeft: 1 }}>
+          <Box sx={{display: 'flex', marginLeft: 1}}>
             <Button
               onClick={handleToggleFullscreen}
               variant="ghost"
@@ -176,8 +178,6 @@ export const NewScorerDrawer: FC<NewScorerDrawerProps> = ({
             flexGrow: 1,
             overflow: 'auto',
           }}>
-
-
           <Box
             style={{
               backgroundColor: MOON_200,
@@ -185,10 +185,14 @@ export const NewScorerDrawer: FC<NewScorerDrawerProps> = ({
               borderRadius: '8px',
             }}>
             <Box mb={1}>
-              This form will allow you to create a <span style={{ fontWeight: 'semibold' }}>Human Annotation</span> scorer which can be used in the trace interface.
+              This form will allow you to create a{' '}
+              <span style={{fontWeight: '600'}}>Human Annotation</span> scorer
+              which can be used in the trace interface.
             </Box>
             <Box>
-              If you would like to create a <span style={{ fontWeight: 'semibold' }}>Programmatic Scorer</span>, please use Python and refer to the{' '}
+              If you would like to create a{' '}
+              <span style={{fontWeight: '600'}}>Programmatic Scorer</span>,
+              please use Python and refer to the{' '}
               <Link to="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">
                 scorer documentation
               </Link>{' '}
@@ -196,7 +200,7 @@ export const NewScorerDrawer: FC<NewScorerDrawerProps> = ({
             </Box>
           </Box>
 
-          <Box sx={{ mt: 4 }}>
+          <Box sx={{mt: 4}}>
             <AnnotationScorerForm.AnnotationScorerForm
               data={formData}
               onDataChange={handleFormDataChange}
@@ -205,8 +209,8 @@ export const NewScorerDrawer: FC<NewScorerDrawerProps> = ({
         </Box>
         <Box
           sx={{
-            pt: "10px",
-            pb: "9px",
+            pt: '10px',
+            pb: '9px',
             px: 0,
             borderTop: `1px solid ${MOON_300}`,
             bgcolor: 'background.paper',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
@@ -2,21 +2,13 @@ import {Box, Typography} from '@material-ui/core';
 import {MOON_200, MOON_300} from '@wandb/weave/common/css/color.styles';
 import {Link} from '@wandb/weave/common/util/links';
 import {Button} from '@wandb/weave/components/Button';
-import {Icon, IconName, IconNames} from '@wandb/weave/components/Icon';
-import React, {
-  FC,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import {IconName, IconNames} from '@wandb/weave/components/Icon';
+import React, {FC, useCallback, useState} from 'react';
 
 import {ResizableDrawer} from '../common/ResizableDrawer';
 import {TraceServerClient} from '../wfReactInterface/traceServerClient';
 import {useGetTraceServerClientContext} from '../wfReactInterface/traceServerClientContext';
 import * as AnnotationScorerForm from './AnnotationScorerForm';
-import {AutocompleteWithLabel} from './FormComponents';
 import * as LLMJudgeScorerForm from './LLMJudgeScorerForm';
 import {ProgrammaticScorerForm, ScorerFormProps} from './ScorerForms';
 
@@ -69,10 +61,6 @@ export const scorerTypeRecord: Record<ScorerType, ScorerTypeConfig<any>> = {
     },
   },
 };
-
-const scorerTypeOptions: OptionType[] = Object.values(scorerTypeRecord).map(
-  ({label, value, icon}) => ({label, value, icon})
-);
 
 interface NewScorerDrawerProps {
   entity: string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/NewScorerDrawer.tsx
@@ -1,5 +1,5 @@
 import {Box, Typography} from '@material-ui/core';
-import {MOON_200, MOON_300} from '@wandb/weave/common/css/color.styles';
+import {MOON_200, MOON_300, MOON_600} from '@wandb/weave/common/css/color.styles';
 import {Link} from '@wandb/weave/common/util/links';
 import {Button} from '@wandb/weave/components/Button';
 import {IconName, IconNames} from '@wandb/weave/components/Icon';
@@ -169,16 +169,16 @@ export const NewScorerDrawer: FC<NewScorerDrawerProps> = ({
           <Box
             style={{
               backgroundColor: MOON_200,
+              color: MOON_600,
               padding: '16px',
               borderRadius: '8px',
             }}>
             <Box mb={1}>
-              This form will allow you to create a{' '}
-              <span style={{fontWeight: '600'}}>Human Annotation</span> scorer
-              which can be used in the trace interface.
+              <span style={{fontWeight: '600'}}>Human Annotation</span> scorers
+              can be used in the trace interface.
             </Box>
             <Box>
-              If you would like to create a{' '}
+              To create a{' '}
               <span style={{fontWeight: '600'}}>Programmatic Scorer</span>,
               please use Python and refer to the{' '}
               <Link to="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorerForms.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorerForms.tsx
@@ -20,10 +20,14 @@ export const ProgrammaticScorerForm: FC<ScorerFormProps<any>> = ({
         borderRadius: '8px',
       }}>
       <Box mb={1}>
-        This form will allow you to create a <span style={{fontWeight: 'semibold'}}>Human Annotation</span> scorer which can be used in the trace interface.
+        This form will allow you to create a{' '}
+        <span style={{fontWeight: 'semibold'}}>Human Annotation</span> scorer
+        which can be used in the trace interface.
       </Box>
       <Box>
-        If you would like to create a <span style={{fontWeight: 'semibold'}}>Programmatic Scorer</span>, please use Python and refer to the{' '}
+        If you would like to create a{' '}
+        <span style={{fontWeight: 'semibold'}}>Programmatic Scorer</span>,
+        please use Python and refer to the{' '}
         <Link to="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">
           scorer documentation
         </Link>{' '}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorerForms.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorerForms.tsx
@@ -19,11 +19,16 @@ export const ProgrammaticScorerForm: FC<ScorerFormProps<any>> = ({
         padding: '16px',
         borderRadius: '8px',
       }}>
-      Programmatic scorers must be written in Python. Please refer to the{' '}
-      <Link to="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">
-        scorer documentation
-      </Link>{' '}
-      for more information.
+      <Box mb={1}>
+        This form will allow you to create a <span style={{fontWeight: 'semibold'}}>Human Annotation</span> scorer which can be used in the trace interface.
+      </Box>
+      <Box>
+        If you would like to create a <span style={{fontWeight: 'semibold'}}>Programmatic Scorer</span>, please use Python and refer to the{' '}
+        <Link to="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">
+          scorer documentation
+        </Link>{' '}
+        for more information.
+      </Box>
     </Box>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
@@ -3,13 +3,13 @@ import {IconNames} from '@wandb/weave/components/Icon';
 import React, {useState} from 'react';
 
 import {SimplePageLayoutWithHeader} from '../common/SimplePageLayout';
+import {CombinedScorersTable} from './CombinedScorersTable';
 import {
   HUMAN_ANNOTATION_VALUE,
   NewScorerDrawer,
   ScorerType,
   scorerTypeRecord,
 } from './NewScorerDrawer';
-import {CombinedScorersTable} from './CombinedScorersTable';
 
 export const ScorersPage: React.FC<{
   entity: string;
@@ -27,8 +27,8 @@ export const ScorersPage: React.FC<{
         tabs={[
           {
             label: 'All Scorers',
-            content: <CombinedScorersTable entity={entity} project={project} />
-          }
+            content: <CombinedScorersTable entity={entity} project={project} />,
+          },
         ]}
         hideTabsIfSingle
         headerExtra={

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
@@ -35,8 +35,8 @@ export const ScorersPage: React.FC<{
           <Button
             icon={IconNames.AddNew}
             onClick={() => setIsModalOpen(true)}
-            variant="secondary">
-            Create scorer
+            variant="ghost">
+            New scorer
           </Button>
         }
         headerContent={undefined}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
@@ -3,21 +3,20 @@ import {IconNames} from '@wandb/weave/components/Icon';
 import React, {useState} from 'react';
 
 import {SimplePageLayoutWithHeader} from '../common/SimplePageLayout';
-import {AnnotationsTab} from './AnnotationsTab';
-import {ProgrammaticScorersTab} from './CoreScorersTab';
 import {
   HUMAN_ANNOTATION_VALUE,
   NewScorerDrawer,
   ScorerType,
   scorerTypeRecord,
 } from './NewScorerDrawer';
+import {CombinedScorersTable} from './CombinedScorersTable';
 
 export const ScorersPage: React.FC<{
   entity: string;
   project: string;
 }> = ({entity, project}) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedTab, setSelectedTab] = useState<ScorerType>(
+  const [selectedScorerType, setSelectedScorerType] = useState<ScorerType>(
     scorerTypeRecord.ANNOTATION.value
   );
 
@@ -27,18 +26,11 @@ export const ScorersPage: React.FC<{
         title="Scorers"
         tabs={[
           {
-            label: scorerTypeRecord.ANNOTATION.label + 's',
-            icon: scorerTypeRecord.ANNOTATION.icon,
-            content: <AnnotationsTab entity={entity} project={project} />,
-          },
-          {
-            label: scorerTypeRecord.PROGRAMMATIC.label + 's',
-            icon: scorerTypeRecord.PROGRAMMATIC.icon,
-            content: (
-              <ProgrammaticScorersTab entity={entity} project={project} />
-            ),
-          },
+            label: 'All Scorers',
+            content: <CombinedScorersTable entity={entity} project={project} />
+          }
         ]}
+        hideTabsIfSingle
         headerExtra={
           <Button
             icon={IconNames.AddNew}
@@ -48,19 +40,12 @@ export const ScorersPage: React.FC<{
           </Button>
         }
         headerContent={undefined}
-        onTabSelectedCallback={tab =>
-          setSelectedTab(
-            // Hacky that we have to do the `"s"` thing, but it works
-            Object.values(scorerTypeRecord).find(t => t.label + 's' === tab)
-              ?.value ?? HUMAN_ANNOTATION_VALUE
-          )
-        }
       />
       <NewScorerDrawer
         entity={entity}
         project={project}
         open={isModalOpen}
-        initialScorerType={selectedTab}
+        initialScorerType={selectedScorerType}
         onClose={() => setIsModalOpen(false)}
       />
     </>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ScorersPage.tsx
@@ -4,19 +4,14 @@ import React, {useState} from 'react';
 
 import {SimplePageLayoutWithHeader} from '../common/SimplePageLayout';
 import {CombinedScorersTable} from './CombinedScorersTable';
-import {
-  HUMAN_ANNOTATION_VALUE,
-  NewScorerDrawer,
-  ScorerType,
-  scorerTypeRecord,
-} from './NewScorerDrawer';
+import {NewScorerDrawer, ScorerType, scorerTypeRecord} from './NewScorerDrawer';
 
 export const ScorersPage: React.FC<{
   entity: string;
   project: string;
 }> = ({entity, project}) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedScorerType, setSelectedScorerType] = useState<ScorerType>(
+  const [selectedScorerType] = useState<ScorerType>(
     scorerTypeRecord.ANNOTATION.value
   );
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ZodSchemaForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ScorersPage/ZodSchemaForm.tsx
@@ -119,6 +119,7 @@ const DiscriminatedUnionField: React.FC<{
     <Box style={{marginBottom: GAP_BETWEEN_ITEMS_PX + 'px'}}>
       <AutocompleteWithLabel
         label={keyName}
+        description={getFieldDescription(fieldSchema)}
         options={options.map(option => ({
           value: distiminatorOptionToValue(option, discriminator),
           label: distiminatorOptionToValue(option, discriminator),
@@ -338,6 +339,7 @@ const NestedForm: React.FC<{
     <TextFieldWithLabel
       isOptional={isOptional}
       label={!hideLabel ? keyName : undefined}
+      description={getFieldDescription(fieldSchema)}
       type={fieldType}
       value={currentValue ?? ''}
       onChange={handleChange}
@@ -507,6 +509,7 @@ const EnumField: React.FC<{
   return (
     <AutocompleteWithLabel
       label={noLabel ? undefined : keyName}
+      description={getFieldDescription(fieldSchema)}
       options={options.map(option => ({value: option, label: option}))}
       value={{
         value: selectedValue,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Empty.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Empty.tsx
@@ -17,6 +17,8 @@ export type EmptyProps = {
   description: string;
   moreInformation: React.ReactNode;
   size?: EmptySize;
+  entity?: string;
+  project?: string;
 };
 
 const Container = styled.div`
@@ -92,16 +94,22 @@ export const Empty = ({
   description,
   moreInformation,
   size = 'medium',
+  entity,
+  project,
 }: EmptyProps) => {
   return (
     <Container>
       <Content>
         <Circle size={size}>
-          <CircleIcon size={size} name={icon} />
+          <CircleIcon name={icon} size={size} />
         </Circle>
         <Heading size={size}>{heading}</Heading>
         <Description size={size}>{description}</Description>
-        <MoreInformation size={size}>{moreInformation}</MoreInformation>
+        <MoreInformation size={size}>
+          {typeof moreInformation === 'function'
+            ? moreInformation({entity, project})
+            : moreInformation}
+        </MoreInformation>
       </Content>
     </Container>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -222,3 +222,22 @@ export const EMPTY_PROPS_ANNOTATIONS: EmptyProps = {
     </>
   ),
 };
+
+export const EMPTY_PROPS_SCORERS: EmptyProps = {
+  icon: 'type-number-alt' as const,
+  heading: 'No scorers yet',
+  description: 'Create programmatic scorers in Python or human annotations in the UI.',
+  moreInformation: (
+    <>
+      Learn about{' '}
+      <TargetBlank href="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">
+        programmatic scorers
+      </TargetBlank>
+      {' '}or{' '}
+      <TargetBlank href="https://weave-docs.wandb.ai/guides/tracking/feedback#add-human-annotations">
+        human annotations
+      </TargetBlank>
+      {' '}to get started.
+    </>
+  ),
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -1,8 +1,35 @@
-import React from 'react';
+import React, {useState} from 'react';
+import {Box} from '@mui/material';
 
 import {TargetBlank} from '../../../../../../common/util/links';
+import {Button} from '../../../../../Button';
 import {EmptyProps} from './Empty';
 import {Link} from './Links';
+import {NewScorerDrawer} from '../ScorersPage/NewScorerDrawer';
+
+const NewScorerButton: React.FC<{entity: string; project: string}> = ({
+  entity,
+  project,
+}) => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="primary"
+        icon="add-new"
+        onClick={() => setIsDrawerOpen(true)}>
+        New scorer
+      </Button>
+      <NewScorerDrawer
+        open={isDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+        entity={entity}
+        project={project}
+      />
+    </>
+  );
+};
 
 export const EMPTY_PROPS_TRACES: EmptyProps = {
   icon: 'layout-tabs' as const,
@@ -225,10 +252,10 @@ export const EMPTY_PROPS_ANNOTATIONS: EmptyProps = {
 
 export const EMPTY_PROPS_SCORERS: EmptyProps = {
   icon: 'type-number-alt' as const,
-  heading: 'No scorers yet',
+  heading: 'Create your first scorer',
   description:
     'Create programmatic scorers in Python or human annotations in the UI.',
-  moreInformation: (
+  moreInformation: ({entity, project}: {entity: string; project: string}) => (
     <>
       Learn about{' '}
       <TargetBlank href="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">
@@ -239,6 +266,9 @@ export const EMPTY_PROPS_SCORERS: EmptyProps = {
         human annotations
       </TargetBlank>{' '}
       to get started.
+      <Box sx={{mt: 2}}>
+        <NewScorerButton entity={entity} project={project} />
+      </Box>
     </>
   ),
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -226,18 +226,19 @@ export const EMPTY_PROPS_ANNOTATIONS: EmptyProps = {
 export const EMPTY_PROPS_SCORERS: EmptyProps = {
   icon: 'type-number-alt' as const,
   heading: 'No scorers yet',
-  description: 'Create programmatic scorers in Python or human annotations in the UI.',
+  description:
+    'Create programmatic scorers in Python or human annotations in the UI.',
   moreInformation: (
     <>
       Learn about{' '}
       <TargetBlank href="https://weave-docs.wandb.ai/guides/evaluation/scorers#class-based-scorers">
         programmatic scorers
-      </TargetBlank>
-      {' '}or{' '}
+      </TargetBlank>{' '}
+      or{' '}
       <TargetBlank href="https://weave-docs.wandb.ai/guides/tracking/feedback#add-human-annotations">
         human annotations
-      </TargetBlank>
-      {' '}to get started.
+      </TargetBlank>{' '}
+      to get started.
     </>
   ),
 };


### PR DESCRIPTION
## Description

| Empty | Table | Drawer |
| -------- | ------- | ------- |
| ![CleanShot 2025-03-25 at 12 52 32](https://github.com/user-attachments/assets/a2ad520f-417f-40eb-af96-d6ef4993aa11) | ![CleanShot 2025-03-25 at 12 54 14](https://github.com/user-attachments/assets/cd3c3ee1-49ca-431a-8ba2-6c362f5c4354) | ![CleanShot 2025-03-25 at 13 00 18](https://github.com/user-attachments/assets/5c51ed68-06fd-447b-a9ae-506ae261eb24) |

- Created a new combined scorers tab (programmatic scorers / annotations).
- Updated create scorer sidebar (made it annotation focused / added callout).
- Updated zod template to display descriptions for fields.
- Added empty state w/ CTA for creating new scorer.

**ToDo:**

- [ ] Light refactor / cleanup orphan views / variables