### PR TITLE
fix(app): Transform input data to table-like before passing to paginated Plots

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -52,7 +52,7 @@ const PanelPlotConfig: React.FC<PanelPlotProps> = props => {
   const weave = useWeaveContext();
 
   const {tableState, autoTable} = useAutomatedTableState(
-    input,
+    inputNode,
     (config as any).tableState,
     weave
   );
@@ -632,7 +632,7 @@ const PanelPlot2: React.FC<PanelPlotProps> = props => {
   const weave = useWeaveContext();
 
   const {tableState, autoTable} = useAutomatedTableState(
-    input,
+    inputNode,
     (config as any).tableState,
     weave
   );


### PR DESCRIPTION
## Description

- Fixes [WB-23945](https://wandb.atlassian.net/browse/WB-23945)
- Use the transformed table-like `inputNode` instead of `input`, which may not have the files/rows expanded. This is a regression while adding the functionality to reference derived columns

## Testing

Local FE Invoker


https://github.com/user-attachments/assets/d250cac8-d3b0-41ce-bd78-f362f02157be



