### PR TITLE
docs(weave): add 3 integrations to index page

### DIFF
--- a/docs/docs/guides/integrations/index.md
+++ b/docs/docs/guides/integrations/index.md
@@ -31,10 +31,11 @@ LLM providers are the vendors that offer access to large language models for gen
 
 Frameworks help orchestrate the actual execution pipelines in AI applications. They provide tools and abstractions for building complex workflows. Weave integrates with these frameworks to trace the entire pipeline:
 
+- **[OpenAI Agents SDK](/guides/integrations/openai_agents)**
 - **[LangChain](/guides/integrations/langchain)**
 - **[LlamaIndex](/guides/integrations/llamaindex)**
 - **[DSPy](/guides/integrations/dspy)**
-
-
+- **[Instructor](/guides/integrations/instructor)**
+- **[CrewAI](/guides/integrations/crewai)**
 
 Choose an integration from the lists above to learn more about how to use Weave with your preferred LLM provider or framework. Whether you're directly accessing LLM APIs or building complex pipelines with orchestration frameworks, Weave provides the tools to trace and analyze your AI applications effectively.


### PR DESCRIPTION
## Description

We had a couple of integrations that were only added to the sidebar and not to the integrations index page. 

## Testing

yarn start on docs
