### PR TITLE
fix(ui): Clear traces / evals on page change

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -807,9 +807,14 @@ export const CallsTable: FC<{
               />
               <div className="text-sm">
                 {selectedCalls.length}{' '}
-                {isEvaluateTable 
-                  ? selectedCalls.length === 1 ? 'evaluation' : 'evaluations'
-                  : selectedCalls.length === 1 ? 'trace' : 'traces'} selected:
+                {isEvaluateTable
+                  ? selectedCalls.length === 1
+                    ? 'evaluation'
+                    : 'evaluations'
+                  : selectedCalls.length === 1
+                  ? 'trace'
+                  : 'traces'}{' '}
+                selected:
               </div>
               {isEvaluateTable ? (
                 <CompareEvaluationsTableButton

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -570,6 +570,12 @@ export const CallsTable: FC<{
   const clearSelectedCalls = useCallback(() => {
     setSelectedCalls([]);
   }, [setSelectedCalls]);
+
+  // Clear selections when switching table types
+  useEffect(() => {
+    clearSelectedCalls();
+  }, [isEvaluateTable, clearSelectedCalls]);
+
   const muiColumns = useMemo(() => {
     const cols: GridColDef[] = [
       {
@@ -801,7 +807,9 @@ export const CallsTable: FC<{
               />
               <div className="text-sm">
                 {selectedCalls.length}{' '}
-                {isEvaluateTable ? 'evaluations' : 'traces'} selected:
+                {isEvaluateTable 
+                  ? selectedCalls.length === 1 ? 'evaluation' : 'evaluations'
+                  : selectedCalls.length === 1 ? 'trace' : 'traces'} selected:
               </div>
               {isEvaluateTable ? (
                 <CompareEvaluationsTableButton


### PR DESCRIPTION
## Description

| Before | After |
| -------- | ------- |
| ![before](https://github.com/user-attachments/assets/1573ce11-9e7c-4ddc-8014-030a2f9f5ea5) | ![after](https://github.com/user-attachments/assets/91ff36b3-a44c-4b8a-bddc-1c0ee4d080ab) |

This was present on old version of header bar, but is more apparent now.
When switching between Traces and Evals the selection doesn't clear - selecting Compare on Eval with the traces selected can cause a stalled page.

- Clears evals / traces when switching between views.
- Also adds / removes "s" on multiple traces / evals selected.