### PR TITLE
feat(ui): allow zooming images in lightbox to 5x natural pixel size

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueImage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueImage.tsx
@@ -46,6 +46,7 @@ export const CellValueImage = ({value}: CellValueImageProps) => {
           buttonNext: () => null,
         }}
         carousel={{finite: true}}
+        zoom={{maxZoomPixelRatio: 5}}
       />
     </>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewImage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewImage.tsx
@@ -87,6 +87,7 @@ export const ValueViewImage = ({value}: ValueViewImageProps) => {
           buttonNext: () => null,
         }}
         carousel={{finite: true}}
+        zoom={{maxZoomPixelRatio: 5}}
       />
     </>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/PIL.Image.Image/PILImageImage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/PIL.Image.Image/PILImageImage.tsx
@@ -247,6 +247,7 @@ const PILImageImageLoaded = ({
           buttonNext: () => null,
         }}
         carousel={{finite: true}}
+        zoom={{maxZoomPixelRatio: 5}}
       />
     </>
   );


### PR DESCRIPTION
## Description

Internal Jira: https://wandb.atlassian.net/browse/WB-23981

By default the `maxZoomPixelRatio` for our lightbox component is 1, meaning you can't zoom in beyond the image's actual size. This changes the max ratio to 5, which can be helpful for e.g. reading small text in an image.
https://yet-another-react-lightbox.com/plugins/zoom#Documentation

## Testing

wf values example
