### PR TITLE
chore(weave): Add a project allow list to the bucket rollout

### DIFF
--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -83,6 +83,7 @@ class TestS3Storage:
                 "WF_FILE_STORAGE_AWS_ACCESS_KEY_ID": "test-key",
                 "WF_FILE_STORAGE_AWS_SECRET_ACCESS_KEY": "test-secret",
                 "WF_FILE_STORAGE_URI": f"s3://{TEST_BUCKET}",
+                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "test-project",
             },
         ):
             yield
@@ -168,6 +169,7 @@ class TestGCSStorage:
                 }"""
                 ).decode(),
                 "WF_FILE_STORAGE_URI": f"gs://{TEST_BUCKET}",
+                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "test-project",
             },
         ):
             yield
@@ -221,6 +223,7 @@ class TestAzureStorage:
                 "WF_FILE_STORAGE_AZURE_CREDENTIAL_B64": AZURITE_B64_KEY,
                 "WF_FILE_STORAGE_AZURE_ACCOUNT_URL": AZURITE_URL,
                 "WF_FILE_STORAGE_URI": f"az://{AZURITE_ACCOUNT}/{TEST_BUCKET}",
+                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "test-project",
             },
         ):
             yield

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -83,7 +83,7 @@ class TestS3Storage:
                 "WF_FILE_STORAGE_AWS_ACCESS_KEY_ID": "test-key",
                 "WF_FILE_STORAGE_AWS_SECRET_ACCESS_KEY": "test-secret",
                 "WF_FILE_STORAGE_URI": f"s3://{TEST_BUCKET}",
-                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "test-project",
+                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
             },
         ):
             yield
@@ -169,7 +169,7 @@ class TestGCSStorage:
                 }"""
                 ).decode(),
                 "WF_FILE_STORAGE_URI": f"gs://{TEST_BUCKET}",
-                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "test-project",
+                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
             },
         ):
             yield
@@ -223,7 +223,7 @@ class TestAzureStorage:
                 "WF_FILE_STORAGE_AZURE_CREDENTIAL_B64": AZURITE_B64_KEY,
                 "WF_FILE_STORAGE_AZURE_ACCOUNT_URL": AZURITE_URL,
                 "WF_FILE_STORAGE_URI": f"az://{AZURITE_ACCOUNT}/{TEST_BUCKET}",
-                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "test-project",
+                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
             },
         ):
             yield

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -193,7 +193,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         password: str = "",
         database: str = "default",
         use_async_insert: bool = False,
-        file_storage_uri_str: Optional[str] = None,
     ):
         super().__init__()
         self._thread_local = threading.local()
@@ -206,7 +205,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         self._call_batch: list[list[Any]] = []
         self._use_async_insert = use_async_insert
         self._model_to_provider_info_map = read_model_to_provider_info_map()
-        self._file_storage_uri_str = file_storage_uri_str
 
     @classmethod
     def from_env(cls, use_async_insert: bool = False) -> "ClickHouseTraceServer":
@@ -219,7 +217,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             password=wf_env.wf_clickhouse_pass(),
             database=wf_env.wf_clickhouse_database(),
             use_async_insert=use_async_insert,
-            file_storage_uri_str=wf_env.wf_file_storage_uri(),
         )
 
     @contextmanager
@@ -1257,7 +1254,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
     def file_create(self, req: tsi.FileCreateReq) -> tsi.FileCreateRes:
         digest = bytes_digest(req.content)
-        base_file_storage_uri = self._get_base_file_storage_uri()
+        base_file_storage_uri = self._get_base_file_storage_uri(req.project_id)
 
         if base_file_storage_uri is not None:
             self._file_create_bucket(req, digest, base_file_storage_uri)
@@ -1334,7 +1331,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             ],
         )
 
-    def _get_base_file_storage_uri(self) -> Optional[FileStorageURI]:
+    def _get_base_file_storage_uri(self, project_id: str) -> Optional[FileStorageURI]:
         """
         Get the base storage URI for a project.
 
@@ -1345,12 +1342,18 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         the project or a context variable. Leaving this method here for clarity
         and future extensibility.
         """
-        if not self._file_storage_uri_str:
+        file_storage_uri_str = wf_env.wf_file_storage_uri()
+        if not file_storage_uri_str:
             return None
-        res = FileStorageURI.parse_uri_str(self._file_storage_uri_str)
+        project_allow_list = wf_env.wf_file_storage_project_allow_list()
+        if project_allow_list is None:
+            return None
+        if project_id not in project_allow_list:
+            return None
+        res = FileStorageURI.parse_uri_str(file_storage_uri_str)
         if res.has_path():
             raise ValueError(
-                f"Supplied file storage uri contains path components: {self._file_storage_uri_str}"
+                f"Supplied file storage uri contains path components: {file_storage_uri_str}"
             )
         return res
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1350,7 +1350,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         if project_allow_list is None:
             return None
 
-        if project_id not in project_allow_list:
+        universally_enabled = (
+            len(project_allow_list) == 1 and project_allow_list[0] == "*"
+        )
+
+        if not universally_enabled and project_id not in project_allow_list:
             return None
 
         res = FileStorageURI.parse_uri_str(file_storage_uri_str)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1335,15 +1335,12 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         """
         Get the base storage URI for a project.
 
-        Args:
-            project_id: The ID of the project requesting file storage access.
+        Currently this is quite simple as it uses the default storage bucket
+        for the entire client (most typically configured via environment variable).
 
-        Returns:
-            Optional[FileStorageURI]: The base storage URI if the project has access,
-                None otherwise.
-
-        Raises:
-            ValueError: If the configured storage URI is invalid.
+        However, in the near future, this might be something that is driven by
+        the project or a context variable. Leaving this method here for clarity
+        and future extensibility.
         """
         file_storage_uri_str = wf_env.wf_file_storage_uri()
         if not file_storage_uri_str:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1335,21 +1335,27 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         """
         Get the base storage URI for a project.
 
-        Currently this is quite simple as it uses the default storage bucket
-        for the entire client (most typically configured via environment variable).
+        Args:
+            project_id: The ID of the project requesting file storage access.
 
-        However, in the near future, this might be something that is driven by
-        the project or a context variable. Leaving this method here for clarity
-        and future extensibility.
+        Returns:
+            Optional[FileStorageURI]: The base storage URI if the project has access,
+                None otherwise.
+
+        Raises:
+            ValueError: If the configured storage URI is invalid.
         """
         file_storage_uri_str = wf_env.wf_file_storage_uri()
         if not file_storage_uri_str:
             return None
+
         project_allow_list = wf_env.wf_file_storage_project_allow_list()
         if project_allow_list is None:
             return None
+
         if project_id not in project_allow_list:
             return None
+
         res = FileStorageURI.parse_uri_str(file_storage_uri_str)
         if res.has_path():
             raise ValueError(

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -35,6 +35,19 @@ def wf_file_storage_uri() -> Optional[str]:
     return os.environ.get("WF_FILE_STORAGE_URI")
 
 
+def wf_file_storage_project_allow_list() -> Optional[list[str]]:
+    """The project allowed list."""
+    allow_list = os.environ.get("WF_FILE_STORAGE_PROJECT_ALLOW_LIST")
+    if allow_list is None:
+        return None
+    try:
+        return allow_list.split(",")
+    except Exception:
+        raise ValueError(
+            f"WF_FILE_STORAGE_PROJECT_ALLOW_LIST is not a valid comma-separated list: {allow_list}"
+        )
+
+
 def wf_storage_bucket_aws_access_key_id() -> Optional[str]:
     """The AWS access key ID."""
     return os.environ.get("WF_FILE_STORAGE_AWS_ACCESS_KEY_ID")

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -36,16 +36,27 @@ def wf_file_storage_uri() -> Optional[str]:
 
 
 def wf_file_storage_project_allow_list() -> Optional[list[str]]:
-    """The project allowed list."""
+    """Get the list of project IDs allowed to use file storage.
+
+    Returns:
+        Optional[list[str]]: A list of project IDs that are allowed to use file storage.
+            Returns None if no allow list is configured.
+
+    Raises:
+        ValueError: If the allow list environment variable is set but contains invalid data.
+            The value must be a comma-separated list of non-empty project IDs.
+    """
     allow_list = os.environ.get("WF_FILE_STORAGE_PROJECT_ALLOW_LIST")
     if allow_list is None:
         return None
     try:
-        return allow_list.split(",")
-    except Exception:
+        project_ids = [pid.strip() for pid in allow_list.split(",") if pid.strip()]
+    except Exception as e:
         raise ValueError(
-            f"WF_FILE_STORAGE_PROJECT_ALLOW_LIST is not a valid comma-separated list: {allow_list}"
+            f"WF_FILE_STORAGE_PROJECT_ALLOW_LIST is not a valid comma-separated list: {allow_list}. Error: {str(e)}"
         )
+
+    return project_ids
 
 
 def wf_storage_bucket_aws_access_key_id() -> Optional[str]:


### PR DESCRIPTION
Adds a comma-seperated `WF_FILE_STORAGE_PROJECT_ALLOW_LIST` to the file storage env variables to allow incremental rollout. Note: will need to use the internal project id.

A value of "*" enables for all projects