### PR TITLE
chore(weave_query): Handle DictionaryArray inputs for remaining AWL string ops

### DIFF
--- a/weave_query/tests/ops_arrow/test_string.py
+++ b/weave_query/tests/ops_arrow/test_string.py
@@ -287,7 +287,6 @@ class TestConcatenateStrings:
         expected = [None, None, None]
         assert result.to_pylist_notags() == expected
 
-    # @pytest.mark.xfail(reason="Dictionary array concatenation is not supported yet")
     def test_dictionary_array(self):
         arrow_data = ["hello", "world", None]
         dict_array = pa.DictionaryArray.from_arrays(

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -43,12 +43,12 @@ self_type_output_type_fn = lambda input_types: input_types["self"]
 
 def _concatenate_strings(
     left: ArrowWeaveList[str],
-    right: typing.Optional[typing.Union[str, ArrowWeaveList[str]]],
-) -> ArrowWeaveList[str]:
+    right: typing.Union[str, ArrowWeaveList[str], None],
+) -> ArrowWeaveList[typing.Optional[str]]:
     if right is None:
         return ArrowWeaveList(
             pa.nulls(len(left._arrow_data), type=left._arrow_data.type),
-            types.optional(types.String()),
+            types.NoneType(),
             left._artifact,
         )
 

--- a/weave_query/weave_query/ops_arrow/string.py
+++ b/weave_query/weave_query/ops_arrow/string.py
@@ -70,8 +70,11 @@ def _concatenate_strings(
 def __eq__(self, other):
     if isinstance(other, ArrowWeaveList):
         other = other._arrow_data
-    result = util.equal(self._arrow_data, other)
-    return ArrowWeaveList(result, types.Boolean(), self._artifact)
+    return util.handle_dictionary_array(
+        self,
+        lambda arr: util.equal(arr, other),
+        types.Boolean(),
+    )
 
 
 @arrow_op(
@@ -82,8 +85,11 @@ def __eq__(self, other):
 def __ne__(self, other):
     if isinstance(other, ArrowWeaveList):
         other = other._arrow_data
-    result = util.not_equal(self._arrow_data, other)
-    return ArrowWeaveList(result, types.Boolean(), self._artifact)
+    return util.handle_dictionary_array(
+        self,
+        lambda arr: util.not_equal(arr, other),
+        types.Boolean(),
+    )
 
 
 @arrow_op(


### PR DESCRIPTION
## Description

JIRA: https://wandb.atlassian.net/browse/WB-23892

Previous PRs: 
- Part 1: https://github.com/wandb/weave/pull/3905
- Part 2: https://github.com/wandb/weave/pull/3942

This should be the final PR and fixes the following ops to handle `DictionaryArray`s:
* \_\_eq\_\_
* \_\_ne\_\_
* \_\_contains\_\_ - Note: corrected the behaviour of this op a bit to handle null/`None` values based on how `pyarrow.compute.match_substring` handles null values
* string_add
* append
* prepend

Skipped the following ops that were planned to be modified:
* string\_right\_add - Not sure how this is supposed to differ from `string_add` or `append` and it also doesn't seem to be used anywhere so we can ignore this for now
* in\_\_ - This is hidden on the FE


## Testing

Unit Tests, Local Invoker (see CSVs and screenshots in JIRA)

