### PR TITLE
docs(weave): improve python notebook conversion script

### DIFF
--- a/docs/CONTRIBUTING_DOCS.md
+++ b/docs/CONTRIBUTING_DOCS.md
@@ -119,9 +119,25 @@ To improve docs, basically follow FastAPI's instructions to create good Swagger 
 
 ### Notebook Doc Gen
 
-See `docs/scripts/generate_notebooks.py`, `./docs/notebooks`, and `./docs/reference/gen_notebooks`.
+Summary: Use `docs/scripts/generate_notebooks.py` to convert Jupyter notebooks (`.ipynb`) in  `./docs/notebooks` to Markdown files in `./docs/reference/gen_notebooks`.
 
-This script will load all notebooks in `./docs/notebooks`, transforming them into viable markdown docs in `./docs/reference/gen_notebooks` which can be referenced by docusaurus just like any other markdown file. If you need header metadata, you can add a markdown block at the top of your notebook with:
+This script converts Jupyter notebooks (`.ipynb`) into Markdown files that can be referenced by Docusaurus just like any other `.md` doc. By default, it loads all notebooks in `./docs/notebooks` and writes the converted Markdown to `./docs/reference/gen_notebooks`.
+
+To run the default export for all notebooks:
+
+```bash
+python docs/scripts/generate_notebooks.py
+```
+
+To convert a single notebook:
+
+```bash
+python docs/scripts/generate_notebooks.py path/to/your_notebook.ipynb
+```
+
+This will generate a Markdown file with the same base name in `./docs/reference/gen_notebooks`.
+
+If your notebook requires Docusaurus header metadata, you can include a special markdown block at the top of a markdown cell in your notebook:
 
 ```
 <!-- docusaurus_head_meta::start

--- a/docs/scripts/generate_notebooks.py
+++ b/docs/scripts/generate_notebooks.py
@@ -1,7 +1,8 @@
+import argparse
 import os
 import re
 import tempfile
-import argparse
+
 import nbformat
 from nbconvert import MarkdownExporter
 
@@ -97,7 +98,9 @@ def export_all_notebooks_in_primary_dir():
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Convert Python notebooks to Markdown docs.")
+    parser = argparse.ArgumentParser(
+        description="Convert Python notebooks to Markdown docs."
+    )
     parser.add_argument(
         "notebook_path",
         nargs="?",
@@ -118,10 +121,10 @@ def main():
     else:
         export_all_notebooks_in_primary_dir()
         export_notebook(
-            "./intro_notebook.ipynb", "./docs/reference/gen_notebooks/01-intro_notebook.md"
+            "./intro_notebook.ipynb",
+            "./docs/reference/gen_notebooks/01-intro_notebook.md",
         )
         print("All notebooks exported.")
-
 
 
 if __name__ == "__main__":

--- a/docs/scripts/generate_notebooks.py
+++ b/docs/scripts/generate_notebooks.py
@@ -1,7 +1,7 @@
 import os
 import re
 import tempfile
-
+import argparse
 import nbformat
 from nbconvert import MarkdownExporter
 
@@ -97,10 +97,31 @@ def export_all_notebooks_in_primary_dir():
 
 
 def main():
-    export_all_notebooks_in_primary_dir()
-    export_notebook(
-        "./intro_notebook.ipynb", "./docs/reference/gen_notebooks/01-intro_notebook.md"
+    parser = argparse.ArgumentParser(description="Convert Python notebooks to Markdown docs.")
+    parser.add_argument(
+        "notebook_path",
+        nargs="?",
+        help="Optional path to a single .ipynb file to convert",
     )
+    args = parser.parse_args()
+
+    if args.notebook_path:
+        notebook_path = args.notebook_path
+        if not notebook_path.endswith(".ipynb"):
+            print("ERROR: The provided file must be a .ipynb notebook.")
+            return
+
+        base_name = os.path.basename(notebook_path).replace(".ipynb", ".md")
+        output_path = f"./docs/reference/gen_notebooks/{base_name}"
+        export_notebook(notebook_path, output_path)
+        print(f"Exported {notebook_path} to {output_path}")
+    else:
+        export_all_notebooks_in_primary_dir()
+        export_notebook(
+            "./intro_notebook.ipynb", "./docs/reference/gen_notebooks/01-intro_notebook.md"
+        )
+        print("All notebooks exported.")
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1365

updates the generate_notebooks.py script to support converting a single .ipynb notebook to Markdown by passing the notebook path as a command-line argument. If no argument is provided, the script defaults to its original behavior of exporting all notebooks in the notebooks/ directory along with the intro notebook.

Also updates usage instructions in docs/CONTRIBUTING_DOCS.md

## Testing

- yarn start  on local
- run script locally on single file to generate MD equivalent, confirm you can actually do this locally 

