### PR TITLE
feat(weave_query): Provide caption attribute in ImageArtifactFileRef

### DIFF
--- a/weave_query/tests/test_wb_tables.py
+++ b/weave_query/tests/test_wb_tables.py
@@ -3,8 +3,8 @@ import time
 import numpy as np
 import wandb
 
-import weave_query as weave
 import weave_query
+import weave_query as weave
 from weave_query.language_features.tagging import make_tag_getter_op
 from weave_query.language_features.tagging.tagged_value_type import TaggedValueType
 from weave_query.ops_arrow.list_ops import filter
@@ -177,6 +177,7 @@ def test_join_table_with_images(fake_wandb):
                         "sha256": "e7bdc527afd649f51950b4524b0c15aecaf7f484448a6cdfcdc2ecd9bba0f5a7",
                         "boxes": {},
                         "masks": {},
+                        "caption": None,
                     },
                 },
                 "1": {"name": "a", "score": 1.0},
@@ -196,6 +197,7 @@ def test_join_table_with_images(fake_wandb):
                         "sha256": "61cd2467cff9f0666c730c57d065cfe834765ba26514b46f91735c750676876a",
                         "boxes": {},
                         "masks": {},
+                        "caption": None,
                     },
                 },
                 "1": {"name": "b", "score": 2.0},

--- a/weave_query/weave_query/ops_domain/table.py
+++ b/weave_query/weave_query/ops_domain/table.py
@@ -1,24 +1,23 @@
 import asyncio
 import dataclasses
-import datetime
 import json
 import logging
 import typing
 
-from weave_query import weave_internal
-from weave_query import weave_types as types
-from weave_query.api import op, weave_class
 from weave_query import (
     artifact_fs,
     artifact_wandb,
+    engine_trace,
+    errors,
     io_service,
     ops_arrow,
+    util,
     wandb_util,
-    engine_trace,
-    errors, 
-    util, 
+    weave_internal,
 )
 from weave_query import timestamp as weave_timestamp
+from weave_query import weave_types as types
+from weave_query.api import op, weave_class
 from weave_query.ops_domain import trace_tree, wbmedia
 
 
@@ -363,6 +362,7 @@ def _table_data_to_weave1_objects(
                 boxes=cell.get("boxes", {}),  # type: ignore
                 masks=cell.get("masks", {}),  # type: ignore
                 classes=cell.get("classes"),  # type: ignore
+                caption=cell.get("caption", None),
             )
         elif file_type in [
             "audio-file",
@@ -861,6 +861,7 @@ def file_table(file: artifact_fs.FilesystemArtifactFile) -> typing.Optional[Tabl
     # https://wandb.atlassian.net/browse/WB-22355
     except OSError as e:
         import errno
+
         if e.errno == errno.ESTALE:
             return None
         raise

--- a/weave_query/weave_query/ops_domain/wbmedia.py
+++ b/weave_query/weave_query/ops_domain/wbmedia.py
@@ -5,8 +5,7 @@ import json
 import typing
 
 from weave_query import api as weave
-from weave_query import types
-from weave_query import errors, engine_trace, artifact_fs, file_base
+from weave_query import artifact_fs, engine_trace, errors, file_base, types
 from weave_query.language_features.tagging.tag_store import isolated_tagging_context
 from weave_query.ops_primitives import html, markdown
 
@@ -155,6 +154,7 @@ class ImageArtifactFileRefType(types.ObjectType):
                     }
                 )
             ),
+            "caption": types.optional(types.String()),
         }
         return res
 
@@ -213,6 +213,7 @@ class ImageArtifactFileRef:
         default_factory=dict
     )  # type: ignore
     classes: typing.Optional[typing.Optional[dict]] = None
+    caption: typing.Optional[str] = None
 
 
 ImageArtifactFileRef.WeaveType = ImageArtifactFileRefType  # type: ignore
@@ -365,6 +366,7 @@ def file_media(file: artifact_fs.FilesystemArtifactFile):
             height=data.get("height", 0),
             width=data.get("width", 0),
             sha256=data.get("sha256", file_path),
+            caption=data.get("caption", None),
         )
     elif any(
         file.path.endswith(path_suffix)


### PR DESCRIPTION
## Description

- Follow-up to https://github.com/wandb/weave/pull/3807
- Implements the BE portion to enable https://wandb.atlassian.net/browse/WB-22188
- There's some un-related linting changes that got included so I've added some comments on the functional changes which is effectively just adding the attribute to the dataclass and providing a value for it when the `file-media` op is called.

## Testing

* Local invoker on personal test workspace and also made sure some of the workspaces from the [sentry](https://weights-biases.sentry.io/issues/6360852706/?alert_rule_id=11833737&alert_timestamp=1741211855806&alert_type=email&environment=prod&notification_uuid=dee6ae8c-9ea3-4f5a-8c5d-d83352e7356b&project=6620563) we triggered before isn't crashing with the changes.

https://github.com/user-attachments/assets/6f280931-7807-4461-8299-344be01b2b78

* Updated test to include a logged image with a caption
