### PR TITLE
chore(app): Filter steps to non-null tables in runs history step slider

### DIFF
--- a/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelRunHistoryTablesStepper/index.tsx
@@ -15,6 +15,8 @@ import {
   opFileTable,
   opFilter,
   opIndex,
+  opIsNone,
+  opNot,
   opNumberEqual,
   opPick,
   opRunHistory,
@@ -149,8 +151,21 @@ const PanelRunHistoryTablesStepper: React.FC<
     props.config?.tableHistoryKey
   );
 
+  // runs.history.concat.filter((row) => !row[<table-history-key>].isNone)
+  const filteredRunsHistoryNode = opFilter({
+    arr: runsHistoryNode,
+    filterFn: constFunction({row: runsHistoryNode.type}, ({row}) =>
+      opNot({
+        bool: opIsNone({
+          val: opPick({obj: row, key: constString(tableHistoryKey)}),
+        }),
+      })
+    ),
+  });
+
+  // runs.history.concat.filter((row) => !row[<table-history-key>].isNone)["_step"]
   const stepsNode = opPick({
-    obj: runsHistoryNode,
+    obj: filteredRunsHistoryNode,
     key: constString('_step'),
   });
   const {result: stepsNodeResult, loading: stepsNodeLoading} =


### PR DESCRIPTION
## Description

Step slider should skip over steps when no table (of the selected table key) was logged at that step.

## Testing

Local FE

https://github.com/user-attachments/assets/4405a4c5-d199-4c4b-9269-5804d71eb47e
