### PR TITLE
fix(weave): Fix Anthropic tool call results when content is array of blocks

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanelPart.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanelPart.tsx
@@ -54,10 +54,11 @@ export const MessagePanelPart = ({
     };
     return <ToolCalls toolCalls={[toolCall]} />;
   }
-  console.log('value', value);
+
   if (value.type === 'tool_result' && 'content' in value) {
+    // value.content can be a string or an array of content blocks
     const contentArray = Array.isArray(value.content) ? value.content : [value.content];
-    return contentArray.map((content) => {
+    return <>{contentArray.map((content) => {
       const stringContent = _.isObject(content) && "text" in content ? content.text : content;
       try {
         const jsonContent = JSON.stringify(
@@ -69,7 +70,7 @@ export const MessagePanelPart = ({
       } catch (error) {
         return <span className="whitespace-break-spaces">{stringContent}</span>;
       }
-    });
+    })}</>;
   }
   return null;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanelPart.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanelPart.tsx
@@ -1,5 +1,5 @@
 import 'prismjs/components/prism-markup-templating';
-
+import _ from 'lodash';
 import React from 'react';
 
 import {TargetBlank} from '../../../../../../common/util/links';
@@ -54,17 +54,22 @@ export const MessagePanelPart = ({
     };
     return <ToolCalls toolCalls={[toolCall]} />;
   }
+  console.log('value', value);
   if (value.type === 'tool_result' && 'content' in value) {
-    try {
-      const jsonContent = JSON.stringify(
-        JSON.parse(value.content as string),
-        null,
-        2
-      );
+    const contentArray = Array.isArray(value.content) ? value.content : [value.content];
+    return contentArray.map((content) => {
+      const stringContent = _.isObject(content) && "text" in content ? content.text : content;
+      try {
+        const jsonContent = JSON.stringify(
+          JSON.parse(stringContent as string),
+          null,
+          2
+        );
       return <CodeEditor language="json" value={jsonContent} readOnly />;
-    } catch (error) {
-      return <span className="whitespace-break-spaces">{value.content}</span>;
-    }
+      } catch (error) {
+        return <span className="whitespace-break-spaces">{stringContent}</span>;
+      }
+    });
   }
   return null;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanelPart.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/MessagePanelPart.tsx
@@ -1,4 +1,5 @@
 import 'prismjs/components/prism-markup-templating';
+
 import _ from 'lodash';
 import React from 'react';
 
@@ -57,20 +58,29 @@ export const MessagePanelPart = ({
 
   if (value.type === 'tool_result' && 'content' in value) {
     // value.content can be a string or an array of content blocks
-    const contentArray = Array.isArray(value.content) ? value.content : [value.content];
-    return <>{contentArray.map((content) => {
-      const stringContent = _.isObject(content) && "text" in content ? content.text : content;
-      try {
-        const jsonContent = JSON.stringify(
-          JSON.parse(stringContent as string),
-          null,
-          2
-        );
-      return <CodeEditor language="json" value={jsonContent} readOnly />;
-      } catch (error) {
-        return <span className="whitespace-break-spaces">{stringContent}</span>;
-      }
-    })}</>;
+    const contentArray = Array.isArray(value.content)
+      ? value.content
+      : [value.content];
+    return (
+      <>
+        {contentArray.map(content => {
+          const stringContent =
+            _.isObject(content) && 'text' in content ? content.text : content;
+          try {
+            const jsonContent = JSON.stringify(
+              JSON.parse(stringContent as string),
+              null,
+              2
+            );
+            return <CodeEditor language="json" value={jsonContent} readOnly />;
+          } catch (error) {
+            return (
+              <span className="whitespace-break-spaces">{stringContent}</span>
+            );
+          }
+        })}
+      </>
+    );
   }
   return null;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/types.ts
@@ -18,7 +18,7 @@ export type InternalMessage = {
   text?: string;
   image_url?: ImageUrl;
   input?: Record<string, any>;
-  content?: string;
+  content?: string | Record<string, any>[];
   name?: string;
   id?: string;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/types.ts
@@ -18,7 +18,7 @@ export type InternalMessage = {
   text?: string;
   image_url?: ImageUrl;
   input?: Record<string, any>;
-  content?: string | Record<string, any>[];
+  content?: string | Array<Record<string, any>>;
   name?: string;
   id?: string;
 };


### PR DESCRIPTION
## Description

It turns out according to Anthropic docs:

> The result of the tool, as a string (e.g. "content": "15 degrees") or list of nested content blocks

This PR takes this into account.

## Testing

How was this PR tested?

- Tested on my own project with string results
- Tested on Sam's skills-assembly project
