### PR TITLE
chore(ui): Remove visual cue that artifact file is selectable for restricted viewers

### DIFF
--- a/weave-js/src/components/Panel2/PanelDir/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelDir/Component.tsx
@@ -174,7 +174,9 @@ const SubfileRow: React.FC<SubfileRowProps> = props => {
           ) : (
             <LegacyWBIcon className="file-browser-icon" name={iconName} />
           )}
-          <span className="file-browser-file-name" style={!isDownloadable ? { color: 'inherit' } : undefined}>
+          <span
+            className="file-browser-file-name"
+            style={!isDownloadable ? {color: 'inherit'} : undefined}>
             {fileName.split('/').pop()}
           </span>
         </div>

--- a/weave-js/src/components/Panel2/PanelDir/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelDir/Component.tsx
@@ -174,7 +174,7 @@ const SubfileRow: React.FC<SubfileRowProps> = props => {
           ) : (
             <LegacyWBIcon className="file-browser-icon" name={iconName} />
           )}
-          <span className="file-browser-file-name">
+          <span className="file-browser-file-name" style={!isDownloadable ? { color: 'inherit' } : undefined}>
             {fileName.split('/').pop()}
           </span>
         </div>


### PR DESCRIPTION
…or restricted viewers

## Description

Artifact file names turn blue over cursor hover, which misleads users into thinking the file is clickable/downloadable. This code removes that visual cue for restricted viewers.

## Testing

Tested locally in SaaS

This is what the artifact file looks like on hover if you are not a restricted viewer:
![Screenshot 2025-03-27 at 12 50 03 PM](https://github.com/user-attachments/assets/66067f72-4609-4f25-b5d8-4bf549005737)

If you are a restricted viewer who cannot download files:
![Screenshot 2025-03-27 at 12 52 37 PM](https://github.com/user-attachments/assets/13c0ea32-771c-4936-aa37-d276664f9ec6)
