### PR TITLE
chore(ui): Fix nested buttons in removable tag/alias

### DIFF
--- a/weave-js/src/components/Tag/Alias.tsx
+++ b/weave-js/src/components/Tag/Alias.tsx
@@ -2,6 +2,7 @@ import React, {FC, ReactElement} from 'react';
 import {twMerge} from 'tailwind-merge';
 
 import {Icon} from '../Icon';
+import {Tailwind} from '../Tailwind';
 import {
   TruncateByCharsProps,
   TruncateByCharsWithTooltip,
@@ -63,25 +64,28 @@ export const RemovableAlias: FC<RemovableAliasProps> = ({
   showIcon = false,
   maxChars = TAG_DEFAULT_MAX_CHARS,
   truncatedPart,
-  Wrapper,
+  Wrapper = Tailwind,
 }) => {
   const classes = useTagClasses({color, label, isInteractive: true});
-  const truncationProps = {text: label, maxChars, truncatedPart, Wrapper};
+  const truncationProps = {text: label, maxChars, truncatedPart, Wrapper: null};
+  if (Wrapper === null) {
+    Wrapper = React.Fragment;
+  }
   return (
-    <TruncateByCharsWithTooltip {...truncationProps}>
-      {({truncatedText}) => (
-        <div className={twMerge(classes, 'px-4 font-mono text-[13px]')}>
-          {showIcon && (
-            <Icon
-              role="presentation"
-              className="mr-4 h-14 w-14"
-              name={DEFAULT_ALIAS_ICON}
-            />
-          )}
-          <span>{truncatedText}</span>
-          {removeAction}
-        </div>
-      )}
-    </TruncateByCharsWithTooltip>
+    <Wrapper>
+      <div className={twMerge(classes, 'px-4 font-mono text-[13px]')}>
+        {showIcon && (
+          <Icon
+            role="presentation"
+            className="mr-4 h-14 w-14"
+            name={DEFAULT_ALIAS_ICON}
+          />
+        )}
+        <TruncateByCharsWithTooltip {...truncationProps}>
+          {({truncatedText}) => <span>{truncatedText}</span>}
+        </TruncateByCharsWithTooltip>
+        {removeAction}
+      </div>
+    </Wrapper>
   );
 };

--- a/weave-js/src/components/Tag/Tag.tsx
+++ b/weave-js/src/components/Tag/Tag.tsx
@@ -113,22 +113,25 @@ export const RemovableTag: FC<RemovableTagProps> = ({
   Wrapper = Tailwind,
 }) => {
   const classes = useTagClasses({color, isInteractive: true, label});
-  const truncationProps = {text: label, maxChars, truncatedPart, Wrapper};
+  const truncationProps = {text: label, maxChars, truncatedPart, Wrapper: null};
+  if (Wrapper === null) {
+    Wrapper = React.Fragment;
+  }
   return (
-    <TruncateByCharsWithTooltip {...truncationProps}>
-      {({truncatedText}) => (
-        <div className={twMerge(classes, showIcon ? 'px-4' : 'pl-6 pr-4')}>
-          {showIcon && (
-            <Icon
-              role="presentation"
-              className="mr-4 h-14 w-14"
-              name={iconName ?? DEFAULT_TAG_ICON}
-            />
-          )}
-          <span>{truncatedText}</span>
-          {removeAction}
-        </div>
-      )}
-    </TruncateByCharsWithTooltip>
+    <Wrapper>
+      <div className={twMerge(classes, showIcon ? 'px-4' : 'pl-6 pr-4')}>
+        {showIcon && (
+          <Icon
+            role="presentation"
+            className="mr-4 h-14 w-14"
+            name={iconName ?? DEFAULT_TAG_ICON}
+          />
+        )}
+        <TruncateByCharsWithTooltip {...truncationProps}>
+          {({truncatedText}) => <span>{truncatedText}</span>}
+        </TruncateByCharsWithTooltip>
+        {removeAction}
+      </div>
+    </Wrapper>
   );
 };


### PR DESCRIPTION
## Description

`RemovableTag` and `RemovableAlias` with truncated texts cause this console error:

https://github.com/user-attachments/assets/19d82512-9b7c-4278-a260-379839fb43aa

This is because we wrap the tag/alias in a tooltip when truncated. Tooltip triggers get `button` role for accessibility. The remove icon button is included as part of the tooltip trigger, which is the problem. This change moves the remove button outside of the truncation wrapper.

## Testing

Console error no longer appears

https://github.com/user-attachments/assets/a5211b7f-950f-47db-a9d6-f13ce23f593a
