### PR TITLE
chore(weave): fix hour bias by simplifying utc handling

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -16,12 +16,7 @@ import {Icon} from '@wandb/weave/components/Icon';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import * as userEvents from '../../../../../integrations/analytics/userEvents';
-import {
-  formatDate,
-  formatDateOnly,
-  parseDate,
-  utcToLocalTimeString,
-} from '../../../../../util/date';
+import {formatDate, formatDateOnly, parseDate} from '../../../../../util/date';
 
 type PredefinedSuggestion = {
   abbreviation: string;
@@ -56,7 +51,7 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
   isActive,
 }) => {
   // We have to play this game because
-  const [inputValue, setInputValue] = useState(utcToLocalTimeString(value));
+  const [inputValue, setInputValue] = useState(value);
   const [isDropdownVisible, setDropdownVisible] = useState(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [selectedSuggestion, setSelectedSuggestion] = useState<string | null>(
@@ -77,9 +72,9 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
     if (!value) {
       const defaultDate = parseDate('1mo');
       if (defaultDate) {
-        const utcDate = formatDate(defaultDate, 'YYYY-MM-DD HH:mm:ss', true);
-        onChange(utcDate);
-        setInputValue(utcToLocalTimeString(utcDate));
+        const localDate = formatDate(defaultDate);
+        onChange(localDate);
+        setInputValue(localDate);
       }
     }
     // Only run on first render
@@ -129,8 +124,9 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
     (newInputValue: string, skipDebounce = false) => {
       const date = parseDate(newInputValue);
       if (date) {
-        const utcDate = formatDate(date, 'YYYY-MM-DD HH:mm:ss', true);
-        onChange(utcDate);
+        const formattedDate = formatDate(date);
+        setInputValue(formattedDate);
+        onChange(formattedDate);
         setIsInvalid(false);
       } else {
         setIsInvalid(true);
@@ -177,9 +173,9 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
 
   const handleDateChange = (date: Date | null) => {
     if (date) {
-      setInputValue(formatDate(date));
-      const utcDate = formatDate(date, 'YYYY-MM-DD HH:mm:ss', true);
-      onChange(utcDate);
+      const formattedDate = formatDate(date);
+      setInputValue(formattedDate);
+      onChange(formattedDate);
       setIsInvalid(false);
     }
   };
@@ -328,7 +324,7 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
           <DateTimePicker
             open={isCalendarOpen}
             onClose={() => setIsCalendarOpen(false)}
-            value={parseDate(inputValue) ?? null}
+            value={new Date(inputValue) ?? null}
             onChange={handleDateChange}
             onAccept={handleAccept}
             slotProps={{

--- a/weave-js/src/components/Timestamp.tsx
+++ b/weave-js/src/components/Timestamp.tsx
@@ -181,8 +181,8 @@ export const TimestampSmall = ({
   /* TimestampSmall displays a small timestamp format, e.g. "1d" or "1w".
      in a nice gray tooltip
    */
-  const valueMoment = valueToMoment(value);
-  const {long, small} = formatTimestampInternal(valueMoment);
+  const localValueMoment = moment(value);
+  const {long, small} = formatTimestampInternal(localValueMoment);
   if (!small) {
     // default to regular timestamp, which expects utc
     return <Timestamp value={value} dropTimeWhenDefault />;

--- a/weave-js/src/util/date.ts
+++ b/weave-js/src/util/date.ts
@@ -329,16 +329,3 @@ export const formatDateOnly = (
   }
   return moment(date).local().format(format);
 };
-
-/**
- * Converts a UTC time string to a local time string
- *
- * @param utcTime The UTC time string to convert
- * @returns A local time string in the format 'YYYY-MM-DD HH:mm:ss'
- */
-export const utcToLocalTimeString = (utcTime: string): string => {
-  return moment
-    .utc(utcTime, 'YYYY-MM-DDTHH:mm:ss')
-    .local()
-    .format('YYYY-MM-DD HH:mm:ss');
-};


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fix an issue with the datetime selector where the displayed Time was correct but the backend filter was incorrect. The backend filter was converting utc to local.

Now we just store everything in local where we can. 

## Testing

prod:
<img width="739" alt="Screenshot 2025-03-27 at 10 45 59 AM" src="https://github.com/user-attachments/assets/c3ef17ae-f3f9-4414-b6fe-ea8c4e277411" />

branch:
<img width="738" alt="Screenshot 2025-03-27 at 10 45 39 AM" src="https://github.com/user-attachments/assets/5089f234-f319-48d3-bfa9-02b664afec6d" />
