### PR TITLE
chore(weave): exclude inputs.self from call data in add to dataset

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
@@ -140,12 +140,14 @@ export const extractSourceSchema = (calls: CallData[]): SchemaField[] => {
     }
   });
 
-  return allFields.reduce((acc, field) => {
-    if (!acc.some(f => f.name === field.name)) {
-      acc.push(field);
-    }
-    return acc;
-  }, [] as SchemaField[]);
+  return allFields
+    .filter(field => field.name !== 'inputs.self')
+    .reduce((acc, field) => {
+      if (!acc.some(f => f.name === field.name)) {
+        acc.push(field);
+      }
+      return acc;
+    }, [] as SchemaField[]);
 };
 
 /**


### PR DESCRIPTION
## Description

Always exclude `inputs.self` from the available call fields in the add to dataset flow.