### PR TITLE
chore(app): Delay computing column variables until typed node is ready

### DIFF
--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -23,7 +23,7 @@ import * as TableType from '../PanelTable/tableType';
 import {getColumnVariables, useAutomatedTableState} from '../PanelTable/util';
 import {useConfig} from './config';
 import {ConfigDimComponent} from './ConfigDimComponent';
-import {PanelPlot2Inner} from './PanelPlot2Inner';
+import {PanelPlot2ContextWrapper, PanelPlot2Inner} from './PanelPlot2Inner';
 import * as PlotState from './plotState';
 import {isValidConfig} from './plotState';
 import {ScaleConfigOption} from './ScaleConfigOption';
@@ -47,33 +47,37 @@ const PanelPlotConfig: React.FC<PanelPlotProps> = props => {
 
   const loaderComp = <Panel2Loader />;
 
-  const {config} = useConfig(inputNode, newProps.config);
-
-  const weave = useWeaveContext();
-
-  const {tableState, autoTable} = useAutomatedTableState(
-    inputNode,
-    (config as any).tableState,
-    weave
-  );
-
-  const columnVariables: {[key: string]: NodeOrVoidNode} = useMemo(() => {
-    return getColumnVariables(
-      (config as any).tableState ?? tableState ?? autoTable
-    );
-  }, [config, tableState, autoTable]);
-
   if (typedInputNodeUse.loading) {
     return loaderComp;
   } else if (typedInputNodeUse.result.nodeType === 'void') {
     return <></>;
   } else {
-    return (
-      <PanelContextProvider newVars={columnVariables}>
-        <PanelPlotConfigInner {...newProps} />
-      </PanelContextProvider>
-    );
+    return <PanelPlotConfigContextWrapper {...newProps} />;
   }
+};
+
+const PanelPlotConfigContextWrapper: React.FC<PanelPlotProps> = props => {
+  const {input} = props;
+  const {config} = useConfig(input, props.config);
+  const weave = useWeaveContext();
+
+  const {tableState, autoTable} = useAutomatedTableState(
+    input,
+    (config as any)?.tableState,
+    weave
+  );
+
+  const columnVariables: {[key: string]: NodeOrVoidNode} = useMemo(() => {
+    return getColumnVariables(
+      (props.config as any)?.tableState ?? tableState ?? autoTable
+    );
+  }, [props.config, tableState, autoTable]);
+
+  return (
+    <PanelContextProvider newVars={columnVariables}>
+      <PanelPlotConfigInner {...props} />
+    </PanelContextProvider>
+  );
 };
 
 const PanelPlotConfigInner: React.FC<PanelPlotProps> = props => {
@@ -627,22 +631,6 @@ const PanelPlot2: React.FC<PanelPlotProps> = props => {
 
   const loaderComp = useLoader();
 
-  const {config} = useConfig(inputNode, props.config);
-
-  const weave = useWeaveContext();
-
-  const {tableState, autoTable} = useAutomatedTableState(
-    inputNode,
-    (config as any).tableState,
-    weave
-  );
-
-  const columnVariables: {[key: string]: NodeOrVoidNode} = useMemo(() => {
-    return getColumnVariables(
-      (config as any).tableState ?? tableState ?? autoTable
-    );
-  }, [config, tableState, autoTable]);
-
   if (typedInputNodeUse.loading) {
     return <div style={{height: '100%', width: '100%'}}>{loaderComp}</div>;
   } else if (typedInputNodeUse.result.nodeType === 'void') {
@@ -650,9 +638,7 @@ const PanelPlot2: React.FC<PanelPlotProps> = props => {
   } else {
     return (
       <div style={{height: '100%', width: '100%'}}>
-        <PanelContextProvider newVars={columnVariables}>
-          <PanelPlot2Inner {...newProps} />
-        </PanelContextProvider>
+        <PanelPlot2ContextWrapper {...newProps} />
       </div>
     );
   }

--- a/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
+++ b/weave-js/src/components/Panel2/PanelPlot/PanelPlot.tsx
@@ -23,7 +23,7 @@ import * as TableType from '../PanelTable/tableType';
 import {getColumnVariables, useAutomatedTableState} from '../PanelTable/util';
 import {useConfig} from './config';
 import {ConfigDimComponent} from './ConfigDimComponent';
-import {PanelPlot2ContextWrapper, PanelPlot2Inner} from './PanelPlot2Inner';
+import {PanelPlot2ContextWrapper} from './PanelPlot2Inner';
 import * as PlotState from './plotState';
 import {isValidConfig} from './plotState';
 import {ScaleConfigOption} from './ScaleConfigOption';


### PR DESCRIPTION
## Description

Tracking JIRA: https://wandb.atlassian.net/browse/WB-24060

Adds a wrapper component around the inner panel plot components 😓 to compute the column variables for the latest panel context. We need to delay this until the refined node type is ready but also can't call the `useAutomatedTableState` React hook conditionally. 

This is part of a set of 3 PRs to get stepped plots work:
1. Refactor history runs table stepper (https://github.com/wandb/weave/pull/3992)
2. Refactor PanelPlots (This PR)
3. Add the plots stepper functionality (https://github.com/wandb/weave/pull/3995)


## Testing

Local FE Invoker - Verified that plots still work with derived columns

https://github.com/user-attachments/assets/6f6fac03-8e79-4cc8-ace4-65f4cb02805f

