### PR TITLE
feat(app): Implement runs history plots stepper

### DIFF
--- a/weave-js/src/components/Panel2/PanelExpression/hooks.ts
+++ b/weave-js/src/components/Panel2/PanelExpression/hooks.ts
@@ -611,10 +611,15 @@ export function usePanelExpressionState(props: PanelExpressionProps) {
       ];
     }
 
-    // Only paginated tables are supported for run history tables stepper
     results = results.filter(r => {
+      // Only paginated tables are supported for run history tables stepper
       if (r.key.startsWith('run-history-tables-stepper')) {
         return r.key === 'run-history-tables-stepper.row.table';
+      }
+
+      // Only paginated plots are supported for run history plots stepper
+      if (r.key.startsWith('run-history-plots-stepper')) {
+        return r.key === 'run-history-plots-stepper.row.plot';
       }
       return true;
     });

--- a/weave-js/src/components/Panel2/PanelRegistry.tsx
+++ b/weave-js/src/components/Panel2/PanelRegistry.tsx
@@ -48,6 +48,7 @@ import {Spec as RunColorSpec} from './PanelRunColor';
 import {Spec as RunOverviewSpec} from './PanelRunOverview';
 import {Spec as PanelRunsTableSpec} from './PanelRunsTable';
 import {Spec as PanelRunHistoryTablesStepperSpec} from './PanelRunsWithStepper/HistoryTables';
+import {Spec as PanelRunsPlotsWithStepperSpec} from './PanelRunsWithStepper/Plots';
 import {Spec as SavedModelSpec} from './PanelSavedModel';
 import {Spec as StringSpec} from './PanelString';
 import {Spec as StringCompare} from './PanelStringCompare';
@@ -239,4 +240,5 @@ export const ConverterSpecs = (): ConverterSpecArray =>
         Panel.toConvertSpec(ProjectionSpec),
         Panel.toConvertSpec(PanelRunsTableSpec),
         Panel.toConvertSpec(PanelRunHistoryTablesStepperSpec),
+        Panel.toConvertSpec(PanelRunsPlotsWithStepperSpec),
       ]);

--- a/weave-js/src/components/Panel2/PanelRunsWithStepper/Plots.tsx
+++ b/weave-js/src/components/Panel2/PanelRunsWithStepper/Plots.tsx
@@ -1,0 +1,139 @@
+import {LIST_RUNS_TYPE} from '@wandb/weave/common/types/run';
+import {
+  constFunction,
+  constNumber,
+  constString,
+  isVoidNode,
+  NodeOrVoidNode,
+  opConcat,
+  opFileTable,
+  opFilter,
+  opIndex,
+  opNumberEqual,
+  opPick,
+  opRunHistory,
+  opTableRows,
+  voidNode,
+} from '@wandb/weave/core';
+import {useNodeWithServerType} from '@wandb/weave/react';
+import React from 'react';
+
+import * as ConfigPanel from '../ConfigPanel';
+import * as Panel2 from '../panel';
+import {PanelComp2} from '../PanelComp';
+import {Spec as PlotSpec} from '../PanelPlot/PanelPlot';
+import {
+  buildPanelRunsWithStepper,
+  getCurrentTableHistoryKey,
+  getTableKeysFromRunsHistoryPropertyType,
+  PanelRunsWithStepperConfigType,
+  PanelRunsWithStepperProps,
+} from './base';
+
+const PanelRunsPlotsWithStepperConfig: React.FC<
+  PanelRunsWithStepperProps
+> = props => {
+  const runsHistoryNode = opConcat({
+    arr: opRunHistory({run: props.input as any}),
+  });
+  const runsHistoryRefined = useNodeWithServerType(runsHistoryNode);
+  const tableKeys = getTableKeysFromRunsHistoryPropertyType(
+    runsHistoryRefined.result?.type
+  );
+  const tableHistoryKey = getCurrentTableHistoryKey(
+    tableKeys,
+    props.config?.tableHistoryKey
+  );
+
+  const options = tableKeys.map(key => ({text: key, value: key}));
+  const updateConfig = props.updateConfig;
+  const setTableHistoryKey = React.useCallback(
+    val => {
+      updateConfig({tableHistoryKey: val});
+    },
+    [updateConfig]
+  );
+
+  const exampleRow = opIndex({
+    arr: runsHistoryNode,
+    index: constNumber(0),
+  });
+  const exampleRowRefined = useNodeWithServerType(exampleRow);
+  let defaultNode: NodeOrVoidNode = voidNode();
+  if (
+    props.config != null &&
+    props.config.currentStep != null &&
+    props.config.currentStep >= 0 &&
+    tableHistoryKey
+  ) {
+    defaultNode = opTableRows({
+      table: opFileTable({
+        file: opPick({
+          obj: opFilter({
+            arr: runsHistoryNode,
+            filterFn: constFunction(
+              {row: exampleRowRefined.result.type},
+              ({row}) =>
+                opNumberEqual({
+                  lhs: opPick({obj: row, key: constString('_step')}),
+                  rhs: constNumber(props.config!.currentStep),
+                })
+            ),
+          }),
+          key: constString(tableHistoryKey),
+        }),
+      }),
+    });
+  }
+
+  return (
+    <>
+      <ConfigPanel.ConfigSection>
+        <ConfigPanel.ConfigOption label="Table">
+          <ConfigPanel.ModifiedDropdownConfigField
+            selection
+            data-test="compare_method"
+            scrolling
+            multiple={false}
+            options={options}
+            value={tableHistoryKey}
+            onChange={(e, data) => {
+              setTableHistoryKey(data.value as any);
+            }}
+          />
+        </ConfigPanel.ConfigOption>
+      </ConfigPanel.ConfigSection>
+      <ConfigPanel.ConfigSection>
+        {defaultNode != null && !isVoidNode(defaultNode) && (
+          <PanelComp2
+            input={defaultNode}
+            inputType={defaultNode.type}
+            loading={props.loading}
+            panelSpec={PlotSpec}
+            configMode={true}
+            config={props.config}
+            context={props.context}
+            updateConfig={props.updateConfig}
+            updateContext={props.updateContext}
+            updateInput={props.updateInput}
+          />
+        )}
+      </ConfigPanel.ConfigSection>
+    </>
+  );
+};
+
+export const Spec: Panel2.PanelSpec<PanelRunsWithStepperConfigType> = {
+  id: 'run-history-plots-stepper',
+  displayName: 'Run History Plots Stepper',
+  Component: buildPanelRunsWithStepper(PlotSpec),
+  ConfigComponent: PanelRunsPlotsWithStepperConfig,
+  inputType: LIST_RUNS_TYPE,
+  outputType: () => ({
+    type: 'list' as const,
+    objectType: {
+      type: 'list' as const,
+      objectType: {type: 'typedDict' as const, propertyTypes: {}},
+    },
+  }),
+};

--- a/weave-js/src/components/Panel2/panellib/libpanel.ts
+++ b/weave-js/src/components/Panel2/panellib/libpanel.ts
@@ -203,6 +203,11 @@ export function getStackIdAndName<X, C, T extends Type>(
     ) {
       displayName = 'Run History Tables Stepper';
     } else if (
+      ourDisplayName === 'Run History Plots Stepper' &&
+      childDisplayName === 'Paginated Plots'
+    ) {
+      displayName = 'Run History Plots Stepper';
+    } else if (
       ourDisplayName === 'Combined Table' &&
       childDisplayName === 'Table'
     ) {


### PR DESCRIPTION
## Description

Tracking JIRA: https://wandb.atlassian.net/browse/WB-24060

**Note the base branch is `npun-wb-24060`**

Extends history tables stepper to plots. The config is slightly different from the tables case since we also need to render the `PanelPlot` config component

This is part of a set of 3 PRs to get stepped plots work:
1. Refactor history runs table stepper (https://github.com/wandb/weave/pull/3992)
2. Refactor PanelPlots (https://github.com/wandb/weave/pull/3994)
3. Add the plots stepper functionality (This PR)

## Testing

Local FE Invoker


https://github.com/user-attachments/assets/62e09310-eda7-4f15-bc06-93e1f26a3732


