### PR TITLE
feat(weave): adds api capability to include storage size

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -181,6 +181,8 @@ def test_trace_server_call_start_and_end(client):
         "wb_run_id": None,
         "deleted_at": None,
         "display_name": None,
+        "storage_size_bytes": None,
+        "total_storage_size_bytes": None,
     }
 
     end = tsi.EndedCallSchemaForInsert(
@@ -227,6 +229,8 @@ def test_trace_server_call_start_and_end(client):
         "wb_run_id": None,
         "deleted_at": None,
         "display_name": None,
+        "storage_size_bytes": None,
+        "total_storage_size_bytes": None,
     }
 
 

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1,0 +1,114 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch
+
+from weave.trace_server import clickhouse_trace_server_batched as chts
+from weave.trace_server import trace_server_interface as tsi
+
+
+def test_clickhouse_storage_size_query_generation():
+    """Test that ClickHouse storage size query generation works correctly."""
+    # Mock the query builder and query stream
+    with (
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.CallsQuery",
+            autospec=True,
+        ) as mock_cq,
+        patch.object(chts.ClickHouseTraceServer, "_query_stream") as mock_query_stream,
+    ):
+        # Create a mock CallsQuery instance
+        mock_calls_query = Mock()
+        # Mock the CallsQuery class to return our mock instance
+        mock_cq.return_value = mock_calls_query
+
+        # Mock the query stream to return empty list
+        mock_query_stream.return_value = []
+        # Mock the select_fields property to return an empty columns list
+        mock_calls_query.select_fields = []
+
+        # Create a request with storage size fields
+        req = tsi.CallsQueryReq(
+            project_id="test_project",
+            include_storage_size=True,
+            include_total_storage_size=True,
+        )
+
+        # Create server instance
+        server = chts.ClickHouseTraceServer(host="test_host")
+
+        # Call the method that generates the query and consume the generator
+        list(server.calls_query_stream(req))
+
+        # Verify that storage size fields were added
+        mock_calls_query.add_field.assert_any_call("storage_size_bytes")
+        mock_calls_query.add_field.assert_any_call("total_storage_size_bytes")
+
+        # Verify that _query_stream was called once
+        mock_query_stream.assert_called_once()
+        call_args = mock_query_stream.call_args[0]
+        assert (
+            call_args[0] == mock_calls_query.as_sql()
+        )  # First argument should be the query
+        # with mocks, we don't have any params generated
+        assert call_args[1] == {}  # Second argument should be project_id
+
+
+def test_clickhouse_storage_size_schema_conversion():
+    """Test that storage size fields are correctly converted in ClickHouse schema."""
+    # Test data with proper datetime structures
+    started_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ended_at = datetime(2024, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    test_data = {
+        "storage_size_bytes": 1000,
+        "total_storage_size_bytes": 2000,
+        "id": "test_id",
+        "name": "test_name",
+        "project_id": "test_project",
+        "trace_id": "test_trace",
+        "parent_id": None,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "inputs": {},
+        "outputs": {},
+        "error": None,
+        "summary": None,
+        "summary_dump": None,
+        "cost": None,
+        "wb_run_id": None,
+        "wb_user_id": None,
+    }
+
+    # Test ClickHouse conversion
+    ch_schema = chts._ch_call_dict_to_call_schema_dict(test_data)
+    assert ch_schema["storage_size_bytes"] == 1000
+    assert ch_schema["total_storage_size_bytes"] == 2000
+
+
+def test_clickhouse_storage_size_null_handling():
+    """Test that NULL values in storage size fields are handled correctly in ClickHouse."""
+    # Test data with NULL values and proper datetime structures
+    started_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ended_at = datetime(2024, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    test_data = {
+        "storage_size_bytes": None,
+        "total_storage_size_bytes": None,
+        "id": "test_id",
+        "name": "test_name",
+        "project_id": "test_project",
+        "trace_id": "test_trace",
+        "parent_id": None,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "inputs": {},
+        "outputs": {},
+        "error": None,
+        "summary": None,
+        "summary_dump": None,
+        "cost": None,
+        "wb_run_id": None,
+        "wb_user_id": None,
+    }
+
+    # Test ClickHouse conversion
+    ch_schema = chts._ch_call_dict_to_call_schema_dict(test_data)
+    assert ch_schema["storage_size_bytes"] is None
+    assert ch_schema["total_storage_size_bytes"] is None

--- a/tests/trace_server/test_sqlite_trace_server.py
+++ b/tests/trace_server/test_sqlite_trace_server.py
@@ -1,0 +1,39 @@
+from unittest.mock import Mock, patch
+
+from weave.trace_server import sqlite_trace_server as slts
+from weave.trace_server import trace_server_interface as tsi
+
+
+def test_sqlite_storage_size_query_generation():
+    """Test that SQLite storage size query generation works correctly."""
+    # Mock the query builder and cursor.execute
+    with patch.object(slts, "get_conn_cursor") as mock_get_conn_cursor:
+        # Mock cursor and connection
+        mock_cursor = Mock()
+        mock_get_conn_cursor.return_value = (Mock(), mock_cursor)
+
+        # Mock cursor.fetchall() return value
+        mock_cursor.fetchall.return_value = []
+
+        # Create a request with storage size fields
+        req = tsi.CallsQueryReq(
+            project_id="test_project",
+            include_storage_size=True,
+            include_total_storage_size=True,
+        )
+
+        # Create server instance
+        server = slts.SqliteTraceServer("test.db")
+
+        # Call the method that generates the query and consume the generator
+        list(server.calls_query_stream(req))
+
+        # Verify that cursor.execute was called with the correct query
+        mock_cursor.execute.assert_called_once()
+        call_args = mock_cursor.execute.call_args[0]
+        sql = call_args[0]
+        print(sql)
+        assert "storage_size_bytes" in sql  # Query should include storage_size_bytes
+        assert (
+            "total_storage_size_bytes" in sql
+        )  # Query should include total_storage_size_bytes

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -286,6 +286,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 ),
                 limit=1,
                 include_costs=req.include_costs,
+                include_storage_size=req.include_storage_size,
+                include_total_storage_size=req.include_total_storage_size,
             )
         )
         try:
@@ -325,7 +327,10 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
         """Returns a stream of calls that match the given query."""
         cq = CallsQuery(
-            project_id=req.project_id, include_costs=req.include_costs or False
+            project_id=req.project_id,
+            include_costs=req.include_costs or False,
+            include_storage_size=req.include_storage_size or False,
+            include_total_storage_size=req.include_total_storage_size or False,
         )
         columns = all_call_select_columns
         if req.columns:
@@ -347,6 +352,13 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 *[col for col in columns if col not in summary_columns],
                 "summary_dump",
             ]
+
+        if req.include_storage_size:
+            columns.append("storage_size_bytes")
+
+        if req.include_total_storage_size:
+            columns.append("total_storage_size_bytes")
+
         for col in columns:
             cq.add_field(col)
         if req.filter is not None:
@@ -2146,6 +2158,8 @@ def _ch_call_to_call_schema(ch_call: SelectableCHCallSchema) -> tsi.CallSchema:
         wb_run_id=ch_call.wb_run_id,
         wb_user_id=ch_call.wb_user_id,
         display_name=display_name,
+        storage_size_bytes=ch_call.storage_size_bytes,
+        total_storage_size_bytes=ch_call.total_storage_size_bytes,
     )
 
 
@@ -2178,6 +2192,8 @@ def _ch_call_dict_to_call_schema_dict(ch_call_dict: dict) -> dict:
         "wb_run_id": ch_call_dict.get("wb_run_id"),
         "wb_user_id": ch_call_dict.get("wb_user_id"),
         "display_name": display_name,
+        "storage_size_bytes": ch_call_dict.get("storage_size_bytes"),
+        "total_storage_size_bytes": ch_call_dict.get("total_storage_size_bytes"),
     }
 
 

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -118,6 +118,12 @@ class CallSchema(BaseModel):
 
     deleted_at: Optional[datetime.datetime] = None
 
+    # Size of metadata storage for this call
+    storage_size_bytes: Optional[int] = None
+
+    # Total size of metadata storage for the entire trace
+    total_storage_size_bytes: Optional[int] = None
+
     @field_serializer("attributes", "summary", when_used="unless-none")
     def serialize_typed_dicts(self, v: dict[str, Any]) -> dict[str, Any]:
         return dict(v)
@@ -251,6 +257,8 @@ class CallReadReq(BaseModel):
     project_id: str
     id: str
     include_costs: Optional[bool] = False
+    include_storage_size: Optional[bool] = False
+    include_total_storage_size: Optional[bool] = False
 
 
 class CallReadRes(BaseModel):
@@ -351,6 +359,16 @@ class CallsQueryReq(BaseModel):
         default=False,
         description="Beta, subject to change. If true, the response will"
         " include feedback for each call.",
+    )
+    include_storage_size: Optional[bool] = Field(
+        default=False,
+        description="Beta, subject to change. If true, the response will"
+        " include the storage size for a call.",
+    )
+    include_total_storage_size: Optional[bool] = Field(
+        default=False,
+        description="Beta, subject to change. If true, the response will"
+        " include the total storage size for a trace.",
     )
 
     # TODO: type this with call schema columns, following the same rules as


### PR DESCRIPTION
## Description

## Overview
This PR adds the ability to query storage size information for calls in the trace server. It introduces two new features:
1. Individual call storage size
2. Rolled-up storage size for entire traces

## Changes
- Added new fields to `CallSchema`:
  - `storage_size_bytes`: Size of metadata storage for individual calls
  - `total_size_bytes`: Total size of metadata storage for entire traces
- Added new query parameters to `CallsQueryReq`:
  - `include_storage_size`: Returns storage size for each call
  - `include_rolled_up_storage_size`: Returns total size for root calls only
- Implemented storage size calculation in both SQLite and ClickHouse trace servers
- Added unit tests for both features

## Implementation Details
- For SQLite: Uses `length()` function to calculate storage size from JSON fields
- For ClickHouse: Uses `calls_merged_stats` table to get pre-calculated sizes
- Storage size is calculated as sum of:
  - attributes size
  - inputs size
  - output size
  - summary size

CallsQueryReq is added with two new fields `include_storage_size` , `include_rolled_up_storage_size` .

- `include_rolled_up_storage_size` is primarily used for the calls list view UI.
- `include_storage_size` should be included in the call details view
- `include_rolled_up_storage_size` if the FE can detect that the call about to be opened is the root call, include this as well when requesting the call details data.

### Client Tests (SQlite only for now)
1. `test_calls_query_with_storage_size`: Tests individual call storage size
2. `test_calls_query_with_rolled_up_storage_size`: Tests trace-level storage size
3. `test_calls_query_with_both_storage_sizes`: Tests both features together

### Query Builder Tests
1. `test_storage_size_fields`: Tests SQL generation for individual storage size queries
2. `test_rolled_up_storage_size`: Tests SQL generation for rolled-up storage size queries
3. `test_aggregated_data_size_field`: Tests the new `AggregatedDataSizeField` class


### Manual tests:
Despite there is no UI, I did manually set the `include_storage_size` and `include_rolled_up_storage_size` and did see the response contains the expected numbers.


## Notes
- This is marked as beta and subject to change
- This is only the server side change, I will also be responsible for frontend change later.
- Storage size calculation is optimized for ClickHouse backends
- Rolled-up storage size is only available for root calls (calls without parents)
- A mini design-doc can be found [here (internal)](https://www.notion.so/wandbai/Data-Size-display-1bde2f5c7ef38087bc03cb8accb95bfb)

- Addresses task WB-23748


