### PR TITLE
chore(weave): parameterize clickhouse single query max mem usage

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -182,7 +182,7 @@ CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT = 3.5 * 1024 * 1024  # 3.5 MiB
 ENTITY_TOO_LARGE_PAYLOAD = '{"_weave": {"error":"<EXCEEDS_LIMITS>"}}'
 
 CLICKHOUSE_DEFAULT_QUERY_SETTINGS = {
-    "max_memory_usage": 16 * 1024 * 1024 * 1024,  # 16 GiB
+    "max_memory_usage": 32 * 1024 * 1024 * 1024,  # 32 GiB
 }
 
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -181,8 +181,10 @@ ObjRefListType = list[ri.InternalObjectRef]
 CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT = 3.5 * 1024 * 1024  # 3.5 MiB
 ENTITY_TOO_LARGE_PAYLOAD = '{"_weave": {"error":"<EXCEEDS_LIMITS>"}}'
 
+DEFAULT_MAX_MEMORY_USAGE = 16 * 1024 * 1024 * 1024  # 16 GiB
 CLICKHOUSE_DEFAULT_QUERY_SETTINGS = {
-    "max_memory_usage": 32 * 1024 * 1024 * 1024,  # 32 GiB
+    "max_memory_usage": wf_env.wf_clickhouse_max_memory_usage()
+    or DEFAULT_MAX_MEMORY_USAGE
 }
 
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -27,6 +27,17 @@ def wf_clickhouse_database() -> str:
     return os.environ.get("WF_CLICKHOUSE_DATABASE", "default")
 
 
+def wf_clickhouse_max_memory_usage() -> Optional[int]:
+    """The maximum memory usage for the clickhouse server."""
+    mem = os.environ.get("WF_CLICKHOUSE_MAX_MEMORY_USAGE")
+    if mem is None:
+        return None
+    try:
+        return int(mem)
+    except ValueError:
+        return None
+
+
 # BYOB Settings
 
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Add `WF_CLICKHOUSE_MAX_MEMORY_USAGE` to control the single query maximum ch memory