### PR TITLE
chore(weave): remove footgun datetime handling

### DIFF
--- a/weave-js/src/util/date.ts
+++ b/weave-js/src/util/date.ts
@@ -246,13 +246,7 @@ export const parseDate = (dateStr: string): Date | null => {
   // Try parsing with moment for standard date formats
   const momentDate = moment(trimmedStr);
   if (momentDate.isValid()) {
-    // Check if the date is within a year from now
-    const oneYearFromNow = moment().add(1, 'year');
-    const oneYearAgo = moment().subtract(1, 'year');
-
-    if (momentDate.isBetween(oneYearAgo, oneYearFromNow, 'day', '[]')) {
-      return momentDate.toDate();
-    }
+    return momentDate.toDate();
   }
 
   // If all parsing attempts fail, return null


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Previous handling attempted to ensure parsing made sense, but instead is way too strict. Remove footgun. 

## Testing

| prod | branch | 
| ----- | ----- |
| <img width="679" alt="Screenshot 2025-03-28 at 12 51 17 PM" src="https://github.com/user-attachments/assets/f323b5c9-ced2-4d19-9126-5a815df0753c" /> | <img width="671" alt="Screenshot 2025-03-28 at 12 51 03 PM" src="https://github.com/user-attachments/assets/25d4ec82-bd6e-4ae2-b980-3a104dda5f40" /> |



