### PR TITLE
chore(weave): read CH database settings in test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -570,7 +570,9 @@ def create_client(
     elif weave_server_flag == "clickhouse":
         ch_server = clickhouse_trace_server_batched.ClickHouseTraceServer.from_env()
         ch_server.ch_client.command("DROP DATABASE IF EXISTS db_management")
-        ch_server.ch_client.command("DROP DATABASE IF EXISTS default")
+        ch_server.ch_client.command(
+            f"DROP DATABASE IF EXISTS {ts_env.wf_clickhouse_database()}"
+        )
         ch_server._run_migrations()
         server = TestOnlyUserInjectingExternalTraceServer(
             ch_server, DummyIdConverter(), entity


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
By default when running test against clickhouse-backed trace server, the test run will erase the data in the `default` database, which jeopardizes the local dev environment. One way to work around it is to use WF_CLICKHOUSE_DATABASE env var.

However, when I use this command to run a test against the clickhouse server:
```
WF_CLICKHOUSE_DATABASE=test nox -e "tests-3.12(shard='trace')" -- --weave-server=clickhouse
```

Because the conftest is hard coded to use the `default` database, the execution will fail. This PR fixes that. 

However I recommend using an alternative port, which is also supported in [this internal PR](https://github.com/wandb/core/pull/28414).

## Testing

Locally verified by running test.
