### PR TITLE
chore(weave): Add object traversal utilities

### DIFF
--- a/tests/trace/test_traverse.py
+++ b/tests/trace/test_traverse.py
@@ -1,0 +1,161 @@
+import pytest
+
+from weave.trace.traverse import ObjectPath, escape_key, get_paths, sort_paths
+
+
+def test_escape_key() -> None:
+    assert escape_key("") == ""
+    assert escape_key("user") == "user"
+    assert escape_key("user[name]") == "user\\[name\\]"
+    assert escape_key("user.name[0]") == "user\\.name\\[0\\]"
+    assert escape_key("user.name[0].name") == "user\\.name\\[0\\]\\.name"
+
+
+class TestObjectPathToStr:
+    def test_handles_empty_path(self) -> None:
+        assert ObjectPath([]).to_str() == ""
+
+    def test_handles_simple_cases(self) -> None:
+        assert ObjectPath(["foo"]).to_str() == "foo"
+        assert ObjectPath(["foo", "bar"]).to_str() == "foo.bar"
+        assert ObjectPath(["foo", "4"]).to_str() == "foo.4"
+        assert ObjectPath(["foo", 4]).to_str() == "foo[4]"
+
+    def test_escapes_periods(self) -> None:
+        assert ObjectPath(["foo.bar.baz"]).to_str() == "foo\\.bar\\.baz"
+
+    def test_escapes_brackets(self) -> None:
+        assert ObjectPath(["foo[5]"]).to_str() == "foo\\[5\\]"
+
+    def test_str(self) -> None:
+        assert str(ObjectPath(["foo", "bar"])) == "foo.bar"
+        assert str(ObjectPath(["foo", 4])) == "foo[4]"
+
+
+class TestObjectPathParseStr:
+    def test_handles_empty_path(self) -> None:
+        assert ObjectPath.parse_str("").elements == []
+
+    def test_handles_simple_cases(self) -> None:
+        assert ObjectPath.parse_str("foo").elements == ["foo"]
+        assert ObjectPath.parse_str("foo.bar").elements == ["foo", "bar"]
+
+    def test_handles_numeric_keys(self) -> None:
+        assert ObjectPath.parse_str("0").elements == ["0"]
+        assert ObjectPath.parse_str("42").elements == ["42"]
+
+    def test_handles_punctuation_in_keys(self) -> None:
+        assert ObjectPath.parse_str("a,b!").elements == ["a,b!"]
+
+    def test_handles_key_access_errors(self) -> None:
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str(".")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("a[0].")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("a..b")
+
+    def test_handles_array_index_cases(self) -> None:
+        assert ObjectPath.parse_str("foo[2]").elements == ["foo", 2]
+        assert ObjectPath.parse_str("foo[2][3]").elements == ["foo", 2, 3]
+
+    def test_handles_array_index_errors(self) -> None:
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo[")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo[]")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo[1e3]")
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo.[1]")
+
+    def test_handles_escaped_chars(self) -> None:
+        assert ObjectPath.parse_str("foo\\.bar").elements == ["foo.bar"]
+        assert ObjectPath.parse_str("foo\\[").elements == ["foo["]
+
+    def test_handles_escaping_errors(self) -> None:
+        with pytest.raises(ValueError):
+            ObjectPath.parse_str("foo\\")
+
+    def test_handles_complex_cases(self) -> None:
+        assert ObjectPath.parse_str("fo\\.o[1].bar.baz.bim[3][5].wat").elements == [
+            "fo.o",
+            1,
+            "bar",
+            "baz",
+            "bim",
+            3,
+            5,
+            "wat",
+        ]
+
+
+class TestObjectPathDunderMethods:
+    def test_hash(self) -> None:
+        assert isinstance(hash(ObjectPath(["foo", 42, "bar"])), int)
+
+    def test_getitem(self) -> None:
+        path = ObjectPath(["foo", 42, "bar"])
+        assert path[0] == "foo"
+        assert path[1] == 42
+        assert path[2] == "bar"
+
+    def test_add(self) -> None:
+        assert ObjectPath() + ["foo"] == ObjectPath(["foo"])
+        assert ObjectPath(["foo"]) + [0] == ObjectPath(["foo", 0])
+        assert ObjectPath(["foo"]) + [0, "bar"] == ObjectPath(["foo", 0, "bar"])
+
+    def test_len(self) -> None:
+        assert len(ObjectPath(["foo", 42, "bar"])) == 3
+
+    def test_repr(self) -> None:
+        assert repr(ObjectPath(["foo", 42, "bar"])) == "ObjectPath(['foo', 42, 'bar'])"
+
+
+class TestObjectPathComparePaths:
+    def test_simple_cases(self) -> None:
+        assert ObjectPath(["foo"]).__eq__(42) is NotImplemented
+        assert ObjectPath(["foo"]).__ne__(42) is NotImplemented
+        assert ObjectPath(["foo"]) == ObjectPath(["foo"])
+        assert ObjectPath(["foo"]) != ObjectPath(["foo", 42])
+        assert ObjectPath(["foo", 10]) == ObjectPath(["foo", 10])
+        assert ObjectPath(["foo"]) < ObjectPath(["foo", "bar"])
+        assert ObjectPath(["foo"]) <= ObjectPath(["foo", "bar"])
+        assert ObjectPath(["foo"]) <= ObjectPath(["foo"])
+        assert ObjectPath(["foo", "bar"]) > ObjectPath(["foo"])
+        assert ObjectPath(["foo", "bar"]) < ObjectPath(["foo", "baz"])
+        assert ObjectPath(["foo", 9]) < ObjectPath(["foo", 10])
+        assert ObjectPath(["foo", 11]) > ObjectPath(["foo", 1])
+        assert ObjectPath(["foo", 11]) >= ObjectPath(["foo", 11])
+        assert ObjectPath(["foo", "z"]) < ObjectPath(["foo", 0])
+        assert not (ObjectPath(["foo", 0]) < ObjectPath(["foo", "a"]))
+
+
+class TestObjectPathGetPaths:
+    def test_object_cases(self) -> None:
+        assert get_paths({}) == []
+        assert get_paths({"foo": 42}) == [ObjectPath(["foo"])]
+        assert get_paths({"foo": {"bar": 42}}) == [
+            ObjectPath(["foo"]),
+            ObjectPath(["foo", "bar"]),
+        ]
+
+    def test_list_cases(self) -> None:
+        obj = {
+            "foo": [
+                {"bar": 42},
+                {"baz": 43},
+            ]
+        }
+        assert get_paths(obj) == [
+            ObjectPath(["foo"]),
+            ObjectPath(["foo", 0]),
+            ObjectPath(["foo", 0, "bar"]),
+            ObjectPath(["foo", 1]),
+            ObjectPath(["foo", 1, "baz"]),
+        ]
+
+
+class TestObjectPathSortPaths:
+    def test_sorting(self) -> None:
+        assert sort_paths([]) == []

--- a/weave/trace/traverse.py
+++ b/weave/trace/traverse.py
@@ -1,0 +1,215 @@
+"""Utilities for traversing objects."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterator
+from functools import cmp_to_key
+from typing import Any, Union, overload
+
+# String indicates object key access, number indicates array index access
+# This structure allows us to handle corner cases like periods or brackets
+# in object keys.
+
+PathElement = Union[str, int]
+
+
+def escape_key(key: str) -> str:
+    """Escape special characters in a key for path string representation."""
+    return key.replace(".", "\\.").replace("[", "\\[").replace("]", "\\]")
+
+
+class ObjectPath:
+    elements: list[PathElement]
+
+    def __init__(self, elements: list[PathElement] | None = None):
+        self.elements = elements if elements is not None else []
+
+    @overload
+    def __getitem__(self, index: int) -> PathElement: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[PathElement]: ...
+
+    def __getitem__(self, index: int | slice) -> PathElement | list[PathElement]:
+        return self.elements[index]
+
+    def __len__(self) -> int:
+        return len(self.elements)
+
+    def __add__(self, other: list[PathElement]) -> ObjectPath:
+        return ObjectPath(self.elements + other)
+
+    def __iter__(self) -> Iterator[PathElement]:
+        return iter(self.elements)
+
+    def __repr__(self) -> str:
+        return f"ObjectPath({self.elements})"
+
+    def __lt__(self, other: ObjectPath) -> bool:
+        return compare_paths(self, other) < 0
+
+    def __le__(self, other: ObjectPath) -> bool:
+        return compare_paths(self, other) <= 0
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ObjectPath):
+            return NotImplemented
+        return compare_paths(self, other) == 0
+
+    def __ne__(self, other: object) -> bool:
+        if not isinstance(other, ObjectPath):
+            return NotImplemented
+        return compare_paths(self, other) != 0
+
+    def __gt__(self, other: ObjectPath) -> bool:
+        return compare_paths(self, other) > 0
+
+    def __ge__(self, other: ObjectPath) -> bool:
+        return compare_paths(self, other) >= 0
+
+    def __hash__(self) -> int:
+        return hash(tuple(self.elements))
+
+    def __str__(self) -> str:
+        return self.to_str()
+
+    def to_str(self) -> str:
+        """Convert the path to a string representation.
+
+        Returns a string with dot notation for string elements and
+        square brackets for numeric indices.
+        """
+        result = ""
+        for element in self.elements:
+            if isinstance(element, str):
+                # Escape special characters in string keys
+                escaped = escape_key(element)
+                if result:
+                    result += "."
+                result += escaped
+            else:
+                # Use bracket notation for numeric indices
+                result += f"[{element}]"
+        return result
+
+    @classmethod
+    def parse_str(cls, path_string: str) -> ObjectPath:
+        """Parse a string representation of a path into a ObjectPath object.
+
+        Handles dot notation for object access and square brackets for array indices.
+        Supports escaping with backslash.
+
+        Args:
+            path_string: String representation of a path
+
+        Returns:
+            ObjectPath object
+
+        Raises:
+            ValueError: If the path string is invalid
+        """
+        path: list[PathElement] = []
+        key = ""
+        n = len(path_string)
+        i = 0
+
+        while i < n:
+            char = path_string[i]
+            if char == "\\":
+                if i == n - 1:
+                    raise ValueError("Invalid escape sequence")
+                key += path_string[i + 1]
+                i += 2
+            elif char == ".":
+                if i == 0 or i == n - 1:
+                    raise ValueError("Invalid object access")
+                prev = path_string[i - 1]
+                next_char = path_string[i + 1]
+                if not next_char.isalnum() or not (prev.isalnum() or prev == "]"):
+                    raise ValueError("Invalid object access")
+                if key:
+                    path.append(key)
+                    key = ""
+                i += 1
+            elif char == "[":
+                if key:
+                    path.append(key)
+                    key = ""
+                j = i + 1
+                while j < n and path_string[j] != "]":
+                    j += 1
+                index_str = path_string[i + 1 : j]
+                if j == n:
+                    raise ValueError(f"Invalid array index: '{index_str}'")
+                if not index_str.isdigit():
+                    raise ValueError(f"Invalid array index: '{index_str}'")
+                path.append(int(index_str))
+                i = j + 1
+            else:
+                key += char
+                i += 1
+
+        if key:
+            path.append(key)
+
+        return cls(path)
+
+
+ObjectPaths = list[ObjectPath]
+
+
+def get_paths(obj: Any, path: ObjectPath | None = None) -> ObjectPaths:
+    """Traverse an object and return all possible key paths."""
+    if path is None:
+        path = ObjectPath([])
+    paths = [path] if path else []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            paths.extend(get_paths(value, path + [key]))
+    elif isinstance(obj, list):
+        for i, value in enumerate(obj):
+            to_add: list[PathElement] = [i]  # Making pyright happy
+            paths.extend(get_paths(value, path + to_add))
+    return paths
+
+
+def compare_paths(path1: ObjectPath, path2: ObjectPath) -> int:
+    """Compare two paths for sort ordering.
+
+    Returns:
+        -1 if path1 < path2
+        0 if path1 == path2
+        1 if path1 > path2
+    """
+    # Compare elements pairwise
+    for e1, e2 in zip(path1, path2):
+        # If elements are same type, compare directly
+        if isinstance(e1, str) and isinstance(e2, str):
+            if e1 < e2:
+                return -1
+            if e1 > e2:
+                return 1
+        elif isinstance(e1, int) and isinstance(e2, int):
+            if e1 < e2:
+                return -1
+            if e1 > e2:
+                return 1
+
+        # If different types, strings come before integers
+        if isinstance(e1, str) and isinstance(e2, int):
+            return -1
+        if isinstance(e1, int) and isinstance(e2, str):
+            return 1
+
+    # If we get here, all common elements were equal
+    # Shorter paths come before longer paths
+    if len(path1) < len(path2):
+        return -1
+    if len(path1) > len(path2):
+        return 1
+
+    return 0
+
+
+def sort_paths(paths: Collection[ObjectPath]) -> ObjectPaths:
+    return sorted(paths, key=cmp_to_key(compare_paths))


### PR DESCRIPTION
## Description

Extracted from https://github.com/wandb/weave/pull/3854/

As part of Saved Views you can specify a path to an item within a JSON object representation, drilling in by object key or array index. This is used e.g. for extracting `inputs.foo[2].bar` as a column. This Python code for traversing objects is inspired by similar methods we have in the UI.

@tssweeney I believe you've looked at this code previously.

## Testing

Includes unit tests