### PR TITLE
chore(weave): Saved View builtin object definition and registry

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBuiltinObjectClasses.zod.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBuiltinObjectClasses.zod.ts
@@ -9,6 +9,9 @@ export type Model = z.infer<typeof ModelSchema>;
 export const ProviderReturnTypeSchema = z.enum(['openai']);
 export type ProviderReturnType = z.infer<typeof ProviderReturnTypeSchema>;
 
+export const DirectionSchema = z.enum(['asc', 'desc']);
+export type Direction = z.infer<typeof DirectionSchema>;
+
 export const ConfigSchema = z.object({
   action_type: ActionTypeSchema.optional(),
   model: ModelSchema.optional(),
@@ -53,6 +56,46 @@ export const ProviderModelSchema = z.object({
 });
 export type ProviderModel = z.infer<typeof ProviderModelSchema>;
 
+export const ColumnSchema = z.object({
+  label: z.union([z.null(), z.string()]).optional(),
+  path: z
+    .union([z.array(z.union([z.number(), z.string()])), z.null()])
+    .optional(),
+});
+export type Column = z.infer<typeof ColumnSchema>;
+
+export const CallsFilterSchema = z.object({
+  call_ids: z.union([z.array(z.string()), z.null()]).optional(),
+  input_refs: z.union([z.array(z.string()), z.null()]).optional(),
+  op_names: z.union([z.array(z.string()), z.null()]).optional(),
+  output_refs: z.union([z.array(z.string()), z.null()]).optional(),
+  parent_ids: z.union([z.array(z.string()), z.null()]).optional(),
+  trace_ids: z.union([z.array(z.string()), z.null()]).optional(),
+  trace_roots_only: z.union([z.boolean(), z.null()]).optional(),
+  wb_run_ids: z.union([z.array(z.string()), z.null()]).optional(),
+  wb_user_ids: z.union([z.array(z.string()), z.null()]).optional(),
+});
+export type CallsFilter = z.infer<typeof CallsFilterSchema>;
+
+export const PinSchema = z.object({
+  left: z.array(z.string()),
+  right: z.array(z.string()),
+});
+export type Pin = z.infer<typeof PinSchema>;
+
+export const ContainsSpecSchema = z.object({
+  case_insensitive: z.union([z.boolean(), z.null()]).optional(),
+  input: z.any(),
+  substr: z.any(),
+});
+export type ContainsSpec = z.infer<typeof ContainsSpecSchema>;
+
+export const SortBySchema = z.object({
+  direction: DirectionSchema,
+  field: z.string(),
+});
+export type SortBy = z.infer<typeof SortBySchema>;
+
 export const TestOnlyNestedBaseModelSchema = z.object({
   a: z.number(),
 });
@@ -83,6 +126,18 @@ export const LeaderboardSchema = z.object({
 });
 export type Leaderboard = z.infer<typeof LeaderboardSchema>;
 
+export const ExprSchema = z.object({
+  $and: z.array(z.any()).optional(),
+  $or: z.array(z.any()).optional(),
+  $not: z.array(z.any()).optional(),
+  $eq: z.array(z.any()).optional(),
+  $gt: z.array(z.any()).optional(),
+  $gte: z.array(z.any()).optional(),
+  $in: z.array(z.any()).optional(),
+  $contains: ContainsSpecSchema.optional(),
+});
+export type Expr = z.infer<typeof ExprSchema>;
+
 export const TestOnlyExampleSchema = z.object({
   description: z.union([z.null(), z.string()]).optional(),
   name: z.union([z.null(), z.string()]).optional(),
@@ -92,12 +147,38 @@ export const TestOnlyExampleSchema = z.object({
 });
 export type TestOnlyExample = z.infer<typeof TestOnlyExampleSchema>;
 
+export const QuerySchema = z.object({
+  $expr: ExprSchema,
+});
+export type Query = z.infer<typeof QuerySchema>;
+
+export const SavedViewDefinitionSchema = z.object({
+  cols: z.union([z.record(z.string(), z.boolean()), z.null()]).optional(),
+  columns: z.union([z.array(ColumnSchema), z.null()]).optional(),
+  filter: z.union([CallsFilterSchema, z.null()]).optional(),
+  page_size: z.union([z.number(), z.null()]).optional(),
+  pin: z.union([PinSchema, z.null()]).optional(),
+  query: z.union([QuerySchema, z.null()]).optional(),
+  sort_by: z.union([z.array(SortBySchema), z.null()]).optional(),
+});
+export type SavedViewDefinition = z.infer<typeof SavedViewDefinitionSchema>;
+
+export const SavedViewSchema = z.object({
+  definition: SavedViewDefinitionSchema,
+  description: z.union([z.null(), z.string()]).optional(),
+  label: z.string(),
+  name: z.union([z.null(), z.string()]).optional(),
+  view_type: z.string(),
+});
+export type SavedView = z.infer<typeof SavedViewSchema>;
+
 export const builtinObjectClassRegistry = {
   ActionSpec: ActionSpecSchema,
   AnnotationSpec: AnnotationSpecSchema,
   Leaderboard: LeaderboardSchema,
   Provider: ProviderSchema,
   ProviderModel: ProviderModelSchema,
+  SavedView: SavedViewSchema,
   TestOnlyExample: TestOnlyExampleSchema,
   TestOnlyNestedBaseObject: TestOnlyNestedBaseObjectSchema,
 };

--- a/weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py
+++ b/weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py
@@ -10,6 +10,7 @@ from weave.trace_server.interface.builtin_object_classes.provider import (
     Provider,
     ProviderModel,
 )
+from weave.trace_server.interface.builtin_object_classes.saved_view import SavedView
 from weave.trace_server.interface.builtin_object_classes.test_only_example import (
     TestOnlyExample,
     TestOnlyNestedBaseObject,
@@ -35,3 +36,4 @@ register_base_object(ActionSpec)
 register_base_object(AnnotationSpec)
 register_base_object(Provider)
 register_base_object(ProviderModel)
+register_base_object(SavedView)

--- a/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
+++ b/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
@@ -51,6 +51,56 @@
       "title": "ActionSpec",
       "type": "object"
     },
+    "AndOperation": {
+      "properties": {
+        "$and": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LiteralOperation"
+              },
+              {
+                "$ref": "#/$defs/GetFieldOperator"
+              },
+              {
+                "$ref": "#/$defs/ConvertOperation"
+              },
+              {
+                "title": "AndOperation"
+              },
+              {
+                "$ref": "#/$defs/OrOperation"
+              },
+              {
+                "$ref": "#/$defs/NotOperation"
+              },
+              {
+                "$ref": "#/$defs/EqOperation"
+              },
+              {
+                "$ref": "#/$defs/GtOperation"
+              },
+              {
+                "$ref": "#/$defs/GteOperation"
+              },
+              {
+                "$ref": "#/$defs/InOperation"
+              },
+              {
+                "$ref": "#/$defs/ContainsOperation"
+              }
+            ]
+          },
+          "title": "$And",
+          "type": "array"
+        }
+      },
+      "required": [
+        "$and"
+      ],
+      "title": "AndOperation",
+      "type": "object"
+    },
     "AnnotationSpec": {
       "properties": {
         "name": {
@@ -141,6 +191,294 @@
       "title": "AnnotationSpec",
       "type": "object"
     },
+    "CallsFilter": {
+      "properties": {
+        "op_names": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Op Names"
+        },
+        "input_refs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Input Refs"
+        },
+        "output_refs": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Output Refs"
+        },
+        "parent_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parent Ids"
+        },
+        "trace_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Trace Ids"
+        },
+        "call_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Call Ids"
+        },
+        "trace_roots_only": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Trace Roots Only"
+        },
+        "wb_user_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Wb User Ids"
+        },
+        "wb_run_ids": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Wb Run Ids"
+        }
+      },
+      "title": "CallsFilter",
+      "type": "object"
+    },
+    "Column": {
+      "properties": {
+        "path": {
+          "anyOf": [
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Path"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Label"
+        }
+      },
+      "title": "Column",
+      "type": "object"
+    },
+    "ContainsOperation": {
+      "properties": {
+        "$contains": {
+          "$ref": "#/$defs/ContainsSpec"
+        }
+      },
+      "required": [
+        "$contains"
+      ],
+      "title": "ContainsOperation",
+      "type": "object"
+    },
+    "ContainsSpec": {
+      "properties": {
+        "input": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LiteralOperation"
+            },
+            {
+              "$ref": "#/$defs/GetFieldOperator"
+            },
+            {
+              "$ref": "#/$defs/ConvertOperation"
+            },
+            {
+              "title": "AndOperation"
+            },
+            {
+              "$ref": "#/$defs/OrOperation"
+            },
+            {
+              "$ref": "#/$defs/NotOperation"
+            },
+            {
+              "$ref": "#/$defs/EqOperation"
+            },
+            {
+              "$ref": "#/$defs/GtOperation"
+            },
+            {
+              "$ref": "#/$defs/GteOperation"
+            },
+            {
+              "$ref": "#/$defs/InOperation"
+            },
+            {
+              "title": "ContainsOperation"
+            }
+          ],
+          "title": "Input"
+        },
+        "substr": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LiteralOperation"
+            },
+            {
+              "$ref": "#/$defs/GetFieldOperator"
+            },
+            {
+              "$ref": "#/$defs/ConvertOperation"
+            },
+            {
+              "title": "AndOperation"
+            },
+            {
+              "$ref": "#/$defs/OrOperation"
+            },
+            {
+              "$ref": "#/$defs/NotOperation"
+            },
+            {
+              "$ref": "#/$defs/EqOperation"
+            },
+            {
+              "$ref": "#/$defs/GtOperation"
+            },
+            {
+              "$ref": "#/$defs/GteOperation"
+            },
+            {
+              "$ref": "#/$defs/InOperation"
+            },
+            {
+              "title": "ContainsOperation"
+            }
+          ],
+          "title": "Substr"
+        },
+        "case_insensitive": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": false,
+          "title": "Case Insensitive"
+        }
+      },
+      "required": [
+        "input",
+        "substr"
+      ],
+      "title": "ContainsSpec",
+      "type": "object"
+    },
     "ContainsWordsActionConfig": {
       "properties": {
         "action_type": {
@@ -161,6 +499,457 @@
         "target_words"
       ],
       "title": "ContainsWordsActionConfig",
+      "type": "object"
+    },
+    "ConvertOperation": {
+      "properties": {
+        "$convert": {
+          "$ref": "#/$defs/ConvertSpec"
+        }
+      },
+      "required": [
+        "$convert"
+      ],
+      "title": "ConvertOperation",
+      "type": "object"
+    },
+    "ConvertSpec": {
+      "properties": {
+        "input": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LiteralOperation"
+            },
+            {
+              "$ref": "#/$defs/GetFieldOperator"
+            },
+            {
+              "title": "ConvertOperation"
+            },
+            {
+              "title": "AndOperation"
+            },
+            {
+              "$ref": "#/$defs/OrOperation"
+            },
+            {
+              "$ref": "#/$defs/NotOperation"
+            },
+            {
+              "$ref": "#/$defs/EqOperation"
+            },
+            {
+              "$ref": "#/$defs/GtOperation"
+            },
+            {
+              "$ref": "#/$defs/GteOperation"
+            },
+            {
+              "$ref": "#/$defs/InOperation"
+            },
+            {
+              "title": "ContainsOperation"
+            }
+          ],
+          "title": "Input"
+        },
+        "to": {
+          "enum": [
+            "double",
+            "string",
+            "int",
+            "bool",
+            "exists"
+          ],
+          "title": "To",
+          "type": "string"
+        }
+      },
+      "required": [
+        "input",
+        "to"
+      ],
+      "title": "ConvertSpec",
+      "type": "object"
+    },
+    "EqOperation": {
+      "properties": {
+        "$eq": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LiteralOperation"
+                },
+                {
+                  "$ref": "#/$defs/GetFieldOperator"
+                },
+                {
+                  "title": "ConvertOperation"
+                },
+                {
+                  "title": "AndOperation"
+                },
+                {
+                  "$ref": "#/$defs/OrOperation"
+                },
+                {
+                  "$ref": "#/$defs/NotOperation"
+                },
+                {
+                  "title": "EqOperation"
+                },
+                {
+                  "$ref": "#/$defs/GtOperation"
+                },
+                {
+                  "$ref": "#/$defs/GteOperation"
+                },
+                {
+                  "$ref": "#/$defs/InOperation"
+                },
+                {
+                  "title": "ContainsOperation"
+                }
+              ]
+            },
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LiteralOperation"
+                },
+                {
+                  "$ref": "#/$defs/GetFieldOperator"
+                },
+                {
+                  "title": "ConvertOperation"
+                },
+                {
+                  "title": "AndOperation"
+                },
+                {
+                  "$ref": "#/$defs/OrOperation"
+                },
+                {
+                  "$ref": "#/$defs/NotOperation"
+                },
+                {
+                  "title": "EqOperation"
+                },
+                {
+                  "$ref": "#/$defs/GtOperation"
+                },
+                {
+                  "$ref": "#/$defs/GteOperation"
+                },
+                {
+                  "$ref": "#/$defs/InOperation"
+                },
+                {
+                  "title": "ContainsOperation"
+                }
+              ]
+            }
+          ],
+          "title": "$Eq",
+          "type": "array"
+        }
+      },
+      "required": [
+        "$eq"
+      ],
+      "title": "EqOperation",
+      "type": "object"
+    },
+    "GetFieldOperator": {
+      "properties": {
+        "$getField": {
+          "title": "$Getfield",
+          "type": "string"
+        }
+      },
+      "required": [
+        "$getField"
+      ],
+      "title": "GetFieldOperator",
+      "type": "object"
+    },
+    "GtOperation": {
+      "properties": {
+        "$gt": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LiteralOperation"
+                },
+                {
+                  "$ref": "#/$defs/GetFieldOperator"
+                },
+                {
+                  "title": "ConvertOperation"
+                },
+                {
+                  "title": "AndOperation"
+                },
+                {
+                  "$ref": "#/$defs/OrOperation"
+                },
+                {
+                  "$ref": "#/$defs/NotOperation"
+                },
+                {
+                  "title": "EqOperation"
+                },
+                {
+                  "title": "GtOperation"
+                },
+                {
+                  "$ref": "#/$defs/GteOperation"
+                },
+                {
+                  "$ref": "#/$defs/InOperation"
+                },
+                {
+                  "title": "ContainsOperation"
+                }
+              ]
+            },
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LiteralOperation"
+                },
+                {
+                  "$ref": "#/$defs/GetFieldOperator"
+                },
+                {
+                  "title": "ConvertOperation"
+                },
+                {
+                  "title": "AndOperation"
+                },
+                {
+                  "$ref": "#/$defs/OrOperation"
+                },
+                {
+                  "$ref": "#/$defs/NotOperation"
+                },
+                {
+                  "title": "EqOperation"
+                },
+                {
+                  "title": "GtOperation"
+                },
+                {
+                  "$ref": "#/$defs/GteOperation"
+                },
+                {
+                  "$ref": "#/$defs/InOperation"
+                },
+                {
+                  "title": "ContainsOperation"
+                }
+              ]
+            }
+          ],
+          "title": "$Gt",
+          "type": "array"
+        }
+      },
+      "required": [
+        "$gt"
+      ],
+      "title": "GtOperation",
+      "type": "object"
+    },
+    "GteOperation": {
+      "properties": {
+        "$gte": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LiteralOperation"
+                },
+                {
+                  "$ref": "#/$defs/GetFieldOperator"
+                },
+                {
+                  "title": "ConvertOperation"
+                },
+                {
+                  "title": "AndOperation"
+                },
+                {
+                  "$ref": "#/$defs/OrOperation"
+                },
+                {
+                  "$ref": "#/$defs/NotOperation"
+                },
+                {
+                  "title": "EqOperation"
+                },
+                {
+                  "title": "GtOperation"
+                },
+                {
+                  "title": "GteOperation"
+                },
+                {
+                  "$ref": "#/$defs/InOperation"
+                },
+                {
+                  "title": "ContainsOperation"
+                }
+              ]
+            },
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LiteralOperation"
+                },
+                {
+                  "$ref": "#/$defs/GetFieldOperator"
+                },
+                {
+                  "title": "ConvertOperation"
+                },
+                {
+                  "title": "AndOperation"
+                },
+                {
+                  "$ref": "#/$defs/OrOperation"
+                },
+                {
+                  "$ref": "#/$defs/NotOperation"
+                },
+                {
+                  "title": "EqOperation"
+                },
+                {
+                  "title": "GtOperation"
+                },
+                {
+                  "title": "GteOperation"
+                },
+                {
+                  "$ref": "#/$defs/InOperation"
+                },
+                {
+                  "title": "ContainsOperation"
+                }
+              ]
+            }
+          ],
+          "title": "$Gte",
+          "type": "array"
+        }
+      },
+      "required": [
+        "$gte"
+      ],
+      "title": "GteOperation",
+      "type": "object"
+    },
+    "InOperation": {
+      "properties": {
+        "$in": {
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LiteralOperation"
+                },
+                {
+                  "$ref": "#/$defs/GetFieldOperator"
+                },
+                {
+                  "title": "ConvertOperation"
+                },
+                {
+                  "title": "AndOperation"
+                },
+                {
+                  "$ref": "#/$defs/OrOperation"
+                },
+                {
+                  "$ref": "#/$defs/NotOperation"
+                },
+                {
+                  "title": "EqOperation"
+                },
+                {
+                  "title": "GtOperation"
+                },
+                {
+                  "title": "GteOperation"
+                },
+                {
+                  "title": "InOperation"
+                },
+                {
+                  "title": "ContainsOperation"
+                }
+              ]
+            },
+            {
+              "items": {
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/$defs/GetFieldOperator"
+                  },
+                  {
+                    "title": "ConvertOperation"
+                  },
+                  {
+                    "title": "AndOperation"
+                  },
+                  {
+                    "$ref": "#/$defs/OrOperation"
+                  },
+                  {
+                    "$ref": "#/$defs/NotOperation"
+                  },
+                  {
+                    "title": "EqOperation"
+                  },
+                  {
+                    "title": "GtOperation"
+                  },
+                  {
+                    "title": "GteOperation"
+                  },
+                  {
+                    "title": "InOperation"
+                  },
+                  {
+                    "title": "ContainsOperation"
+                  }
+                ]
+              },
+              "type": "array"
+            }
+          ],
+          "title": "$In",
+          "type": "array"
+        }
+      },
+      "required": [
+        "$in"
+      ],
+      "title": "InOperation",
       "type": "object"
     },
     "Leaderboard": {
@@ -238,6 +1027,47 @@
       "title": "LeaderboardColumn",
       "type": "object"
     },
+    "LiteralOperation": {
+      "properties": {
+        "$literal": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "additionalProperties": {
+                "title": "LiteralOperation"
+              },
+              "type": "object"
+            },
+            {
+              "items": {
+                "title": "LiteralOperation"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "title": "$Literal"
+        }
+      },
+      "required": [
+        "$literal"
+      ],
+      "title": "LiteralOperation",
+      "type": "object"
+    },
     "LlmJudgeActionConfig": {
       "properties": {
         "action_type": {
@@ -269,6 +1099,134 @@
         "response_schema"
       ],
       "title": "LlmJudgeActionConfig",
+      "type": "object"
+    },
+    "NotOperation": {
+      "properties": {
+        "$not": {
+          "maxItems": 1,
+          "minItems": 1,
+          "prefixItems": [
+            {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LiteralOperation"
+                },
+                {
+                  "$ref": "#/$defs/GetFieldOperator"
+                },
+                {
+                  "title": "ConvertOperation"
+                },
+                {
+                  "title": "AndOperation"
+                },
+                {
+                  "$ref": "#/$defs/OrOperation"
+                },
+                {
+                  "title": "NotOperation"
+                },
+                {
+                  "title": "EqOperation"
+                },
+                {
+                  "title": "GtOperation"
+                },
+                {
+                  "title": "GteOperation"
+                },
+                {
+                  "title": "InOperation"
+                },
+                {
+                  "title": "ContainsOperation"
+                }
+              ]
+            }
+          ],
+          "title": "$Not",
+          "type": "array"
+        }
+      },
+      "required": [
+        "$not"
+      ],
+      "title": "NotOperation",
+      "type": "object"
+    },
+    "OrOperation": {
+      "properties": {
+        "$or": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/LiteralOperation"
+              },
+              {
+                "$ref": "#/$defs/GetFieldOperator"
+              },
+              {
+                "title": "ConvertOperation"
+              },
+              {
+                "title": "AndOperation"
+              },
+              {
+                "title": "OrOperation"
+              },
+              {
+                "title": "NotOperation"
+              },
+              {
+                "title": "EqOperation"
+              },
+              {
+                "title": "GtOperation"
+              },
+              {
+                "title": "GteOperation"
+              },
+              {
+                "title": "InOperation"
+              },
+              {
+                "title": "ContainsOperation"
+              }
+            ]
+          },
+          "title": "$Or",
+          "type": "array"
+        }
+      },
+      "required": [
+        "$or"
+      ],
+      "title": "OrOperation",
+      "type": "object"
+    },
+    "Pin": {
+      "properties": {
+        "left": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Left",
+          "type": "array"
+        },
+        "right": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Right",
+          "type": "array"
+        }
+      },
+      "required": [
+        "left",
+        "right"
+      ],
+      "title": "Pin",
       "type": "object"
     },
     "Provider": {
@@ -372,6 +1330,208 @@
       ],
       "title": "ProviderReturnType",
       "type": "string"
+    },
+    "Query": {
+      "properties": {
+        "$expr": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AndOperation"
+            },
+            {
+              "$ref": "#/$defs/OrOperation"
+            },
+            {
+              "$ref": "#/$defs/NotOperation"
+            },
+            {
+              "$ref": "#/$defs/EqOperation"
+            },
+            {
+              "$ref": "#/$defs/GtOperation"
+            },
+            {
+              "$ref": "#/$defs/GteOperation"
+            },
+            {
+              "$ref": "#/$defs/InOperation"
+            },
+            {
+              "$ref": "#/$defs/ContainsOperation"
+            }
+          ],
+          "title": "$Expr"
+        }
+      },
+      "required": [
+        "$expr"
+      ],
+      "title": "Query",
+      "type": "object"
+    },
+    "SavedView": {
+      "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "view_type": {
+          "title": "View Type",
+          "type": "string"
+        },
+        "label": {
+          "title": "Label",
+          "type": "string"
+        },
+        "definition": {
+          "$ref": "#/$defs/SavedViewDefinition"
+        }
+      },
+      "required": [
+        "view_type",
+        "label",
+        "definition"
+      ],
+      "title": "SavedView",
+      "type": "object"
+    },
+    "SavedViewDefinition": {
+      "properties": {
+        "filter": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CallsFilter"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "query": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Query"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "cols": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "boolean"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Cols"
+        },
+        "columns": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/Column"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Columns"
+        },
+        "pin": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Pin"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "sort_by": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/SortBy"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sort By"
+        },
+        "page_size": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Page Size"
+        }
+      },
+      "title": "SavedViewDefinition",
+      "type": "object"
+    },
+    "SortBy": {
+      "properties": {
+        "field": {
+          "title": "Field",
+          "type": "string"
+        },
+        "direction": {
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "title": "Direction",
+          "type": "string"
+        }
+      },
+      "required": [
+        "field",
+        "direction"
+      ],
+      "title": "SortBy",
+      "type": "object"
     },
     "TestOnlyExample": {
       "properties": {
@@ -491,6 +1651,9 @@
     },
     "ProviderModel": {
       "$ref": "#/$defs/ProviderModel"
+    },
+    "SavedView": {
+      "$ref": "#/$defs/SavedView"
     }
   },
   "required": [
@@ -500,7 +1663,8 @@
     "ActionSpec",
     "AnnotationSpec",
     "Provider",
-    "ProviderModel"
+    "ProviderModel",
+    "SavedView"
   ],
   "title": "CompositeBaseObject",
   "type": "object"

--- a/weave/trace_server/interface/builtin_object_classes/saved_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/saved_view.py
@@ -1,10 +1,11 @@
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel, Field
 
-from weave.trace.traverse import PathElement
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.builtin_object_classes import base_object_def
+
+PathElement = Union[str, int]
 
 
 class Pin(BaseModel):

--- a/weave/trace_server/interface/builtin_object_classes/saved_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/saved_view.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from weave.trace.traverse import PathElement
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.interface.builtin_object_classes import base_object_def
+
+
+class Pin(BaseModel):
+    left: list[str]
+    right: list[str]
+
+
+class Column(BaseModel):
+    # Optional in case we want something like computed columns in the future.
+    path: Optional[list[PathElement]] = Field(default=None)
+    label: Optional[str] = Field(default=None)
+
+
+class SavedViewDefinition(BaseModel):
+    filter: Optional[tsi.CallsFilter] = Field(default=None)
+
+    query: Optional[tsi.Query] = Field(default=None)
+
+    # cols is the current UI column visibility config that
+    # doesn't allow specifying column order - prefer use of
+    # explicit columns list which is what we should work towards.
+    cols: Optional[dict[str, bool]] = Field(default=None)
+
+    # columns is specifying exactly which columns to include
+    # including order.
+    columns: Optional[list[Column]] = Field(default=None)
+
+    pin: Optional[Pin] = Field(default=None)
+    sort_by: Optional[list[tsi.SortBy]] = Field(default=None)
+    page_size: Optional[int] = Field(default=None)
+
+
+class SavedView(base_object_def.BaseObject):
+    # "traces" or "evaluations", type is str for extensibility
+    view_type: str
+
+    # Avoiding confusion around object_id + name
+    label: str
+
+    definition: SavedViewDefinition
+
+
+__all__ = ["SavedView"]


### PR DESCRIPTION
## Description

Add and registers the builtin object definition of a Saved View. First commit is the actual change, second commit is the codegen.

## Testing

Saved View Python API tests. (Will be in future PR)