### PR TITLE
style(ui): Disable hover effect on non-downloadable files

### DIFF
--- a/weave-js/src/components/Panel2/PanelDir/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelDir/Component.tsx
@@ -158,7 +158,6 @@ const SubfileRow: React.FC<SubfileRowProps> = props => {
       style={
         !isDownloadable
           ? {
-              backgroundColor: 'inherit',
               pointerEvents: 'none',
             }
           : undefined

--- a/weave-js/src/components/Panel2/PanelDir/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelDir/Component.tsx
@@ -155,14 +155,14 @@ const SubfileRow: React.FC<SubfileRowProps> = props => {
 
   return (
     <Table.Row
-    style={
-      !isDownloadable
-        ? {
-            backgroundColor: 'inherit',
-            pointerEvents: 'none',
-          }
-        : undefined
-    }
+      style={
+        !isDownloadable
+          ? {
+              backgroundColor: 'inherit',
+              pointerEvents: 'none',
+            }
+          : undefined
+      }
       onClick={() => {
         if (file.ref) {
           if (file.ref.startsWith('http://')) {

--- a/weave-js/src/components/Panel2/PanelDir/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelDir/Component.tsx
@@ -155,6 +155,14 @@ const SubfileRow: React.FC<SubfileRowProps> = props => {
 
   return (
     <Table.Row
+    style={
+      !isDownloadable
+        ? {
+            backgroundColor: 'inherit',
+            pointerEvents: 'none',
+          }
+        : undefined
+    }
       onClick={() => {
         if (file.ref) {
           if (file.ref.startsWith('http://')) {


### PR DESCRIPTION
## Description

This removes the hover effect for files that are not downloadable or clickable.

Files that are downloadable over hover:
<img width="393" alt="Screenshot 2025-04-01 at 3 45 31 PM" src="https://github.com/user-attachments/assets/5dff8e60-d698-402a-a69d-fe9c2846e446" />

Files that are NOT downloadable over hover:
<img width="341" alt="Screenshot 2025-04-01 at 3 45 12 PM" src="https://github.com/user-attachments/assets/6309bb4b-5eb9-46c3-80ce-7ec1fbed27f0" />

## Testing

Tested locally in SaaS

Registry available for testing: https://wandb.ai/orgs/wandb/registry/ruhi-test-registry
