### PR TITLE
docs(weave): Add local weave scorers doc to sidebar, cosmetics

### DIFF
--- a/docs/docs/guides/evaluation/weave_local_scorers.md
+++ b/docs/docs/guides/evaluation/weave_local_scorers.md
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Local Scorers
+# Weave Local Scorers
 
 <a target="_blank" href="https://colab.research.google.com/github/wandb/examples/blob/master/weave/docs/scorers_local_weave_scorers.ipynb">
 <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
@@ -299,6 +299,7 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
     ### Usage notes
 
+    - To specify specific entity types, such as emails or phone numbers, pass a list of Presidio entities to the `selected_entities` parameter. Otherwise, Presidio will detect all entity types in its default entities list.
     - To detect specific entity types, such as emails or phone numbers, pass a list to the `selected_entities` parameter.
     - You can pass custom recognizers via the `custom_recognizers` parameter as a list of `presidio.EntityRecognizer` instances.
     - To handle non-English input, use the `language` parameter to specify the language.

--- a/docs/docs/guides/evaluation/weave_local_scorers.md
+++ b/docs/docs/guides/evaluation/weave_local_scorers.md
@@ -1,19 +1,19 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Local Weave Scorers
+# Local Scorers
 
 <a target="_blank" href="https://colab.research.google.com/github/wandb/examples/blob/master/weave/docs/scorers_local_weave_scorers.ipynb">
 <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
 </a>
 
-Weave's local scorers are a suite of small language models that run locally on your machine with minimal latency. These models evaluate the **safety** and **quality** of your AI system’s inputs, context, and outputs.
+Weave's local scorers are a suite of small language models that run locally on your machine with minimal latency. These models evaluate the safety and quality of your AI system’s inputs, context, and outputs.
 
 Some of these models are fine-tuned by Weights & Biases, while others are state-of-the-art open-source models trained by the community. Weights & Biases (W&B) Reports were used for training and evaluation. You can find the full details in this [list of W&B Reports](https://wandb.ai/c-metrics/weave-scorers/reports/Weave-Scorers-v1--VmlldzoxMDQ0MDE1OA).
 
-The model weights are publicly available in W&B Artifacts and are automatically downloaded when you instantiate the scorer class. The artifact paths can be found here if you'd like to download them yourself: `weave.scorers.default_models`
+The model weights are publicly available in W&B Artifacts, and are automatically downloaded when you instantiate the scorer class. The artifact paths can be found here if you'd like to download them yourself: `weave.scorers.default_models`
 
-The object returned from calling these scorers contains a `passed` boolean attribute to indicate whether the input text is safe or high quality as well as a `metadata` atttribute that contains more detail such as the raw score from the model.
+The object returned by these scorers contains a `passed` boolean attribute indicating whether the input text is safe or high quality, as well as a `metadata` attribute that contains more detail such as the raw score from the model.
 
 :::tip
 While local scorers can be run on CPUs and GPUs, use GPUs for best performance.  
@@ -38,22 +38,21 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
     |----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
     | [WeaveToxicityScorerV1](#weavetoxicityscorerv1)                  | Identify toxic or harmful content in your AI system's inputs and outputs, including hate speech or threats.                                                       |
     | [WeaveBiasScorerV1](#weavebiasscorerv1)                          | Detect biased or stereotypical content in your AI system's inputs and outputs. Ideal for reducing harmful biases in generated text.                               |
-    | [WeaveHallucinationScorerV1](#weavehallucinationscorerv1)    | Identify whether your RAG system generates hallucinations in its output based on the input and context provided.                                                                                   |
-    | [WeaveContextRelevanceScorerV1](#weavecontextrelevancescorerv1)  | Measure whether the AI system's output is relevant to the input and context provided.                                                                |
-    | [WeaveCoherenceScorerV1](#weavecoherencescorerv1)                | Evaluate the coherence and logical structure of the AI system's output.                                                                               |
-    | [WeaveFluencyScorerV1](#weavefluencyscorerv1)                    | Measure whether the AI system's output is fluent.                                                                |
-    | [WeaveTrustScorerV1](#weavetrustscorerv1)                        | An aggregate scorer that leverages the toxicity, hallucination, context relevance, fluency, coherence scorers.                                                              |
-    | [PresidioScorer](#presidioscorer)                         | Detect Personally Identifiable Information (PII) in your AI system's inputs and outputs using the Presidio library from Microsoft.                                                                |
-
+    | [WeaveHallucinationScorerV1](#weavehallucinationscorerv1)       | Identify whether your RAG system generates hallucinations in its output based on the input and context provided.                                                  |
+    | [WeaveContextRelevanceScorerV1](#weavecontextrelevancescorerv1) | Measure whether the AI system's output is relevant to the input and context provided.                                                                             |
+    | [WeaveCoherenceScorerV1](#weavecoherencescorerv1)                | Evaluate the coherence and logical structure of the AI system's output.                                                                                           |
+    | [WeaveFluencyScorerV1](#weavefluencyscorerv1)                    | Measure whether the AI system's output is fluent.                                                                                                                  |
+    | [WeaveTrustScorerV1](#weavetrustscorerv1)                        | An aggregate scorer that leverages the toxicity, hallucination, context relevance, fluency, and coherence scorers.                                                |
+    | [PresidioScorer](#presidioscorer)                                | Detect Personally Identifiable Information (PII) in your AI system's inputs and outputs using the Presidio library from Microsoft.                                |
 
     ## `WeaveBiasScorerV1`
 
-    This scorer assesses gender and race/origin bias. The scorer assesses bias along two dimensions:
+    This scorer assesses gender and race/origin bias along two dimensions:
         
         - Race and Origin: Racism and bias against a country or region of origin, immigration status, ethnicity, etc.
         - Gender and Sexuality: Sexism, misogyny, homophobia, transphobia, sexual harassment, etc.
 
-    `WeaveBiasScorerV1` uses a fine-tuned [deberta-small-long-nli](https://huggingface.co/tasksource/deberta-small-long-nli) model. For more details on the model, dataset and calibration process, see the [WeaveBiasScorerV1 W&B Report](https://wandb.ai/c-metrics/bias-benchmark/reports/Bias-Scorer--VmlldzoxMDM2MTgzNw) 
+    `WeaveBiasScorerV1` uses a fine-tuned [deberta-small-long-nli](https://huggingface.co/tasksource/deberta-small-long-nli) model. For more details on the model, dataset, and calibration process, see the [WeaveBiasScorerV1 W&B Report](https://wandb.ai/c-metrics/bias-benchmark/reports/Bias-Scorer--VmlldzoxMDM2MTgzNw).
 
     ### Usage notes 
 
@@ -78,12 +77,12 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
     ## `WeaveToxicityScorerV1`
 
-    The `WeaveToxicityScorerV1` scorer assesses the input text for toxicity along five dimensions:
+    This scorer assesses the input text for toxicity along five dimensions:
     
         - Race and Origin: Racism and bias against a country or region of origin, immigration status, ethnicity, etc.
         - Gender and Sexuality: Sexism, misogyny, homophobia, transphobia, sexual harassment, etc.
-        - Religious: Bias or stereotype against someone's religion.
-        - Ability: Bias according to someone's physical, mental, or intellectual ability or disability.
+        - Religious: Bias or stereotypes against someone's religion.
+        - Ability: Bias related to someone's physical, mental, or intellectual ability or disability.
         - Violence and Abuse: Overly graphic descriptions of violence, threats of violence, or incitement of violence.
     
     The `WeaveToxicityScorerV1` uses the open source [Celadon](https://huggingface.co/PleIAs/celadon) model from PleIAs. For more information, see the [WeaveToxicityScorerV1 W&B Report](https://wandb.ai/c-metrics/toxicity-benchmark/reports/Toxicity-Scorer--VmlldzoxMDMyNjc0NQ).
@@ -91,10 +90,10 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
     ### Usage notes
 
     - The `score` method expects a string to be passed to the `output` parameter. 
-    - The model returns scores from `0` to `3` across 5 different categories: 
-      - If the sum of these scores is above `total_threshold` (default value `5`), then the input is flagged as toxic. 
-      - If any single category has a score higher than `category_threshold` (default 2), then the input is flagged as toxic. Default values were fine-tuned to decrease false positives and improve recall.
-    - For more aggressive filtering, override the `category_threshold` parameter or the `total_threshold` parameter in the scorer constructor.
+    - The model returns scores from `0` to `3` across five different categories: 
+      - If the sum of these scores is above `total_threshold` (default value `5`), the input is flagged as toxic. 
+      - If any single category has a score higher than `category_threshold` (default `2`), the input is flagged as toxic.
+    - To make filtering more aggressive, override `category_threshold` or `total_threshold` during initialization.
 
     ### Usage example
 
@@ -103,7 +102,7 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
     from weave.scorers import WeaveToxicityScorerV1
 
     toxicity_scorer = WeaveToxicityScorerV1()
-    result = toxicity_scorer.score(output="people from the south pole of mars are the worst")
+    result = toxicity_scorer.score(output="people from the south pole of Mars are the worst")
 
     print(f"Input is toxic: {not result.passed}")
     print(result)
@@ -118,9 +117,11 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
     The `WeaveHallucinationScorerV1` uses the open source [HHEM 2.1 model](https://huggingface.co/vectara/hallucination_evaluation_model) from Vectara. For more information, see the [WeaveHallucinationScorerV1 W&B Report](https://wandb.ai/c-metrics/hallucination/reports/Hallucination-Scorer--VmlldzoxMDM3NDA3MA).
 
     ### Usage notes
-    - The `score` method expects data to be passed to the `query` and `output` parameters. The context should be passed to the `output` parameter as a string or list of strings.
-    - A higher output score means that there is a stronger prediction of hallucination in the output given the query and context.
-    - The `threshold` parameter is set, but can also be overridden upon initialization.
+
+    - The `score` method expects values to be passed to the `query` and `output` parameters.  
+    - The context should be passed to the `output` parameter (as a string or list of strings).  
+    - A higher output score means a stronger prediction of hallucination in the output.
+    - The `threshold` parameter is set but can be overridden on initialization.
 
     ### Usage example 
 
@@ -131,9 +132,9 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
     hallucination_scorer = WeaveHallucinationScorerV1()
 
     result = hallucination_scorer.score(
-        query="What is the capital of Antartica?",
-        context="People in Antartica love the penguins.",
-        output="While Antartica is known for its sea life, penguins aren't liked there."
+        query="What is the capital of Antarctica?",
+        context="People in Antarctica love the penguins.",
+        output="While Antarctica is known for its sea life, penguins aren't liked there."
     )
 
     print(f"Output is hallucinated: {not result.passed}")
@@ -146,14 +147,14 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
     This scorer is designed to be used when evaluating RAG systems. It scores the relevance of the context to the query.
 
-    The `WeaveContextRelevanceScorerV1` scorer uses a fine-tuned [deberta-small-long-nli](https://huggingface.co/tasksource/deberta-small-long-nli) model from tasksource. For more details, see the [WeaveContextRelevanceScorerV1 W&B Report](https://wandb.ai/c-metrics/context-relevance-scorer/reports/Context-Relevance-Scorer--VmlldzoxMDYxNjEyNA).
+    The `WeaveContextRelevanceScorerV1` uses a fine-tuned [deberta-small-long-nli](https://huggingface.co/tasksource/deberta-small-long-nli) model from tasksource. For more details, see the [WeaveContextRelevanceScorerV1 W&B Report](https://wandb.ai/c-metrics/context-relevance-scorer/reports/Context-Relevance-Scorer--VmlldzoxMDYxNjEyNA).
 
     ### Usage notes
 
-    - The `score` method expects data to be passed to the `query` and `output` parameters. The context should be passed to the `output` parameter as a string or list of strings.
-    - A higher output score means that there is a stronger prediction of that the context is relevant to the query.
-    - The `threshold` parameter is automatically set, but can also be overridden on initialization.
-    - Passing `verbose = True` to the `score` method will return scores for each relevant chunk of text in the context.
+    - The `score` method expects values for `query` and `output`.  
+    - The context should be passed to the `output` parameter (string or list of strings).
+    - A higher score means a stronger prediction that the context is relevant to the query.
+    - You can pass `verbose=True` to the `score` method to get per-chunk scores.
 
     ### Usage example
 
@@ -165,24 +166,23 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
     result = context_relevance_scorer.score(
         query="What is the capital of Antarctica?",
-        output="The Antarctic has the happiest penguins."  # the context is passed to the output parameter
+        output="The Antarctic has the happiest penguins."  # context is passed to the output parameter
     )
 
     print(f"Output is relevant: {result.passed}")
     print(result)
     ```
 
-    ---
-
     ## `WeaveCoherenceScorerV1`
 
-    This scorer checks that the input text is coherent.
+    This scorer checks whether the input text is coherent.
 
-    The `WeaveCoherenceScorerV1` scorer uses a fine-tuned [deberta-small-long-nli](https://huggingface.co/tasksource/deberta-small-long-nli) model from tasksource. For more information, see the [WeaveCoherenceScorerV1 W&B Report](https://wandb.ai/c-metrics/coherence_scorer/reports/Coherence-Scorer--VmlldzoxMDI5MjA1MA).
+    The `WeaveCoherenceScorerV1` uses a fine-tuned [deberta-small-long-nli](https://huggingface.co/tasksource/deberta-small-long-nli) model from tasksource. For more information, see the [WeaveCoherenceScorerV1 W&B Report](https://wandb.ai/c-metrics/coherence_scorer/reports/Coherence-Scorer--VmlldzoxMDI5MjA1MA).
 
     ### Usage notes
+
     - The `score` method expects text to be passed to the `query` and `output` parameters.
-    - A higher output score means that there is a stronger prediction of coherence in the input text.
+    - A higher output score means a stronger prediction of coherence.
 
     ### Usage example 
 
@@ -205,14 +205,14 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
     ## `WeaveFluencyScorerV1`
 
-    This scorer checks the input text is fluent; that is, easy to read and understand, similar to human language. The scorer assesses input along dimensions such as grammar, syntax, and overall readability.
+    This scorer checks whether the input text is fluent—that is, easy to read and understand, similar to natural human language. It evaluates grammar, syntax, and overall readability.
 
-    The `WeaveFluencyScorerV1` scorer uses a fine-tuned [ModernBERT-base](https://huggingface.co/answerdotai/ModernBERT-base) model from AnswerDotAI. For more information, see the [WeaveFluencyScorerV1 W&B Report](https://wandb.ai/c-metrics/fluency-eval/reports/Fluency-Scorer--VmlldzoxMTA3NzE2Ng).
+    The `WeaveFluencyScorerV1` uses a fine-tuned [ModernBERT-base](https://huggingface.co/answerdotai/ModernBERT-base) model from AnswerDotAI. For more information, see the [WeaveFluencyScorerV1 W&B Report](https://wandb.ai/c-metrics/fluency-eval/reports/Fluency-Scorer--VmlldzoxMTA3NzE2Ng).
 
     ### Usage notes
 
     - The `score` method expects text to be passed to the `output` parameter.
-    - A higher output score indicates higher input text fluency.
+    - A higher output score indicates higher fluency.
 
     ### Usage example 
 
@@ -234,28 +234,27 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
     ## `WeaveTrustScorerV1`
 
-    The `WeaveTrustScorerV1` is a composite scorer for RAG systems that evaluates the trustworthiness of model outputs by grouping the outputs of other scorers into two logical categories, Critical and Advisory. Based on the compostite score, `WeaveTrustScorerV1` returns a trust level score. The values for the trust level score are:
-    
-    - `high`: No issues detected
-    - `medium`: Only Advisory issues detected
-    - `low`: Critical issues detected or empty input
-    
-    Any input that does not pass a Critical scorer will automatically cause the `WeaveTrustScorerV1` to return `low`, while input that doesn't pass Advisory scorers will return `medium`.
-    
-    - Critical:
-        - `WeaveToxicityScorerV1`: Detects harmful, offensive, or inappropriate content
-        - `WeaveHallucinationScorerV1`: Identifies fabricated or unsupported information
-        - `WeaveContextRelevanceScorerV1`: Ensures output relevance to provided context
+    The `WeaveTrustScorerV1` is a composite scorer for RAG systems that evaluates the trustworthiness of model outputs by grouping other scorers into two categories: Critical and Advisory. Based on the composite score, it returns a trust level:
 
-    - Advisory:
-        - `WeaveFluencyScorerV1`: Evaluates language quality and coherence
-        - `WeaveCoherenceScorerV1`: Checks for logical consistency and flow
+    - `high`: No issues detected  
+    - `medium`: Only Advisory issues detected  
+    - `low`: Critical issues detected or input is empty  
 
-    
+    Any input that fails a Critical scorer results in a `low` trust level. Failing an Advisory scorer results in `medium`.
+
+    - **Critical:**
+        - `WeaveToxicityScorerV1`
+        - `WeaveHallucinationScorerV1`
+        - `WeaveContextRelevanceScorerV1`
+
+    - **Advisory:**
+        - `WeaveFluencyScorerV1`
+        - `WeaveCoherenceScorerV1`
 
     ### Usage notes
-    - The use case for this scorer is in evalutating RAG pipelines. 
-    - `WeaveFluencyScorerV1` requires query, context and output keys to score correctly.
+
+    - This scorer is designed for evaluating RAG pipelines.  
+    - It requires `query`, `context`, and `output` keys for correct scoring.
 
     ### Usage example
 
@@ -265,7 +264,6 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
     trust_scorer = WeaveTrustScorerV1()
 
-    # A helper function to print the results of the trust scorer
     def print_trust_scorer_result(result):
         print()
         print(f"Output is trustworthy: {result.passed}")
@@ -275,16 +273,14 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
             for scorer_name, scorer_data in result.metadata['raw_outputs'].items():
                 if not scorer_data.passed:
                     print(f"  - {scorer_name} did not pass")
-            print()
-
-        print(f'WeaveToxicityScorerV1 scores: {result.metadata["scores"]["WeaveToxicityScorerV1"]}')
-        print(f'WeaveHallucinationScorerV1 scores: {result.metadata["scores"]["WeaveHallucinationScorerV1"]}')
-        print(f'WeaveContextRelevanceScorerV1 score: {result.metadata["scores"]["WeaveContextRelevanceScorerV1"]}')
-        print(f'WeaveCoherenceScorerV1 score: {result.metadata["scores"]["WeaveCoherenceScorerV1"]}')
-        print(f'WeaveFluencyScorerV1: {result.metadata["scores"]["WeaveFluencyScorerV1"]}')
+        print()
+        print(f"WeaveToxicityScorerV1 scores: {result.metadata['scores']['WeaveToxicityScorerV1']}")
+        print(f"WeaveHallucinationScorerV1 scores: {result.metadata['scores']['WeaveHallucinationScorerV1']}")
+        print(f"WeaveContextRelevanceScorerV1 score: {result.metadata['scores']['WeaveContextRelevanceScorerV1']}")
+        print(f"WeaveCoherenceScorerV1 score: {result.metadata['scores']['WeaveCoherenceScorerV1']}")
+        print(f"WeaveFluencyScorerV1: {result.metadata['scores']['WeaveFluencyScorerV1']}")
         print()
 
-    # There are 2 issues with the input data: irrelevant context, hallucinated output
     result = trust_scorer.score(
         query="What is the capital of Antarctica?",
         context="People in Antarctica love the penguins.",
@@ -303,9 +299,9 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
     ### Usage notes
 
-    - To specify specific entity types, such as emails or phone numbers, pass a list of Presidio entities to the `selected_entities` parameter. Otherwise, Presidio will detect all entity types in its default entities list.
-    - Pass custom recognizers to the scorer as a list of type `presidio.EntityRecognizer` via the `custom_recognizers` parameter. 
-    - To pass non-Englis input to the scorer, use the `language` parameter to specify the language of the text.
+    - To detect specific entity types, such as emails or phone numbers, pass a list to the `selected_entities` parameter.
+    - You can pass custom recognizers via the `custom_recognizers` parameter as a list of `presidio.EntityRecognizer` instances.
+    - To handle non-English input, use the `language` parameter to specify the language.
 
     ### Usage example
 
@@ -316,7 +312,7 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
     presidio_scorer = PresidioScorer()
 
     result = presidio_scorer.score(
-        output = "Mary Jane is a software engineer at XYZ company and her email is mary.jane@xyz.com."
+        output="Mary Jane is a software engineer at XYZ company and her email is mary.jane@xyz.com."
     )
 
     print(f"Output contains PII: {not result.passed}")
@@ -325,8 +321,8 @@ While local scorers can be run on CPUs and GPUs, use GPUs for best performance.
 
   </TabItem>
   <TabItem value="typescript" label="TypeScript">
-    Weave local scorers are not available in TypeScript yet. Stay tuned! 
-    
+    Weave local scorers are not available in TypeScript yet. Stay tuned!
+
     To use Weave scorers in TypeScript, see [function-based scorers](scorers#function-based-scorers).
   </TabItem>
 </Tabs>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -101,6 +101,7 @@ const sidebars: SidebarsConfig = {
             "guides/core-types/datasets",
             "guides/evaluation/scorers",
             "guides/evaluation/builtin_scorers",
+            "guides/evaluation/weave_local_scorers",
           ]
         },
       ],


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1387

1. docs/docs/guides/evaluation/weave_local_scorers.md was missing from sidebar, this adds it in 
2. Fixes various grammar and spelling issues in file

## Testing

yarn start on local
