### PR TITLE
chore(app): Create an action bar for PanelTable and include filter and table selection options

### DIFF
--- a/weave-js/src/components/Panel2/PanelRunsWithStepper/HistoryTables.tsx
+++ b/weave-js/src/components/Panel2/PanelRunsWithStepper/HistoryTables.tsx
@@ -1,65 +1,16 @@
 import {LIST_RUNS_TYPE} from '@wandb/weave/common/types/run';
-import {opConcat, opRunHistory} from '@wandb/weave/core';
-import {useNodeWithServerType} from '@wandb/weave/react';
-import React from 'react';
 
-import * as ConfigPanel from '../ConfigPanel';
 import * as Panel2 from '../panel';
 import {TableSpec} from '../PanelTable/PanelTable';
 import {
   buildPanelRunsWithStepper,
-  getCurrentTableHistoryKey,
-  getTableKeysFromRunsHistoryPropertyType,
   PanelRunsWithStepperConfigType,
-  PanelRunsWithStepperProps,
 } from './base';
-
-const PanelRunsWithStepperConfig: React.FC<
-  PanelRunsWithStepperProps
-> = props => {
-  const runsHistoryNode = opConcat({
-    arr: opRunHistory({run: props.input as any}),
-  });
-  const runsHistoryRefined = useNodeWithServerType(runsHistoryNode);
-  const tableKeys = getTableKeysFromRunsHistoryPropertyType(
-    runsHistoryRefined.result?.type
-  );
-  const tableHistoryKey = getCurrentTableHistoryKey(
-    tableKeys,
-    props.config?.tableHistoryKey
-  );
-
-  const options = tableKeys.map(key => ({text: key, value: key}));
-  const updateConfig = props.updateConfig;
-  const setTableHistoryKey = React.useCallback(
-    val => {
-      updateConfig({tableHistoryKey: val});
-    },
-    [updateConfig]
-  );
-
-  return (
-    <ConfigPanel.ConfigOption label="Table">
-      <ConfigPanel.ModifiedDropdownConfigField
-        selection
-        data-test="compare_method"
-        scrolling
-        multiple={false}
-        options={options}
-        value={tableHistoryKey}
-        onChange={(e, data) => {
-          setTableHistoryKey(data.value as any);
-        }}
-      />
-    </ConfigPanel.ConfigOption>
-  );
-};
 
 export const Spec: Panel2.PanelSpec<PanelRunsWithStepperConfigType> = {
   id: 'run-history-tables-stepper',
   displayName: 'Run History Tables Stepper',
   Component: buildPanelRunsWithStepper(TableSpec),
-  ConfigComponent: PanelRunsWithStepperConfig,
   inputType: LIST_RUNS_TYPE,
   outputType: () => ({
     type: 'list' as const,

--- a/weave-js/src/components/Panel2/PanelRunsWithStepper/base.tsx
+++ b/weave-js/src/components/Panel2/PanelRunsWithStepper/base.tsx
@@ -209,6 +209,17 @@ export const buildPanelRunsWithStepper = (
       });
     }
 
+    const tableSelection = {
+      show: tableKeys.length > 0,
+      keys: tableKeys,
+      currentSelection: tableHistoryKey,
+      callback: (key: string) => {
+        safeUpdateConfig({tableHistoryKey: key});
+      },
+    };
+
+    const newConfig = {...props.config, tableSelection};
+
     return (
       <>
         {defaultNode != null && !isVoidNode(defaultNode) && (
@@ -227,7 +238,7 @@ export const buildPanelRunsWithStepper = (
               loading={props.loading}
               panelSpec={spec}
               configMode={false}
-              config={props.config}
+              config={newConfig}
               context={props.context}
               updateConfig={props.updateConfig}
               updateContext={props.updateContext}

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1148,6 +1148,7 @@ const PanelTableInner: React.FC<
           position="bottom left"
           on="click"
           basic
+          style={{padding: 0, marginTop: '0px'}}
           trigger={
             <Button
               variant="secondary"
@@ -1173,27 +1174,25 @@ const PanelTableInner: React.FC<
             </Button>
           }
           content={
-            <div>
-              Select table:
-              <ModifiedDropdown
-                style={{marginTop: '4px'}}
-                selection
-                scrolling
-                multiple={false}
-                value={props.config.tableSelection?.currentSelection}
-                data-test="table-selection"
-                closeOnBlur
-                closeOnChange
-                options={(props.config.tableSelection?.keys || []).map(key => ({
-                  text: key,
-                  key,
-                  value: key,
-                }))}
-                onChange={(e, {value}) => {
-                  props.config.tableSelection?.callback?.(value as string);
-                }}
-              />
-            </div>
+            <ModifiedDropdown
+              basic
+              selection
+              scrolling
+              multiple={false}
+              defaultOpen
+              value={props.config.tableSelection?.currentSelection}
+              data-test="table-selection"
+              closeOnBlur
+              closeOnChange
+              options={(props.config.tableSelection?.keys || []).map(key => ({
+                text: key,
+                key,
+                value: key,
+              }))}
+              onChange={(e, {value}) => {
+                props.config.tableSelection?.callback?.(value as string);
+              }}
+            />
           }
         />
       )}

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1200,6 +1200,7 @@ const PanelTableInner: React.FC<
       <Button
         variant="secondary"
         size="small"
+        data-test="table-filter-button"
         icon="filter-alt"
         onClick={() => {
           setFilterOpen(!filterOpen);

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1,5 +1,6 @@
 import 'react-base-table/lib/TableRow';
 
+import ModifiedDropdown from '@wandb/weave/common/components/elements/ModifiedDropdown';
 import {MOON_500} from '@wandb/weave/common/css/color.styles';
 import {useRunName} from '@wandb/weave/common/hooks/useRunName';
 import {saveTableAsCSV} from '@wandb/weave/common/util/csv';
@@ -1141,6 +1142,61 @@ const PanelTableInner: React.FC<
         margin: '8px',
       }}
       ref={actionBarRef}>
+      {props.config.tableSelection?.show && (
+        <Popup
+          hoverable
+          position="bottom left"
+          on="click"
+          basic
+          trigger={
+            <Button
+              variant="secondary"
+              size="small"
+              icon="table"
+              tooltip="Select table"
+              tooltipProps={{className: 'py-8 px-12'}}>
+              <>
+                Table:{' '}
+                <span
+                  style={{
+                    fontWeight: 'bold',
+                    maxWidth: '120px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    display: 'inline-block',
+                    whiteSpace: 'nowrap',
+                    verticalAlign: 'bottom',
+                  }}>
+                  {props.config.tableSelection?.currentSelection || 'Table'}
+                </span>
+              </>
+            </Button>
+          }
+          content={
+            <div>
+              Select table:
+              <ModifiedDropdown
+                style={{marginTop: '4px'}}
+                selection
+                scrolling
+                multiple={false}
+                value={props.config.tableSelection?.currentSelection}
+                data-test="table-selection"
+                closeOnBlur
+                closeOnChange
+                options={(props.config.tableSelection?.keys || []).map(key => ({
+                  text: key,
+                  key,
+                  value: key,
+                }))}
+                onChange={(e, {value}) => {
+                  props.config.tableSelection?.callback?.(value as string);
+                }}
+              />
+            </div>
+          }
+        />
+      )}
       <Button
         variant="secondary"
         size="small"

--- a/weave-js/src/components/Panel2/PanelTable/config.ts
+++ b/weave-js/src/components/Panel2/PanelTable/config.ts
@@ -34,6 +34,12 @@ export type PanelTableConfig = {
   pinnedColumns: string[];
   activeRowForGrouping: {[groupKey: string]: number};
   simpleTable?: boolean;
+  tableSelection?: {
+    currentSelection: string;
+    show: boolean;
+    keys: string[];
+    callback: (key: string) => void;
+  };
 };
 
 const tableStateKeys = [


### PR DESCRIPTION
## Description

- Implements [WB-24174](https://wandb.atlassian.net/browse/WB-24174)
- Moves the filter button out into an action bar above PanelTable
- Additionally adds a button to allow for selection between tables (when the appropriate config fields are passed into the component)
- Move the current table selection in the stepper from the Query Panel config to the action bar

## Testing

Local Invoker FE

Verify filtering still works:

https://github.com/user-attachments/assets/5217d92f-1665-467f-a532-feeb7091c62d


Verify table selection works:

https://github.com/user-attachments/assets/c0f74693-4bc4-4f55-9e5a-664cb62b3d3b


Verify filtering works with regular tables (e.g. `run.summary[<table>]`)

https://github.com/user-attachments/assets/9baa49e7-89c1-4a7e-ac75-1294db4b9190




[WB-24174]: https://wandb.atlassian.net/browse/WB-24174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ