### PR TITLE
chore(weave): Fix type generation to replace circular references with Anys

### DIFF
--- a/weave-js/scripts/generate-schemas.sh
+++ b/weave-js/scripts/generate-schemas.sh
@@ -3,13 +3,16 @@
 # Exit on error
 set -e
 
-SCHEMA_INPUT_PATH="../weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json"
-SCHEMA_OUTPUT_PATH="./src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBuiltinObjectClasses.zod.ts"
+SCHEMA_PATH="../weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json"
+OUTPUT_PATH="./src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/generatedBuiltinObjectClasses.zod.ts"
 
 echo "Generating schemas..."
 
+# First resolve circular references in the schema
+python3 ../weave/scripts/resolve_schema_circular_refs.py "$SCHEMA_PATH"
+
 # Generate TypeScript-Zod types from schema
-yarn quicktype -s schema "$SCHEMA_INPUT_PATH" -o "$SCHEMA_OUTPUT_PATH" --lang typescript-zod
+yarn quicktype -s schema "$SCHEMA_PATH" -o "$OUTPUT_PATH" --lang typescript-zod
 
 # Transform the schema to extract the type map
 sed -i.bak '
@@ -30,12 +33,12 @@ sed -i.bak '
 export const GeneratedBuiltinObjectClassesZodSchema = z.object(builtinObjectClassRegistry)
     }
   }
-' "$SCHEMA_OUTPUT_PATH"
+' "$OUTPUT_PATH"
 
 # Remove backup file
-rm "${SCHEMA_OUTPUT_PATH}.bak"
+rm "${OUTPUT_PATH}.bak"
 
 # Format the generated file
-yarn direct-prettier --write "$SCHEMA_OUTPUT_PATH"
+yarn direct-prettier --write "$OUTPUT_PATH"
 
 echo "Schema generation completed successfully" 

--- a/weave-js/scripts/generate-schemas.sh
+++ b/weave-js/scripts/generate-schemas.sh
@@ -9,7 +9,7 @@ OUTPUT_PATH="./src/components/PagePanelComponents/Home/Browse3/pages/wfReactInte
 echo "Generating schemas..."
 
 # First resolve circular references in the schema
-python3 ../weave/scripts/resolve_schema_circular_refs.py "$SCHEMA_PATH"
+python3 ./resolve_schema_circular_refs.py "$SCHEMA_PATH"
 
 # Generate TypeScript-Zod types from schema
 yarn quicktype -s schema "$SCHEMA_PATH" -o "$OUTPUT_PATH" --lang typescript-zod

--- a/weave-js/scripts/generate-schemas.sh
+++ b/weave-js/scripts/generate-schemas.sh
@@ -9,7 +9,7 @@ OUTPUT_PATH="./src/components/PagePanelComponents/Home/Browse3/pages/wfReactInte
 echo "Generating schemas..."
 
 # First resolve circular references in the schema
-python3 ./resolve_schema_circular_refs.py "$SCHEMA_PATH"
+python3 "$(dirname "$0")/resolve_schema_circular_refs.py" "$SCHEMA_PATH"
 
 # Generate TypeScript-Zod types from schema
 yarn quicktype -s schema "$SCHEMA_PATH" -o "$OUTPUT_PATH" --lang typescript-zod

--- a/weave-js/scripts/resolve_schema_circular_refs.py
+++ b/weave-js/scripts/resolve_schema_circular_refs.py
@@ -2,10 +2,10 @@ import json
 import sys
 from collections import deque
 from pathlib import Path
-from typing import Any, Dict, List, Set, Tuple
+from typing import Any
 
 
-def find_child_defs(node: Dict[str, Any]) -> Set[str]:
+def find_child_defs(node: dict[str, Any]) -> set[str]:
     """Find all definition references in a node."""
     child_defs = set()
 
@@ -25,7 +25,7 @@ def find_child_defs(node: Dict[str, Any]) -> Set[str]:
     return child_defs
 
 
-def find_path_to_root(schema: Dict[str, Any], root_def: str) -> List[str]:
+def find_path_to_root(schema: dict[str, Any], root_def: str) -> list[str]:
     """
     Find a path from any descendant back to the root definition.
     Returns the path if found, empty list if no path exists.
@@ -53,7 +53,7 @@ def find_path_to_root(schema: Dict[str, Any], root_def: str) -> List[str]:
     return []
 
 
-def rewrite_circular_refs(schema: Dict[str, Any]) -> Dict[str, Any]:
+def rewrite_circular_refs(schema: dict[str, Any]) -> dict[str, Any]:
     """
     Rewrite circular references in the schema by iteratively finding and breaking cycles.
     For each cycle found, replaces the last reference back to root with 'any'.

--- a/weave/scripts/resolve_schema_circular_refs.py
+++ b/weave/scripts/resolve_schema_circular_refs.py
@@ -1,0 +1,104 @@
+import json
+import sys
+from collections import deque
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
+
+def find_child_defs(node: Dict[str, Any]) -> Set[str]:
+    """Find all definition references in a node."""
+    child_defs = set()
+    
+    def collect_refs(n: Any) -> None:
+        if isinstance(n, dict):
+            if "$ref" in n:
+                ref = n["$ref"]
+                if ref.startswith("#/$defs/"):
+                    child_defs.add(ref[8:])  # Remove "#/$defs/" prefix
+            for v in n.values():
+                collect_refs(v)
+        elif isinstance(n, list):
+            for item in n:
+                collect_refs(item)
+    
+    collect_refs(node)
+    return child_defs
+
+def find_path_to_root(schema: Dict[str, Any], root_def: str) -> List[str]:
+    """
+    Find a path from any descendant back to the root definition.
+    Returns the path if found, empty list if no path exists.
+    """
+    queue = deque([(root_def, [root_def])])
+    visited = {root_def}
+    
+    while queue:
+        current_def, path = queue.popleft()
+        
+        # Get the definition node
+        def_node = schema["$defs"][current_def]
+        
+        # Find all child definitions
+        child_defs = find_child_defs(def_node)
+        
+        for child_def in child_defs:
+            if child_def == root_def:
+                # Found a path back to root
+                return path + [child_def]
+            if child_def not in visited:
+                visited.add(child_def)
+                queue.append((child_def, path + [child_def]))
+    
+    return []
+
+def rewrite_circular_refs(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Rewrite circular references in the schema by iteratively finding and breaking cycles.
+    For each cycle found, replaces the last reference back to root with 'any'.
+    """
+    defs = schema.get("$defs", {})
+    
+    for root_def in defs:
+        while True:
+            # Find a path back to root
+            path = find_path_to_root(schema, root_def)
+            if not path:
+                break
+                
+            # Get the last node before the cycle
+            last_node = schema["$defs"][path[-2]]
+            
+            # Replace the reference to root with any
+            def process_node(node: Any) -> Any:
+                if isinstance(node, dict):
+                    if "$ref" in node and node["$ref"] == f"#/$defs/{root_def}":
+                        return {"title": root_def}
+                    return {k: process_node(v) for k, v in node.items()}
+                elif isinstance(node, list):
+                    return [process_node(item) for item in node]
+                return node
+            
+            schema["$defs"][path[-2]] = process_node(last_node)
+    
+    return schema
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python resolve_schema_circular_refs.py <schema_path>")
+        sys.exit(1)
+        
+    schema_path = Path(sys.argv[1])
+    
+    # Read the schema
+    with schema_path.open("r") as f:
+        schema = json.load(f)
+    
+    # Rewrite circular references
+    schema = rewrite_circular_refs(schema)
+    
+    # Write back the modified schema
+    with schema_path.open("w") as f:
+        json.dump(schema, f, indent=2)
+    print(f"Rewrote circular references in {schema_path}")
+
+if __name__ == "__main__":
+    main() 

--- a/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
+++ b/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
@@ -146,9 +146,6 @@
         "action_type": {
           "const": "contains_words",
           "default": "contains_words",
-          "enum": [
-            "contains_words"
-          ],
           "title": "Action Type",
           "type": "string"
         },
@@ -246,9 +243,6 @@
         "action_type": {
           "const": "llm_judge",
           "default": "llm_judge",
-          "enum": [
-            "llm_judge"
-          ],
           "title": "Action Type",
           "type": "string"
         },
@@ -319,11 +313,7 @@
           "type": "object"
         },
         "return_type": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/ProviderReturnType"
-            }
-          ],
+          "$ref": "#/$defs/ProviderReturnType",
           "default": "openai"
         }
       },
@@ -377,7 +367,6 @@
       "type": "object"
     },
     "ProviderReturnType": {
-      "const": "openai",
       "enum": [
         "openai"
       ],


### PR DESCRIPTION
When generating zod types, circular references cause issues. This PR identifies circular references and fixes them before generation occurs. More advanced replacement could be designed in the future if desired.

This unblocks saved views using Query in the type definition.

I explored more creative ways for unrolling nested structures, but they got overly complicated. Can always make this better in the future.