### PR TITLE
chore(app): extend tables stepper to accept a more generic input type

### DIFF
--- a/weave-js/src/components/Panel2/PanelExpression/hooks.ts
+++ b/weave-js/src/components/Panel2/PanelExpression/hooks.ts
@@ -621,6 +621,11 @@ export function usePanelExpressionState(props: PanelExpressionProps) {
       if (r.key.startsWith('run-history-plots-stepper')) {
         return r.key === 'run-history-plots-stepper.row.plot';
       }
+
+      // Disable runs table conversion to generic tables stepper
+      if (r.key.includes('generic-tables-stepper')) {
+        return r.key !== 'runs-table.generic-tables-stepper';
+      }
       return true;
     });
     return results;

--- a/weave-js/src/components/Panel2/PanelRegistry.tsx
+++ b/weave-js/src/components/Panel2/PanelRegistry.tsx
@@ -48,6 +48,7 @@ import {Spec as RunColorSpec} from './PanelRunColor';
 import {Spec as RunOverviewSpec} from './PanelRunOverview';
 import {Spec as PanelRunsTableSpec} from './PanelRunsTable';
 import {Spec as PanelRunHistoryTablesStepperSpec} from './PanelRunsWithStepper/HistoryTables';
+import {SpecHistoryTables as GenericTablesStepperSpec} from './PanelRunsWithStepper/HistoryTables';
 import {Spec as PanelRunsPlotsWithStepperSpec} from './PanelRunsWithStepper/Plots';
 import {Spec as SavedModelSpec} from './PanelSavedModel';
 import {Spec as StringSpec} from './PanelString';
@@ -108,6 +109,7 @@ const initSpecs = () => {
       TableSpec,
       PlotSpec,
       FacetSpec,
+      GenericTablesStepperSpec,
 
       // numbers
       NumberSpec,

--- a/weave-js/src/components/Panel2/PanelRunsWithStepper/HistoryTables.tsx
+++ b/weave-js/src/components/Panel2/PanelRunsWithStepper/HistoryTables.tsx
@@ -1,65 +1,16 @@
 import {LIST_RUNS_TYPE} from '@wandb/weave/common/types/run';
-import {opConcat, opRunHistory} from '@wandb/weave/core';
-import {useNodeWithServerType} from '@wandb/weave/react';
-import React from 'react';
 
-import * as ConfigPanel from '../ConfigPanel';
 import * as Panel2 from '../panel';
 import {TableSpec} from '../PanelTable/PanelTable';
 import {
   buildPanelRunsWithStepper,
-  getCurrentTableHistoryKey,
-  getTableKeysFromRunsHistoryPropertyType,
   PanelRunsWithStepperConfigType,
-  PanelRunsWithStepperProps,
 } from './base';
-
-const PanelRunsWithStepperConfig: React.FC<
-  PanelRunsWithStepperProps
-> = props => {
-  const runsHistoryNode = opConcat({
-    arr: opRunHistory({run: props.input as any}),
-  });
-  const runsHistoryRefined = useNodeWithServerType(runsHistoryNode);
-  const tableKeys = getTableKeysFromRunsHistoryPropertyType(
-    runsHistoryRefined.result?.type
-  );
-  const tableHistoryKey = getCurrentTableHistoryKey(
-    tableKeys,
-    props.config?.tableHistoryKey
-  );
-
-  const options = tableKeys.map(key => ({text: key, value: key}));
-  const updateConfig = props.updateConfig;
-  const setTableHistoryKey = React.useCallback(
-    val => {
-      updateConfig({tableHistoryKey: val});
-    },
-    [updateConfig]
-  );
-
-  return (
-    <ConfigPanel.ConfigOption label="Table">
-      <ConfigPanel.ModifiedDropdownConfigField
-        selection
-        data-test="compare_method"
-        scrolling
-        multiple={false}
-        options={options}
-        value={tableHistoryKey}
-        onChange={(e, data) => {
-          setTableHistoryKey(data.value as any);
-        }}
-      />
-    </ConfigPanel.ConfigOption>
-  );
-};
 
 export const Spec: Panel2.PanelSpec<PanelRunsWithStepperConfigType> = {
   id: 'run-history-tables-stepper',
   displayName: 'Run History Tables Stepper',
   Component: buildPanelRunsWithStepper(TableSpec),
-  ConfigComponent: PanelRunsWithStepperConfig,
   inputType: LIST_RUNS_TYPE,
   outputType: () => ({
     type: 'list' as const,

--- a/weave-js/src/components/Panel2/PanelRunsWithStepper/HistoryTables.tsx
+++ b/weave-js/src/components/Panel2/PanelRunsWithStepper/HistoryTables.tsx
@@ -1,4 +1,5 @@
 import {LIST_RUNS_TYPE} from '@wandb/weave/common/types/run';
+import {list, typedDict, union} from '@wandb/weave/core';
 
 import * as Panel2 from '../panel';
 import {TableSpec} from '../PanelTable/PanelTable';
@@ -20,3 +21,18 @@ export const Spec: Panel2.PanelSpec<PanelRunsWithStepperConfigType> = {
     },
   }),
 };
+
+export const SpecHistoryTables: Panel2.PanelSpec<PanelRunsWithStepperConfigType> =
+  {
+    id: 'generic-tables-stepper',
+    displayName: 'Run History Tables Stepper',
+    Component: buildPanelRunsWithStepper(TableSpec),
+    inputType: list(list(union([typedDict({})]))),
+    outputType: () => ({
+      type: 'list' as const,
+      objectType: {
+        type: 'list' as const,
+        objectType: {type: 'typedDict' as const, propertyTypes: {}},
+      },
+    }),
+  };

--- a/weave-js/src/components/Panel2/PanelRunsWithStepper/base.tsx
+++ b/weave-js/src/components/Panel2/PanelRunsWithStepper/base.tsx
@@ -113,9 +113,11 @@ export const buildPanelRunsWithStepper = (
       [config, updateConfig]
     );
 
-    const runsHistoryNode = opConcat({
-      arr: opRunHistory({run: input as any}),
-    });
+    const runsHistoryNode = isAssignableTo(input.type, LIST_RUNS_TYPE)
+      ? opConcat({
+          arr: opRunHistory({run: input as any}),
+        })
+      : opConcat({arr: input as any});
     const runsHistoryRefined = useNodeWithServerType(runsHistoryNode);
     const tableKeys = getTableKeysFromRunsHistoryPropertyType(
       runsHistoryRefined.result?.type

--- a/weave-js/src/components/Panel2/PanelRunsWithStepper/base.tsx
+++ b/weave-js/src/components/Panel2/PanelRunsWithStepper/base.tsx
@@ -209,6 +209,17 @@ export const buildPanelRunsWithStepper = (
       });
     }
 
+    const tableSelection = {
+      show: tableKeys.length > 0,
+      keys: tableKeys,
+      currentSelection: tableHistoryKey,
+      callback: (key: string) => {
+        safeUpdateConfig({tableHistoryKey: key});
+      },
+    };
+
+    const newConfig = {...props.config, tableSelection};
+
     return (
       <>
         {defaultNode != null && !isVoidNode(defaultNode) && (
@@ -227,7 +238,7 @@ export const buildPanelRunsWithStepper = (
               loading={props.loading}
               panelSpec={spec}
               configMode={false}
-              config={props.config}
+              config={newConfig}
               context={props.context}
               updateConfig={props.updateConfig}
               updateContext={props.updateContext}

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1148,6 +1148,7 @@ const PanelTableInner: React.FC<
           position="bottom left"
           on="click"
           basic
+          style={{padding: 0, marginTop: '0px'}}
           trigger={
             <Button
               variant="secondary"
@@ -1173,27 +1174,25 @@ const PanelTableInner: React.FC<
             </Button>
           }
           content={
-            <div>
-              Select table:
-              <ModifiedDropdown
-                style={{marginTop: '4px'}}
-                selection
-                scrolling
-                multiple={false}
-                value={props.config.tableSelection?.currentSelection}
-                data-test="table-selection"
-                closeOnBlur
-                closeOnChange
-                options={(props.config.tableSelection?.keys || []).map(key => ({
-                  text: key,
-                  key,
-                  value: key,
-                }))}
-                onChange={(e, {value}) => {
-                  props.config.tableSelection?.callback?.(value as string);
-                }}
-              />
-            </div>
+            <ModifiedDropdown
+              basic
+              selection
+              scrolling
+              multiple={false}
+              defaultOpen
+              value={props.config.tableSelection?.currentSelection}
+              data-test="table-selection"
+              closeOnBlur
+              closeOnChange
+              options={(props.config.tableSelection?.keys || []).map(key => ({
+                text: key,
+                key,
+                value: key,
+              }))}
+              onChange={(e, {value}) => {
+                props.config.tableSelection?.callback?.(value as string);
+              }}
+            />
           }
         />
       )}

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1200,6 +1200,7 @@ const PanelTableInner: React.FC<
       <Button
         variant="secondary"
         size="small"
+        data-test="table-filter-button"
         icon="filter-alt"
         onClick={() => {
           setFilterOpen(!filterOpen);

--- a/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
+++ b/weave-js/src/components/Panel2/PanelTable/PanelTable.tsx
@@ -1,5 +1,6 @@
 import 'react-base-table/lib/TableRow';
 
+import ModifiedDropdown from '@wandb/weave/common/components/elements/ModifiedDropdown';
 import {MOON_500} from '@wandb/weave/common/css/color.styles';
 import {useRunName} from '@wandb/weave/common/hooks/useRunName';
 import {saveTableAsCSV} from '@wandb/weave/common/util/csv';
@@ -1141,6 +1142,61 @@ const PanelTableInner: React.FC<
         margin: '8px',
       }}
       ref={actionBarRef}>
+      {props.config.tableSelection?.show && (
+        <Popup
+          hoverable
+          position="bottom left"
+          on="click"
+          basic
+          trigger={
+            <Button
+              variant="secondary"
+              size="small"
+              icon="table"
+              tooltip="Select table"
+              tooltipProps={{className: 'py-8 px-12'}}>
+              <>
+                Table:{' '}
+                <span
+                  style={{
+                    fontWeight: 'bold',
+                    maxWidth: '120px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    display: 'inline-block',
+                    whiteSpace: 'nowrap',
+                    verticalAlign: 'bottom',
+                  }}>
+                  {props.config.tableSelection?.currentSelection || 'Table'}
+                </span>
+              </>
+            </Button>
+          }
+          content={
+            <div>
+              Select table:
+              <ModifiedDropdown
+                style={{marginTop: '4px'}}
+                selection
+                scrolling
+                multiple={false}
+                value={props.config.tableSelection?.currentSelection}
+                data-test="table-selection"
+                closeOnBlur
+                closeOnChange
+                options={(props.config.tableSelection?.keys || []).map(key => ({
+                  text: key,
+                  key,
+                  value: key,
+                }))}
+                onChange={(e, {value}) => {
+                  props.config.tableSelection?.callback?.(value as string);
+                }}
+              />
+            </div>
+          }
+        />
+      )}
       <Button
         variant="secondary"
         size="small"

--- a/weave-js/src/components/Panel2/PanelTable/config.ts
+++ b/weave-js/src/components/Panel2/PanelTable/config.ts
@@ -34,6 +34,12 @@ export type PanelTableConfig = {
   pinnedColumns: string[];
   activeRowForGrouping: {[groupKey: string]: number};
   simpleTable?: boolean;
+  tableSelection?: {
+    currentSelection: string;
+    show: boolean;
+    keys: string[];
+    callback: (key: string) => void;
+  };
 };
 
 const tableStateKeys = [


### PR DESCRIPTION
## Description

**Note:** The base branch is `npun-WB-24174`

- Implements [WB-24167](https://wandb.atlassian.net/browse/WB-24167)
- Adds another spec that accepts a type in the shape of the return value of `runs.history`

TODO:
- I think this needs to be extended to the plot stepper as well
- This may not work for `run[0].history` (and probably should)

## Testing

https://github.com/user-attachments/assets/1d680c76-09a6-4ab2-b097-135b69c1c212




[WB-24167]: https://wandb.atlassian.net/browse/WB-24167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ