### PR TITLE
fix(weave): Loosen the regex check to accept potentially CJK characters

### DIFF
--- a/weave-js/src/react.tsx
+++ b/weave-js/src/react.tsx
@@ -516,7 +516,7 @@ const RE_WEAVE_OBJECT_REF_PATHNAME = new RegExp(
     '/',
     '(object|op)', // Weave kind
     '/',
-    '([a-zA-Z0-9-_/. ]{1,128})', // Artifact name
+    '([^\\#?%:]{1,128})', // Artifact name
     ':',
     '([*]|[a-zA-Z0-9]+)', // Artifact version, allowing '*' for any version
     '/?', // Ref extra portion is optional


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-23821
- Fixes WB-21343

There's no point in restricting artifact names to only ASCII characters.

If we need these checks, they should be handled at the server or SDK level (during creation).

Since users often use CJK characters for dataset names and other objects without issues, I'm temporarily relaxing the frontend regex restrictions.

## Testing

I tested the scenario of 

1. Getting the dataset details which uses CJK characters

<img width="1197" alt="image" src="https://github.com/user-attachments/assets/3c2cf420-3ac1-4588-a15d-cadf4cc9c9cd" />

2. Compare evaluations using a dataset with CJK characters
<img width="1264" alt="image" src="https://github.com/user-attachments/assets/d8217266-6345-4498-b974-f1e4fe80be34" />

These scenarios were previously broken without this change.