### PR TITLE
chore(weave): convert 12m to 1y

### DIFF
--- a/weave-js/src/components/Timestamp.tsx
+++ b/weave-js/src/components/Timestamp.tsx
@@ -43,17 +43,16 @@ const formatSmallTime = (then: moment.Moment): string | null => {
     return `${years}y`;
   }
 
-  // Calculate months using moment's built-in month diff
   const monthDiff = now.diff(then, 'months');
-
-  // Get remaining days by moving forward the months and checking what's left
-  const afterMonths = then.clone().add(monthDiff, 'months');
-  const remainingDays = now.diff(afterMonths, 'days');
 
   // Always show months if 3 or more
   if (monthDiff >= 3) {
     return `${monthDiff}mo`;
   }
+
+  // Get remaining days by moving forward the months and checking what's left
+  const afterMonths = then.clone().add(monthDiff, 'months');
+  const remainingDays = now.diff(afterMonths, 'days');
 
   // Show months if exact multiple
   if (monthDiff > 0 && remainingDays === 0) {
@@ -71,7 +70,7 @@ const formatSmallTime = (then: moment.Moment): string | null => {
     return `${weeks}w`;
   }
 
-  // Otherwise use days for more precision
+  // Otherwise use days or more precise units
   if (days >= 1) {
     return days === 1 ? '1d' : `${days}d`;
   } else if (hours >= 1) {

--- a/weave-js/src/components/Timestamp.tsx
+++ b/weave-js/src/components/Timestamp.tsx
@@ -55,8 +55,8 @@ const formatSmallTime = (then: moment.Moment): string | null => {
     return `${monthDiff}mo`;
   }
 
-  // Show months if exact(ish) multiple
-  if (monthDiff > 0 && remainingDays < 5) {
+  // Show months if exact multiple
+  if (monthDiff > 0 && remainingDays === 0) {
     return `${monthDiff}mo`;
   }
 

--- a/weave-js/src/components/Timestamp.tsx
+++ b/weave-js/src/components/Timestamp.tsx
@@ -38,6 +38,18 @@ const formatSmallTime = (then: moment.Moment): string | null => {
   const hours = Math.floor(diffMs / (1000 * 60 * 60));
   const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
+  const years = now.diff(then, 'years');
+  if (years > 0) {
+    const remainingDays = days - years * 365;
+    if (remainingDays < 7) {
+      if (years === 1) {
+        return '1y';
+      } else if (years > 1) {
+        return `${years}y`;
+      }
+    }
+  }
+
   // Calculate months using moment's diff
   const months = now.diff(then, 'months');
   if (months > 0) {
@@ -49,15 +61,6 @@ const formatSmallTime = (then: moment.Moment): string | null => {
       } else if (months > 1) {
         return `${months}mo`;
       }
-    }
-  }
-
-  const years = now.diff(then, 'years');
-  if (years > 0) {
-    if (years === 1) {
-      return '1y';
-    } else if (years > 1) {
-      return `${years}y`;
     }
   }
 

--- a/weave-js/src/components/Timestamp.tsx
+++ b/weave-js/src/components/Timestamp.tsx
@@ -42,11 +42,7 @@ const formatSmallTime = (then: moment.Moment): string | null => {
   if (years > 0) {
     const remainingDays = days - years * 365;
     if (remainingDays < 7) {
-      if (years === 1) {
-        return '1y';
-      } else if (years > 1) {
-        return `${years}y`;
-      }
+      return `${years}y`;
     }
   }
 

--- a/weave-js/src/components/Timestamp.tsx
+++ b/weave-js/src/components/Timestamp.tsx
@@ -40,34 +40,35 @@ const formatSmallTime = (then: moment.Moment): string | null => {
 
   const years = now.diff(then, 'years');
   if (years > 0) {
-    const remainingDays = days - years * 365;
-    if (remainingDays < 7) {
-      return `${years}y`;
-    }
+    return `${years}y`;
   }
 
-  // Calculate months using moment's diff
-  const months = now.diff(then, 'months');
-  if (months > 0) {
-    // Only show months if the remaining days are less than 7
-    const remainingDays = days - months * 30;
-    if (remainingDays < 7) {
-      if (months === 1) {
-        return '1mo';
-      } else if (months > 1) {
-        return `${months}mo`;
-      }
-    }
+  // Calculate months using moment's built-in month diff
+  const monthDiff = now.diff(then, 'months');
+
+  // Get remaining days by moving forward the months and checking what's left
+  const afterMonths = then.clone().add(monthDiff, 'months');
+  const remainingDays = now.diff(afterMonths, 'days');
+
+  // Always show months if 3 or more
+  if (monthDiff >= 3) {
+    return `${monthDiff}mo`;
   }
 
-  // Only use weeks when it's an exact multiple
+  // Show months if exact(ish) multiple
+  if (monthDiff > 0 && remainingDays < 5) {
+    return `${monthDiff}mo`;
+  }
+
+  // Show weeks when more than 14 days or exact
+  const weeks = Math.round(days / 7);
+  if (weeks >= 2) {
+    return `${weeks}w`;
+  }
+
+  // Show weeks when exact multiple
   if (days % 7 === 0) {
-    const weeks = days / 7;
-    if (weeks === 1) {
-      return '1w';
-    } else if (weeks > 1) {
-      return `${weeks}w`;
-    }
+    return `${weeks}w`;
   }
 
   // Otherwise use days for more precision


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24241](https://wandb.atlassian.net/browse/WB-24241)

Convert anything thats a nice even (ish) multiple of a year into `1y` in the timestamp filter bar.

## Testing

prod:
<img width="672" alt="Screenshot 2025-04-03 at 1 59 07 PM" src="https://github.com/user-attachments/assets/0b21a0f4-5178-4d60-96c2-485164b10d34" />


branch:
<img width="677" alt="Screenshot 2025-04-03 at 1 58 52 PM" src="https://github.com/user-attachments/assets/9c742ebd-289d-47f9-ae7c-26fe46dc654e" />



[WB-24241]: https://wandb.atlassian.net/browse/WB-24241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ