### PR TITLE
chore(app): Fix alignment of arrows on NumberInput

### DIFF
--- a/weave-js/src/common/components/elements/NumberInput.tsx
+++ b/weave-js/src/common/components/elements/NumberInput.tsx
@@ -90,7 +90,7 @@ const NumberInput: React.FC<NumberInputProps> = props => {
         className={`number-input__input ${props.className || ''}`}
         disabled={props.disabled}
         placeholder={props.placeholder}
-        style={props.inputStyle}
+        style={{marginRight: 0, ...props.inputStyle}} // the default margin right is 4px but that misaligns the arrow buttons
         type="number"
         value={stringValue}
         onFocus={() => {


### PR DESCRIPTION
## Description

The arrows could be pushed out of the input box if the input was less wide, because the number input has a default margin right of 4 px. We can just set it to 0px.

## Testing

How was this PR tested?

Before:

<img width="302" alt="Screenshot 2025-04-03 at 3 47 53 PM" src="https://github.com/user-attachments/assets/7d20e156-f3fb-487d-b837-c61f567d0cf4" />
<img width="159" alt="Screenshot 2025-04-03 at 3 48 01 PM" src="https://github.com/user-attachments/assets/bd96bd04-1d49-46f2-9810-04ca63a9323c" />

After:

<img width="300" alt="Screenshot 2025-04-03 at 3 47 16 PM" src="https://github.com/user-attachments/assets/94eadddd-86cb-4d37-9db9-c7d66dae420d" />
<img width="149" alt="Screenshot 2025-04-03 at 3 47 26 PM" src="https://github.com/user-attachments/assets/cf0b7d00-5ba6-4211-8d8d-1394bbd60ddb" />

