### PR TITLE
feat(weave): Display trace storage size in Trace view

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -265,6 +265,8 @@ export const CallsTable: FC<{
     [expandedRefCols]
   );
 
+  const shouldIncludeTotalStorageSize = effectiveFilter.traceRootsOnly;
+
   // Fetch the calls
   const calls = useCallsForQuery(
     entity,
@@ -273,7 +275,13 @@ export const CallsTable: FC<{
     filterModelResolved,
     paginationModelResolved,
     sortModelResolved,
-    expandedRefCols
+    expandedRefCols,
+    undefined,
+    {
+      // The total storage size only makes sense for traces,
+      // and not for calls.
+      includeTotalStorageSize: shouldIncludeTotalStorageSize,
+    }
   );
 
   // Here, we only update our local state once the calls have loaded.
@@ -445,7 +453,10 @@ export const CallsTable: FC<{
     columnIsRefExpanded,
     allowedColumnPatterns,
     onAddFilter,
-    calls.costsLoading
+    calls.costsLoading,
+    shouldIncludeTotalStorageSize,
+    shouldIncludeTotalStorageSize ? calls.storageSizeResults : null,
+    shouldIncludeTotalStorageSize && calls.storageSizeLoading
   );
 
   // This contains columns which are suitable for selection and raw data

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -73,6 +73,7 @@ export type TraceCallSchema = {
   summary?: SummaryMap;
   wb_run_id?: string;
   wb_user_id?: string;
+  total_storage_size_bytes?: number;
 };
 export type TraceCallReadReq = {
   project_id: string;
@@ -112,6 +113,7 @@ export type TraceCallsQueryReq = {
   expand_columns?: string[];
   include_costs?: boolean;
   include_feedback?: boolean;
+  include_total_storage_size?: boolean;
 };
 
 export type TraceCallsQueryRes = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -253,6 +253,7 @@ const useCallsNoExpansion = (
     refetchOnDelete?: boolean;
     includeCosts?: boolean;
     includeFeedback?: boolean;
+    includeTotalStorageSize?: boolean;
   }
 ): Loadable<CallSchema[]> & Refetchable => {
   const getTsClient = useGetTraceServerClientContext();
@@ -287,6 +288,9 @@ const useCallsNoExpansion = (
       columns,
       include_costs: opts?.includeCosts,
       include_feedback: opts?.includeFeedback,
+      ...(opts?.includeTotalStorageSize
+        ? {include_total_storage_size: true}
+        : null),
     };
     const onSuccess = (res: traceServerTypes.TraceCallsQueryRes) => {
       loadingRef.current = false;
@@ -299,18 +303,27 @@ const useCallsNoExpansion = (
     };
     getTsClient().callsStreamQuery(req).then(onSuccess).catch(onError);
   }, [
-    entity,
-    project,
-    deepFilter,
-    limit,
     opts?.skip,
     opts?.includeCosts,
     opts?.includeFeedback,
-    getTsClient,
+    opts?.includeTotalStorageSize,
+    entity,
+    project,
+    deepFilter.opVersionRefs,
+    deepFilter.inputObjectVersionRefs,
+    deepFilter.outputObjectVersionRefs,
+    deepFilter.parentIds,
+    deepFilter.traceId,
+    deepFilter.callIds,
+    deepFilter.traceRootsOnly,
+    deepFilter.runIds,
+    deepFilter.userIds,
+    limit,
     offset,
     sortBy,
     query,
     columns,
+    getTsClient,
   ]);
 
   // register doFetch as a callback after deletion
@@ -397,6 +410,7 @@ const useCalls = (
     refetchOnDelete?: boolean;
     includeCosts?: boolean;
     includeFeedback?: boolean;
+    includeTotalStorageSize?: boolean;
   }
 ): Loadable<CallSchema[]> & Refetchable => {
   const calls = useCallsNoExpansion(
@@ -1953,6 +1967,7 @@ export const traceCallToUICallSchema = (
     userId: traceCall.wb_user_id ?? null,
     runId: traceCall.wb_run_id ?? null,
     traceCall,
+    totalStorageSizeBytes: traceCall.total_storage_size_bytes ?? null,
   };
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -49,6 +49,7 @@ export type CallSchema = CallKey & {
   userId: string | null;
   runId: string | null;
   traceCall?: traceServerClientTypes.TraceCallSchema; // this will eventually be the entire call schema
+  totalStorageSizeBytes?: number | null;
 };
 
 export type CallFilter = {
@@ -183,6 +184,7 @@ export type WFDataModelHooksInterface = {
       refetchOnDelete?: boolean;
       includeCosts?: boolean;
       includeFeedback?: boolean;
+      includeTotalStorageSize?: boolean;
     }
   ) => Loadable<CallSchema[]> & Refetchable;
   useCallsStats: (

--- a/weave-js/src/util.ts
+++ b/weave-js/src/util.ts
@@ -61,3 +61,17 @@ export function formatRelativeTime(unixTimestamp: number): string {
     return inFuture ? 'in a moment' : 'just now';
   }
 }
+
+export function convertBytes(result: any) {
+  if (typeof result !== 'number') {
+    return '';
+  }
+  if (result > 10e9) {
+    return `${(result / 10e9).toFixed(1)}GB`;
+  } else if (result > 10e6) {
+    return `${(result / 10e6).toFixed(1)}MB`;
+  } else if (result > 10e3) {
+    return `${(result / 10e3).toFixed(1)}KB`;
+  }
+  return `${result}B`;
+}


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-23748

Add storage size column to CallsTable

Changes:
- Added storage size column to display total storage usage for each call
- Implemented loading state handling with LoadingDots component
- Added proper null checking for storage size values

The storage size column shows human-readable byte sizes (e.g., "1.5 MB") and handles loading states appropriately.


## Screenshot

<img width="479" alt="image" src="https://github.com/user-attachments/assets/f3867c72-4571-42ac-acaa-a464a90e71a3" />

## Design doc

Please also refer this [mini design doc(private)](https://www.notion.so/wandbai/Data-Size-display-1bde2f5c7ef38087bc03cb8accb95bfb?pvs=4#1cfe2f5c7ef3805e9f73f9ddc4575460) for greater context.

## Performance Study

At the beginning of implementing this PR, I debated myself how to load the data for this additional column.

The `/calls/stream_query` API  is capable of either:
1: accepting a group (about 50) of call_ids, and do table joins to calculated an aggregated result for each of the row_ids.
2: or it can accept a single row_id, and do the same expensive calculation of an aggregated result for that single row_id.

Given that the table join and the aggregation is expensive, I need to decide whether I make a single call with a group of ids, or invoke each id and have parallel requests on the frontend. 

If I do parallel requests, the code structure would be simpler, because each frontend component (a ColumnCellRenderer) can encapsulate the data loading logic within itself.

Doing a single request with a group ids might be harder to implement, because I have to centralize the data loading at one place and dispatch the results separately.

To make a sensible decision, during the first several hours, instead of writing the feature code, I did some study and measurement, here is the result:

```
Query Performance Analysis:
callsTableQuery.ts:180 

Batch Size: 1
callsTableQuery.ts:181 Average Total Time: 67.10ms
callsTableQuery.ts:182 Average DB Time: 17.60ms
callsTableQuery.ts:183 Average Network Time: 49.50ms
callsTableQuery.ts:184 Average Memory Usage: 0.04MB
callsTableQuery.ts:189 Error Rate: 0.00%
callsTableQuery.ts:180 

Batch Size: 10
callsTableQuery.ts:181 Average Total Time: 56.16ms
callsTableQuery.ts:182 Average DB Time: 16.20ms
callsTableQuery.ts:183 Average Network Time: 39.96ms
callsTableQuery.ts:184 Average Memory Usage: 0.03MB
callsTableQuery.ts:189 Error Rate: 0.00%
callsTableQuery.ts:180 

Batch Size: 50
callsTableQuery.ts:181 Average Total Time: 56.20ms
callsTableQuery.ts:182 Average DB Time: 15.80ms
callsTableQuery.ts:183 Average Network Time: 40.40ms
callsTableQuery.ts:184 Average Memory Usage: 0.07MB
callsTableQuery.ts:189 Error Rate: 0.00%
callsTableQuery.ts:180 

Batch Size: 100
callsTableQuery.ts:181 Average Total Time: 58.64ms
callsTableQuery.ts:182 Average DB Time: 15.60ms
callsTableQuery.ts:183 Average Network Time: 43.04ms
callsTableQuery.ts:184 Average Memory Usage: 0.13MB
callsTableQuery.ts:189 Error Rate: 0.00%
```
From these measurement, it can be seen that the DB query time is not significantly impacted by the size of IDs. At least within 100 number of ids, the query time is roughly un-impacted. 

On the other hand, network transportation takes the major portion of the time. 

Therefore, parallelizing request makes little sense in terms of UX. And centralizing the processing with a group of ID is the wiser move. 

## Testing

The PR is currently manually tested. 