### PR TITLE
chore(weave): less aggressive default date filters

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
@@ -62,7 +62,6 @@ export const CallsTableNoRowsOverlay: React.FC<
       return (
         <DateFilterEmptyState
           filterModelResolved={filterModelResolved}
-          opCreatedAt={opCreatedAt ?? null}
           clearFilters={clearFilters}
           setFilterModel={setFilterModel}
         />
@@ -77,7 +76,6 @@ export const CallsTableNoRowsOverlay: React.FC<
     return (
       <DateFilterEmptyState
         filterModelResolved={filterModelResolved}
-        opCreatedAt={opCreatedAt ?? null}
         clearFilters={clearFilters}
         setFilterModel={setFilterModel}
       />
@@ -89,74 +87,54 @@ export const CallsTableNoRowsOverlay: React.FC<
 
 type DateFilterEmptyStateProps = {
   filterModelResolved: GridFilterModel;
-  opCreatedAt: number | null;
   clearFilters?: () => void;
   setFilterModel?: (model: GridFilterModel) => void;
 };
 
 const DateFilterEmptyState: React.FC<DateFilterEmptyStateProps> = ({
   filterModelResolved,
-  opCreatedAt,
   clearFilters,
   setFilterModel,
 }) => {
+  const existingFilter = filterModelResolved.items.find(
+    item => item.field === 'started_at' && item.operator === '(date): after'
+  );
+
+  const now = new Date();
+  const existingFilterDays = existingFilter
+    ? Math.round(
+        (now.getTime() - new Date(existingFilter.value).getTime()) /
+          (24 * 60 * 60 * 1000)
+      )
+    : 0;
+
+  const clearingFilters = !setFilterModel || existingFilterDays > 7;
+
   const expandDateRange = () => {
     if (!setFilterModel) {
       clearFilters?.();
       return;
     }
-    const currentFilterModel = {...filterModelResolved};
-    const items = [...currentFilterModel.items];
 
-    const existingFilter = items.find(
-      item => item.field === 'started_at' && item.operator === '(date): after'
+    const currentFilterModel = {...filterModelResolved};
+    const filteredItems = currentFilterModel.items.filter(
+      item => item.field !== 'started_at'
     );
-    // Remove any existing started_at filters
-    const filteredItems = items.filter(item => item.field !== 'started_at');
 
     // Determine new date range based on opCreatedAt
     let newDateFilter;
-    if (opCreatedAt) {
-      const filterDate = new Date(opCreatedAt);
-      const now = new Date();
-
-      const daysSinceOpCreated = Math.round(
-        (now.getTime() - filterDate.getTime()) / (24 * 60 * 60 * 1000)
-      );
-
-      // If there's an existing filter, calculate how many days it spans
-      // default to the number of days since last op
-      let existingFilterDays = daysSinceOpCreated;
-      if (existingFilter) {
-        const existingDate = new Date(existingFilter.value);
-        existingFilterDays = Math.round(
-          (now.getTime() - existingDate.getTime()) / (24 * 60 * 60 * 1000)
-        );
-      }
-
-      // Determine the appropriate bucket size, ensuring it's larger than the existing filter
-      if (existingFilterDays < 4) {
-        newDateFilter = makeDateFilter(7);
-      } else if (existingFilterDays <= 7) {
-        // Month is a special case, depends on the # of days in last month
-        newDateFilter = makeMonthFilter();
-      } else if (existingFilterDays <= 31) {
-        newDateFilter = makeDateFilter(365);
-      } else {
-        // If we're already at the largest bucket, remove the date filter
-        setFilterModel({
-          ...currentFilterModel,
-          items: filteredItems,
-        });
-        return;
-      }
-    } else {
-      // Impossible (block conditioned on hasDateFilter), but default to 3 months
+    if (existingFilterDays < 4) {
+      newDateFilter = makeDateFilter(7);
+    } else if (existingFilterDays <= 7) {
       newDateFilter = makeMonthFilter();
+    } else {
+      newDateFilter = undefined;
     }
 
     // Add the new date filter
-    filteredItems.push(newDateFilter);
+    if (newDateFilter) {
+      filteredItems.push(newDateFilter);
+    }
 
     // Update the filter model
     setFilterModel({
@@ -165,16 +143,17 @@ const DateFilterEmptyState: React.FC<DateFilterEmptyStateProps> = ({
     });
   };
 
+  const dateRangeText = clearingFilters
+    ? 'clearing your date range'
+    : 'expanding your date range';
+
   return (
     <EmptyStateBox>
       No calls found for the specified date range.{' '}
       <>
         Try{' '}
-        <ClearFiltersAction
-          onClick={expandDateRange}
-          text="expanding your date range"
-        />{' '}
-        or looking for data in a different time period.
+        <ClearFiltersAction onClick={expandDateRange} text={dateRangeText} /> or
+        looking for data in a different time period.
       </>
     </EmptyStateBox>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
@@ -52,16 +52,27 @@ export const CallsTableNoRowsOverlay: React.FC<
   }
 
   const opExists = opCreatedAt != null;
+  const hasDateFilter = filterHasCalledAfterDateFilter(filterModelResolved);
 
   // Handle special empty states
   if (isEvaluateTable) {
-    return <Empty {...EMPTY_PROPS_EVALUATIONS} />;
+    if (!hasDateFilter) {
+      return <Empty {...EMPTY_PROPS_EVALUATIONS} />;
+    } else {
+      return (
+        <DateFilterEmptyState
+          filterModelResolved={filterModelResolved}
+          opCreatedAt={opCreatedAt ?? null}
+          clearFilters={clearFilters}
+          setFilterModel={setFilterModel}
+        />
+      );
+    }
     // Show empty page if we have no ops, and thus haven't logged a real trace
   } else if (effectiveFilter.traceRootsOnly && !opExists) {
     return <Empty {...EMPTY_PROPS_TRACES} />;
   }
 
-  const hasDateFilter = filterHasCalledAfterDateFilter(filterModelResolved);
   if (hasDateFilter) {
     return (
       <DateFilterEmptyState

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
@@ -141,10 +141,6 @@ const DateFilterEmptyState: React.FC<DateFilterEmptyStateProps> = ({
         // Month is a special case, depends on the # of days in last month
         newDateFilter = makeMonthFilter();
       } else if (existingFilterDays <= 31) {
-        newDateFilter = makeDateFilter(90);
-      } else if (existingFilterDays <= 90) {
-        newDateFilter = makeDateFilter(180);
-      } else if (existingFilterDays <= 180) {
         newDateFilter = makeDateFilter(365);
       } else {
         // If we're already at the largest bucket, remove the date filter

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -350,7 +350,7 @@ export const useMakeInitialDatetimeFilter = (
       };
     } else if (callStats30Days.result && callStats30Days.result.count < 50) {
       newFilter = {
-        items: [makeDateFilter(180)],
+        items: [makeDateFilter(365)],
         logicOperator: GridLogicOperator.And,
       };
     }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -349,8 +349,9 @@ export const useMakeInitialDatetimeFilter = (
         logicOperator: GridLogicOperator.And,
       };
     } else if (callStats30Days.result && callStats30Days.result.count < 50) {
+      // If there are no calls found in the last 30 days, just don't set a filter
       newFilter = {
-        items: [makeDateFilter(365)],
+        items: [],
         logicOperator: GridLogicOperator.And,
       };
     }


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Simplify datetime handling for older projects. This pr: 
- Show the correct either no traces or none within the filter range screen for the evaluation page too (even though we don't do defaults on the top level, you can get there by clicking on evaluation children)
- Now, if we don't find any calls in the last 30 days, we don't even try to set a default. The motivation for this is that very high velocity projects probably will have logged in the past month. We never want users of old projects to see no traces, this ensures that. 
- Now when you click the "expand daterange" button we skip 90 and 180 days, just go from 30 days to 1y. 
- When we clear the daterange after expanding, change the text to reflect that 

## Testing

Using tims really old hooman [proj](https://wandb.ai/timssweeney/hooman-0_49_0-rc-002/weave/traces?filter=%7B%22opVersionRefs%22%3A%5B%22weave%3A%2F%2F%2Ftimssweeney%2Fhooman-0_49_0-rc-002%2Fop%2FEvaluation.predict_and_score%3AisSwuD95uXiaNZwAqQ8Fiv5PtMXvRQgN6KjDDSgPTfE%22%5D%2C%22parentId%22%3A%221917b061-958e-4b54-8608-8bacc3946f5e%22%7D)

branch:
<img width="1728" alt="Screenshot 2025-04-04 at 10 45 05 AM" src="https://github.com/user-attachments/assets/b53250d7-0c4d-4bf5-bf26-fdb234079a59" />

prod:
<img width="1723" alt="Screenshot 2025-04-04 at 10 42 01 AM" src="https://github.com/user-attachments/assets/809c4151-0fc8-4690-822d-15be11f94d37" />

branch:
![datet-time-expand-3](https://github.com/user-attachments/assets/58063a9e-050e-41d6-a1bd-4e73d2d8d7a0)
