### PR TITLE
chore(weave): pin transfomers library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,8 @@ scorers = [
   "litellm>=1.58",
   "sentence-transformers>=3.3.1",
   "scikit-learn>=1.5.2",
-  "transformers>=4.48.2",
+  # Pin until transformers releases https://github.com/huggingface/transformers/pull/37337
+  "transformers>=4.48.2,<4.51.0",
   "torch>=2.4.1",
   "sentencepiece>=0.2.0",
   "pip>=20.0",                    # this is needed for presidio-analyzer to pull the spacy models


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1744045751469129

The scorers shard of our CI tests was broken. The symptom is `NameError: name 'init_empty_weights' is not defined` - I think this was caused by the [April 5th release of the transformers library](https://pypi.org/project/transformers/#history) - it looks like a [fix landed today](https://github.com/huggingface/transformers/pull/37337) - but since we don't know when that will get released I am pinning to an older version for now.
