### PR TITLE
chore(weave): cap hardcoded filters to 1000

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -2,6 +2,7 @@ import asyncio
 import dataclasses
 import json
 import platform
+import re
 import sys
 import time
 import uuid
@@ -2709,3 +2710,57 @@ async def test_tracing_enabled_context(client):
     # Test finish_call with tracing disabled
     with tracing_disabled():
         client.finish_call(call)  # Should not raise any error
+
+
+def test_calls_query_hardcoded_filter_length_validation(client):
+    @weave.op
+    def test():
+        return {"foo": "bar"}
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Parameter: 'call_ids' request length is greater than max length (1000). Actual length: 1001"
+        ),
+    ):
+        calls = client.get_calls(filter={"call_ids": ["11111"] * 1001})[0]
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Parameter: 'op_names' request length is greater than max length (1000). Actual length: 1001"
+        ),
+    ):
+        calls = client.get_calls(filter={"op_names": ["11111"] * 1001})[0]
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Parameter: 'input_refs' request length is greater than max length (1000). Actual length: 1001"
+        ),
+    ):
+        calls = client.get_calls(filter={"input_refs": ["11111"] * 1001})[0]
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Parameter: 'output_refs' request length is greater than max length (1000). Actual length: 1001"
+        ),
+    ):
+        calls = client.get_calls(filter={"output_refs": ["11111"] * 1001})[0]
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Parameter: 'parent_ids' request length is greater than max length (1000). Actual length: 1001"
+        ),
+    ):
+        calls = client.get_calls(filter={"parent_ids": ["11111"] * 1001})[0]
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Parameter: 'trace_ids' request length is greater than max length (1000). Actual length: 1001"
+        ),
+    ):
+        calls = client.get_calls(filter={"trace_ids": ["11111"] * 1001})[0]

--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -1,3 +1,4 @@
+import pytest
 import sqlparse
 
 from weave.trace_server import trace_server_interface as tsi
@@ -1673,3 +1674,49 @@ def test_aggregated_data_size_field():
     assert "CASE" in sql
     assert "parent_id" in sql
     assert "rolled_up_cms.total_storage_size_bytes" in sql
+
+
+def test_filter_length_validation():
+    """Test that filter length validation works"""
+    pb = ParamBuilder()
+    cq = CallsQuery(project_id="test/project")
+    cq.hardcoded_filter = HardCodedFilter(
+        filter={"op_names": ["weave-trace-internal:///%"] * 1001}
+    )
+    with pytest.raises(ValueError):
+        cq.as_sql(pb)
+
+    cq = CallsQuery(project_id="test/project")
+    cq.hardcoded_filter = HardCodedFilter(
+        filter={"input_refs": ["weave-trace-internal:///%"] * 1001}
+    )
+    with pytest.raises(ValueError):
+        cq.as_sql(pb)
+
+    cq = CallsQuery(project_id="test/project")
+    cq.hardcoded_filter = HardCodedFilter(
+        filter={"output_refs": ["weave-trace-internal:///%"] * 1001}
+    )
+    with pytest.raises(ValueError):
+        cq.as_sql(pb)
+
+    cq = CallsQuery(project_id="test/project")
+    cq.hardcoded_filter = HardCodedFilter(
+        filter={"parent_ids": ["weave-trace-internal:///%"] * 1001}
+    )
+    with pytest.raises(ValueError):
+        cq.as_sql(pb)
+
+    cq = CallsQuery(project_id="test/project")
+    cq.hardcoded_filter = HardCodedFilter(
+        filter={"trace_ids": ["weave-trace-internal:///%"] * 1001}
+    )
+    with pytest.raises(ValueError):
+        cq.as_sql(pb)
+
+    cq = CallsQuery(project_id="test/project")
+    cq.hardcoded_filter = HardCodedFilter(
+        filter={"call_ids": ["weave-trace-internal:///%"] * 1001}
+    )
+    with pytest.raises(ValueError):
+        cq.as_sql(pb)

--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -44,6 +44,7 @@ from weave.trace_server.orm import (
     quote_json_path_parts,
 )
 from weave.trace_server.token_costs import cost_query
+from weave.trace_server.trace_server_common import assert_length_less_than_max
 from weave.trace_server.trace_server_interface_util import (
     WILDCARD_ARTIFACT_VERSION_AND_PATH,
 )
@@ -860,14 +861,6 @@ def get_field_by_name(name: str) -> CallsMergedField:
     return ALLOWED_CALL_FIELDS[name]
 
 
-MAX_FILTER_LENGTH = 1000
-
-
-def assert_length_less_than_max(arr: list, max_length: int = MAX_FILTER_LENGTH) -> None:
-    if len(arr) > max_length:
-        raise ValueError(f"Array length is greater than max length: {len(arr)}")
-
-
 # Handler function for status summary field
 def _handle_status_summary_field(pb: ParamBuilder, table_alias: str) -> str:
     # Status logic:
@@ -1064,7 +1057,7 @@ def process_calls_filter_to_conditions(
     conditions: list[str] = []
 
     if filter.op_names:
-        assert_length_less_than_max(filter.op_names)
+        assert_length_less_than_max("op_names", len(filter.op_names))
 
         # We will build up (0 or 1) + N conditions for the op_version_refs
         # If there are any non-wildcarded names, then we at least have an IN condition
@@ -1095,31 +1088,31 @@ def process_calls_filter_to_conditions(
             conditions.append(combine_conditions(or_conditions, "OR"))
 
     if filter.input_refs:
-        assert_length_less_than_max(filter.input_refs)
+        assert_length_less_than_max("input_refs", len(filter.input_refs))
         conditions.append(
             f"hasAny({get_field_by_name('input_refs').as_sql(param_builder, table_alias)}, {_param_slot(param_builder.add_param(filter.input_refs), 'Array(String)')})"
         )
 
     if filter.output_refs:
-        assert_length_less_than_max(filter.output_refs)
+        assert_length_less_than_max("output_refs", len(filter.output_refs))
         conditions.append(
             f"hasAny({get_field_by_name('output_refs').as_sql(param_builder, table_alias)}, {_param_slot(param_builder.add_param(filter.output_refs), 'Array(String)')})"
         )
 
     if filter.parent_ids:
-        assert_length_less_than_max(filter.parent_ids)
+        assert_length_less_than_max("parent_ids", len(filter.parent_ids))
         conditions.append(
             f"{get_field_by_name('parent_id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.parent_ids), 'Array(String)')}"
         )
 
     if filter.trace_ids:
-        assert_length_less_than_max(filter.trace_ids)
+        assert_length_less_than_max("trace_ids", len(filter.trace_ids))
         conditions.append(
             f"{get_field_by_name('trace_id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.trace_ids), 'Array(String)')}"
         )
 
     if filter.call_ids:
-        assert_length_less_than_max(filter.call_ids)
+        assert_length_less_than_max("call_ids", len(filter.call_ids))
         conditions.append(
             f"{get_field_by_name('id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.call_ids), 'Array(String)')}"
         )

--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -860,6 +860,14 @@ def get_field_by_name(name: str) -> CallsMergedField:
     return ALLOWED_CALL_FIELDS[name]
 
 
+MAX_FILTER_LENGTH = 1000
+
+
+def assert_length_less_than_max(arr: list, max_length: int = MAX_FILTER_LENGTH) -> None:
+    if len(arr) > max_length:
+        raise ValueError(f"Array length is greater than max length: {len(arr)}")
+
+
 # Handler function for status summary field
 def _handle_status_summary_field(pb: ParamBuilder, table_alias: str) -> str:
     # Status logic:
@@ -1056,6 +1064,8 @@ def process_calls_filter_to_conditions(
     conditions: list[str] = []
 
     if filter.op_names:
+        assert_length_less_than_max(filter.op_names)
+
         # We will build up (0 or 1) + N conditions for the op_version_refs
         # If there are any non-wildcarded names, then we at least have an IN condition
         # If there are any wildcarded names, then we have a LIKE condition for each
@@ -1085,26 +1095,31 @@ def process_calls_filter_to_conditions(
             conditions.append(combine_conditions(or_conditions, "OR"))
 
     if filter.input_refs:
+        assert_length_less_than_max(filter.input_refs)
         conditions.append(
             f"hasAny({get_field_by_name('input_refs').as_sql(param_builder, table_alias)}, {_param_slot(param_builder.add_param(filter.input_refs), 'Array(String)')})"
         )
 
     if filter.output_refs:
+        assert_length_less_than_max(filter.output_refs)
         conditions.append(
             f"hasAny({get_field_by_name('output_refs').as_sql(param_builder, table_alias)}, {_param_slot(param_builder.add_param(filter.output_refs), 'Array(String)')})"
         )
 
     if filter.parent_ids:
+        assert_length_less_than_max(filter.parent_ids)
         conditions.append(
             f"{get_field_by_name('parent_id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.parent_ids), 'Array(String)')}"
         )
 
     if filter.trace_ids:
+        assert_length_less_than_max(filter.trace_ids)
         conditions.append(
             f"{get_field_by_name('trace_id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.trace_ids), 'Array(String)')}"
         )
 
     if filter.call_ids:
+        assert_length_less_than_max(filter.call_ids)
         conditions.append(
             f"{get_field_by_name('id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.call_ids), 'Array(String)')}"
         )

--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -44,7 +44,7 @@ from weave.trace_server.orm import (
     quote_json_path_parts,
 )
 from weave.trace_server.token_costs import cost_query
-from weave.trace_server.trace_server_common import assert_length_less_than_max
+from weave.trace_server.trace_server_common import assert_parameter_length_less_than_max
 from weave.trace_server.trace_server_interface_util import (
     WILDCARD_ARTIFACT_VERSION_AND_PATH,
 )
@@ -1057,7 +1057,7 @@ def process_calls_filter_to_conditions(
     conditions: list[str] = []
 
     if filter.op_names:
-        assert_length_less_than_max("op_names", len(filter.op_names))
+        assert_parameter_length_less_than_max("op_names", len(filter.op_names))
 
         # We will build up (0 or 1) + N conditions for the op_version_refs
         # If there are any non-wildcarded names, then we at least have an IN condition
@@ -1088,31 +1088,31 @@ def process_calls_filter_to_conditions(
             conditions.append(combine_conditions(or_conditions, "OR"))
 
     if filter.input_refs:
-        assert_length_less_than_max("input_refs", len(filter.input_refs))
+        assert_parameter_length_less_than_max("input_refs", len(filter.input_refs))
         conditions.append(
             f"hasAny({get_field_by_name('input_refs').as_sql(param_builder, table_alias)}, {_param_slot(param_builder.add_param(filter.input_refs), 'Array(String)')})"
         )
 
     if filter.output_refs:
-        assert_length_less_than_max("output_refs", len(filter.output_refs))
+        assert_parameter_length_less_than_max("output_refs", len(filter.output_refs))
         conditions.append(
             f"hasAny({get_field_by_name('output_refs').as_sql(param_builder, table_alias)}, {_param_slot(param_builder.add_param(filter.output_refs), 'Array(String)')})"
         )
 
     if filter.parent_ids:
-        assert_length_less_than_max("parent_ids", len(filter.parent_ids))
+        assert_parameter_length_less_than_max("parent_ids", len(filter.parent_ids))
         conditions.append(
             f"{get_field_by_name('parent_id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.parent_ids), 'Array(String)')}"
         )
 
     if filter.trace_ids:
-        assert_length_less_than_max("trace_ids", len(filter.trace_ids))
+        assert_parameter_length_less_than_max("trace_ids", len(filter.trace_ids))
         conditions.append(
             f"{get_field_by_name('trace_id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.trace_ids), 'Array(String)')}"
         )
 
     if filter.call_ids:
-        assert_length_less_than_max("call_ids", len(filter.call_ids))
+        assert_parameter_length_less_than_max("call_ids", len(filter.call_ids))
         conditions.append(
             f"{get_field_by_name('id').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(filter.call_ids), 'Array(String)')}"
         )

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -30,7 +30,7 @@ from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.object_class_util import process_incoming_object_val
 from weave.trace_server.orm import Row, quote_json_path
 from weave.trace_server.trace_server_common import (
-    assert_length_less_than_max,
+    assert_parameter_length_less_than_max,
     digest_is_version_like,
     empty_str_to_none,
     get_nested_key,
@@ -266,7 +266,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         filter = req.filter
         if filter:
             if filter.op_names:
-                assert_length_less_than_max("op_names", len(filter.op_names))
+                assert_parameter_length_less_than_max("op_names", len(filter.op_names))
                 or_conditions: list[str] = []
 
                 non_wildcarded_names: list[str] = []
@@ -289,27 +289,35 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     conds.append("(" + " OR ".join(or_conditions) + ")")
 
             if filter.input_refs:
-                assert_length_less_than_max("input_refs", len(filter.input_refs))
+                assert_parameter_length_less_than_max(
+                    "input_refs", len(filter.input_refs)
+                )
                 or_conditions = []
                 for ref in filter.input_refs:
                     or_conditions.append(f"input_refs LIKE '%{ref}%'")
                 conds.append("(" + " OR ".join(or_conditions) + ")")
             if filter.output_refs:
-                assert_length_less_than_max("output_refs", len(filter.output_refs))
+                assert_parameter_length_less_than_max(
+                    "output_refs", len(filter.output_refs)
+                )
                 or_conditions = []
                 for ref in filter.output_refs:
                     or_conditions.append(f"output_refs LIKE '%{ref}%'")
                 conds.append("(" + " OR ".join(or_conditions) + ")")
             if filter.parent_ids:
-                assert_length_less_than_max("parent_ids", len(filter.parent_ids))
+                assert_parameter_length_less_than_max(
+                    "parent_ids", len(filter.parent_ids)
+                )
                 in_expr = ", ".join(f"'{x}'" for x in filter.parent_ids)
                 conds += [f"parent_id IN ({in_expr})"]
             if filter.trace_ids:
-                assert_length_less_than_max("trace_ids", len(filter.trace_ids))
+                assert_parameter_length_less_than_max(
+                    "trace_ids", len(filter.trace_ids)
+                )
                 in_expr = ", ".join(f"'{x}'" for x in filter.trace_ids)
                 conds += [f"trace_id IN ({in_expr})"]
             if filter.call_ids:
-                assert_length_less_than_max("call_ids", len(filter.call_ids))
+                assert_parameter_length_less_than_max("call_ids", len(filter.call_ids))
                 in_expr = ", ".join(f"'{x}'" for x in filter.call_ids)
                 conds += [f"id IN ({in_expr})"]
             if filter.trace_roots_only:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -30,6 +30,7 @@ from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.object_class_util import process_incoming_object_val
 from weave.trace_server.orm import Row, quote_json_path
 from weave.trace_server.trace_server_common import (
+    assert_length_less_than_max,
     digest_is_version_like,
     empty_str_to_none,
     get_nested_key,
@@ -265,6 +266,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         filter = req.filter
         if filter:
             if filter.op_names:
+                assert_length_less_than_max("op_names", len(filter.op_names))
                 or_conditions: list[str] = []
 
                 non_wildcarded_names: list[str] = []
@@ -287,22 +289,27 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                     conds.append("(" + " OR ".join(or_conditions) + ")")
 
             if filter.input_refs:
+                assert_length_less_than_max("input_refs", len(filter.input_refs))
                 or_conditions = []
                 for ref in filter.input_refs:
                     or_conditions.append(f"input_refs LIKE '%{ref}%'")
                 conds.append("(" + " OR ".join(or_conditions) + ")")
             if filter.output_refs:
+                assert_length_less_than_max("output_refs", len(filter.output_refs))
                 or_conditions = []
                 for ref in filter.output_refs:
                     or_conditions.append(f"output_refs LIKE '%{ref}%'")
                 conds.append("(" + " OR ".join(or_conditions) + ")")
             if filter.parent_ids:
+                assert_length_less_than_max("parent_ids", len(filter.parent_ids))
                 in_expr = ", ".join(f"'{x}'" for x in filter.parent_ids)
                 conds += [f"parent_id IN ({in_expr})"]
             if filter.trace_ids:
+                assert_length_less_than_max("trace_ids", len(filter.trace_ids))
                 in_expr = ", ".join(f"'{x}'" for x in filter.trace_ids)
                 conds += [f"trace_id IN ({in_expr})"]
             if filter.call_ids:
+                assert_length_less_than_max("call_ids", len(filter.call_ids))
                 in_expr = ", ".join(f"'{x}'" for x in filter.call_ids)
                 conds += [f"id IN ({in_expr})"]
             if filter.trace_roots_only:

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -212,3 +212,15 @@ def digest_is_version_like(digest: str) -> tuple[bool, int]:
         return (True, int(digest[1:]))
     except ValueError:
         return (False, -1)
+
+
+MAX_FILTER_LENGTH = 1000
+
+
+def assert_length_less_than_max(
+    param_name: str, arr_len: int, max_length: int = MAX_FILTER_LENGTH
+) -> None:
+    if arr_len > max_length:
+        raise ValueError(
+            f"Parameter: '{param_name}' request length is greater than max length ({max_length}). Actual length: {arr_len}"
+        )

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -217,7 +217,7 @@ def digest_is_version_like(digest: str) -> tuple[bool, int]:
 MAX_FILTER_LENGTH = 1000
 
 
-def assert_length_less_than_max(
+def assert_parameter_length_less_than_max(
     param_name: str, arr_len: int, max_length: int = MAX_FILTER_LENGTH
 ) -> None:
     if arr_len > max_length:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24092](https://wandb.atlassian.net/browse/WB-24092)

TODO:
- do we want to set this to log a warning instead of raising? It's technically possible users are using the app around its limits here and will be forced to change their workflow. We could track the errors? probably not necessary, there are very few use cases for spamming thousands of ids, other endpoints cap it at 1000 like delete. 

We can't handle more than a couple thousand parameters in the calls query filter because the clickhouse client passes parameters in the URL, instead of in a post body payload like a sane request...

This pr limit each of these hardcoded filters to 1000. 

## Testing

- Add unit test
- add end to end client test


[WB-24092]: https://wandb.atlassian.net/browse/WB-24092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ