### PR TITLE
feat(ui): Conditionally add trace metadata to ObjectView

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -89,10 +89,7 @@ export const CallDetails: FC<{
     () => getDisplayInputsAndOutput(call),
     [call]
   );
-  const { attributes, events, links, resource } = useMemo(
-    () => getDisplayOtelSpan(call),
-    [call]
-  );
+  const {otelSpan} = useMemo(() => getDisplayOtelSpan(call), [call]);
   const columns = useMemo(() => ['parent_id', 'started_at', 'ended_at'], []);
   const childCalls = useCalls(
     call.entity,
@@ -183,71 +180,18 @@ export const CallDetails: FC<{
             }px)`,
             p: 2,
           }}>
-          {attributes && Object.keys(attributes).length > 0 && (
+          {otelSpan && Object.keys(otelSpan).length > 0 && (
             <CustomWeaveTypeProjectContext.Provider
               value={{
                 entity: call.entity,
                 project: call.project,
                 mode: 'object_viewer',
               }}>
-              <ObjectViewerSection title="OTEL Attributes" data={attributes} isExpanded />
-            </CustomWeaveTypeProjectContext.Provider>
-          )}
-        </Box>
-        <Box
-          sx={{
-            flex: '0 0 auto',
-            maxHeight: `calc(100% - ${
-              multipleChildCallOpRefs.length > 0 ? HEADER_HEIGHT_BUFFER : 0
-            }px)`,
-            p: 2,
-          }}>
-          {events && Object.keys(events).length > 0 && (
-            <CustomWeaveTypeProjectContext.Provider
-              value={{
-                entity: call.entity,
-                project: call.project,
-                mode: 'object_viewer',
-              }}>
-              <ObjectViewerSection title="OTEL Events" data={events} isExpanded />
-            </CustomWeaveTypeProjectContext.Provider>
-          )}
-        </Box>
-        <Box
-          sx={{
-            flex: '0 0 auto',
-            maxHeight: `calc(100% - ${
-              multipleChildCallOpRefs.length > 0 ? HEADER_HEIGHT_BUFFER : 0
-            }px)`,
-            p: 2,
-          }}>
-          {links && Object.keys(links).length > 0 && (
-            <CustomWeaveTypeProjectContext.Provider
-              value={{
-                entity: call.entity,
-                project: call.project,
-                mode: 'object_viewer',
-              }}>
-              <ObjectViewerSection title="OTEL Links" data={links} isExpanded />
-            </CustomWeaveTypeProjectContext.Provider>
-          )}
-        </Box>
-        <Box
-          sx={{
-            flex: '0 0 auto',
-            maxHeight: `calc(100% - ${
-              multipleChildCallOpRefs.length > 0 ? HEADER_HEIGHT_BUFFER : 0
-            }px)`,
-            p: 2,
-          }}>
-          {resource && Object.keys(resource).length > 0 && (
-            <CustomWeaveTypeProjectContext.Provider
-              value={{
-                entity: call.entity,
-                project: call.project,
-                mode: 'object_viewer',
-              }}>
-              <ObjectViewerSection title="OTEL Resource" data={resource} isExpanded />
+              <ObjectViewerSection
+                title="OTEL Span"
+                data={otelSpan}
+                isExpanded
+              />
             </CustomWeaveTypeProjectContext.Provider>
           )}
         </Box>
@@ -339,11 +283,10 @@ export const CallDetails: FC<{
 
 const getDisplayOtelSpan = (call: CallSchema) => {
   const span = call.rawSpan;
-  const otel_span = span.attributes
-    ? span.attributes['otel_span'] ?? {}
-    : {};
-  const { attributes, events, links, resource } = otel_span;
-  return { attributes, events, links, resource }
+  if ('otel_span' in span.attributes) {
+    return {otelSpan: span.attributes.otel_span};
+  }
+  return {};
 };
 
 const getDisplayInputsAndOutput = (call: CallSchema) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -89,8 +89,8 @@ export const CallDetails: FC<{
     () => getDisplayInputsAndOutput(call),
     [call]
   );
-  const {trace_metadata} = useMemo(
-    () => getDisplayTraceMetadata(call),
+  const { attributes, events, links, resource } = useMemo(
+    () => getDisplayOtelSpan(call),
     [call]
   );
   const columns = useMemo(() => ['parent_id', 'started_at', 'ended_at'], []);
@@ -183,14 +183,71 @@ export const CallDetails: FC<{
             }px)`,
             p: 2,
           }}>
-          {Object.keys(trace_metadata).length > 0 && (
+          {attributes && Object.keys(attributes).length > 0 && (
             <CustomWeaveTypeProjectContext.Provider
               value={{
                 entity: call.entity,
                 project: call.project,
                 mode: 'object_viewer',
               }}>
-              <ObjectViewerSection title="Trace Attributes" data={trace_metadata} isExpanded />
+              <ObjectViewerSection title="OTEL Attributes" data={attributes} isExpanded />
+            </CustomWeaveTypeProjectContext.Provider>
+          )}
+        </Box>
+        <Box
+          sx={{
+            flex: '0 0 auto',
+            maxHeight: `calc(100% - ${
+              multipleChildCallOpRefs.length > 0 ? HEADER_HEIGHT_BUFFER : 0
+            }px)`,
+            p: 2,
+          }}>
+          {events && Object.keys(events).length > 0 && (
+            <CustomWeaveTypeProjectContext.Provider
+              value={{
+                entity: call.entity,
+                project: call.project,
+                mode: 'object_viewer',
+              }}>
+              <ObjectViewerSection title="OTEL Events" data={events} isExpanded />
+            </CustomWeaveTypeProjectContext.Provider>
+          )}
+        </Box>
+        <Box
+          sx={{
+            flex: '0 0 auto',
+            maxHeight: `calc(100% - ${
+              multipleChildCallOpRefs.length > 0 ? HEADER_HEIGHT_BUFFER : 0
+            }px)`,
+            p: 2,
+          }}>
+          {links && Object.keys(links).length > 0 && (
+            <CustomWeaveTypeProjectContext.Provider
+              value={{
+                entity: call.entity,
+                project: call.project,
+                mode: 'object_viewer',
+              }}>
+              <ObjectViewerSection title="OTEL Links" data={links} isExpanded />
+            </CustomWeaveTypeProjectContext.Provider>
+          )}
+        </Box>
+        <Box
+          sx={{
+            flex: '0 0 auto',
+            maxHeight: `calc(100% - ${
+              multipleChildCallOpRefs.length > 0 ? HEADER_HEIGHT_BUFFER : 0
+            }px)`,
+            p: 2,
+          }}>
+          {resource && Object.keys(resource).length > 0 && (
+            <CustomWeaveTypeProjectContext.Provider
+              value={{
+                entity: call.entity,
+                project: call.project,
+                mode: 'object_viewer',
+              }}>
+              <ObjectViewerSection title="OTEL Resource" data={resource} isExpanded />
             </CustomWeaveTypeProjectContext.Provider>
           )}
         </Box>
@@ -280,14 +337,13 @@ export const CallDetails: FC<{
   );
 };
 
-const getDisplayTraceMetadata = (call: CallSchema) => {
+const getDisplayOtelSpan = (call: CallSchema) => {
   const span = call.rawSpan;
-  console.log(span);
-  console.log(span.attributes);
-  const trace_metadata = span.attributes
-    ? span.attributes['trace_metadata'] ?? {}
+  const otel_span = span.attributes
+    ? span.attributes['otel_span'] ?? {}
     : {};
-  return {trace_metadata}
+  const { attributes, events, links, resource } = otel_span;
+  return { attributes, events, links, resource }
 };
 
 const getDisplayInputsAndOutput = (call: CallSchema) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -89,6 +89,10 @@ export const CallDetails: FC<{
     () => getDisplayInputsAndOutput(call),
     [call]
   );
+  const {trace_metadata} = useMemo(
+    () => getDisplayTraceMetadata(call),
+    [call]
+  );
   const columns = useMemo(() => ['parent_id', 'started_at', 'ended_at'], []);
   const childCalls = useCalls(
     call.entity,
@@ -168,6 +172,25 @@ export const CallDetails: FC<{
                 mode: 'object_viewer',
               }}>
               <ObjectViewerSection title="Output" data={output} isExpanded />
+            </CustomWeaveTypeProjectContext.Provider>
+          )}
+        </Box>
+        <Box
+          sx={{
+            flex: '0 0 auto',
+            maxHeight: `calc(100% - ${
+              multipleChildCallOpRefs.length > 0 ? HEADER_HEIGHT_BUFFER : 0
+            }px)`,
+            p: 2,
+          }}>
+          {Object.keys(trace_metadata).length > 0 && (
+            <CustomWeaveTypeProjectContext.Provider
+              value={{
+                entity: call.entity,
+                project: call.project,
+                mode: 'object_viewer',
+              }}>
+              <ObjectViewerSection title="Trace Attributes" data={trace_metadata} isExpanded />
             </CustomWeaveTypeProjectContext.Provider>
           )}
         </Box>
@@ -255,6 +278,16 @@ export const CallDetails: FC<{
       </Box>
     </Box>
   );
+};
+
+const getDisplayTraceMetadata = (call: CallSchema) => {
+  const span = call.rawSpan;
+  console.log(span);
+  console.log(span.attributes);
+  const trace_metadata = span.attributes
+    ? span.attributes['trace_metadata'] ?? {}
+    : {};
+  return {trace_metadata}
 };
 
 const getDisplayInputsAndOutput = (call: CallSchema) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -264,7 +264,6 @@ export const ObjectViewer = ({
         // For now we'll hide all keys that start with an underscore, is a name field, or is a null description.
         // Eventually we might offer a user toggle to display them.
         if (context.path.hasHiddenKey() || isNullDescriptionOrName) {
-          console.log(context)
           return 'skip';
         }
         if (isExpandableRef(context.value)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -264,6 +264,7 @@ export const ObjectViewer = ({
         // For now we'll hide all keys that start with an underscore, is a name field, or is a null description.
         // Eventually we might offer a user toggle to display them.
         if (context.path.hasHiddenKey() || isNullDescriptionOrName) {
+          console.log(context)
           return 'skip';
         }
         if (isExpandableRef(context.value)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -112,7 +112,7 @@ export const DEFAULT_HIDDEN_COLUMN_PREFIXES = [
   'attributes.weave',
   'summary.weave.feedback',
   'wb_run_id',
-  'attributes.otel_span'
+  'attributes.otel_span',
 ];
 
 export const ALWAYS_PIN_LEFT_CALLS = ['CustomCheckbox'];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -112,7 +112,7 @@ export const DEFAULT_HIDDEN_COLUMN_PREFIXES = [
   'attributes.weave',
   'summary.weave.feedback',
   'wb_run_id',
-  'attributes.trace_metadata'
+  'attributes.otel_span'
 ];
 
 export const ALWAYS_PIN_LEFT_CALLS = ['CustomCheckbox'];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -112,6 +112,7 @@ export const DEFAULT_HIDDEN_COLUMN_PREFIXES = [
   'attributes.weave',
   'summary.weave.feedback',
   'wb_run_id',
+  'attributes.trace_metadata'
 ];
 
 export const ALWAYS_PIN_LEFT_CALLS = ['CustomCheckbox'];


### PR DESCRIPTION
## Description

- Fixes WB-24306

Adds a conditionally available section to the ObjectView which displays full otel trace metadata when the field is available.

![image](https://github.com/user-attachments/assets/09edbc2a-80dd-405b-ba54-a664b7fca762)
