### PR TITLE
fix(weave): remove deterministic attribute error from openai agents integration

### DIFF
--- a/weave/integrations/openai_agents/openai_agents.py
+++ b/weave/integrations/openai_agents/openai_agents.py
@@ -221,9 +221,9 @@ class WeaveTracingProcessor(TracingProcessor):  # pyright: ignore[reportGeneralT
                 "model_config": span.span_data.model_config,
             },
             metrics={
-                "tokens": span.data_usage.usage.get("total_tokens"),
-                "prompt_tokens": span.data_usage.usage.get("prompt_tokens"),
-                "completion_tokens": span.data_usage.usage.get("completion_tokens"),
+                "tokens": span.span_data.usage.get("total_tokens"),
+                "prompt_tokens": span.span_data.usage.get("prompt_tokens"),
+                "completion_tokens": span.span_data.usage.get("completion_tokens"),
             },
             error=None,
         )


### PR DESCRIPTION
The openai-agents sdk integration looks for usage data in a place on the `GenerationSpanData` that does not exist and deterministically crashes the user process. This PR updates the attribute access to read from the correct field.