### PR TITLE
chore(weave): Temporary patch for auth url referrer

### DIFF
--- a/weave/trace/wandb_termlog_patch.py
+++ b/weave/trace/wandb_termlog_patch.py
@@ -29,7 +29,13 @@ def unsafe_termlog(*args: Any, **kwargs: Any) -> None:
     bound_args.apply_defaults()
     if string_arg_val := bound_args.arguments.get("string"):
         if isinstance(string_arg_val, str):
-            if string_arg_val.endswith("/authorize"):
+            if (
+                string_arg_val.startswith(
+                    "You can find your API key in your browser here:"
+                )
+                and "http" in string_arg_val
+                and string_arg_val.endswith("/authorize")
+            ):
                 string_arg_val = string_arg_val + "?ref=weave"
     bound_args.arguments["string"] = string_arg_val
     return wandb_termlog(**bound_args.arguments)

--- a/weave/trace/wandb_termlog_patch.py
+++ b/weave/trace/wandb_termlog_patch.py
@@ -1,0 +1,50 @@
+"""
+This is a temporary patch for wandb in order to implement basic referrer tracking in
+auth URLs. This commit: https://github.com/wandb/wandb/commit/5db4d763516ba2a3e8d94a85ba67bdf6fc124423 
+adds a utility for refferer tracking, but is not yet released. Once released, this patch
+can be removed and instead https://github.com/wandb/weave/pull/4004/files can be merged.
+
+Since this will take more than a month, we need a short-term patch to ensure that we can
+start to track referrers.
+"""
+
+import inspect
+from functools import wraps
+
+import wandb
+
+original_termlog = None
+
+@wraps(wandb.termlog)
+def unsafe_termlog(*args, **kwargs):
+    bound_args = inspect.signature(wandb.termlog).bind(*args, **kwargs)
+    bound_args.apply_defaults()
+    if string_arg_val := bound_args.arguments.get("string"):
+        if isinstance(string_arg_val, str):
+            if string_arg_val.endswith("/authorize"):
+                string_arg_val = string_arg_val + "?ref=weave"
+    bound_args.arguments["string"] = string_arg_val
+    return wandb.termlog(**bound_args.arguments)
+
+@wraps(wandb.termlog)
+def safe_termlog(*args, **kwargs):
+    try:
+        return unsafe_termlog(*args, **kwargs)
+    except Exception as e:
+        return wandb.termlog(*args, **kwargs)
+
+
+def ensure_patched():
+    global original_termlog
+    if original_termlog:
+        return
+    original_termlog = wandb.termlog
+    wandb.termlog = safe_termlog
+
+
+def ensure_unpatched():
+    global original_termlog
+    if not original_termlog:
+        return
+    wandb.termlog = original_termlog
+    original_termlog = None

--- a/weave/trace/wandb_termlog_patch.py
+++ b/weave/trace/wandb_termlog_patch.py
@@ -1,7 +1,7 @@
 """
 This is a temporary patch for wandb in order to implement basic referrer tracking in
 auth URLs. This commit: https://github.com/wandb/wandb/commit/5db4d763516ba2a3e8d94a85ba67bdf6fc124423 
-adds a utility for refferer tracking, but is not yet released. Once released, this patch
+adds a utility for referrer tracking, but is not yet released. Once released, this patch
 can be removed and instead https://github.com/wandb/weave/pull/4004/files can be merged.
 
 Since this will take more than a month, we need a short-term patch to ensure that we can

--- a/weave/trace/wandb_termlog_patch.py
+++ b/weave/trace/wandb_termlog_patch.py
@@ -1,6 +1,6 @@
 """
 This is a temporary patch for wandb in order to implement basic referrer tracking in
-auth URLs. This commit: https://github.com/wandb/wandb/commit/5db4d763516ba2a3e8d94a85ba67bdf6fc124423 
+auth URLs. This commit: https://github.com/wandb/wandb/commit/5db4d763516ba2a3e8d94a85ba67bdf6fc124423
 adds a utility for referrer tracking, but is not yet released. Once released, this patch
 can be removed and instead https://github.com/wandb/weave/pull/4004/files can be merged.
 
@@ -10,17 +10,19 @@ start to track referrers.
 
 import inspect
 from functools import wraps
+from typing import Any
 
 import wandb
 
 wandb_termlog = wandb.termlog
 patched = False
 
+
 @wraps(wandb_termlog)
-def unsafe_termlog(*args, **kwargs):
+def unsafe_termlog(*args: Any, **kwargs: Any) -> None:
     """
     Appends a `?ref=weave` to the end of the string if it ends with `/authorize`.
-    This is used deep in the auth flow in wandb and allows us to determine that 
+    This is used deep in the auth flow in wandb and allows us to determine that
     signups are coming from weave.
     """
     bound_args = inspect.signature(wandb_termlog).bind(*args, **kwargs)
@@ -32,22 +34,24 @@ def unsafe_termlog(*args, **kwargs):
     bound_args.arguments["string"] = string_arg_val
     return wandb_termlog(**bound_args.arguments)
 
+
 @wraps(wandb_termlog)
-def safe_termlog(*args, **kwargs):
+def safe_termlog(*args: Any, **kwargs: Any) -> None:
     try:
         return unsafe_termlog(*args, **kwargs)
     except Exception as e:
         return wandb_termlog(*args, **kwargs)
 
 
-def ensure_patched():
+def ensure_patched() -> None:
     global patched
     if patched:
         return
     wandb.termlog = safe_termlog
     patched = True
 
-def ensure_unpatched():
+
+def ensure_unpatched() -> None:
     global patched
     if not patched:
         return

--- a/weave/trace/wandb_termlog_patch.py
+++ b/weave/trace/wandb_termlog_patch.py
@@ -18,6 +18,11 @@ patched = False
 
 @wraps(wandb_termlog)
 def unsafe_termlog(*args, **kwargs):
+    """
+    Appends a `?ref=weave` to the end of the string if it ends with `/authorize`.
+    This is used deep in the auth flow in wandb and allows us to determine that 
+    signups are coming from weave.
+    """
     bound_args = inspect.signature(wandb_termlog).bind(*args, **kwargs)
     bound_args.apply_defaults()
     if string_arg_val := bound_args.arguments.get("string"):

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from weave.trace import autopatch, init_message, trace_sentry, weave_client
+from weave.trace import (
+    autopatch,
+    init_message,
+    trace_sentry,
+    wandb_termlog_patch,
+    weave_client,
+)
 from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace.settings import should_redact_pii, use_server_cache
 from weave.trace_server import sqlite_trace_server
@@ -97,6 +103,7 @@ def init_weave(
         import wandb
 
         print("Please login to Weights & Biases (https://wandb.ai/) to continue:")
+        wandb_termlog_patch.ensure_patched()
         wandb.login(anonymous="never", force=True)  # type: ignore
         wandb_api.init()
         wandb_context = wandb_api.get_wandb_api_context()


### PR DESCRIPTION
This is a temporary patch for `wandb` in order to implement basic referrer tracking in
auth URLs. This commit: https://github.com/wandb/wandb/commit/5db4d763516ba2a3e8d94a85ba67bdf6fc124423 adds a utility for referrer tracking, but is not yet released. Once released, this patch can be removed and instead https://github.com/wandb/weave/pull/4004/files can be merged. Since this will take more than a month, we need a short-term patch to ensure that we can start to track referrers.