### PR TITLE
fix(weave): require opentelemetry proto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,16 +36,17 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
   "pydantic>=2.0.0",
-  "wandb>=0.17.1",
-  "packaging>=21.0",         # For version parsing in integrations
-  "tenacity>=8.3.0,!=8.4.0", # Excluding 8.4.0 because it had a bug on import of AsyncRetrying
-  "emoji>=2.12.1",           # For emoji shortcode support in Feedback
-  "uuid-utils>=0.9.0",       # Used for ID generation - remove once python's built-in uuid supports UUIDv7
-  "numpy>1.21.0",            # Used in box.py and scorer.py (should be made optional)
-  "rich",                    # Used for special formatting of tables (should be made optional)
-  "gql[aiohttp,requests]",   # Used exclusively in wandb_api.py
-  "jsonschema>=4.23.0",      # Used by scorers for field validation
-  "diskcache==5.6.3",        # Used for data caching
+  "wandb>=0.17.1", 
+  "packaging>=21.0",                  # For version parsing in integrations
+  "tenacity>=8.3.0,!=8.4.0",          # Excluding 8.4.0 because it had a bug on import of AsyncRetrying
+  "emoji>=2.12.1",                    # For emoji shortcode support in Feedback
+  "uuid-utils>=0.9.0",                # Used for ID generation - remove once python's built-in uuid supports UUIDv7
+  "numpy>1.21.0",                     # Used in box.py and scorer.py (should be made optional)
+  "rich",                             # Used for special formatting of tables (should be made optional) 
+  "gql[aiohttp,requests]",            # Used exclusively in wandb_api.py
+  "jsonschema>=4.23.0",               # Used by scorers for field validation
+  "diskcache==5.6.3",                 # Used for data caching
+  "opentelemetry-proto>=1.12.0",      # Used for OTEL trace support
 
   # This dependency will be updated each time we regenerate the trace server bindings.
   # 1. For normal dev, pin to a SHA and allow direct references.  This will look like:
@@ -71,14 +72,12 @@ trace_server = [
   "google-cloud-storage>=2.7.0",
   # LLM Support
   "litellm>=1.36.1",
-   # OTEL tracing support
-  "opentelemetry-proto>=1.12.0",
 ]
 trace_server_tests = [
   # BYOB - S3
   "moto[s3]>=5.0.0",
 ]
-docs = ["playwright", "lazydocs", "nbformat", "nbconvert", "weave[trace_server]"]
+docs = ["playwright", "lazydocs", "nbformat", "nbconvert"]
 anthropic = ["anthropic>=0.18.0"]
 cerebras = ["cerebras-cloud-sdk"]
 cohere = ["cohere>=5.9.1,<5.9.3"]


### PR DESCRIPTION
`import weave` fails with `ModuleNotFoundError: No module named 'opentelemetry'`. This PR moves `opentelemetry-proto` from an optional to required dependency. It's eagerly imported by `trace_server_interface.py` which runs on `import weave`. Alternate approach would be to conditionally import.