### PR TITLE
chore(weave): dont show weeks unless at least one week

### DIFF
--- a/weave-js/src/components/Timestamp.tsx
+++ b/weave-js/src/components/Timestamp.tsx
@@ -66,7 +66,7 @@ const formatSmallTime = (then: moment.Moment): string | null => {
   }
 
   // Show weeks when exact multiple
-  if (days % 7 === 0) {
+  if (days >= 7 && days % 7 === 0) {
     return `${weeks}w`;
   }
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

one-liner fix for displaying week timestamps when actually a week. 0 weeks is not valid.

## Testing

Prod:
<img width="189" alt="Screenshot 2025-04-07 at 6 04 11 PM" src="https://github.com/user-attachments/assets/58a573df-6ee1-4540-bdf1-6ce41a23f278" />

Branch:
<img width="189" alt="Screenshot 2025-04-07 at 6 03 58 PM" src="https://github.com/user-attachments/assets/db9400eb-a906-423b-9ed6-129744b8365a" />
