### PR TITLE
chore(weave): fix team admin check add new hook

### DIFF
--- a/weave-js/src/common/hooks/useIsTeamAdmin.ts
+++ b/weave-js/src/common/hooks/useIsTeamAdmin.ts
@@ -1,0 +1,113 @@
+import {gql, TypedDocumentNode, useApolloClient} from '@apollo/client';
+import {useEffect, useState} from 'react';
+
+import {useViewerInfo} from './useViewerInfo';
+
+interface EntityMemberRolesData {
+  entity: {
+    id: string;
+    members: Array<{
+      id: string;
+      username: string;
+      role: string;
+    }>;
+  };
+}
+
+interface EntityMemberRolesVars {
+  entityName: string;
+}
+
+export const ENTITY_MEMBER_ROLES_QUERY = gql`
+  query EntityMemberRoles($entityName: String!) {
+    entity(name: $entityName) {
+      id
+      members {
+        id
+        username
+        role
+      }
+    }
+  }
+` as TypedDocumentNode<EntityMemberRolesData, EntityMemberRolesVars>;
+
+type TeamAdminResponse = {
+  loading: boolean;
+  isAdmin: boolean | null;
+  error?: string;
+};
+
+export const useIsTeamAdmin = (
+  entityName: string,
+  username: string
+): TeamAdminResponse => {
+  const [response, setResponse] = useState<TeamAdminResponse>({
+    loading: true,
+    isAdmin: null,
+  });
+
+  const apolloClient = useApolloClient();
+
+  useEffect(() => {
+    let mounted = true;
+
+    const fetchEntityData = async () => {
+      try {
+        const result = await apolloClient.query({
+          query: ENTITY_MEMBER_ROLES_QUERY,
+          variables: {entityName},
+        });
+
+        if (!mounted) {
+          return;
+        }
+
+        const entityData = result.data.entity;
+
+        if (!entityData) {
+          setResponse({
+            loading: false,
+            isAdmin: false,
+            error: 'Team not found',
+          });
+          return;
+        }
+
+        const userMember = entityData.members.find(
+          (member: {username: string; role: string}) =>
+            member.username === username
+        );
+
+        setResponse({
+          loading: false,
+          isAdmin: userMember?.role === 'admin',
+        });
+      } catch (error) {
+        if (mounted) {
+          setResponse({
+            loading: false,
+            isAdmin: false,
+            error: 'Error fetching team data',
+          });
+        }
+      }
+    };
+
+    fetchEntityData();
+
+    return () => {
+      mounted = false;
+    };
+  }, [apolloClient, entityName, username]);
+
+  return response;
+};
+
+export const useIsViewerTeamAdmin = (entityName: string): boolean => {
+  const {userInfo} = useViewerInfo();
+  const {isAdmin} = useIsTeamAdmin(
+    entityName,
+    userInfo && 'username' in userInfo ? userInfo.username : ''
+  );
+  return isAdmin ?? false;
+};

--- a/weave-js/src/common/hooks/useViewerInfo.ts
+++ b/weave-js/src/common/hooks/useViewerInfo.ts
@@ -17,11 +17,6 @@ const VIEWER_QUERY = gql`
           node {
             id
             name
-            members {
-              id
-              username
-              role
-            }
           }
         }
       }
@@ -35,7 +30,6 @@ export type UserInfo = {
   username: string;
   teams: string[];
   admin: boolean;
-  roles: {[team: string]: string};
 };
 export type MaybeUserInfo = UserInfo | null;
 
@@ -75,16 +69,6 @@ export const useViewerInfo = (): UserInfoResponse => {
       const {id, username} = userInfo;
       const teamEdges = userInfo?.teams?.edges ?? [];
       const teams = teamEdges.map((edge: any) => edge.node.name).sort();
-      const roles: {[team: string]: string} = {};
-      teamEdges.forEach((edge: any) => {
-        const teamName = edge.node.name;
-        const userMember = edge.node.members.find(
-          (member: any) => member.username === username
-        );
-        if (userMember) {
-          roles[teamName] = userMember.role;
-        }
-      });
       setResponse({
         loading: false,
         userInfo: {
@@ -92,7 +76,6 @@ export const useViewerInfo = (): UserInfoResponse => {
           username,
           teams,
           admin: userInfo.admin,
-          roles,
         },
       });
     });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OverviewPage/ProvidersTab.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OverviewPage/ProvidersTab.tsx
@@ -1,7 +1,7 @@
 import {ApolloProvider} from '@apollo/client';
 import {GridColDef, GridRenderCellParams} from '@mui/x-data-grid-pro';
 import {makeGorillaApolloClient} from '@wandb/weave/apollo';
-import {useViewerInfo} from '@wandb/weave/common/hooks/useViewerInfo';
+import {useIsViewerTeamAdmin} from '@wandb/weave/common/hooks/useIsTeamAdmin';
 import {Button} from '@wandb/weave/components/Button';
 import {Icon} from '@wandb/weave/components/Icon';
 import {Pill} from '@wandb/weave/components/Tag';
@@ -16,7 +16,6 @@ import {WFDataModelAutoProvider} from '../wfReactInterface/context';
 import {AddProviderDrawer} from './AddProviderDrawer';
 import {ProviderTable} from './ProviderTable';
 import {useCustomProviders} from './useCustomProviders';
-
 const ProviderStatus = ({isActive}: {isActive: boolean}) => {
   return (
     <div className="flex items-center">
@@ -130,9 +129,8 @@ export const ProvidersTabInner: React.FC<{
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [editingProvider, setEditingProvider] = useState<any>(null);
   const [deletingProvider, setDeletingProvider] = useState<any>(null);
-  const {loading: loadingUserInfo, userInfo} = useViewerInfo();
-  const isAdmin = !loadingUserInfo && userInfo?.roles[entityName] === 'admin';
 
+  const isAdmin = useIsViewerTeamAdmin(entityName);
   const {result: configuredProviders, loading: configuredProvidersLoading} =
     useConfiguredProviders(entityName);
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
@@ -1,5 +1,5 @@
 import {Box} from '@mui/material';
-import {useViewerInfo} from '@wandb/weave/common/hooks/useViewerInfo';
+import {useIsViewerTeamAdmin} from '@wandb/weave/common/hooks/useIsTeamAdmin';
 import {Select} from '@wandb/weave/components/Form/Select';
 import React, {useCallback, useState} from 'react';
 
@@ -59,8 +59,7 @@ export const LLMDropdown: React.FC<LLMDropdownProps> = ({
 
   const customLoading = customProvidersLoading || customProviderModelsLoading;
 
-  const {loading: loadingUserInfo, userInfo} = useViewerInfo();
-  const isTeamAdmin = !loadingUserInfo && userInfo?.roles[entity] === 'admin';
+  const isTeamAdmin = useIsViewerTeamAdmin(entity);
 
   const options: ProviderOption[] = [];
   const disabledOptions: ProviderOption[] = [];


### PR DESCRIPTION
## Description
I added a role check to useViewerInfo
That was incorrect the roles come back as viewer every time
Add new hook to check if viewer is team admin

these two things now properly show if admin

option to add secret

<img width="991" alt="Screenshot 2025-04-08 at 10 54 15 AM" src="https://github.com/user-attachments/assets/e27ad61f-9474-4034-b334-397c593d3b2b" />

link 

<img width="266" alt="Screenshot 2025-04-08 at 10 54 41 AM" src="https://github.com/user-attachments/assets/07066ec9-3284-4464-8ac7-b8438b469f46" />
