### PR TITLE
chore(ui): Trace tree - leave descendants collapsed on expanding

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -428,9 +428,20 @@ export const TreeView: React.FC<
   const handleToggleExpand = (id: string) => {
     const newExpandedNodes = new Set(collapsedNodes);
     if (newExpandedNodes.has(id)) {
+      // When expanding, only remove current node from collapsed nodes
       newExpandedNodes.delete(id);
     } else {
-      newExpandedNodes.add(id);
+      // When collapsing, we add this node and all its descendants to collapsed nodes
+      const addDescendants = (nodeId: string) => {
+        newExpandedNodes.add(nodeId);
+        const node = traceTreeFlat[nodeId];
+        if (node) {
+          node.childrenIds.forEach(childId => {
+            addDescendants(childId);
+          });
+        }
+      };
+      addDescendants(id);
     }
     setCollapsedNodes(newExpandedNodes);
   };


### PR DESCRIPTION
## Description

![trace-tree](https://github.com/user-attachments/assets/7b2801a6-212a-4614-b700-8a281bbcfa52)

- On expanding trace tree nodes, leave descendants collapsed.
- Allows for quicker parsing of large complex trace trees.