### PR TITLE
chore(ui): Trace tree - fix padding on un-nested node levels

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -137,7 +137,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                 className="p-0.5 shrink-0 cursor-pointer rounded hover:bg-moon-300"
               />
             ) : (
-              <div className="w-[8px]" />
+              <div className="w-[18px]" />
             )}
             <div className="truncate pl-4 font-medium">
               <Tooltip


### PR DESCRIPTION
## Description

| Before | After |
| -------- | ------- |
| ![Screenshot 2025-04-08 at 3 28 19 PM](https://github.com/user-attachments/assets/f0a11e16-01ec-4e3b-9cb5-e40cef9e9bd3) | ![Screenshot 2025-04-08 at 3 27 23 PM](https://github.com/user-attachments/assets/a7bd5490-0460-4917-9576-57cc3800783d) |

- Fixes padding on un-nested node levels to match nested text (since they're on the same level).