### PR TITLE
feat(ui): Add status filtering

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -63,7 +63,8 @@ export const FilterRow = ({
   };
 
   const isOperatorDisabled =
-    isWeaveRef(item.value) || ['id', 'user'].includes(getFieldType(item.field));
+    isWeaveRef(item.value) ||
+    ['id', 'status', 'user'].includes(getFieldType(item.field));
 
   return (
     <>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -22,6 +22,7 @@ import {
   isWeaveRef,
 } from './common';
 import {FilterTag} from './FilterTag';
+import {FilterTagStatus} from './FilterTagStatus';
 import {IdList} from './IdList';
 
 type FilterTagItemProps = {
@@ -54,6 +55,8 @@ export const FilterTagItem = ({
     value = <IdList ids={getStringList(item.value)} type="Call" />;
   } else if (fieldType === 'user') {
     value = <UserLink userId={item.value} hasPopover={false} />;
+  } else if (fieldType === 'status') {
+    value = <FilterTagStatus value={item.value} />;
   } else if (isWeaveRef(item.value)) {
     value = <SmallRef objRef={parseRef(item.value)} />;
   } else if (isValuelessOperator(item.operator)) {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagStatus.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagStatus.tsx
@@ -1,0 +1,32 @@
+/**
+ * This component is used to display the status values in the filter bar.
+ */
+
+import React from 'react';
+
+import {FILTER_TO_STATUS, StatusChip} from '../pages/common/StatusChip';
+
+type FilterTagStatusProps = {
+  value: string;
+};
+
+export const FilterTagStatus = ({value}: FilterTagStatusProps) => {
+  const enabled = value.split(',');
+  return (
+    <div className="flex gap-2">
+      {Object.keys(FILTER_TO_STATUS).map(status => {
+        const isEnabled = enabled.includes(status);
+        if (isEnabled) {
+          return (
+            <StatusChip
+              key={status}
+              value={FILTER_TO_STATUS[status]}
+              iconOnly
+            />
+          );
+        }
+        return null;
+      })}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
@@ -19,6 +19,7 @@ import {IdList} from './IdList';
 import {SelectDatetimeDropdown} from './SelectDatetimeDropdown';
 import {TextValue} from './TextValue';
 import {ValueInputBoolean} from './ValueInputBoolean';
+import {ValueInputStatus} from './ValueInputStatus';
 
 type SelectValueProps = {
   entity: string;
@@ -54,6 +55,9 @@ export const SelectValue = ({
 
   if (fieldType === 'id' && operator.endsWith('in')) {
     return <IdList ids={getStringList(value)} type="Call" />;
+  }
+  if (fieldType === 'status') {
+    return <ValueInputStatus value={value} onSetValue={onSetValue} />;
   }
   if (fieldType === 'user') {
     return <UserLink userId={value} includeName={true} hasPopover={false} />;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/ValueInputStatus.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/ValueInputStatus.tsx
@@ -1,0 +1,49 @@
+/**
+ * This component is used within a FilterRow to allow toggling
+ * status values on or off in the filter.
+ */
+
+import React from 'react';
+
+import {Button} from '../../../../Button';
+import {FILTER_TO_STATUS, StatusChip} from '../pages/common/StatusChip';
+
+type ValueInputStatusProps = {
+  value: string | undefined;
+  onSetValue: (value: string) => void;
+};
+
+export const ValueInputStatus = ({
+  value,
+  onSetValue,
+}: ValueInputStatusProps) => {
+  const enabled = value ? value.split(',') : [];
+  const onClick = (toToggle: string) => {
+    if (value === toToggle) {
+      // Can't remove the last selected status
+      return;
+    }
+    if (enabled.includes(toToggle)) {
+      onSetValue(enabled.filter(s => s !== toToggle).join(','));
+    } else {
+      const newValue = Object.keys(FILTER_TO_STATUS)
+        .filter(s => enabled.includes(s) || toToggle === s)
+        .join(',');
+      onSetValue(newValue);
+    }
+  };
+  return (
+    <div>
+      {Object.keys(FILTER_TO_STATUS).map(status => (
+        <Button
+          key={status}
+          size="small"
+          variant="ghost"
+          active={enabled.includes(status)}
+          onClick={() => onClick(status)}>
+          <StatusChip value={FILTER_TO_STATUS[status]} iconOnly />
+        </Button>
+      ))}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -33,7 +33,6 @@ export type FilterId = number | string | undefined;
 // For most of these it would be great if we could enable filtering in the future.
 export const UNFILTERABLE_FIELDS = [
   'feedback',
-  'summary.weave.status',
   'summary.weave.latency_ms',
   'summary.weave.trace_name',
   'tokens',
@@ -49,6 +48,7 @@ export type ColumnInfo = {
 
 export const FIELD_LABELS: Record<string, string> = {
   id: 'Call ID',
+  'summary.weave.status': 'Status',
   started_at: 'Called',
   wb_user_id: 'User',
 };
@@ -262,14 +262,9 @@ export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
   if ('status' === fieldType) {
     return [
       {
-        value: 'is',
-        label: 'is',
-        group: 'boolean',
-      },
-      {
-        value: 'is not',
-        label: 'is not',
-        group: 'boolean',
+        value: '(string): in',
+        label: 'in',
+        group: 'string',
       },
     ];
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -363,6 +363,8 @@ export const CallsTable: FC<{
     [callsResult, columnIsRefExpanded, expandedRefCols]
   );
 
+  // TODO: Despite the name, this has changed to be slightly more sophisticated,
+  //       where it may replace or toggle a filter off. We should consider renaming.
   const onAddFilter: OnAddFilter | undefined =
     filterModel && setFilterModel
       ? (field: string, operator: string | null, value: any, rowId: string) => {
@@ -377,6 +379,44 @@ export const CallsTable: FC<{
             field = expandedRef.field;
           }
           const op = operator ? operator : getDefaultOperatorForValue(value);
+
+          // Check if there is an exact match for field, operator, and value in filterModel.items
+          // If an exact match exists, remove it instead of adding a duplicate.
+          const existingFullMatchIndex = filterModel.items.findIndex(
+            item =>
+              item.field === field &&
+              item.operator === op &&
+              JSON.stringify(item.value) === JSON.stringify(value)
+          );
+          if (existingFullMatchIndex !== -1) {
+            const newItems = [...filterModel.items];
+            newItems.splice(existingFullMatchIndex, 1);
+            setFilterModel({
+              ...filterModel,
+              items: newItems,
+            });
+            return;
+          }
+
+          // Check if there is a match for field and operator in filterModel.items
+          // If a match exists, update the value instead of adding a new filter
+          const existingFieldOpMatchIndex = filterModel.items.findIndex(
+            item => item.field === field && item.operator === op
+          );
+          if (existingFieldOpMatchIndex !== -1) {
+            const newItems = [...filterModel.items];
+            newItems[existingFieldOpMatchIndex] = {
+              ...newItems[existingFieldOpMatchIndex],
+              value,
+            };
+            setFilterModel({
+              ...filterModel,
+              items: newItems,
+            });
+            return;
+          }
+
+          // There is no match, add a new filter.
           const newModel = {
             ...filterModel,
             items: [

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -47,7 +47,7 @@ import {
 } from '../CallPage/cost';
 import {isEvaluateOp} from '../common/heuristics';
 import {CallLink} from '../common/Links';
-import {StatusChip} from '../common/StatusChip';
+import {STATUS_TO_FILTER, StatusChip} from '../common/StatusChip';
 import {buildDynamicColumns} from '../common/tabularListViews/columnBuilder';
 import {TraceCallSchema} from '../wfReactInterface/traceServerClientTypes';
 import {
@@ -340,10 +340,19 @@ function buildCallsTableColumns(
         return traceCallStatusCode(row);
       },
       renderCell: cellParams => {
+        const valueStatus = traceCallStatusCode(cellParams.row);
+        const valueFilter = STATUS_TO_FILTER[valueStatus];
         return (
-          <div style={{margin: 'auto'}}>
-            <StatusChip value={traceCallStatusCode(cellParams.row)} iconOnly />
-          </div>
+          <CellFilterWrapper
+            onAddFilter={onAddFilter}
+            field="summary.weave.status"
+            rowId={cellParams.id.toString()}
+            operation={'(string): in'}
+            value={valueFilter}>
+            <div style={{margin: 'auto'}}>
+              <StatusChip value={valueStatus} iconOnly />
+            </div>
+          </CellFilterWrapper>
         );
       },
     },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
@@ -4,12 +4,21 @@
  */
 import {IconName} from '@wandb/weave/components/Icon';
 import {IconOnlyPill, Pill, TagColorName} from '@wandb/weave/components/Tag';
+import _ from 'lodash';
 import React from 'react';
 
 import {Tooltip} from '../../../../../Tooltip';
 
 export const CALL_STATUS = ['SUCCESS', 'DESCENDANT_ERROR', 'ERROR', 'UNSET'];
 export type CallStatusType = (typeof CALL_STATUS)[number];
+
+export const STATUS_TO_FILTER: Record<CallStatusType, string> = {
+  SUCCESS: 'success',
+  UNSET: 'running',
+  ERROR: 'error',
+};
+export const FILTER_TO_STATUS: Record<string, CallStatusType> =
+  _.invert(STATUS_TO_FILTER);
 
 type StatusChipProps = {
   value: CallStatusType;


### PR DESCRIPTION
## Description

Wires up the UI to allow filtering by status, either through the filter popup form or Option+Click. Backend support for this was added in https://github.com/wandb/weave/pull/3797

Also makes Option+Click more useful. Currently doing Option+Click on the same value adds multiple duplicate filters. With this PR we change it so a second Option+Click will either toggle the filter off or replace it with an updated one (e.g. in the case where you have an `OR` of status values and want to filter to one.)

<img width="613" alt="Screenshot 2025-04-09 at 11 32 51 AM" src="https://github.com/user-attachments/assets/ad18b0fa-68a0-4713-961f-c1af797efbc9" />



## Testing

How was this PR tested?
