### PR TITLE
feat(app): Allow selection of custom step metric in stepper panel

### DIFF
--- a/weave-js/src/components/Panel2/PanelStepper/component.tsx
+++ b/weave-js/src/components/Panel2/PanelStepper/component.tsx
@@ -20,7 +20,7 @@ export const PanelStepper: React.FC<
 
   const stepsNode = opPick({
     obj: filteredNode,
-    key: constString(config?.workingSliderKey ?? '_step'),
+    key: constString(config?.workingSliderKey!),
   });
   const {result: stepsNodeResult, loading: stepsNodeLoading} =
     useNodeValue(stepsNode);
@@ -30,9 +30,9 @@ export const PanelStepper: React.FC<
       return;
     }
 
-    const newSteps: number[] = [...new Set<number>(stepsNodeResult)].sort(
-      (a, b) => a - b
-    );
+    const newSteps: number[] = [...new Set<number>(stepsNodeResult)]
+      .filter(n => n != null)
+      .sort((a, b) => a - b);
 
     const currentConfigSteps = config?.steps;
 
@@ -45,11 +45,10 @@ export const PanelStepper: React.FC<
       safeUpdateConfig({steps: newSteps});
     }
 
-    const configCurrentStep = config?.currentStep ?? -1;
+    const configCurrentStep = config?.currentStep;
     const shouldUpdateCurrentStep =
       hasStepsChanged ||
       configCurrentStep === undefined ||
-      configCurrentStep < 0 ||
       !newSteps.includes(configCurrentStep);
 
     if (shouldUpdateCurrentStep) {
@@ -58,58 +57,72 @@ export const PanelStepper: React.FC<
   }, [stepsNodeResult, stepsNodeLoading, config, safeUpdateConfig]);
 
   return (
-    <>
-      {outputNode != null && !isVoidNode(outputNode) && (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        height: '100%',
+        padding: '2px',
+        overflowY: 'auto',
+      }}>
+      {outputNode != null && !isVoidNode(outputNode) ? (
+        <PanelComp2
+          input={outputNode}
+          inputType={outputNode.type}
+          loading={props.loading}
+          panelSpec={childPanelHandler as PanelStack}
+          configMode={false}
+          config={props.config}
+          context={props.context}
+          updateConfig={props.updateConfig}
+          updateContext={props.updateContext}
+          updateInput={props.updateInput}
+        />
+      ) : (
         <div
           style={{
-            display: 'flex',
-            flexDirection: 'column',
-            width: '100%',
             height: '100%',
-            padding: '2px',
-            overflowY: 'auto',
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#666',
+            fontSize: '14px',
           }}>
-          <PanelComp2
-            input={outputNode}
-            inputType={outputNode.type}
-            loading={props.loading}
-            panelSpec={childPanelHandler as PanelStack}
-            configMode={false}
-            config={props.config}
-            context={props.context}
-            updateConfig={props.updateConfig}
-            updateContext={props.updateContext}
-            updateInput={props.updateInput}
-          />
-          {(config?.steps?.length || 0) > 0 && (
-            <div
-              style={{
-                padding: '8px',
-                borderTop: '1px solid #ddd',
-                backgroundColor: '#f8f8f8',
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                marginTop: '8px',
-              }}>
-              Step:{' '}
-              <SliderInput
-                min={config!.steps![0]}
-                max={config!.steps![config!.steps!.length - 1]}
-                minLabel={config!.steps![0].toString()}
-                maxLabel={config!.steps![config!.steps!.length - 1].toString()}
-                hasInput={true}
-                value={config!.currentStep!}
-                step={1}
-                ticks={config!.steps}
-                onChange={val => {
-                  safeUpdateConfig({currentStep: val});
-                }}
-              />
-            </div>
-          )}
+          <div>
+            No data found for property <i>{config?.workingKeyAndType?.key}</i>{' '}
+            with slider key <i>{config?.workingSliderKey}</i>
+          </div>
         </div>
       )}
-    </>
+      {(config?.steps?.length || 0) > 0 && (
+        <div
+          style={{
+            padding: '8px',
+            borderTop: '1px solid #ddd',
+            backgroundColor: '#f8f8f8',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            marginTop: '8px',
+          }}>
+          Step:{' '}
+          <SliderInput
+            min={config!.steps![0]}
+            max={config!.steps![config!.steps!.length - 1]}
+            minLabel={config!.steps![0].toString()}
+            maxLabel={config!.steps![config!.steps!.length - 1].toString()}
+            hasInput={true}
+            value={config!.currentStep!}
+            step={1}
+            ticks={config!.steps}
+            onChange={val => {
+              safeUpdateConfig({currentStep: val});
+            }}
+          />
+        </div>
+      )}
+    </div>
   );
 };

--- a/weave-js/src/components/Panel2/PanelStepper/configComponent.tsx
+++ b/weave-js/src/components/Panel2/PanelStepper/configComponent.tsx
@@ -19,15 +19,6 @@ export const PanelStepperConfig: React.FC<
     childPanelHandler,
   } = props;
 
-  // TODO (nicholaspun-wandb): Used for the "Slider Key" config option below
-  // const sliderKeys = useMemo(
-  //   () =>
-  //     Object.keys(keysAndTypes).filter(key =>
-  //       isAssignableTo(keysAndTypes[key], 'number')
-  //     ),
-  //   [keysAndTypes]
-  // );
-
   const handlerHasConfigComponent =
     childPanelHandler != null &&
     (childPanelHandler.ConfigComponent != null ||
@@ -36,11 +27,7 @@ export const PanelStepperConfig: React.FC<
 
   return (
     <>
-      {/*
-      TODO (nicholaspun-wandb): This technically works, but slider keys that aren't integral
-      numbers don't work well.
-
-      <ConfigOption label="Slider Key">
+      <ConfigPanel.ConfigOption label="Slider Key">
         <ModifiedDropdownConfigField
           selection
           search
@@ -48,19 +35,17 @@ export const PanelStepperConfig: React.FC<
           scrolling
           item
           direction="left"
-          options={sliderKeys.map(key => ({
+          options={(config?.validSliderKeys ?? []).map(key => ({
             key,
             value: key,
             text: key,
           }))}
-          value={config?.workingSliderKey ?? '_step'}
+          value={config?.workingSliderKey ?? config?.validSliderKeys?.[0]}
           onChange={(e, {value}) =>
             safeUpdateConfig({workingSliderKey: value as string})
           }
         />
-      </ConfigOption> 
-      
-      */}
+      </ConfigPanel.ConfigOption>
       <ConfigPanel.ConfigOption label="Property Key">
         <ModifiedDropdownConfigField
           selection

--- a/weave-js/src/components/Panel2/PanelStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelStepper/index.tsx
@@ -1,6 +1,4 @@
-import {useWeaveContext} from '@wandb/weave/context';
 import {
-  constBoolean,
   constFunction,
   constNumber,
   constString,

--- a/weave-js/src/components/Panel2/PanelStepper/index.tsx
+++ b/weave-js/src/components/Panel2/PanelStepper/index.tsx
@@ -208,6 +208,7 @@ const PanelStepperEntryComponent: React.FC<PanelStepperEntryProps> = props => {
   const numericalKeys = Object.keys(propertyKeysAndTypes).filter(
     key =>
       isAssignableTo(propertyKeysAndTypes[key], union(['none', 'number'])) &&
+      // Special filtering for metrics that could be integers but are not step related.
       !['loss', 'accuracy', 'precision', 'recall'].some(metric =>
         key.includes(metric)
       )

--- a/weave-js/src/components/Panel2/PanelStepper/types.tsx
+++ b/weave-js/src/components/Panel2/PanelStepper/types.tsx
@@ -10,6 +10,7 @@ export type PanelStepperConfigType = {
   workingPanelId: string | undefined;
   workingKeyAndType: {key: string; type: Type};
   workingSliderKey: string | null;
+  validSliderKeys: string[];
 };
 
 export const LIST_ANY_TYPE: Type = {


### PR DESCRIPTION
## Description

- Implements [WB-24236](https://wandb.atlassian.net/browse/WB-24236)
- Adds a selection to the stepper panel config to allow the user to select the step key.
- Valid step keys are those where the values are all integers, but can contain null values (e.g. in the case where a custom step key is logged for one run but not for another).
    - We ignore monotonicity since the data could span across runs (e.g. `runs.history`), in which case the entire sequence may not be monotonic 

## Testing

Local FE Invoker


https://github.com/user-attachments/assets/47de0543-7426-4b03-a619-fc9f1dbb718c




[WB-24236]: https://wandb.atlassian.net/browse/WB-24236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ