### PR TITLE
fix(weave): convert filter for query used in default time windor

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -64,6 +64,7 @@ import {
   DEFAULT_SORT_CALLS,
   filterHasCalledAfterDateFilter,
 } from './Browse3/pages/CallsPage/CallsTable';
+import {WFHighLevelCallFilter} from './Browse3/pages/CallsPage/callsTableFilter';
 import {
   DEFAULT_FILTER_CALLS,
   useMakeInitialDatetimeFilter,
@@ -761,7 +762,7 @@ const CallsPageBinding = () => {
   const {entity, project, tab} = useParamsDecoded<Browse3TabParams>();
   const query = useURLSearchParamsDict();
   const isEvaluationsTab = tab === 'evaluations';
-  const initialFilter = useMemo(() => {
+  const initialFilter: WFHighLevelCallFilter = useMemo(() => {
     if (isEvaluationsTab) {
       return {
         frozen: true,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -284,7 +284,7 @@ const CACHE_EXPIRY_MS = 24 * 60 * 60 * 1000; // 1 day
 const datetimeFilterCacheKey = (
   entity: string,
   project: string,
-  filter: CallFilter
+  filter: WFHighLevelCallFilter
 ) => {
   // hash the filter
   const filterHash = simpleHash(JSON.stringify(filter));
@@ -294,7 +294,7 @@ const datetimeFilterCacheKey = (
 export const useMakeInitialDatetimeFilter = (
   entity: string,
   project: string,
-  filter: CallFilter,
+  highLevelFilter: WFHighLevelCallFilter,
   skip: boolean
 ): {initialDatetimeFilter: GridFilterModel} => {
   // Fire off 2 stats queries, one for the # of calls in the last 7 days
@@ -312,11 +312,14 @@ export const useMakeInitialDatetimeFilter = (
     return makeRawDateFilter(7);
   }, []);
 
-  const key = datetimeFilterCacheKey(entity, project, filter);
+  const key = datetimeFilterCacheKey(entity, project, highLevelFilter);
   const cachedFilter = useMemo(
     () => getCachedByKeyWithExpiry(key, CACHE_EXPIRY_MS),
     [key]
   );
+  const filter: CallFilter = useMemo(() => {
+    return convertHighLevelFilterToLowLevelFilter(highLevelFilter);
+  }, [highLevelFilter]);
 
   const callStats7Days = useCallsStats(entity, project, filter, d7filter, {
     skip: skip || cachedFilter != null,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24343](https://wandb.atlassian.net/browse/WB-24343)

Type fix from high level query to low level query, which affects the use of `parentId` in filters used to determine the default date range. 

## Testing

prod:
<img width="1728" alt="Screenshot 2025-04-09 at 11 31 54 AM" src="https://github.com/user-attachments/assets/d91fe320-ec03-4f32-b0aa-993b64b932f5" />


branch:
 
<img width="1725" alt="Screenshot 2025-04-09 at 11 31 24 AM" src="https://github.com/user-attachments/assets/f789c06d-d455-45ad-9323-ab54814e3132" />


[WB-24343]: https://wandb.atlassian.net/browse/WB-24343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ