### PR TITLE
fix(weave): add other required columns when `summary` requested

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -2178,7 +2178,8 @@ def test_call_query_stream_columns(client):
 
     # NO output returned because not required and not requested
     assert calls[0].output is None
-    assert calls[0].ended_at is None
+    # still need ended_at (always)
+    assert calls[0].ended_at is not None
     assert calls[0].attributes == {}
     assert calls[0].inputs == {"a": 0, "b": 0}
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -161,7 +161,14 @@ all_call_insert_columns = list(
 
 all_call_select_columns = list(SelectableCHCallSchema.model_fields.keys())
 all_call_json_columns = ("inputs", "output", "attributes", "summary")
-required_call_columns = ["id", "project_id", "trace_id", "op_name", "started_at"]
+required_call_columns = [
+    "id",
+    "project_id",
+    "trace_id",
+    "op_name",
+    "started_at",
+    "ended_at",
+]
 
 
 # Columns in the calls_merged table with special aggregation functions:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -366,7 +366,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             # If we are returning a summary object, make sure that all fields
             # required to compute the summary are in the columns
             if "summary" in columns or req.include_costs:
-                columns += ["ended_at", "op_name", "exception", "display_name"]
+                columns += ["ended_at", "exception", "display_name"]
 
             # Set columns to user-requested columns, w/ required columns
             # These are all formatted by the CallsQuery, which prevents injection

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -161,13 +161,7 @@ all_call_insert_columns = list(
 
 all_call_select_columns = list(SelectableCHCallSchema.model_fields.keys())
 all_call_json_columns = ("inputs", "output", "attributes", "summary")
-required_call_columns = [
-    "id",
-    "project_id",
-    "trace_id",
-    "op_name",
-    "started_at",
-]
+required_call_columns = ["id", "project_id", "trace_id", "op_name", "started_at"]
 
 
 # Columns in the calls_merged table with special aggregation functions:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -167,7 +167,6 @@ required_call_columns = [
     "trace_id",
     "op_name",
     "started_at",
-    "ended_at",
 ]
 
 
@@ -369,6 +368,12 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             # TODO: add support for json extract fields
             # Split out any nested column requests
             columns = [col.split(".")[0] for col in req.columns]
+
+            # If we are returning a summary object, make sure that all fields
+            # required to compute the summary are in the columns
+            if "summary" in columns or req.include_costs:
+                columns += ["ended_at", "op_name", "exception", "display_name"]
+
             # Set columns to user-requested columns, w/ required columns
             # These are all formatted by the CallsQuery, which prevents injection
             # and other attack vectors.

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -425,6 +425,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         if req.columns:
             # TODO(gst): allow json fields to be selected
             simple_columns = list({x.split(".")[0] for x in req.columns})
+            if "summary" in simple_columns or req.include_costs:
+                simple_columns += ["ended_at", "exception", "display_name"]
+
             select_columns = [x for x in simple_columns if x in select_columns]
             # add required columns, preserving requested column order
             select_columns += [


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
[WB-24344](https://wandb.atlassian.net/browse/WB-24344)

This pr adds additional columns to the calls query process when a user requests  a calls query that returns a `summary` but does not already have the required columns. This happens when a user explicitly sets columns to include `summary` (but not other columns) or sets the `include_costs` flag.

When a user requests a `summary` payload or `include_costs`, now we select the following additional columns:
- `ended_at`
- `display_name`
- `exception`

## Testing

todo add unit

master:
<img width="553" alt="Screenshot 2025-04-09 at 2 49 59 PM" src="https://github.com/user-attachments/assets/f57cb580-8b23-4e8a-b01a-ec1b7e59ca35" />

branch:
<img width="539" alt="Screenshot 2025-04-09 at 2 49 21 PM" src="https://github.com/user-attachments/assets/0f687100-6824-43a2-a0fc-e3bbde6d3bca" />


[WB-24344]: https://wandb.atlassian.net/browse/WB-24344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ