### PR TITLE
chore(weave): Create long-live storage clients per instance

### DIFF
--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -29,7 +29,6 @@ AZURITE_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1
 AZURITE_B64_KEY = base64.b64encode(AZURITE_KEY.encode()).decode()
 AZURITE_URL = f"http://127.0.0.1:10000/{AZURITE_ACCOUNT}"
 
-
 @pytest.fixture
 def run_storage_test(client: WeaveClient):
     """Shared test runner for all storage implementations."""
@@ -56,7 +55,6 @@ def run_storage_test(client: WeaveClient):
     if client_is_sqlite(client):
         pytest.skip("Not implemented in SQLite")
     return _run_test
-
 
 class TestS3Storage:
     """Tests for AWS S3 storage implementation."""
@@ -102,6 +100,54 @@ class TestS3Storage:
         obj = response["Contents"][0]
         obj_response = s3.get_object(Bucket=TEST_BUCKET, Key=obj["Key"])
         assert obj_response["Body"].read() == TEST_CONTENT
+
+    def test_client_caching(self, run_storage_test, s3, aws_storage_env):
+        """Test that client is properly cached and reused."""
+        with mock.patch("weave.trace_server.file_storage.S3StorageClient") as mock_s3_client:
+            # First call should create a new client
+            res1 = run_storage_test()
+            mock_s3_client.assert_called_once()
+            
+            # Second call should reuse the same client
+            mock_s3_client.reset_mock()
+            res2 = run_storage_test()
+            mock_s3_client.assert_not_called()
+
+    def test_client_reset(self, run_storage_test, s3, aws_storage_env):
+        """Test that client is properly reset when needed."""
+        with mock.patch("weave.trace_server.file_storage.S3StorageClient") as mock_s3_client:
+            # First call creates client
+            res1 = run_storage_test()
+            mock_s3_client.assert_called_once()
+            
+            # Reset client
+            client = run_storage_test.client.server
+            if hasattr(client, "_reset_storage_client"):
+                client._reset_storage_client()
+            
+            # Next call should create new client
+            mock_s3_client.reset_mock()
+            res2 = run_storage_test()
+            mock_s3_client.assert_called_once()
+
+    def test_client_error_handling(self, run_storage_test, s3, aws_storage_env):
+        """Test that client errors are properly handled."""
+        with mock.patch("weave.trace_server.file_storage_credentials.get_aws_credentials") as mock_get_creds:
+            # First call succeeds
+            res1 = run_storage_test()
+            
+            # Make credentials fail
+            mock_get_creds.side_effect = ValueError("Invalid credentials")
+            
+            # Next call should fail but clear the client
+            with pytest.raises(ValueError):
+                res2 = run_storage_test()
+            
+            # Fix credentials
+            mock_get_creds.side_effect = None
+            
+            # Should work again with new client
+            res3 = run_storage_test()
 
 
 class TestGCSStorage:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1427,16 +1427,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         )
 
     def _should_use_file_storage_for_writes(self, project_id: str) -> bool:
-        """
-        Get the base storage URI for a project.
-
-        Currently this is quite simple as it uses the default storage bucket
-        for the entire client (most typically configured via environment variable).
-
-        However, in the near future, this might be something that is driven by
-        the project or a context variable. Leaving this method here for clarity
-        and future extensibility.
-        """
+        """Determine if we should use file storage for a project."""
         project_allow_list = wf_env.wf_file_storage_project_allow_list()
         if project_allow_list is None:
             return False

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -82,7 +82,7 @@ from weave.trace_server.feedback import (
 from weave.trace_server.file_storage import (
     FileStorageReadError,
     FileStorageWriteError,
-    get_storage_client_for_uri,
+    get_storage_client_from_env,
     key_for_project_digest,
     read_from_bucket,
     store_in_bucket,
@@ -234,19 +234,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
     def file_storage_client(self) -> Optional[FileStorageClient]:
         if self._file_storage_client is not None:
             return self._file_storage_client
-        file_storage_uri = wf_env.wf_file_storage_uri()
-        if file_storage_uri is None:
-            return None
-        try:
-            parsed_uri = FileStorageURI.parse_uri_str(file_storage_uri)
-        except Exception as e:
-            logger.exception(f"Error parsing file storage URI: {e}")
-            return None
-        if parsed_uri.has_path():
-            raise ValueError(
-                f"Supplied file storage uri contains path components: {file_storage_uri}"
-            )
-        self._file_storage_client = get_storage_client_for_uri(parsed_uri)
+        self._file_storage_client = get_storage_client_from_env()
         return self._file_storage_client
 
     def otel_export(self, req: tsi.OtelExportReq) -> tsi.OtelExportRes:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -83,8 +83,8 @@ from weave.trace_server.file_storage import (
     FileStorageClient,
     FileStorageReadError,
     FileStorageWriteError,
-    get_storage_client_from_env,
     key_for_project_digest,
+    maybe_get_storage_client_from_env,
     read_from_bucket,
     store_in_bucket,
 )
@@ -234,7 +234,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
     def file_storage_client(self) -> Optional[FileStorageClient]:
         if self._file_storage_client is not None:
             return self._file_storage_client
-        self._file_storage_client = get_storage_client_from_env()
+        self._file_storage_client = maybe_get_storage_client_from_env()
         return self._file_storage_client
 
     def otel_export(self, req: tsi.OtelExportReq) -> tsi.OtelExportRes:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -80,6 +80,7 @@ from weave.trace_server.feedback import (
     validate_feedback_purge_req,
 )
 from weave.trace_server.file_storage import (
+    FileStorageClient,
     FileStorageReadError,
     FileStorageWriteError,
     get_storage_client_from_env,
@@ -87,7 +88,6 @@ from weave.trace_server.file_storage import (
     read_from_bucket,
     store_in_bucket,
 )
-from weave.trace_server.file_storage_client import FileStorageClient
 from weave.trace_server.file_storage_uris import FileStorageURI
 from weave.trace_server.ids import generate_id
 from weave.trace_server.llm_completion import (

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -137,8 +137,10 @@ def create_retry_decorator(operation_name: str) -> Callable[[Any], Any]:
 class S3StorageClient(FileStorageClient):
     """AWS S3 storage implementation with retry logic and configurable timeouts."""
 
-    def __init__(self, credentials: AWSCredentials):
+    def __init__(self, base_uri: FileStorageURI, credentials: AWSCredentials):
         """Initialize S3 client with credentials and default timeout configuration."""
+        assert isinstance(base_uri, S3FileStorageURI)
+        super().__init__(base_uri)
         config = Config(
             connect_timeout=DEFAULT_CONNECT_TIMEOUT,
             read_timeout=DEFAULT_READ_TIMEOUT,
@@ -173,8 +175,10 @@ class S3StorageClient(FileStorageClient):
 class GCSStorageClient(FileStorageClient):
     """Google Cloud Storage implementation with retry logic and configurable timeouts."""
 
-    def __init__(self, credentials: GCPCredentials):
+    def __init__(self, base_uri: FileStorageURI, credentials: GCPCredentials):
         """Initialize GCS client with credentials and default timeout configuration."""
+        assert isinstance(base_uri, GCSFileStorageURI)
+        super().__init__(base_uri)
         self.client = storage.Client(
             credentials=credentials,
         )
@@ -204,9 +208,13 @@ class AzureStorageClient(FileStorageClient):
     """Azure Blob Storage implementation supporting both connection string and account credentials."""
 
     def __init__(
-        self, credentials: Union[AzureConnectionCredentials, AzureAccountCredentials]
+        self,
+        base_uri: FileStorageURI,
+        credentials: Union[AzureConnectionCredentials, AzureAccountCredentials],
     ):
         """Initialize Azure client with either connection string or account credentials."""
+        assert isinstance(base_uri, AzureFileStorageURI)
+        super().__init__(base_uri)
         self.credentials = credentials
 
     def _get_client(self, account: str) -> BlobServiceClient:

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -263,7 +263,7 @@ class AzureStorageClient(FileStorageClient):
         return stream.readall()
 
 
-def get_storage_client_from_env() -> Optional[FileStorageClient]:
+def maybe_get_storage_client_from_env() -> Optional[FileStorageClient]:
     """Factory method that returns appropriate storage client based on URI type.
     Supports S3, GCS, and Azure storage URIs."""
     file_storage_uri = wf_file_storage_uri()

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -155,13 +155,17 @@ class S3StorageClient(FileStorageClient):
     @create_retry_decorator("s3_storage")
     def store(self, uri: S3FileStorageURI, data: bytes) -> None:
         """Store data in S3 bucket with automatic retries on failure."""
-        assert isinstance(uri, S3FileStorageURI)
+        assert isinstance(uri, S3FileStorageURI) and uri.to_uri_str().startswith(
+            self.base_uri.to_uri_str()
+        )
         self.client.put_object(Bucket=uri.bucket, Key=uri.path, Body=data)
 
     @create_retry_decorator("s3_read")
     def read(self, uri: S3FileStorageURI) -> bytes:
         """Read data from S3 bucket with automatic retries on failure."""
-        assert isinstance(uri, S3FileStorageURI)
+        assert isinstance(uri, S3FileStorageURI) and uri.to_uri_str().startswith(
+            self.base_uri.to_uri_str()
+        )
         response = self.client.get_object(Bucket=uri.bucket, Key=uri.path)
         return response["Body"].read()
 
@@ -178,7 +182,9 @@ class GCSStorageClient(FileStorageClient):
     @create_retry_decorator("gcs_storage")
     def store(self, uri: GCSFileStorageURI, data: bytes) -> None:
         """Store data in GCS bucket with automatic retries on failure."""
-        assert isinstance(uri, GCSFileStorageURI)
+        assert isinstance(uri, GCSFileStorageURI) and uri.to_uri_str().startswith(
+            self.base_uri.to_uri_str()
+        )
         bucket = self.client.bucket(uri.bucket)
         blob = bucket.blob(uri.path)
         blob.upload_from_string(data, timeout=DEFAULT_READ_TIMEOUT)
@@ -186,7 +192,9 @@ class GCSStorageClient(FileStorageClient):
     @create_retry_decorator("gcs_read")
     def read(self, uri: GCSFileStorageURI) -> bytes:
         """Read data from GCS bucket with automatic retries on failure."""
-        assert isinstance(uri, GCSFileStorageURI)
+        assert isinstance(uri, GCSFileStorageURI) and uri.to_uri_str().startswith(
+            self.base_uri.to_uri_str()
+        )
         bucket = self.client.bucket(uri.bucket)
         blob = bucket.blob(uri.path)
         return blob.download_as_bytes(timeout=DEFAULT_READ_TIMEOUT)
@@ -226,7 +234,9 @@ class AzureStorageClient(FileStorageClient):
     @create_retry_decorator("azure_storage")
     def store(self, uri: AzureFileStorageURI, data: bytes) -> None:
         """Store data in Azure container with automatic retries on failure."""
-        assert isinstance(uri, AzureFileStorageURI)
+        assert isinstance(uri, AzureFileStorageURI) and uri.to_uri_str().startswith(
+            self.base_uri.to_uri_str()
+        )
         client = self._get_client(uri.account)
         container_client = client.get_container_client(uri.container)
         blob_client = container_client.get_blob_client(uri.path)
@@ -235,7 +245,9 @@ class AzureStorageClient(FileStorageClient):
     @create_retry_decorator("azure_read")
     def read(self, uri: AzureFileStorageURI) -> bytes:
         """Read data from Azure container with automatic retries on failure."""
-        assert isinstance(uri, AzureFileStorageURI)
+        assert isinstance(uri, AzureFileStorageURI) and uri.to_uri_str().startswith(
+            self.base_uri.to_uri_str()
+        )
         client = self._get_client(uri.account)
         container_client = client.get_container_client(uri.container)
         blob_client = container_client.get_blob_client(uri.path)


### PR DESCRIPTION
This is a pure refactor of the file storage mechanics such that the trace server client only has instantiates a single connection to the bucket. As implemented today, a client connection is minted for each request which is not as performant as it could be. 

Furthermore, it correctly decouples the loading of an environment-configured client from something that could be generated at runtime. This is the first step to moving to the better auth system.