### PR TITLE
feat(weave): Show storage size on call summary page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -64,8 +64,9 @@ export const CallPage: FC<CallPageProps> = props => {
       entity: props.entity,
       project: props.project,
       callId: descendentCallId,
+      withTotalStorageSize: true,
     },
-    {includeCosts: true}
+    {includeCosts: true, includeTotalStorageSize: true}
   );
 
   // This is a little hack, but acceptable for now.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -1,5 +1,8 @@
+import {Button} from '@wandb/weave/components/Button/Button';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
+import {convertBytes, getJsonPayloadSize} from '@wandb/weave/util';
 import _ from 'lodash';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import {parseRefMaybe} from '../../../../../../react';
 import {Timestamp} from '../../../../../Timestamp';
@@ -15,6 +18,20 @@ const SUMMARY_FIELDS_EXCLUDED_FROM_GENERAL_RENDER = [
   'usage',
   'weave',
 ];
+
+const StorageSizeDisplay: React.FC<{
+  size: number;
+}> = ({size}) => (
+  <span className="flex items-center gap-2">
+    {convertBytes(size)}
+    <Tooltip
+      content="The size does not include referenced objects, for example, images or audio blob storage."
+      trigger={
+        <Button icon="info" variant="ghost" size="small" active={false} />
+      }
+    />
+  </span>
+);
 
 export const CallSummary: React.FC<{
   call: CallSchema;
@@ -36,6 +53,34 @@ export const CallSummary: React.FC<{
     )
   );
   const costData = call.traceCall?.summary?.weave?.costs;
+
+  const storageSizeBytesRow = useMemo(() => {
+    const size =
+      getJsonPayloadSize(span.inputs) +
+      getJsonPayloadSize(span.output) +
+      getJsonPayloadSize(span.attributes) +
+      getJsonPayloadSize(span.summary);
+
+    if (size === 0) {
+      return null;
+    }
+
+    return {
+      'Call Storage Size': <StorageSizeDisplay size={size} />,
+    };
+  }, [span]);
+
+  const traceStorageSizeBytesRow = useMemo(() => {
+    if (call.parentId !== null) {
+      return null;
+    }
+
+    return {
+      'Trace Storage Size': (
+        <StorageSizeDisplay size={call.totalStorageSizeBytes ?? 0} />
+      ),
+    };
+  }, [call.parentId, call.totalStorageSizeBytes]);
 
   return (
     <div className="overflow-auto px-16 pt-12">
@@ -88,6 +133,8 @@ export const CallSummary: React.FC<{
                   Latency: span.summary.latency_s.toFixed(3) + 's',
                 }
               : {}),
+            ...storageSizeBytesRow,
+            ...traceStorageSizeBytesRow,
             ...(Object.keys(summary).length > 0 ? summary : {}),
           }}
         />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cache.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cache.ts
@@ -6,6 +6,7 @@
  * re-fetching the same data multiple times in a single page view.
  */
 
+import {isEmpty} from 'lodash';
 import LRUCache from 'lru-cache';
 
 import {Node} from '../../../../../../core';
@@ -42,7 +43,9 @@ const makeSpecificCache = <K, V>(
 };
 
 export const callCache = makeSpecificCache<CallKey, CallSchema>(key => {
-  return `call:${key.entity}/${key.project}/${key.callId}`;
+  const {entity, project, callId, ...rest} = key;
+  const meta = isEmpty(rest) ? '' : `?meta=${JSON.stringify(rest)}`;
+  return `call:${entity}/${project}/${callId}${meta}`;
 });
 
 export const opVersionCache = makeSpecificCache<OpVersionKey, OpVersionSchema>(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -79,6 +79,7 @@ export type TraceCallReadReq = {
   project_id: string;
   id: string;
   include_costs?: boolean;
+  include_total_storage_size?: boolean;
 };
 
 export type TraceCallReadSuccess = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -34,8 +34,8 @@ import * as traceServerTypes from './traceServerClientTypes';
 import {useClientSideCallRefExpansion} from './tsDataModelHooksCallRefExpansion';
 import {opVersionRefOpName, refUriToObjectVersionKey} from './utilities';
 import {
+  CacheableCallKey,
   CallFilter,
-  CallKey,
   CallSchema,
   FeedbackKey,
   Loadable,
@@ -165,8 +165,8 @@ const useMakeTraceServerEndpoint = <
 };
 
 const useCall = (
-  key: CallKey | null,
-  opts?: {includeCosts?: boolean}
+  key: CacheableCallKey | null,
+  opts?: {includeCosts?: boolean; includeTotalStorageSize?: boolean}
 ): Loadable<CallSchema | null> => {
   const getTsClient = useGetTraceServerClientContext();
   const loadingRef = useRef(false);
@@ -183,13 +183,16 @@ const useCall = (
           project_id: projectIdFromParts(deepKey),
           id: deepKey.callId,
           include_costs: opts?.includeCosts,
+          ...(opts?.includeTotalStorageSize
+            ? {include_total_storage_size: true}
+            : null),
         })
         .then(res => {
           loadingRef.current = false;
           setCallRes(res);
         });
     }
-  }, [deepKey, getTsClient, opts?.includeCosts]);
+  }, [deepKey, getTsClient, opts?.includeCosts, opts?.includeTotalStorageSize]);
 
   useEffect(() => {
     doFetch();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -36,6 +36,9 @@ export type CallKey = {
   project: string;
   callId: string;
 };
+
+export type CacheableCallKey = CallKey & Record<string, unknown>;
+
 export type CallSchema = CallKey & {
   spanName: string;
   displayName: string | null;
@@ -166,8 +169,8 @@ export type Refetchable = {
 
 export type WFDataModelHooksInterface = {
   useCall: (
-    key: CallKey | null,
-    opts?: {includeCosts?: boolean}
+    key: CacheableCallKey | null,
+    opts?: {includeCosts?: boolean; includeTotalStorageSize?: boolean}
   ) => Loadable<CallSchema | null>;
   useCalls: (
     entity: string,

--- a/weave-js/src/util.ts
+++ b/weave-js/src/util.ts
@@ -75,3 +75,8 @@ export function convertBytes(result: any) {
   }
   return `${result}B`;
 }
+
+export function getJsonPayloadSize(json: any): number {
+  const jsonString = JSON.stringify(json);
+  return new Blob([jsonString]).size;
+}

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -391,6 +391,14 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         # sort the columns such that similar queries are grouped together
         columns = sorted(columns)
 
+        # The order is actually important, it has something to do with how the cost_query wants to arrange things.
+        # specifically, the summary column should always be the last.
+        if req.include_storage_size:
+            columns.append("storage_size_bytes")
+
+        if req.include_total_storage_size:
+            columns.append("total_storage_size_bytes")
+
         # We put summary_dump last so that when we compute the costs and summary its in the right place
         if req.include_costs:
             summary_columns = ["summary", "summary_dump"]
@@ -398,12 +406,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 *[col for col in columns if col not in summary_columns],
                 "summary_dump",
             ]
-
-        if req.include_storage_size:
-            columns.append("storage_size_bytes")
-
-        if req.include_total_storage_size:
-            columns.append("total_storage_size_bytes")
 
         for col in columns:
             cq.add_field(col)

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -70,6 +70,16 @@ def get_calls_merged_columns() -> list[Column]:
     return columns
 
 
+def get_optional_join_field_columns() -> list[Column]:
+    return [
+        # These two columns are added here, because the ORM will validate that
+        # the table contains those columns in case any of the storage size column
+        # is included.
+        Column(name="storage_size_bytes", type="float"),
+        Column(name="total_storage_size_bytes", type="float"),
+    ]
+
+
 # SELECT
 #     *,
 #     Extracted Usage Fields
@@ -397,7 +407,12 @@ def final_call_select_with_cost(
     ]
 
     ranked_price_table = Table(
-        price_table_alias, [*get_calls_merged_columns(), *usage_with_costs_fields]
+        price_table_alias,
+        [
+            *get_calls_merged_columns(),
+            *get_optional_join_field_columns(),
+            *usage_with_costs_fields,
+        ],
     )
 
     final_query = (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

## Changes
This PR adds storage size information to the call summary page, providing users with visibility into the storage footprint of their calls and traces.

Here is [a mini design doc](https://www.notion.so/wandbai/Data-Size-display-1bde2f5c7ef38087bc03cb8accb95bfb) for the context.

### Key Features
- Added storage size display for individual calls, showing the sum of the size of inputs, outputs, attributes, and summary data
- Added total storage size display for root traces
- Included a tooltip explaining that the size doesn't include referenced objects (e.g., images or audio blob storage)
- Added storage size information to the trace server API and data model

### Preview
Root trace call:
<img width="519" alt="image" src="https://github.com/user-attachments/assets/b36b3236-5f36-4da7-93c9-37b76e515485" />

Non-root call:
<img width="527" alt="image" src="https://github.com/user-attachments/assets/dabebb70-e740-41a0-a24b-e2431c4ad3e6" />


### Technical Details
- Frontend:
  - Added new storage size display components with human-readable byte formatting
  - Extended the call cache to support storage size metadata. I have to do a separate caching for a call request with the usage of `withStorageSize`.
  - Added storage size calculation utilities
  - Updated TypeScript interfaces to include storage size fields

- Backend:
  - Added storage size fields to ClickHouse trace server query requests
  - Updated token costs calculation to include storage size information, before this PR, there was a conflict using both "include_costs" and "include_total_storage_cost"
  - Modified call schema conversion to handle storage size data

### Notes
- For the storage size of a specific call, the size is calculated purely on the frontend, there is no separate backend call.
- The implementation maintains backward compatibility with existing call queries
- Storage size information is cached along with other call data to optimize performance

This change helps users better understand their storage usage and make informed decisions about data management.

## Testing

This PR is currently manually tested UI-wise.
I also added a python unit test to ensure that the query refactoring does not break things.
