### PR TITLE
Griffin/speedy calls migration

### DIFF
--- a/weave/trace_server/migrations/012_add_call_start_fast.down.sql
+++ b/weave/trace_server/migrations/012_add_call_start_fast.down.sql
@@ -1,0 +1,3 @@
+
+DROP TABLE IF EXISTS call_start_fast;
+DROP VIEW IF EXISTS call_starts_fast_view;

--- a/weave/trace_server/migrations/012_add_call_start_fast.up.sql
+++ b/weave/trace_server/migrations/012_add_call_start_fast.up.sql
@@ -1,5 +1,4 @@
-DROP TABLE IF EXISTS call_start_fast;
-CREATE TABLE call_start_fast (
+CREATE TABLE IF NOT EXISTS call_start_fast (
   id String,
   project_id String,
   started_at Datetime(6),
@@ -11,8 +10,7 @@ CREATE TABLE call_start_fast (
 ) ENGINE = MergeTree
 ORDER BY (project_id, op_name, trace_id, parent_id, started_at, id);
 
-DROP VIEW IF EXISTS call_start_fast_view;
-CREATE MATERIALIZED VIEW call_start_fast_view TO call_start_fast AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS call_start_fast_view TO call_start_fast AS
 SELECT 
    project_id,
    id,
@@ -23,3 +21,28 @@ SELECT
 FROM call_parts
 WHERE started_at is not NULL
 ORDER BY (project_id, op_name, trace_id, parent_id, started_at, id);
+
+--------------- [backfill] -----------------
+INSERT INTO call_start_fast (
+    id,
+    project_id,
+    started_at,
+    op_name,
+    trace_id,
+    parent_id
+) SELECT
+    id,
+    project_id,
+    started_at,
+    op_name,
+    trace_id,
+    COALESCE(parent_id, '') as parent_id
+FROM call_parts
+WHERE started_at is not NULL
+AND created_at >= (
+    SELECT COALESCE(
+        -- Get the oldest started_at in call_start_fast, or oldest created from call_parts
+        (SELECT min(started_at) FROM call_parts WHERE started_at > (SELECT max(started_at) FROM call_start_fast)),
+        (SELECT min(created_at) FROM call_parts)
+    )
+);

--- a/weave/trace_server/migrations/012_add_call_start_fast.up.sql
+++ b/weave/trace_server/migrations/012_add_call_start_fast.up.sql
@@ -1,0 +1,25 @@
+DROP TABLE IF EXISTS call_start_fast;
+CREATE TABLE call_start_fast (
+  id String,
+  project_id String,
+  started_at Datetime(6),
+  
+  op_name String,
+  trace_id String,
+  
+  parent_id String DEFAULT ''
+) ENGINE = MergeTree
+ORDER BY (project_id, op_name, trace_id, parent_id, id, started_at);
+
+DROP VIEW IF EXISTS call_start_fast_view;
+CREATE MATERIALIZED VIEW call_start_fast_view TO call_start_fast AS
+SELECT 
+   project_id,
+   id,
+   started_at,
+   op_name,
+   trace_id,
+   COALESCE(parent_id, '') as parent_id
+FROM call_parts
+WHERE started_at is not NULL
+ORDER BY (project_id, op_name, trace_id, parent_id, id, started_at);

--- a/weave/trace_server/migrations/012_add_call_start_fast.up.sql
+++ b/weave/trace_server/migrations/012_add_call_start_fast.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE call_start_fast (
   
   parent_id String DEFAULT ''
 ) ENGINE = MergeTree
-ORDER BY (project_id, op_name, trace_id, parent_id, id, started_at);
+ORDER BY (project_id, op_name, trace_id, parent_id, started_at, id);
 
 DROP VIEW IF EXISTS call_start_fast_view;
 CREATE MATERIALIZED VIEW call_start_fast_view TO call_start_fast AS
@@ -22,4 +22,4 @@ SELECT
    COALESCE(parent_id, '') as parent_id
 FROM call_parts
 WHERE started_at is not NULL
-ORDER BY (project_id, op_name, trace_id, parent_id, id, started_at);
+ORDER BY (project_id, op_name, trace_id, parent_id, started_at, id);


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr: 
- runs a migration adding a `call_start_fast` table with a meaty primary key
- runs a backfill inserting all the call_start parts from `call_parts` into the new table 

## Testing

migrated prod clone in 95 seconds. Peak memory consumption ~3.5GB

<img width="407" alt="Screenshot 2025-04-09 at 4 38 37 PM" src="https://github.com/user-attachments/assets/4feebb4e-c019-453a-9af8-81908f77e2e5" />

