### PR TITLE
chore(weave): remove unused code

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -137,9 +137,6 @@ from weave.trace_server.trace_server_interface_util import (
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-MAX_FLUSH_COUNT = 10000
-MAX_FLUSH_AGE = 15
-
 FILE_CHUNK_SIZE = 100000
 
 MAX_DELETE_CALLS_COUNT = 1000

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -52,10 +52,6 @@ from weave.trace_server.trace_server_interface_util import (
 )
 from weave.trace_server.validation import object_id_validator
 
-MAX_FLUSH_COUNT = 10000
-MAX_FLUSH_AGE = 15
-
-
 _conn_cursor: contextvars.ContextVar[
     Optional[tuple[sqlite3.Connection, sqlite3.Cursor]]
 ] = contextvars.ContextVar("conn_cursor", default=None)

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -70,10 +70,6 @@ def get_calls_merged_columns() -> list[Column]:
     return columns
 
 
-def calls_merged_table(table_alias: str) -> Table:
-    return Table(table_alias, get_calls_merged_columns())
-
-
 # SELECT
 #     *,
 #     Extracted Usage Fields

--- a/weave/trace_server/trace_server_interface_util.py
+++ b/weave/trace_server/trace_server_interface_util.py
@@ -28,26 +28,6 @@ def _order_dict(dictionary: dict) -> dict:
     }
 
 
-def encode_bytes_as_b64(contents: dict[str, bytes]) -> dict[str, str]:
-    res = {}
-    for k, v in contents.items():
-        if isinstance(v, bytes):
-            res[k] = base64.b64encode(v).decode("ascii")
-        else:
-            raise TypeError(f"Unexpected type for file {k}: {type(v)}")
-    return res
-
-
-def decode_b64_to_bytes(contents: dict[str, str]) -> dict[str, bytes]:
-    res = {}
-    for k, v in contents.items():
-        if isinstance(v, str):
-            res[k] = base64.b64decode(v.encode("ascii"))
-        else:
-            raise TypeError(f"Unexpected type for file {k}: {type(v)}")
-    return res
-
-
 valid_schemes = [
     TRACE_REF_SCHEME,
     ARTIFACT_REF_SCHEME,


### PR DESCRIPTION
## Description

After removing some code in https://github.com/wandb/weave/pull/4091 that I happened to notice wasn't used anywhere, I remembered that there are tools like [vulture](https://github.com/jendrikseipp/vulture) that can help with finding unused code. This is removing just a few of its detections.

