### PR TITLE
chore(weave): unpin transformers library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,7 @@ scorers = [
   "litellm>=1.58",
   "sentence-transformers>=3.3.1",
   "scikit-learn>=1.5.2",
-  # Pin until transformers releases https://github.com/huggingface/transformers/pull/37337
-  "transformers>=4.48.2,<4.51.0",
+  "transformers>=4.51.1",
   "torch>=2.4.1",
   "sentencepiece>=0.2.0",
   "pip>=20.0",                    # this is needed for presidio-analyzer to pull the spacy models


### PR DESCRIPTION
## Description

See https://github.com/wandb/weave/pull/4062 - latest release of transformers fixes the reason we had to have the version constraint.

