### PR TITLE
chore(weave): improve filter interactions, fewer refreshes

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -231,19 +231,14 @@ export const FilterBar = ({
       const items = localFilterModel.items.filter(f => f.id !== filterId);
       const newModel = {...localFilterModel, items};
       setLocalFilterModel(newModel);
-
-      // Apply filter removal immediately since this is a deliberate user action
-      const completeFilterItems = items.filter(
-        item => !isFilterIncomplete(item)
-      );
-      setFilterModel({...localFilterModel, items: completeFilterItems});
+      applyCompletedFilters(newModel);
 
       // Clear active edit if removed
       if (activeEditId === filterId) {
         setActiveEditId(null);
       }
     },
-    [localFilterModel, setFilterModel, activeEditId]
+    [localFilterModel, applyCompletedFilters, activeEditId]
   );
 
   const onSetSelected = useCallback(() => {
@@ -269,19 +264,19 @@ export const FilterBar = ({
 
     // Apply filter immediately (won't be incomplete)
     setLocalFilterModel(newModel);
-
-    // Use the consistent filter application
-    const completeFilters = newModel.items.filter(
-      item => !isFilterIncomplete(item)
-    );
-    setFilterModel({...newModel, items: completeFilters});
+    applyCompletedFilters(newModel);
 
     clearSelectedCalls();
     setAnchorEl(null);
 
     // Clear active edit when popover is closed
     setActiveEditId(null);
-  }, [localFilterModel, setFilterModel, selectedCalls, clearSelectedCalls]);
+  }, [
+    localFilterModel,
+    applyCompletedFilters,
+    selectedCalls,
+    clearSelectedCalls,
+  ]);
 
   const onFilterTagClick = useCallback((filterId: FilterId) => {
     setActiveEditId(filterId);


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24373](https://wandb.atlassian.net/browse/WB-24373)

Typing into the string filter leads to many more queries than necessary. Example:
- [11s query](https://us5.datadoghq.com/logs?query=trace_id%3A67f7fe1c00000000285d6f06728f0022&cols=host%2Cservice&event=AwAAAZYguMhY6jqs4AAAABhBWllndU02QUFBQ0xnOHI2S2E4dU9RQVkAAAAkMDE5NjIwYmMtZGU0Zi00N2YwLThmYzMtYzI0NWM2MGZkNDg1AAaBMQ&fromUser=true&index=&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1744304692493&to_ts=1744306703588&live=false) from user just bringing up the filter (before even typing)
- Then the actual[ full filter query](https://us5.datadoghq.com/logs?query=trace_id%3A67f7fe2f00000000e97a4c881cd8fa88&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZYguPNQIyesygAAABhBWllndVFrWUFBQ0xnOHI2S2E5bkpnQUMAAAAkMDE5NjIwYmMtZGU0Zi00N2YwLThmYzMtYzI0NWM2MGZkNDg1AAaAWw&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1744304711438&to_ts=1744306714374&live=false) when completed was only 2.5s

This pr:
- now considers the empty string an incomplete filter
- filters out incomplete filters from the filter state (including display)

## Testing

prod:
![filter-empty-value-prod](https://github.com/user-attachments/assets/8516a24b-b3b4-4eab-a952-91c21c96d7ac)


branch:
![filter-empty-value](https://github.com/user-attachments/assets/e09da562-a2b0-4576-8e24-bf74bf64a28b)



[WB-24373]: https://wandb.atlassian.net/browse/WB-24373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ