### PR TITLE
fix(weave): lazy import sqlite server for otel support

### DIFF
--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -9,7 +9,6 @@ from weave.trace import (
 )
 from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace.settings import should_redact_pii, use_server_cache
-from weave.trace_server import sqlite_trace_server
 from weave.trace_server.trace_server_interface import TraceServerInterface
 from weave.trace_server_bindings import remote_http_trace_server
 from weave.trace_server_bindings.caching_middleware_trace_server import (
@@ -206,6 +205,8 @@ def init_weave_get_server(
 
 
 def init_local() -> InitializedClient:
+    from weave.trace_server import sqlite_trace_server
+
     server = sqlite_trace_server.SqliteTraceServer("weave.db")
     server.setup_tables()
     client = weave_client.WeaveClient("none", "none", server)


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Defer import of sqlite trace server until the very rare init_local case. 

## Testing

Prod:
```python
>>> import weave
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/__init__.py", line 4, in <module>
    from weave.trace.api import *
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/api.py", line 12, in <module>
    from weave.trace import urls, weave_client, weave_init
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace/weave_init.py", line 12, in <module>
    from weave.trace_server import sqlite_trace_server
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace_server/sqlite_trace_server.py", line 34, in <module>
    from weave.trace_server.opentelemetry.python_spans import ResourceSpans
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace_server/opentelemetry/python_spans.py", line 34, in <module>
    from .attributes import (
  File "/Users/griffin/Desktop/core/services/weave-python/weave-public/weave/trace_server/opentelemetry/attributes.py", line 10, in <module>
    import openinference.semconv.trace as oi
ModuleNotFoundError: No module named 'openinference'
```

Branch:
```python
>>> import weave
>>> 
```

