### PR TITLE
chore(app): Update NumberInput to new designs

### DIFF
--- a/weave-js/src/common/components/elements/NumberInput.tsx
+++ b/weave-js/src/common/components/elements/NumberInput.tsx
@@ -1,11 +1,10 @@
 import {Icon, IconName} from '@wandb/weave/components/Icon';
-import _, {property} from 'lodash';
+import _ from 'lodash';
 import React from 'react';
 import {Input} from 'semantic-ui-react';
 
-import clamp from '../../util/clamp';
 import {Button} from '../../../components/Button';
-import {TextField} from '../../../components/Form/TextField';
+import clamp from '../../util/clamp';
 
 interface NumberInputProps {
   className?: string;

--- a/weave-js/src/common/components/elements/SliderInput.tsx
+++ b/weave-js/src/common/components/elements/SliderInput.tsx
@@ -29,6 +29,7 @@ export interface SliderInputProps {
     [key: string]: SliderKeyboardOperation;
   };
   onChange(value: number): void;
+  useStepperPlusMinus?: boolean;
 }
 
 export const INPUT_SLIDER_CLASS = 'input__slider';
@@ -51,6 +52,7 @@ const SliderInput: React.FC<SliderInputProps> = React.memo(
     strideLength,
     keyboardBindings,
     onChange,
+    useStepperPlusMinus = false,
   }) => {
     const [sliderValue, setSliderValue] = React.useState(value ?? 0);
 
@@ -194,6 +196,7 @@ const SliderInput: React.FC<SliderInputProps> = React.memo(
           value={value}
           ticks={ticks}
           onChange={update}
+          useStepperPlusMinus={useStepperPlusMinus}
         />
       );
     };

--- a/weave-js/src/common/css/NumberInput.less
+++ b/weave-js/src/common/css/NumberInput.less
@@ -18,3 +18,15 @@
     width: 10 * @spu
   }
 }
+
+.number-input-plus-minus {
+  &__input>input {
+    border: none !important;
+    width: 64px;
+    height: 24px;
+  }
+  &__input {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+}


### PR DESCRIPTION
## Description

This updates the NumberInput to have an option for the newest designs with a +/- stepper. Since the wider width may not be compatible with older usages, I added an optional prop so that it's opt-in as older ones are migrated. 

See designs here: 
https://www.figma.com/design/BsoKhzDe7Q8OX08owa9DuM/Media-panel-improvements?node-id=5257-141396&m=dev

## Testing

How was this PR tested?

Tested in https://github.com/wandb/core/pull/28695. It should only be enabled in that one place, which is currently behind a ramp flag.
