### PR TITLE
perf(weave): filter op_name pre group by 

### DIFF
--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -114,12 +114,13 @@ def test_query_heavy_column_simple_filter() -> None:
                 calls_merged.id AS id
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_1:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
+                    OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.started_at) IS NULL))))
-            AND
-                (any(calls_merged.op_name) IN {pb_0:Array(String)}))
+            )
         )
         SELECT
             calls_merged.id AS id,
@@ -155,12 +156,13 @@ def test_query_heavy_column_simple_filter_with_order() -> None:
                 calls_merged.id AS id
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_1:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
+                    OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.started_at) IS NULL))))
-            AND
-                (any(calls_merged.op_name) IN {pb_0:Array(String)}))
+            )
         )
         SELECT
             calls_merged.id AS id,
@@ -198,13 +200,13 @@ def test_query_heavy_column_simple_filter_with_order_and_limit() -> None:
                 calls_merged.id AS id
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_1:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
+                    OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
             AND
                 ((NOT ((any(calls_merged.started_at) IS NULL))))
-            AND
-                (any(calls_merged.op_name) IN {pb_0:Array(String)})
             )
             ORDER BY any(calls_merged.started_at) DESC
             LIMIT 10
@@ -270,6 +272,8 @@ def test_query_heavy_column_simple_filter_with_order_and_limit_and_mixed_query_c
                 calls_merged.id AS id
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_2:String}
+                AND ((calls_merged.op_name IN {pb_1:Array(String)})
+                    OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
                 ((any(calls_merged.wb_user_id) = {pb_0:String}))
@@ -277,8 +281,6 @@ def test_query_heavy_column_simple_filter_with_order_and_limit_and_mixed_query_c
                 ((any(calls_merged.deleted_at) IS NULL))
             AND
                 ((NOT ((any(calls_merged.started_at) IS NULL))))
-            AND
-                (any(calls_merged.op_name) IN {pb_1:Array(String)})
             )
         )
         SELECT
@@ -346,10 +348,13 @@ def test_query_light_column_with_costs() -> None:
                 SELECT calls_merged.id AS id
                 FROM calls_merged
                 WHERE calls_merged.project_id = {pb_1:String}
+                    AND ((calls_merged.op_name IN {pb_0:Array(String)})
+                        OR (calls_merged.op_name IS NULL))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING (((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.started_at) IS NULL))))
-                AND (any(calls_merged.op_name) IN {pb_0:Array(String)}))),
+                )
+            ),
             all_calls AS (
                 SELECT
                     calls_merged.id AS id,
@@ -538,13 +543,15 @@ def test_query_with_simple_feedback_sort_with_op_name() -> None:
             calls_merged
         WHERE
             calls_merged.project_id = {pb_1:String}
+            AND ((calls_merged.op_name IN {pb_0:Array(String)})
+                OR (calls_merged.op_name IS NULL))
         GROUP BY
             (calls_merged.project_id,
             calls_merged.id)
         HAVING
             (((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.started_at) IS NULL))))
-                    AND (any(calls_merged.op_name) IN {pb_0:Array(String)})))
+            ))
         SELECT
             calls_merged.id AS id
         FROM
@@ -1316,11 +1323,12 @@ def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
                 calls_merged.id AS id
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_1:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
+                    OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.started_at) IS NULL))))
-                AND (any(calls_merged.op_name) IN {pb_0:Array(String)})
             )
         )
         SELECT

--- a/weave/trace_server/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder.py
@@ -703,6 +703,12 @@ class CallsQuery(BaseModel):
                 having_conditions_sql, "AND"
             )
 
+        op_name_sql = process_op_name_filter_to_conditions(
+            self.hardcoded_filter,
+            pb,
+            table_alias,
+        )
+
         optimization_conditions = process_query_to_optimization_sql(
             self.query_conditions,
             pb,
@@ -787,6 +793,7 @@ class CallsQuery(BaseModel):
         {feedback_where_sql}
         {id_mask_sql}
         {id_subquery_sql}
+        {op_name_sql}
         {str_filter_opt_sql}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         {having_filter_sql}
@@ -1048,44 +1055,67 @@ def process_query_to_conditions(
     )
 
 
+def process_op_name_filter_to_conditions(
+    hardcoded_filter: Optional[HardCodedFilter],
+    param_builder: ParamBuilder,
+    table_alias: str,
+) -> str:
+    """Pulls out the op_name and returns a sql string if there are any op_names."""
+    if hardcoded_filter is None or not hardcoded_filter.filter.op_names:
+        return ""
+
+    op_names = hardcoded_filter.filter.op_names
+
+    assert_parameter_length_less_than_max("op_names", len(op_names))
+
+    # We will build up (0 or 1) + N conditions for the op_version_refs
+    # If there are any non-wildcarded names, then we at least have an IN condition
+    # If there are any wildcarded names, then we have a LIKE condition for each
+    or_conditions: list[str] = []
+    non_wildcarded_names: list[str] = []
+    wildcarded_names: list[str] = []
+
+    op_field = get_field_by_name("op_name")
+    if not isinstance(op_field, CallsMergedAggField):
+        raise TypeError("op_name is not an aggregate field")
+
+    op_field_sql = op_field.as_sql(param_builder, table_alias, use_agg_fn=False)
+    for name in op_names:
+        if name.endswith(WILDCARD_ARTIFACT_VERSION_AND_PATH):
+            wildcarded_names.append(name)
+        else:
+            non_wildcarded_names.append(name)
+
+    if non_wildcarded_names:
+        or_conditions.append(
+            f"{op_field_sql} IN {_param_slot(param_builder.add_param(non_wildcarded_names), 'Array(String)')}"
+        )
+
+    for name in wildcarded_names:
+        like_name = name[: -len(WILDCARD_ARTIFACT_VERSION_AND_PATH)] + ":%"
+        or_conditions.append(
+            f"{op_field_sql} LIKE {_param_slot(param_builder.add_param(like_name), 'String')}"
+        )
+
+    if not or_conditions:
+        return ""
+
+    # Account for unmerged call parts by including null op_name (call ends)
+    or_conditions += [f"{op_field_sql} IS NULL"]
+
+    return " AND " + combine_conditions(or_conditions, "OR")
+
+
 def process_calls_filter_to_conditions(
     filter: tsi.CallsFilter,
     param_builder: ParamBuilder,
     table_alias: str,
 ) -> list[str]:
-    """Converts a CallsFilter to a list of conditions for a clickhouse query."""
+    """Converts a CallsFilter to a list of conditions for a clickhouse query.
+
+    Excludes the op_name, which is handled separately.
+    """
     conditions: list[str] = []
-
-    if filter.op_names:
-        assert_parameter_length_less_than_max("op_names", len(filter.op_names))
-
-        # We will build up (0 or 1) + N conditions for the op_version_refs
-        # If there are any non-wildcarded names, then we at least have an IN condition
-        # If there are any wildcarded names, then we have a LIKE condition for each
-
-        or_conditions: list[str] = []
-
-        non_wildcarded_names: list[str] = []
-        wildcarded_names: list[str] = []
-        for name in filter.op_names:
-            if name.endswith(WILDCARD_ARTIFACT_VERSION_AND_PATH):
-                wildcarded_names.append(name)
-            else:
-                non_wildcarded_names.append(name)
-
-        if non_wildcarded_names:
-            or_conditions.append(
-                f"{get_field_by_name('op_name').as_sql(param_builder, table_alias)} IN {_param_slot(param_builder.add_param(non_wildcarded_names), 'Array(String)')}"
-            )
-
-        for name in wildcarded_names:
-            like_name = name[: -len(WILDCARD_ARTIFACT_VERSION_AND_PATH)] + ":%"
-            or_conditions.append(
-                f"{get_field_by_name('op_name').as_sql(param_builder, table_alias)} LIKE {_param_slot(param_builder.add_param(like_name), 'String')}"
-            )
-
-        if or_conditions:
-            conditions.append(combine_conditions(or_conditions, "OR"))
 
     if filter.input_refs:
         assert_parameter_length_less_than_max("input_refs", len(filter.input_refs))


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24386](https://wandb.atlassian.net/browse/WB-24386)

In this pr we handle the `op_name` separately from the other having conditions. So we can pull it before the group by. Because ALL call starts are guaranteed to have an `op_name` we can always filter by `op_name LIKE <> or op_name is NULL` to grab all possible rows that match. 

Example:
```sql
SELECT calls_merged.id AS id
   FROM calls_merged
   WHERE calls_merged.project_id = {pb_263_2:String}
     -------------------------
     AND ((calls_merged.op_name LIKE {pb_263_1:String}) OR (calls_merged.op_name IS NULL))
     -------------------------
   GROUP BY (calls_merged.project_id,
             calls_merged.id)
   HAVING (((any(calls_merged.started_at) > {pb_263_0:Float64}))
           AND ((any(calls_merged.deleted_at) IS NULL))
           AND ((NOT ((any(calls_merged.started_at) IS NULL)))))
   ORDER BY any(calls_merged.started_at) DESC
   LIMIT 50
   OFFSET 0
```

## Testing

- update unit tests

Replica tests:
| Environment | Num Runs | Avg Mem     | Rows Read | p50 Latency | p90 Latency | p99 Latency |
|-------------|----------|-------------|-----------|-------------|-------------|-------------|
| prod        | 7        | 3.47 GiB    | 8,451,140 | 2.294s      | 4.534s      | 4.534s      |
| branch      | 9        | 204.58 MiB  | 8,451,140 | 1.366s      | 1.643s      | 1.643s      |


[WB-24386]: https://wandb.atlassian.net/browse/WB-24386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ