### PR TITLE
fix(weave): length calculation when offset > available

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -351,7 +351,7 @@ def _make_calls_iterator(
         )
         if limit_override is not None:
             offset = offset_override or 0
-            return min(limit_override, response.count - offset)
+            return min(limit_override, max(0, response.count - offset))
         if offset_override is not None:
             return response.count - offset_override
         return response.count


### PR DESCRIPTION
## Description

Consider the API call:
```
import weave

client = weave.init("jamie-rasmussen/2025-04-11_values")
calls = client.get_calls(
    filter={"trace_roots_only": True},
    query={"$expr":{"$gt":[{"$getField":"started_at"},{"$literal":1743780131.121}]}},
    sort_by=[{"field":"started_at","direction":"desc"}],
    limit=1000,
    offset=0,
)
```

This returned 110 results. If I run the query with an offset greater than that, e.g.
```
import weave

client = weave.init("jamie-rasmussen/2025-04-11_values")
calls = client.get_calls(
    filter={"trace_roots_only": True},
    query={"$expr":{"$gt":[{"$getField":"started_at"},{"$literal":1743780131.121}]}},
    sort_by=[{"field":"started_at","direction":"desc"}],
    limit=1000,
    offset=500,
)
```

I will get: `ValueError: __len__() should return >= 0`