### PR TITLE
fix(weave): paginated iterator offset fix

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -537,6 +537,37 @@ def test_get_calls_limit_offset(client):
         assert call.inputs["a"] == 7 + i
 
 
+def test_get_calls_page_size_with_offset(client):
+    batch_size = 3
+    batch_num = 0
+    all_call_ids = []
+    all_values = []
+
+    while True:
+        call_batch = client.get_calls(
+            limit=batch_size,
+            offset=batch_num * batch_size,
+            page_size=2,
+        )
+
+        # Convert to list to force fetch
+        call_batch_list = list(call_batch)
+        if not call_batch_list:
+            break
+
+        # Store call IDs
+        batch_call_ids = [call.id for call in call_batch_list]
+        all_call_ids.extend(batch_call_ids)
+
+        values = [call.inputs["a"] for call in call_batch_list]
+        all_values.extend(values)
+        batch_num += 1
+
+    assert len(all_call_ids) == 10
+    assert all_call_ids == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert all_values == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
 def test_calls_delete(client):
     call0 = client.create_call("x", {"a": 5, "b": 10})
     call0_child1 = client.create_call("x", {"a": 5, "b": 11}, call0)

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -538,7 +538,10 @@ def test_get_calls_limit_offset(client):
 
 
 def test_get_calls_page_size_with_offset(client):
-    batch_size = 3
+    for i in range(20):
+        client.create_call("x", {"a": i})
+
+    batch_size = 5
     batch_num = 0
     all_call_ids = []
     all_values = []
@@ -563,9 +566,8 @@ def test_get_calls_page_size_with_offset(client):
         all_values.extend(values)
         batch_num += 1
 
-    assert len(all_call_ids) == 10
-    assert all_call_ids == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-    assert all_values == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    assert len(all_call_ids) == 20
+    assert all_values == list(range(20))
 
 
 def test_calls_delete(client):

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -198,9 +198,6 @@ class PaginatedIterator(Generic[T, R]):
         if self.limit is not None and index >= self.limit + (self.offset or 0):
             raise IndexError(f"Index {index} out of range")
 
-        if self.offset is not None:
-            index += self.offset
-
         page_index = index // self.page_size
         page_offset = index % self.page_size
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -180,8 +180,6 @@ class PaginatedIterator(Generic[T, R]):
             raise ValueError("page_size must be greater than 0")
         if limit is not None and limit <= 0:
             raise ValueError("limit must be greater than 0")
-        if offset is not None and offset < 0:
-            raise ValueError("offset must be greater than or equal to 0")
 
     @lru_cache
     def _fetch_page(self, index: int) -> list[T]:
@@ -361,6 +359,9 @@ def _make_calls_iterator(
         if offset_override is not None:
             return response.count - offset_override
         return response.count
+
+    if offset_override is not None and offset_override < 0:
+        raise ValueError("offset must be greater than or equal to 0")
 
     return PaginatedIterator(
         fetch_func,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24388](https://wandb.atlassian.net/browse/WB-24388)

We are doubling the offset when we fire the fetch func when we provide an offset override to PaginatedIterator. 

## Testing

adds unit test


[WB-24388]: https://wandb.atlassian.net/browse/WB-24388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ