### PR TITLE
chore(weave): increase filter bar debounce + fix character reappearing

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -224,7 +224,7 @@ export const FilterBar = ({
         debouncedSetFilterModel(newItemsModel);
       }
     },
-    [localFilterModel, debouncedSetFilterModel, applyCompletedFilters]
+    [localFilterModel, debouncedSetFilterModel]
   );
 
   const onRemoveFilter = useCallback(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -222,9 +222,6 @@ export const FilterBar = ({
       // Only trigger debounced update if the filter is complete
       if (!isFilterIncomplete(item)) {
         debouncedSetFilterModel(newItemsModel);
-      } else if (item.value === '') {
-        // Edge case for when we remove the filter
-        applyCompletedFilters(newItemsModel);
       }
     },
     [localFilterModel, debouncedSetFilterModel, applyCompletedFilters]

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -30,7 +30,7 @@ import {combineRangeFilters, getNextFilterId} from './filterUtils';
 import {GroupedOption, SelectFieldOption} from './SelectField';
 import {VariableChildrenDisplay} from './VariableChildrenDisplayer';
 
-const DEBOUNCE_MS = 700;
+const DEBOUNCE_MS = 1_000;
 
 type FilterBarProps = {
   entity: string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -195,6 +195,7 @@ export const FilterBar = ({
 
   const onUpdateFilter = useCallback(
     (item: GridFilterItem) => {
+      debouncedSetFilterModel.cancel();
       const oldItems = localFilterModel.items;
       const index = oldItems.findIndex(f => f.id === item.id);
 
@@ -221,9 +222,12 @@ export const FilterBar = ({
       // Only trigger debounced update if the filter is complete
       if (!isFilterIncomplete(item)) {
         debouncedSetFilterModel(newItemsModel);
+      } else if (item.value === '') {
+        // Edge case for when we remove the filter
+        applyCompletedFilters(newItemsModel);
       }
     },
-    [localFilterModel, debouncedSetFilterModel]
+    [localFilterModel, debouncedSetFilterModel, applyCompletedFilters]
   );
 
   const onRemoveFilter = useCallback(


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24415](https://wandb.atlassian.net/browse/WB-24415)

This pr: 
- increases the debounce time from 700ms to 1s
- fixes an issue with the string filter where rapidly deleting the filter results in the last character reappearing
   - Now we explicitly keep track of incomplete filters. We only submit filters that are complete, and keep in local state the rest. This is only when a filter row has been modified from complete to incomplete. Instead of removing the entire row, which causes a large UI change and the filter to disappear, we keep it around in local state and render it with the value field as empty (which is what you expect as a user). 
   - This should feel exactly the same as the current flow, without the reappearing character bug, _and_ now when the filter is incomplete we query the backend as if the filter was not present. 

## Testing

prod:
![filter-debounce-prod-2](https://github.com/user-attachments/assets/da9f6ce4-a057-4286-9e94-4a5ef7968188)

branch:
![filter-debounce-branch](https://github.com/user-attachments/assets/85b435e6-7a4c-4b16-b1c2-56c755af3824)


[WB-24415]: https://wandb.atlassian.net/browse/WB-24415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ