### PR TITLE
chore(weave): Add gpt4.1 models, makes 4.1-mini the default

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
@@ -4,49 +4,59 @@ import levenshtein from 'js-levenshtein';
 // Directly from the pycache model_providers.json in trace_server.
 // Some were removed because they are not supported when Josiah tried on Oct 30, 2024.
 export const LLM_MAX_TOKENS = {
-  'gpt-4o-mini': {
+  'gpt-4.1-mini-2025-04-14': {
+    provider: 'openai',
+    max_tokens: 32768,
+    supports_function_calling: true,
+  },
+  'gpt-4.1-mini': {
+    provider: 'openai',
+    max_tokens: 32768,
+    supports_function_calling: true,
+  },
+  'gpt-4.1-2025-04-14': {
+    provider: 'openai',
+    max_tokens: 32768,
+    supports_function_calling: true,
+  },
+  'gpt-4.1': {
+    provider: 'openai',
+    max_tokens: 32768,
+    supports_function_calling: true,
+  },
+  'gpt-4.1-nano-2025-04-14': {
+    provider: 'openai',
+    max_tokens: 32768,
+    supports_function_calling: true,
+  },
+  'gpt-4.1-nano': {
+    provider: 'openai',
+    max_tokens: 32768,
+    supports_function_calling: true,
+  },
+  'gpt-4.5-preview-2025-02-27': {
     provider: 'openai',
     max_tokens: 16384,
     supports_function_calling: true,
   },
-  'gpt-3.5-turbo-0125': {
+  'gpt-4.5-preview': {
     provider: 'openai',
-    max_tokens: 4096,
+    max_tokens: 16384,
     supports_function_calling: true,
   },
-  'gpt-3.5-turbo-1106': {
+  'o3-mini-2025-01-31': {
     provider: 'openai',
-    max_tokens: 4096,
+    max_tokens: 100000,
     supports_function_calling: true,
   },
-  'gpt-4-1106-preview': {
+  'o3-mini': {
     provider: 'openai',
-    max_tokens: 4096,
+    max_tokens: 100000,
     supports_function_calling: true,
   },
-  'gpt-4-32k-0314': {
+  'gpt-4o-mini': {
     provider: 'openai',
-    max_tokens: 4096,
-    supports_function_calling: false,
-  },
-  'gpt-4-turbo-2024-04-09': {
-    provider: 'openai',
-    max_tokens: 4096,
-    supports_function_calling: true,
-  },
-  'gpt-4-turbo-preview': {
-    provider: 'openai',
-    max_tokens: 4096,
-    supports_function_calling: true,
-  },
-  'gpt-4-turbo': {
-    provider: 'openai',
-    max_tokens: 4096,
-    supports_function_calling: true,
-  },
-  'gpt-4': {
-    provider: 'openai',
-    max_tokens: 4096,
+    max_tokens: 16384,
     supports_function_calling: true,
   },
   'gpt-4o-2024-05-13': {
@@ -99,24 +109,44 @@ export const LLM_MAX_TOKENS = {
     max_tokens: 100000,
     supports_function_calling: true,
   },
-  'o3-mini': {
+  'gpt-4-1106-preview': {
     provider: 'openai',
-    max_tokens: 100000,
+    max_tokens: 4096,
     supports_function_calling: true,
   },
-  'o3-mini-2025-01-31': {
+  'gpt-4-32k-0314': {
     provider: 'openai',
-    max_tokens: 100000,
+    max_tokens: 4096,
+    supports_function_calling: false,
+  },
+  'gpt-4-turbo-2024-04-09': {
+    provider: 'openai',
+    max_tokens: 4096,
     supports_function_calling: true,
   },
-  'gpt-4.5-preview': {
+  'gpt-4-turbo-preview': {
     provider: 'openai',
-    max_tokens: 16384,
+    max_tokens: 4096,
     supports_function_calling: true,
   },
-  'gpt-4.5-preview-2025-02-27': {
+  'gpt-4-turbo': {
     provider: 'openai',
-    max_tokens: 16384,
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'gpt-4': {
+    provider: 'openai',
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'gpt-3.5-turbo-0125': {
+    provider: 'openai',
+    max_tokens: 4096,
+    supports_function_calling: true,
+  },
+  'gpt-3.5-turbo-1106': {
+    provider: 'openai',
+    max_tokens: 4096,
     supports_function_calling: true,
   },
 
@@ -560,7 +590,7 @@ export const LLM_MAX_TOKENS = {
   },
 };
 
-export const DEFAULT_LLM_MODEL: LLMMaxTokensKey = 'gpt-4o-mini-2024-07-18';
+export const DEFAULT_LLM_MODEL: LLMMaxTokensKey = 'gpt-4.1-mini-2025-04-14';
 
 export type LLMMaxTokensKey = keyof typeof LLM_MAX_TOKENS;
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -6,7 +6,11 @@ import {
   hasStringProp,
   isAnthropicCompletionFormat,
 } from '../ChatView/hooks';
-import {LLM_MAX_TOKENS_KEYS, LLMMaxTokensKey} from './llmMaxTokens';
+import {
+  DEFAULT_LLM_MODEL,
+  LLM_MAX_TOKENS_KEYS,
+  LLMMaxTokensKey,
+} from './llmMaxTokens';
 import {
   OptionalTraceCallSchema,
   PlaygroundResponseFormats,
@@ -21,8 +25,6 @@ export const DEFAULT_SYSTEM_MESSAGE = {
   role: 'system',
   content: DEFAULT_SYSTEM_MESSAGE_CONTENT,
 };
-
-const DEFAULT_MODEL = 'gpt-4o-mini-2024-07-18' as LLMMaxTokensKey;
 
 const DEFAULT_PLAYGROUND_STATE = {
   traceCall: {
@@ -42,7 +44,7 @@ const DEFAULT_PLAYGROUND_STATE = {
   presencePenalty: 0,
   nTimes: 1,
   maxTokensLimit: 16384,
-  model: DEFAULT_MODEL,
+  model: DEFAULT_LLM_MODEL,
   selectedChoiceIndex: 0,
 };
 
@@ -155,7 +157,7 @@ export const usePlaygroundState = () => {
             ) as LLMMaxTokensKey;
           }
           if (newState.model === undefined) {
-            newState.model = DEFAULT_MODEL;
+            newState.model = DEFAULT_LLM_MODEL;
           }
         }
         return [newState];

--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -6754,5 +6754,53 @@
       "output": 4.4e-06,
       "created_at": "2025-04-14 09:41:48"
     }
+  ],
+  "gpt-4.1": [
+    {
+      "provider": "openai",
+      "input": 2e-06,
+      "output": 8e-06,
+      "created_at": "2025-04-14 12:39:15"
+    }
+  ],
+  "gpt-4.1-2025-04-14": [
+    {
+      "provider": "openai",
+      "input": 2e-06,
+      "output": 8e-06,
+      "created_at": "2025-04-14 12:39:15"
+    }
+  ],
+  "gpt-4.1-mini": [
+    {
+      "provider": "openai",
+      "input": 4e-07,
+      "output": 1.6e-06,
+      "created_at": "2025-04-14 12:39:15"
+    }
+  ],
+  "gpt-4.1-mini-2025-04-14": [
+    {
+      "provider": "openai",
+      "input": 4e-07,
+      "output": 1.6e-06,
+      "created_at": "2025-04-14 12:39:15"
+    }
+  ],
+  "gpt-4.1-nano": [
+    {
+      "provider": "openai",
+      "input": 1e-07,
+      "output": 4e-07,
+      "created_at": "2025-04-14 12:39:15"
+    }
+  ],
+  "gpt-4.1-nano-2025-04-14": [
+    {
+      "provider": "openai",
+      "input": 1e-07,
+      "output": 4e-07,
+      "created_at": "2025-04-14 12:39:15"
+    }
   ]
 }

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -15,6 +15,30 @@
     "litellm_provider": "openai",
     "api_key_name": "OPENAI_API_KEY"
   },
+  "gpt-4.1": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-4.1-2025-04-14": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-4.1-mini": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-4.1-mini-2025-04-14": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-4.1-nano": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
+  "gpt-4.1-nano-2025-04-14": {
+    "litellm_provider": "openai",
+    "api_key_name": "OPENAI_API_KEY"
+  },
   "gpt-4o": {
     "litellm_provider": "openai",
     "api_key_name": "OPENAI_API_KEY"


### PR DESCRIPTION
## Description
also reorgs dropdown to have newer models closer to the top
updates costs and model providers to have 4.1 models

<img width="682" alt="Screenshot 2025-04-14 at 12 48 31 PM" src="https://github.com/user-attachments/assets/c57adeb5-fcc7-42ee-8306-33ecb6fd8969" />

https://github.com/user-attachments/assets/311bf432-0973-4c7e-90dc-2a0eade8366a


## Testing

How was this PR tested?
