### PR TITLE
fix(ui): limit expansion of nested call data in add to dataset flow

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetDrawerContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetDrawerContext.tsx
@@ -4,6 +4,7 @@ import React, {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useReducer,
 } from 'react';
 
@@ -16,8 +17,8 @@ import {FieldConfig} from './NewDatasetSchemaStep';
 import {
   CallData,
   createProcessedRowsMap,
+  createTargetSchema,
   FieldMapping,
-  inferSchema,
   mapCallsToDatasetRows,
   suggestFieldMappings,
 } from './schemaUtils';
@@ -84,7 +85,7 @@ export interface DatasetDrawerState {
 export type DatasetDrawerAction =
   | {
       type: typeof ACTION_TYPES.SET_CURRENT_STEP;
-      payload: {step: number; setAddedRows?: (rows: Map<string, any>) => void};
+      payload: {step: number};
     }
   | {type: typeof ACTION_TYPES.SET_DATASETS; payload: ObjectVersionSchema[]}
   | {
@@ -110,7 +111,6 @@ export type DatasetDrawerAction =
       type: typeof ACTION_TYPES.PROCESS_ROWS_FOR_EDITOR;
       payload?: {
         selectedCalls: CallData[];
-        setAddedRows?: (rows: Map<string, any>) => void;
       };
     }
   | {type: typeof ACTION_TYPES.SET_USER_MODIFIED_MAPPINGS; payload: boolean};
@@ -164,14 +164,12 @@ function handleTransitionToStep1(
  * @param state - Current state of the dataset drawer
  * @param newStep - The step number to transition to
  * @param currentStep - The current step number
- * @param setAddedRows - Optional callback to update rows in the editor
  * @returns Updated state after the step transition
  */
 function handleStepTransition(
   state: DatasetDrawerState,
   newStep: number,
-  currentStep: number,
-  setAddedRows?: (rows: Map<string, any>) => void
+  currentStep: number
 ): DatasetDrawerState {
   // Handle step transition from 1 to 2 specifically
   if (currentStep === 1 && newStep === 2) {
@@ -203,10 +201,10 @@ function datasetDrawerReducer(
       // Extract parameters from the action payload
       const newStep = action.payload.step;
       const currentStep = state.currentStep;
-      const setAddedRows = action.payload.setAddedRows;
 
-      // Use the helper function to handle the step transition
-      return handleStepTransition(state, newStep, currentStep, setAddedRows);
+      // No longer storing setAddedRows in the action payload
+      // Just return the state transition without calling setAddedRows directly
+      return handleStepTransition(state, newStep, currentStep);
     }
 
     case ACTION_TYPES.SET_DATASETS:
@@ -274,7 +272,7 @@ function datasetDrawerReducer(
       const mappings = suggestFieldMappings(
         state.sourceSchema,
         action.payload,
-        state.selectedDataset ? state.fieldMappings : []
+        state.fieldMappings
       );
 
       return {
@@ -311,7 +309,7 @@ function datasetDrawerReducer(
         return state;
       }
 
-      const {selectedCalls, setAddedRows} = action.payload;
+      const {selectedCalls} = action.payload;
       const isNewDataset = state.selectedDataset === null;
 
       try {
@@ -344,11 +342,7 @@ function datasetDrawerReducer(
           state.datasetObject
         );
 
-        // Update the editor with the processed rows
-        if (setAddedRows) {
-          setAddedRows(processedRowsMap);
-        }
-
+        // We don't set the rows directly here anymore - return the processed rows in state
         return {
           ...state,
           processedRows: processedRowsMap,
@@ -463,14 +457,22 @@ const DatasetDrawerProviderInner: React.FC<DatasetDrawerProviderProps> = ({
 
   const [state, dispatch] = useReducer(wrappedReducer, initialState);
 
+  // Effect to update editor rows when processedRows changes
+  // This solves the setState-during-render problem by moving the state update to an effect
+  useEffect(() => {
+    if (state.processedRows.size > 0 && !state.addedRowsDirty) {
+      setAddedRows(state.processedRows);
+    }
+  }, [state.processedRows, state.addedRowsDirty, setAddedRows]);
+
   // Memoized action dispatchers
   const setCurrentStep = useCallback(
     (step: number) =>
       dispatch({
         type: ACTION_TYPES.SET_CURRENT_STEP,
-        payload: {step, setAddedRows: step === 2 ? setAddedRows : undefined},
+        payload: {step},
       }),
-    [setAddedRows]
+    []
   );
 
   const handleDatasetSelect = useCallback(
@@ -506,7 +508,7 @@ const DatasetDrawerProviderInner: React.FC<DatasetDrawerProviderProps> = ({
 
       // If rows data is provided, infer the target schema
       if (rowsData && rowsData.length > 0) {
-        const inferredSchema = inferSchema(rowsData.map(row => row.val));
+        const inferredSchema = createTargetSchema(rowsData.map(row => row.val));
 
         // Setting the target schema will also trigger field mapping suggestions
         // in the reducer's SET_TARGET_SCHEMA case
@@ -671,11 +673,10 @@ const DatasetDrawerProviderInner: React.FC<DatasetDrawerProviderProps> = ({
         type: ACTION_TYPES.PROCESS_ROWS_FOR_EDITOR,
         payload: {
           selectedCalls,
-          setAddedRows,
         },
       });
     },
-    [dispatch, setAddedRows]
+    [dispatch]
   );
 
   // Add reset edit state - now uses both contexts

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/__tests__/DatasetDrawerContext.test.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/__tests__/DatasetDrawerContext.test.tsx
@@ -32,7 +32,7 @@ vi.mock('../schemaUtils', () => ({
     return new Map([['call1', {text: 'Sample text'}]]);
   }),
   filterRowsForNewDataset: vi.fn(rows => rows),
-  inferSchema: vi.fn(() => []),
+  createTargetSchema: vi.fn(() => []),
 }));
 
 // Test component to expose context values

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
@@ -1,4 +1,13 @@
-import {flattenObject, inferSchema, inferType} from './schemaUtils';
+import {
+  CallData,
+  createProcessedRowsMap,
+  createSourceSchema,
+  createTargetSchema,
+  extractTopLevelFields,
+  inferType,
+  mapCallsToDatasetRows,
+  unwrapRefValue,
+} from './schemaUtils';
 
 describe('inferType', () => {
   test('identifies null type', () => {
@@ -27,16 +36,8 @@ describe('inferType', () => {
   });
 });
 
-describe('flattenObject', () => {
-  test('flattens simple object', () => {
-    const result = flattenObject({a: 1, b: 'test'});
-    expect(result).toEqual([
-      {name: 'a', type: 'number'},
-      {name: 'b', type: 'string'},
-    ]);
-  });
-
-  test('flattens nested objects', () => {
+describe('extractTopLevelFields', () => {
+  test('extracts only top-level fields', () => {
     const obj = {
       user: {
         name: 'Alice',
@@ -47,80 +48,503 @@ describe('flattenObject', () => {
       age: 30,
     };
 
-    expect(flattenObject(obj)).toEqual([
-      {name: 'user.name', type: 'string'},
-      {name: 'user.address.city', type: 'string'},
+    expect(extractTopLevelFields(obj)).toEqual([
+      {name: 'user', type: 'object'},
       {name: 'age', type: 'number'},
     ]);
   });
 
-  test('handles arrays as leaf nodes', () => {
+  test('handles arrays as single fields', () => {
     const obj = {tags: ['a', 'b', 'c']};
-    expect(flattenObject(obj)).toEqual([{name: 'tags', type: 'array'}]);
+    expect(extractTopLevelFields(obj)).toEqual([{name: 'tags', type: 'array'}]);
   });
 
-  test('handles date objects', () => {
-    const date = new Date();
-    const obj = {created: date};
-    expect(flattenObject(obj)).toEqual([{name: 'created', type: 'date'}]);
-  });
-
-  test('handles null values', () => {
-    const obj = {value: null};
-    expect(flattenObject(obj)).toEqual([{name: 'value', type: 'null'}]);
-  });
-
-  test('handles undefined values', () => {
-    const obj = {value: undefined};
-    expect(flattenObject(obj)).toEqual([{name: 'value', type: 'undefined'}]);
-  });
-});
-
-describe('inferSchema', () => {
-  test('infers schema from single object', () => {
-    const data = {name: 'Alice', age: 30};
-    expect(inferSchema(data)).toEqual([
-      {name: 'name', type: 'string'},
-      {name: 'age', type: 'number'},
-    ]);
-  });
-
-  test('merges types from multiple objects', () => {
-    const data = [
-      {name: 'Alice', age: 30},
-      {name: 'Bob', age: 'thirty'},
-    ];
-
-    expect(inferSchema(data)).toEqual([
-      {name: 'name', type: 'string'},
-      {name: 'age', type: 'number | string'},
-    ]);
-  });
-
-  test('handles nested structures', () => {
-    const data = [{user: {name: 'Alice'}}, {user: {age: 30}}];
-
-    expect(inferSchema(data)).toEqual([
+  test('handles prefix correctly', () => {
+    const obj = {name: 'Alice', age: 30};
+    expect(extractTopLevelFields(obj, 'user')).toEqual([
       {name: 'user.name', type: 'string'},
       {name: 'user.age', type: 'number'},
     ]);
   });
+});
+
+describe('createTargetSchema', () => {
+  test('creates schema from single object', () => {
+    const data = {name: 'Alice', age: 30};
+    expect(createTargetSchema(data)).toEqual([
+      {name: 'name', type: 'string'},
+      {name: 'age', type: 'number'},
+    ]);
+  });
+
+  test('handles arrays as single fields with array type', () => {
+    const data = {
+      name: 'Alice',
+      tags: ['tag1', 'tag2'],
+      scores: [90, 85, 95],
+    };
+
+    expect(createTargetSchema(data)).toEqual([
+      {name: 'name', type: 'string'},
+      {name: 'tags', type: 'array'},
+      {name: 'scores', type: 'array'},
+    ]);
+  });
+
+  test('does not flatten nested objects in target schema', () => {
+    const data = {
+      user: {
+        name: 'Alice',
+        profile: {
+          age: 30,
+          hobbies: ['reading', 'coding'],
+        },
+      },
+    };
+
+    expect(createTargetSchema(data)).toEqual([{name: 'user', type: 'object'}]);
+  });
 
   test('handles empty input', () => {
-    expect(inferSchema([])).toEqual([]);
-    expect(inferSchema({})).toEqual([]);
+    expect(createTargetSchema([])).toEqual([]);
+    expect(createTargetSchema({})).toEqual([]);
   });
 
   test('handles mixed types including null/undefined', () => {
+    const data = {
+      value1: 42,
+      value2: null,
+      value3: 'text',
+      value4: undefined,
+    };
+
+    expect(createTargetSchema(data)).toEqual([
+      {name: 'value1', type: 'number'},
+      {name: 'value2', type: 'null'},
+      {name: 'value3', type: 'string'},
+      {name: 'value4', type: 'undefined'},
+    ]);
+  });
+
+  test('processes arrays of objects (dataset rows)', () => {
     const data = [
-      {value: 42},
-      {value: null},
-      {value: 'text'},
-      {value: undefined},
+      {id: 1, name: 'Alice', tags: ['tag1', 'tag2']},
+      {id: 2, name: 'Bob', details: {age: 30}},
+      {id: 3, name: 'Charlie', scores: [90, 95, 100]},
     ];
 
-    expect(inferSchema(data)).toEqual([
-      {name: 'value', type: 'number | null | string | undefined'},
+    expect(createTargetSchema(data)).toEqual([
+      {name: 'id', type: 'number'},
+      {name: 'name', type: 'string'},
+      {name: 'tags', type: 'array'},
+      {name: 'details', type: 'object'},
+      {name: 'scores', type: 'array'},
     ]);
+  });
+});
+
+describe('createSourceSchema', () => {
+  const mockTraceCallProps = {
+    project_id: 'test-project',
+    id: 'test-id',
+    op_name: 'test-op',
+    trace_id: 'test-trace',
+    span_id: 'test-span',
+    timestamp: 123456789,
+    started_at: '123456789',
+    attributes: {},
+  };
+
+  test('creates schema from call data with top-level fields only', () => {
+    const calls: CallData[] = [
+      {
+        digest: '123',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {
+            prompt: 'Hello',
+            options: {
+              temperature: 0.7,
+              details: {
+                mode: 'creative',
+              },
+            },
+          },
+          output: 'Hi there!',
+        },
+      },
+    ];
+
+    expect(createSourceSchema(calls)).toEqual([
+      {name: 'inputs.prompt', type: 'string'},
+      {name: 'inputs.options', type: 'object'},
+      {name: 'output', type: 'string'},
+    ]);
+  });
+
+  test('handles structured outputs', () => {
+    const calls: CallData[] = [
+      {
+        digest: '123',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {prompt: 'Tell me about Paris'},
+          output: {
+            text: 'Paris is the capital of France',
+            metadata: {
+              confidence: 0.95,
+              sources: ['Wikipedia'],
+            },
+          },
+        },
+      },
+    ];
+
+    expect(createSourceSchema(calls)).toEqual([
+      {name: 'inputs.prompt', type: 'string'},
+      {name: 'output.text', type: 'string'},
+      {name: 'output.metadata', type: 'object'},
+    ]);
+  });
+
+  test('filters out inputs.self and merges duplicates', () => {
+    const calls: CallData[] = [
+      {
+        digest: '123',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {
+            prompt: 'Hello',
+            self: {id: '456'},
+          },
+          output: 'Hi',
+        },
+      },
+      {
+        digest: '456',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {
+            prompt: 'Goodbye',
+          },
+          output: 'Bye',
+        },
+      },
+    ];
+
+    expect(createSourceSchema(calls)).toEqual([
+      {name: 'inputs.prompt', type: 'string'},
+      {name: 'output', type: 'string'},
+    ]);
+  });
+});
+
+describe('mapCallsToDatasetRows', () => {
+  const mockTraceCallProps = {
+    project_id: 'test-project',
+    id: 'test-id',
+    op_name: 'test-op',
+    trace_id: 'test-trace',
+    span_id: 'test-span',
+    timestamp: 123456789,
+    started_at: '123456789',
+    attributes: {},
+  };
+
+  test('maps calls to rows with primitive values', () => {
+    const calls: CallData[] = [
+      {
+        digest: 'call1',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {
+            prompt: 'Hello world',
+            temperature: 0.7,
+          },
+          output: 'Response text',
+        },
+      },
+    ];
+
+    const fieldMappings = [
+      {sourceField: 'inputs.prompt', targetField: 'prompt'},
+      {sourceField: 'inputs.temperature', targetField: 'temp'},
+      {sourceField: 'output', targetField: 'response'},
+    ];
+
+    const result = mapCallsToDatasetRows(calls, fieldMappings);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      ___weave: {
+        id: 'call1',
+        isNew: true,
+      },
+      prompt: 'Hello world',
+      temp: 0.7,
+      response: 'Response text',
+    });
+  });
+
+  test('flattens nested objects in the output', () => {
+    const calls: CallData[] = [
+      {
+        digest: 'call2',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {
+            user: {
+              name: 'Alice',
+              profile: {
+                age: 30,
+                location: 'New York',
+              },
+            },
+          },
+          output: 'OK',
+        },
+      },
+    ];
+
+    const fieldMappings = [
+      {sourceField: 'inputs.user', targetField: 'user_data'},
+    ];
+
+    const result = mapCallsToDatasetRows(calls, fieldMappings);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      ___weave: {
+        id: 'call2',
+        isNew: true,
+      },
+      'user_data.name': 'Alice',
+      'user_data.profile.age': 30,
+      'user_data.profile.location': 'New York',
+    });
+  });
+
+  test('preserves arrays without flattening them', () => {
+    const calls: CallData[] = [
+      {
+        digest: 'call3',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {
+            tags: ['tag1', 'tag2', 'tag3'],
+            config: {
+              options: ['opt1', 'opt2'],
+              nested: {
+                array: [1, 2, 3],
+              },
+            },
+          },
+          output: 'OK',
+        },
+      },
+    ];
+
+    const fieldMappings = [
+      {sourceField: 'inputs.tags', targetField: 'tags'},
+      {sourceField: 'inputs.config', targetField: 'config'},
+    ];
+
+    const result = mapCallsToDatasetRows(calls, fieldMappings);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      ___weave: {
+        id: 'call3',
+        isNew: true,
+      },
+      tags: ['tag1', 'tag2', 'tag3'],
+      'config.options': ['opt1', 'opt2'],
+      'config.nested.array': [1, 2, 3],
+    });
+  });
+
+  test('handles ref/val pattern correctly', () => {
+    const calls: CallData[] = [
+      {
+        digest: 'call4',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {
+            data: {
+              __ref__: 'ref-id',
+              __val__: {
+                name: 'Test',
+                details: {
+                  __ref__: 'nested-ref',
+                  __val__: {
+                    score: 95,
+                  },
+                },
+              },
+            },
+          },
+          output: 'OK',
+        },
+      },
+    ];
+
+    const fieldMappings = [{sourceField: 'inputs.data', targetField: 'data'}];
+
+    const result = mapCallsToDatasetRows(calls, fieldMappings);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      ___weave: {
+        id: 'call4',
+        isNew: true,
+      },
+      'data.name': 'Test',
+      'data.details.score': 95,
+    });
+  });
+
+  test('handles mixed flat and nested mappings', () => {
+    const calls: CallData[] = [
+      {
+        digest: 'call6',
+        val: {
+          ...mockTraceCallProps,
+          inputs: {
+            simple: 'value',
+            nested: {
+              prop1: 'val1',
+              prop2: 'val2',
+            },
+          },
+          output: {
+            result: 'success',
+            metadata: {
+              time: 123,
+            },
+          },
+        },
+      },
+    ];
+
+    const fieldMappings = [
+      {sourceField: 'inputs.simple', targetField: 'simple'},
+      {sourceField: 'inputs.nested', targetField: 'complex'},
+      {sourceField: 'output', targetField: 'output'},
+    ];
+
+    const result = mapCallsToDatasetRows(calls, fieldMappings);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      ___weave: {
+        id: 'call6',
+        isNew: true,
+      },
+      simple: 'value',
+      'complex.prop1': 'val1',
+      'complex.prop2': 'val2',
+      'output.result': 'success',
+      'output.metadata.time': 123,
+    });
+  });
+});
+
+describe('unwrapRefValue', () => {
+  test('unwraps simple ref/val pattern', () => {
+    const input = {
+      __ref__: 'ref-id',
+      __val__: 'actual value',
+    };
+
+    expect(unwrapRefValue(input)).toBe('actual value');
+  });
+
+  test('unwraps nested ref/val patterns', () => {
+    const input = {
+      __ref__: 'outer-ref',
+      __val__: {
+        name: 'Test',
+        details: {
+          __ref__: 'inner-ref',
+          __val__: {
+            score: 95,
+          },
+        },
+      },
+    };
+
+    expect(unwrapRefValue(input)).toEqual({
+      name: 'Test',
+      details: {
+        score: 95,
+      },
+    });
+  });
+
+  test('handles arrays with ref/val objects', () => {
+    const input = [
+      {
+        __ref__: 'ref1',
+        __val__: 'value1',
+      },
+      {
+        __ref__: 'ref2',
+        __val__: 'value2',
+      },
+    ];
+
+    expect(unwrapRefValue(input)).toEqual(['value1', 'value2']);
+  });
+
+  test('returns primitive values unchanged', () => {
+    expect(unwrapRefValue('string')).toBe('string');
+    expect(unwrapRefValue(42)).toBe(42);
+    expect(unwrapRefValue(true)).toBe(true);
+    expect(unwrapRefValue(null)).toBe(null);
+    expect(unwrapRefValue(undefined)).toBe(undefined);
+  });
+});
+
+describe('createProcessedRowsMap', () => {
+  test('creates a map from row data with schema filtering', () => {
+    const mappedRows = [
+      {
+        ___weave: {id: 'row1', isNew: true},
+        name: 'Alice',
+        age: 30,
+        extra: 'This should be filtered out',
+      },
+      {
+        ___weave: {id: 'row2', isNew: true},
+        name: 'Bob',
+        age: 25,
+        score: 95,
+      },
+    ];
+
+    const datasetObject = {
+      schema: [
+        {name: 'name', type: 'string'},
+        {name: 'age', type: 'number'},
+      ],
+    };
+
+    const result = createProcessedRowsMap(mappedRows, datasetObject);
+
+    expect(result.size).toBe(2);
+
+    // First row - extra field should be filtered out
+    const row1 = result.get('row1');
+    expect(row1).toHaveProperty('name', 'Alice');
+    expect(row1).toHaveProperty('age', 30);
+    expect(row1).not.toHaveProperty('extra');
+    expect(row1.___weave.serverValue).toEqual({name: 'Alice', age: 30});
+
+    // Second row - score field should be filtered out
+    const row2 = result.get('row2');
+    expect(row2).toHaveProperty('name', 'Bob');
+    expect(row2).toHaveProperty('age', 25);
+    expect(row2).not.toHaveProperty('score');
+    expect(row2.___weave.serverValue).toEqual({name: 'Bob', age: 25});
   });
 });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
@@ -21,67 +21,206 @@ export const inferType = (value: any): string => {
   return typeof value;
 };
 
-export const flattenObject = (obj: any, prefix = ''): SchemaField[] => {
-  let fields: SchemaField[] = [];
+/**
+ * Re-nests flattened data with dot notation paths into a nested object structure.
+ * @param flatData Object with flattened dot notation paths
+ * @returns Hierarchically nested object
+ */
+export const denestData = (
+  flatData: Record<string, any>
+): Record<string, any> => {
+  const nestedObject: Record<string, any> = {};
+  Object.entries(flatData).forEach(([key, value]) => {
+    const parts = key.split('.');
+    let current = nestedObject;
+
+    // Build the nested structure
+    for (let i = 0; i < parts.length - 1; i++) {
+      const part = parts[i];
+      if (!current[part]) {
+        current[part] = {};
+      }
+      current = current[part];
+    }
+
+    // Set the value at the final part
+    const lastPart = parts[parts.length - 1];
+    current[lastPart] = value;
+  });
+
+  return nestedObject;
+};
+
+/**
+ * Extracts only the top-level fields from an object without deep flattening.
+ * Used primarily for source/call schema where we only want the top-level structure.
+ */
+export const extractTopLevelFields = (obj: any, prefix = ''): SchemaField[] => {
+  const fields: SchemaField[] = [];
 
   // Return empty array for null or undefined inputs
   if (obj == null) {
     return fields;
   }
 
+  if (Array.isArray(obj)) {
+    fields.push({
+      name: prefix,
+      type: 'array',
+    });
+    return fields;
+  }
+
   // Special handling for __ref__ and __val__ pattern
   if (typeof obj === 'object' && '__ref__' in obj && '__val__' in obj) {
-    if (typeof obj.__val__ === 'object') {
-      return flattenObject(obj.__val__, prefix);
+    if (typeof obj.__val__ === 'object' && !Array.isArray(obj.__val__)) {
+      // For object values, extract its top-level fields
+      return extractTopLevelFields(obj.__val__, prefix);
     } else {
+      // For primitive or array values, return as is
       return [{name: prefix, type: inferType(obj.__val__)}];
     }
   }
 
   for (const [key, value] of Object.entries(obj)) {
     const newKey = prefix ? `${prefix}.${key}` : key;
-
-    if (
-      value !== null &&
-      typeof value === 'object' &&
-      !Array.isArray(value) &&
-      !(value instanceof Date)
-    ) {
-      fields = [...fields, ...flattenObject(value, newKey)];
-    } else {
-      fields.push({
-        name: newKey,
-        type: inferType(value),
-      });
-    }
+    fields.push({
+      name: newKey,
+      type: inferType(value),
+    });
   }
 
   return fields;
 };
 
-export const inferSchema = (data: any): SchemaField[] => {
+/**
+ * Creates a schema representation of a dataset object by identifying top-level fields
+ * and marking nested paths as objects without expanding them.
+ */
+export const createTargetSchema = (data: any): SchemaField[] => {
   const schemaMap = new Map<string, Set<string>>();
 
-  const addToSchema = (obj: any) => {
-    const flatFields = flattenObject(obj);
-    flatFields.forEach(field => {
-      if (!schemaMap.has(field.name)) {
-        schemaMap.set(field.name, new Set());
-      }
-      schemaMap.get(field.name)?.add(field.type);
-    });
+  const processField = (key: string, value: any) => {
+    // Split the key to get just the top-level part
+    const parts = key.split('.');
+    const topLevelKey = parts[0];
+
+    // Determine the type
+    let type: string;
+    if (parts.length > 1) {
+      // If the key has dots, it's a nested object path
+      type = 'object';
+    } else {
+      // Otherwise use the actual type of the value
+      type = inferType(value);
+    }
+
+    // Add to schema map
+    if (!schemaMap.has(topLevelKey)) {
+      schemaMap.set(topLevelKey, new Set());
+    }
+    schemaMap.get(topLevelKey)?.add(type);
   };
 
+  // Process each item in the dataset
   if (Array.isArray(data)) {
-    data.forEach(item => addToSchema(item));
-  } else {
-    addToSchema(data);
+    data.forEach(item => {
+      if (item && typeof item === 'object') {
+        Object.entries(item).forEach(([key, value]) => {
+          processField(key, value);
+        });
+      }
+    });
+  } else if (data && typeof data === 'object') {
+    Object.entries(data).forEach(([key, value]) => {
+      processField(key, value);
+    });
   }
 
+  // Convert schema map to schema fields
   return Array.from(schemaMap.entries()).map(([name, types]) => ({
     name,
     type: Array.from(types).join(' | '),
   }));
+};
+
+// Alternative implementation of createTargetSchema that accepts pre-denested data
+export const createTargetSchemaFromDenested = (data: any[]): SchemaField[] => {
+  const schemaMap = new Map<string, Set<string>>();
+
+  // Process each denested data item
+  data.forEach(item => {
+    // Only process top-level keys
+    if (item && typeof item === 'object') {
+      Object.entries(item).forEach(([key, value]) => {
+        if (!schemaMap.has(key)) {
+          schemaMap.set(key, new Set());
+        }
+        schemaMap.get(key)?.add(inferType(value));
+      });
+    }
+  });
+
+  // Convert schema map to schema fields
+  return Array.from(schemaMap.entries()).map(([name, types]) => ({
+    name,
+    type: Array.from(types).join(' | '),
+  }));
+};
+
+/**
+ * Creates a schema representation of call data (source) by only extracting
+ * top-level fields under inputs and output, without deep flattening.
+ */
+export const createSourceSchema = (calls: CallData[]): SchemaField[] => {
+  const allFields: SchemaField[] = [];
+
+  if (!calls || !Array.isArray(calls)) {
+    return allFields;
+  }
+
+  calls.forEach(call => {
+    // Skip if call or call.val is undefined
+    if (!call || !call.val) {
+      return;
+    }
+
+    if (call.val.inputs) {
+      Object.entries(call.val.inputs).forEach(([key, value]) => {
+        allFields.push({
+          name: `inputs.${key}`,
+          type: inferType(value),
+        });
+      });
+    }
+
+    const output = call.val.output;
+    if (output !== undefined) {
+      if (
+        output !== null &&
+        typeof output === 'object' &&
+        !Array.isArray(output)
+      ) {
+        Object.entries(output).forEach(([key, value]) => {
+          allFields.push({
+            name: `output.${key}`,
+            type: inferType(value),
+          });
+        });
+      } else {
+        allFields.push({name: 'output', type: inferType(output)});
+      }
+    }
+  });
+
+  return allFields
+    .filter(field => !field.name.startsWith('inputs.self'))
+    .reduce((acc, field) => {
+      if (!acc.some(f => f.name === field.name)) {
+        acc.push(field);
+      }
+      return acc;
+    }, [] as SchemaField[]);
 };
 
 export interface CallData {
@@ -148,111 +287,13 @@ export const getNestedValue = (obj: any, path: string[]): any => {
 };
 
 export const extractSourceSchema = (calls: CallData[]): SchemaField[] => {
-  const allFields: SchemaField[] = [];
-
-  if (!calls || !Array.isArray(calls)) {
-    return allFields;
-  }
-
-  calls.forEach(call => {
-    // Skip if call or call.val is undefined
-    if (!call || !call.val) {
-      return;
-    }
-
-    if (call.val.inputs) {
-      allFields.push(...flattenObject(call.val.inputs, 'inputs'));
-    }
-
-    const output = call.val.output;
-    if (output !== undefined) {
-      if (typeof output === 'string') {
-        allFields.push({name: 'output', type: 'string'});
-      } else {
-        allFields.push(...flattenObject(output, 'output'));
-      }
-    }
-  });
-
-  return allFields
-    .filter(field => !field.name.startsWith('inputs.self'))
-    .reduce((acc, field) => {
-      if (!acc.some(f => f.name === field.name)) {
-        acc.push(field);
-      }
-      return acc;
-    }, [] as SchemaField[]);
-};
-
-/**
- * Suggests field mappings between a source schema and target schema, with support for nested paths
- * and existing mappings.
- *
- * The function follows this priority order for suggesting mappings:
- * 1. Keeps all valid existing mappings
- * 2. Exact matches between source and target field names
- * 3. Matches based on the last segment of nested paths (e.g. "inputs.examples.question" matches "question")
- * 4. Falls back to mapping remaining fields to "output" if available
- *
- * For nested path matching:
- * - Source field "inputs.examples.question" will match target field "question"
- * - Only the first source field ending in a given name is mapped (e.g. if both
- *   "inputs.question" and "inputs.examples.question" exist, first one is used)
- *
- * @param sourceSchema - Array of fields available in the source data
- * @param targetSchema - Array of fields required by the target schema
- * @param existingMappings - Array of existing field mappings to preserve if still valid
- * @returns Array of suggested field mappings, including preserved valid existing mappings
- */
-export const suggestMappings = (
-  sourceSchema: SchemaField[],
-  targetSchema: SchemaField[],
-  existingMappings: FieldMapping[]
-): FieldMapping[] => {
-  const sourceNames = new Set(sourceSchema.map(s => s.name));
-  const targetNames = new Set(targetSchema.map(t => t.name));
-  const sourcePathMap = new Map<string, string>();
-  sourceSchema.forEach(source => {
-    const parts = source.name.split('.');
-    const lastPart = parts[parts.length - 1];
-    if (!sourcePathMap.has(lastPart)) {
-      sourcePathMap.set(lastPart, source.name);
-    }
-  });
-  const suggested: FieldMapping[] = existingMappings.filter(
-    m => targetNames.has(m.targetField) && sourceNames.has(m.sourceField)
-  );
-  const mappedTargets = new Set(suggested.map(m => m.targetField));
-  const remainingTargets = targetSchema.filter(
-    target => !mappedTargets.has(target.name)
-  );
-  remainingTargets.forEach(target => {
-    if (sourceNames.has(target.name)) {
-      suggested.push({sourceField: target.name, targetField: target.name});
-      mappedTargets.add(target.name);
-    }
-  });
-  remainingTargets.forEach(target => {
-    if (!mappedTargets.has(target.name)) {
-      const sourcePath = sourcePathMap.get(target.name);
-      if (sourcePath) {
-        suggested.push({sourceField: sourcePath, targetField: target.name});
-        mappedTargets.add(target.name);
-      }
-    }
-  });
-  if (sourceNames.has('output')) {
-    remainingTargets.forEach(target => {
-      if (!mappedTargets.has(target.name)) {
-        suggested.push({sourceField: 'output', targetField: target.name});
-      }
-    });
-  }
-  return suggested;
+  return createSourceSchema(calls);
 };
 
 /**
  * Maps an array of call data to dataset rows formatted for MUI DataGrid consumption.
+ * This function flattens nested dictionaries in the output, creating separate entries
+ * with path-based keys for each primitive value or list.
  *
  * @param selectedCalls - Array of call data containing inputs and outputs
  * @param fieldMappings - Array of mappings that define how call data fields map to dataset columns
@@ -264,7 +305,8 @@ export const suggestMappings = (
  *   - id: The digest of the call
  *   - isNew: Flag indicating this is a newly created row
  * - Include mapped values from the call's inputs/outputs based on fieldMappings
- * - Only include fields where the source value is defined
+ * - Dictionary values will be flattened with path-based keys (e.g., "parent.child.value")
+ * - Only primitive values and lists will be included as entries
  */
 export const mapCallsToDatasetRows = (
   selectedCalls: CallData[],
@@ -293,8 +335,46 @@ export const mapCallsToDatasetRows = (
     return unwrapRefValue(current);
   };
 
+  // Helper function to flatten nested objects
+  const flattenObject = (obj: any, prefix = ''): Record<string, any> => {
+    const result: Record<string, any> = {};
+
+    // Return immediately if value is null or undefined
+    if (obj === null || obj === undefined) {
+      return result;
+    }
+
+    // Unwrap any ref/val pattern
+    obj = unwrapRefValue(obj);
+
+    // If it's a primitive or array, just return it with the prefix
+    if (typeof obj !== 'object' || Array.isArray(obj)) {
+      return prefix ? {[prefix]: obj} : obj;
+    }
+
+    // Process each key in the object
+    Object.keys(obj).forEach(key => {
+      const value = obj[key];
+      const newPrefix = prefix ? `${prefix}.${key}` : key;
+
+      // If it's an object and not an array, recurse and merge results
+      if (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+      ) {
+        Object.assign(result, flattenObject(value, newPrefix));
+      } else {
+        // For primitives and arrays, add directly with the constructed key
+        result[newPrefix] = value;
+      }
+    });
+
+    return result;
+  };
+
   return selectedCalls.map(call => {
-    const row: Record<string, any> = {};
+    const rowData: Record<string, any> = {};
 
     fieldMappings.forEach(mapping => {
       const inputs = call.val.inputs || {};
@@ -308,7 +388,21 @@ export const mapCallsToDatasetRows = (
       }
 
       if (sourceValue !== undefined) {
-        row[mapping.targetField] = sourceValue;
+        if (
+          typeof sourceValue === 'object' &&
+          sourceValue !== null &&
+          !Array.isArray(sourceValue)
+        ) {
+          // Flatten nested objects into path-based keys
+          const flattenedValues = flattenObject(sourceValue);
+          Object.keys(flattenedValues).forEach(key => {
+            const fullKey = `${mapping.targetField}.${key}`;
+            rowData[fullKey] = flattenedValues[key];
+          });
+        } else {
+          // For primitive values and arrays, add directly
+          rowData[mapping.targetField] = sourceValue;
+        }
       }
     });
 
@@ -317,7 +411,7 @@ export const mapCallsToDatasetRows = (
         id: call.digest,
         isNew: true,
       },
-      ...row,
+      ...rowData,
     };
   });
 };


### PR DESCRIPTION
## Description

The add to dataset ui extracts schema for call data and datasets. This PR modifies the logic of schema extraction to treat all objects and arrays encountered during object traversal as a blanket object and array types.

This PR also adds separate methods in the schema utils for extracting the schema from call data and datasets. The logic is different we should have separate implementations with some common dependencies.

Here is an example trace with list of objects https://wandb.ai/bcanfieldsherman/hello/weave/traces?peekPath=%2Fbcanfieldsherman%2Fhello%2Fcalls%2F0196362e-b5a6-7380-bc6b-38f5fecc7a36

Here is a before and after of creating a new dataset from the call liked above:
Before
<img width="1085" alt="Screenshot 2025-04-14 at 2 45 08 PM" src="https://github.com/user-attachments/assets/80e65752-3184-439d-9ab9-34007588a735" />


After 
<img width="1085" alt="Screenshot 2025-04-14 at 2 44 35 PM" src="https://github.com/user-attachments/assets/4d3c3e5d-8798-458a-a99e-1ed002b1416c" />