### PR TITLE
explicit adjusting filter loading state -- still bugged

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -789,12 +789,13 @@ const CallsPageBinding = () => {
   const history = useHistory();
   const routerContext = useWeaveflowCurrentRouteContext();
 
-  const {initialDatetimeFilter} = useMakeInitialDatetimeFilter(
-    entity,
-    project,
-    initialFilter,
-    isEvaluationsTab
-  );
+  const {initialDatetimeFilter, isFilterAdjusting} =
+    useMakeInitialDatetimeFilter(
+      entity,
+      project,
+      initialFilter,
+      isEvaluationsTab
+    );
 
   const onFilterUpdate = useCallback(
     filter => {
@@ -912,6 +913,7 @@ const CallsPageBinding = () => {
       setSortModel={setSortModel}
       paginationModel={paginationModel}
       setPaginationModel={setPaginationModel}
+      isFilterAdjusting={isFilterAdjusting}
     />
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -5,7 +5,7 @@ import {
   GridPinnedColumnFields,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
-import React, {FC, useMemo} from 'react';
+import React, {createContext, FC, useContext, useMemo} from 'react';
 
 import {
   WeaveHeaderExtrasContext,
@@ -18,6 +18,10 @@ import {opVersionRefOpName} from '../wfReactInterface/utilities';
 import {CallsTable} from './CallsTable';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {useCurrentFilterIsEvaluationsFilter} from './evaluationsFilter';
+
+// Create a context to track if we're still adjusting the filter
+export const FilterAdjustingContext = createContext<boolean>(false);
+export const useFilterAdjusting = () => useContext(FilterAdjustingContext);
 
 const HeaderExtras = () => {
   const {renderExtras} = React.useContext(WeaveHeaderExtrasContext);
@@ -46,6 +50,9 @@ export const CallsPage: FC<{
 
   paginationModel: GridPaginationModel;
   setPaginationModel: (newModel: GridPaginationModel) => void;
+
+  // Optional flag to indicate if we're still adjusting the filter
+  isFilterAdjusting?: boolean;
 }> = props => {
   const [filter, setFilter] = useControllableState(
     props.initialFilter ?? {},
@@ -73,42 +80,44 @@ export const CallsPage: FC<{
 
   return (
     <WeaveHeaderExtrasProvider>
-      <SimplePageLayout
-        title={title}
-        hideTabsIfSingle
-        tabs={[
-          {
-            label: 'All',
-            content: (
-              <CallsTable
-                {...props}
-                // CPR (Tim): Applying "hide controls" when the filter is frozen is pretty crude.
-                // We will likely need finer-grained control over the filter enablement states
-                // rather than just a boolean flag. Note: "frozen === hideControls" at the moment.
-                // In fact, it probably should be used to determine if the filter should be applied
-                // to the frozenFilter prop. Furthermore, "frozen" is only used when showing the
-                // evaluations table. So, in this case, I think we should really just remove the
-                // `frozen` property completely and have a top-level evaluations tab that hides controls.
-                hideControls={filter.frozen && !isEvaluationTable}
-                hideOpSelector={isEvaluationTable}
-                initialFilter={filter}
-                onFilterUpdate={setFilter}
-                columnVisibilityModel={props.columnVisibilityModel}
-                setColumnVisibilityModel={props.setColumnVisibilityModel}
-                pinModel={props.pinModel}
-                setPinModel={props.setPinModel}
-                filterModel={props.filterModel}
-                setFilterModel={props.setFilterModel}
-                sortModel={props.sortModel}
-                setSortModel={props.setSortModel}
-                paginationModel={props.paginationModel}
-                setPaginationModel={props.setPaginationModel}
-              />
-            ),
-          },
-        ]}
-        headerExtra={<HeaderExtras />}
-      />
+      <FilterAdjustingContext.Provider value={props.isFilterAdjusting || false}>
+        <SimplePageLayout
+          title={title}
+          hideTabsIfSingle
+          tabs={[
+            {
+              label: 'All',
+              content: (
+                <CallsTable
+                  {...props}
+                  // CPR (Tim): Applying "hide controls" when the filter is frozen is pretty crude.
+                  // We will likely need finer-grained control over the filter enablement states
+                  // rather than just a boolean flag. Note: "frozen === hideControls" at the moment.
+                  // In fact, it probably should be used to determine if the filter should be applied
+                  // to the frozenFilter prop. Furthermore, "frozen" is only used when showing the
+                  // evaluations table. So, in this case, I think we should really just remove the
+                  // `frozen` property completely and have a top-level evaluations tab that hides controls.
+                  hideControls={filter.frozen && !isEvaluationTable}
+                  hideOpSelector={isEvaluationTable}
+                  initialFilter={filter}
+                  onFilterUpdate={setFilter}
+                  columnVisibilityModel={props.columnVisibilityModel}
+                  setColumnVisibilityModel={props.setColumnVisibilityModel}
+                  pinModel={props.pinModel}
+                  setPinModel={props.setPinModel}
+                  filterModel={props.filterModel}
+                  setFilterModel={props.setFilterModel}
+                  sortModel={props.sortModel}
+                  setSortModel={props.setSortModel}
+                  paginationModel={props.paginationModel}
+                  setPaginationModel={props.setPaginationModel}
+                />
+              ),
+            },
+          ]}
+          headerExtra={<HeaderExtras />}
+        />
+      </FilterAdjustingContext.Provider>
     </WeaveHeaderExtrasProvider>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -83,6 +83,7 @@ import {
 } from '../wfReactInterface/wfDataModelHooksInterface';
 import {CallsCharts} from './CallsCharts';
 import {CallsCustomColumnMenu} from './CallsCustomColumnMenu';
+import {useFilterAdjusting} from './CallsPage';
 import {
   BulkAddToDatasetButton,
   BulkDeleteButton,
@@ -214,6 +215,9 @@ export const CallsTable: FC<{
     () => getEffectiveFilter(filter, frozenFilter),
     [filter, frozenFilter]
   );
+
+  // Get the isFilterAdjusting state from context instead of local state
+  const contextIsFilterAdjusting = useFilterAdjusting();
 
   // 2. Filter (Unstructured Filter)
   const filterModelResolved = filterModel ?? DEFAULT_FILTER_CALLS;
@@ -995,7 +999,7 @@ export const CallsTable: FC<{
         // End Column Menu
         columnHeaderHeight={40}
         apiRef={apiRef}
-        loading={callsLoading}
+        loading={callsLoading || contextIsFilterAdjusting}
         rows={tableData}
         // initialState={initialState}
         onColumnVisibilityModelChange={onColumnVisibilityModelChange}
@@ -1052,6 +1056,7 @@ export const CallsTable: FC<{
               filterModelResolved={filterModelResolved}
               clearFilters={clearFilters}
               setFilterModel={setFilterModel}
+              isFilterAdjusting={contextIsFilterAdjusting}
             />
           ),
           columnMenu: CallsCustomColumnMenu,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
@@ -26,6 +26,7 @@ type CallsTableNoRowsOverlayProps = {
   filterModelResolved: GridFilterModel;
   clearFilters?: () => void;
   setFilterModel?: (model: GridFilterModel) => void;
+  isFilterAdjusting?: boolean;
 };
 
 export const CallsTableNoRowsOverlay: React.FC<
@@ -40,9 +41,11 @@ export const CallsTableNoRowsOverlay: React.FC<
   filterModelResolved,
   clearFilters,
   setFilterModel,
+  isFilterAdjusting,
 }) => {
   const {opLoading, opCreatedAt} = useCallsTableNoRowsOpLookup(entity, project);
-  if (callsLoading || opLoading) {
+
+  if (callsLoading || opLoading || isFilterAdjusting) {
     return null;
   }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -194,11 +194,10 @@ export const useCallsForQuery = (
       storageSizeResults,
       loading: calls.loading,
       // Return faster calls query results until cost query finishes
-      result: calls.loading
-        ? []
-        : costResults.length > 0
-        ? addCostsToCallResults(callResults, costResults)
-        : callResults,
+      result:
+        costResults.length > 0
+          ? addCostsToCallResults(callResults, costResults)
+          : callResults,
       total,
       refetch,
     };
@@ -345,7 +344,10 @@ export const useMakeInitialDatetimeFilter = (
   project: string,
   highLevelFilter: WFHighLevelCallFilter,
   skip: boolean
-): {initialDatetimeFilter: GridFilterModel} => {
+): {
+  initialDatetimeFilter: GridFilterModel;
+  isFilterAdjusting: boolean;
+} => {
   // Fire off 2 stats queries, one for the # of calls in the last 7 days
   // one for the  # of calls in the last 30 days.
   // If the first query returns > 50 calls, set the default filter to 7 days
@@ -414,13 +416,19 @@ export const useMakeInitialDatetimeFilter = (
     return newFilter;
   }, [callStats7Days, callStats30Days, defaultDatetimeFilter, key]);
 
+  // If we have a cached filter, we're not adjusting
   if (cachedFilter) {
     return {
       initialDatetimeFilter: cachedFilter as GridFilterModel,
+      isFilterAdjusting: false,
     };
   }
 
+  // We're still adjusting if either stats query is still loading
+  const isFilterAdjusting = callStats7Days.loading || callStats30Days.loading;
+
   return {
     initialDatetimeFilter: computedDatetimeFilter ?? defaultDatetimeFilter,
+    isFilterAdjusting,
   };
 };


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24243](https://wandb.atlassian.net/browse/WB-24243)

TODO:
- how can it be possible that call.loading returns false but callsResult is empty?? tableData computation? When exactly does this happen, on filter updates? on interrupted filter updates? 

## Testing

How was this PR tested?
