### PR TITLE
feat(weave): Support emitting storage size in object details view (trace_server)

### DIFF
--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -156,3 +156,4 @@ class SelectableCHObjSchema(BaseModel):
     version_index: int
     is_latest: int
     deleted_at: Optional[datetime.datetime] = None
+    size_bytes: Optional[int] = None

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -115,6 +115,7 @@ from weave.trace_server.table_query_builder import (
     VAL_DUMP_COLUMN_NAME,
     make_natural_sort_table_query,
     make_standard_table_query,
+    make_table_stats_query_with_storage_size,
 )
 from weave.trace_server.token_costs import (
     LLM_TOKEN_PRICES_TABLE,
@@ -745,8 +746,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 object_query_builder.add_order(sort.field, sort.direction)
         metadata_only = req.metadata_only or False
         object_query_builder.set_include_deleted(include_deleted=False)
+        object_query_builder.include_storage_size = req.include_storage_size or False
         objs = self._select_objs_query(object_query_builder, metadata_only)
-
         return tsi.ObjQueryRes(objs=[_ch_obj_to_obj_schema(obj) for obj in objs])
 
     def obj_delete(self, req: tsi.ObjDeleteReq) -> tsi.ObjDeleteRes:
@@ -1037,22 +1038,52 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 digest=row[0], val=json.loads(row[1]), original_index=row[2]
             )
 
+    # This is a legacy endpoint, it should be removed once the client is mostly updated
     def table_query_stats(self, req: tsi.TableQueryStatsReq) -> tsi.TableQueryStatsRes:
+        batch_req = tsi.TableQueryStatsBatchReq(
+            project_id=req.project_id, digests=[req.digest]
+        )
+
+        res = self.table_query_stats_batch(batch_req)
+
+        if len(res.tables) != 1:
+            raise ValueError("Unexpected number of results", res)
+
+        count = res.tables[0].count
+        return tsi.TableQueryStatsRes(count=count)
+
+    def table_query_stats_batch(
+        self, req: tsi.TableQueryStatsBatchReq
+    ) -> tsi.TableQueryStatsBatchRes:
         parameters: dict[str, Any] = {
             "project_id": req.project_id,
-            "digest": req.digest,
+            "digests": req.digests,
         }
 
         query = """
-        SELECT length(row_digests)
+        SELECT digest, length(row_digests)
         FROM tables
-        WHERE project_id = {project_id:String} AND digest = {digest:String}
+        WHERE project_id = {project_id:String} AND digest IN {digests:Array(String)}
         """
 
-        query_result = self.ch_client.query(query, parameters=parameters)
-        count = query_result.result_rows[0][0] if query_result.result_rows else 0
+        if req.include_storage_size:
+            # Use an advanced query builder to get the storage size
+            pb = ParamBuilder()
+            query = make_table_stats_query_with_storage_size(
+                project_id=req.project_id,
+                table_digests=cast(list[str], req.digests),
+                pb=pb,
+            )
+            parameters = pb.get_params()
 
-        return tsi.TableQueryStatsRes(count=count)
+        query_result = self.ch_client.query(query, parameters=parameters)
+
+        tables = [
+            _ch_table_stats_to_table_stats_schema(row)
+            for row in query_result.result_rows
+        ]
+
+        return tsi.TableQueryStatsBatchRes(tables=tables)
 
     def refs_read_batch(self, req: tsi.RefsReadBatchReq) -> tsi.RefsReadBatchRes:
         # TODO: This reads one ref at a time, it should read them in batches
@@ -1951,7 +1982,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         obj_metadata_query = object_query_builder.make_metadata_query()
         parameters = object_query_builder.parameters or {}
         query_result = self._query_stream(obj_metadata_query, parameters)
-        metadata_result = format_metadata_objects_from_query_result(query_result)
+        metadata_result = format_metadata_objects_from_query_result(
+            query_result, object_query_builder.include_storage_size
+        )
 
         # -- Don't make second query for object values if metadata_only --
         if metadata_only or len(metadata_result) == 0:
@@ -2261,6 +2294,21 @@ def _ch_obj_to_obj_schema(ch_obj: SelectableCHObjSchema) -> tsi.ObjSchema:
         kind=ch_obj.kind,
         base_object_class=ch_obj.base_object_class,
         val=json.loads(ch_obj.val_dump),
+        size_bytes=ch_obj.size_bytes,
+    )
+
+
+def _ch_table_stats_to_table_stats_schema(
+    ch_table_stats_row: Sequence[Any],
+) -> tsi.TableStatsRow:
+    digest, count, storage_size_bytes = (lambda a, b, c=cast(Any, None): (a, b, c))(
+        *ch_table_stats_row
+    )
+
+    return tsi.TableStatsRow(
+        count=count,
+        digest=digest,
+        storage_size_bytes=storage_size_bytes,
     )
 
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -289,9 +289,16 @@ class ExternalTraceServer(tsi.TraceServerInterface):
             self._internal_trace_server.table_query_stream, req
         )
 
+    # This is a legacy endpoint, it should be removed once the client is mostly updated
     def table_query_stats(self, req: tsi.TableQueryStatsReq) -> tsi.TableQueryStatsRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.table_query_stats, req)
+
+    def table_query_stats_batch(
+        self, req: tsi.TableQueryStatsBatchReq
+    ) -> tsi.TableQueryStatsBatchRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.table_query_stats_batch, req)
 
     def refs_read_batch(self, req: tsi.RefsReadBatchReq) -> tsi.RefsReadBatchRes:
         return self._ref_apply(self._internal_trace_server.refs_read_batch, req)

--- a/weave/trace_server/objects_query_builder.py
+++ b/weave/trace_server/objects_query_builder.py
@@ -85,13 +85,21 @@ def _make_object_id_conditions_part(
 
 def format_metadata_objects_from_query_result(
     query_result: Iterator[tuple[Any, ...]],
+    include_storage_size: bool = False,
 ) -> list[SelectableCHObjSchema]:
     result = []
     for row in query_result:
         # Add an empty val_dump to the end of the row
         row_with_val_dump = row + ("{}",)
-        columns_with_val_dump = OBJECT_METADATA_COLUMNS + ["val_dump"]
+        columns_with_val_dump = list(OBJECT_METADATA_COLUMNS)
+
+        if include_storage_size:
+            columns_with_val_dump += ["size_bytes"]
+
+        columns_with_val_dump += ["val_dump"]
+
         row_dict = dict(zip(columns_with_val_dump, row_with_val_dump))
+
         row_model = SelectableCHObjSchema.model_validate(row_dict)
         result.append(row_model)
     return result
@@ -116,6 +124,7 @@ class ObjectMetadataQueryBuilder:
         self._offset: Optional[int] = None
         self._sort_by: list[tsi.SortBy] = []
         self._include_deleted: bool = include_deleted
+        self.include_storage_size: bool = False
 
     @property
     def conditions_part(self) -> str:
@@ -242,10 +251,25 @@ class ObjectMetadataQueryBuilder:
         self._include_deleted = include_deleted
 
     def make_metadata_query(self) -> str:
-        columns = ",\n    ".join(OBJECT_METADATA_COLUMNS)
+        columns = list(OBJECT_METADATA_COLUMNS)
+
+        main_table_alias = "main"
+
+        if self.include_storage_size:
+            columns += ["size_bytes"]
+        columns_str = ",\n    ".join(columns)
+
+        join_clause = ""
+        if self.include_storage_size:
+            join_clause = f"""
+            LEFT JOIN (
+                SELECT * FROM object_versions_stats WHERE object_versions_stats.project_id = {{project_id: String}}
+            ) as object_versions_stats ON object_versions_stats.digest = {main_table_alias}.digest
+            """
+
         query = f"""
 SELECT
-    {columns}
+    {columns_str}
 FROM (
     SELECT
         project_id,
@@ -308,7 +332,9 @@ FROM (
         WHERE project_id = {{project_id: String}}{self.object_id_conditions_part}
     )
     WHERE rn = 1
-)"""
+) as {main_table_alias}
+    {join_clause}
+"""
         if self.conditions_part:
             query += f"\n{self.conditions_part}"
         if self.sort_part:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1127,26 +1127,49 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             ]
         )
 
+    # This is a legacy endpoint, it should be removed once the client is mostly updated
     def table_query_stats(self, req: tsi.TableQueryStatsReq) -> tsi.TableQueryStatsRes:
-        parameters: list[Any] = [req.project_id, req.digest]
+        batch_req = tsi.TableQueryStatsBatchReq(
+            project_id=req.project_id, digests=[req.digest]
+        )
 
-        query = """
-        SELECT json_array_length(row_digests)
+        res = self.table_query_stats_batch(batch_req)
+
+        if len(res.tables) != 1:
+            raise ValueError("Unexpected number of results", res)
+
+        count = res.tables[0].count
+        return tsi.TableQueryStatsRes(count=count)
+
+    def table_query_stats_batch(
+        self, req: tsi.TableQueryStatsBatchReq
+    ) -> tsi.TableQueryStatsBatchRes:
+        parameters: list[Any] = [req.project_id] + list(req.digests or [])
+
+        placeholders = ",".join(["?" for _ in (req.digests or [])])
+
+        query = f"""
+        SELECT digest, json_array_length(row_digests)
         FROM
             tables
         WHERE
             tables.project_id = ? AND
-            tables.digest = ?
+            tables.digest in ({placeholders})
         """
 
         conn, cursor = get_conn_cursor(self.db_path)
         cursor.execute(query, parameters)
-        row = cursor.fetchone()
-        count = 0
-        if row is not None:
-            count = row[0]
 
-        return tsi.TableQueryStatsRes(count=count)
+        query_result = cursor.fetchall()
+
+        tables = []
+
+        for row in query_result:
+            count = row[1]
+            digest = row[0]
+            tables.append(tsi.TableStatsRow(count=count, digest=digest))
+
+        return tsi.TableQueryStatsBatchRes(tables=tables)
 
     def refs_read_batch(self, req: tsi.RefsReadBatchReq) -> tsi.RefsReadBatchRes:
         # TODO: This reads one ref at a time, it should read them in batches

--- a/weave/trace_server/table_query_builder.py
+++ b/weave/trace_server/table_query_builder.py
@@ -113,3 +113,29 @@ def make_standard_table_query(
     {sql_safe_offset}
     """
     return query
+
+
+def make_table_stats_query_with_storage_size(
+    project_id: str,
+    table_digests: list[str],
+    pb: ParamBuilder,
+) -> str:
+    """Generate a query for table stats with storage size and length(num of rows)."""
+    project_id_name = pb.add_param(project_id)
+    digest_ids = pb.add_param(table_digests)
+
+    query = f"""
+    SELECT tb_digest, any(length), sum(size_bytes) FROM
+    (
+        SELECT digest as tb_digest, length(row_digests) as length, row_digests
+        FROM tables
+        WHERE project_id = {{{project_id_name}: String}} AND digest in {{{digest_ids}: Array(String)}}
+    ) ARRAY JOIN row_digests as row_digest
+    LEFT JOIN
+    (
+        SELECT * FROM table_rows_stats WHERE table_rows_stats.project_id = {{{project_id_name}: String}}
+    ) as table_rows_stats ON table_rows_stats.digest = row_digest
+
+    GROUP BY tb_digest
+    """
+    return query

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -198,6 +198,7 @@ class ObjSchema(BaseModel):
     val: Any
 
     wb_user_id: Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)
+    size_bytes: Optional[int] = None
 
 
 class ObjSchemaForInsert(BaseModel):
@@ -547,6 +548,10 @@ class ObjQueryReq(BaseModel):
         description="If true, the `val` column is not read from the database and is empty."
         "All other fields are returned.",
     )
+    include_storage_size: Optional[bool] = Field(
+        default=False,
+        description="If true, the `size_bytes` column is returned.",
+    )
 
 
 class ObjDeleteReq(BaseModel):
@@ -751,12 +756,40 @@ class TableQueryStatsReq(BaseModel):
     )
     digest: str = Field(
         description="The digest of the table to query",
-        examples=["aonareimsvtl13apimtalpa4435rpmgnaemrpgmarltarstaorsnte134avrims"],
+    )
+
+
+class TableQueryStatsBatchReq(BaseModel):
+    project_id: str = Field(
+        description="The ID of the project", examples=["my_entity/my_project"]
+    )
+
+    digests: Optional[list[str]] = Field(
+        description="The digests of the tables to query",
+        examples=[
+            "aonareimsvtl13apimtalpa4435rpmgnaemrpgmarltarstaorsnte134avrims",
+            "smirva431etnsroatsratlrampgrmeangmpr5344aplatmipa31ltvsmiераnoa",
+        ],
+        default=[],
+    )
+    include_storage_size: Optional[bool] = Field(
+        default=False,
+        description="If true, the `storage_size_bytes` column is returned.",
     )
 
 
 class TableQueryStatsRes(BaseModel):
     count: int
+
+
+class TableStatsRow(BaseModel):
+    count: int
+    digest: str
+    storage_size_bytes: Optional[int] = None
+
+
+class TableQueryStatsBatchRes(BaseModel):
+    tables: list[TableStatsRow]
 
 
 class RefsReadBatchReq(BaseModel):
@@ -1005,6 +1038,9 @@ class TraceServerInterface(Protocol):
     def table_query(self, req: TableQueryReq) -> TableQueryRes: ...
     def table_query_stream(self, req: TableQueryReq) -> Iterator[TableRowSchema]: ...
     def table_query_stats(self, req: TableQueryStatsReq) -> TableQueryStatsRes: ...
+    def table_query_stats_batch(
+        self, req: TableQueryStatsBatchReq
+    ) -> TableQueryStatsBatchRes: ...
 
     # Ref API
     def refs_read_batch(self, req: RefsReadBatchReq) -> RefsReadBatchRes: ...

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -280,11 +280,23 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         # I am not sure the best way to cache the iterator here. TODO
         return self._next_trace_server.table_query_stream(req)
 
+    # This is a legacy endpoint, it should be removed once the client is mostly updated
     def table_query_stats(self, req: tsi.TableQueryStatsReq) -> tsi.TableQueryStatsRes:
         if not digest_is_cacheable(req.digest):
             return self._next_trace_server.table_query_stats(req)
         return self._with_cache_pydantic(
             self._next_trace_server.table_query_stats, req, tsi.TableQueryStatsRes
+        )
+
+    def table_query_stats_batch(
+        self, req: tsi.TableQueryStatsBatchReq
+    ) -> tsi.TableQueryStatsBatchRes:
+        if any(not digest_is_cacheable(digest) for digest in req.digests or []):
+            return self._next_trace_server.table_query_stats_batch(req)
+        return self._with_cache_pydantic(
+            self._next_trace_server.table_query_stats_batch,
+            req,
+            tsi.TableQueryStatsBatchRes,
         )
 
     def refs_read_batch(self, req: tsi.RefsReadBatchReq) -> tsi.RefsReadBatchRes:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -451,6 +451,16 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/table/query_stats", req, tsi.TableQueryStatsReq, tsi.TableQueryStatsRes
         )
 
+    def table_query_stats_batch(
+        self, req: Union[tsi.TableQueryStatsReq, dict[str, Any]]
+    ) -> tsi.TableQueryStatsRes:
+        return self._generic_request(
+            "/table/query_stats_batch",
+            req,
+            tsi.TableQueryStatsBatchReq,
+            tsi.TableQueryStatsBatchRes,
+        )
+
     def refs_read_batch(
         self, req: Union[tsi.RefsReadBatchReq, dict[str, Any]]
     ) -> tsi.RefsReadBatchRes:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

## Summary
This PR adds support for displaying storage size information in the object details view and table statistics. It consists of mostly the backend changes, and minimum frontend changes to fit the interface changes related to object storage size only.

TLDR, I changed the following two APIs to include storage size information

```
/objs/query  ---> this will be used to retrieve each individual object version's storage size,
/table/query_stats_batch ---> this will be used to retrieve each table's storage size from all of its rows.
```

After this PR is merged. The internal PR https://github.com/wandb/core/pull/28783 should merge soon.

As a reference, the Frontend change that is going to utilize the API endpoint in this PR can be reviewed [here](https://github.com/wandb/weave/pull/4142).

## Changes
### Backend Changes
1. Enhanced object querying:
   - Added `include_storage_size` option to `ObjQueryReq`
   - Updated `ObjectMetadataQueryBuilder` to handle storage size inclusion
   - Modified query result formatting to include storage size when requested
   -
2. In order to prevent breaking existing clients (FE+SDK) due to tempering the existing endpoint of `table_stats_query`:
   - Created a new endpoint `table_stats_query_batch` which takes plural form parameter `digests`
   - Added `include_storage_size` flag to control storage size retrieval
   - Created new `make_table_stats_query_with_storage_size` function for efficient storage size queries


### Frontend Changes
   - Updated TypeScript interfaces to include new storage size fields for object queries

### Testing
1. Added new test cases:
   - `test_obj_query_with_storage_size_clickhouse` to verify object storage size functionality
   - `test_table_query_stats_with_storage_size` to verify table storage size retrieval
   - Updated existing tests in `test_table_query.py` suite to test against the `table_stats_query_batch` api.

2. Added SQL query tests:
   - Fixed breakage in the `test_objects_query_builder.py` with storage size related tests
   - Added SQL formatting assertions for better query validation


## Future Improvements
- Hook up the frontend.
- Remove the deprecated `table/query_stats` endpoint, and use the batch API `table/query_stats_batch` (Far future when the conditions meet)

