### PR TITLE
fix(app): Fix image mask visibility hierarchy

### DIFF
--- a/weave-js/src/components/Panel2/ImageWithOverlays.tsx
+++ b/weave-js/src/components/Panel2/ImageWithOverlays.tsx
@@ -220,7 +220,7 @@ const OverlayCanvas = styled.canvas`
 interface SegmentationCanvasProps {
   segmentation: ImageData;
   classState: Record<string, ClassState>;
-  classOverlay: Record<string, Controls.OverlayClassState>;
+  classOverlay: Partial<Record<string, Controls.OverlayClassState>>;
 }
 
 /**

--- a/weave-js/src/components/Panel2/ImageWithOverlays.tsx
+++ b/weave-js/src/components/Panel2/ImageWithOverlays.tsx
@@ -242,8 +242,11 @@ const SegmentationCanvas: FC<SegmentationCanvasProps> = ({
       _.map(classState, ({color}, classId) => {
         const classToggle = classOverlay[classId] ?? DEFAULT_CLASS_MASK_CONTROL;
 
-        const {disabled, opacity} = classToggle;
-        const isDisabled = allToggle.disabled || disabled;
+        const {opacity} = classToggle;
+        const isDisabled =
+          classOverlay[classId]?.disabled ??
+          classOverlay.all?.disabled ??
+          DEFAULT_CLASS_MASK_CONTROL.disabled;
 
         const rgb = colorFromString(color);
         const alpha = isDisabled ? 0 : allToggle.opacity * opacity * 255;


### PR DESCRIPTION
## Description

https://weightsandbiases.slack.com/archives/C085WBN5FPV/p1744673754916729 for context. We want to be consistent in having the "lower" level override the higher one.

## Testing

How was this PR tested?


https://github.com/user-attachments/assets/c1600c81-699c-4101-a814-35e5f09f55de


