### PR TITLE
chore(weave): Perform insert in place for otel_export

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -253,15 +253,10 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     start_call, end_call = span.to_call(req.project_id)
                     calls.extend(
                         [
-                            {
-                                "mode": "start",
-                                "req": tsi.CallStartReq(start=start_call),
-                            },
-                            {"mode": "end", "req": tsi.CallEndReq(end=end_call)},
+                            self.call_start(tsi.CallStartReq(start=start_call)),
+                            self.call_end(tsi.CallEndReq(end=end_call)),
                         ]
                     )
-        # TODO: Actually populate the error fields if call_start_batch fails
-        self.call_start_batch(tsi.CallCreateBatchReq(batch=calls))
         return tsi.OtelExportRes()
 
     @contextmanager


### PR DESCRIPTION
## Description

Logically there isn't any change to code flow here, it just pulls up the code from the batched insert to make it clearer what is happening during the insertion step. As a side note, this doesn't actually seem to be batched unless I am missing something. It appears that each call is individually inserted.
