### PR TITLE
fix(weave): serialization in map_to_refs wasn't recursing into tuples

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -482,7 +482,7 @@ def map_to_refs(obj: Any) -> Any:
         return obj.ref
     elif isinstance(obj, WeaveTable):
         return obj.ref
-    elif isinstance(obj, list):
+    elif isinstance(obj, (list, tuple)):
         return [map_to_refs(v) for v in obj]
     elif isinstance(obj, dict):
         return {k: map_to_refs(v) for k, v in obj.items()}

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -482,6 +482,8 @@ def map_to_refs(obj: Any) -> Any:
         return obj.ref
     elif isinstance(obj, WeaveTable):
         return obj.ref
+    elif isinstance_namedtuple(obj):
+        return {k: map_to_refs(v) for k, v in obj._asdict().items()}
     elif isinstance(obj, (list, tuple)):
         return [map_to_refs(v) for v in obj]
     elif isinstance(obj, dict):


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C0880TX4U5V/p1744740337426419

We aren't recursing into tuples in the `map_to_refs` part of our serialization. The symptom was that a Pydantic object inside the tuple was getting rendered as a string.