### PR TITLE
feat(weave): Frontend Implementation for Storage Size Display

### DIFF
--- a/weave-js/src/common/hooks/useStorageSizeCalculation.ts
+++ b/weave-js/src/common/hooks/useStorageSizeCalculation.ts
@@ -1,0 +1,120 @@
+import {parseRefMaybe} from '@wandb/weave/react';
+import {useMemo} from 'react';
+
+import {ObjectVersionSchema} from '../../components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
+
+interface StorageSizeResult {
+  currentVersionSizeBytes?: number;
+  allVersionsSizeBytes?: number;
+  shouldShowAllVersions: boolean;
+  isLoading: boolean;
+}
+
+/**
+ * Calculate storage size for dataset versions
+ */
+export function useDatasetStorageSizeCalculation(
+  objectVersions: {loading: boolean; result?: ObjectVersionSchema[] | null},
+  objectVersionIndex: number,
+  tableStats: {
+    loading: boolean;
+    result?: {
+      tables: Array<{
+        digest: string;
+        storage_size_bytes: number;
+      }>;
+    } | null;
+  }
+): StorageSizeResult {
+  return useMemo(() => {
+    // Track the loading state
+    const isLoading = objectVersions.loading || tableStats.loading;
+
+    // Return early with consistent undefined values if data is not available
+    if (
+      !objectVersions.result ||
+      !tableStats.result ||
+      !tableStats.result.tables
+    ) {
+      return {
+        currentVersionSizeBytes: undefined,
+        allVersionsSizeBytes: undefined,
+        shouldShowAllVersions: false,
+        isLoading,
+      };
+    }
+
+    // Build a map of table digests to their storage sizes
+    const tableSizeMap = new Map(
+      tableStats.result.tables.map(r => [r.digest, r.storage_size_bytes])
+    );
+
+    // Calculate size for each version
+    const versionSizeMap = new Map(
+      objectVersions.result.map(({versionIndex, sizeBytes, val}) => {
+        const metadataSizeBytes = sizeBytes ?? 0;
+        const ref = parseRefMaybe(val.rows);
+
+        const tableDataSizeBytes =
+          tableSizeMap.get(ref?.artifactVersion ?? '') ?? 0;
+
+        return [versionIndex, metadataSizeBytes + tableDataSizeBytes];
+      })
+    );
+
+    const currentVersionSizeBytes = versionSizeMap.get(objectVersionIndex);
+
+    // Calculate total size directly during iteration to avoid creating additional arrays
+    let totalSize = 0;
+    versionSizeMap.forEach(size => {
+      totalSize += size;
+    });
+
+    return {
+      currentVersionSizeBytes,
+      allVersionsSizeBytes: totalSize,
+      shouldShowAllVersions: objectVersions.result.length > 1,
+      isLoading,
+    };
+  }, [objectVersions, objectVersionIndex, tableStats]);
+}
+
+/**
+ * Calculate storage size for regular object versions
+ */
+export function useObjectStorageSizeCalculation(
+  objectVersions: {loading: boolean; result?: ObjectVersionSchema[] | null},
+  objectVersionIndex: number
+): StorageSizeResult {
+  return useMemo(() => {
+    // Track loading state
+    const isLoading = objectVersions.loading;
+
+    // Return early with consistent undefined values if data is not available
+    if (!objectVersions.result) {
+      return {
+        currentVersionSizeBytes: undefined,
+        allVersionsSizeBytes: undefined,
+        shouldShowAllVersions: false,
+        isLoading,
+      };
+    }
+
+    const currentVersion = objectVersions.result.find(
+      v => v.versionIndex === objectVersionIndex
+    );
+
+    // Calculate total size directly in the loop to avoid unnecessary array operations
+    let totalSize = 0;
+    for (const version of objectVersions.result) {
+      totalSize += version.sizeBytes ?? 0;
+    }
+
+    return {
+      currentVersionSizeBytes: currentVersion?.sizeBytes,
+      allVersionsSizeBytes: totalSize,
+      shouldShowAllVersions: objectVersions.result.length > 1,
+      isLoading,
+    };
+  }, [objectVersions, objectVersionIndex]);
+}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetVersionPage.tsx
@@ -1,9 +1,11 @@
 import {Box, Tooltip} from '@mui/material';
 import {UserLink} from '@wandb/weave/components/UserLink';
 import {maybePluralize} from '@wandb/weave/core/util/string';
-import React, {useCallback, useState} from 'react';
+import {parseRefMaybe} from '@wandb/weave/react';
+import React, {useCallback, useMemo, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 
+import {useDatasetStorageSizeCalculation} from '../../../../../common/hooks/useStorageSizeCalculation';
 import {Button} from '../../../../Button';
 import {Icon} from '../../../../Icon';
 import {LoadingDots} from '../../../../LoadingDots';
@@ -17,6 +19,7 @@ import {
   ScrollableTabContent,
   SimplePageLayoutWithHeader,
 } from '../pages/common/SimplePageLayout';
+import {StorageSizeSection} from '../pages/common/StorageSizeSection';
 import {DeleteObjectButtonWithModal} from '../pages/ObjectsPage/ObjectDeleteButtons';
 import {TabUseDataset} from '../pages/ObjectsPage/Tabs/TabUseDataset';
 import {useWFHooks} from '../pages/wfReactInterface/context';
@@ -50,8 +53,13 @@ export const DatasetVersionPage: React.FC<{
     convertEditsToTableUpdateSpec,
   } = useDatasetEditContext();
   const router = useWeaveflowCurrentRouteContext();
-  const {useRootObjectVersions, useRefsData, useTableUpdate, useObjCreate} =
-    useWFHooks();
+  const {
+    useRootObjectVersions,
+    useRefsData,
+    useTableUpdate,
+    useObjCreate,
+    useTableQueryStats,
+  } = useWFHooks();
 
   const [isEditing, setIsEditing] = useState(false);
 
@@ -67,7 +75,8 @@ export const DatasetVersionPage: React.FC<{
     projectName,
     {objectIds: [objectName]},
     undefined,
-    true
+    false,
+    {includeStorageSize: true}
   );
   const objectVersionCount = (objectVersions.result ?? []).length;
   const refUri = objectVersionKeyToRefUri(objectVersion);
@@ -114,6 +123,41 @@ export const DatasetVersionPage: React.FC<{
     entityName,
     projectName,
   ]);
+
+  const tableDigests = useMemo(() => {
+    if (objectVersions.loading || objectVersions.result == null) {
+      return null;
+    }
+    return Array.from(
+      new Set(
+        objectVersions.result.map(v => {
+          const ref = parseRefMaybe(v.val.rows);
+          return ref?.artifactVersion;
+        })
+      )
+    ).filter(Boolean) as string[];
+  }, [objectVersions]);
+
+  const tableStats = useTableQueryStats(
+    entityName,
+    projectName,
+    tableDigests ?? [],
+    {
+      skip: tableDigests == null,
+      includeStorageSize: true,
+    }
+  );
+
+  const {
+    currentVersionSizeBytes,
+    allVersionsSizeBytes,
+    shouldShowAllVersions,
+    isLoading,
+  } = useDatasetStorageSizeCalculation(
+    objectVersions,
+    objectVersionIndex,
+    tableStats
+  );
 
   const renderEditingControls = () => {
     const editCountStr = String(Array.from(editedRows.keys()).length);
@@ -232,7 +276,14 @@ export const DatasetVersionPage: React.FC<{
                   <UserLink userId={objectVersion.userId} includeName />
                 </div>
               )}
+              <StorageSizeSection
+                isLoading={isLoading}
+                shouldShowAllVersions={shouldShowAllVersions}
+                currentVersionBytes={currentVersionSizeBytes}
+                allVersionsSizeBytes={allVersionsSizeBytes}
+              />
             </div>
+
             <div className="ml-auto flex-shrink-0">
               {isEditing ? (
                 renderEditingControls()

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
@@ -155,9 +155,16 @@ export const EditableDatasetView: React.FC<EditableDatasetViewProps> = ({
   const numRowsQuery = useTableQueryStats(
     lookupKey?.entity ?? '',
     lookupKey?.project ?? '',
-    lookupKey?.digest ?? '',
+    lookupKey?.digest ? [lookupKey?.digest] : [],
     {skip: lookupKey == null}
   );
+
+  const totalRows = useMemo(() => {
+    if (numRowsQuery.result == null) {
+      return 0;
+    }
+    return numRowsQuery.result.tables?.[0]?.count ?? 0;
+  }, [numRowsQuery.result]);
 
   const numAddedRows = useMemo(
     () => Array.from(addedRows.values()).length,
@@ -541,9 +548,7 @@ export const EditableDatasetView: React.FC<EditableDatasetViewProps> = ({
         paginationMode="server"
         paginationModel={paginationModel}
         onPaginationModelChange={setPaginationModel}
-        rowCount={
-          (numRowsQuery.result?.count ?? 0) + (isEditing ? numAddedRows : 0)
-        }
+        rowCount={totalRows + (isEditing ? numAddedRows : 0)}
         disableMultipleColumnsSorting
         loading={!fetchQueryLoaded}
         disableRowSelectionOnClick

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/DataTableView.tsx
@@ -98,7 +98,7 @@ export const WeaveCHTable: FC<{
   const numRowsQuery = useTableQueryStats(
     lookupKey?.entity ?? '',
     lookupKey?.project ?? '',
-    lookupKey?.digest ?? '',
+    lookupKey?.digest ? [lookupKey?.digest] : [],
     {skip: lookupKey == null}
   );
 
@@ -168,7 +168,7 @@ export const WeaveCHTable: FC<{
   }, [loadedRows]);
 
   const totalRows = useMemo(() => {
-    return numRowsQuery.result?.count ?? pagedRows.length;
+    return numRowsQuery.result?.tables?.[0]?.count ?? pagedRows.length;
   }, [numRowsQuery.result, pagedRows]);
 
   // In this block, we setup a click handler. The underlying datatable is more general

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
@@ -3,6 +3,7 @@ import {UserLink} from '@wandb/weave/components/UserLink';
 import {useObjectViewEvent} from '@wandb/weave/integrations/analytics/useViewEvents';
 import React, {useMemo} from 'react';
 
+import {useObjectStorageSizeCalculation} from '../../../../../../common/hooks/useStorageSizeCalculation';
 import {maybePluralizeWord} from '../../../../../../core/util/string';
 import {Icon, IconName} from '../../../../../Icon';
 import {LoadingDots} from '../../../../../LoadingDots';
@@ -34,6 +35,7 @@ import {
   SimpleKeyValueTable,
   SimplePageLayoutWithHeader,
 } from '../common/SimplePageLayout';
+import {StorageSizeSection} from '../common/StorageSizeSection';
 import {EvaluationLeaderboardTab} from '../LeaderboardTab';
 import {TabUsePrompt} from '../OpsPage/Tabs/TabUsePrompt';
 import {KNOWN_BASE_OBJECT_CLASSES} from '../wfReactInterface/constants';
@@ -140,7 +142,10 @@ const ObjectVersionPageInner: React.FC<{
       objectIds: [objectName],
     },
     undefined,
-    true
+    true,
+    {
+      includeStorageSize: true,
+    }
   );
   const objectVersionCount = (objectVersions.result ?? []).length;
   const baseObjectClass = useMemo(() => {
@@ -215,6 +220,13 @@ const ObjectVersionPageInner: React.FC<{
   const isScorer = baseObjectClass === 'Scorer' && refExtra == null;
   const evalHasCalls = (consumingCalls.result?.length ?? 0) > 0;
   const evalHasCallsLoading = consumingCalls.loading;
+
+  const {
+    currentVersionSizeBytes,
+    allVersionsSizeBytes,
+    shouldShowAllVersions,
+    isLoading,
+  } = useObjectStorageSizeCalculation(objectVersions, objectVersionIndex);
 
   if (isEvaluation && evalHasCallsLoading) {
     return <CenteredAnimatedLoader />;
@@ -292,6 +304,12 @@ const ObjectVersionPageInner: React.FC<{
                 <UserLink userId={objectVersion.userId} includeName />
               </div>
             )}
+            <StorageSizeSection
+              isLoading={isLoading}
+              shouldShowAllVersions={shouldShowAllVersions}
+              currentVersionBytes={currentVersionSizeBytes}
+              allVersionsSizeBytes={allVersionsSizeBytes}
+            />
             {isScorer && (
               <div className="block">
                 <p className="text-moon-500">Scores</p>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StorageSizeSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StorageSizeSection.tsx
@@ -1,0 +1,47 @@
+import {LoadingDots} from '@wandb/weave/components/LoadingDots';
+import {convertBytes} from '@wandb/weave/util';
+import React, {useMemo} from 'react';
+
+interface StorageSizeSectionProps {
+  isLoading?: boolean;
+  currentVersionBytes?: number;
+  allVersionsSizeBytes?: number;
+  shouldShowAllVersions: boolean;
+}
+export const StorageSizeSection: React.FC<StorageSizeSectionProps> = ({
+  currentVersionBytes,
+  isLoading,
+  allVersionsSizeBytes,
+  shouldShowAllVersions,
+}) => {
+  const presentation = useMemo(() => {
+    if (isLoading) {
+      return <LoadingDots />;
+    }
+
+    if (currentVersionBytes === undefined) {
+      return 'Not available';
+    }
+
+    let allVersionsSize = '';
+    if (shouldShowAllVersions) {
+      allVersionsSize = ` (${convertBytes(
+        allVersionsSizeBytes
+      )} from all versions)`;
+    }
+
+    return `${convertBytes(currentVersionBytes)}${allVersionsSize}`;
+  }, [
+    currentVersionBytes,
+    isLoading,
+    allVersionsSizeBytes,
+    shouldShowAllVersions,
+  ]);
+
+  return (
+    <div className="block">
+      <p className="text-moon-500">Storage size</p>
+      {presentation}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerCachingClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerCachingClient.ts
@@ -7,8 +7,8 @@ import {
   TraceObjReadRes,
   TraceTableQueryReq,
   TraceTableQueryRes,
-  TraceTableQueryStatsReq,
-  TraceTableQueryStatsRes,
+  TraceTableQueryStatsBatchReq,
+  TraceTableQueryStatsBatchRes,
 } from './traceServerClientTypes';
 import {DirectTraceServerClient} from './traceServerDirectClient';
 
@@ -43,9 +43,9 @@ export class CachingTraceServerClient extends DirectTraceServerClient {
       getCacheKey: (req: TraceTableQueryReq) => JSON.stringify(req),
     });
 
-    this.addCache('tableQueryStats', {
+    this.addCache('tableQueryStatsBatch', {
       max: 1000,
-      getCacheKey: (req: TraceTableQueryStatsReq) => JSON.stringify(req),
+      getCacheKey: (req: TraceTableQueryStatsBatchReq) => JSON.stringify(req),
     });
   }
 
@@ -96,11 +96,11 @@ export class CachingTraceServerClient extends DirectTraceServerClient {
     return this.withCache('tableQuery', req, () => super.tableQuery(req));
   }
 
-  public override tableQueryStats(
-    req: TraceTableQueryStatsReq
-  ): Promise<TraceTableQueryStatsRes> {
-    return this.withCache('tableQueryStats', req, () =>
-      super.tableQueryStats(req)
+  public override tableQueryStatsBatch(
+    req: TraceTableQueryStatsBatchReq
+  ): Promise<TraceTableQueryStatsBatchRes> {
+    return this.withCache('tableQueryStatsBatch', req, () =>
+      super.tableQueryStatsBatch(req)
     );
   }
 }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -211,6 +211,7 @@ export type TraceObjQueryReq = {
   offset?: number;
   sort_by?: SortBy[];
   metadata_only?: boolean;
+  include_storage_size?: boolean;
 };
 
 export interface TraceObjSchema<
@@ -288,13 +289,18 @@ export type TraceTableQueryReq = {
   sort_by?: SortBy[];
 };
 
-export type TraceTableQueryStatsReq = {
+export type TraceTableQueryStatsBatchReq = {
   project_id: string;
-  digest: string;
+  digests: string[];
+  include_storage_size?: boolean;
 };
 
-export type TraceTableQueryStatsRes = {
-  count: number;
+export type TraceTableQueryStatsBatchRes = {
+  tables: Array<{
+    digest: string;
+    count: number;
+    storage_size_bytes: number;
+  }>;
 };
 
 export type TraceTableQueryRes = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -228,6 +228,7 @@ export interface TraceObjSchema<
   base_object_class?: OBC;
   val: T;
   wb_user_id?: string;
+  size_bytes?: number;
 }
 
 export type TraceObjQueryRes<T extends any = any> = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
@@ -54,8 +54,8 @@ import {
   TraceRefsReadBatchRes,
   TraceTableQueryReq,
   TraceTableQueryRes,
-  TraceTableQueryStatsReq,
-  TraceTableQueryStatsRes,
+  TraceTableQueryStatsBatchReq,
+  TraceTableQueryStatsBatchRes,
 } from './traceServerClientTypes';
 
 export class DirectTraceServerClient {
@@ -287,13 +287,13 @@ export class DirectTraceServerClient {
     );
   }
 
-  public tableQueryStats(
-    req: TraceTableQueryStatsReq
-  ): Promise<TraceTableQueryStatsRes> {
-    return this.makeRequest<TraceTableQueryStatsReq, TraceTableQueryStatsRes>(
-      '/table/query_stats',
-      req
-    );
+  public tableQueryStatsBatch(
+    req: TraceTableQueryStatsBatchReq
+  ): Promise<TraceTableQueryStatsBatchRes> {
+    return this.makeRequest<
+      TraceTableQueryStatsBatchReq,
+      TraceTableQueryStatsBatchRes
+    >('/table/query_stats_batch', req);
   }
 
   public feedbackCreate(req: FeedbackCreateReq): Promise<FeedbackCreateRes> {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -1077,6 +1077,7 @@ export const convertTraceServerObjectVersionToSchema = <
     versionIndex: obj.version_index,
     val: obj.val,
     userId: obj.wb_user_id,
+    sizeBytes: obj.size_bytes,
   };
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -118,6 +118,7 @@ export type ObjectVersionSchema<T extends any = any> = ObjectVersionKey & {
   createdAtMs: number;
   val: T;
   userId?: string;
+  sizeBytes?: number;
 };
 
 export type ObjectVersionFilter = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -259,16 +259,20 @@ export type WFDataModelHooksInterface = {
   useTableQueryStats: (
     entity: string,
     project: string,
-    digest: string,
-    opts?: {skip?: boolean}
-  ) => Loadable<traceServerClientTypes.TraceTableQueryStatsRes>;
+    digests: string[],
+    opts?: {skip?: boolean; includeStorageSize?: boolean}
+  ) => Loadable<traceServerClientTypes.TraceTableQueryStatsBatchRes>;
   useRootObjectVersions: (
     entity: string,
     project: string,
     filter: ObjectVersionFilter,
     limit?: number,
     metadataOnly?: boolean,
-    opts?: {skip?: boolean; noAutoRefresh?: boolean}
+    opts?: {
+      skip?: boolean;
+      noAutoRefresh?: boolean;
+      includeStorageSize?: boolean;
+    }
   ) => LoadableWithError<ObjectVersionSchema[]>;
   useObjectDeleteFunc: () => {
     objectVersionsDelete: (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Address [WB-23748](https://wandb.atlassian.net/browse/WB-23748)

## Summary
This PR implements the frontend components and data flow for displaying storage size information in object and dataset detail views. It includes UI components, data fetching logic, and type updates to support the new storage size feature.

Preview:

<img width="968" alt="image" src="https://github.com/user-attachments/assets/b1a33014-b4b0-4b07-a674-d46b921729d6" />

<img width="963" alt="image" src="https://github.com/user-attachments/assets/75d1d494-731f-47b6-94fd-d89eedbaa567" />


## Changes

### New Components
1. Added `StorageSizeSection` component:
   - Displays storage size for current version and all versions
   - Handles loading states with LoadingDots
   - Formats byte sizes using `convertBytes` utility
   - Shows total size across all versions when applicable

### New UI features
1. Updated `DatasetVersionPage`:
   - Added storage size display with version comparison
   - Integrated table size calculations for datasets
   - Added storage usage tracking for both metadata and table data

2. Enhanced `ObjectVersionPage`:
   - Added storage size section to object details
   - Added loading states for size calculations

### Data Layer Updates
1. Modified `traceServerClientTypes`:
   - Switch to using the `TraceTableQueryStatsBatchReq/Res` types and deprecating the old format of  `TraceTableQueryStatsReq/Res` to
   - Added `include_storage_size` option to object queries
   - Updated response types to include storage size information

2. Updated data hooks:
   - Enhanced `useRootObjectVersions` to support storage size fetching
   - Modified `useTableQueryStats` to handle multiple digests by using the new batch API
   - Added storage size options to hook interfaces

3. Client Implementation:
   - Updated `CachingTraceServerClient` to support new batch stats endpoint
   - Modified `DirectTraceServerClient` to use new API endpoints
   - Added caching support for storage size queries


## Testing
1. View an object's details page:
   - Verify storage size is displayed correctly
   - Check loading states work properly

2. View a dataset's details:
   - Verify both metadata and table data sizes are calculated
   - Check total size across versions is displayed correctly
   - Confirm loading states during size calculations




[WB-23748]: https://wandb.atlassian.net/browse/WB-23748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ