### PR TITLE
chore(app): Center number input and handle empty values better

### DIFF
--- a/weave-js/src/common/components/elements/NumberInput.tsx
+++ b/weave-js/src/common/components/elements/NumberInput.tsx
@@ -87,7 +87,7 @@ const NumberInput: React.FC<NumberInputProps> = ({
       setStringValue(newValue.toString());
       onChange(newValue);
     },
-    [onChange, ticks, stringValue, strideLength, min, max]
+    [onChange, ticks, stringValue, strideLength, min, max, props?.placeholder]
   );
 
   if (props.stepper && useStepperPlusMinus) {

--- a/weave-js/src/common/components/elements/NumberInput.tsx
+++ b/weave-js/src/common/components/elements/NumberInput.tsx
@@ -53,7 +53,12 @@ const NumberInput: React.FC<NumberInputProps> = ({
         // Do nothing on non arrow keys
         return;
       }
-      const v = parseFloat(stringValue);
+      // If the value is empty, try falling back to the placeholder in case it's a number
+      // since that's what the input will show. We will want to be able to shift the value
+      // from the empty state in this case.
+      const v = parseFloat(
+        stringValue === '' ? props?.placeholder?.toString() ?? '' : stringValue
+      );
       let newValue;
       if (ticks) {
         if (strideLength) {
@@ -104,7 +109,7 @@ const NumberInput: React.FC<NumberInputProps> = ({
           className={`number-input-plus-minus__input ${props.className || ''}`}
           disabled={props.disabled}
           placeholder={props.placeholder}
-          style={{marginRight: 0, ...props.inputStyle}} // the default margin right is 4px but that misaligns the arrow buttons
+          style={props.inputStyle}
           type="number"
           value={stringValue}
           onFocus={() => {

--- a/weave-js/src/common/css/NumberInput.less
+++ b/weave-js/src/common/css/NumberInput.less
@@ -24,6 +24,7 @@
     border: none !important;
     width: 64px;
     height: 24px;
+    text-align: center !important;
   }
   &__input {
     padding-top: 4px;


### PR DESCRIPTION
## Description

This centers the input so it looks nicer in between the plus and minus buttons. It also tries falling back to the placeholder value in case that's a number so that we can have an empty input but have the arrows work to get from placeholder '1' to value '2' for example.

## Testing

How was this PR tested?


https://github.com/user-attachments/assets/e70257b8-615b-49a3-a4c0-5a875817b942


