### PR TITLE
chore(app): fix unscrollable media in tables

### DIFF
--- a/weave-js/src/components/Panel2/PanelComp.tsx
+++ b/weave-js/src/components/Panel2/PanelComp.tsx
@@ -608,7 +608,7 @@ const ControlWrapper: React.FC<ControlWrapperProps> = ({
           <Modal.Content
             style={{
               height: 'calc(90vh - 73px)',
-              overflow: 'hidden',
+              overflow: 'auto',
               display: 'flex',
             }}>
             <div


### PR DESCRIPTION
- Fixes WB-22129

This PR fixes the issue of the settings for an image within a table not being scrollable.

Before: 


https://github.com/user-attachments/assets/e0d79542-0c56-4443-afce-b233daa74ac5


After:


https://github.com/user-attachments/assets/6148324f-a8e5-436d-b5ea-1c08137416a1

