### PR TITLE
feat(weave): include annotations when adding calls to dataset

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/AddToDatasetDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/AddToDatasetDrawer.tsx
@@ -97,11 +97,20 @@ export const AddToDatasetDrawerInner: React.FC<AddToDatasetDrawerProps> = ({
     entity,
     project,
     {callIds: selectedCallIds},
-    selectedCallIds.length // limit to fetch all selected calls
+    selectedCallIds.length, // limit to fetch all selected calls
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {includeFeedback: true}
   );
 
-  // Recursively expand all refs in inputs and output
-  const expandRefColumns = useMemo(() => new Set(['inputs', 'output']), []);
+  // Recursively expand all refs in inputs, output, and summary
+  const expandRefColumns = useMemo(
+    () => new Set(['inputs', 'output', 'summary']),
+    []
+  );
 
   // Use the enhanced useClientSideCallRefExpansion hook with recursiveUnwrap option,
   // but only for inputs.* fields

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/SchemaMappingStep.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/SchemaMappingStep.tsx
@@ -14,7 +14,7 @@ import {
   denestData,
   extractSourceSchema,
   FieldMapping,
-  getNestedValue,
+  generateFieldPreviews,
 } from './schemaUtils';
 
 export interface SchemaMappingStepProps {
@@ -147,30 +147,7 @@ export const SchemaMappingStep: React.FC<SchemaMappingStepProps> = ({
   );
 
   const fieldPreviews = useMemo(() => {
-    const previews = new Map<string, Array<Record<string, any>>>();
-
-    sourceSchema.forEach(field => {
-      const fieldData = selectedCalls.map(call => {
-        let value: any;
-        if (field.name.startsWith('inputs.')) {
-          const path = field.name.slice(7).split('.');
-          value = getNestedValue(call.val.inputs, path);
-        } else if (field.name.startsWith('output.')) {
-          if (typeof call.val.output === 'object' && call.val.output !== null) {
-            const path = field.name.slice(7).split('.');
-            value = getNestedValue(call.val.output, path);
-          } else {
-            value = call.val.output;
-          }
-        } else {
-          const path = field.name.split('.');
-          value = getNestedValue(call.val, path);
-        }
-        return {[field.name]: value};
-      });
-      previews.set(field.name, fieldData);
-    });
-    return previews;
+    return generateFieldPreviews(sourceSchema, selectedCalls);
   }, [sourceSchema, selectedCalls]);
 
   const formatOptionLabel = useCallback(


### PR DESCRIPTION
## Description

This PR includes annotations in the set of call fields that can be mapped to dataset columns in the add to dataset flow. Annotations will appear in the schema mapping step for new and existing datasets, see below:

![Screenshot 2025-04-16 at 5 35 54 PM](https://github.com/user-attachments/assets/9211aa80-1a52-4609-8f57-943510dbc05d)

![Screenshot 2025-04-16 at 5 35 27 PM](https://github.com/user-attachments/assets/b4b7f01d-b191-4aef-adb9-fd53fe3551a3)

The column name can be changed for new datasets but will default to the name of the annotation:

![Screenshot 2025-04-16 at 5 37 42 PM](https://github.com/user-attachments/assets/9287ad39-b6c2-4f68-93fb-d9e42fd58e14)

This PR also includes handling for scorer output on a call, but the code disables these from appearing in the list of available fields. There may be a good use case for this now but it may also just clutter the options.