### PR TITLE
chore(app): Add hideWhenDetached prop to ToggleButtonGroup Tooltip

### DIFF
--- a/weave-js/src/components/ToggleButtonGroup.tsx
+++ b/weave-js/src/components/ToggleButtonGroup.tsx
@@ -22,6 +22,7 @@ export type ToggleButtonGroupProps = {
   isDisabled?: boolean;
   onValueChange: (value: string) => void;
   className?: string;
+  hideWhenDetached?: boolean; // whether to hide the tooltip when the button is detached from the DOM
 };
 
 /**
@@ -32,7 +33,15 @@ export const ToggleButtonGroup = React.forwardRef<
   ToggleButtonGroupProps
 >(
   (
-    {options, value, size, isDisabled = false, onValueChange, className},
+    {
+      options,
+      value,
+      size,
+      isDisabled = false,
+      onValueChange,
+      className,
+      hideWhenDetached = false,
+    },
     ref
   ) => {
     if (options.length < 2) {
@@ -105,7 +114,11 @@ export const ToggleButtonGroup = React.forwardRef<
                     disabled={isDisabled}
                     asChild>
                     {tooltip ? (
-                      <Tooltip content={tooltip} trigger={button} />
+                      <Tooltip
+                        content={tooltip}
+                        trigger={button}
+                        hideWhenDetached={hideWhenDetached}
+                      />
                     ) : (
                       button
                     )}

--- a/weave-js/src/components/Tooltip.tsx
+++ b/weave-js/src/components/Tooltip.tsx
@@ -39,6 +39,9 @@ type TooltipProps = {
 
   /** Position for the popover. This is for backwards compatibility. Prefer side/align */
   position?: TooltipPosition;
+
+  /** Whether to hide the tooltip when the trigger is detached from the DOM. */
+  hideWhenDetached?: boolean;
 };
 
 type ParsedPosition = {
@@ -76,6 +79,7 @@ export const Tooltip = ({
   align,
   position,
   children,
+  hideWhenDetached = false,
 }: TooltipProps) => {
   const defaultPosition = parsePosition(position);
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
@@ -100,7 +104,8 @@ export const Tooltip = ({
               zIndex: 2147483606,
             }}
             side={side ?? defaultPosition.side}
-            align={align ?? defaultPosition.align}>
+            align={align ?? defaultPosition.align}
+            hideWhenDetached={hideWhenDetached}>
             {children ?? content}
           </Content>
         </Portal>


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-23072 

If the trigger of a tooltip is detached from the DOM for whatever reason, this prop detaches the Tooltip as well so that it's not just floating on nothing.

## Testing

How was this PR tested?

Tested in https://github.com/wandb/core/pull/28848
