### PR TITLE
fix(ui): evaluation compare goes back to evals

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -144,6 +144,9 @@ export const browse2Context = {
   ) => {
     return `/${entityName}/${projectName}/OpDef/${opName}/${opVersionHash}`;
   },
+  evaluationsUIUrl: (entityName: string, projectName: string) => {
+    throw new Error('Not implemented');
+  },
   tracesUIUrl: (entityName: string, projectName: string) => {
     throw new Error('Not implemented');
   },
@@ -371,6 +374,9 @@ export const browse3ContextGen = (
       }
       return url;
     },
+    evaluationsUIUrl: (entityName: string, projectName: string) => {
+      return `${projectRoot(entityName, projectName)}/evaluations`;
+    },
     tracesUIUrl: (entityName: string, projectName: string) => {
       return `${projectRoot(entityName, projectName)}/traces`;
     },
@@ -545,6 +551,7 @@ type RouteType = {
     hideTraceTree?: boolean,
     showFeedback?: boolean
   ) => string;
+  evaluationsUIUrl: (entityName: string, projectName: string) => string;
   tracesUIUrl: (entityName: string, projectName: string) => string;
   callsUIUrl: (
     entityName: string,
@@ -676,6 +683,11 @@ const useMakePeekingRouter = (): RouteType => {
     },
     callUIUrl: (...args: Parameters<typeof baseContext.callUIUrl>) => {
       return setSearchParam(PEEK_PARAM, baseContext.callUIUrl(...args));
+    },
+    evaluationsUIUrl: (
+      ...args: Parameters<typeof baseContext.evaluationsUIUrl>
+    ) => {
+      return setSearchParam(PEEK_PARAM, baseContext.evaluationsUIUrl(...args));
     },
     tracesUIUrl: (...args: Parameters<typeof baseContext.tracesUIUrl>) => {
       return setSearchParam(PEEK_PARAM, baseContext.tracesUIUrl(...args));

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -17,7 +17,6 @@ import {
   WeaveflowPeekContext,
 } from '../../context';
 import {CustomWeaveTypeProjectContext} from '../../typeViews/CustomWeaveTypeDispatcher';
-import {useEvaluationsFilter} from '../CallsPage/evaluationsFilter';
 import {SimplePageLayout} from '../common/SimplePageLayout';
 import {
   CompareEvaluationsProvider,
@@ -149,10 +148,9 @@ const ReturnToEvaluationsButton: FC<{entity: string; project: string}> = ({
 }) => {
   const history = useHistory();
   const router = useWeaveflowCurrentRouteContext();
-  const evaluationsFilter = useEvaluationsFilter(entity, project);
   const onClick = useCallback(() => {
-    history.push(router.callsUIUrl(entity, project, evaluationsFilter));
-  }, [entity, evaluationsFilter, history, project, router]);
+    history.push(router.evaluationsUIUrl(entity, project));
+  }, [entity, history, project, router]);
   return (
     <Box
       sx={{


### PR DESCRIPTION
## Description

When you click the "Return to Evaluations" button on the Evaluation Compare page, it was taking you to the traces page with a filter, rather than to the evaluations URL.

Prod: Note the "Traces" in the breadcrumbs and nav sidebar.
![2025-04-17_tutorial-rag-Workspace-–-Weights-Biases-04-17-2025_07_17_PM](https://github.com/user-attachments/assets/a83465ed-548f-4b22-9da7-b917291fe86a)

PR:
![2025-04-17_tutorial-rag-Workspace-–-Weights-Biases-04-17-2025_07_18_PM](https://github.com/user-attachments/assets/1627c340-9e2e-4047-b108-02c5dbf24e93)

