### PR TITLE
fix(weave): Fix trace export error when op_name is too long

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -40,6 +40,10 @@ from weave.trace_server.opentelemetry.python_spans import (
     SpanKind,
     StatusCode,
 )
+from weave.trace_server.opentelemetry.helpers import (
+    capture_parts,
+    shorten_name,
+)
 from weave.trace_server.opentelemetry.python_spans import TracesData as PyTracesData
 
 
@@ -625,3 +629,81 @@ class TestSemanticConventionParsing:
         )
         generic_attrs = factory.from_proto([generic_key_value])
         assert isinstance(generic_attrs, GenericAttributes)
+
+
+class TestHelpers:
+    def test_capture_parts(self):
+        """Test capturing parts of a string split by delimiters."""
+        # Test with a single delimiter
+        assert capture_parts("part1.part2") == ["part1", ".", "part2"]
+
+        # Test with multiple delimiters
+        assert capture_parts("part1.part2,part3") == ["part1", ".", "part2", ",", "part3"]
+
+        # Test with delimiters that don't appear in the string
+        assert capture_parts("nodelimiters") == ["nodelimiters"]
+
+        # Test with an empty string
+        assert capture_parts("") == [""]
+
+        # Test with custom delimiters
+        assert capture_parts("a-b-c", delimiters=["-"]) == ["a", "-", "b", "-", "c"]
+
+        # Test with adjacent delimiters
+        assert capture_parts("part1..part2") == ["part1", ".", ".", "part2"]
+
+    def test_shorten_name_no_delimiters(self):
+        """Test shortening a name with no delimiters."""
+        # Test a string shorter than max_len - the function always adds ellipsis
+        assert shorten_name("short", 10) == "short..."
+
+        # Test a string longer than max_len with no delimiters
+        long_name = "abcdefghijklmnopqrstuvwxyz"
+        assert shorten_name(long_name, 10) == "abcdefg..."
+
+    def test_shorten_name_with_delimiters(self):
+        """Test shortening a name with delimiters."""
+        # Test with a single delimiter
+        assert shorten_name("part1.part2", 10) == "part1...."
+
+        # Test with multiple delimiters where it fits
+        assert shorten_name("a.b.c", 10) == "a.b.c"
+
+        # Test with multiple delimiters where it needs truncation
+        assert shorten_name("part1.part2.part3", 12) == "part1...."
+
+    def test_shorten_name_first_part_too_long(self):
+        """Test shortening a name where first part is already too long."""
+        # First part already exceeds max_len
+        assert shorten_name("verylongfirstpart.second", 10) == "verylon..."
+
+    def test_shorten_name_custom_abbreviation(self):
+        """Test shortening a name with custom abbreviation."""
+        assert shorten_name("part1.part2.part3", 10, "***") == "part1.***"
+
+        # Test with empty abbreviation
+        assert shorten_name("part1.part2.part3", 10, "") == "part1."
+
+    def test_shorten_name_different_delimiters(self):
+        """Test shortening a name with different types of delimiters."""
+        # Test with a space delimiter
+        assert shorten_name("word1 word2 word3", 12) == "word1 ..."
+
+        # Test with a slash delimiter
+        assert shorten_name("path/to/file", 8) == "path/..."
+
+        # Test with mixed delimiters
+        assert shorten_name("user.name@example.com", 12) == "user...."
+
+        # Test with a delimiter not in the default list
+        # Note: This will be treated as having no delimiters since '-' is not in the default list
+        assert shorten_name("part1-part2-part3", 10) == "part1-p..."
+
+        # Test with a question mark delimiter
+        assert shorten_name("api/endpoint?param=value", 15) == "api/..."
+
+    def test_long_url_regression(self):
+        # Test for a modified version of the URL which caused failed traces due to op_name length
+        actual = shorten_name("GET /api/trpc/lambda/organization.getActiveOrganization,account.getSubscription,checkout.getPrices,user.getUserToolGroupsConfig?batch=1&input=%8A%220%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%221%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%222%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%223%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%8D", 128)
+        expected = "GET /api/trpc/lambda/organization.getActiveOrganization,account.getSubscription,checkout.getPrices,user.getUserToolGroupsConfig..."
+        assert actual == expected

--- a/weave/trace_server/opentelemetry/helpers.py
+++ b/weave/trace_server/opentelemetry/helpers.py
@@ -1,0 +1,55 @@
+import re
+
+# TODO: Move shared helpers into this file
+# This logic doesn't really belong in any existing files, but there is logic in existing files that belongs here.
+
+def capture_parts(
+    s: str,
+    delimiters: list[str]=[",", ";", "|", " ", "/", "?", "."]
+) -> list[str]:
+    """
+    # Split a string based on multiple patterns, including the split characters in the result.
+    """
+
+    # Escape special regex characters and join with | for regex alternation
+    capture = '|'.join(map(re.escape, delimiters))
+    pattern = f"({(capture)})"
+
+    # Use re.split with capturing groups to include the delimiters
+    parts = re.split(pattern, s)
+
+    # Filter out empty strings that might result from the split
+    result = [part for part in parts if part != '']
+
+    result = list(filter(lambda x: len(x) > 0, parts))
+    # If no split occurred, return the original string in a list
+    if len(result) == 0:
+        return [s]
+
+    return result
+
+def shorten_name(name: str, max_len: int, abbrv="...") -> str:
+    # Split the string based on all of the listed delimiters
+    parts = capture_parts(name)
+    if len(parts) <= 1:
+        # No delimiters found, just truncate
+        return name[:max_len-(len(abbrv))] + abbrv
+
+    shortened_name = parts[0]
+
+    # If the first part is already longer than max_len, truncate it
+    if len(shortened_name) > max_len-len(abbrv):
+        return shortened_name[:max_len-len(abbrv)] + abbrv
+
+    # We already have the first part in shortened_name, so skip it
+    for i in range(1, len(parts)-1, 2):
+        # Concatenate the delimiter with the next part
+        next_delimiter = parts[i]
+        next_part = f"{next_delimiter}{parts[i+1]}"
+        if len(shortened_name) + len(next_part) > max_len-(len(abbrv)+1):
+            shortened_name += f"{next_delimiter}{abbrv}"
+            break
+        shortened_name += next_part
+
+    return shortened_name
+

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -9,7 +9,7 @@ from binascii import hexlify
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope
 from opentelemetry.proto.resource.v1.resource_pb2 import Resource as PbResource
@@ -38,6 +38,8 @@ from .attributes import (
     unflatten_key_values,
 )
 
+from weave.trace_server.constants import MAX_OP_NAME_LENGTH
+from weave.trace_server.opentelemetry.helpers import shorten_name
 
 class SpanKind(Enum):
     """Enum representing the span's kind."""
@@ -274,6 +276,9 @@ class Span:
         attributes = self.attributes.get_weave_attributes(
             extra={"otel_span": self.as_dict()}
         )
+        op_name = self.name
+        if len(op_name) >= MAX_OP_NAME_LENGTH:
+            op_name = shorten_name(op_name, MAX_OP_NAME_LENGTH)
 
         # Options: set
         start_call = tsi.StartedCallSchemaForInsert(


### PR DESCRIPTION
## Description
- Fixes WB-24498

Adds a `shorten_name` helper and validates `op_name` is not too long for otel traces

## Testing

Added unit tests for introduced helpers and added regression test for modified version of the failing payload
