### PR TITLE
fix(weave): fixes the case tha Trace Size becomes a filter condition

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3751,3 +3751,26 @@ def test_call_query_stream_with_costs_and_storage_size(client, clickhouse_client
 
     assert parent_call.total_storage_size_bytes is not None
     assert child_call.storage_size_bytes is None
+
+
+def test_call_query_stream_with_invalid_filter_field(client):
+    if client_is_sqlite(client):
+        # dont run this test for sqlite
+        return
+
+    with pytest.raises(InvalidFieldError):
+        res = get_client_trace_server(client).calls_query(
+            tsi.CallsQueryReq.model_validate(
+                {
+                    "project_id": get_client_project_id(client),
+                    "query": {
+                        "$expr": {
+                            "$contains": {
+                                "input": {"$getField": "total_storage_size_bytes"},
+                                "substr": {"$literal": "2025-04-11T05:56:12.957Z"},
+                            }
+                        }
+                    },
+                }
+            )
+        )

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -39,6 +39,7 @@ export const UNFILTERABLE_FIELDS = [
   'cost',
   'wb_user_id', // Option+Click works
   'wb_run_id', // Option+Click works
+  'total_storage_size_bytes',
 ];
 
 export type ColumnInfo = {

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -861,6 +861,8 @@ ALLOWED_CALL_FIELDS = {
     ),
 }
 
+DISALLOWED_FILTERING_FIELDS = {"storage_size_bytes", "total_storage_size_bytes"}
+
 
 def get_field_by_name(name: str) -> CallsMergedField:
     if name not in ALLOWED_CALL_FIELDS:
@@ -1033,7 +1035,11 @@ def process_query_to_conditions(
                 python_value_to_ch_type(operand.literal_),
             )
         elif isinstance(operand, tsi_query.GetFieldOperator):
+            if operand.get_field_ in DISALLOWED_FILTERING_FIELDS:
+                raise InvalidFieldError(f"Field {operand.get_field_} is not allowed")
+
             structured_field = get_field_by_name(operand.get_field_)
+
             if isinstance(structured_field, CallsMergedDynamicField):
                 field = structured_field.as_sql(
                     param_builder, table_alias, use_agg_fn=use_agg_fn


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes a bug that impacts production right now

1. Disables total_storage_size_bytes as a filterable column in the filter dropdown.
2. Add detection logic in the query builder which rejects unexpected filter conditions. 

## Testing
Manually tested the UI,

Added a unit test for `#2`
