### PR TITLE
feat(weave): use otel attribute keys as input and output subfields

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -426,7 +426,6 @@ class TestSemanticConventionParsing:
 
         # Test get_weave_attributes
         extracted = get_weave_attributes(attributes)
-        print(extracted)
         assert extracted["system"] == "This is a system prompt"
         assert extracted["provider"] == "test-provider"
         assert extracted["model"] == "test-model"
@@ -449,8 +448,7 @@ class TestSemanticConventionParsing:
         # Test get_weave_inputs with text input
         inputs = get_weave_inputs([], attributes)
         assert inputs == {
-            "value": "What is machine learning?",
-            "type": "text/plain",
+            "input.value": "What is machine learning?",
         }
 
         # Test with JSON input
@@ -470,13 +468,12 @@ class TestSemanticConventionParsing:
         )
         inputs = get_weave_inputs([], attributes)
         assert inputs == {
-            "value": {
+            "input.value": {
                 "messages": [
                     {"role": "system", "content": "You are an assistant"},
                     {"role": "user", "content": "What is machine learning?"},
                 ]
             },
-            "type": "application/json",
         }
 
     def test_openinference_outputs_extraction(self):
@@ -494,8 +491,7 @@ class TestSemanticConventionParsing:
         # Test get_weave_outputs with text output
         outputs = get_weave_outputs([], attributes)
         assert outputs == {
-            "value": "Machine learning is a field of AI...",
-            "type": "text/plain",
+            "output.value": "Machine learning is a field of AI...",
         }
 
         # Test with JSON output
@@ -515,13 +511,12 @@ class TestSemanticConventionParsing:
         )
         outputs = get_weave_outputs([], attributes)
         assert outputs == {
-            "value": {
+            "output.value": {
                 "response": {
                     "role": "assistant",
                     "content": "Machine learning is a field of AI...",
                 }
             },
-            "type": "application/json",
         }
 
     def test_openinference_usage_extraction(self):
@@ -579,7 +574,7 @@ class TestSemanticConventionParsing:
         # Test get_weave_inputs
         inputs = get_weave_inputs([], attributes)
         assert inputs == {
-            "value": [{"role": "user", "content": "Tell me about quantum computing"}]
+            "gen_ai.prompt": [{"role": "user", "content": "Tell me about quantum computing"}]
         }
 
         # Test with multiple prompts
@@ -594,7 +589,7 @@ class TestSemanticConventionParsing:
         )
         inputs = get_weave_inputs([], attributes)
         assert inputs == {
-            "value": [
+            "gen_ai.prompt": [
                 {"role": "system", "content": "You are an expert in quantum physics"},
                 {"role": "user", "content": "Tell me about quantum computing"},
             ]
@@ -622,7 +617,7 @@ class TestSemanticConventionParsing:
         # Test get_weave_outputs
         outputs = get_weave_outputs([], attributes)
         assert outputs == {
-            "value": [
+            "gen_ai.completion": [
                 {
                     "role": "assistant",
                     "content": "Quantum computing uses quantum mechanics...",

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -574,7 +574,9 @@ class TestSemanticConventionParsing:
         # Test get_weave_inputs
         inputs = get_weave_inputs([], attributes)
         assert inputs == {
-            "gen_ai.prompt": [{"role": "user", "content": "Tell me about quantum computing"}]
+            "gen_ai.prompt": [
+                {"role": "user", "content": "Tell me about quantum computing"}
+            ]
         }
 
         # Test with multiple prompts

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -28,6 +28,7 @@ from weave.trace_server.opentelemetry.attributes import (
     expand_attributes,
     flatten_attributes,
     get_attribute,
+    get_wandb_attributes,
     get_weave_attributes,
     get_weave_inputs,
     get_weave_outputs,
@@ -452,6 +453,49 @@ class TestSemanticConventionParsing:
         assert extracted["kind"] == "llm"
         assert extracted["model_parameters"]["max_tokens"] == 100
         assert extracted["model_parameters"]["temperature"] == 0.7
+
+    def test_wandb_attributes_extraction(self):
+        """Test extracting wandb-specific attributes."""
+        # Create attribute dictionary with W&B specific attributes
+        attributes = create_attributes(
+            {
+                "wandb.display_name": "My Custom Display Name",
+                "wandb.project_id": "project-123",
+            }
+        )
+
+        # Test get_wandb_attributes
+        extracted = get_wandb_attributes(attributes)
+        assert extracted["display_name"] == "My Custom Display Name"
+        assert extracted["project_id"] == "project-123"
+
+        # Test with missing attributes
+        empty_attributes = create_attributes({})
+        extracted = get_wandb_attributes(empty_attributes)
+        assert extracted == {}
+
+        # Test with partial attributes
+        partial_attributes = create_attributes(
+            {
+                "wandb.display_name": "Only Display Name",
+            }
+        )
+        extracted = get_wandb_attributes(partial_attributes)
+        assert extracted["display_name"] == "Only Display Name"
+        assert "project_id" not in extracted
+
+        # Test with nested attributes format
+        nested_attributes = create_attributes(
+            {
+                "wandb": {
+                    "display_name": "Nested Display Name",
+                    "project_id": "nested-project-123",
+                }
+            }
+        )
+        extracted = get_wandb_attributes(nested_attributes)
+        assert extracted["display_name"] == "Nested Display Name"
+        assert extracted["project_id"] == "nested-project-123"
 
     def test_openinference_inputs_extraction(self):
         """Test extracting inputs from OpenInference attributes."""

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -460,14 +460,12 @@ class TestSemanticConventionParsing:
         attributes = create_attributes(
             {
                 "wandb.display_name": "My Custom Display Name",
-                "wandb.project_id": "project-123",
             }
         )
 
         # Test get_wandb_attributes
         extracted = get_wandb_attributes(attributes)
         assert extracted["display_name"] == "My Custom Display Name"
-        assert extracted["project_id"] == "project-123"
 
         # Test with missing attributes
         empty_attributes = create_attributes({})
@@ -489,13 +487,11 @@ class TestSemanticConventionParsing:
             {
                 "wandb": {
                     "display_name": "Nested Display Name",
-                    "project_id": "nested-project-123",
                 }
             }
         )
         extracted = get_wandb_attributes(nested_attributes)
         assert extracted["display_name"] == "Nested Display Name"
-        assert extracted["project_id"] == "nested-project-123"
 
     def test_openinference_inputs_extraction(self):
         """Test extracting inputs from OpenInference attributes."""

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -348,6 +348,7 @@ class SpanEvent(dict):
     attributes: dict[str, Any]
     dropped_attributes_count: int
 
+
 def parse_weave_values(
     attributes: dict[str, Any],
     key_mapping: Union[list[str], dict[str, list[str]]],

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -348,14 +348,26 @@ class SpanEvent(dict):
     attributes: dict[str, Any]
     dropped_attributes_count: int
 
-
 def parse_weave_values(
     attributes: dict[str, Any],
     key_mapping: Union[list[str], dict[str, list[str]]],
 ) -> dict[str, Any]:
-    if isinstance(key_mapping, list):
-        key_mapping = {key: [key] for key in key_mapping}
     result = {}
+    # If list use the attribute as the key - Prevents synthetic attributes under input and output
+    if isinstance(key_mapping, list):
+        for attribute_key in key_mapping:
+            value = get_attribute(attributes, attribute_key)
+            if value:
+                if attribute_key in KEY_HANDLERS:
+                    try:
+                        value = KEY_HANDLERS[attribute_key](value)
+                    except:
+                        pass
+                result[attribute_key] = value
+                break
+        return result
+
+    # If dict, unpack to associate all nested keys with their parent
     for key, attribute_key_list in key_mapping.items():
         for attribute_key in attribute_key_list:
             value = get_attribute(attributes, attribute_key)
@@ -392,9 +404,11 @@ def get_weave_usage(attributes: dict[str, Any]) -> dict[str, Any]:
     return usage
 
 
+# Pass events here even though they are unused because some libraries put input in event attribtes
 def get_weave_inputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str, Any]:
     return parse_weave_values(attributes, INPUT_KEYS)
 
 
+# Pass events here even though they are unused because some libraries put output in event attribtes
 def get_weave_outputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str, Any]:
     return parse_weave_values(attributes, OUTPUT_KEYS)

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -346,8 +346,11 @@ class SpanEvent(dict):
 
 
 def parse_weave_values(
-    attributes: dict[str, Any], key_mapping: dict[str, list[str]]
+    attributes: dict[str, Any],
+    key_mapping: Union[list[str], dict[str, list[str]]],
 ) -> dict[str, Any]:
+    if isinstance(key_mapping, list):
+        key_mapping = {key: [key] for key in key_mapping}
     result = {}
     for key, attribute_key_list in key_mapping.items():
         for attribute_key in attribute_key_list:

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -12,6 +12,7 @@ from weave.trace_server.opentelemetry.constants import (
     INPUT_KEYS,
     OUTPUT_KEYS,
     USAGE_KEYS,
+    WB_KEYS,
 )
 
 
@@ -413,3 +414,8 @@ def get_weave_inputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str
 # Pass events here even though they are unused because some libraries put output in event attribtes
 def get_weave_outputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str, Any]:
     return parse_weave_values(attributes, OUTPUT_KEYS)
+
+
+# Custom attributes for weave to enable setting fields like wb_user_id otherwise unavailable in OTEL Traces
+def get_wandb_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
+    return parse_weave_values(attributes, WB_KEYS)

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -1,33 +1,19 @@
-INPUT_KEYS = {
-    "value": [
-        "weave.input",  # Weave
-        "input.value",  # OpenInference
-        "gen_ai.prompt",  # OpenTelemetry
-        "mlflow.spanInputs",  # MLFlow
-        "traceloop.entity.input"  # Traceloop
-        "input",  # Pydantic - This must execute after checking input.value
-    ],
-    "type": [
-        "input.mime_type",  # OpenInference
-        "gen_ai.input.type",
-    ],
-}
+INPUT_KEYS = [
+    "input.value",  # OpenInference
+    "gen_ai.prompt",  # OpenTelemetry
+    "mlflow.spanInputs",  # MLFlow
+    "traceloop.entity.input"  # Traceloop
+    "input",  # Pydantic - This must execute after checking input.value
+]
 
-OUTPUT_KEYS = {
-    "value": [
-        "weave.output",  # Weave
-        "output.value",  # OpenInference
-        "gen_ai.completion",  # OTEL Semconv
-        "mlflow.spanOutputs",  # MLFlow
-        "gen_ai.content.completion",  # OpenLit
-        "traceloop.entity.output",  # Traceloop
-        "output",  # Pydantic - This must execute after checking output.value
-    ],
-    "type": [
-        "output.mime_type",  # OpenInference
-        "gen_ai.output.type",  # OTEL Semconv
-    ],
-}
+OUTPUT_KEYS = [
+    "output.value",  # OpenInference
+    "gen_ai.completion",  # OTEL Semconv
+    "mlflow.spanOutputs",  # MLFlow
+    "gen_ai.content.completion",  # OpenLit
+    "traceloop.entity.output",  # Traceloop
+    "output",  # Pydantic - This must execute after checking output.value
+]
 
 USAGE_KEYS = {
     "prompt_tokens": ["gen_ai.usage.prompt_tokens", "llm.token_count.prompt"],

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -40,3 +40,9 @@ ATTRIBUTE_KEYS = {
     ],
     "model_parameters": ["gen_ai.request", "llm.invocation_parameters"],
 }
+
+# Wandb/Weave specific call attributes
+WB_KEYS = {
+    "display_name": ["wandb.display_name"],
+    "project_id": ["wandb.project_id"],
+}

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -44,5 +44,4 @@ ATTRIBUTE_KEYS = {
 # Wandb/Weave specific call attributes
 WB_KEYS = {
     "display_name": ["wandb.display_name"],
-    "project_id": ["wandb.project_id"],
 }


### PR DESCRIPTION
## Description

- Fixes WB-24515

Required for #4143

Example for OpenInference (input.value and output.value are the attributes in the OTEL span)
![image](https://github.com/user-attachments/assets/c6df6acb-9aea-4dde-8044-985aa0e17795)

Note: While it the key display is a bit wonky since input.value is parsed as two layers of headers, that's for the frontend to handle not the backend.