### PR TITLE
feat(weave): allow setting display name through weave attribute

### DIFF
--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -415,6 +415,7 @@ def get_weave_inputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str
 def get_weave_outputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str, Any]:
     return parse_weave_values(attributes, OUTPUT_KEYS)
 
+
 # Custom attributes for weave to enable setting fields like wb_user_id otherwise unavailable in OTEL Traces
 def get_wandb_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
     return parse_weave_values(attributes, WB_KEYS)

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -12,6 +12,7 @@ from weave.trace_server.opentelemetry.constants import (
     INPUT_KEYS,
     OUTPUT_KEYS,
     USAGE_KEYS,
+    WB_KEYS,
 )
 
 
@@ -413,3 +414,7 @@ def get_weave_inputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str
 # Pass events here even though they are unused because some libraries put output in event attribtes
 def get_weave_outputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str, Any]:
     return parse_weave_values(attributes, OUTPUT_KEYS)
+
+# Custom attributes for weave to enable setting fields like wb_user_id otherwise unavailable in OTEL Traces
+def get_wandb_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
+    return parse_weave_values(attributes, WB_KEYS)

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -40,3 +40,14 @@ ATTRIBUTE_KEYS = {
     ],
     "model_parameters": ["gen_ai.request", "llm.invocation_parameters"],
 }
+
+# Wandb/Weave specific call attributes
+WB_KEYS = {
+    "wb_user_id": ["wandb.user_id"],
+    "wb_run_id": ["wandb.run_id"],
+    "display_name": ["wandb.display_name"],
+
+    # TODO: Currently unused, should fall back to these values if not sent in headers
+    "project_id": ["wandb.project_id"],
+    "entity": ["wandb.entity"],
+}

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -43,11 +43,6 @@ ATTRIBUTE_KEYS = {
 
 # Wandb/Weave specific call attributes
 WB_KEYS = {
-    "wb_user_id": ["wandb.user_id"],
-    "wb_run_id": ["wandb.run_id"],
     "display_name": ["wandb.display_name"],
-
-    # TODO: Currently unused, should fall back to these values if not sent in headers
     "project_id": ["wandb.project_id"],
-    "entity": ["wandb.entity"],
 }

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -332,8 +332,8 @@ class Span:
             attributes=attributes,
             inputs=inputs,
             display_name=wandb_attributes.get("display_name"),
-            wb_user_id=wandb_attributes.get("wb_user_id"),
-            wb_run_id=wandb_attributes.get("wb_run_id"),
+            wb_user_id=None,
+            wb_run_id=None,
         )
         exception_msg = (
             self.status.message if self.status.code == StatusCode.ERROR else None

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -35,6 +35,7 @@ from weave.trace_server.opentelemetry.helpers import shorten_name
 
 from .attributes import (
     SpanEvent,
+    get_wandb_attributes,
     get_weave_attributes,
     get_weave_inputs,
     get_weave_outputs,
@@ -286,6 +287,8 @@ class Span:
         inputs = get_weave_inputs(events, self.attributes) or {}
         outputs = get_weave_outputs(events, self.attributes) or {}
         attributes = get_weave_attributes(self.attributes) or {}
+        wandb_attributes = get_wandb_attributes(self.attributes) or {}
+
         llm_usage = tsi.LLMUsageSchema(
             input_tokens=usage.get("input_tokens"),
             output_tokens=usage.get("output_tokens"),
@@ -328,8 +331,9 @@ class Span:
             started_at=self.start_time,
             attributes=attributes,
             inputs=inputs,
-            wb_user_id=None,
-            wb_run_id=None,
+            display_name=wandb_attributes.get("display_name"),
+            wb_user_id=wandb_attributes.get("wb_user_id"),
+            wb_run_id=wandb_attributes.get("wb_run_id"),
         )
         exception_msg = (
             self.status.message if self.status.code == StatusCode.ERROR else None

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -30,7 +30,7 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 )
 
 from weave.trace_server import trace_server_interface as tsi
-from weave.trace_server.constants import MAX_OP_NAME_LENGTH
+from weave.trace_server.constants import MAX_DISPLAY_NAME_LENGTH, MAX_OP_NAME_LENGTH
 from weave.trace_server.opentelemetry.helpers import shorten_name
 
 from .attributes import (
@@ -321,6 +321,9 @@ class Span:
         op_name = self.name
         if len(op_name) >= MAX_OP_NAME_LENGTH:
             op_name = shorten_name(op_name, MAX_OP_NAME_LENGTH)
+        display_name = wandb_attributes.get("display_name")
+        if display_name and len(display_name) >= MAX_DISPLAY_NAME_LENGTH:
+            display_name = shorten_name(display_name, MAX_DISPLAY_NAME_LENGTH)
 
         start_call = tsi.StartedCallSchemaForInsert(
             project_id=project_id,
@@ -331,7 +334,7 @@ class Span:
             started_at=self.start_time,
             attributes=attributes,
             inputs=inputs,
-            display_name=wandb_attributes.get("display_name"),
+            display_name=display_name,
             wb_user_id=None,
             wb_run_id=None,
         )


### PR DESCRIPTION
## Description

- Fixes WB-24499

creates new `wandb.display_name` check for otel attributes to allow setting `display_name` for call through traces

## Testing

added unit tests
