### PR TITLE
chore(weave): dump option click filter values to string

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -10,6 +10,7 @@ import {
   FilterId,
   getFieldType,
   getGroupedOperatorOptions,
+  getOperatorValueType,
   isWeaveRef,
 } from './common';
 import {SelectField, SelectFieldOption} from './SelectField';
@@ -55,6 +56,17 @@ export const FilterRow = ({
   );
 
   const onSelectOperator = (operator: string) => {
+    // If the operator type changes, clear the value
+    if (item.operator && operator) {
+      const oldType = getOperatorValueType(item.operator);
+      const newType = getOperatorValueType(operator);
+
+      if (oldType !== newType) {
+        onUpdateFilter({...item, operator, value: undefined});
+        return;
+      }
+    }
+
     onUpdateFilter({...item, operator});
   };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -10,7 +10,6 @@ import {
   FilterId,
   getFieldType,
   getGroupedOperatorOptions,
-  getOperatorValueType,
   isWeaveRef,
 } from './common';
 import {SelectField, SelectFieldOption} from './SelectField';
@@ -56,17 +55,6 @@ export const FilterRow = ({
   );
 
   const onSelectOperator = (operator: string) => {
-    // If the operator type changes, clear the value
-    if (item.operator && operator) {
-      const oldType = getOperatorValueType(item.operator);
-      const newType = getOperatorValueType(operator);
-
-      if (oldType !== newType) {
-        onUpdateFilter({...item, operator, value: undefined});
-        return;
-      }
-    }
-
     onUpdateFilter({...item, operator});
   };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -387,6 +387,7 @@ export const CallsTable: FC<{
             field = expandedRef.field;
           }
           const op = operator ? operator : getDefaultOperatorForValue(value);
+          const strVal = JSON.stringify(value);
 
           // Check if there is an exact match for field, operator, and value in filterModel.items
           // If an exact match exists, remove it instead of adding a duplicate.
@@ -394,7 +395,7 @@ export const CallsTable: FC<{
             item =>
               item.field === field &&
               item.operator === op &&
-              JSON.stringify(item.value) === JSON.stringify(value)
+              JSON.stringify(item.value) === strVal
           );
           if (existingFullMatchIndex !== -1) {
             const newItems = [...filterModel.items];
@@ -415,7 +416,7 @@ export const CallsTable: FC<{
             const newItems = [...filterModel.items];
             newItems[existingFieldOpMatchIndex] = {
               ...newItems[existingFieldOpMatchIndex],
-              value,
+              value: strVal,
             };
             setFilterModel({
               ...filterModel,
@@ -433,7 +434,7 @@ export const CallsTable: FC<{
                 id: filterModel.items.length,
                 field,
                 operator: op,
-                value,
+                value: strVal,
               },
             ],
           };


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24519](https://wandb.atlassian.net/browse/WB-24519)

"option click" filters use the raw value, which is fine for the initial filter, until you change the operator. Lets just cast to string, which should also always work (also tested for bool)

Prevents the weird class of errors highlighted in the ticket. It is still possible to create these errors through the API, not exactly sure how to deal with that...

## Testing

Prod: 
![filter-op-value-prod-1](https://github.com/user-attachments/assets/c78627ab-d983-4494-ad44-af7f28bfa0d1)

Branch:
![filter-op-value-branch-1](https://github.com/user-attachments/assets/7064520c-3c2c-4d60-95f2-2c4b7202f24d)



[WB-24519]: https://wandb.atlassian.net/browse/WB-24519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ