### PR TITLE
docs(weave): typo in prompts.md

### DIFF
--- a/docs/docs/guides/core-types/prompts.md
+++ b/docs/docs/guides/core-types/prompts.md
@@ -1,7 +1,7 @@
 # Prompts
 
 :::important
-Curremtly, this feature is only accessible through the Python SDK. All code examples on this page are provided in Python.
+This feature is only accessible through the Python SDK. All code examples on this page are provided in Python.
 :::
 
 Creating, evaluating, and refining prompts is a core activity for AI engineers.


### PR DESCRIPTION
Fix typo on prompts page

## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1427



## Testing

yarn start on local
