### PR TITLE
fix(ui): inverted photo in filter tag

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -54,7 +54,13 @@ export const FilterTagItem = ({
   if (fieldType === 'id') {
     value = <IdList ids={getStringList(item.value)} type="Call" />;
   } else if (fieldType === 'user') {
-    value = <UserLink userId={item.value} hasPopover={false} />;
+    // This additional night-aware is unfortunate, necessary to counteract
+    // the night-aware in FilterTag's useTagClasses call.
+    value = (
+      <div className="night-aware">
+        <UserLink userId={item.value} hasPopover={false} />
+      </div>
+    );
   } else if (fieldType === 'status') {
     value = <FilterTagStatus value={item.value} />;
   } else if (isWeaveRef(item.value)) {


### PR DESCRIPTION
## Description

This is a little ugly. For context, night mode inverts everything with a CSS filter, and then an additional rule for images normally inverts that (not perfectly, but that's besides the point here). However, tags, including the Filters tag, use a `useTagClasses` hook which applies `night-aware` which overrides this. The solution in this PR is to apply night-aware to just the user filter tag contents to invert that yet again, making the profile picture look right.

A better solution would be to figure out why tags were set to be night aware not just for themselves but for their children as well. However, that would require a larger code audit than I think we want to take on right now.

Before:
<img width="215" alt="Screenshot 2025-04-21 at 1 29 13 PM" src="https://github.com/user-attachments/assets/12f8464f-42be-4372-91e8-a1c840a6eb2e" />

After:
<img width="215" alt="Screenshot 2025-04-21 at 1 29 32 PM" src="https://github.com/user-attachments/assets/6fba3894-011a-416b-809a-0858a74cbd5b" />


## Testing

How was this PR tested?
