### PR TITLE
chore(weave): add frontend not equal string operator

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -109,6 +109,11 @@ const allOperators: SelectOperatorOption[] = [
     group: 'string',
   },
   {
+    value: '(string): notEquals',
+    label: 'not equals',
+    group: 'string',
+  },
+  {
     value: '(number): =',
     label: '=',
     group: 'number',
@@ -242,6 +247,11 @@ export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
       {
         value: '(string): in',
         label: 'in',
+        group: 'string',
+      },
+      {
+        value: '(string): notEquals',
+        label: 'not equals',
         group: 'string',
       },
     ];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -38,6 +38,10 @@ export const operationConverter = (
       $eq: [{$getField: item.field}, {$literal: v}],
     }));
     return {$or: clauses};
+  } else if (item.operator === '(string): notEquals') {
+    return {
+      $not: [{$eq: [{$getField: item.field}, {$literal: item.value}]}],
+    };
   } else if (item.operator === '(number): =') {
     if (item.value === '') {
       return null;


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24546](https://wandb.atlassian.net/browse/WB-24546)

Add a "not equals" string operator selectable from the frontend filter bar.

![Screenshot 2025-04-21 at 12 12 40 PM](https://github.com/user-attachments/assets/22516f3b-c002-4058-93f2-b08de4477c67)


## Testing

![not-equal-filter-2](https://github.com/user-attachments/assets/9526f7ca-d2ea-40ec-ab10-1c607c89bdde)



[WB-24546]: https://wandb.atlassian.net/browse/WB-24546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ