### PR TITLE
chore(weave): add "does not contain" string filter

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -75,7 +75,7 @@ export const FilterRow = ({
           onSelectField={onSelectField}
         />
       </div>
-      <div className="w-[140px]">
+      <div className="w-[165px]">
         {item.field && (
           <SelectOperator
             options={operatorOptions}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -93,6 +93,7 @@ export type SelectOperatorOption = {
 };
 
 const allOperators: SelectOperatorOption[] = [
+  // String operators
   {
     value: '(string): contains',
     label: 'contains',
@@ -113,6 +114,12 @@ const allOperators: SelectOperatorOption[] = [
     label: 'not equals',
     group: 'string',
   },
+  {
+    value: '(string): notContains',
+    label: 'does not contain',
+    group: 'string',
+  },
+  // Number operators
   {
     value: '(number): =',
     label: '=',
@@ -143,11 +150,13 @@ const allOperators: SelectOperatorOption[] = [
     label: '≥',
     group: 'number',
   },
+  // Boolean operators
   {
     value: '(bool): is',
     label: 'is',
     group: 'boolean',
   },
+  // Date operators
   {
     value: '(date): after',
     label: 'after',
@@ -158,6 +167,7 @@ const allOperators: SelectOperatorOption[] = [
     label: 'before',
     group: 'date',
   },
+  // Any operators
   {
     value: '(any): isEmpty',
     label: 'is empty',
@@ -252,6 +262,11 @@ export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
       {
         value: '(string): notEquals',
         label: 'not equals',
+        group: 'string',
+      },
+      {
+        value: '(string): notContains',
+        label: 'does not contain',
         group: 'string',
       },
     ];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -42,6 +42,17 @@ export const operationConverter = (
     return {
       $not: [{$eq: [{$getField: item.field}, {$literal: item.value}]}],
     };
+  } else if (item.operator === '(string): notContains') {
+    return {
+      $not: [
+        {
+          $contains: {
+            input: {$getField: item.field},
+            substr: {$literal: item.value},
+          },
+        },
+      ],
+    };
   } else if (item.operator === '(number): =') {
     if (item.value === '') {
       return null;


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24553](https://wandb.atlassian.net/browse/WB-24553)

Add a "does not contain" string filter operator. Increase the width of the operator dropdown. 

![Screenshot 2025-04-21 at 1 14 47 PM](https://github.com/user-attachments/assets/3ba61f66-3268-4115-9a84-a39b3e8951b8)

## Testing

![not-contains-filter-1](https://github.com/user-attachments/assets/f9e5758b-1125-46a8-a0dc-1be54cd5bd19)


[WB-24553]: https://wandb.atlassian.net/browse/WB-24553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ