### PR TITLE
refactor(dev): simplify dataset cell renderers

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CellRenderers.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CellRenderers.tsx
@@ -1,20 +1,13 @@
-import {Box, Tooltip} from '@mui/material';
-import {
-  GridRenderCellParams,
-  GridRenderEditCellParams,
-} from '@mui/x-data-grid-pro';
+import {Box, Tooltip, TooltipProps} from '@mui/material';
+import {GridRenderCellParams} from '@mui/x-data-grid-pro';
 import {Button} from '@wandb/weave/components/Button';
 import {Icon} from '@wandb/weave/components/Icon';
-import set from 'lodash/set';
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
 import {CellValue} from '../../Browse2/CellValue';
 import {isRefPrefixedString} from '../filters/common';
-import {DatasetRow, useDatasetEditContext} from './DatasetEditorContext';
-import {CodeEditor} from './editors/CodeEditor';
-import {DiffEditor} from './editors/DiffEditor';
-import {TextEditor} from './editors/TextEditor';
-import {EditorMode, EditPopover} from './EditPopover';
+import {useDatasetEditContext} from './DatasetEditorContext';
+import {EditPopover} from './EditPopover';
 
 export const CELL_COLORS = {
   DELETED: '#FFE6E6', // Red 200
@@ -38,59 +31,108 @@ const cellViewingStyles = {
   transition: 'background-color 0.2s ease',
 };
 
-interface CellViewingRendererProps {
+interface CellProps extends GridRenderCellParams {
   isEdited?: boolean;
   isDeleted?: boolean;
   isNew?: boolean;
-  isEditing?: boolean;
   serverValue?: any;
   disableNewRowHighlight?: boolean;
+  preserveFieldOrder?: (row: any) => any;
 }
 
-export const CellViewingRenderer: React.FC<
-  GridRenderCellParams & CellViewingRendererProps
-> = ({
+// Custom tooltip component to reduce repetition
+const CellTooltip: React.FC<{
+  title: string;
+  children: React.ReactElement;
+  placement?: TooltipProps['placement'];
+}> = ({title, children, placement = 'top'}) => (
+  <Tooltip
+    title={title}
+    enterDelay={1000}
+    enterNextDelay={1000}
+    leaveDelay={0}
+    placement={placement}
+    slotProps={{
+      tooltip: {
+        sx: {
+          fontFamily: '"Source Sans Pro", sans-serif',
+          fontSize: '14px',
+        },
+      },
+    }}>
+    {children}
+  </Tooltip>
+);
+
+export const DatasetCellRenderer: React.FC<CellProps> = ({
   value,
   isEdited = false,
   isDeleted = false,
   isNew = false,
-  isEditing = false,
-  api,
   id,
   field,
+  row,
   serverValue,
   disableNewRowHighlight = false,
+  preserveFieldOrder,
 }) => {
+  const [isEditing, setIsEditing] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
-  const {setEditedRows, setAddedRows, setFieldEdited} = useDatasetEditContext();
+  const [editedValue, setEditedValue] = useState(value);
+  const {updateCellValue} = useDatasetEditContext();
+
+  // Refs and state for edit popover
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
+  const initialWidth = useRef<number>();
+  const initialHeight = useRef<number>();
+
+  useLayoutEffect(() => {
+    if (isEditing) {
+      const element = document.activeElement?.closest('.MuiDataGrid-cell');
+      if (element) {
+        setAnchorEl(element as HTMLDivElement);
+      }
+    }
+  }, [isEditing]);
 
   const isWeaveUrl = isRefPrefixedString(value);
   const isEditable =
-    !isWeaveUrl && typeof value !== 'object' && typeof value !== 'boolean';
+    !isDeleted &&
+    !isWeaveUrl &&
+    typeof value !== 'object' &&
+    typeof value !== 'boolean';
+
+  // Use the context's updateCellValue function instead of local implementation
+  const handleUpdateValue = useCallback(
+    (newValue: any) => {
+      updateCellValue(row, field, newValue, serverValue, preserveFieldOrder);
+    },
+    [row, field, serverValue, preserveFieldOrder, updateCellValue]
+  );
 
   const handleEditClick = (event: React.MouseEvent) => {
     event.stopPropagation();
     if (isEditable) {
-      api.startCellEditMode({id, field});
+      setIsEditing(true);
+    }
+  };
+
+  const handleCloseEdit = (valueOverride?: any) => {
+    setIsEditing(false);
+    // Use the provided valueOverride if available, otherwise use editedValue
+    const finalValue =
+      valueOverride !== undefined ? valueOverride : editedValue;
+    // Only update if the value has changed
+    if (finalValue !== value) {
+      handleUpdateValue(finalValue);
     }
   };
 
   const handleRevert = (event: React.MouseEvent) => {
     event.stopPropagation();
-    const existingRow = api.getRow(id);
-    const updatedRow = {...existingRow};
-
-    set(updatedRow, field, serverValue);
-    api.updateRows([{id, ...updatedRow}]);
-    api.setEditCellValue({id, field, value: serverValue});
-    setEditedRows(prev => {
-      const newMap = new Map(prev);
-      newMap.set(existingRow.___weave?.index, updatedRow);
-      return newMap;
-    });
-    if (existingRow.___weave?.index !== undefined) {
-      setFieldEdited(existingRow.___weave.index, field, false);
-    }
+    setEditedValue(serverValue); // Reset editedValue to serverValue
+    handleUpdateValue(serverValue);
   };
 
   const getBackgroundColor = () => {
@@ -106,49 +148,20 @@ export const CellViewingRenderer: React.FC<
     return CELL_COLORS.TRANSPARENT;
   };
 
+  const handleValueChange = (newValue: string) => {
+    setEditedValue(newValue);
+  };
+
+  // Special handler for boolean values - toggle directly
   if (typeof value === 'boolean') {
     const handleToggle = (e: React.MouseEvent) => {
       e.stopPropagation();
       e.preventDefault();
-      const existingRow = api.getRow(id);
-      const updatedRow = {...existingRow, [field]: !value};
-      api.updateRows([{id, ...updatedRow}]);
-      const rowToUpdate = {...updatedRow};
-
-      if (existingRow.___weave?.isNew) {
-        setAddedRows(prev => {
-          const newMap = new Map(prev);
-          newMap.set(existingRow.___weave?.id, rowToUpdate);
-          return newMap;
-        });
-      } else {
-        if (!rowToUpdate.___weave.editedFields) {
-          rowToUpdate.___weave.editedFields = new Set<string>();
-        }
-        rowToUpdate.___weave.editedFields.add(field);
-        setEditedRows(prev => {
-          const newMap = new Map(prev);
-          newMap.set(existingRow.___weave?.index, rowToUpdate);
-          return newMap;
-        });
-      }
+      handleUpdateValue(!value);
     };
 
     return (
-      <Tooltip
-        title="Click to toggle"
-        enterDelay={1000}
-        enterNextDelay={1000}
-        leaveDelay={0}
-        placement="top"
-        slotProps={{
-          tooltip: {
-            sx: {
-              fontFamily: '"Source Sans Pro", sans-serif',
-              fontSize: '14px',
-            },
-          },
-        }}>
+      <CellTooltip title="Click to toggle">
         <Box
           onClick={handleToggle}
           onDoubleClick={handleToggle}
@@ -181,26 +194,14 @@ export const CellViewingRenderer: React.FC<
             }}
           />
         </Box>
-      </Tooltip>
+      </CellTooltip>
     );
   }
 
+  // Non-editable cell types (objects, weave URLs)
   if (!isEditable) {
     return (
-      <Tooltip
-        title="Cell type cannot be edited"
-        enterDelay={1000}
-        enterNextDelay={1000}
-        leaveDelay={0}
-        placement="top"
-        slotProps={{
-          tooltip: {
-            sx: {
-              fontFamily: '"Source Sans Pro", sans-serif',
-              fontSize: '14px',
-            },
-          },
-        }}>
+      <CellTooltip title="Cell type cannot be edited">
         <Box
           onClick={e => {
             e.stopPropagation();
@@ -211,7 +212,7 @@ export const CellViewingRenderer: React.FC<
             e.preventDefault();
           }}
           onKeyDown={e => e.preventDefault()}
-          onFocus={e => e.target.blur()}
+          tabIndex={-1}
           onMouseDown={e => {
             e.stopPropagation();
             e.preventDefault();
@@ -228,405 +229,145 @@ export const CellViewingRenderer: React.FC<
           }}>
           <CellValue value={value} noLink={true} />
         </Box>
-      </Tooltip>
+      </CellTooltip>
     );
   }
 
-  return (
-    <Tooltip
-      title="Click to edit"
-      enterDelay={1000}
-      enterNextDelay={1000}
-      leaveDelay={0}
-      placement="top"
-      slotProps={{
-        tooltip: {
-          sx: {
-            fontFamily: '"Source Sans Pro", sans-serif',
-            fontSize: '14px',
-          },
-        },
-      }}>
+  // Render cell in view mode
+  if (!isEditing) {
+    return (
+      <CellTooltip title="Click to edit">
+        <Box
+          onClick={handleEditClick}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          sx={{
+            ...cellViewingStyles,
+            position: 'relative',
+            cursor: 'pointer',
+            backgroundColor: getBackgroundColor(),
+            opacity: isDeleted ? DELETED_CELL_STYLES.opacity : 1,
+            textDecoration: isDeleted
+              ? DELETED_CELL_STYLES.textDecoration
+              : 'none',
+            borderLeft: '1px solid transparent',
+            borderRight: '1px solid transparent',
+            '&:hover': {
+              borderLeft: '1px solid #DFE0E2',
+              borderRight: '1px solid #DFE0E2',
+            },
+          }}>
+          <span style={{flex: 1, position: 'relative', overflow: 'hidden'}}>
+            {value}
+          </span>
+          {isHovered && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '4px',
+                opacity: 0,
+                transition: 'opacity 0.2s ease',
+                cursor: 'pointer',
+                animation: 'fadeIn 0.2s ease forwards',
+                '@keyframes fadeIn': {
+                  from: {opacity: 0},
+                  to: {opacity: 0.5},
+                },
+                '&:hover': {
+                  opacity: 0.8,
+                },
+              }}>
+              {isEdited ? (
+                <Button
+                  icon="undo"
+                  onClick={handleRevert}
+                  variant="secondary"
+                  size="small"
+                  style={{padding: '2px 4px', minWidth: 0}}
+                  tooltip="Revert to original value"
+                />
+              ) : (
+                <Icon name="pencil-edit" height={14} width={14} />
+              )}
+            </Box>
+          )}
+        </Box>
+      </CellTooltip>
+    );
+  }
+
+  // Render cell in edit mode
+  if (typeof value === 'number') {
+    return (
       <Box
-        onClick={handleEditClick}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          height: '100%',
+          width: '100%',
+          border: '2px solid rgb(77, 208, 225)',
+          backgroundColor: 'rgba(77, 208, 225, 0.2)',
+        }}>
+        <input
+          type="number"
+          value={typeof editedValue === 'number' ? editedValue.toString() : ''}
+          onChange={e => setEditedValue(Number(e.target.value))}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              handleCloseEdit();
+            } else if (e.key === 'Enter') {
+              handleCloseEdit();
+            } else if (e.key === 'Escape') {
+              setIsEditing(false);
+              setEditedValue(value); // Reset to original
+            }
+          }}
+          onBlur={() => handleCloseEdit()}
+          autoFocus
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 'none',
+            outline: 'none',
+            background: 'none',
+            textAlign: 'left',
+            padding: '8px 12px',
+            fontFamily: 'inherit',
+            fontSize: 'inherit',
+            color: 'inherit',
+          }}
+        />
+      </Box>
+    );
+  }
+
+  // For text/string values with EditPopover
+  return (
+    <>
+      <Box
         sx={{
           ...cellViewingStyles,
           position: 'relative',
           cursor: 'pointer',
-          backgroundColor: getBackgroundColor(),
-          opacity: isDeleted ? DELETED_CELL_STYLES.opacity : 1,
-          textDecoration: isDeleted
-            ? DELETED_CELL_STYLES.textDecoration
-            : 'none',
-          borderLeft: '1px solid transparent',
-          borderRight: '1px solid transparent',
-          '&:hover': {
-            borderLeft: '1px solid #DFE0E2',
-            borderRight: '1px solid #DFE0E2',
-          },
-          ...(isEditing && {
-            border: '2px solid rgb(77, 208, 225)',
-            backgroundColor: 'rgba(77, 208, 225, 0.2)',
-          }),
+          backgroundColor: 'rgba(77, 208, 225, 0.2)',
+          border: '2px solid rgb(77, 208, 225)',
         }}>
         <span style={{flex: 1, position: 'relative', overflow: 'hidden'}}>
           {value}
-          {isEditing}
         </span>
-        {isHovered && (
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '4px',
-              opacity: 0,
-              transition: 'opacity 0.2s ease',
-              cursor: 'pointer',
-              animation: 'fadeIn 0.2s ease forwards',
-              '@keyframes fadeIn': {
-                from: {opacity: 0},
-                to: {opacity: 0.5},
-              },
-              '&:hover': {
-                opacity: 0.8,
-              },
-            }}>
-            {isEdited ? (
-              <Button
-                icon="undo"
-                onClick={handleRevert}
-                variant="secondary"
-                size="small"
-                style={{padding: '2px 4px', minWidth: 0}}
-                tooltip="Revert to original value"
-              />
-            ) : (
-              <Icon name="pencil-edit" height={14} width={14} />
-            )}
-          </Box>
-        )}
       </Box>
-    </Tooltip>
-  );
-};
-
-export interface CellEditingRendererProps extends GridRenderEditCellParams {
-  serverValue?: string;
-  preserveFieldOrder?: (row: any) => any;
-}
-
-const NumberEditor: React.FC<{
-  value: number;
-  onClose: () => void;
-  api: any;
-  id: string | number;
-  field: string;
-  serverValue?: any;
-}> = ({value, onClose, api, id, field, serverValue}) => {
-  const [inputValue, setInputValue] = useState(value.toString());
-  const {setEditedRows, setAddedRows, setFieldEdited} = useDatasetEditContext();
-
-  const handleValueUpdate = (newValue: string) => {
-    setInputValue(newValue);
-    if (newValue !== '') {
-      const numValue = Number(newValue);
-      api.setEditCellValue({id, field, value: numValue});
-    }
-  };
-
-  const handleBlur = () => {
-    if (inputValue !== '') {
-      const numValue = Number(inputValue);
-      const existingRow = api.getRow(id);
-      const isValueChanged = numValue !== serverValue;
-
-      if (existingRow.___weave?.isNew) {
-        setAddedRows((prev: Map<string, DatasetRow>) => {
-          const newMap = new Map(prev);
-          const updatedRow = {...existingRow};
-          updatedRow[field] = numValue;
-          newMap.set(existingRow.___weave?.id, updatedRow);
-          return newMap;
-        });
-      } else {
-        const updatedRow = {...existingRow};
-        updatedRow[field] = numValue;
-        setEditedRows((prev: Map<number, DatasetRow>) => {
-          const newMap = new Map(prev);
-          newMap.set(existingRow.___weave?.index, updatedRow);
-          return newMap;
-        });
-        if (isValueChanged && existingRow.___weave?.index !== undefined) {
-          setFieldEdited(existingRow.___weave.index, field, isValueChanged);
-        }
-      }
-    }
-    onClose();
-  };
-
-  return (
-    <Box
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        height: '100%',
-        width: '100%',
-        border: '2px solid rgb(77, 208, 225)',
-        backgroundColor: 'rgba(77, 208, 225, 0.2)',
-      }}>
-      <input
-        type="number"
-        value={inputValue}
-        onChange={e => handleValueUpdate(e.target.value)}
-        onKeyDown={e => {
-          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-            handleBlur();
-          } else if (e.key === 'Enter') {
-            handleBlur();
-          }
-        }}
-        onBlur={handleBlur}
-        autoFocus
-        style={{
-          width: '100%',
-          height: '100%',
-          border: 'none',
-          outline: 'none',
-          background: 'none',
-          textAlign: 'left',
-          padding: '8px 12px',
-          fontFamily: 'inherit',
-          fontSize: 'inherit',
-          color: 'inherit',
-        }}
-      />
-    </Box>
-  );
-};
-
-const StringEditor: React.FC<{
-  value: string;
-  serverValue?: string;
-  onClose: () => void;
-  params: GridRenderCellParams;
-}> = ({value, serverValue, onClose, params}) => {
-  const inputRef = React.useRef<HTMLTextAreaElement>(null);
-  const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
-  const [hasInitialFocus, setHasInitialFocus] = useState(false);
-  const initialWidth = React.useRef<number>();
-  const initialHeight = React.useRef<number>();
-  const [editorMode, setEditorMode] = useState<EditorMode>('text');
-  const [editedValue, setEditedValue] = useState(value);
-
-  const handleEditorModeChange = (newMode: EditorMode) => {
-    setEditorMode(newMode);
-    initialWidth.current = getPopoverWidth(newMode);
-    initialHeight.current = getPopoverHeight();
-  };
-
-  const handleValueChange = (newValue: string) => {
-    setEditedValue(newValue);
-    params.api.setEditCellValue({
-      id: params.id,
-      field: params.field,
-      value: newValue,
-    });
-  };
-
-  const getPopoverWidth = useCallback(
-    (mode: EditorMode = editorMode) => {
-      const screenWidth = window.innerWidth;
-      const maxWidth = screenWidth - 48;
-      const minWidth = 400;
-      const valueLength = typeof value === 'string' ? value.length : 0;
-      const approximateWidth = Math.min(
-        Math.max(valueLength, minWidth),
-        maxWidth
-      );
-      return mode === 'diff'
-        ? Math.min(approximateWidth * 2, maxWidth)
-        : approximateWidth;
-    },
-    [editorMode, value]
-  );
-
-  const getPopoverHeight = useCallback(() => {
-    const width = getPopoverWidth();
-    const charsPerLine = Math.floor(width / 8);
-    const lines =
-      typeof value === 'string'
-        ? value.split('\n').reduce((acc, line) => {
-            return acc + Math.ceil(line.length / charsPerLine);
-          }, 0)
-        : 1;
-
-    const maxHeight = Math.min(window.innerHeight / 2, 400);
-    const contentHeight = Math.min(Math.max(lines * 24 + 80, 120), maxHeight);
-    return contentHeight;
-  }, [value, getPopoverWidth]);
-
-  React.useLayoutEffect(() => {
-    const element = document.activeElement?.closest('.MuiDataGrid-cell');
-    if (element) {
-      setAnchorEl(element as HTMLDivElement);
-      if (!initialWidth.current) {
-        initialWidth.current = getPopoverWidth();
-      }
-      if (!initialHeight.current) {
-        initialHeight.current = getPopoverHeight();
-      }
-    }
-  }, [getPopoverWidth, getPopoverHeight]);
-
-  React.useEffect(() => {
-    if (!hasInitialFocus) {
-      setTimeout(() => {
-        const textarea = inputRef.current?.querySelector('textarea');
-        if (textarea) {
-          textarea.focus();
-          textarea.setSelectionRange(0, textarea.value.length);
-          setHasInitialFocus(true);
-        }
-      }, 0);
-    }
-  }, [hasInitialFocus]);
-
-  const renderEditor = () => {
-    switch (editorMode) {
-      case 'text':
-        return (
-          <TextEditor
-            value={editedValue}
-            onChange={handleValueChange}
-            onClose={onClose}
-            inputRef={inputRef}
-          />
-        );
-      case 'code':
-        return (
-          <CodeEditor
-            value={editedValue}
-            onChange={handleValueChange}
-            onClose={onClose}
-          />
-        );
-      case 'diff':
-        return (
-          <DiffEditor
-            value={editedValue}
-            originalValue={serverValue ?? ''}
-            onChange={handleValueChange}
-            onClose={onClose}
-          />
-        );
-    }
-  };
-
-  return (
-    <>
-      <CellViewingRenderer {...params} isEditing />
       <EditPopover
         anchorEl={anchorEl}
-        onClose={onClose}
+        onClose={finalValue => handleCloseEdit(finalValue)}
         initialWidth={initialWidth.current}
         initialHeight={initialHeight.current}
-        editorMode={editorMode}
-        setEditorMode={handleEditorModeChange}>
-        {renderEditor()}
-      </EditPopover>
-    </>
-  );
-};
-
-export const CellEditingRenderer: React.FC<
-  CellEditingRendererProps
-> = props => {
-  const {setEditedRows, setAddedRows} = useDatasetEditContext();
-  const {id, value, field, api, serverValue, preserveFieldOrder} = props;
-
-  // Convert edit params to render params
-  const renderParams: GridRenderCellParams = {
-    ...props,
-    value,
-  };
-
-  const updateRow = useCallback(
-    (existingRow: any, newValue: any) => {
-      const baseRow = {...existingRow};
-      baseRow[field] = newValue;
-      return preserveFieldOrder ? preserveFieldOrder(baseRow) : baseRow;
-    },
-    [field, preserveFieldOrder]
-  );
-
-  // For boolean values, don't show edit mode at all
-  if (typeof value === 'boolean') {
-    return null;
-  }
-
-  // For numeric values, show number editor
-  if (typeof value === 'number') {
-    return (
-      <NumberEditor
-        value={value}
-        onClose={() => api.stopCellEditMode({id, field})}
-        api={api}
-        id={id}
-        field={field}
-        serverValue={serverValue}
+        value={typeof editedValue === 'string' ? editedValue : ''}
+        originalValue={serverValue ?? ''}
+        onChange={handleValueChange}
+        inputRef={inputRef}
       />
-    );
-  }
-
-  // Text editor with popover for string values
-  return (
-    <StringEditor
-      value={value as string}
-      serverValue={serverValue}
-      onClose={() => {
-        const existingRow = api.getRow(id);
-        const updatedRow = updateRow(existingRow, value);
-
-        const isValueChanged = value !== serverValue;
-        const rowToUpdate = {...updatedRow};
-
-        if (existingRow.___weave?.isNew) {
-          setAddedRows(prev => {
-            const newMap = new Map(prev);
-            newMap.set(existingRow.___weave?.id, rowToUpdate);
-            return newMap;
-          });
-        } else {
-          if (!rowToUpdate.___weave.editedFields) {
-            rowToUpdate.___weave.editedFields = new Set<string>();
-          }
-
-          if (isValueChanged) {
-            rowToUpdate.___weave.editedFields.add(field);
-          } else {
-            rowToUpdate.___weave.editedFields.delete(field);
-          }
-
-          setEditedRows(prev => {
-            const newMap = new Map(prev);
-
-            // If we don't have any edited fields and it's not a new row,
-            // don't add it to the editedRows map
-            if (rowToUpdate.___weave.editedFields.size === 0) {
-              newMap.delete(existingRow.___weave?.index);
-            } else {
-              newMap.set(existingRow.___weave?.index, rowToUpdate);
-            }
-
-            return newMap;
-          });
-        }
-        api.stopCellEditMode({id, field});
-      }}
-      params={renderParams}
-    />
+    </>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetEditorContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetEditorContext.tsx
@@ -37,6 +37,14 @@ interface DatasetEditContextType {
   >;
   /** Get rows without any mui datagrid or weave metadata */
   getRowsNoMeta: () => Array<Record<string, any>>;
+  /** Update cell value and track edit state */
+  updateCellValue: (
+    row: DatasetRow,
+    field: string,
+    newValue: any,
+    serverValue: any,
+    preserveFieldOrder?: (row: DatasetRow) => DatasetRow
+  ) => void;
 }
 
 export const DatasetEditContext = createContext<
@@ -114,6 +122,82 @@ export const DatasetEditProvider: React.FC<DatasetEditProviderProps> = ({
     [setEditedRows]
   );
 
+  const updateCellValue = useCallback(
+    (
+      row: DatasetRow,
+      field: string,
+      newValue: any,
+      serverValue: any,
+      preserveFieldOrder?: (row: DatasetRow) => DatasetRow
+    ) => {
+      const existingRow = {...row};
+      const updatedRow = {...existingRow};
+      updatedRow[field] = newValue;
+
+      const finalRow = preserveFieldOrder
+        ? preserveFieldOrder(updatedRow)
+        : updatedRow;
+
+      const isValueChanged = newValue !== serverValue;
+
+      if (existingRow.___weave?.isNew) {
+        // For newly added rows
+        setAddedRows(prev => {
+          const newMap = new Map(prev);
+          if (existingRow.___weave?.id) {
+            newMap.set(existingRow.___weave.id, finalRow);
+          }
+          return newMap;
+        });
+      } else {
+        // For existing rows
+        if (!finalRow.___weave) {
+          // If ___weave object is missing completely, recreate it with required properties
+          const rowId = existingRow.___weave?.id || `generated-${Date.now()}`;
+          finalRow.___weave = {
+            id: rowId,
+            index: existingRow.___weave?.index,
+            editedFields: new Set<string>(),
+          };
+        } else if (!finalRow.___weave.editedFields) {
+          finalRow.___weave.editedFields = new Set<string>();
+        }
+
+        // Ensure editedFields exists before using it
+        if (!finalRow.___weave.editedFields) {
+          finalRow.___weave.editedFields = new Set<string>();
+        }
+
+        if (isValueChanged) {
+          finalRow.___weave.editedFields.add(field);
+        } else {
+          finalRow.___weave.editedFields.delete(field);
+        }
+
+        // Only process if we have a valid row index
+        const rowIndex = existingRow.___weave?.index;
+        if (rowIndex !== undefined) {
+          setEditedRows(prev => {
+            const newMap = new Map(prev);
+
+            // We can now safely access editedFields since we ensured it exists above
+            // Use non-null assertion operator to tell TypeScript we guarantee editedFields exists
+            if (finalRow.___weave.editedFields!.size === 0) {
+              newMap.delete(rowIndex);
+            } else {
+              newMap.set(rowIndex, finalRow);
+            }
+
+            return newMap;
+          });
+
+          setFieldEdited(rowIndex, field, isValueChanged);
+        }
+      }
+    },
+    [setAddedRows, setEditedRows, setFieldEdited]
+  );
+
   const reset = useCallback(() => {
     setEditedRows(new Map());
     setDeletedRows([]);
@@ -188,6 +272,7 @@ export const DatasetEditProvider: React.FC<DatasetEditProviderProps> = ({
         resetEditState: reset,
         convertEditsToTableUpdateSpec,
         getRowsNoMeta,
+        updateCellValue,
       }}>
       {children}
     </DatasetEditContext.Provider>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/EditableDatasetView.tsx
@@ -5,7 +5,6 @@ import {
   GridPagination,
   GridPaginationModel,
   GridRenderCellParams,
-  GridRenderEditCellParams,
   GridRowModel,
   GridSortModel,
   useGridApiRef,
@@ -36,9 +35,8 @@ import {SortBy} from '../pages/wfReactInterface/traceServerClientTypes';
 import {StyledDataGrid} from '../StyledDataGrid';
 import {
   CELL_COLORS,
-  CellEditingRenderer,
-  CellViewingRenderer,
   ControlCell,
+  DatasetCellRenderer,
   DELETED_CELL_STYLES,
 } from './CellRenderers';
 import {useDatasetEditContext} from './DatasetEditorContext';
@@ -419,7 +417,7 @@ export const EditableDatasetView: React.FC<EditableDatasetViewProps> = ({
       width: columnWidths[field as string] ?? undefined,
       flex: columnWidths[field as string] ? undefined : 1,
       minWidth: 100,
-      editable: isEditing,
+      editable: false,
       sortable: true,
       filterable: false,
       renderCell: (params: GridRenderCellParams) => {
@@ -438,7 +436,7 @@ export const EditableDatasetView: React.FC<EditableDatasetViewProps> = ({
         const rowIndex = params.row.___weave?.index;
 
         return (
-          <CellViewingRenderer
+          <DatasetCellRenderer
             {...params}
             isEdited={
               rowIndex != null && !params.row.___weave?.isNew
@@ -452,19 +450,6 @@ export const EditableDatasetView: React.FC<EditableDatasetViewProps> = ({
               field as string
             )}
             disableNewRowHighlight={disableNewRowHighlight}
-          />
-        );
-      },
-      renderEditCell: (params: GridRenderEditCellParams) => {
-        const rowIndex = params.row.___weave?.index;
-        const serverValue =
-          rowIndex != null && !params.row.___weave?.isNew
-            ? get(loadedRows[rowIndex - offset]?.val ?? {}, params.field)
-            : '';
-        return (
-          <CellEditingRenderer
-            {...params}
-            serverValue={serverValue}
             preserveFieldOrder={preserveFieldOrder}
           />
         );
@@ -552,7 +537,6 @@ export const EditableDatasetView: React.FC<EditableDatasetViewProps> = ({
         sortingMode="server"
         sortModel={sortModel}
         onSortModelChange={onSortModelChange}
-        editMode="cell"
         pagination
         paginationMode="server"
         paginationModel={paginationModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/editors/DiffEditor.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/editors/DiffEditor.tsx
@@ -1,13 +1,12 @@
 import {DiffEditor as MonacoDiffEditor} from '@monaco-editor/react';
 import {Box} from '@mui/material';
-import type {editor as monacoEditor} from 'monaco-editor';
-import React from 'react';
+import React, {useRef} from 'react';
 
 interface DiffEditorProps {
   value: string;
   originalValue: string;
   onChange: (value: string) => void;
-  onClose: () => void;
+  onClose: (value?: any) => void;
 }
 
 export const DiffEditor: React.FC<DiffEditorProps> = ({
@@ -16,6 +15,43 @@ export const DiffEditor: React.FC<DiffEditorProps> = ({
   onChange,
   onClose,
 }) => {
+  const editorRef = useRef<any>(null);
+  const currentValueRef = useRef(value);
+
+  const handleEditorDidMount = (editor: any, monaco: any) => {
+    editorRef.current = editor;
+
+    // Get the modified editor (right side of diff)
+    const modifiedEditor = editor.getModifiedEditor();
+
+    // Track content changes
+    modifiedEditor.onDidChangeModelContent(() => {
+      const newValue = modifiedEditor.getValue();
+      currentValueRef.current = newValue;
+      onChange(newValue);
+    });
+
+    // Override the default Enter key behavior to prevent newlines on Cmd+Enter
+    modifiedEditor.onKeyDown((e: any) => {
+      if ((e.metaKey || e.ctrlKey) && e.code === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Get the latest value before closing
+        onClose(modifiedEditor.getValue());
+      } else if (e.code === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Also close and pass value on Escape
+        onClose(modifiedEditor.getValue());
+      }
+    });
+  };
+
+  // Update ref when value changes - not using effect now
+  currentValueRef.current = value;
+
   return (
     <Box
       sx={
@@ -40,39 +76,7 @@ export const DiffEditor: React.FC<DiffEditorProps> = ({
         height="100%"
         original={originalValue}
         modified={value}
-        onMount={(editor: monacoEditor.IStandaloneDiffEditor, monaco) => {
-          const modifiedEditor = editor.getModifiedEditor();
-          modifiedEditor.addAction({
-            id: 'closeEditor',
-            label: 'Close Editor',
-            keybindings: [monaco.KeyMod.CtrlCmd + monaco.KeyCode.Enter],
-            run: () => {
-              onClose();
-            },
-          });
-
-          const keyDisposable = modifiedEditor.onKeyDown(e => {
-            if (e.browserEvent.key === 'Enter' && !e.browserEvent.metaKey) {
-              e.browserEvent.preventDefault();
-              e.browserEvent.stopPropagation();
-              modifiedEditor.trigger('keyboard', 'type', {text: '\n'});
-            }
-          });
-
-          const changeDisposable = modifiedEditor.onDidChangeModelContent(
-            () => {
-              const model = modifiedEditor.getModel();
-              if (model) {
-                onChange(model.getValue());
-              }
-            }
-          );
-
-          modifiedEditor.onDidDispose(() => {
-            keyDisposable.dispose();
-            changeDisposable.dispose();
-          });
-        }}
+        onMount={handleEditorDidMount}
         options={{
           minimap: {enabled: false},
           scrollBeyondLastLine: true,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/editors/TextEditor.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/editors/TextEditor.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 interface TextEditorProps {
   value: string;
   onChange: (value: string) => void;
-  onClose: () => void;
+  onClose: (value?: any) => void;
   inputRef?: React.RefObject<HTMLTextAreaElement>;
 }
 
@@ -14,19 +14,32 @@ export const TextEditor: React.FC<TextEditorProps> = ({
   onClose,
   inputRef,
 }) => {
+  const localInputRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const actualInputRef = inputRef || localInputRef;
+
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    // Only prevent propagation for normal Enter key
     if (event.key === 'Enter' && !event.metaKey) {
       event.stopPropagation();
     } else if (event.key === 'Enter' && event.metaKey) {
-      onClose();
+      event.stopPropagation();
+      // Get the current value directly when closing
+      onClose(value);
+    } else if (event.key === 'Escape') {
+      event.stopPropagation();
+      // Also get the value directly when escaping
+      onClose(value);
     }
   };
 
   return (
     <TextField
-      inputRef={inputRef}
+      inputRef={actualInputRef}
       value={value}
-      onChange={e => onChange(e.target.value)}
+      onChange={e => {
+        const newValue = e.target.value;
+        onChange(newValue);
+      }}
       onKeyDown={handleKeyDown}
       onFocus={e => {
         const target = e.target as HTMLTextAreaElement;


### PR DESCRIPTION
## Description

- We were using the datagrid api's edit mode control, which meant we were managing a piece of datagrid state and also adding separate components for rendering the cells in edit and non edit modes. This was not necessary and has been replaced with a single component.
- Moves some repeated logic for updating the editor state into a hook into the editor context called `updateCellValue`, which hides the details of the update logic from the components that accept new cell values from the user.
- Moves control of the editor mode and the assembly of the children editor components from the cell renderers file and into the edit popover component.