### PR TITLE
chore(weave_query): clarify behaviour of cache bucketing

### DIFF
--- a/weave_query/weave_query/cache.py
+++ b/weave_query/weave_query/cache.py
@@ -20,20 +20,21 @@ def bucket_timestamp(interval_days: int) -> str:
     so it is easier for the caller to know when a cache interval will no longer be used.
 
     For another example, if we want a bucket interval of 7 days, then here are some example values:
-    system time             bucketed time
+    system time            bucketed time
     11:22 Jan 1 1970       00:00 Jan 8 1970
-    23:59 Jan 7 1970       00:00 Jan 14 1970
+    00:00 Jan 2 1970       00:00 Jan 8 1970
+    23:59 Jan 7 1970       00:00 Jan 8 1970
+
     00:00 Jan 8 1970       00:00 Jan 15 1970
-    16:00 Jan 12 1970      00:00 Jan 19 1970
-    12:00 Jan 3 2024       00:00 Jan 10 2024
+    16:00 Jan 12 1970      00:00 Jan 15 1970
     """
     if interval_days == 0:
         return "0"
-    now_datetime = datetime.datetime.fromtimestamp(time.time(), datetime.timezone.utc)
-    EPOCH_TIME = datetime.datetime(1970, 1, 1, 0, 0, 0, 0, datetime.timezone.utc)
-    days_since_epoch = (now_datetime - EPOCH_TIME).days
+    now = time.time()
+    interval_seconds = interval_days * 24 * 60 * 60
+    num_intervals = int(now / interval_seconds)
     # use the bucket end time because this makes it easy to know when a cache interval will no longer be used
-    bucket_end_time = (days_since_epoch + interval_days) * 24 * 60 * 60
+    bucket_end_time = (num_intervals + 1) * interval_seconds
     return str(
         datetime.datetime.fromtimestamp(bucket_end_time, datetime.timezone.utc)
         .timestamp()

--- a/weave_query/weave_query/cache.py
+++ b/weave_query/weave_query/cache.py
@@ -6,36 +6,34 @@ import shutil
 import time
 import typing
 
-from weave_query import errors
-from weave_query import context_state, environment, wandb_api, engine_trace
+from weave_query import context_state, engine_trace, environment, errors, wandb_api
 
 statsd = engine_trace.statsd()  # type: ignore
 logger = logging.getLogger("root")
 
-"""
-Returns a timestamp bucketed by interval days that is calculated from epoch time. For example, if we want
-a bucket interval of 1 day, the anytime this function is called between 0 and 86399 seconds during the first
-day of unix time (Jan 1 1970), it will return Jan 2 1970. This function returns the END time of the bucket
-so it is easier for the caller to know when a cache interval will no longer be used. 
-
-For another example, if we want a bucket interval of 7 days, then here are some example values:
-system time             bucketed time
-11:22 Jan 1 1970       00:00 Jan 8 1970
-23:59 Jan 7 1970       00:00 Jan 14 1970
-00:00 Jan 8 1970       00:00 Jan 15 1970
-16:00 Jan 12 1970      00:00 Jan 19 1970
-12:00 Jan 3 2024       00:00 Jan 10 2024
-"""
-
 
 def bucket_timestamp(interval_days: int) -> str:
+    """
+    Returns a timestamp bucketed by interval days that is calculated from epoch time. For example, if we want
+    a bucket interval of 1 day, the anytime this function is called between 0 and 86399 seconds during the first
+    day of unix time (Jan 1 1970), it will return Jan 2 1970. This function returns the END time of the bucket
+    so it is easier for the caller to know when a cache interval will no longer be used.
+
+    For another example, if we want a bucket interval of 7 days, then here are some example values:
+    system time             bucketed time
+    11:22 Jan 1 1970       00:00 Jan 8 1970
+    23:59 Jan 7 1970       00:00 Jan 14 1970
+    00:00 Jan 8 1970       00:00 Jan 15 1970
+    16:00 Jan 12 1970      00:00 Jan 19 1970
+    12:00 Jan 3 2024       00:00 Jan 10 2024
+    """
     if interval_days == 0:
         return "0"
-    now = time.time()
-    interval_seconds = interval_days * 24 * 60 * 60
-    num_intervals = int(now / interval_seconds)
+    now_datetime = datetime.datetime.fromtimestamp(time.time(), datetime.timezone.utc)
+    EPOCH_TIME = datetime.datetime(1970, 1, 1, 0, 0, 0, 0, datetime.timezone.utc)
+    days_since_epoch = (now_datetime - EPOCH_TIME).days
     # use the bucket end time because this makes it easy to know when a cache interval will no longer be used
-    bucket_end_time = (num_intervals + 1) * interval_seconds
+    bucket_end_time = (days_since_epoch + interval_days) * 24 * 60 * 60
     return str(
         datetime.datetime.fromtimestamp(bucket_end_time, datetime.timezone.utc)
         .timestamp()


### PR DESCRIPTION
## Description

Update incorrect example in docstring and verify example behaviour in unit tests

--- 

<details>
<summary>PR was updated to only change the docstring and unit tests, here's the original PR description</summary>

This PR corrects the behaviour of our cache bucketing method to what I believe is the intended implementation.

---

Currently, timestamps starting at the current interval and up to the next interval will be assigned into the same bucket. Concretely, given an interval of 7 days and the days: [day 0, day 1, ..., day 6]. All 7 days will be assigned the "day 7" bucket. Consequently, the following unit test will fail: 

```
  # self.DAY_IN_SECONDS = 24 * 60 * 60
   def test_bucket_should_advance_when_time_passes(self):
        INTERVAL_DAYS = 7
        INITIAL_TIME = 100
        with mock.patch("time.time", return_value=100):
            initial_bucket = int(cache.bucket_timestamp(INTERVAL_DAYS), 10)
            assert initial_bucket == INTERVAL_DAYS * self.DAY_IN_SECONDS

        with mock.patch("time.time", return_value=INITIAL_TIME + self.DAY_IN_SECONDS):
            print("INITIAL BUCKET: ", initial_bucket)
            print("NEW BUCKET: ", cache.bucket_timestamp(INTERVAL_DAYS))
            assert (
                int(cache.bucket_timestamp(INTERVAL_DAYS), 10)
                == initial_bucket + self.DAY_IN_SECONDS
            )
```
with the following buckets returned:
```
INITIAL BUCKET:  604800
NEW BUCKET:  604800
```

---

This differs from the explanation provided in the comment, which provides the following example:
```
system time             bucketed time
11:22 Jan 1 1970       00:00 Jan 8 1970
12:00 Jan 3 2024       00:00 Jan 10 2024
```
So as time advances by the day, we should see that the bucket also advances. Concretely, back to our example with an interval of 7 days and the days: [day 0, day 1, ... day 6], the buckets should be: [day 0 + 7, day 1 + 7, ..., day 6 + 7]. With the changes to the method in this PR, the unit test above passes, and we can see that the buckets are different.
```
INITIAL BUCKET:  604800
NEW BUCKET:  691200
```
The new bucket being one day later than the initial since the mock timestamps differ by one day.

</details>


## Testing

Unit Tests