### PR TITLE
chore(weave): improve loading state management for default date filters

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -2,7 +2,6 @@ import {ApolloProvider} from '@apollo/client';
 import {Box, Drawer} from '@mui/material';
 import {
   GridColumnVisibilityModel,
-  GridFilterModel,
   GridPaginationModel,
   GridPinnedColumnFields,
   GridSortModel,
@@ -48,7 +47,9 @@ import {
   useWeaveflowRouteContext,
   WeaveflowPeekContext,
 } from './Browse3/context';
+import {hasDefaultDateFilter} from './Browse3/filters/filterUtils';
 import {FullPageButton} from './Browse3/FullPageButton';
+import {ExtendedGridFilterModel} from './Browse3/grid/extendedFilters';
 import {getValidFilterModel} from './Browse3/grid/filters';
 import {
   DEFAULT_PAGE_SIZE,
@@ -62,7 +63,6 @@ import {
   ALWAYS_PIN_LEFT_CALLS,
   DEFAULT_PIN_CALLS,
   DEFAULT_SORT_CALLS,
-  filterHasCalledAfterDateFilter,
 } from './Browse3/pages/CallsPage/CallsTable';
 import {WFHighLevelCallFilter} from './Browse3/pages/CallsPage/callsTableFilter';
 import {
@@ -844,11 +844,11 @@ const CallsPageBinding = () => {
     [query.filters, defaultFilter]
   );
 
-  const setFilterModel = (newModel: GridFilterModel) => {
+  const setFilterModel = (newModel: ExtendedGridFilterModel) => {
     // If there was a date filter and now there isn't, mark it as explicitly removed
     // so we don't add it back on subsequent navigations
-    const hadDateFilter = filterHasCalledAfterDateFilter(filterModel);
-    if (hadDateFilter && !filterHasCalledAfterDateFilter(newModel)) {
+    const hadDefaultFilters = hasDefaultDateFilter(filterModel);
+    if (hadDefaultFilters && !hasDefaultDateFilter(newModel)) {
       hasRemovedDateFilter.current = true;
     }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -1,4 +1,3 @@
-import {GridFilterModel} from '@mui/x-data-grid-pro';
 import {
   isWandbArtifactRef,
   isWeaveObjectRef,
@@ -16,6 +15,7 @@ import React, {
 } from 'react';
 import {useHistory, useLocation} from 'react-router-dom';
 
+import {ExtendedGridFilterModel} from './grid/extendedFilters';
 import {WFHighLevelCallFilter} from './pages/CallsPage/callsTableFilter';
 import {WFHighLevelObjectVersionFilter} from './pages/ObjectsPage/objectsPageTypes';
 import {WFHighLevelOpVersionFilter} from './pages/OpsPage/opsPageTypes';
@@ -154,7 +154,7 @@ export const browse2Context = {
     entityName: string,
     projectName: string,
     filter?: WFHighLevelCallFilter,
-    gridFilters?: GridFilterModel
+    gridFilters?: ExtendedGridFilterModel
   ) => {
     throw new Error('Not implemented');
   },
@@ -378,7 +378,7 @@ export const browse3ContextGen = (
       entityName: string,
       projectName: string,
       filter?: WFHighLevelCallFilter,
-      gridFilters?: GridFilterModel
+      gridFilters?: ExtendedGridFilterModel
     ) => {
       const searchParams = new URLSearchParams();
       const prunedFilter = pruneEmptyFields(filter);
@@ -549,7 +549,7 @@ type RouteType = {
     // the implementation and now it is a part of our URL spec forever... :(
     // It should have been implemented as the `query` component of WFHighLevelCallFilter
     // which maps to our actual service API.
-    gridFilters?: GridFilterModel
+    gridFilters?: ExtendedGridFilterModel
   ) => string;
   objectVersionsUIUrl: (
     entityName: string,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -3,7 +3,6 @@
  */
 
 import {Popover} from '@mui/material';
-import {GridFilterItem, GridFilterModel} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
@@ -15,6 +14,10 @@ import {
   convertFeedbackFieldToBackendFilter,
   parseFeedbackType,
 } from '../feedback/HumanFeedback/tsHumanFeedback';
+import {
+  ExtendedGridFilterItem,
+  ExtendedGridFilterModel,
+} from '../grid/extendedFilters';
 import {ColumnInfo} from '../types';
 import {
   FIELD_DESCRIPTIONS,
@@ -35,8 +38,8 @@ const DEBOUNCE_MS = 1_000;
 type FilterBarProps = {
   entity: string;
   project: string;
-  filterModel: GridFilterModel;
-  setFilterModel: (newModel: GridFilterModel) => void;
+  filterModel: ExtendedGridFilterModel;
+  setFilterModel: (newModel: ExtendedGridFilterModel) => void;
   columnInfo: ColumnInfo;
   selectedCalls: string[];
   clearSelectedCalls: () => void;
@@ -45,7 +48,7 @@ type FilterBarProps = {
   height: number;
 };
 
-const isFilterIncomplete = (filter: GridFilterItem): boolean => {
+const isFilterIncomplete = (filter: ExtendedGridFilterItem): boolean => {
   return (
     filter.field === undefined ||
     // Empty string is never valid
@@ -74,9 +77,9 @@ export const FilterBar = ({
   const [activeEditId, setActiveEditId] = useState<FilterId | null>(null);
 
   // Keep track of incomplete filters that should be preserved during state sync
-  const [incompleteFilters, setIncompleteFilters] = useState<GridFilterItem[]>(
-    []
-  );
+  const [incompleteFilters, setIncompleteFilters] = useState<
+    ExtendedGridFilterItem[]
+  >([]);
 
   // Merge the parent filter model with our incomplete filters
   useEffect(() => {
@@ -197,7 +200,7 @@ export const FilterBar = ({
 
   // Only send complete filters to the parent component
   const applyCompletedFilters = useCallback(
-    (model: GridFilterModel) => {
+    (model: ExtendedGridFilterModel) => {
       const completeFilters = model.items.filter(
         item => !isFilterIncomplete(item)
       );
@@ -213,7 +216,7 @@ export const FilterBar = ({
   );
 
   const onUpdateFilter = useCallback(
-    (item: GridFilterItem) => {
+    (item: ExtendedGridFilterItem) => {
       debouncedSetFilterModel.cancel();
       const oldItems = localFilterModel.items;
       const index = oldItems.findIndex(f => f.id === item.id);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterPanel.tsx
@@ -2,20 +2,20 @@
  * This gets size information and passes it down.
  */
 
-import {GridFilterModel} from '@mui/x-data-grid-pro';
 import {LocalizationProvider} from '@mui/x-date-pickers';
 import {AdapterMoment} from '@mui/x-date-pickers/AdapterMoment';
 import React from 'react';
 import {AutoSizer} from 'react-virtualized';
 
+import {ExtendedGridFilterModel} from '../grid/extendedFilters';
 import {ColumnInfo} from '../types';
 import {FilterBar} from './FilterBar';
 
 type FilterPanelProps = {
   entity: string;
   project: string;
-  filterModel: GridFilterModel;
-  setFilterModel: (newModel: GridFilterModel) => void;
+  filterModel: ExtendedGridFilterModel;
+  setFilterModel: (newModel: ExtendedGridFilterModel) => void;
   columnInfo: ColumnInfo;
   selectedCalls: string[];
   clearSelectedCalls: () => void;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -2,10 +2,10 @@
  * Each filter in the filter popup is shown as one row.
  */
 
-import {GridFilterItem} from '@mui/x-data-grid-pro';
 import React, {useMemo} from 'react';
 
 import {Button} from '../../../../Button';
+import {ExtendedGridFilterItem} from '../grid/extendedFilters';
 import {
   FilterId,
   getFieldType,
@@ -19,10 +19,10 @@ import {SelectValue} from './SelectValue';
 type FilterRowProps = {
   entity: string;
   project: string;
-  item: GridFilterItem;
+  item: ExtendedGridFilterItem;
   options: SelectFieldOption[];
   onAddFilter: (field: string) => void;
-  onUpdateFilter: (item: GridFilterItem) => void;
+  onUpdateFilter: (item: ExtendedGridFilterItem) => void;
   onRemoveFilter: (id: FilterId) => void;
   activeEditId?: FilterId | null;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -2,13 +2,13 @@
  * FilterTagItem shows one filter. It can be removed by clicking the 'x' button.
  */
 
-import {GridFilterItem} from '@mui/x-data-grid-pro';
 import {RemoveAction} from '@wandb/weave/components/Tag';
 import React from 'react';
 
 import {parseRef} from '../../../../../react';
 import {Timestamp, TimestampRange, TimestampSmall} from '../../../../Timestamp';
 import {UserLink} from '../../../../UserLink';
+import {ExtendedGridFilterItem} from '../grid/extendedFilters';
 import {SmallRef} from '../smallRef/SmallRef';
 import {
   FilterId,
@@ -26,7 +26,7 @@ import {FilterTagStatus} from './FilterTagStatus';
 import {IdList} from './IdList';
 
 type FilterTagItemProps = {
-  item: GridFilterItem;
+  item: ExtendedGridFilterItem;
   onRemoveFilter: (id: FilterId) => void;
   isEditing?: boolean;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -2,12 +2,7 @@
  * Shared type definitions and utility methods for filtering UI.
  */
 
-import {
-  GridColDef,
-  GridColumnGroupingModel,
-  GridFilterItem,
-  GridFilterModel,
-} from '@mui/x-data-grid-pro';
+import {GridColDef, GridColumnGroupingModel} from '@mui/x-data-grid-pro';
 import {
   isWandbArtifactRef,
   isWeaveObjectRef,
@@ -20,6 +15,10 @@ import {
   parseScorerFeedbackField,
   RUNNABLE_FEEDBACK_IN_SUMMARY_PREFIX,
 } from '../feedback/HumanFeedback/tsScorerFeedback';
+import {
+  ExtendedGridFilterItem,
+  ExtendedGridFilterModel,
+} from '../grid/extendedFilters';
 import {
   WANDB_ARTIFACT_REF_PREFIX,
   WEAVE_REF_PREFIX,
@@ -365,14 +364,14 @@ export const getStringList = (value: any): string[] => {
   throw new Error('Invalid value');
 };
 
-type ReplacementTest = (item: GridFilterItem) => boolean;
+type ReplacementTest = (item: ExtendedGridFilterItem) => boolean;
 
 export const upsertFilter = (
-  model: GridFilterModel,
-  item: GridFilterItem,
+  model: ExtendedGridFilterModel,
+  item: ExtendedGridFilterItem,
   replacementTest: ReplacementTest
-): GridFilterModel => {
-  const items: GridFilterItem[] = [];
+): ExtendedGridFilterModel => {
+  const items: ExtendedGridFilterItem[] = [];
   let found = false;
   for (const i of model.items) {
     if (replacementTest(i)) {
@@ -415,14 +414,14 @@ export const makeRawDateFilter = (
  * @param id Optional filter ID (defaults to 0)
  * @param field Optional field name (defaults to 'started_at')
  * @param operator Optional operator (defaults to '(date): after')
- * @returns GridFilterItem configured with the specified parameters
+ * @returns ExtendedGridFilterItem configured with the specified parameters
  */
 export const makeDateFilter = (
   days: number,
   id: number | string = 0,
   field: string = 'started_at',
   operator: string = '(date): after'
-): GridFilterItem => {
+): ExtendedGridFilterItem => {
   const pastDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
   return {
     id,
@@ -432,7 +431,7 @@ export const makeDateFilter = (
   };
 };
 
-export const makeMonthFilter = (): GridFilterItem => {
+export const makeMonthFilter = (): ExtendedGridFilterItem => {
   // Get last month
   const curMonth = new Date().getMonth();
   // Number of days in the previous month

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/filterUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/filterUtils.ts
@@ -1,5 +1,8 @@
-import {GridFilterItem} from '@mui/x-data-grid-pro';
-
+import {
+  ExtendedGridFilterItem,
+  ExtendedGridFilterModel,
+  hasDefaultFilters,
+} from '../grid/extendedFilters';
 import {FilterId} from './common';
 
 /**
@@ -9,7 +12,7 @@ import {FilterId} from './common';
  * - Converts string IDs to numbers, defaulting to 0 if parsing fails
  * - Returns the maximum ID + 1
  */
-export const getNextFilterId = (items: GridFilterItem[]): number => {
+export const getNextFilterId = (items: ExtendedGridFilterItem[]): number => {
   if (items.length === 0) {
     return 0;
   }
@@ -31,13 +34,13 @@ export const getNextFilterId = (items: GridFilterItem[]): number => {
  * - Returns combined items and active edit IDs
  */
 export const combineRangeFilters = (
-  items: GridFilterItem[],
+  items: ExtendedGridFilterItem[],
   activeEditId: FilterId | null
-): {items: GridFilterItem[]; activeIds: Set<FilterId>} => {
-  const result: GridFilterItem[] = [];
+): {items: ExtendedGridFilterItem[]; activeIds: Set<FilterId>} => {
+  const result: ExtendedGridFilterItem[] = [];
   const dateRanges = new Map<
     string,
-    {before?: GridFilterItem; after?: GridFilterItem}
+    {before?: ExtendedGridFilterItem; after?: ExtendedGridFilterItem}
   >();
   const activeIds = new Set<FilterId>();
 
@@ -90,4 +93,18 @@ export const combineRangeFilters = (
   });
 
   return {items: result, activeIds};
+};
+
+export const hasDefaultDateFilter = (
+  model: ExtendedGridFilterModel
+): boolean => {
+  return (
+    hasDefaultFilters(model) &&
+    model.items.some(item => {
+      if (item.field === 'started_at' && item.operator === '(date): after') {
+        return true;
+      }
+      return false;
+    })
+  );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/extendedFilters.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/extendedFilters.ts
@@ -1,0 +1,68 @@
+import {
+  GridFilterItem,
+  GridFilterModel,
+  GridLogicOperator,
+} from '@mui/x-data-grid-pro';
+
+/**
+ * Extended version of GridFilterItem that includes an isDefault flag
+ * to track whether a filter was added as a default or by the user
+ */
+export interface ExtendedGridFilterItem extends GridFilterItem {
+  isDefault?: boolean;
+}
+
+/**
+ * Extended version of GridFilterModel that works with ExtendedGridFilterItem
+ */
+export interface ExtendedGridFilterModel
+  extends Omit<GridFilterModel, 'items'> {
+  items: ExtendedGridFilterItem[];
+}
+
+/**
+ * Create a new filter model with default items marked
+ */
+export const createFilterModelWithDefaults = (
+  defaultItems: GridFilterItem[],
+  existingModel?: Partial<GridFilterModel>
+): ExtendedGridFilterModel => {
+  // Mark the default items
+  const markedDefaultItems: ExtendedGridFilterItem[] = defaultItems.map(
+    item => ({
+      ...item,
+      isDefault: true,
+    })
+  );
+
+  // Get existing non-default items
+  const existingItems = existingModel?.items || [];
+
+  return {
+    items: [...markedDefaultItems, ...existingItems],
+    logicOperator: existingModel?.logicOperator || GridLogicOperator.And,
+  };
+};
+
+/**
+ * Helper to check if a filter item is default
+ */
+const isDefaultFilterItem = (item: GridFilterItem): boolean => {
+  return (item as ExtendedGridFilterItem).isDefault === true;
+};
+
+export const hasDefaultFilters = (model: GridFilterModel): boolean => {
+  return model.items.some(isDefaultFilterItem);
+};
+
+/**
+ * Helper to remove default filters from a model
+ */
+export const removeDefaultFilters = (
+  model: GridFilterModel
+): ExtendedGridFilterModel => {
+  return {
+    ...model,
+    items: model.items.filter(item => !isDefaultFilterItem(item)),
+  };
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/filters.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/grid/filters.ts
@@ -1,11 +1,12 @@
-import {
-  GridFilterItem,
-  GridFilterModel,
-  GridLogicOperator,
-} from '@mui/x-data-grid-pro';
+import {GridLogicOperator} from '@mui/x-data-grid-pro';
 import _ from 'lodash';
 
-const isValidFilterItem = (obj: any): obj is GridFilterItem => {
+import {
+  ExtendedGridFilterItem,
+  ExtendedGridFilterModel,
+} from './extendedFilters';
+
+const isValidFilterItem = (obj: any): obj is ExtendedGridFilterItem => {
   if (!_.isPlainObject(obj)) {
     return false;
   }
@@ -20,7 +21,7 @@ const isValidFilterItem = (obj: any): obj is GridFilterItem => {
   return false;
 };
 
-export const getValidFilterModel = <T extends GridFilterModel | null>(
+export const getValidFilterModel = <T extends ExtendedGridFilterModel | null>(
   jsonString: string,
   def: T = null as T
 ): T => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCharts.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsCharts.tsx
@@ -1,4 +1,4 @@
-import {GridFilterModel, GridSortModel} from '@mui/x-data-grid-pro';
+import {GridSortModel} from '@mui/x-data-grid-pro';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {MOON_400} from '../../../../../../common/css/color.styles';
@@ -6,6 +6,7 @@ import * as userEvents from '../../../../../../integrations/analytics/userEvents
 import {IconInfo} from '../../../../../Icon';
 import {WaveLoader} from '../../../../../Loaders/WaveLoader';
 import {Tailwind} from '../../../../../Tailwind';
+import {ExtendedGridFilterModel} from '../../grid/extendedFilters';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 import {useCallsForQuery} from './callsTableQuery';
 import {
@@ -17,7 +18,7 @@ import {
 type CallsChartsProps = {
   entity: string;
   project: string;
-  filterModelProp: GridFilterModel;
+  filterModelProp: ExtendedGridFilterModel;
   filter: WFHighLevelCallFilter;
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -1,6 +1,5 @@
 import {
   GridColumnVisibilityModel,
-  GridFilterModel,
   GridPaginationModel,
   GridPinnedColumnFields,
   GridSortModel,
@@ -11,6 +10,7 @@ import {
   WeaveHeaderExtrasContext,
   WeaveHeaderExtrasProvider,
 } from '../../context';
+import {ExtendedGridFilterModel} from '../../grid/extendedFilters';
 import {opNiceName} from '../common/opNiceName';
 import {SimplePageLayout} from '../common/SimplePageLayout';
 import {useControllableState} from '../util';
@@ -38,8 +38,8 @@ export const CallsPage: FC<{
   pinModel: GridPinnedColumnFields;
   setPinModel: (newModel: GridPinnedColumnFields) => void;
 
-  filterModel: GridFilterModel;
-  setFilterModel: (newModel: GridFilterModel) => void;
+  filterModel: ExtendedGridFilterModel;
+  setFilterModel: (newModel: ExtendedGridFilterModel) => void;
 
   sortModel: GridSortModel;
   setSortModel: (newModel: GridSortModel) => void;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -1,6 +1,5 @@
 import {Box, Popover} from '@mui/material';
 import {
-  GridFilterModel,
   gridPageCountSelector,
   gridPageSelector,
   gridPageSizeSelector,
@@ -27,6 +26,7 @@ import React, {Dispatch, FC, SetStateAction, useRef, useState} from 'react';
 
 import * as userEvents from '../../../../../../integrations/analytics/userEvents';
 import {Select} from '../../../../../Form/Select';
+import {ExtendedGridFilterModel} from '../../grid/extendedFilters';
 import {useWFHooks} from '../wfReactInterface/context';
 import {Query} from '../wfReactInterface/traceServerClientInterface/query';
 import {
@@ -85,7 +85,7 @@ export const ExportSelector = ({
     entity: string;
     project: string;
     filter: WFHighLevelCallFilter;
-    gridFilter: GridFilterModel;
+    gridFilter: ExtendedGridFilterModel;
     gridSort?: GridSortModel;
   };
   disabled: boolean;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableNoRowsOverlay.tsx
@@ -1,9 +1,10 @@
 import {Box, Typography} from '@mui/material';
-import {GridFilterModel} from '@mui/x-data-grid-pro';
 import React from 'react';
 
 import {A, TargetBlank} from '../../../../../../common/util/links';
 import {makeDateFilter, makeMonthFilter} from '../../filters/common';
+import {hasDefaultDateFilter} from '../../filters/filterUtils';
+import {ExtendedGridFilterModel} from '../../grid/extendedFilters';
 import {Empty} from '../common/Empty';
 import {
   EMPTY_PROPS_EVALUATIONS,
@@ -11,7 +12,6 @@ import {
 } from '../common/EmptyContent';
 import {useWFHooks} from '../wfReactInterface/context';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
-import {filterHasCalledAfterDateFilter} from './CallsTable';
 
 type CallsTableNoRowsOverlayProps = {
   entity: string;
@@ -23,9 +23,9 @@ type CallsTableNoRowsOverlayProps = {
     traceRootsOnly?: boolean;
     [key: string]: any;
   };
-  filterModelResolved: GridFilterModel;
+  filterModelResolved: ExtendedGridFilterModel;
   clearFilters?: () => void;
-  setFilterModel?: (model: GridFilterModel) => void;
+  setFilterModel?: (model: ExtendedGridFilterModel) => void;
 };
 
 export const CallsTableNoRowsOverlay: React.FC<
@@ -52,11 +52,11 @@ export const CallsTableNoRowsOverlay: React.FC<
   }
 
   const opExists = opCreatedAt != null;
-  const hasDateFilter = filterHasCalledAfterDateFilter(filterModelResolved);
+  const hasDefaultFilter = hasDefaultDateFilter(filterModelResolved);
 
   // Handle special empty states
   if (isEvaluateTable) {
-    if (!hasDateFilter) {
+    if (!hasDefaultFilter) {
       return <Empty {...EMPTY_PROPS_EVALUATIONS} />;
     } else {
       return (
@@ -72,7 +72,7 @@ export const CallsTableNoRowsOverlay: React.FC<
     return <Empty {...EMPTY_PROPS_TRACES} />;
   }
 
-  if (hasDateFilter) {
+  if (hasDefaultFilter) {
     return (
       <DateFilterEmptyState
         filterModelResolved={filterModelResolved}
@@ -86,9 +86,9 @@ export const CallsTableNoRowsOverlay: React.FC<
 };
 
 type DateFilterEmptyStateProps = {
-  filterModelResolved: GridFilterModel;
+  filterModelResolved: ExtendedGridFilterModel;
   clearFilters?: () => void;
-  setFilterModel?: (model: GridFilterModel) => void;
+  setFilterModel?: (model: ExtendedGridFilterModel) => void;
 };
 
 const DateFilterEmptyState: React.FC<DateFilterEmptyStateProps> = ({

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -1,5 +1,4 @@
 import {
-  GridFilterModel,
   GridLogicOperator,
   GridPaginationModel,
   GridSortModel,
@@ -18,6 +17,7 @@ import {
   makeMonthFilter,
   makeRawDateFilter,
 } from '../../filters/common';
+import {ExtendedGridFilterModel} from '../../grid/extendedFilters';
 import {addCostsToCallResults} from '../CallPage/cost';
 import {operationConverter} from '../common/tabularListViews/operators';
 import {useWFHooks} from '../wfReactInterface/context';
@@ -28,7 +28,7 @@ import {
 } from '../wfReactInterface/wfDataModelHooksInterface';
 import {WFHighLevelCallFilter} from './callsTableFilter';
 
-export const DEFAULT_FILTER_CALLS: GridFilterModel = {
+export const DEFAULT_FILTER_CALLS: ExtendedGridFilterModel = {
   items: [],
   logicOperator: GridLogicOperator.And,
 };
@@ -47,7 +47,7 @@ export const useCallsForQuery = (
   entity: string,
   project: string,
   filter: WFHighLevelCallFilter,
-  gridFilter: GridFilterModel,
+  gridFilter: ExtendedGridFilterModel,
   gridPage: GridPaginationModel,
   gridSort?: GridSortModel,
   expandedColumns?: Set<string>,
@@ -216,7 +216,7 @@ export const useCallsForQuery = (
 
 export const useFilterSortby = (
   filter: WFHighLevelCallFilter,
-  gridFilter: GridFilterModel,
+  gridFilter: ExtendedGridFilterModel,
   gridSort: GridSortModel | undefined
 ) => {
   const sortBy = useDeepMemo(
@@ -239,7 +239,7 @@ export const useFilterSortby = (
 };
 
 const getFilterByRaw = (
-  gridFilter: GridFilterModel
+  gridFilter: ExtendedGridFilterModel
 ): Query['$expr'] | undefined => {
   const completeItems = gridFilter.items.filter(
     item => item.value !== undefined || isValuelessOperator(item.operator)
@@ -345,7 +345,7 @@ export const useMakeInitialDatetimeFilter = (
   project: string,
   highLevelFilter: WFHighLevelCallFilter,
   skip: boolean
-): {initialDatetimeFilter: GridFilterModel} => {
+): {initialDatetimeFilter: ExtendedGridFilterModel} => {
   // Fire off 2 stats queries, one for the # of calls in the last 7 days
   // one for the  # of calls in the last 30 days.
   // If the first query returns > 50 calls, set the default filter to 7 days
@@ -379,7 +379,12 @@ export const useMakeInitialDatetimeFilter = (
 
   const defaultDatetimeFilter = useMemo(
     () => ({
-      items: [makeDateFilter(7)],
+      items: [
+        {
+          ...makeDateFilter(7),
+          isDefault: true,
+        },
+      ],
       logicOperator: GridLogicOperator.And,
     }),
     []
@@ -397,7 +402,12 @@ export const useMakeInitialDatetimeFilter = (
       newFilter = defaultDatetimeFilter;
     } else if (callStats30Days.result && callStats30Days.result.count >= 50) {
       newFilter = {
-        items: [makeMonthFilter()],
+        items: [
+          {
+            ...makeMonthFilter(),
+            isDefault: true,
+          },
+        ],
         logicOperator: GridLogicOperator.And,
       };
     } else if (callStats30Days.result && callStats30Days.result.count < 50) {
@@ -416,7 +426,7 @@ export const useMakeInitialDatetimeFilter = (
 
   if (cachedFilter) {
     return {
-      initialDatetimeFilter: cachedFilter as GridFilterModel,
+      initialDatetimeFilter: cachedFilter as ExtendedGridFilterModel,
     };
   }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -1,4 +1,3 @@
-import {GridFilterModel} from '@mui/x-data-grid-pro';
 import {
   MOON_200,
   MOON_700,
@@ -18,6 +17,7 @@ import {
   usePeekLocation,
   useWeaveflowRouteContext,
 } from '../../context';
+import {ExtendedGridFilterModel} from '../../grid/extendedFilters';
 import {WFHighLevelCallFilter} from '../CallsPage/callsTableFilter';
 import {WFHighLevelObjectVersionFilter} from '../ObjectsPage/objectsPageTypes';
 import {WFHighLevelOpVersionFilter} from '../OpsPage/opsPageTypes';
@@ -420,7 +420,7 @@ export const CallsLink: React.FC<{
   callCount?: number;
   countIsLimited?: boolean;
   filter?: WFHighLevelCallFilter;
-  gridFilters?: GridFilterModel;
+  gridFilters?: ExtendedGridFilterModel;
   neverPeek?: boolean;
   variant?: LinkVariant;
 }> = props => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -1,11 +1,11 @@
-import {GridFilterItem} from '@mui/x-data-grid';
 import _ from 'lodash';
 
+import {ExtendedGridFilterItem} from '../../../grid/extendedFilters';
 import {Query} from '../../wfReactInterface/traceServerClientInterface/query';
 
-// Convert one Material GridFilterItem to our Mongo-like query format.
+// Convert one ExtendedGridFilterItem to our Mongo-like query format.
 export const operationConverter = (
-  item: GridFilterItem
+  item: ExtendedGridFilterItem
 ): null | Query['$expr'] => {
   if (item.operator === '(any): isEmpty') {
     return {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -260,7 +260,7 @@ const useCallsNoExpansion = (
   }
 ): Loadable<CallSchema[]> & Refetchable => {
   const getTsClient = useGetTraceServerClientContext();
-  const loadingRef = useRef(false);
+  const [loading, setLoading] = useState(true);
   const [callRes, setCallRes] =
     useState<traceServerTypes.TraceCallsQueryRes | null>(null);
   const deepFilter = useDeepMemo(filter);
@@ -270,7 +270,7 @@ const useCallsNoExpansion = (
       return;
     }
     setCallRes(null);
-    loadingRef.current = true;
+    setLoading(true);
     const req: traceServerTypes.TraceCallsQueryReq = {
       project_id: projectIdFromParts({entity, project}),
       filter: {
@@ -296,11 +296,11 @@ const useCallsNoExpansion = (
         : null),
     };
     const onSuccess = (res: traceServerTypes.TraceCallsQueryRes) => {
-      loadingRef.current = false;
       setCallRes(res);
+      setLoading(false);
     };
     const onError = (e: any) => {
-      loadingRef.current = false;
+      setLoading(false);
       console.error(e);
       setCallRes({calls: []});
     };
@@ -367,7 +367,7 @@ const useCallsNoExpansion = (
       .map(traceCallToUICallSchema);
     const result = allResults;
 
-    if (callRes == null || loadingRef.current) {
+    if (callRes == null || loading) {
       return {
         loading: true,
         result: [],
@@ -395,7 +395,7 @@ const useCallsNoExpansion = (
         refetch,
       };
     }
-  }, [opts?.skip, callRes, columns, refetch, entity, project]);
+  }, [opts?.skip, callRes, columns, refetch, entity, project, loading]);
 };
 
 const useCalls = (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24243](https://wandb.atlassian.net/browse/WB-24243)

This pr:
- refactors `GridFilterItem` and `GridFilterModel` to `ExtendedGridFilterItem` and `ExtendedGridFilterModel` so that we can track more information on the filter. Specifically, we want to keep track of if the filter was applied by the user or was a default filter. Currently we are using a heuristic, but that breaks when we want to more aggressively condition on it. 
- Prolongs the `callsTable` loading state to wait until we are done adjusting the datetime filter.
- Slightly changes the `useCallsNoExpansion` loading state management, moving from a ref to explicitly use state hooks. This allows us to set the `loading=false` state after setting `callRes` which leads to one fewer render where the `loading` and `results` states are out of sync. 

This pr does not **solve** the issue, but reduces the prevalence of this specific race condition. The root of the issue comes from inconsistent results from the hook, where the hook returns "all good, done loading" but the results are empty. This happens most consistently when repeatedly refreshing the hook, but because we are caching our datetime filter selection, this should not be an issue. 

## Testing

Prod


Prod (caching disabled)


Branch (caching disabled)


[WB-24243]: https://wandb.atlassian.net/browse/WB-24243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ