### PR TITLE
feat(ui): edit list valued dataset cells

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CellRenderers.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CellRenderers.tsx
@@ -97,10 +97,11 @@ export const DatasetCellRenderer: React.FC<CellProps> = ({
   }, [isEditing]);
 
   const isWeaveUrl = isRefPrefixedString(value);
+  const isJsonList = Array.isArray(value);
   const isEditable =
     !isDeleted &&
     !isWeaveUrl &&
-    typeof value !== 'object' &&
+    (typeof value !== 'object' || isJsonList) &&
     typeof value !== 'boolean';
 
   // Use the context's updateCellValue function instead of local implementation
@@ -129,6 +130,10 @@ export const DatasetCellRenderer: React.FC<CellProps> = ({
     }
   };
 
+  const handleValueChange = (newValue: string | any[]) => {
+    setEditedValue(newValue);
+  };
+
   const handleRevert = (event: React.MouseEvent) => {
     event.stopPropagation();
     setEditedValue(serverValue); // Reset editedValue to serverValue
@@ -146,10 +151,6 @@ export const DatasetCellRenderer: React.FC<CellProps> = ({
       return CELL_COLORS.NEW;
     }
     return CELL_COLORS.TRANSPARENT;
-  };
-
-  const handleValueChange = (newValue: string) => {
-    setEditedValue(newValue);
   };
 
   // Special handler for boolean values - toggle directly
@@ -198,7 +199,7 @@ export const DatasetCellRenderer: React.FC<CellProps> = ({
     );
   }
 
-  // Non-editable cell types (objects, weave URLs)
+  // Non-editable cell types (objects except arrays, weave URLs)
   if (!isEditable) {
     return (
       <CellTooltip title="Cell type cannot be edited">
@@ -258,7 +259,7 @@ export const DatasetCellRenderer: React.FC<CellProps> = ({
             },
           }}>
           <span style={{flex: 1, position: 'relative', overflow: 'hidden'}}>
-            {value}
+            {isJsonList ? JSON.stringify(value) : value}
           </span>
           {isHovered && (
             <Box
@@ -297,7 +298,6 @@ export const DatasetCellRenderer: React.FC<CellProps> = ({
     );
   }
 
-  // Render cell in edit mode
   if (typeof value === 'number') {
     return (
       <Box
@@ -362,10 +362,11 @@ export const DatasetCellRenderer: React.FC<CellProps> = ({
         onClose={finalValue => handleCloseEdit(finalValue)}
         initialWidth={initialWidth.current}
         initialHeight={initialHeight.current}
-        value={typeof editedValue === 'string' ? editedValue : ''}
+        value={value}
         originalValue={serverValue ?? ''}
         onChange={handleValueChange}
         inputRef={inputRef}
+        initialEditorMode={isJsonList ? 'code' : 'text'}
       />
     </>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetEditorContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetEditorContext.tsx
@@ -138,7 +138,11 @@ export const DatasetEditProvider: React.FC<DatasetEditProviderProps> = ({
         ? preserveFieldOrder(updatedRow)
         : updatedRow;
 
-      const isValueChanged = newValue !== serverValue;
+      // Compare arrays by value instead of by reference
+      const isValueChanged =
+        Array.isArray(newValue) && Array.isArray(serverValue)
+          ? JSON.stringify(newValue) !== JSON.stringify(serverValue)
+          : newValue !== serverValue;
 
       if (existingRow.___weave?.isNew) {
         // For newly added rows

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/editors/CodeEditor.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/editors/CodeEditor.tsx
@@ -6,12 +6,16 @@ interface CodeEditorProps {
   value: string;
   onChange: (value: string) => void;
   onClose: (value?: any) => void;
+  language?: string;
+  disableClosing?: boolean;
 }
 
 export const CodeEditor: React.FC<CodeEditorProps> = ({
   value,
   onChange,
   onClose,
+  language,
+  disableClosing = false,
 }) => {
   const editorRef = useRef<any>(null);
   const currentValueRef = useRef(value);
@@ -20,7 +24,9 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     editorRef.current = editor;
 
     // Set initial value
-    editor.setValue(value);
+    if (editor.getValue() !== value) {
+      editor.setValue(value);
+    }
 
     // Track content changes
     editor.onDidChangeModelContent(() => {
@@ -35,19 +41,29 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         e.preventDefault();
         e.stopPropagation();
 
+        // Don't close if closing is disabled
+        if (disableClosing) {
+          return;
+        }
+
         // Get the latest value directly from the editor
         onClose(editor.getValue());
       } else if (e.code === 'Escape') {
         e.preventDefault();
         e.stopPropagation();
 
-        // Also close and get value directly from editor
-        onClose(editor.getValue());
+        // Don't close if closing is disabled
+        if (disableClosing) {
+          return;
+        }
+
+        // Escape cancels the edit
+        onClose();
       }
     });
   };
 
-  // Update ref when value changes - not using effect now
+  // Update ref when value changes
   currentValueRef.current = value;
 
   return (
@@ -73,7 +89,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
       <Editor
         height="100%"
         width="100%"
-        defaultValue={value}
+        value={value}
+        language={language}
         onMount={handleEditorDidMount}
         options={{
           minimap: {enabled: false},

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/editors/TextEditor.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/editors/TextEditor.tsx
@@ -1,5 +1,5 @@
 import {TextField} from '@mui/material';
-import React from 'react';
+import React, {useRef} from 'react';
 
 interface TextEditorProps {
   value: string;
@@ -14,7 +14,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
   onClose,
   inputRef,
 }) => {
-  const localInputRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const localInputRef = useRef<HTMLTextAreaElement | null>(null);
   const actualInputRef = inputRef || localInputRef;
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -22,13 +22,15 @@ export const TextEditor: React.FC<TextEditorProps> = ({
     if (event.key === 'Enter' && !event.metaKey) {
       event.stopPropagation();
     } else if (event.key === 'Enter' && event.metaKey) {
+      event.preventDefault();
       event.stopPropagation();
       // Get the current value directly when closing
       onClose(value);
     } else if (event.key === 'Escape') {
+      event.preventDefault();
       event.stopPropagation();
-      // Also get the value directly when escaping
-      onClose(value);
+      // Escape should cancel without applying changes
+      onClose();
     }
   };
 
@@ -41,6 +43,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
         onChange(newValue);
       }}
       onKeyDown={handleKeyDown}
+      // Focus the input and position cursor at the end
       onFocus={e => {
         const target = e.target as HTMLTextAreaElement;
         target.setSelectionRange(target.value.length, target.value.length);
@@ -50,20 +53,24 @@ export const TextEditor: React.FC<TextEditorProps> = ({
       autoFocus
       sx={{
         width: '100%',
+        height: '100%',
         '& .MuiInputBase-root': {
           fontFamily: '"Source Sans Pro", sans-serif',
           fontSize: '14px',
           border: 'none',
           backgroundColor: 'white',
+          height: '100%',
         },
         '& .MuiInputBase-input': {
           padding: '0px',
+          height: '100%',
         },
         '& .MuiOutlinedInput-notchedOutline': {
           border: 'none',
         },
         '& textarea': {
-          overflow: 'hidden !important',
+          overflow: 'auto !important',
+          height: '100% !important',
           resize: 'none',
         },
       }}


### PR DESCRIPTION
## Description

Enable editing of list valued dataset cells in the UI. Prior to this PR list values are not editable and users see a tooltip saying the cell can't be edited.

Now list values can be edited as json in the same popout editor used for strings. Only code and diff mode can be used and json syntax highlighting is applied. The popover editor cannot be closed while the value is invalid json or not a list. Validation errors are shown in a footer at the bottom of the editor.

<img width="1073" alt="Screenshot 2025-04-21 at 8 03 56 PM" src="https://github.com/user-attachments/assets/90441669-187d-4201-a26f-5e06a1f12716" />


<img width="1073" alt="Screenshot 2025-04-21 at 8 04 04 PM" src="https://github.com/user-attachments/assets/704f9594-d3c9-4ddb-86e0-5818e33f291e" />

