### PR TITLE
fix(ui): react 18 createRoot warning

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/VariableChildrenDisplayer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/VariableChildrenDisplayer.tsx
@@ -5,7 +5,11 @@
 
 import _ from 'lodash';
 import React, {isValidElement, ReactChild, useEffect, useState} from 'react';
-import ReactDOM from 'react-dom';
+// We have a mismatch between our react version (v18) and react types version (v17).
+// Unfortunately my preferred fix of upgrading the types causes integration test failures
+// in artifacts that we don't have time to debug right now.
+// @ts-ignore
+import {createRoot} from 'react-dom/client';
 
 import {useDeepMemo} from '../../../../../hookUtils';
 
@@ -73,12 +77,16 @@ const measureWidths = (nodes: ReactChild[]): Promise<number[]> => {
 
       // Render the node and measure its width
       if (React.isValidElement(node)) {
-        ReactDOM.render(node, wrapper, () => {
+        const root = createRoot(wrapper);
+        root.render(node);
+
+        // Use requestAnimationFrame to ensure the component has rendered
+        requestAnimationFrame(() => {
           const width = wrapper.offsetWidth;
           resolve(width);
 
           // Clean up after measuring
-          ReactDOM.unmountComponentAtNode(wrapper);
+          root.unmount();
           container.removeChild(wrapper);
         });
       } else {


### PR DESCRIPTION
## Description

Fixes this error:
<img width="1121" alt="Screenshot 2025-04-21 at 9 40 40 AM" src="https://github.com/user-attachments/assets/d8eba364-9bbd-4faa-9a26-964e0521a1a4" />

This was also the root cause behind a Saved Views bug with filters.