### PR TITLE
chore(weave): add error and span logging for inserts

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2123,13 +2123,14 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 )
             raise
         except Exception as e:
+            data_bytes = sum(_num_bytes(row) for row in data)
             logger.exception(
                 "clickhouse_insert_error",
                 extra={
                     "error_str": str(e),
                     "table": table,
                     "data_len": len(data),
-                    "data_bytes": sum(len(row) for row in data),
+                    "data_bytes": data_bytes,
                     "example_data": None if len(data) == 0 else data[0],
                     "column_names": column_names,
                     "settings": settings,

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2123,6 +2123,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 )
             raise
         except Exception as e:
+            # Do potentially expensive data length calculation, only on
+            # error, which should be very rare!
             data_bytes = sum(_num_bytes(row) for row in data)
             logger.exception(
                 "clickhouse_insert_error",

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2130,7 +2130,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                     "table": table,
                     "data_len": len(data),
                     "data_bytes": sum(len(row) for row in data),
-                    "example_data": data[0],
+                    "example_data": None if len(data) == 0 else data[0],
                     "column_names": column_names,
                     "settings": settings,
                 },

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2149,13 +2149,6 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_calls")
     def _flush_calls(self) -> None:
-        ddtrace.tracer.current_span().set_tags(
-            {
-                "clickhouse_trace_server_batched._flush_calls.insert_bytes": str(
-                    sum(len(row) for row in self._call_batch)
-                )
-            }
-        )
         try:
             self._insert_call_batch(self._call_batch)
         except InsertTooLarge:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2128,7 +2128,9 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 extra={
                     "error_str": str(e),
                     "table": table,
-                    "data": data,
+                    "data_len": len(data),
+                    "data_bytes": sum(len(row) for row in data),
+                    "example_data": data[0],
                     "column_names": column_names,
                     "settings": settings,
                 },


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr: 
- logs error information (`table`, `data_len`, `data_bytes`, `example_data` (first row), `column_names`, `settings`) when an insert fails
- adds the count of stripped payloads to the dd trace in `_strip_large_values`

## Testing

- really hard to test the error reporting, i'm not sure how to cause the error, thats why we need the additional logging. 
