### PR TITLE
fix(weave): Fixes call view loading hand for unfinished calls

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -71,8 +71,8 @@ export const CallPage: FC<CallPageProps> = props => {
       // in null response (bug on server side). As a result, the summary
       // will not show costs. FIXME (This results in a second query in
       // CallSummary.tsx)
-      // includeCosts: true, 
-      includeTotalStorageSize: true
+      // includeCosts: true,
+      includeTotalStorageSize: true,
     }
   );
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -66,7 +66,14 @@ export const CallPage: FC<CallPageProps> = props => {
       callId: descendentCallId,
       withTotalStorageSize: true,
     },
-    {includeCosts: true, includeTotalStorageSize: true}
+    {
+      // Sadly we cannot include costs as unfinished calls will result
+      // in null response (bug on server side). As a result, the summary
+      // will not show costs. FIXME (This results in a second query in
+      // CallSummary.tsx)
+      // includeCosts: true, 
+      includeTotalStorageSize: true
+    }
   );
 
   // This is a little hack, but acceptable for now.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -12,6 +12,7 @@ import {SimpleKeyValueTable} from '../common/SimplePageLayout';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CostTable} from './cost';
 import {ObjectViewerSection} from './ObjectViewerSection';
+import { useWFHooks } from '../wfReactInterface/context';
 
 const SUMMARY_FIELDS_EXCLUDED_FROM_GENERAL_RENDER = [
   'latency_s',
@@ -36,6 +37,7 @@ const StorageSizeDisplay: React.FC<{
 export const CallSummary: React.FC<{
   call: CallSchema;
 }> = ({call}) => {
+  const {useCall} = useWFHooks();
   const span = call.rawSpan;
   // Process attributes, only filtering out null values and keys starting with '_'
   const attributes = _.fromPairs(
@@ -52,7 +54,26 @@ export const CallSummary: React.FC<{
         !SUMMARY_FIELDS_EXCLUDED_FROM_GENERAL_RENDER.includes(k)
     )
   );
-  const costData = call.traceCall?.summary?.weave?.costs;
+
+  // TODO: Once the server responds with costs even for unfinished calls,
+  // we can remove this second call. See the comment in CallPage.tsx.
+  // with `(This results in a second query in CallSummary.tsx)`
+  const callWithCosts = useCall(
+    {
+      entity: call.entity,
+      project: call.project,
+      callId: call.callId,
+      includeCosts: true, 
+    },
+    {
+      includeCosts: true, 
+    }
+  );
+
+
+  const costData = useMemo(() => {
+    return callWithCosts.result?.traceCall?.summary?.weave?.costs;
+  }, [callWithCosts.result]);
 
   const storageSizeBytesRow = useMemo(() => {
     const size =

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -9,10 +9,10 @@ import {Timestamp} from '../../../../../Timestamp';
 import {UserLink} from '../../../../../UserLink';
 import {SmallRef} from '../../smallRef/SmallRef';
 import {SimpleKeyValueTable} from '../common/SimplePageLayout';
+import {useWFHooks} from '../wfReactInterface/context';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CostTable} from './cost';
 import {ObjectViewerSection} from './ObjectViewerSection';
-import { useWFHooks } from '../wfReactInterface/context';
 
 const SUMMARY_FIELDS_EXCLUDED_FROM_GENERAL_RENDER = [
   'latency_s',
@@ -63,13 +63,12 @@ export const CallSummary: React.FC<{
       entity: call.entity,
       project: call.project,
       callId: call.callId,
-      includeCosts: true, 
+      includeCosts: true,
     },
     {
-      includeCosts: true, 
+      includeCosts: true,
     }
   );
-
 
   const costData = useMemo(() => {
     return callWithCosts.result?.traceCall?.summary?.weave?.costs;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -224,6 +224,11 @@ const useCall = (
         loading: true,
         result: null,
       };
+    } else if (result == null) {
+      return {
+        loading: false,
+        result: null,
+      };
     } else if (result?.callId === key?.callId) {
       if (result) {
         callCache.set(key, result);


### PR DESCRIPTION
Currently, all unfinished calls fail to load, resulting in really bad user experience.

2 bugs:
1. When returning no call, we just show loader - this is fixed now to show "No call found"
2. When loading the call page, if a call is still running, AND we request costs, the backend incorrectly returns 0 calls. This is a bug!. I added a UI fix to load this in two steps (inefficient, but fixes for now)