### PR TITLE
feat(weave): Refactor otel parsing to standardize fields

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -1,8 +1,9 @@
+import hashlib
 import json
 import uuid
 from binascii import hexlify
 from datetime import datetime
-from unittest.mock import patch
+from typing import Any
 
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -23,19 +24,25 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.opentelemetry.attributes import (
-    Attributes,
-    AttributesFactory,
-    GenericAttributes,
-    OpenInferenceAttributes,
-    OpenTelemetryAttributes,
+    get_wandb_attributes,
+    get_weave_attributes,
+    get_weave_inputs,
+    get_weave_outputs,
+    get_weave_usage,
+)
+from weave.trace_server.opentelemetry.helpers import (
+    capture_parts,
     convert_numeric_keys_to_list,
     expand_attributes,
     flatten_attributes,
     get_attribute,
+    shorten_name,
     to_json_serializable,
     unflatten_key_values,
 )
-from weave.trace_server.opentelemetry.python_spans import Span as PySpan
+from weave.trace_server.opentelemetry.python_spans import (
+    Span as PySpan,
+)
 from weave.trace_server.opentelemetry.python_spans import (
     SpanKind,
     StatusCode,
@@ -156,22 +163,21 @@ def test_otel_export_clickhouse(client: weave_client.WeaveClient):
     assert call.id == decoded_span
     assert call.trace_id == decoded_trace
 
-    call_attributes = Attributes(_attributes=call.attributes)
     for kv in export_span.attributes:
         key = kv.key
         value = kv.value
         if value.HasField("string_value"):
-            assert call_attributes.get_attribute_value(key) == value.string_value
+            assert get_attribute(call.attributes, key) == value.string_value
         elif value.HasField("int_value"):
-            assert call_attributes.get_attribute_value(key) == value.int_value
+            assert get_attribute(call.attributes, key) == value.int_value
         elif value.HasField("double_value"):
-            assert call_attributes.get_attribute_value(key) == value.double_value
+            assert get_attribute(call.attributes, key) == value.double_value
         elif value.HasField("bool_value"):
-            assert call_attributes.get_attribute_value(key) == value.bool_value
+            assert get_attribute(call.attributes, key) == value.bool_value
         elif value.HasField("array_value"):
             # Handle array values
             array_values = [v.string_value for v in value.array_value.values]
-            assert call_attributes.get_attribute_value(key) == array_values
+            assert get_attribute(call.attributes, key) == array_values
 
     # Verify call deletion using client provided ID works
     client.server.calls_delete(
@@ -206,13 +212,13 @@ class TestPythonSpans:
         assert py_span.status.message == pb_span.status.message
 
         # Verify attributes were correctly converted
-        assert py_span.attributes.get_attribute_value("test.attribute") == "test_value"
-        assert py_span.attributes.get_attribute_value("test.number") == 42
+        assert get_attribute(py_span.attributes, "test.attribute") == "test_value"
+        assert get_attribute(py_span.attributes, "test.number") == 42
         assert (
-            py_span.attributes.get_attribute_value("test.nested.value")
+            get_attribute(py_span.attributes, "test.nested.value")
             == "nested_test_value"
         )
-        array_value = py_span.attributes.get_attribute_value("test.array")
+        array_value = get_attribute(py_span.attributes, "test.array")
         assert isinstance(array_value, list)
         assert len(array_value) == 2
         assert array_value[0] == "value1"
@@ -223,15 +229,41 @@ class TestPythonSpans:
         pb_span = create_test_span()
         py_span = PySpan.from_proto(pb_span)
 
-        start_call, end_call = py_span.to_call("test_project")
+        start_call, _ = py_span.to_call("test_project")
 
         # Verify start call
         assert isinstance(start_call, tsi.StartedCallSchemaForInsert)
         assert start_call.project_id == "test_project"
         assert start_call.id == py_span.span_id
-        assert start_call.op_name == py_span.name
+        assert (
+            start_call.op_name == py_span.name
+        )  # This should be using the shortened name if necessary
         assert start_call.trace_id == py_span.trace_id
         assert start_call.started_at == py_span.start_time
+
+    def test_span_to_call_long_name(self):
+        """Test that span names are properly shortened when too long."""
+        from weave.trace_server.constants import MAX_OP_NAME_LENGTH
+        from weave.trace_server.opentelemetry.helpers import shorten_name
+
+        # Create a test span with a very long name
+        pb_span = create_test_span()
+        long_name = "a" * (MAX_OP_NAME_LENGTH + 10)
+        pb_span.name = long_name
+
+        py_span = PySpan.from_proto(pb_span)
+        start_call, end_call = py_span.to_call("test_project")
+
+        # Verify that the op_name was shortened
+        identifier = hashlib.sha256(long_name.encode("utf-8")).hexdigest()[:4]
+        shortened_name = shorten_name(
+            long_name,
+            MAX_OP_NAME_LENGTH,
+            abbrv=f":{identifier}",
+            use_delimiter_in_abbr=False,
+        )
+        assert start_call.op_name == shortened_name
+        assert len(start_call.op_name) <= MAX_OP_NAME_LENGTH
 
         # Verify attributes in start call
         assert "test" in start_call.attributes
@@ -242,6 +274,17 @@ class TestPythonSpans:
         assert start_call.attributes["test"]["nested"]["value"] == "nested_test_value"
         assert "array" in start_call.attributes["test"]
         assert start_call.attributes["test"]["array"] == ["value1", "value2"]
+
+        # Verify otel_span is included in attributes
+        assert "otel_span" in start_call.attributes
+        assert start_call.attributes["otel_span"]["name"] == py_span.name
+        assert (
+            start_call.attributes["otel_span"]["context"]["trace_id"]
+            == py_span.trace_id
+        )
+        assert (
+            start_call.attributes["otel_span"]["context"]["span_id"] == py_span.span_id
+        )
 
         # Verify end call
         assert isinstance(end_call, tsi.EndedCallSchemaForInsert)
@@ -296,6 +339,133 @@ class TestAttributes:
         # Test enums
         assert to_json_serializable(SpanKind.INTERNAL) == 1
 
+    def test_to_json_serializable_special_floats(self):
+        """Test converting special float values (NaN, Infinity)."""
+        # Test NaN
+        assert to_json_serializable(float("nan")) == "nan"
+
+        # Test positive infinity
+        assert to_json_serializable(float("inf")) == "inf"
+
+        # Test negative infinity
+        assert to_json_serializable(float("-inf")) == "-inf"
+
+    def test_to_json_serializable_date_time(self):
+        """Test converting date and time objects."""
+        from datetime import date, time
+
+        # Test date
+        d = date(2023, 1, 1)
+        assert to_json_serializable(d) == "2023-01-01"
+
+        # Test time
+        t = time(12, 30, 45)
+        assert to_json_serializable(t) == "12:30:45"
+
+    def test_to_json_serializable_timedelta(self):
+        """Test converting timedelta objects."""
+        from datetime import timedelta
+
+        # Test one day
+        td = timedelta(days=1)
+        assert to_json_serializable(td) == 86400.0  # 24 * 60 * 60 seconds
+
+        # Test complex timedelta
+        td = timedelta(days=1, hours=2, minutes=30, seconds=15)
+        expected_seconds = (1 * 24 * 60 * 60) + (2 * 60 * 60) + (30 * 60) + 15
+        assert to_json_serializable(td) == expected_seconds
+
+    def test_to_json_serializable_uuid(self):
+        """Test converting UUID objects."""
+        import uuid
+
+        # Create a UUID with a known value
+        test_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        assert to_json_serializable(test_uuid) == "12345678-1234-5678-1234-567812345678"
+
+    def test_to_json_serializable_decimal(self):
+        """Test converting Decimal objects."""
+        from decimal import Decimal
+
+        # Test simple decimal
+        assert to_json_serializable(Decimal("10.5")) == 10.5
+
+        # Test high precision decimal
+        assert (
+            to_json_serializable(Decimal("3.14159265358979323846"))
+            == 3.14159265358979323846
+        )
+
+        # Test zero
+        assert to_json_serializable(Decimal("0")) == 0.0
+
+    def test_to_json_serializable_sets(self):
+        """Test converting set and frozenset objects."""
+        # Test set
+        s = {1, 2, 3, "test"}
+        result = to_json_serializable(s)
+        assert isinstance(result, list)
+        assert len(result) == 4
+        assert 1 in result
+        assert 2 in result
+        assert 3 in result
+        assert "test" in result
+
+        # Test frozenset
+        fs = frozenset([4, 5, 6, "frozen"])
+        result = to_json_serializable(fs)
+        assert isinstance(result, list)
+        assert len(result) == 4
+        assert 4 in result
+        assert 5 in result
+        assert 6 in result
+        assert "frozen" in result
+
+    def test_to_json_serializable_complex(self):
+        """Test converting complex numbers."""
+        c = complex(3, 4)
+        result = to_json_serializable(c)
+        assert isinstance(result, dict)
+        assert result == {"real": 3.0, "imag": 4.0}
+
+        # Test complex with negative imaginary part
+        c = complex(1, -2)
+        assert to_json_serializable(c) == {"real": 1.0, "imag": -2.0}
+
+    def test_to_json_serializable_bytes(self):
+        """Test converting bytes and bytearray objects."""
+        # Test bytes
+        b = b"hello world"
+        assert to_json_serializable(b) == "aGVsbG8gd29ybGQ="  # Base64 encoded
+
+        # Test bytearray
+        ba = bytearray(b"hello world")
+        assert to_json_serializable(ba) == "aGVsbG8gd29ybGQ="  # Base64 encoded
+
+    def test_to_json_serializable_dataclass(self):
+        """Test converting dataclass objects."""
+        from dataclasses import dataclass
+
+        @dataclass
+        class Person:
+            name: str
+            age: int
+
+        person = Person(name="John", age=30)
+        result = to_json_serializable(person)
+        assert isinstance(result, dict)
+        assert result == {"name": "John", "age": 30}
+
+        # Nested dataclass
+        @dataclass
+        class Department:
+            name: str
+            head: Person
+
+        dept = Department(name="Engineering", head=Person(name="Jane", age=35))
+        result = to_json_serializable(dept)
+        assert result == {"name": "Engineering", "head": {"name": "Jane", "age": 35}}
+
     def test_unflatten_key_values(self):
         """Test unflattening key-value pairs into nested structure."""
         # Create key-value pairs
@@ -322,13 +492,7 @@ class TestAttributes:
         assert get_attribute(nested, "a.b") == {"c": "value1"}
         assert get_attribute(nested, "d") == [1, 2, 3]
 
-        # Need to patch get_attribute function to correctly handle array indices
-        with patch(
-            "weave.trace_server.opentelemetry.attributes._get_value_from_nested_dict"
-        ) as mock_get:
-            mock_get.return_value = 1
-            assert get_attribute(nested, "d.0") == 1
-            mock_get.assert_called_once_with(nested, "d.0")
+        assert get_attribute(nested, "d.0") == 1
 
         assert get_attribute(nested, "nonexistent") is None
 
@@ -386,6 +550,10 @@ class TestAttributes:
         assert result == expected
 
 
+def create_attributes(d: dict[str, Any]):
+    return expand_attributes(d.items())
+
+
 class TestSemanticConventionParsing:
     """Test the semantic convention parsing functionality in attributes.py."""
 
@@ -394,89 +562,150 @@ class TestSemanticConventionParsing:
         from openinference.semconv.trace import SpanAttributes as OISpanAttr
 
         # Create attribute dictionary with OpenInference attributes
-        attributes = {
-            "openinference": True,
-            OISpanAttr.LLM_SYSTEM: "This is a system prompt",
-            OISpanAttr.LLM_PROVIDER: "test-provider",
-            OISpanAttr.LLM_MODEL_NAME: "test-model",
-            OISpanAttr.OPENINFERENCE_SPAN_KIND: "llm",
-            OISpanAttr.LLM_INVOCATION_PARAMETERS: json.dumps(
-                {"temperature": 0.7, "max_tokens": 100}
-            ),
-        }
-
-        # Create OpenInference attributes object
-        oi_attrs = OpenInferenceAttributes(attributes)
+        attributes = create_attributes(
+            {
+                OISpanAttr.LLM_SYSTEM: "This is a system prompt",
+                OISpanAttr.LLM_PROVIDER: "test-provider",
+                OISpanAttr.LLM_MODEL_NAME: "test-model",
+                OISpanAttr.OPENINFERENCE_SPAN_KIND: "llm",
+                OISpanAttr.LLM_INVOCATION_PARAMETERS: json.dumps(
+                    {"temperature": 0.7, "max_tokens": 100}
+                ),
+            }
+        )
 
         # Test get_weave_attributes
-        extracted = oi_attrs.get_weave_attributes()
+        extracted = get_weave_attributes(attributes)
         assert extracted["system"] == "This is a system prompt"
         assert extracted["provider"] == "test-provider"
         assert extracted["model"] == "test-model"
         assert extracted["kind"] == "llm"
-        assert extracted["temperature"] == "0.7"
-        assert extracted["max_tokens"] == "100"
+        assert extracted["model_parameters"]["max_tokens"] == 100
+        assert extracted["model_parameters"]["temperature"] == 0.7
+
+    def test_wandb_attributes_extraction(self):
+        """Test extracting wandb-specific attributes."""
+        # Create attribute dictionary with W&B specific attributes
+        attributes = create_attributes(
+            {
+                "wandb.display_name": "My Custom Display Name",
+            }
+        )
+
+        # Test get_wandb_attributes
+        extracted = get_wandb_attributes(attributes)
+        assert extracted["display_name"] == "My Custom Display Name"
+
+        # Test with missing attributes
+        empty_attributes = create_attributes({})
+        extracted = get_wandb_attributes(empty_attributes)
+        assert extracted == {}
+
+        # Test with partial attributes
+        partial_attributes = create_attributes(
+            {
+                "wandb.display_name": "Only Display Name",
+            }
+        )
+        extracted = get_wandb_attributes(partial_attributes)
+        assert extracted["display_name"] == "Only Display Name"
+        assert "project_id" not in extracted
+
+        # Test with nested attributes format
+        nested_attributes = create_attributes(
+            {
+                "wandb": {
+                    "display_name": "Nested Display Name",
+                }
+            }
+        )
+        extracted = get_wandb_attributes(nested_attributes)
+        assert extracted["display_name"] == "Nested Display Name"
 
     def test_openinference_inputs_extraction(self):
         """Test extracting inputs from OpenInference attributes."""
         from openinference.semconv.trace import SpanAttributes as OISpanAttr
 
-        # Create attribute dictionary with OpenInference input messages
-        input_messages = {"0": {"role": "user", "content": "What is machine learning?"}}
-        attributes = {
-            "openinference": True,
-            OISpanAttr.LLM_INPUT_MESSAGES: input_messages,
-        }
+        # Create attribute dictionary with OpenInference input value and mime type
+        attributes = create_attributes(
+            {
+                OISpanAttr.INPUT_VALUE: "What is machine learning?",
+                OISpanAttr.INPUT_MIME_TYPE: "text/plain",
+            }
+        )
 
-        # Create OpenInference attributes object
-        oi_attrs = OpenInferenceAttributes(attributes)
-
-        # Test get_weave_inputs
-        inputs = oi_attrs.get_weave_inputs()
-        assert inputs == {"role_0": "user", "content_0": "What is machine learning?"}
-
-        # Test with multiple messages
-        input_messages_multiple = {
-            "0": {"role": "system", "content": "You are an assistant"},
-            "1": {"role": "user", "content": "What is machine learning?"},
-        }
-        attributes = {
-            "openinference": True,
-            OISpanAttr.LLM_INPUT_MESSAGES: input_messages_multiple,
-        }
-        oi_attrs = OpenInferenceAttributes(attributes)
-        inputs = oi_attrs.get_weave_inputs()
+        # Test get_weave_inputs with text input
+        inputs = get_weave_inputs([], attributes)
         assert inputs == {
-            "role_0": "system",
-            "content_0": "You are an assistant",
-            "role_1": "user",
-            "content_1": "What is machine learning?",
+            "input.value": "What is machine learning?",
+        }
+
+        # Test with JSON input
+        json_input = json.dumps(
+            {
+                "messages": [
+                    {"role": "system", "content": "You are an assistant"},
+                    {"role": "user", "content": "What is machine learning?"},
+                ]
+            }
+        )
+        attributes = create_attributes(
+            {
+                OISpanAttr.INPUT_VALUE: json_input,
+                OISpanAttr.INPUT_MIME_TYPE: "application/json",
+            }
+        )
+        inputs = get_weave_inputs([], attributes)
+        assert inputs == {
+            "input.value": {
+                "messages": [
+                    {"role": "system", "content": "You are an assistant"},
+                    {"role": "user", "content": "What is machine learning?"},
+                ]
+            },
         }
 
     def test_openinference_outputs_extraction(self):
         """Test extracting outputs from OpenInference attributes."""
         from openinference.semconv.trace import SpanAttributes as OISpanAttr
 
-        # Create attribute dictionary with OpenInference output messages
-        output_messages = {
-            "0": {
-                "role": "assistant",
-                "content": "Machine learning is a field of AI...",
+        # Create attribute dictionary with OpenInference output value and mime type
+        attributes = create_attributes(
+            {
+                OISpanAttr.OUTPUT_VALUE: "Machine learning is a field of AI...",
+                OISpanAttr.OUTPUT_MIME_TYPE: "text/plain",
             }
-        }
-        attributes = {
-            "openinference": True,
-            OISpanAttr.LLM_OUTPUT_MESSAGES: output_messages,
-        }
+        )
 
-        # Create OpenInference attributes object
-        oi_attrs = OpenInferenceAttributes(attributes)
-
-        # Test get_weave_outputs
-        outputs = oi_attrs.get_weave_outputs()
+        # Test get_weave_outputs with text output
+        outputs = get_weave_outputs([], attributes)
         assert outputs == {
-            "role_0": "assistant",
-            "content_0": "Machine learning is a field of AI...",
+            "output.value": "Machine learning is a field of AI...",
+        }
+
+        # Test with JSON output
+        json_output = json.dumps(
+            {
+                "response": {
+                    "role": "assistant",
+                    "content": "Machine learning is a field of AI...",
+                }
+            }
+        )
+        attributes = create_attributes(
+            {
+                OISpanAttr.OUTPUT_VALUE: json_output,
+                OISpanAttr.OUTPUT_MIME_TYPE: "application/json",
+            }
+        )
+        outputs = get_weave_outputs([], attributes)
+        assert outputs == {
+            "output.value": {
+                "response": {
+                    "role": "assistant",
+                    "content": "Machine learning is a field of AI...",
+                }
+            },
         }
 
     def test_openinference_usage_extraction(self):
@@ -484,18 +713,16 @@ class TestSemanticConventionParsing:
         from openinference.semconv.trace import SpanAttributes as OISpanAttr
 
         # Create attribute dictionary with OpenInference token counts
-        attributes = {
-            "openinference": True,
-            OISpanAttr.LLM_TOKEN_COUNT_PROMPT: 10,
-            OISpanAttr.LLM_TOKEN_COUNT_COMPLETION: 20,
-            OISpanAttr.LLM_TOKEN_COUNT_TOTAL: 30,
-        }
-
-        # Create OpenInference attributes object
-        oi_attrs = OpenInferenceAttributes(attributes)
+        attributes = create_attributes(
+            {
+                OISpanAttr.LLM_TOKEN_COUNT_PROMPT: 10,
+                OISpanAttr.LLM_TOKEN_COUNT_COMPLETION: 20,
+                OISpanAttr.LLM_TOKEN_COUNT_TOTAL: 30,
+            }
+        )
 
         # Test get_weave_usage
-        usage = oi_attrs.get_weave_usage()
+        usage = get_weave_usage(attributes)
         assert usage.get("prompt_tokens") == 10
         assert usage.get("completion_tokens") == 20
         assert usage.get("total_tokens") == 30
@@ -505,21 +732,19 @@ class TestSemanticConventionParsing:
         from opentelemetry.semconv_ai import SpanAttributes as OTSpanAttr
 
         # Create attribute dictionary with OpenTelemetry attributes
-        attributes = {
-            "gen_ai": True,
-            OTSpanAttr.LLM_SYSTEM: "You are a helpful assistant",
-            OTSpanAttr.LLM_REQUEST_MAX_TOKENS: 150,
-            OTSpanAttr.TRACELOOP_SPAN_KIND: "llm",
-            OTSpanAttr.LLM_RESPONSE_MODEL: "gpt-4",
-        }
-
-        # Create OpenTelemetry attributes object
-        ot_attrs = OpenTelemetryAttributes(attributes)
+        attributes = create_attributes(
+            {
+                OTSpanAttr.LLM_SYSTEM: "You are a helpful assistant",
+                OTSpanAttr.LLM_REQUEST_MAX_TOKENS: 150,
+                OTSpanAttr.TRACELOOP_SPAN_KIND: "llm",
+                OTSpanAttr.LLM_RESPONSE_MODEL: "gpt-4",
+            }
+        )
 
         # Test get_weave_attributes
-        extracted = ot_attrs.get_weave_attributes()
+        extracted = get_weave_attributes(attributes)
         assert extracted["system"] == "You are a helpful assistant"
-        assert extracted["max_tokens"] == 150
+        assert extracted["model_parameters"]["max_tokens"] == 150
         assert extracted["kind"] == "llm"
         assert extracted["model"] == "gpt-4"
 
@@ -529,18 +754,18 @@ class TestSemanticConventionParsing:
 
         # Create attribute dictionary with OpenTelemetry prompts
         prompts = {"0": {"role": "user", "content": "Tell me about quantum computing"}}
-        attributes = {
-            "gen_ai": True,
-            OTSpanAttr.LLM_PROMPTS: prompts,
-        }
-
-        # Create OpenTelemetry attributes object
-        ot_attrs = OpenTelemetryAttributes(attributes)
+        attributes = create_attributes(
+            {
+                OTSpanAttr.LLM_PROMPTS: prompts,
+            }
+        )
 
         # Test get_weave_inputs
-        inputs = ot_attrs.get_weave_inputs()
+        inputs = get_weave_inputs([], attributes)
         assert inputs == {
-            "0": {"role": "user", "content": "Tell me about quantum computing"}
+            "gen_ai.prompt": [
+                {"role": "user", "content": "Tell me about quantum computing"}
+            ]
         }
 
         # Test with multiple prompts
@@ -548,13 +773,18 @@ class TestSemanticConventionParsing:
             "0": {"role": "system", "content": "You are an expert in quantum physics"},
             "1": {"role": "user", "content": "Tell me about quantum computing"},
         }
-        attributes = {
-            "gen_ai": True,
-            OTSpanAttr.LLM_PROMPTS: prompts_multiple,
+        attributes = create_attributes(
+            {
+                OTSpanAttr.LLM_PROMPTS: prompts_multiple,
+            }
+        )
+        inputs = get_weave_inputs([], attributes)
+        assert inputs == {
+            "gen_ai.prompt": [
+                {"role": "system", "content": "You are an expert in quantum physics"},
+                {"role": "user", "content": "Tell me about quantum computing"},
+            ]
         }
-        ot_attrs = OpenTelemetryAttributes(attributes)
-        inputs = ot_attrs.get_weave_inputs()
-        assert inputs == prompts_multiple
 
     def test_opentelemetry_outputs_extraction(self):
         """Test extracting outputs from OpenTelemetry attributes."""
@@ -567,21 +797,23 @@ class TestSemanticConventionParsing:
                 "content": "Quantum computing uses quantum mechanics...",
             }
         }
-        attributes = {
-            "gen_ai": True,
-            OTSpanAttr.LLM_COMPLETIONS: completions,
-        }
+        attributes = create_attributes(
+            {
+                OTSpanAttr.LLM_COMPLETIONS: completions,
+            }
+        )
 
         # Create OpenTelemetry attributes object
-        ot_attrs = OpenTelemetryAttributes(attributes)
 
         # Test get_weave_outputs
-        outputs = ot_attrs.get_weave_outputs()
+        outputs = get_weave_outputs([], attributes)
         assert outputs == {
-            "0": {
-                "role": "assistant",
-                "content": "Quantum computing uses quantum mechanics...",
-            }
+            "gen_ai.completion": [
+                {
+                    "role": "assistant",
+                    "content": "Quantum computing uses quantum mechanics...",
+                }
+            ]
         }
 
     def test_opentelemetry_usage_extraction(self):
@@ -589,39 +821,110 @@ class TestSemanticConventionParsing:
         from opentelemetry.semconv_ai import SpanAttributes as OTSpanAttr
 
         # Create attribute dictionary with OpenTelemetry token usage
-        attributes = {
-            "gen_ai": True,
-            OTSpanAttr.LLM_USAGE_PROMPT_TOKENS: 15,
-            OTSpanAttr.LLM_USAGE_COMPLETION_TOKENS: 25,
-            OTSpanAttr.LLM_USAGE_TOTAL_TOKENS: 40,
-        }
+        attributes = create_attributes(
+            {
+                OTSpanAttr.LLM_USAGE_PROMPT_TOKENS: 15,
+                OTSpanAttr.LLM_USAGE_COMPLETION_TOKENS: 25,
+                OTSpanAttr.LLM_USAGE_TOTAL_TOKENS: 40,
+            }
+        )
 
         # Create OpenTelemetry attributes object
-        ot_attrs = OpenTelemetryAttributes(attributes)
+        usage = get_weave_usage(attributes) or {}
 
-        # Test get_weave_usage
-        usage = ot_attrs.get_weave_usage()
         assert usage.get("prompt_tokens") == 15
         assert usage.get("completion_tokens") == 25
         assert usage.get("total_tokens") == 40
 
-    def test_attributes_factory(self):
-        """Test the AttributesFactory for creating the correct attributes object."""
-        factory = AttributesFactory()
 
-        # Test OpenInference detection
-        oi_key_value = KeyValue(key="openinference", value=AnyValue(bool_value=True))
-        oi_attrs = factory.from_proto([oi_key_value])
-        assert isinstance(oi_attrs, OpenInferenceAttributes)
+class TestHelpers:
+    def test_capture_parts(self):
+        """Test capturing parts of a string split by delimiters."""
+        # Test with a single delimiter
+        assert capture_parts("part1.part2") == ["part1", ".", "part2"]
 
-        # Test OpenTelemetry detection
-        ot_key_value = KeyValue(key="gen_ai", value=AnyValue(bool_value=True))
-        ot_attrs = factory.from_proto([ot_key_value])
-        assert isinstance(ot_attrs, OpenTelemetryAttributes)
+        # Test with multiple delimiters
+        assert capture_parts("part1.part2,part3") == [
+            "part1",
+            ".",
+            "part2",
+            ",",
+            "part3",
+        ]
 
-        # Test generic attributes (no specific convention)
-        generic_key_value = KeyValue(
-            key="some_key", value=AnyValue(string_value="some_value")
+        # Test with delimiters that don't appear in the string
+        assert capture_parts("nodelimiters") == ["nodelimiters"]
+
+        # Test with an empty string
+        assert capture_parts("") == [""]
+
+        # Test with custom delimiters
+        assert capture_parts("a-b-c", delimiters=["-"]) == ["a", "-", "b", "-", "c"]
+
+        # Test with adjacent delimiters
+        assert capture_parts("part1..part2") == ["part1", ".", ".", "part2"]
+
+    def test_shorten_name_no_delimiters(self):
+        """Test shortening a name with no delimiters."""
+        # Test a string shorter than max_len - the function always adds ellipsis
+        assert shorten_name("short", 10) == "short"
+
+        # Test a string longer than max_len with no delimiters
+        long_name = "abcdefghijklmnopqrstuvwxyz"
+        assert shorten_name(long_name, 10) == "abcdefg..."
+
+    def test_shorten_name_with_delimiters(self):
+        """Test shortening a name with delimiters."""
+        # Test with a single delimiter
+        assert shorten_name("part1.part2", 10) == "part1..."
+
+        # Test with multiple delimiters where it fits within the max_len
+        assert shorten_name("a.b.c", 10) == "a.b.c"
+
+        # Test with multiple delimiters where it needs truncation
+        assert shorten_name("part1.part2.part3", 12) == "part1..."
+
+    def test_shorten_name_first_part_too_long(self):
+        """Test shortening a name where first part is already too long."""
+        # First part already exceeds max_len
+        assert shorten_name("verylongfirstpart.second", 10) == "verylon..."
+
+    def test_shorten_name_custom_abbreviation(self):
+        """Test shortening a name with custom abbreviation."""
+        assert shorten_name("part1.part2.part3", 10, "***") == "part1.***"
+
+        # Test with empty abbreviation
+        assert shorten_name("part1.part2.part3", 10, "") == "part1"
+
+    def test_shorten_name_different_delimiters(self):
+        """Test shortening a name with different types of delimiters."""
+        # Test with a space delimiter
+        assert shorten_name("word1 word2 word3", 12) == "word1 ..."
+
+        # Test with a slash delimiter
+        assert shorten_name("path/to/file", 8) == "path/..."
+
+        # Test with mixed delimiters
+        assert shorten_name("user.name@example.com", 12) == "user..."
+
+        # Test with a delimiter not in the default list
+        # Since '-' is not in the default delimiters list, it's treated as part of the string
+        result = shorten_name("part1-part2-part3", 10)
+        assert result.startswith("part1-")
+        assert result.endswith("...")
+        assert len(result) == 10
+
+        # Test with a question mark delimiter
+        assert shorten_name("api/endpoint?param=value", 15) == "api/..."
+
+    def test_long_url_regression(self):
+        # Test for a modified version of the URL which caused failed traces due to op_name length
+        actual = shorten_name(
+            "GET /api/trpc/lambda/organization.getActiveOrganization,account.getSubscription,checkout.getPrices,user.getUserToolGroupsConfig?batch=1&input=%8A%220%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%221%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%222%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%223%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%8D",
+            128,
         )
-        generic_attrs = factory.from_proto([generic_key_value])
-        assert isinstance(generic_attrs, GenericAttributes)
+        # The new implementation shortens the URL differently, so we check that it has the correct format
+        # and doesn't exceed the maximum length
+        assert actual.startswith("GET /")
+        assert actual.endswith("...")
+        assert len(actual) <= 128

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -1,511 +1,116 @@
-import json
-from abc import abstractmethod
-from collections.abc import Iterable
-from dataclasses import field
 from datetime import datetime
-from enum import Enum
-from typing import Any, Optional, Union
-from uuid import UUID
+from typing import Any, Callable, Union
 
-import openinference.semconv.trace as oi
-import opentelemetry.semconv_ai as ot
-from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
-
-from weave.trace_server.trace_server_interface import LLMUsageSchema, SummaryInsertMap
-
-
-def to_json_serializable(value: Any) -> Any:
-    """
-    Transform common data types into JSON-serializable values.
-
-    Args:
-        value: Any value that needs to be converted to JSON-serializable format
-
-    Returns:
-        A JSON-serializable version of the input value
-
-    Raises:
-        ValueError: If the value type is not supported for JSON serialization
-    """
-    if value is None:
-        return None
-    elif isinstance(value, (str, int, float, bool)):
-        return value
-    elif isinstance(value, (list, tuple)):
-        return [to_json_serializable(item) for item in value]
-    elif isinstance(value, dict):
-        return {str(k): to_json_serializable(v) for k, v in value.items()}
-    elif isinstance(value, datetime):
-        return value.isoformat()
-    elif isinstance(value, UUID):
-        return str(value)
-    elif isinstance(value, Enum):
-        return value.value
-    elif hasattr(value, "__dataclass_fields__"):  # Handle dataclasses
-        return {
-            k: to_json_serializable(getattr(value, k))
-            for k in value.__dataclass_fields__
-        }
-    else:
-        raise ValueError(f"Unsupported type for JSON serialization: {type(value)}")
+from weave.trace_server.opentelemetry.constants import (
+    ATTRIBUTE_KEYS,
+    INPUT_KEYS,
+    OUTPUT_KEYS,
+    USAGE_KEYS,
+    WB_KEYS,
+)
+from weave.trace_server.opentelemetry.helpers import (
+    get_attribute,
+    to_json_serializable,
+    try_convert_numeric_keys_to_list,
+)
 
 
-def resolve_pb_any_value(value: AnyValue) -> Any:
-    """
-    Resolve the value field of an AnyValue protobuf message.
-
-    Args:
-        value: An AnyValue protobuf message
-
-    Returns:
-        The resolved value as a Python type
-
-    Raises:
-        ValueError: If the AnyValue has no value set or has an unsupported type
-    """
-    if value.HasField("string_value"):
-        return value.string_value
-    elif value.HasField("bool_value"):
-        return value.bool_value
-    elif value.HasField("int_value"):
-        return value.int_value
-    elif value.HasField("double_value"):
-        return value.double_value
-    elif value.HasField("array_value"):
-        return [resolve_pb_any_value(v) for v in value.array_value.values]
-    elif value.HasField("kvlist_value"):
-        return dict(resolve_pb_key_value(kv) for kv in value.kvlist_value.values)
-    elif value.HasField("bytes_value"):
-        return value.bytes_value
-    else:
-        raise ValueError("AnyValue has no value set")
+class SpanEvent(dict):
+    name: str
+    timestamp: datetime
+    attributes: dict[str, Any]
+    dropped_attributes_count: int
 
 
-def resolve_pb_key_value(key_value: KeyValue) -> tuple[str, Any]:
-    """
-    Resolve a KeyValue protobuf message into a tuple of key and value.
-
-    Args:
-        key_value: A KeyValue protobuf message
-
-    Returns:
-        A tuple containing the key and resolved value
-
-    Raises:
-        ValueError: If the KeyValue has no value set or has an unsupported type
-    """
-    return (key_value.key, resolve_pb_any_value(key_value.value))
-
-
-def _get_value_from_nested_dict(d: dict[str, Any], key: str) -> Any:
-    """Get a value from a nested dictionary using a dot-separated key."""
-    if "." not in key:
-        return d.get(key)
-
-    parts = key.split(".")
-    current = d
-    for part in parts:
-        if part not in current or not isinstance(current, dict):
-            return None
-        current = current[part]
-    return current
-
-
-def _set_value_in_nested_dict(d: dict[str, Any], key: str, value: Any) -> None:
-    """Set a value in a nested dictionary using a dot-separated key."""
-    if "." not in key:
-        d[key] = value
-        return
-
-    parts = key.split(".")
-    current = d
-    for _, part in enumerate(parts[:-1]):
-        if part not in current:
-            current[part] = {}
-        current = current[part]
-    current[parts[-1]] = value
-
-
-def convert_numeric_keys_to_list(
-    obj: dict[str, Any],
-) -> Union[dict[str, Any], list[Any]]:
-    """
-    Convert dictionaries with numeric-only keys to lists.
-
-    If all keys in a dictionary are numeric strings (0, 1, 2, ...),
-    convert it to a list. Recursively processes nested dictionaries.
-    """
-    # Process all nested dictionaries first
-    for key, value in obj.items():
-        if isinstance(value, dict):
-            obj[key] = convert_numeric_keys_to_list(value)
-
-    # Check if all keys are numeric strings and contiguous starting from 0
-    try:
-        keys = sorted(int(k) for k in obj.keys())
-        if keys == list(range(len(keys))) and all(
-            isinstance(k, str) and k.isdigit() for k in obj.keys()
-        ):
-            # Convert to list, preserving order
-            return [obj[str(i)] for i in range(len(keys))]
-    except (ValueError, TypeError):
-        # Not all keys are numeric
-        pass
-
-    return obj
-
-
-def expand_attributes(
-    kv: Iterable[tuple[str, str]], json_attributes: list[str] = []
+def parse_weave_values(
+    attributes: dict[str, Any],
+    key_mapping: Union[
+        list[str],
+        dict[str, list[str]],
+        list[tuple[str, Callable[..., Any]]],
+        dict[str, list[tuple[str, Callable[..., Any]]]],
+    ],
 ) -> dict[str, Any]:
-    """
-    Expand a flattened JSON attributes file into a nested Python dictionary.
+    result = {}
+    # If list use the attribute as the key - Prevents synthetic attributes under input and output
 
-    Args:
-        file_path: Path to the JSON file with flattened attributes
-        json_attributes: list of attributes to parse as JSON strings
+    if isinstance(key_mapping, list):
+        for attribute_key_or_tuple in key_mapping:
+            handler = None
+            if isinstance(attribute_key_or_tuple, tuple):
+                attribute_key, handler = attribute_key_or_tuple
+            else:
+                attribute_key = attribute_key_or_tuple
+            value = get_attribute(attributes, attribute_key)
+            if value:
+                # Handler should never raise - Always use a try in handler and default to passed in value
+                if handler:
+                    value = handler(value)
+                result[attribute_key] = value
+                break
+        if result != {}:
+            to_json_serializable(try_convert_numeric_keys_to_list(result))
+        return result
 
-    Returns:
-        A nested Python dictionary
-    """
-    # Read the JSON file
+    # If dict, unpack to associate all nested keys with their parent
+    for key, attribute_key_list in key_mapping.items():
+        for attribute_key_or_tuple in attribute_key_list:
+            handler = None
+            if isinstance(attribute_key_or_tuple, tuple):
+                attribute_key, handler = attribute_key_or_tuple
+            else:
+                attribute_key = attribute_key_or_tuple
 
-    # Create the result dictionary
-    result_dict: dict[str, Any] = {}
+            value = get_attribute(attributes, attribute_key)
+            if value:
+                if handler:
+                    # Handler should never raise - Always use a try in handler and default to passed in value
+                    value = handler(value)
+                result[key] = value
+                break
 
-    # Process each key-value pair
-    for flat_key, value in kv:
-        # Check if the value should be parsed as JSON
-        should_parse_as_json = any(
-            flat_key.endswith(attr) or flat_key == attr for attr in json_attributes
-        )
-
-        if should_parse_as_json and isinstance(value, str):
-            try:
-                value = json.loads(value)
-            except json.JSONDecodeError:
-                # If JSON parsing fails, keep the original value
-                pass
-
-        # Add the nested key to the result
-        _set_value_in_nested_dict(result_dict, flat_key, value)
-
-    # Convert dictionaries with numeric keys to lists
-    return result_dict
-
-
-def flatten_attributes(
-    data: dict[str, Any], json_attributes: list[str] = []
-) -> dict[str, Any]:
-    """
-    Flatten a nested Python dictionary into a flat dictionary with dot-separated keys.
-
-    Args:
-        data: Nested Python dictionary to flatten
-        json_attributes: list of attributes to stringify as JSON
-
-    Returns:
-        A flattened dictionary with dot-separated keys
-    """
-    result: dict[str, Any] = {}
-
-    def _flatten(obj: Union[dict[str, Any], list[Any]], prefix: str = "") -> None:
-        # Check if the entire object should be stringified as JSON
-        should_stringify_entire_obj = any(
-            prefix.rstrip(".") == attr for attr in json_attributes
-        )
-
-        if should_stringify_entire_obj:
-            result[prefix.rstrip(".")] = json.dumps(obj)
-            return
-
-        if isinstance(obj, dict):
-            for key, value in obj.items():
-                new_key = f"{prefix}{key}" if prefix else key
-
-                # Check if this exact key's value should be stringified as JSON
-                should_stringify_as_json = any(
-                    new_key == attr for attr in json_attributes
-                )
-
-                if (
-                    isinstance(value, dict) or isinstance(value, list)
-                ) and not should_stringify_as_json:
-                    # Recursively flatten nested dictionaries or lists
-                    _flatten(value, f"{new_key}.")
-                else:
-                    # If the value matches a JSON attribute, stringify it
-                    if should_stringify_as_json and not isinstance(value, str):
-                        value = json.dumps(value)
-                    result[new_key] = value
-        elif isinstance(obj, list):
-            # Handle lists by using numeric indices as keys
-            for i, item in enumerate(obj):
-                new_key = f"{prefix}{i}"
-
-                # Check if this exact key's value should be stringified as JSON
-                should_stringify_as_json = any(
-                    new_key == attr for attr in json_attributes
-                )
-
-                if (
-                    isinstance(item, dict) or isinstance(item, list)
-                ) and not should_stringify_as_json:
-                    # Recursively flatten nested dictionaries or lists
-                    _flatten(item, f"{new_key}.")
-                else:
-                    # If the item matches a JSON attribute, stringify it
-                    if should_stringify_as_json and not isinstance(item, str):
-                        item = json.dumps(item)
-                    result[new_key] = item
-
-    _flatten(data)
+    # Prevent empty dict from becoming empty list
+    if result != {}:
+        to_json_serializable(try_convert_numeric_keys_to_list(result))
     return result
 
 
-def get_attribute(data: dict[str, Any], key: str) -> Any:
-    """
-    Get the value of a nested attribute from either a nested or flattened dictionary.
-
-    Args:
-        data: dictionary to get value from
-        key: Dot-separated key to get
-
-    Returns:
-        The value at the specified key or None if not found
-    """
-    # Check if it's a flat dictionary
-    if key in data:
-        return data[key]
-
-    # Try to get from nested structure
-    return _get_value_from_nested_dict(data, key)
+def get_weave_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
+    value = parse_weave_values(attributes, ATTRIBUTE_KEYS)
+    return value
 
 
-def unflatten_key_values(
-    key_values: Iterable[KeyValue],
-) -> dict[str, Any]:
-    """
-    Transform a list of KeyValue pairs into a nested dictionary structure.
-
-    Args:
-        key_values: An iterable of KeyValue protobuf messages
-        separator: The character used to separate nested keys (default: '.')
-
-    Returns:
-        A nested dictionary where keys are split by the separator
-
-    Example:
-        Input: [("llm.token_count.completion", 123)]
-        Output: {"llm": {"token_count": {"completion": 123}}}
-
-        Input: [
-            ("retrieval.documents.0.document.content", 'A'),
-            ("retrieval.documents.1.document.content", 'B')
-        ]
-        Output: {
-            "retrieval": {
-                "documents": {
-                    "0": {"document": {"content": "A"}},
-                    "1": {"document": {"content": "B"}}
-                }
-            }
-        }
-    """
-    iterator = ((kv.key, resolve_pb_any_value(kv.value)) for kv in key_values)
-    return expand_attributes(iterator, json_attributes=[])
+def get_weave_usage(attributes: dict[str, Any]) -> dict[str, Any]:
+    usage = parse_weave_values(attributes, USAGE_KEYS)
+    if (
+        "prompt_tokens" in usage
+        and "completion_tokens" in usage
+        and "total_tokens" not in usage
+        and isinstance(usage["prompt_tokens"], int)
+        and isinstance(usage["completion_tokens"], int)
+    ):
+        usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+    if (
+        "input_tokens" in usage
+        and "output_tokens" in usage
+        and "total_tokens" not in usage
+        and isinstance(usage["input_tokens"], int)
+        and isinstance(usage["output_tokens"], int)
+    ):
+        usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+    return usage
 
 
-class ConventionType(Enum):
-    OPENINFERENCE = "openinference"
-    OPENTELEMETRY = "gen_ai"
-    CUSTOM = "custom"
+# Pass events here even though they are unused because some libraries put input in event attribtes
+def get_weave_inputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str, Any]:
+    return parse_weave_values(attributes, INPUT_KEYS)
 
 
-class Attributes:
-    _attributes: dict[str, Any] = field(default_factory=dict)
-
-    def __init__(self, _attributes: dict[str, Any] = {}) -> None:
-        self._attributes = _attributes
-
-    def __getitem__(self, key: str) -> Any:
-        return self._attributes.__getitem__(key)
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        return self._attributes.__setitem__(key, value)
-
-    def get(self, key: str, default: Any = None) -> Any:
-        return self._attributes.get(key, default)
-
-    def get_attribute_value(self, key: str) -> Any:
-        return get_attribute(self._attributes, key)
-
-    @abstractmethod
-    def get_weave_inputs(self) -> dict[str, Any]: ...
-
-    @abstractmethod
-    def get_weave_outputs(self) -> Any: ...
-
-    @abstractmethod
-    def get_weave_usage(self) -> LLMUsageSchema: ...
-
-    @abstractmethod
-    def get_weave_summary(self) -> SummaryInsertMap: ...
-
-    @abstractmethod
-    def get_weave_attributes(self, extra: Optional[dict[str, Any]] = None) -> Any: ...
+# Pass events here even though they are unused because some libraries put output in event attribtes
+def get_weave_outputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[str, Any]:
+    return parse_weave_values(attributes, OUTPUT_KEYS)
 
 
-# If we don't have any conventions to follow, just dump everything to attributes
-# Later we may add support for user defined conventions through headers
-class GenericAttributes(Attributes):
-    def get_weave_usage(self) -> LLMUsageSchema:
-        return {}
-
-    def get_weave_summary(self) -> SummaryInsertMap:
-        return {}
-
-    def get_weave_inputs(self) -> Any:
-        return {}
-
-    def get_weave_outputs(self) -> Any:
-        return {}
-
-    def get_weave_attributes(self, extra: Optional[dict[str, Any]] = None) -> Any:
-        result = self._attributes.copy()
-        result.update(extra or {})
-        return result
-
-
-class OpenInferenceAttributes(Attributes):
-    def get_weave_usage(self) -> LLMUsageSchema:
-        prompt_tokens = self.get_attribute_value(
-            oi.SpanAttributes.LLM_TOKEN_COUNT_PROMPT
-        )
-        completion_tokens = self.get_attribute_value(
-            oi.SpanAttributes.LLM_TOKEN_COUNT_COMPLETION
-        )
-        total_tokens = self.get_attribute_value(oi.SpanAttributes.LLM_TOKEN_COUNT_TOTAL)
-        return LLMUsageSchema(
-            prompt_tokens=int(prompt_tokens) if prompt_tokens else None,
-            completion_tokens=int(completion_tokens) if completion_tokens else None,
-            total_tokens=int(total_tokens) if total_tokens else None,
-        )
-
-    def get_weave_summary(self) -> SummaryInsertMap:
-        return SummaryInsertMap(usage={"usage": self.get_weave_usage()})
-
-    def get_weave_outputs(self) -> Any:
-        outputs: dict[str, Any] = (
-            self.get_attribute_value(oi.SpanAttributes.LLM_OUTPUT_MESSAGES) or {}
-        )
-        result = {}
-        for k, v in outputs.items():
-            if k.isdigit() and isinstance(v, dict):
-                for key in v.keys():
-                    result[key + f"_{k}"] = v[key]
-        return to_json_serializable(result)
-
-    def get_weave_inputs(self) -> Any:
-        inputs: dict[str, Any] = (
-            self.get_attribute_value(oi.SpanAttributes.LLM_INPUT_MESSAGES) or {}
-        )
-        result = {}
-        for k, v in inputs.items():
-            if k.isdigit() and isinstance(v, dict):
-                for key in v.keys():
-                    result[key + f"_{k}"] = v[key]
-        return to_json_serializable(result)
-
-    def get_weave_attributes(
-        self, extra: Optional[dict[str, Any]] = None
-    ) -> dict[str, Any]:
-        system = self.get_attribute_value(oi.SpanAttributes.LLM_SYSTEM)
-        provider = self.get_attribute_value(oi.SpanAttributes.LLM_PROVIDER)
-        invocation_parameters = self.get_attribute_value(
-            oi.SpanAttributes.LLM_INVOCATION_PARAMETERS
-        )
-        kind = self.get_attribute_value(oi.SpanAttributes.OPENINFERENCE_SPAN_KIND)
-        model = self.get_attribute_value(oi.SpanAttributes.LLM_MODEL_NAME)
-        attributes = {
-            "system": str(system) if system else None,
-            "provider": str(provider) if provider else None,
-            "kind": str(kind) if kind else None,
-            "model": str(model) if model else None,
-        }
-
-        if invocation_parameters:
-            try:
-                js = json.loads(invocation_parameters)
-                for k, v in js.items():
-                    attributes[k] = str(v)
-            except json.JSONDecodeError:
-                raise ValueError(f"Invalid JSON string: {invocation_parameters}")
-
-        if extra:
-            attributes.update(extra)
-
-        return to_json_serializable(attributes)
-
-
-class OpenTelemetryAttributes(Attributes):
-    def get_weave_usage(self) -> LLMUsageSchema:
-        prompt_tokens = self.get_attribute_value(
-            ot.SpanAttributes.LLM_USAGE_PROMPT_TOKENS
-        )
-        completion_tokens = self.get_attribute_value(
-            ot.SpanAttributes.LLM_USAGE_COMPLETION_TOKENS
-        )
-        total_tokens = self.get_attribute_value(
-            ot.SpanAttributes.LLM_USAGE_TOTAL_TOKENS
-        )
-        return LLMUsageSchema(
-            prompt_tokens=int(prompt_tokens) if prompt_tokens else None,
-            completion_tokens=int(completion_tokens) if completion_tokens else None,
-            total_tokens=int(total_tokens) if total_tokens else None,
-        )
-
-    def get_weave_summary(self) -> SummaryInsertMap:
-        return SummaryInsertMap(usage={"usage": self.get_weave_usage()})
-
-    def get_weave_outputs(self) -> Any:
-        outputs: dict[str, Any] = (
-            self.get_attribute_value(ot.SpanAttributes.LLM_COMPLETIONS) or {}
-        )
-        return to_json_serializable(outputs)
-
-    def get_weave_inputs(self) -> Any:
-        inputs: dict[str, Any] = (
-            self.get_attribute_value(ot.SpanAttributes.LLM_PROMPTS) or {}
-        )
-        return to_json_serializable(inputs)
-
-    def get_weave_attributes(
-        self, extra: Optional[dict[str, Any]] = None
-    ) -> dict[str, Any]:
-        max_tokens = self.get_attribute_value(ot.SpanAttributes.LLM_REQUEST_MAX_TOKENS)
-        system = self.get_attribute_value(ot.SpanAttributes.LLM_SYSTEM)
-        kind = self.get_attribute_value(ot.SpanAttributes.TRACELOOP_SPAN_KIND)
-        model = self.get_attribute_value(ot.SpanAttributes.LLM_RESPONSE_MODEL)
-
-        attributes = {
-            "system": str(system) if system else None,
-            "max_tokens": int(max_tokens) if max_tokens else None,
-            "kind": str(kind) if kind else None,
-            "model": str(model) if model else None,
-        }
-
-        if extra:
-            attributes.update(extra)
-
-        return to_json_serializable(attributes)
-
-
-class AttributesFactory:
-    def from_proto(self, key_values: Iterable[KeyValue]) -> "Attributes":
-        expanded = unflatten_key_values(key_values)
-        if get_attribute(expanded, ConventionType.OPENINFERENCE.value):
-            return OpenInferenceAttributes(expanded)
-        elif get_attribute(expanded, ConventionType.OPENTELEMETRY.value):
-            return OpenTelemetryAttributes(expanded)
-        return GenericAttributes(expanded)
+# Custom attributes for weave to enable setting fields like wb_user_id otherwise unavailable in OTEL Traces
+def get_wandb_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
+    return parse_weave_values(attributes, WB_KEYS)

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -1,0 +1,121 @@
+from weave.trace_server.opentelemetry.helpers import try_parse_int
+
+"""
+The constants defined in this file map attribute keys from various telemetry standards
+to a common format used by Weave. This enables Weave to ingest traces and spans from
+different instrumentation libraries while normalizing the data into a consistent format.
+
+For INPUT_KEYS and OUTPUT_KEYS we respect the original source key when placing it into
+our input and output fields respectively.
+
+E.g. If a value is discovered in the `input.value` field of attributes the dict dumped
+to clickhouse is:
+{ "input.value": SOME_JSON_OR_STR_VALUE, }
+
+For prefix values with nested keys (such as `gen_ai.prompt`) we might see attributes like:
+
+gen_ai.prompt.0.role: user
+gen_ai.prompt.0.content: abc
+
+gen_ai.prompt.1.role: user
+gen_ai.prompt.1.content: def
+
+the dict dumped to clickhouse is:
+{ "gen_ai.prompt": [{ "role": user, "content": abc }, { "role": user, "content": def }] }
+
+For these fields, once a value is discovered in the attributes, so the ordering of these keys matters.
+
+
+For the other key mappings, a dict is dumped with each of the top level keys in the dict.
+The inner list of those key represents the attributes which are checked similarly to
+how INPUT_KEYS and OUTPUT_KEYS are checked, where the first one found is used.
+
+If we recieved attributes where:
+gen_ai.usage.prompt_tokens: 30
+gen_ai.usage.completion_tokens: 40
+gen_ai.usage.llm.usage.total_tokens: 70
+
+This would be the resulting dict dumped to clickhouse:
+{ "prompt_tokens": 30, "completion_tokens": 40, "total_tokens": 70 }
+"""
+
+# These mappings prioritize standards in a specific order for each attribute type.
+
+# INPUT_KEYS: Maps attribute keys that represent user prompts or inputs to LLMs
+# Priority is given to standards in this order:
+# This is used to populate the `inputs_dump` column in clickhouse
+from weave.trace_server.opentelemetry.helpers import try_parse_int
+
+INPUT_KEYS = [
+    "gen_ai.prompt",  # From OpenTelemetry AI semantic conventions
+    "input.value",  # From OpenInference standard - highest priority
+    "mlflow.spanInputs",  # From MLFlow's tracking format
+    "traceloop.entity.input"  # From Traceloop's conventions
+    "input",  # Generic fallback for Pydantic models - lowest priority
+]
+
+# OUTPUT_KEYS: Maps attribute keys that represent model completions or outputs
+# Priority is given to standards in this order:
+# This is used to populate the `output_dump` column in clickhouse
+OUTPUT_KEYS = [
+    "gen_ai.completion",  # From OpenTelemetry AI semantic conventions
+    "output.value",  # From OpenInference standard - highest priority
+    "mlflow.spanOutputs",  # From MLFlow's tracking format
+    "gen_ai.content.completion",  # From OpenLit project's format
+    "traceloop.entity.output",  # From Traceloop's conventions
+    "output",  # Generic fallback for Pydantic models - lowest priority
+]
+
+# USAGE_KEYS: Maps internal Weave usage metric names to their equivalent keys in
+# various telemetry standards. Used for token counting and usage statistics.
+# Used to populate the usage field of `summary_dump` in clickhouse
+# The tuples represent handlers which the value should be passed through when found
+# Never assume that the value is of a certain type or error, conventions provide no guarantees
+USAGE_KEYS = {
+    # Maps Weave's "prompt_tokens" to keys from different standards
+    "prompt_tokens": [
+        ("gen_ai.usage.prompt_tokens", try_parse_int),
+        ("llm.token_count.prompt", try_parse_int),
+    ],
+    # Maps Weave's "completion_tokens" to keys from different standards
+    "completion_tokens": [
+        ("gen_ai.usage.completion_tokens", try_parse_int),
+        ("llm.token_count.completion", try_parse_int),
+    ],
+    # Maps Weave's "total_tokens" to keys from different standards
+    "total_tokens": [
+        ("llm.usage.total_tokens", try_parse_int),
+        ("llm.token_count.total", try_parse_int),
+    ],
+}
+
+# ATTRIBUTE_KEYS: Maps common LLM call metadata attributes to the types of attributes expected in weave traces
+# This is used to populate the `attributes_dump` column in clickhouse
+# Prior to dumping, the full span is dumped under another key not listed here called `otel_span`
+ATTRIBUTE_KEYS = {
+    # System prompt/instructions
+    "system": [
+        "gen_ai.system",  # OpenTelemetry AI
+        "llm.system",  # OpenInference
+    ],
+    # Span kind - identifies the type of operation
+    "kind": [
+        "weave.span.kind",  # Weave-specific
+        "traceloop.span.kind",  # Traceloop
+        "openinference.span.kind",  # OpenInference
+    ],
+    # Model name/identifier
+    "model": ["gen_ai.response.model", "llm.model_name"],
+    # Provider/vendor of the model
+    "provider": [
+        "llm.provider",  # Common across standards
+    ],
+    # Model generation parameters (temperature, max_tokens, etc.)
+    "model_parameters": ["gen_ai.request", "llm.invocation_parameters"],
+}
+
+# WB_KEYS: Wandb/Weave specific attributes for enhanced visualization and reporting
+WB_KEYS = {
+    # Custom display name for the call in the UI
+    "display_name": ["wandb.display_name"],
+}

--- a/weave/trace_server/opentelemetry/helpers.py
+++ b/weave/trace_server/opentelemetry/helpers.py
@@ -1,0 +1,454 @@
+import base64
+import json
+import math
+import re
+from collections.abc import Iterable
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Union
+from uuid import UUID
+
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+
+
+def to_json_serializable(value: Any) -> Any:
+    # Transform common data types into JSON-serializable values.
+    if value is None:
+        return None
+    elif isinstance(value, (str, bool)):
+        return value
+    elif isinstance(value, int):
+        return value
+    elif isinstance(value, float):
+        # Handle special floats: NaN, inf, -inf
+        if math.isnan(value) or math.isinf(value):
+            return str(value)
+        return value
+    elif isinstance(value, (list, tuple)):
+        return [to_json_serializable(item) for item in value]
+    elif isinstance(value, dict):
+        return {str(k): to_json_serializable(v) for k, v in value.items()}
+    elif isinstance(value, datetime):
+        return value.isoformat()
+    elif isinstance(value, date):  # date without time
+        return value.isoformat()
+    elif isinstance(value, time):  # time without date
+        return value.isoformat()
+    elif isinstance(value, timedelta):
+        return value.total_seconds()
+    elif isinstance(value, UUID):
+        return str(value)
+    elif isinstance(value, Enum):
+        return value.value
+    elif isinstance(value, Decimal):
+        # Convert Decimal to float or str, depending on requirements.
+        return float(value)
+    elif isinstance(value, (set, frozenset)):
+        return [to_json_serializable(item) for item in value]
+    elif isinstance(value, complex):
+        return {"real": value.real, "imag": value.imag}
+    elif isinstance(value, (bytes, bytearray)):
+        return base64.b64encode(value).decode("ascii")
+    elif hasattr(value, "__dataclass_fields__"):
+        return {
+            k: to_json_serializable(getattr(value, k))
+            for k in value.__dataclass_fields__
+        }
+    else:
+        raise ValueError(f"Unsupported type for JSON serialization: {type(value)}")
+
+
+def resolve_pb_any_value(value: AnyValue) -> Any:
+    """
+    Resolve the value field of an AnyValue protobuf message.
+
+    Args:
+        value: An AnyValue protobuf message
+
+    Returns:
+        The resolved value as a Python type
+
+    Raises:
+        ValueError: If the AnyValue has no value set or has an unsupported type
+    """
+    if value.HasField("string_value"):
+        return value.string_value
+    elif value.HasField("bool_value"):
+        return value.bool_value
+    elif value.HasField("int_value"):
+        return value.int_value
+    elif value.HasField("double_value"):
+        return value.double_value
+    elif value.HasField("array_value"):
+        return [resolve_pb_any_value(v) for v in value.array_value.values]
+    elif value.HasField("kvlist_value"):
+        return dict(resolve_pb_key_value(kv) for kv in value.kvlist_value.values)
+    elif value.HasField("bytes_value"):
+        return value.bytes_value
+    else:
+        raise ValueError("AnyValue has no value set")
+
+
+def resolve_pb_key_value(key_value: KeyValue) -> tuple[str, Any]:
+    """
+    Resolve a KeyValue protobuf message into a tuple of key and value.
+
+    Args:
+        key_value: A KeyValue protobuf message
+
+    Returns:
+        A tuple containing the key and resolved value
+
+    Raises:
+        ValueError: If the KeyValue has no value set or has an unsupported type
+    """
+    return (key_value.key, resolve_pb_any_value(key_value.value))
+
+
+def _get_value_from_nested_dict(d: dict[str, Any], key: str) -> Any:
+    """Get a value from a nested dictionary using a dot-separated key."""
+    if "." not in key:
+        return d.get(key)
+
+    parts = key.split(".")
+    current = d
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            if isinstance(current, list) and part.isdigit():
+                part = int(part)
+                current = current[part] if part < len(current) else None
+                continue
+            else:
+                return None
+        current = current[part]
+    return current
+
+
+def _set_value_in_nested_dict(d: dict[str, Any], key: str, value: Any) -> None:
+    """Set a value in a nested dictionary using a dot-separated key."""
+    if "." not in key:
+        d[key] = value
+        return
+
+    parts = key.split(".")
+    current = d
+    for _, part in enumerate(parts[:-1]):
+        if part not in current:
+            current[part] = {}
+        current = current[part]
+    current[parts[-1]] = value
+
+
+def convert_numeric_keys_to_list(
+    obj: dict[str, Any],
+) -> Union[dict[str, Any], list[Any]]:
+    """
+    Convert dictionaries with numeric-only keys to lists.
+
+    If all keys in a dictionary are numeric strings (0, 1, 2, ...),
+    convert it to a list. Recursively processes nested dictionaries.
+    """
+    # Process all nested dictionaries first
+    for key, value in obj.items():
+        if isinstance(value, dict):
+            obj[key] = convert_numeric_keys_to_list(value)
+
+    # Check if all keys are numeric strings and contiguous starting from 0
+    try:
+        keys = sorted(int(k) for k in obj.keys())
+        if keys == list(range(len(keys))) and all(
+            isinstance(k, str) and k.isdigit() for k in obj.keys()
+        ):
+            # Convert to list, preserving order
+            return [obj[str(i)] for i in range(len(keys))]
+    except (ValueError, TypeError):
+        # Not all keys are numeric
+        pass
+
+    return obj
+
+
+def expand_attributes(kv: Iterable[tuple[str, Any]]) -> dict[str, Any]:
+    """
+    Expand a flattened JSON attributes file into a nested Python dictionary.
+
+    Args:
+        file_path: Path to the JSON file with flattened attributes
+        json_attributes: list of attributes to parse as JSON strings
+
+    Returns:
+        A nested Python dictionary
+    """
+    # Read the JSON file
+
+    # Create the result dictionary
+    result_dict: dict[str, Any] = {}
+
+    # Process each key-value pair
+    for flat_key, value in kv:
+        # Weave expects JSON strings to be loaded to display properly, so just try and load every string as json
+        if isinstance(value, str) and (value.startswith("[") or value.startswith("{")):
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                # If JSON parsing fails, keep the original value
+                pass
+
+        # Add the nested key to the result
+        _set_value_in_nested_dict(result_dict, flat_key, value)
+
+    # Convert dictionaries with numeric keys to lists
+    return result_dict
+
+
+def flatten_attributes(
+    data: dict[str, Any], json_attributes: list[str] = []
+) -> dict[str, Any]:
+    """
+    Flatten a nested Python dictionary into a flat dictionary with dot-separated keys.
+
+    Args:
+        data: Nested Python dictionary to flatten
+        json_attributes: list of attributes to stringify as JSON
+
+    Returns:
+        A flattened dictionary with dot-separated keys
+    """
+    result: dict[str, Any] = {}
+
+    def _flatten(obj: Union[dict[str, Any], list[Any]], prefix: str = "") -> None:
+        # Check if the entire object should be stringified as JSON
+        should_stringify_entire_obj = any(
+            prefix.rstrip(".") == attr for attr in json_attributes
+        )
+
+        if should_stringify_entire_obj:
+            result[prefix.rstrip(".")] = json.dumps(obj)
+            return
+
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                new_key = f"{prefix}{key}" if prefix else key
+
+                # Check if this exact key's value should be stringified as JSON
+                should_stringify_as_json = any(
+                    new_key == attr for attr in json_attributes
+                )
+
+                if (
+                    isinstance(value, dict) or isinstance(value, list)
+                ) and not should_stringify_as_json:
+                    # Recursively flatten nested dictionaries or lists
+                    _flatten(value, f"{new_key}.")
+                else:
+                    # If the value matches a JSON attribute, stringify it
+                    if should_stringify_as_json and not isinstance(value, str):
+                        value = json.dumps(value)
+                    result[new_key] = value
+        elif isinstance(obj, list):
+            # Handle lists by using numeric indices as keys
+            for i, item in enumerate(obj):
+                new_key = f"{prefix}{i}"
+
+                # Check if this exact key's value should be stringified as JSON
+                should_stringify_as_json = any(
+                    new_key == attr for attr in json_attributes
+                )
+
+                if (
+                    isinstance(item, dict) or isinstance(item, list)
+                ) and not should_stringify_as_json:
+                    # Recursively flatten nested dictionaries or lists
+                    _flatten(item, f"{new_key}.")
+                else:
+                    # If the item matches a JSON attribute, stringify it
+                    if should_stringify_as_json and not isinstance(item, str):
+                        item = json.dumps(item)
+                    result[new_key] = item
+
+    _flatten(data)
+    return result
+
+
+def get_attribute(data: dict[str, Any], key: str) -> Any:
+    """
+    Get the value of a nested attribute from either a nested or flattened dictionary.
+
+    Args:
+        data: dictionary to get value from
+        key: Dot-separated key to get
+
+    Returns:
+        The value at the specified key or None if not found
+    """
+    # Check if it's a flat dictionary
+    if key in data:
+        return data[key]
+
+    # Try to get from nested structure
+    return _get_value_from_nested_dict(data, key)
+
+
+def unflatten_key_values(
+    key_values: Iterable[KeyValue],
+) -> dict[str, Any]:
+    """
+    Transform a list of KeyValue pairs into a nested dictionary structure.
+
+    Args:
+        key_values: An iterable of KeyValue protobuf messages
+        separator: The character used to separate nested keys (default: '.')
+
+    Returns:
+        A nested dictionary where keys are split by the separator
+
+    Example:
+        Input: [("llm.token_count.completion", 123)]
+        Output: {"llm": {"token_count": {"completion": 123}}}
+
+        Input: [
+            ("retrieval.documents.0.document.content", 'A'),
+            ("retrieval.documents.1.document.content", 'B')
+        ]
+        Output: {
+            "retrieval": {
+                "documents": {
+                    "0": {"document": {"content": "A"}},
+                    "1": {"document": {"content": "B"}}
+                }
+            }
+        }
+    """
+    iterator = ((kv.key, resolve_pb_any_value(kv.value)) for kv in key_values)
+    return expand_attributes(iterator)
+
+
+def try_parse_int(value: Any) -> Any:
+    try:
+        value = int(value)
+    except:
+        pass
+    return value
+
+
+def try_convert_numeric_keys_to_list(value: Any) -> Any:
+    if isinstance(value, dict):
+        try:
+            value = convert_numeric_keys_to_list(value)
+        except:
+            pass
+    return value
+
+
+def capture_parts(
+    s: str, delimiters: list[str] = [",", ";", "|", " ", "/", "?", "."]
+) -> list[str]:
+    """Split a string on multiple delimiters while preserving the delimiters in the result.
+
+    This function splits a string using the specified delimiters and includes those
+    delimiters in the resulting list. Empty strings are filtered out from the result.
+
+    Args:
+        s: The input string to split.
+        delimiters: A list of delimiter strings to split on. Defaults to common delimiters.
+
+    Returns:
+        A list containing the parts of the split string, including the delimiters.
+        If no splits occurred, returns the original string in a list.
+
+    Example:
+        >>> capture_parts("hello/world.txt")
+        ['hello', '/', 'world', '.', 'txt']
+    """
+    # Escape special regex characters and join with | for regex alternation
+    capture = "|".join(map(re.escape, delimiters))
+    pattern = f"({(capture)})"
+
+    # Use re.split with capturing groups to include the delimiters
+    parts = re.split(pattern, s)
+
+    # Filter out empty strings that might result from the split
+    result = [part for part in parts if part != ""]
+
+    result = list(filter(lambda x: len(x) > 0, parts))
+    # If no split occurred, return the original string in a list
+    if len(result) == 0:
+        return [s]
+
+    return result
+
+
+def shorten_name(
+    name: str, max_len: int, abbrv: str = "...", use_delimiter_in_abbr: bool = True
+) -> str:
+    """Shorten a string to a maximum length by intelligently abbreviating at delimiters.
+
+    This function shortens a string to fit within a specified maximum length.
+    It tries to shorten at natural break points (delimiters) rather than
+    arbitrarily truncating in the middle of words.
+
+    Args:
+        name: The input string to shorten.
+        max_len: The maximum allowed length of the output string.
+        abbrv: The abbreviation string to append when shortening (default "...").
+        use_delimiter_in_abbr: If True, includes the delimiter before the abbreviation
+                              when shortening at a delimiter (default True).
+
+    Returns:
+        A shortened version of the input string that doesn't exceed max_len characters.
+
+    Examples:
+        >>> shorten_name("hello/world.txt", 10)
+        'hello/...'
+        >>> shorten_name("hello/world.txt", 10, use_delimiter_in_abbr=False)
+        'hello...'
+        >>> shorten_name("hello/world.txt", 20)
+        'hello/world.txt'
+        >>> shorten_name("verylongword", 8)
+        'verylo...'
+        >>> shorten_name("hello/world.txt", 10, ":1234" use_delimiter_in_abbr=False)
+        'hello:1234'
+    """
+    if len(name) <= max_len:
+        return name
+    # Split the string based on all of the listed delimiters
+    delimiters = [",", ";", "|", " ", "/", "?", "."]
+    parts = capture_parts(name, delimiters)
+    abbrv_len = len(abbrv)
+    if len(parts) <= 1:
+        # No delimiters found, just truncate
+        return name[: max_len - abbrv_len] + abbrv
+
+    shortened_name = parts[0]
+
+    # If the first part is already longer than max_len, truncate it
+    if len(shortened_name) > max_len - abbrv_len:
+        return shortened_name[: max_len - abbrv_len] + abbrv
+
+    i = 1
+    while i < len(parts):
+        # Concatenate the delimiter with the next part
+        next_delimiter = ""
+        while parts[i] in delimiters:
+            next_delimiter = next_delimiter + parts[i]
+            i += 1
+
+        next_part = f"{next_delimiter}{parts[i]}"
+        # If there is no abbreviation, do not end on a delimiter (ex. no trailing periods)
+        if not abbrv_len:
+            delimiter_with_abbrv = ""
+        elif abbrv.startswith(next_delimiter) or not use_delimiter_in_abbr:
+            delimiter_with_abbrv = abbrv
+        else:
+            delimiter_with_abbrv = f"{next_delimiter}{abbrv}"
+
+        if len(shortened_name) + len(next_part) >= max_len - (
+            len(delimiter_with_abbrv)
+        ):
+            shortened_name += delimiter_with_abbrv
+            break
+        else:
+            shortened_name += next_part
+        i += 1
+    return shortened_name

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -5,6 +5,7 @@ trace protocol buffer definitions from opentelemetry.proto.trace.v1.trace_pb2.
 """
 
 import datetime
+import hashlib
 from binascii import hexlify
 from collections.abc import Iterator
 from dataclasses import dataclass, field
@@ -30,10 +31,17 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 )
 
 from weave.trace_server import trace_server_interface as tsi
-
-from .attributes import (
-    Attributes,
-    AttributesFactory,
+from weave.trace_server.constants import MAX_DISPLAY_NAME_LENGTH, MAX_OP_NAME_LENGTH
+from weave.trace_server.opentelemetry.attributes import (
+    SpanEvent,
+    get_wandb_attributes,
+    get_weave_attributes,
+    get_weave_inputs,
+    get_weave_outputs,
+    get_weave_usage,
+)
+from weave.trace_server.opentelemetry.helpers import (
+    shorten_name,
     to_json_serializable,
     unflatten_key_values,
 )
@@ -123,6 +131,14 @@ class Event:
             dropped_attributes_count=proto_event.dropped_attributes_count,
         )
 
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "timestamp": self.datetime,
+            "attributes": self.attributes,
+            "dropped_attributes_count": self.dropped_attributes_count,
+        }
+
 
 @dataclass
 class Link:
@@ -180,7 +196,7 @@ class Span:
     span_id: str
     start_time_unix_nano: int
     end_time_unix_nano: int
-    attributes: Attributes
+    attributes: dict[str, Any] = field(default_factory=dict)
     kind: SpanKind = SpanKind.UNSPECIFIED
     parent_id: Optional[str] = None
     trace_state: str = ""
@@ -233,7 +249,7 @@ class Span:
             parent_id=parent_id,
             trace_state=proto_span.trace_state,
             flags=proto_span.flags,
-            attributes=AttributesFactory().from_proto(key_values=proto_span.attributes),
+            attributes=unflatten_key_values(proto_span.attributes),
             dropped_attributes_count=proto_span.dropped_attributes_count,
             events=[Event.from_proto(e) for e in proto_span.events],
             dropped_events_count=proto_span.dropped_events_count,
@@ -258,7 +274,7 @@ class Span:
                 "start_time": self.start_time,
                 "end_time": self.end_time,
                 "status": self.status.as_dict(),
-                "attributes": self.attributes._attributes,
+                "attributes": self.attributes,
                 "events": self.events,
                 "links": self.links,
                 "resource": self.resource.as_dict() if self.resource else None,
@@ -268,23 +284,69 @@ class Span:
     def to_call(
         self, project_id: str
     ) -> tuple[tsi.StartedCallSchemaForInsert, tsi.EndedCallSchemaForInsert]:
-        summary_insert_map = self.attributes.get_weave_summary()
-        inputs = self.attributes.get_weave_inputs()
-        outputs = self.attributes.get_weave_outputs()
-        attributes = self.attributes.get_weave_attributes(
-            extra={"otel_span": self.as_dict()}
+        events = [SpanEvent(e.as_dict()) for e in self.events]
+        usage = get_weave_usage(self.attributes) or {}
+        inputs = get_weave_inputs(events, self.attributes) or {}
+        outputs = get_weave_outputs(events, self.attributes) or {}
+        attributes = get_weave_attributes(self.attributes) or {}
+        wandb_attributes = get_wandb_attributes(self.attributes) or {}
+
+        llm_usage = tsi.LLMUsageSchema(
+            input_tokens=usage.get("input_tokens"),
+            output_tokens=usage.get("output_tokens"),
+            completion_tokens=usage.get("completion_tokens"),
+            prompt_tokens=usage.get("prompt_tokens"),
+            total_tokens=usage.get("total_tokens"),
+            requests=usage.get("requests"),
         )
 
-        # Options: set
+        # Read the model name from attributes to load cost info
+        model = attributes.get("model")
+        if not model:
+            model_parameters = attributes.get("model_parameters")
+            if model_parameters:
+                model = model_parameters.get("model")
+
+        usage_key = model or "usage"
+        summary_insert_map = tsi.SummaryInsertMap(usage={usage_key: llm_usage})
+
+        has_attributes = len(attributes) > 0
+        has_inputs = len(inputs) > 0
+        has_outputs = len(outputs) > 0
+        has_usage = len(usage) > 0
+
+        # We failed to load any of the Weave attributes, dump all attributes
+        if not has_attributes and not has_inputs and not has_outputs and not has_usage:
+            attributes = to_json_serializable(self.attributes)
+
+        attributes["otel_span"] = self.as_dict()
+        op_name = self.name
+
+        display_name = wandb_attributes.get("display_name")
+        if display_name and len(display_name) >= MAX_DISPLAY_NAME_LENGTH:
+            display_name = shorten_name(display_name, MAX_DISPLAY_NAME_LENGTH)
+
+        if len(op_name) >= MAX_OP_NAME_LENGTH:
+            # Since op_name will typically be what is displayed, we don't want to just truncate
+            # Create an identifier abbreviation so similar long names can be distinguished
+            identifier = hashlib.sha256(op_name.encode("utf-8")).hexdigest()[:4]
+            op_name = shorten_name(
+                op_name,
+                MAX_OP_NAME_LENGTH,
+                abbrv=f":{identifier}",
+                use_delimiter_in_abbr=False,
+            )
+
         start_call = tsi.StartedCallSchemaForInsert(
             project_id=project_id,
             id=self.span_id,
-            op_name=self.name,
+            op_name=op_name,
             trace_id=self.trace_id,
             parent_id=self.parent_id,
             started_at=self.start_time,
             attributes=attributes,
             inputs=inputs,
+            display_name=display_name,
             wb_user_id=None,
             wb_run_id=None,
         )


### PR DESCRIPTION
## Description
- Fixes WB-24513
- Fixes WB-24514

This adjusts the parsing logic to make it simple to generate and keep docs in line with the parser code. This adjusts the parser such that a set of standard fields are created for each of input, output, summary and attributes. Each field is assigned a list of keys which are checked until a valid entry is discovered or the possible key entries are exhausted.

Also includes cost calculation fix