### PR TITLE
chore(weave): fix not equals string filter copy

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -111,7 +111,7 @@ const allOperators: SelectOperatorOption[] = [
   },
   {
     value: '(string): notEquals',
-    label: 'not equals',
+    label: 'does not equal',
     group: 'string',
   },
   {
@@ -261,7 +261,7 @@ export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
       },
       {
         value: '(string): notEquals',
-        label: 'not equals',
+        label: 'does not equal',
         group: 'string',
       },
       {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

`"not equals"` -> `"does not equal"`

## Testing

Branch:
![Screenshot 2025-04-22 at 11 51 30 AM](https://github.com/user-attachments/assets/a13703cc-6400-427a-86d4-99e259842965)

prod:
![Screenshot 2025-04-22 at 11 51 57 AM](https://github.com/user-attachments/assets/f6b354b4-1ce7-4cc2-b1b9-34b30c3d3525)

