### PR TITLE
chore(weave): Add pyrightconfig.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gha-creds-*.json
 tests/weave_models/
 tools/codegen/generate_config.yaml
 .cursor
+pyrightconfig.json


### PR DESCRIPTION
## Description

Just prevents git from checking in pyrightconfig.json which is a very useful tool for configuring editor environment.
