### PR TITLE
chore(weave): Fix nulls returning from cost query

### DIFF
--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -373,9 +373,11 @@ def test_query_light_column_with_costs() -> None:
                     *,
                     ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                     arrayJoin(
-                        if(usage_raw != '',
-                        JSONExtractKeysAndValuesRaw(usage_raw),
-                        [('weave_dummy_llm_id', '{"requests": 0, "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}')])
+                        if(
+                            usage_raw != '',
+                            JSONExtractKeysAndValuesRaw(usage_raw),
+                            [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')]
+                        )
                     ) AS kv,
                     kv.1 AS llm_id,
                     JSONExtractInt(kv.2, 'requests') AS requests,

--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -374,7 +374,7 @@ def test_query_light_column_with_costs() -> None:
                     ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                     arrayJoin(
                         if(
-                            usage_raw != '',
+                            usage_raw != '' and usage_raw != '{}',
                             JSONExtractKeysAndValuesRaw(usage_raw),
                             [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')]
                         )


### PR DESCRIPTION
## Description
Fixes issue where unfinished calls returned nulls in the cost query

2 errors
1. if we did default to the proper empty usage json, it was not properly escaped and the query would error returning null
fixed default usage not being properly escaped
2. we needed to account for the default usage being {}

https://github.com/user-attachments/assets/2a8eaa17-5a9b-4db0-a473-6b96a40f1452




## Testing

updated test
check the fetching works for finished, unfinished and failed calls
