### PR TITLE
chore(weave): Refactor the cache key usage

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -64,7 +64,6 @@ export const CallPage: FC<CallPageProps> = props => {
       entity: props.entity,
       project: props.project,
       callId: descendentCallId,
-      withTotalStorageSize: true,
     },
     {
       // Sadly we cannot include costs as unfinished calls will result

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -63,7 +63,6 @@ export const CallSummary: React.FC<{
       entity: call.entity,
       project: call.project,
       callId: call.callId,
-      includeCosts: true,
     },
     {
       includeCosts: true,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cache.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/cache.ts
@@ -11,7 +11,7 @@ import LRUCache from 'lru-cache';
 
 import {Node} from '../../../../../../core';
 import {
-  CallKey,
+  CacheableCallKey,
   CallSchema,
   ObjectVersionKey,
   ObjectVersionSchema,
@@ -42,11 +42,13 @@ const makeSpecificCache = <K, V>(
   };
 };
 
-export const callCache = makeSpecificCache<CallKey, CallSchema>(key => {
-  const {entity, project, callId, ...rest} = key;
-  const meta = isEmpty(rest) ? '' : `?meta=${JSON.stringify(rest)}`;
-  return `call:${entity}/${project}/${callId}${meta}`;
-});
+export const callCache = makeSpecificCache<CacheableCallKey, CallSchema>(
+  key => {
+    const {entity, project, callId, ...rest} = key;
+    const meta = isEmpty(rest) ? '' : `?meta=${JSON.stringify(rest)}`;
+    return `call:${entity}/${project}/${callId}${meta}`;
+  }
+);
 
 export const opVersionCache = makeSpecificCache<OpVersionKey, OpVersionSchema>(
   key => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -34,8 +34,8 @@ import * as traceServerTypes from './traceServerClientTypes';
 import {useClientSideCallRefExpansion} from './tsDataModelHooksCallRefExpansion';
 import {opVersionRefOpName, refUriToObjectVersionKey} from './utilities';
 import {
-  CacheableCallKey,
   CallFilter,
+  CallKey,
   CallSchema,
   FeedbackKey,
   Loadable,
@@ -165,15 +165,28 @@ const useMakeTraceServerEndpoint = <
 };
 
 const useCall = (
-  key: CacheableCallKey | null,
+  key: CallKey | null,
   opts?: {includeCosts?: boolean; includeTotalStorageSize?: boolean}
 ): Loadable<CallSchema | null> => {
   const getTsClient = useGetTraceServerClientContext();
   const loadingRef = useRef(false);
-  const cachedCall = key ? callCache.get(key) : null;
+
+  const effectiveKey = useMemo(() => {
+    if (key == null) {
+      return null;
+    }
+    return {
+      ...key,
+      withCosts: !!opts?.includeCosts,
+      withTotalStorageSize: !!opts?.includeTotalStorageSize,
+    };
+  }, [key, opts?.includeCosts, opts?.includeTotalStorageSize]);
+  const deepKey = useDeepMemo(effectiveKey);
+
+  const cachedCall = deepKey ? callCache.get(deepKey) : null;
+
   const [callRes, setCallRes] =
     useState<traceServerTypes.TraceCallReadRes | null>(null);
-  const deepKey = useDeepMemo(key);
   const doFetch = useCallback(() => {
     if (deepKey) {
       loadingRef.current = true;
@@ -203,7 +216,7 @@ const useCall = (
   }, [getTsClient, doFetch]);
 
   return useMemo(() => {
-    if (key == null) {
+    if (deepKey == null) {
       return {
         loading: false,
         result: null,
@@ -229,9 +242,9 @@ const useCall = (
         loading: false,
         result: null,
       };
-    } else if (result?.callId === key?.callId) {
+    } else if (result?.callId === deepKey?.callId) {
       if (result) {
-        callCache.set(key, result);
+        callCache.set(deepKey, result);
       }
       return {
         loading: false,
@@ -244,7 +257,7 @@ const useCall = (
         result: null,
       };
     }
-  }, [cachedCall, callRes, key]);
+  }, [cachedCall, callRes, deepKey]);
 };
 
 const useCallsNoExpansion = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -169,7 +169,7 @@ export type Refetchable = {
 
 export type WFDataModelHooksInterface = {
   useCall: (
-    key: CacheableCallKey | null,
+    key: CallKey | null,
     opts?: {includeCosts?: boolean; includeTotalStorageSize?: boolean}
   ) => Loadable<CallSchema | null>;
   useCalls: (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Sig:
```
const useCall = (
  key: CacheableCallKey | null,
  opts?: {includeCosts?: boolean; includeTotalStorageSize?: boolean}
):
```
Caller Code:
```
  const call = useCall(
    {
      entity: props.entity,
      project: props.project,
      callId: descendentCallId,
      withTotalStorageSize: true,
    },
    {
      includeTotalStorageSize: true
    }
  );
```
We shouldn't ask the user to have the withTotalStorageSize in the first part of the param. the useCall should abstract that detail away and use the second param options as additional key values if appropriate

## Testing

Manually re-validated the related UX, and saw no breakage.
