### PR TITLE
docs(weave): Avoid use of the word "attributes" unless it refers to `weave.attributes`

### DIFF
--- a/docs/docs/guides/core-types/evaluations.md
+++ b/docs/docs/guides/core-types/evaluations.md
@@ -81,7 +81,7 @@ See the tutorial on defining a `Scorer` class in the next chapter on [Model-Base
 
 ### Define a Model to evaluate
 
-To evaluate a `Model`, call `evaluate` on it using an `Evaluation`. `Models` are used when you have attributes that you want to experiment with and capture in weave.
+To evaluate a `Model`, call `evaluate` on it using an `Evaluation`. `Models` are used when you have parameters that you want to experiment with and capture in weave.
 
 ```python
 from weave import Model, Evaluation

--- a/docs/docs/guides/core-types/models.md
+++ b/docs/docs/guides/core-types/models.md
@@ -10,7 +10,7 @@ A `Model` is a combination of data (which can include configuration, trained mod
     To create a model in Weave, you need the following:
 
     - a class that inherits from `weave.Model`
-    - type definitions on all attributes
+    - type definitions on all parameters
     - a typed `predict` function with `@weave.op()` decorator
 
     ```python
@@ -42,7 +42,7 @@ A `Model` is a combination of data (which can include configuration, trained mod
 
     ## Automatic versioning of models
 
-    When you change the attributes or the code that defines your model, these changes will be logged and the version will be updated.
+    When you change the parameters or the code that defines your model, these changes will be logged and the version will be updated.
     This ensures that you can compare the predictions across different versions of your model. Use this to iterate on prompts or to try the latest LLM and compare predictions across different settings.
 
     For example, here we create a new model:

--- a/docs/docs/guides/evaluation/builtin_scorers.mdx
+++ b/docs/docs/guides/evaluation/builtin_scorers.mdx
@@ -30,7 +30,7 @@ import TabItem from '@theme/TabItem';
 
     **Customization:**
 
-    - Customize the `system_prompt` and `user_prompt` attributes of the scorer to define what "hallucination" means for you.
+    - Customize the `system_prompt` and `user_prompt` fields of the scorer to define what "hallucination" means for you.
 
     **Notes:**
 

--- a/docs/docs/guides/integrations/langchain.md
+++ b/docs/docs/guides/integrations/langchain.md
@@ -34,9 +34,9 @@ output = llm_chain.invoke({"number": 2})
 print(output)
 ```
 
-## Tracking Call Attributes
+## Tracking Call Metadata
 
-To track attributes for your langchain calls, you can use the [`weave.attributes`](https://weave-docs.wandb.ai/reference/python-sdk/weave/#function-attributes) context manager. This context manager allows you to set attributes for a specific block of code, such as a chain or a single request.
+To track metadata from your LangChain calls, you can use the [`weave.attributes`](https://weave-docs.wandb.ai/reference/python-sdk/weave/#function-attributes) context manager. This context manager allows you to set custom metadata for a specific block of code, such as a chain or a single request.
 
 ```python
 import weave
@@ -58,7 +58,7 @@ with weave.attributes({"my_awesome_attribute": "value"}):
 
 print(output)
 ```
-Weave automatically tracks the attributes against the trace of the LangChain call. You can view the attributes in the Weave web interface as shown below:
+Weave automatically tracks the metadat against the trace of the LangChain call. You can view the metadata in the Weave web interface as shown below:
 
 [![langchain_attributes.png](imgs/langchain_attributes.png)](https://wandb.ai/parambharat/langchain_demo/weave/traces?cols=%7B%22attributes.weave.client_version%22%3Afalse%2C%22attributes.weave.os_name%22%3Afalse%2C%22attributes.weave.os_release%22%3Afalse%2C%22attributes.weave.os_version%22%3Afalse%2C%22attributes.weave.source%22%3Afalse%2C%22attributes.weave.sys_version%22%3Afalse%7D)
 

--- a/docs/docs/guides/integrations/litellm.md
+++ b/docs/docs/guides/integrations/litellm.md
@@ -10,7 +10,7 @@ Weave automatically tracks and logs LLM calls made via LiteLLM, after `weave.ini
 
 It's important to store traces of LLM applications in a central database, both during development and in production. You'll use these traces for debugging, and as a dataset that will help you improve your application.
 
-> **Note:** When using LiteLLM, make sure to import the library using `import litellm` and call the completion function with `litellm.completion` instead of `from litellm import completion`. This ensures that all functions and attributes are correctly referenced.
+> **Note:** When using LiteLLM, make sure to import the library using `import litellm` and call the completion function with `litellm.completion` instead of `from litellm import completion`. This ensures that all functions and parameters are correctly referenced.
 
 Weave will automatically capture traces for LiteLLM. You can use the library as usual, start by calling `weave.init()`:
 

--- a/docs/docs/guides/tools/otel.md
+++ b/docs/docs/guides/tools/otel.md
@@ -174,7 +174,7 @@ python openllmetry_example.py
 
 ### Without Instrumentation
 
-If you would prefer to use OTEL directly instead of an instrumentation package, you may do so. Attributes will be parsed according to the OpenTelemetry semantic conventions described at [https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/).
+If you would prefer to use OTEL directly instead of an instrumentation package, you may do so. Span attributes will be parsed according to the OpenTelemetry semantic conventions described at [https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/).
 
 First, install the required dependencies:
 
@@ -259,4 +259,4 @@ Finally, once you have set the fields specified above to their correct values, r
 python opentelemetry_example.py
 ```
 
-The attribute prefixes `gen_ai` and `openinference` are used to determine which convention to use, if any, when interpreting the trace. If neither key is detected, then all attributes are visible in the trace view. The full span is available in the side panel when you select a trace.
+The span attribute prefixes `gen_ai` and `openinference` are used to determine which convention to use, if any, when interpreting the trace. If neither key is detected, then all span attributes are visible in the trace view. The full span is available in the side panel when you select a trace.

--- a/docs/docs/guides/tracking/faqs.md
+++ b/docs/docs/guides/tracking/faqs.md
@@ -27,7 +27,7 @@ A function can be designated as a Weave [Op](/guides/tracking/ops) either manual
 
 - **Derived information** - Weave may compute derived information from the raw information logged, for example a cost estimate may be calculated based on token usage and knowledge of the model used. Weave also aggregates some information over calls.
 
-- **Additional information you choose** - You can choose to log [custom attributes](/guides/core-types/models#track-production-calls) as part of your call or attach [feedback](/guides/tracking/feedback#add-feedback-to-a-call) to a call.
+- **Additional information you choose** - You can choose to log [custom metadata with `weave.attributes`](/guides/core-types/models#track-production-calls) as part of your call or attach [feedback](/guides/tracking/feedback#add-feedback-to-a-call) to a call.
 
 ## How can I disable code capture?
 

--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -260,7 +260,7 @@ However, often LLM applications have additional logic (such as pre/post processi
         return f"Hello, {name}!"
     ```
 
-    4. The `call_display_name` can also be a function that takes in a `Call` object and returns a string.  The `Call` object will be passed automatically when the function is called, so you can use it to dynamically generate names based on the function's name, call inputs, attributes, etc.
+    4. The `call_display_name` can also be a function that takes in a `Call` object and returns a string.  The `Call` object will be passed automatically when the function is called, so you can use it to dynamically generate names based on the function's name, call inputs, fields, etc.
 
     1. One common use case is just appending a timestamp to the function's name.
 
@@ -272,7 +272,7 @@ However, often LLM applications have additional logic (such as pre/post processi
             return ...
         ```
 
-    2. You can also get creative with custom attributes
+    2. You can also log custom metadata using `.attributes`
 
         ```py
         def custom_attribute_name(call):
@@ -335,12 +335,12 @@ However, often LLM applications have additional logic (such as pre/post processi
 
 <Tabs groupId="programming-language">
   <TabItem value="python" label="Python" default>
-    When calling tracked functions, you can add additional metadata to the call by using the [`weave.attributes`](../../reference/python-sdk/weave/index.md#function-attributes) context manager. In the example below, we add an `env` attribute to the call specified as `'production'`.
+    When calling tracked functions, you can add additional metadata to the call by using [`weave.attributes`](../../reference/python-sdk/weave/index.md#function-attributes) context manager. In the example below, we add an `env` attribute to the call specified as `'production'`.
 
     ```python showLineNumbers
     # ... continued from above ...
 
-    # Add additional "attributes" to the call
+    # Add additional attributes to the call
     with weave.attributes({'env': 'production'}):
         print(my_function.call("World"))
     ```
@@ -424,7 +424,7 @@ You can also manually create Calls using the API directly.
     2. Find the call you want to view in the list
     3. Click on the call to open its details page
     
-    The details page will show the call's inputs, outputs, runtime, and any additional attributes or metadata.
+    The details page will show the call's inputs, outputs, runtime, and any additional metadata.
     
     ![View Call in Web App](../../../static/img/screenshots/basic_call.png)
     </TabItem>

--- a/docs/docs/reference/gen_notebooks/chain_of_density.md
+++ b/docs/docs/reference/gen_notebooks/chain_of_density.md
@@ -258,9 +258,9 @@ class ArxivChainOfDensityPipeline(weave.Model):
 This `ArxivChainOfDensityPipeline` class encapsulates our summarization logic as a Weave Model, providing several key benefits:
 
 1. Automatic experiment tracking: Weave captures inputs, outputs, and parameters for each run of the model.
-2. Versioning: Changes to the model's attributes or code are automatically versioned, creating a clear history of how your summarization pipeline evolves over time.
+2. Versioning: Changes to the model's parameters or code are automatically versioned, creating a clear history of how your summarization pipeline evolves over time.
 3. Reproducibility: The versioning and tracking make it easy to reproduce any previous result or configuration of your summarization pipeline.
-4. Hyperparameter management: Model attributes (like `model` and `density_iterations`) are clearly defined and tracked across different runs, facilitating experimentation.
+4. Hyperparameter management: Model parameters (like `model` and `density_iterations`) are clearly defined and tracked across different runs, facilitating experimentation.
 5. Integration with Weave ecosystem: Using `weave.Model` allows seamless integration with other Weave tools, such as evaluations and serving capabilities.
 
 ## Implement evaluation metrics

--- a/docs/docs/reference/gen_notebooks/codegen.md
+++ b/docs/docs/reference/gen_notebooks/codegen.md
@@ -266,9 +266,9 @@ class CodeGenerationPipeline(weave.Model):
 This `CodeGenerationPipeline` class encapsulates our code generation logic as a Weave Model, providing several key benefits:
 
 1. Automatic experiment tracking: Weave captures inputs, outputs, and parameters for each run of the model.
-2. Versioning: Changes to the model's attributes or code are automatically versioned, creating a clear history of how your code generation pipeline evolves over time.
+2. Versioning: Changes to the model's parameters or code are automatically versioned, creating a clear history of how your code generation pipeline evolves over time.
 3. Reproducibility: The versioning and tracking make it easy to reproduce any previous result or configuration of your code generation pipeline.
-4. Hyperparameter management: Model attributes (like `model_name`) are clearly defined and tracked across different runs, facilitating experimentation.
+4. Hyperparameter management: Model parameters (like `model_name`) are clearly defined and tracked across different runs, facilitating experimentation.
 5. Integration with Weave ecosystem: Using `weave.Model` allows seamless integration with other Weave tools, such as evaluations and serving capabilities.
 
 ## Implement evaluation metrics

--- a/docs/docs/reference/gen_notebooks/feedback_prod.md
+++ b/docs/docs/reference/gen_notebooks/feedback_prod.md
@@ -152,7 +152,7 @@ def display_chat_prompt():
         ]
 
         with st.chat_message("assistant"):
-            # Attach Weave attributes for tracking of conversation instances
+            # Use `weave.attributes` to track conversation instances
             with weave.attributes(
                 {"session": st.session_state["session_id"], "env": "prod"}
             ):
@@ -225,7 +225,7 @@ We can use it as usual to deliver some model response to the user:
 ```python
 with weave.attributes(
     {"session": "123abc", "env": "prod"}
-):  # attach arbitrary attributes to the call alongside inputs & outputs
+):  # attach arbitrary metadata to the call alongside inputs & outputs
     result = predict(input_data="your data here")  # user question through the App UI
 ```
 

--- a/docs/docs/reference/python-sdk/weave/index.md
+++ b/docs/docs/reference/python-sdk/weave/index.md
@@ -34,7 +34,7 @@ The top-level functions and classes for working with Weave.
 - [`call_context.get_current_call`](#function-get_current_call): Get the Call object for the currently executing Op, within that Op.
 - [`api.finish`](#function-finish): Stops logging to weave.
 - [`op.op`](#function-op): A decorator to weave op-ify a function or method.  Works for both sync and async.
-- [`api.attributes`](#function-attributes): Context manager for setting attributes on a call.
+- [`api.attributes`](#function-attributes): Context manager for setting z on a call.
 
 
 ---

--- a/docs/docs/tutorial-tracing_2.md
+++ b/docs/docs/tutorial-tracing_2.md
@@ -175,7 +175,7 @@ Continuing our example from above:
 :::note
 It's recommended to use metadata tracking to track metadata at run time, e.g. user ids or whether or not the call is part of the development process or is in production etc.
 
-To track system attributes, such as a System Prompt, we recommend using [weave Models](guides/core-types/models)
+To track system settings, such as a System Prompt, we recommend using [weave Models](guides/core-types/models)
 :::
 
 ## What's next?

--- a/docs/docs/tutorial-weave_models.md
+++ b/docs/docs/tutorial-weave_models.md
@@ -3,11 +3,11 @@ import TabItem from '@theme/TabItem';
 
 # Tutorial: App versioning
 
-Tracking the [inputs, outputs, metadata](/quickstart) as well as [data flowing through your app](/tutorial-tracing_2) is critical to understanding the performance of your system. However **versioning your app over time** is also critical to understand how modifications to your code or app attributes change your outputs. Weave's `Model` class is how these changes can be tracked in Weave.
+Tracking the [inputs, outputs, metadata](/quickstart) as well as [data flowing through your app](/tutorial-tracing_2) is critical to understanding the performance of your system. However **versioning your app over time** is also critical to understand how modifications to your code or application parameters change your outputs. Weave's `Model` class is how these changes can be tracked in Weave.
 
 In this tutorial you'll learn:
 
-- How to use Weave `Model` to track and version your app and its attributes.
+- How to use Weave `Model` to track and version your application and its parameters.
 - How to export, modify and re-use a Weave `Model` already logged.
 
 ## Using `weave.Model`
@@ -18,15 +18,15 @@ The `weave.Model` class is currently only supported in Python.
 
 :::
 
-Using Weave `Model`s means that attributes such as model vendor ids, prompts, temperature, and more are stored and versioned when they change.
+Using Weave `Model`s means that parameters such as model vendor ids, prompts, temperature, and more are stored and versioned when they change.
 
 To create a `Model` in Weave, you need the following:
 
 - a class that inherits from `weave.Model`
-- type definitions on all class attributes
+- type definitions on all class fields
 - a typed `invoke` function with the `@weave.op()` decorator
 
-When you change the class attributes or the code that defines your model, **these changes will be logged and the version will be updated**. This ensures that you can compare the generations across different versions of your app.
+When you change the class fields or the code that defines your model, **these changes will be logged and the version will be updated**. This ensures that you can compare the generations across different versions of your app.
 
 In the example below, the **model name, temperature and system prompt will be tracked and versioned**:
 
@@ -118,7 +118,7 @@ Now you can instantiate and call the model with `invoke`:
   </TabItem>
 </Tabs>
 
-Now after calling `.invoke` you can see the trace in Weave **now tracks the model attributes as well as the code** for the model functions that have been decorated with `weave.op()`. You can see the model is also versioned, "v21" in this case, and if you click on the model **you can see all of the calls** that have used that version of the model
+Now after calling `.invoke` you can see the trace in Weave **now tracks the model parameters as well as the code** for the model functions that have been decorated with `weave.op()`. You can see the model is also versioned, "v21" in this case, and if you click on the model **you can see all of the calls** that have used that version of the model
 
 ![Re-using a weave model](../static/img/tutorial-model_invoke3.png)
 
@@ -126,7 +126,7 @@ Now after calling `.invoke` you can see the trace in Weave **now tracks the mode
 
 - You can use `predict` instead of `invoke` for the name of the function in your Weave `Model` if you prefer.
 - If you want other class methods to be tracked by weave they need to be wrapped in `weave.op()`
-- Attributes starting with an underscore are ignored by weave and won't be logged
+- Parameter starting with an underscore are ignored by weave and won't be logged
 
 ## Exporting and re-using a logged `weave.Model`
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1434

It's difficult to find info on how to use the `weave.attributes`, because we use the word “attributes” on a bunch of other pages not related to call attributes.

This PR updates word usage so that we avoid using the word "attributes" unless it's referring to Weave-native concept, or at least clarify that it is not the Weave thing (like with OTEL span attributes). There are also a few cosmetic changes such as spacing or typos

## Testing

yarn start on local
