### PR TITLE
feat(weave): Communicate trace endpoint errors to users

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -26,6 +26,7 @@ import {
 import {MOON_200, TEAL_300} from '@wandb/weave/common/css/color.styles';
 import {Button} from '@wandb/weave/components/Button';
 import {Checkbox} from '@wandb/weave/components/Checkbox/Checkbox';
+import {ErrorPanel} from '@wandb/weave/components/ErrorPanel';
 import {
   Icon,
   IconNotVisible,
@@ -464,9 +465,11 @@ export const CallsTable: FC<{
     allowedColumnPatterns,
     onAddFilter,
     calls.costsLoading,
+    !!calls.costsError,
     shouldIncludeTotalStorageSize,
     shouldIncludeTotalStorageSize ? calls.storageSizeResults : null,
-    shouldIncludeTotalStorageSize && calls.storageSizeLoading
+    shouldIncludeTotalStorageSize && calls.storageSizeLoading,
+    !!calls.storageSizeError
   );
 
   // This contains columns which are suitable for selection and raw data
@@ -794,6 +797,41 @@ export const CallsTable: FC<{
     [callsLoading, setPaginationModel]
   );
 
+  const noRowsOverlay = useCallback(() => {
+    if (calls.primaryError) {
+      return (
+        <ErrorPanel
+          title="Oh no! Unable to load traces!..."
+          error={calls.primaryError}
+        />
+      );
+    }
+    return (
+      <CallsTableNoRowsOverlay
+        entity={entity}
+        project={project}
+        callsLoading={callsLoading}
+        callsResult={callsResult}
+        isEvaluateTable={isEvaluateTable}
+        effectiveFilter={effectiveFilter}
+        filterModelResolved={filterModelResolved}
+        clearFilters={clearFilters}
+        setFilterModel={setFilterModel}
+      />
+    );
+  }, [
+    calls.primaryError,
+    callsLoading,
+    callsResult,
+    clearFilters,
+    effectiveFilter,
+    filterModelResolved,
+    isEvaluateTable,
+    setFilterModel,
+    entity,
+    project,
+  ]);
+
   // CPR (Tim) - (GeneralRefactoring): Pull out different inline-properties and create them above
   return (
     <FilterLayoutTemplate
@@ -1032,7 +1070,7 @@ export const CallsTable: FC<{
         // SORT SECTION END
         // PAGINATION SECTION START
         pagination
-        rowCount={callsTotal}
+        rowCount={calls.primaryError ? 0 : callsTotal}
         paginationMode="server"
         paginationModel={paginationModel}
         onPaginationModelChange={onPaginationModelChange}
@@ -1066,19 +1104,7 @@ export const CallsTable: FC<{
           },
         }}
         slots={{
-          noRowsOverlay: () => (
-            <CallsTableNoRowsOverlay
-              entity={entity}
-              project={project}
-              callsLoading={callsLoading}
-              callsResult={callsResult}
-              isEvaluateTable={isEvaluateTable}
-              effectiveFilter={effectiveFilter}
-              filterModelResolved={filterModelResolved}
-              clearFilters={clearFilters}
-              setFilterModel={setFilterModel}
-            />
-          ),
+          noRowsOverlay,
           columnMenu: CallsCustomColumnMenu,
           pagination: () => <PaginationButtons hideControls={hideControls} />,
           columnMenuSortDescendingIcon: IconSortDescending,
@@ -1089,6 +1115,7 @@ export const CallsTable: FC<{
           ),
           columnMenuPinRightIcon: IconPinToRight,
         }}
+        className="tw-style"
       />
     </FilterLayoutTemplate>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -801,7 +801,7 @@ export const CallsTable: FC<{
     if (calls.primaryError) {
       return (
         <ErrorPanel
-          title="Oh no! Unable to load traces!..."
+          title="Oh no! Unable to load traces..."
           error={calls.primaryError}
         />
       );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -84,9 +84,11 @@ export const useCallsTableColumns = (
   allowedColumnPatterns?: string[],
   onAddFilter?: OnAddFilter,
   costsLoading: boolean = false,
+  costsHasError: boolean = false,
   includeTotalStorageSizeBytes: boolean = false,
   storageSizeResults: Map<string, number> | null = null,
-  storageSizeLoading: boolean = false
+  storageSizeLoading: boolean = false,
+  storageHasError: boolean = false
 ) => {
   const [userDefinedColumnWidths, setUserDefinedColumnWidths] = useState<
     Record<string, number>
@@ -164,12 +166,14 @@ export const useCallsTableColumns = (
         allowedColumnPatterns,
         onAddFilter,
         costsLoading,
+        costsHasError,
         includeTotalStorageSizeBytes
           ? {
               storageSizeResults,
               storageSizeLoading,
             }
-          : null
+          : null,
+        storageHasError
       ),
     [
       entity,
@@ -190,6 +194,8 @@ export const useCallsTableColumns = (
       includeTotalStorageSizeBytes,
       storageSizeResults,
       storageSizeLoading,
+      storageHasError,
+      costsHasError,
     ]
   );
 
@@ -251,10 +257,12 @@ function buildCallsTableColumns(
   allowedColumnPatterns?: string[],
   onAddFilter?: OnAddFilter,
   costsLoading: boolean = false,
+  costsHasError: boolean = false,
   storageSizeInfo: {
     storageSizeResults: Map<string, number> | null;
     storageSizeLoading: boolean;
-  } | null = null
+  } | null = null,
+  storageHasError: boolean = false
 ): {
   cols: Array<GridColDef<TraceCallSchema>>;
   colGroupingModel: GridColumnGroupingModel;
@@ -654,6 +662,16 @@ function buildCallsTableColumns(
       if (costsLoading) {
         return <LoadingDots />;
       }
+      if (costsHasError) {
+        return (
+          <div className="flex h-full w-full items-center justify-center">
+            <StatusChip
+              value="ERROR"
+              tooltipOverride="There was an error fetching the cost for this call."
+            />
+          </div>
+        );
+      }
       const {cost, costToolTipContent} = getCostsFromCellParams(cellParams.row);
       return (
         <Tooltip trigger={<div>{cost}</div>} content={costToolTipContent} />
@@ -703,6 +721,16 @@ function buildCallsTableColumns(
       renderCell: cellParams => {
         if (storageSizeInfo.storageSizeLoading) {
           return <LoadingDots />;
+        }
+        if (storageHasError) {
+          return (
+            <div className="flex h-full w-full items-center justify-center">
+              <StatusChip
+                value="ERROR"
+                tooltipOverride="There was an error fetching the storage size for this call."
+              />
+            </div>
+          );
         }
         const storageSize =
           storageSizeInfo.storageSizeResults?.get(cellParams.row.id) ?? null;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -63,6 +63,9 @@ export const useCallsForQuery = (
   refetch: () => void;
   storageSizeLoading: boolean;
   storageSizeResults: Map<string, number> | null;
+  primaryError?: Error | null;
+  costsError?: Error | null;
+  storageSizeError?: Error | null;
 } => {
   const {useCalls, useCallsStats} = useWFHooks();
   const effectiveOffset = gridPage?.page * gridPage?.pageSize;
@@ -201,6 +204,9 @@ export const useCallsForQuery = (
         : callResults,
       total,
       refetch,
+      primaryError: calls.error,
+      costsError: costs.error,
+      storageSizeError: storageSize.error,
     };
   }, [
     callResults,
@@ -211,6 +217,9 @@ export const useCallsForQuery = (
     refetch,
     storageSize.loading,
     storageSizeResults,
+    calls.error,
+    costs.error,
+    storageSize.error,
   ]);
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
@@ -23,6 +23,7 @@ export const FILTER_TO_STATUS: Record<string, CallStatusType> =
 type StatusChipProps = {
   value: CallStatusType;
   iconOnly?: boolean;
+  tooltipOverride?: string;
 };
 
 type CallStatusInfo = {
@@ -58,7 +59,11 @@ export const STATUS_INFO: Record<CallStatusType, CallStatusInfo> = {
   },
 };
 
-export const StatusChip = ({value, iconOnly}: StatusChipProps) => {
+export const StatusChip = ({
+  value,
+  iconOnly,
+  tooltipOverride,
+}: StatusChipProps) => {
   const statusInfo = STATUS_INFO[value];
   const {icon, color, label, tooltip} = statusInfo;
 
@@ -67,5 +72,10 @@ export const StatusChip = ({value, iconOnly}: StatusChipProps) => {
   ) : (
     <Pill icon={icon} color={color} label={label} />
   );
-  return <Tooltip trigger={<span>{pill}</span>} content={tooltip} />;
+  return (
+    <Tooltip
+      trigger={<span>{pill}</span>}
+      content={tooltipOverride ?? tooltip}
+    />
+  );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerDirectClient.ts
@@ -13,6 +13,7 @@
  */
 
 import {getCookie} from '@wandb/weave/common/util/cookie';
+import {HTTPError} from '@wandb/weave/errors';
 import fetch from 'isomorphic-unfetch';
 
 import {
@@ -404,7 +405,14 @@ export class DirectTraceServerClient {
       headers,
       body: reqBody,
     })
-      .then(response => {
+      .then(async response => {
+        if (!response.ok) {
+          throw new HTTPError(
+            response.statusText,
+            response.status,
+            await response.text()
+          );
+        }
         if (responseReturnType === 'text') {
           return response.text();
         } else if (responseReturnType === 'arrayBuffer') {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -281,6 +281,7 @@ const useCallsNoExpansion = (
   const loadingRef = useRef(false);
   const [callRes, setCallRes] =
     useState<traceServerTypes.TraceCallsQueryRes | null>(null);
+  const [error, setError] = useState<Error | null>(null);
   const deepFilter = useDeepMemo(filter);
 
   const req = useMemo((): traceServerTypes.TraceCallsQueryReq => {
@@ -343,6 +344,7 @@ const useCallsNoExpansion = (
       if (_.isEqual(expectedRequestRef.current, req)) {
         loadingRef.current = false;
         console.error(e);
+        setError(e);
         setCallRes({calls: []});
       }
     };
@@ -413,9 +415,10 @@ const useCallsNoExpansion = (
         loading: false,
         result,
         refetch,
+        error,
       };
     }
-  }, [opts?.skip, callRes, columns, refetch, entity, project]);
+  }, [opts?.skip, callRes, columns, refetch, entity, project, error]);
 };
 
 const useCalls = (
@@ -462,8 +465,9 @@ const useCalls = (
       loading,
       result: loading ? [] : expandedCalls.map(traceCallToUICallSchema),
       refetch: calls.refetch,
+      error: calls.error,
     };
-  }, [calls.refetch, expandedCalls, loading]);
+  }, [calls.refetch, expandedCalls, loading, calls.error]);
 };
 
 const useCallsStats = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -23,6 +23,7 @@ export type KnownBaseObjectClassType =
 export type Loadable<T> = {
   loading: boolean;
   result: T | null;
+  error?: Error | null;
 };
 
 export type LoadableWithError<T> = {

--- a/weave-js/src/errors.ts
+++ b/weave-js/src/errors.ts
@@ -5,6 +5,12 @@ import {WeaveApp} from './weave';
 
 export class UseNodeValueServerExecutionError extends Error {}
 
+export class HTTPError<T = unknown> extends Error {
+  constructor(message: string, public statusCode: number, public body?: T) {
+    super(message);
+  }
+}
+
 export function extractErrorMessageFromApolloError(
   err: unknown
 ): string | undefined {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-24053](https://wandb.atlassian.net/browse/WB-24053)

Communicate trace endpoint errors to users

In case of a trace call loading error due to network or auth issues, user will see this:

<img width="1165" alt="image" src="https://github.com/user-attachments/assets/752293b6-f99f-4cdb-b14f-42790da26d03" />

Ok, based on [the latest feedback](https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1745524789840019?thread_ts=1745451631.673699&cid=C03BSTEBD7F): 

I have decided to show StatusChip in place of the costs/storage size errors, which would look like this:

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/c65add9d-9040-492a-bbe0-1cd943645800" />

when a user hovers it, we will see:

<img width="364" alt="image" src="https://github.com/user-attachments/assets/d32f89e3-a589-42f5-b4a7-c08f0b7ea05c" />


## Testing

Manually tested with auth error and a forged bad server response


[WB-24053]: https://wandb.atlassian.net/browse/WB-24053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ