### PR TITLE
chore(dev): increase trace test timeout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -217,7 +217,7 @@ jobs:
 
   trace-tests:
     name: Trace nox tests
-    timeout-minutes: 15
+    timeout-minutes: 18
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Description

Our trace tests are regularly timing out. E.g.

[Trace nox tests (3, 9, trace)](https://github.com/wandb/weave/actions/runs/14623990680/job/41030949100?pr=4243#logs)
succeeded 13 minutes ago in 14m 44s
[Trace nox tests (3, 10, trace)](https://github.com/wandb/weave/actions/runs/14623990680/job/41030975195?pr=4243#logs)
succeeded 14 minutes ago in 14m 44s
[Trace nox tests (3, 11, trace)](https://github.com/wandb/weave/actions/runs/14623990680/job/41030988008?pr=4243#logs)
succeeded 15 minutes ago in 13m 55s
[Trace nox tests (3, 12, trace)](https://github.com/wandb/weave/actions/runs/14623990680/job/41031002516?pr=4243#logs)
succeeded 14 minutes ago in 14m 50s
[Trace nox tests (3, 13, trace)](https://github.com/wandb/weave/actions/runs/14623990680/job/41031016003?pr=4243#logs)
failed 13 minutes ago in 15m 14s

(This was a typo-only PR to make sure it wasn't related to new saved view tests.)

18 minutes (20% increase) is somewhat arbitrary, open to other suggestions.
