### PR TITLE
fix(weave): remove duplicate project_id condition

### DIFF
--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -496,7 +496,6 @@ def test_query_with_simple_feedback_sort() -> None:
             calls_merged.id))
         WHERE
             calls_merged.project_id = {pb_4:String}
-            AND calls_merged.project_id = {pb_4:String}
         GROUP BY
             (calls_merged.project_id,
             calls_merged.id)
@@ -569,7 +568,6 @@ def test_query_with_simple_feedback_sort_with_op_name() -> None:
             calls_merged.id))
         WHERE
             calls_merged.project_id = {pb_1:String}
-            AND calls_merged.project_id = {pb_1:String}
             AND (calls_merged.id IN filtered_calls)
         GROUP BY
             (calls_merged.project_id,
@@ -632,7 +630,6 @@ def test_query_with_simple_feedback_filter() -> None:
             calls_merged.id))
         WHERE
             calls_merged.project_id = {pb_3:String}
-            AND calls_merged.project_id = {pb_3:String}
         GROUP BY
             (calls_merged.project_id,
             calls_merged.id)
@@ -684,7 +681,6 @@ def test_query_with_simple_feedback_sort_and_filter() -> None:
             calls_merged.id))
         WHERE
             calls_merged.project_id = {pb_6:String}
-            AND calls_merged.project_id = {pb_6:String}
         GROUP BY
             (calls_merged.project_id,
             calls_merged.id)
@@ -1958,7 +1954,6 @@ def test_query_with_feedback_filter_and_datetime_and_string_filter() -> None:
         FROM calls_merged
         LEFT JOIN feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_2:String}, '/call/', calls_merged.id))
         WHERE calls_merged.project_id = {pb_2:String}
-            AND calls_merged.project_id = {pb_2:String}
             AND (calls_merged.id IN filtered_calls)
             AND ((calls_merged.inputs_dump LIKE {pb_8:String}
                 OR calls_merged.inputs_dump IS NULL))

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -770,11 +770,7 @@ class CallsQuery(BaseModel):
         # TODO: We should also pull out id-masks from the dynamic query
 
         feedback_join_sql = ""
-        feedback_where_sql = ""
         if needs_feedback:
-            feedback_where_sql = (
-                f" AND calls_merged.project_id = {param_slot(project_param, 'String')}"
-            )
             feedback_join_sql = f"""
             LEFT JOIN feedback
             ON (feedback.weave_ref = concat('weave-trace-internal:///', {param_slot(project_param, "String")}, '/call/', calls_merged.id))
@@ -811,7 +807,6 @@ class CallsQuery(BaseModel):
         {storage_size_sql}
         {total_storage_size_sql}
         WHERE calls_merged.project_id = {param_slot(project_param, "String")}
-        {feedback_where_sql}
         {id_mask_sql}
         {id_subquery_sql}
         {sortable_datetime_sql}


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

We explicitly add a `project_id` condition when joining on the feedback table, but this is not necessary.  As far as I can tell, it is impossible to generate a feedback join without the existing `project_id` condition, making this redundant and safe to remove. 

Introduced in [this pr](https://github.com/wandb/weave/pull/2865). 

## Testing

Updated unit tests. 
