### PR TITLE
chore(dev): add typos config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -315,3 +315,6 @@ commit_args = ""
 [tool.bumpversion.parts.pre_l]
 values = ["dev", "final"]
 optional_value = "final"
+
+[tool.typos.default.extend-words]
+fasion = "fasion" # Wandb lore


### PR DESCRIPTION
## Description

[typos](https://crates.io/crates/typos-cli) is a very useful tool for finding spelling mistakes in source code. I often fix typos not just to be fussy but because it is helpful for testing CI, where I want to have confidence that I'm not getting some cached behavior and that the CI behavior isn't a result of what's in the PR.

Adding some minimal configuration to reduce the amount of output to make it easier to detect new errors.

## Testing

`typos --color always | less -R`
