### PR TITLE
perf(weave): add trace id filter when only querying one parent

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -95,6 +95,7 @@ export const CallDetails: FC<{
     call.entity,
     call.project,
     {
+      traceId: call.traceId,
       parentIds: [call.callId],
     },
     undefined,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

When grabbing the call details, we query for `childCalls` by setting the `parentIds` filter. We know this is only one call, and we know the `traceId` should be the same, so lets also set that in the filter. This should massively improve this query performance, as the trace id is handled pre-groupby and we usually have not so many calls in one trace when compared to the rest of the project. 

This is causing a huge number of errors in a well known instance:
![Screenshot 2025-04-23 at 12 55 37 PM](https://github.com/user-attachments/assets/bdb55f26-1f77-4ef4-ae5b-0147d92018e2)


## Testing

Tested in an infamous project (5x faster, 20x less memory): 

| Environment | Elapsed Time | Rows Read           | Data Size | **Memory Usage**   |
|-------------|--------------|---------------------|-----------|----------------|
| prod        | 7.703s       | 81,199,925 rows     | 11.86 GB  | 26 GB          |
| branch      | 1.536s       | 81,202,664 rows     | 3.74 GB   | 131.22 MiB     |

