### PR TITLE
perf(weave): add purpose built endpoint for project data

### DIFF
--- a/tests/trace/test_trace_server.py
+++ b/tests/trace/test_trace_server.py
@@ -2,6 +2,7 @@ import urllib
 
 import pytest
 
+import weave
 from weave.trace_server import trace_server_interface as tsi
 
 
@@ -80,3 +81,26 @@ def test_robust_to_url_sensitive_chars(client):
         )
     )
     assert read_res.vals[0] == bad_val[bad_key]
+
+
+def test_project_check(client):
+    # real project, no data
+    proj = client._project_id()
+    res = client.server.project_check(tsi.ProjectCheckReq(project_id=proj))
+    assert not res.has_data
+
+    # fake project
+    res = client.server.project_check(
+        tsi.ProjectCheckReq(project_id="shawn/proj-does-not-exist")
+    )
+    assert not res.has_data
+
+    # real project w/ data
+    @weave.op
+    def log():
+        return "a"
+
+    log()
+
+    res = client.server.project_check(tsi.ProjectCheckReq(project_id=proj))
+    assert res.has_data

--- a/tests/trace/test_trace_server.py
+++ b/tests/trace/test_trace_server.py
@@ -95,7 +95,7 @@ def test_project_check(client):
     )
     assert not res.has_data
 
-    # real project w/ data
+    # real project w/ just calls data
     @weave.op
     def log():
         return "a"
@@ -103,4 +103,27 @@ def test_project_check(client):
     log()
 
     res = client.server.project_check(tsi.ProjectCheckReq(project_id=proj))
+    assert res.has_data
+
+    # new project, no data
+    client.project = "new-project"
+    project2 = f"{client.entity}/{client.project}"
+    res = client.server.project_check(tsi.ProjectCheckReq(project_id=project2))
+    assert not res.has_data
+
+    # real project w/ just object data
+    obj = {"a": 1}
+    client.save(obj, "o")
+
+    res = client.server.project_check(tsi.ProjectCheckReq(project_id=project2))
+    assert res.has_data
+
+    # both
+    @weave.op
+    def log2():
+        return "a"
+
+    log2()
+
+    res = client.server.project_check(tsi.ProjectCheckReq(project_id=project2))
     assert res.has_data

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2011,6 +2011,17 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             obj.val_dump = object_values.get((obj.object_id, obj.digest), "{}")
         return metadata_result
 
+    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.project_check")
+    def project_check(self, req: tsi.ProjectCheckReq) -> tsi.ProjectCheckRes:
+        query = f"""
+        SELECT id
+        FROM calls_merged
+        WHERE project_id = '{req.project_id}'
+        LIMIT 1
+        """
+        res = self._query(query, {})
+        return tsi.ProjectCheckRes(has_data=len(res.result_rows) > 0)
+
     def _run_migrations(self) -> None:
         logger.info("Running migrations")
         migrator = wf_migrator.ClickHouseTraceServerMigrator(self._mint_client())

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2013,14 +2013,15 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.project_check")
     def project_check(self, req: tsi.ProjectCheckReq) -> tsi.ProjectCheckRes:
-        query = f"""
+        query = """
         SELECT id
         FROM calls_merged
-        WHERE project_id = '{req.project_id}'
+        WHERE project_id = {project_id: String}
         LIMIT 1
         """
-        res = self._query(query, {})
-        return tsi.ProjectCheckRes(has_data=len(res.result_rows) > 0)
+        res = self._query(query, {"project_id": req.project_id})
+        has_data = len(res.result_rows) > 0
+        return tsi.ProjectCheckRes(has_data=has_data)
 
     def _run_migrations(self) -> None:
         logger.info("Running migrations")

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -395,3 +395,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         res = self._ref_apply(self._internal_trace_server.completions_create, req)
         return res
+
+    def project_check(self, req: tsi.ProjectCheckReq) -> tsi.ProjectCheckRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.project_check, req)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1521,10 +1521,20 @@ class SqliteTraceServer(tsi.TraceServerInterface):
     def project_check(self, req: tsi.ProjectCheckReq) -> tsi.ProjectCheckRes:
         conn, cursor = get_conn_cursor(self.db_path)
         cursor.execute(
-            "SELECT id FROM calls WHERE project_id = ? LIMIT 1", (req.project_id,)
+            """
+            SELECT 1
+            WHERE EXISTS (
+                SELECT 1 FROM calls WHERE project_id = ?
+            )
+            OR EXISTS (
+                SELECT 1 FROM objects WHERE project_id = ?
+            )
+            """,
+            (req.project_id, req.project_id),
         )
         res = cursor.fetchone()
-        return tsi.ProjectCheckRes(has_data=res is not None)
+        has_data = res is not None
+        return tsi.ProjectCheckRes(has_data=has_data)
 
 
 def get_type(val: Any) -> str:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1518,6 +1518,14 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         results = self.table_query(req)
         yield from results.rows
 
+    def project_check(self, req: tsi.ProjectCheckReq) -> tsi.ProjectCheckRes:
+        conn, cursor = get_conn_cursor(self.db_path)
+        cursor.execute(
+            "SELECT id FROM calls WHERE project_id = ? LIMIT 1", (req.project_id,)
+        )
+        res = cursor.fetchone()
+        return tsi.ProjectCheckRes(has_data=res is not None)
+
 
 def get_type(val: Any) -> str:
     if val == None:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -996,11 +996,23 @@ class ActionsExecuteBatchRes(BaseModel):
     pass
 
 
+class ProjectCheckReq(BaseModel):
+    project_id: str
+
+
+class ProjectCheckRes(BaseModel):
+    has_data: bool
+
+
 class TraceServerInterface(Protocol):
+    # Check for gorilla project existence
     def ensure_project_exists(
         self, entity: str, project: str
     ) -> EnsureProjectExistsRes:
         return EnsureProjectExistsRes(project_name=project)
+
+    # Project API
+    def project_check(self, req: ProjectCheckReq) -> ProjectCheckRes: ...
 
     # OTEL API
     def otel_export(self, req: OtelExportReq) -> OtelExportRes: ...

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -448,3 +448,6 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         self, req: tsi.CompletionsCreateReq
     ) -> tsi.CompletionsCreateRes:
         return self._next_trace_server.completions_create(req)
+
+    def project_check(self, req: tsi.ProjectCheckReq) -> tsi.ProjectCheckRes:
+        return self._next_trace_server.project_check(req)

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -565,6 +565,11 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             tsi.CompletionsCreateRes,
         )
 
+    def project_check(self, req: tsi.ProjectCheckReq) -> tsi.ProjectCheckRes:
+        return self._generic_request(
+            "/project/check", req, tsi.ProjectCheckReq, tsi.ProjectCheckRes
+        )
+
 
 __docspec__ = [
     RemoteHTTPTraceServer,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24603](https://wandb.atlassian.net/browse/WB-24603)

Adds a purpose built endpoint for checking if a project has traces. Query `project_check` with a request payload of the `project_id` and get back a `has_data` bool. 

Fast follow in core: https://github.com/wandb/core/pull/28989

## Testing

- Unit test
- Manual performance testing, in high trace environment:

| Environment | Elapsed Time | Rows Read  | Data Read | Peak Memory   | Error |
|-------------|--------------|------------|-----------|----------------|--------|
| Prod        | 3.5s         | 53,890,051 | –         | 31.94 GiB      | True   |
| Branch      | 0.008s       | 15,631     | 1.24 MB   | 126.63 MiB     | False  |

In prod, this query is run 1.2 million times a week, so even modest improvements in speed might actually have an impact on clickhouse performance. 

| Env | Runs | Errors | Avg. Read Rows | Avg. Memory Usage | p5 | p90 | p99 |
|-------------|------------------|--------|----------------|-------------------|-------------|-------------|-------------|
| Prod        | 1,169,821        | 0      | 30,333.25      | 95.86 MiB         | 0.019s      | 0.04s       | 0.541s      |

[WB-24603]: https://wandb.atlassian.net/browse/WB-24603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ