### PR TITLE
fix(weave) ensures that the failures in table_query_stats triggers 500 error

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1047,7 +1047,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         res = self.table_query_stats_batch(batch_req)
 
         if len(res.tables) != 1:
-            raise ValueError("Unexpected number of results", res)
+            raise RuntimeError("Unexpected number of results", res)
 
         count = res.tables[0].count
         return tsi.TableQueryStatsRes(count=count)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1136,7 +1136,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         res = self.table_query_stats_batch(batch_req)
 
         if len(res.tables) != 1:
-            raise ValueError("Unexpected number of results", res)
+            raise RuntimeError("Unexpected number of results", res)
 
         count = res.tables[0].count
         return tsi.TableQueryStatsRes(count=count)


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes an issue that errors in `table_query_stats` used to trigger 400 (Bad request) error, now it will be 500.

## Testing

manually tested
