### PR TITLE
feat(weave): Dataset.add_rows helper for efficient append to an existing dataset

### DIFF
--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -141,3 +141,31 @@ def test_dataset_caching(client):
 
     with raise_on_captured_errors():
         assert len(ds2) == 200
+
+
+def test_add_rows(client):
+    ds = weave.Dataset(name="test", rows=[{"a": i} for i in range(10)])
+    ref = weave.publish(ds)
+
+    ds = ref.get()
+    ds2 = ds.add_rows([{"a": 10}])
+
+    assert len(ds2) == 11
+    assert ds2.rows[10]["a"] == 10
+
+    ds3 = ds2.add_rows([{"a": 11}, {"a": 12}, {"a": 13}])
+    assert len(ds3) == 14
+    assert ds3.rows[12]["a"] == 12
+    assert ds3.rows[11]["a"] == 11
+    assert ds3.rows[10]["a"] == 10
+
+    # Verify that publishing an already published dataset doesn't
+    # do anything.
+    ds4 = weave.publish(ds3).get()
+    assert ds3.rows == ds4.rows
+
+
+def test_add_rows_to_unsaved_dataset(client):
+    ds = weave.Dataset(rows=[{"a": i} for i in range(10)])
+    with pytest.raises(TypeError):
+        ds.add_rows([{"a": 10}])

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -286,7 +286,7 @@ class WeaveObject(Traceable):
 
 
 class WeaveTable(Traceable):
-    filter: TableRowFilter
+    filter: Optional[TableRowFilter] = None
     _known_length: Optional[int] = None
     _rows: Optional[Sequence[dict]] = None
     # _prefetched_rows is a local cache of rows that can be used to
@@ -295,11 +295,11 @@ class WeaveTable(Traceable):
 
     def __init__(
         self,
-        table_ref: Optional[TableRef],
-        ref: Optional[RefWithExtra],
         server: TraceServerInterface,
-        filter: TableRowFilter,
-        root: Optional[Traceable],
+        table_ref: Optional[TableRef] = None,
+        ref: Optional[RefWithExtra] = None,
+        filter: Optional[TableRowFilter] = None,
+        root: Optional[Traceable] = None,
         parent: Optional[Traceable] = None,
     ) -> None:
         self.table_ref = table_ref


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-24473

Adds public `add_rows` method on the `Dataset` class. This method takes rows to be appended to the dataset as input and returns a new dataset derived from appending the provided rows to the existing dataset. The new dataset returned by the helper has already been published to the server.

To use:

```python
import weave

weave.init("bcanfieldsherman/tldr")

dataset = weave.ref(
    "weave:///bcanfieldsherman/tldr/object/annotated_loops:33yoXWgOPrFNqhXhrDkiaoGMXPeaAjQEkocRmeRjCpk"
).get()


new_dataset = dataset.add_rows(
    [
        {
            "output": "The pull request introduces a really mid method that does not work. Whoever wrote this should be fired.",
            "reactions": ["👎", "😠", "💩"],
            "notes": ["This is really mean", "Please never do this again", "Not cool"],
        },
        {
            "output": "Whoever wrote this is a genius. I love this method.",
            "reactions": ["👍", "😊", "🚀"],
            "notes": [
                "Really good summary",
                "I love this method",
                "This is a masterpiece",
            ],
        },
    ]
)
```
