### PR TITLE
docs(weave): Update all scorer code examples to use `output` instead of `models_output`

### DIFF
--- a/docs/docs/guides/core-types/evaluations.md
+++ b/docs/docs/guides/core-types/evaluations.md
@@ -18,7 +18,7 @@ examples = [
 
 # Define any custom scoring function
 @weave.op()
-def match_score1(expected: str, model_output: dict) -> dict:
+def match_score1(expected: str, output: dict) -> dict:
     # Here is where you'd define the logic to score the model output
     return {'match': expected == model_output['generated_text']}
 
@@ -68,7 +68,7 @@ examples = [
 
 # Define any custom scoring function
 @weave.op()
-def match_score1(expected: str, model_output: dict) -> dict:
+def match_score1(expected: str, output: dict) -> dict:
     # Here is where you'd define the logic to score the model output
     return {'match': expected == model_output['generated_text']}
 ```
@@ -159,11 +159,11 @@ examples = [
 ]
 
 @weave.op()
-def match_score1(expected: str, model_output: dict) -> dict:
+def match_score1(expected: str, output: dict) -> dict:
     return {'match': expected == model_output['generated_text']}
 
 @weave.op()
-def match_score2(expected: dict, model_output: dict) -> dict:
+def match_score2(expected: dict, output: dict) -> dict:
     return {'match': expected == model_output['generated_text']}
 
 class MyModel(Model):
@@ -219,7 +219,7 @@ def preprocess_example(example):
     }
 
 @weave.op()
-def match_score(expected: str, model_output: dict) -> dict:
+def match_score(expected: str, output: dict) -> dict:
     return {'match': expected == model_output['generated_text']}
 
 @weave.op()

--- a/docs/docs/guides/integrations/langchain.md
+++ b/docs/docs/guides/integrations/langchain.md
@@ -247,7 +247,7 @@ examples = [
 ]
 
 @weave.op()
-def fruit_name_score(target: dict, model_output: dict) -> dict:
+def fruit_name_score(target: dict, output: dict) -> dict:
     return {"correct": target["fruit"] == model_output["fruit"]}
 
 

--- a/docs/docs/guides/integrations/llamaindex.md
+++ b/docs/docs/guides/integrations/llamaindex.md
@@ -177,7 +177,7 @@ evaluator = CorrectnessEvaluator(llm=llm_judge)
 
 # highlight-next-line
 @weave.op()
-def correctness_evaluator(query: str, ground_truth: str, model_output: dict):
+def correctness_evaluator(query: str, ground_truth: str, output: dict):
     result = evaluator.evaluate(
         query=query, reference=ground_truth, response=model_output["response"]
     )


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1450

Update all scorer code examples for latest version: use `output` instead of `models_output` 

## Testing

yarn start on local
