### PR TITLE
fix(ui): show less confusing empty page for object versions

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionsTable.tsx
@@ -23,6 +23,7 @@ import {
   EMPTY_PROPS_DATASETS,
   EMPTY_PROPS_LEADERBOARDS,
   EMPTY_PROPS_MODEL,
+  EMPTY_PROPS_OBJECT_VERSIONS,
   EMPTY_PROPS_OBJECTS,
   EMPTY_PROPS_PROGRAMMATIC_SCORERS,
   EMPTY_PROPS_PROMPTS,
@@ -403,6 +404,7 @@ export const FilterableObjectVersionsTable: React.FC<{
     return {...props.initialFilter, ...props.frozenFilter};
   }, [props.initialFilter, props.frozenFilter]);
 
+  const isOneObject = effectiveFilter.objectName != null;
   const effectivelyLatestOnly = !effectiveFilter.objectName;
 
   const filteredObjectVersions = useRootObjectVersions(
@@ -432,7 +434,9 @@ export const FilterableObjectVersionsTable: React.FC<{
   const objectVersions = filteredObjectVersions.result ?? [];
   const isEmpty = objectVersions.length === 0;
   if (isEmpty) {
-    let propsEmpty = EMPTY_PROPS_OBJECTS;
+    let propsEmpty = isOneObject
+      ? EMPTY_PROPS_OBJECT_VERSIONS
+      : EMPTY_PROPS_OBJECTS;
     const base = props.initialFilter?.baseObjectClass;
     if ('Prompt' === base) {
       propsEmpty = EMPTY_PROPS_PROMPTS;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -219,6 +219,21 @@ export const EMPTY_PROPS_OBJECTS: EmptyProps = {
   ),
 };
 
+export const EMPTY_PROPS_OBJECT_VERSIONS: EmptyProps = {
+  icon: 'cube-container' as const,
+  heading: 'No object versions',
+  description:
+    'The requested object does not exist or all versions of it have been deleted.',
+  moreInformation: (
+    <>
+      Learn{' '}
+      <TargetBlank href="http://wandb.me/weave_objects">
+        object basics
+      </TargetBlank>
+      .
+    </>
+  ),
+};
 export const EMPTY_NO_TRACE_SERVER: EmptyProps = {
   icon: 'weave' as const,
   heading: 'Weave coming soon!',


### PR DESCRIPTION
## Description

When you delete all versions of an object, we show "No objects yet" messaging, which is confusing. This is a quick fix to display a more correct message, though we should probably think about what we actually want the UX to be. (E.g. return to objects list page?)

Before:
![image](https://github.com/user-attachments/assets/6a272178-f201-40a7-8148-7d37ae41aea1)

After:

![image](https://github.com/user-attachments/assets/90fb67e4-f112-465f-a23c-af9b8e2cf8f7)


## Testing

wf versions example, deleted object versions.
