### PR TITLE
chore(ui): update styling for protected aliases

### DIFF
--- a/weave-js/src/common/components/Tags.styles.ts
+++ b/weave-js/src/common/components/Tags.styles.ts
@@ -1,49 +1,35 @@
-import {WBIcon} from '@wandb/ui';
 import {Icon} from '@wandb/weave/components/Icon';
 import styled, {css} from 'styled-components';
 
 const IconVariants = {
   small: css`
-    font-size: 12px;
+    width: 12px;
+    height: 12px;
   `,
   medium: css`
-    font-size: 14px;
+    width: 14px;
+    height: 14px;
   `,
   large: css`
-    font-size: 16px;
+    width: 16px;
+    height: 16px;
   `,
 };
 
-export const StyledIcon = styled(WBIcon)<{
+export const StyledIcon = styled(Icon)<{
   size: keyof typeof IconVariants;
   $pos: string;
   $opacity?: number;
   $cursor?: string;
 }>`
   ${props => IconVariants[props.size]};
-  margin: 4px 4px 4px 4px;
+  margin: auto 4px;
   ${props =>
     props.$pos === 'left' ? `margin-left: -4px;` : `margin-right: -4px;`}
   display: flex;
   align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
   opacity: ${props => props.$opacity};
   ${props => (props.$cursor ? `cursor: ${props.$cursor};` : '')}
-`;
-
-export const ProtectedAliasIcon = styled(Icon)<{
-  size: keyof typeof IconVariants;
-  $pos: string;
-  $opacity?: number;
-  $cursor?: string;
-}>`
-  ${props => IconVariants[props.size]};
-  margin: 4px 4px 4px 4px;
-  ${props =>
-    props.$pos === 'left' ? `margin-left: -4px;` : `margin-right: -4px;`}
-  display: flex;
-  align-items: center;
-  opacity: ${props => props.$opacity};
-  ${props => (props.$cursor ? `cursor: ${props.$cursor};` : '')}
-  width: 16px;
-  height: 16px;
 `;

--- a/weave-js/src/common/components/Tags.styles.ts
+++ b/weave-js/src/common/components/Tags.styles.ts
@@ -1,4 +1,5 @@
 import {WBIcon} from '@wandb/ui';
+import {Icon} from '@wandb/weave/components/Icon';
 import styled, {css} from 'styled-components';
 
 const IconVariants = {
@@ -13,7 +14,7 @@ const IconVariants = {
   `,
 };
 
-export const Icon = styled(WBIcon)<{
+export const StyledIcon = styled(WBIcon)<{
   size: keyof typeof IconVariants;
   $pos: string;
   $opacity?: number;
@@ -27,4 +28,22 @@ export const Icon = styled(WBIcon)<{
   align-items: center;
   opacity: ${props => props.$opacity};
   ${props => (props.$cursor ? `cursor: ${props.$cursor};` : '')}
+`;
+
+export const ProtectedAliasIcon = styled(Icon)<{
+  size: keyof typeof IconVariants;
+  $pos: string;
+  $opacity?: number;
+  $cursor?: string;
+}>`
+  ${props => IconVariants[props.size]};
+  margin: 4px 4px 4px 4px;
+  ${props =>
+    props.$pos === 'left' ? `margin-left: -4px;` : `margin-right: -4px;`}
+  display: flex;
+  align-items: center;
+  opacity: ${props => props.$opacity};
+  ${props => (props.$cursor ? `cursor: ${props.$cursor};` : '')}
+  width: 16px;
+  height: 16px;
 `;

--- a/weave-js/src/common/components/Tags.tsx
+++ b/weave-js/src/common/components/Tags.tsx
@@ -49,9 +49,22 @@ function colorIndexToName(showColor: boolean, index?: number): string {
     case TagType.ALIAS:
       return 'tag-sienna-light';
     case TagType.PROTECTED_ALIAS:
-      return 'tag-purple';
+      return 'tag-lightGray';
     default:
       return 'tag-lightGray';
+  }
+}
+
+function nounToIconName(noun: string): string {
+  switch (noun) {
+    case 'tag':
+      return 'tag-latest';
+    case 'alias':
+      return 'email-at';
+    case 'protected-alias':
+      return 'lock-closed';
+    default:
+      return 'email-at';
   }
 }
 
@@ -87,11 +100,15 @@ export const Tag: React.FC<TagProps> = React.memo(
         }
         key={tag.name}
         onClick={onClick}>
-        <S.Icon
-          name={noun === 'tag' ? 'tag-latest' : 'email-at'}
-          size={size}
-          $pos="left"
-        />
+        {noun === 'protected-alias' ? (
+          <S.ProtectedAliasIcon
+            name={nounToIconName(noun)}
+            size={size}
+            $pos="left"
+          />
+        ) : (
+          <S.StyledIcon name={nounToIconName(noun)} size={size} $pos="left" />
+        )}
         <SingleLineText alignSelf={'center'}>
           {highlightedText
             ? regexMatchHighlight(tag.name, new RegExp(highlightedText, 'i'), {
@@ -101,7 +118,7 @@ export const Tag: React.FC<TagProps> = React.memo(
             : tag.name}
         </SingleLineText>
         {canDelete && onDelete && (
-          <S.Icon
+          <S.StyledIcon
             className="delete-tag"
             name="close-latest"
             size={size}

--- a/weave-js/src/common/components/Tags.tsx
+++ b/weave-js/src/common/components/Tags.tsx
@@ -58,7 +58,7 @@ function colorIndexToName(showColor: boolean, index?: number): string {
 function nounToIconName(noun: string): string {
   switch (noun) {
     case 'tag':
-      return 'tag-latest';
+      return 'tag';
     case 'alias':
       return 'email-at';
     case 'protected-alias':
@@ -100,15 +100,7 @@ export const Tag: React.FC<TagProps> = React.memo(
         }
         key={tag.name}
         onClick={onClick}>
-        {noun === 'protected-alias' ? (
-          <S.ProtectedAliasIcon
-            name={nounToIconName(noun)}
-            size={size}
-            $pos="left"
-          />
-        ) : (
-          <S.StyledIcon name={nounToIconName(noun)} size={size} $pos="left" />
-        )}
+        <S.StyledIcon name={nounToIconName(noun)} size={size} $pos="left" />
         <SingleLineText alignSelf={'center'}>
           {highlightedText
             ? regexMatchHighlight(tag.name, new RegExp(highlightedText, 'i'), {
@@ -120,7 +112,7 @@ export const Tag: React.FC<TagProps> = React.memo(
         {canDelete && onDelete && (
           <S.StyledIcon
             className="delete-tag"
-            name="close-latest"
+            name="close"
             size={size}
             onClick={(e: React.MouseEvent<HTMLElement>) => {
               e.stopPropagation();


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-23977](https://wandb.atlassian.net/browse/WB-23977)

This PR updates the protected alias tag design in the (deprecated) tag component. While the component is deprecated, it is still used in various locations for artifacts. switching them out to the current component would require heavier work, so for now we're still updating this component & plan to switch to the current component later.

protected aliases design: 
- [notion link](https://www.notion.so/wandbai/Protected-alias-tag-1c8e2f5c7ef38078b75dfecdb5e80a9f)
- [figma link](https://www.figma.com/design/vXjdSVJ18xjU3T2pKnLuVd/QA-for-Workspaces?node-id=3033-26667&t=exnXegNXf7GUJyZ3-11)

## Testing
the screenshots below also include tags since those icons were also affected by this PR

protected aliases in collection card:
![Screenshot 2025-04-28 at 3 43 03 PM](https://github.com/user-attachments/assets/edc28453-0bee-42f3-8d48-5167b364a3c5)

deletable protected aliases on versions page:
![Screenshot 2025-04-28 at 3 57 57 PM](https://github.com/user-attachments/assets/e11a4933-9671-4cf2-becc-f61dbc767428)

not deletable protected aliases on versions page:
![Screenshot 2025-04-28 at 3 43 53 PM](https://github.com/user-attachments/assets/a9dee7e2-354d-4732-a191-9c68c37648be)

[WB-23977]: https://wandb.atlassian.net/browse/WB-23977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ