### PR TITLE
fix(weave): Add subquery alias 

### DIFF
--- a/weave/trace_server/table_query_builder.py
+++ b/weave/trace_server/table_query_builder.py
@@ -130,7 +130,7 @@ def make_table_stats_query_with_storage_size(
         SELECT digest as tb_digest, length(row_digests) as length, row_digests
         FROM tables
         WHERE project_id = {{{project_id_name}: String}} AND digest in {{{digest_ids}: Array(String)}}
-    ) ARRAY JOIN row_digests as row_digest
+    ) AS sub ARRAY JOIN row_digests as row_digest
     LEFT JOIN
     (
         SELECT * FROM table_rows_stats WHERE table_rows_stats.project_id = {{{project_id_name}: String}}


### PR DESCRIPTION
## Description

- Fixes a SQL query syntax error in the `make_table_stats_query_with_storage_size` function
- Adds an explicit table alias "AS sub" to the subquery because the ClickHouse version 24.12.* demands it

## Testing

Tested by verifying the corrected SQL query executes successfully against the database without syntax errors.