### PR TITLE
feat(weave): Vercel OTEL conventions integration

### DIFF
--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -47,8 +47,9 @@ This would be the resulting dict dumped to clickhouse:
 from weave.trace_server.opentelemetry.helpers import try_parse_int
 
 INPUT_KEYS = [
+    "ai.prompt",  # Vercel
     "gen_ai.prompt",  # From OpenTelemetry AI semantic conventions
-    "input.value",  # From OpenInference standard - highest priority
+    "input.value",  # From OpenInference standard
     "mlflow.spanInputs",  # From MLFlow's tracking format
     "traceloop.entity.input"  # From Traceloop's conventions
     "input",  # Generic fallback for Pydantic models - lowest priority
@@ -58,6 +59,7 @@ INPUT_KEYS = [
 # Priority is given to standards in this order:
 # This is used to populate the `output_dump` column in clickhouse
 OUTPUT_KEYS = [
+    "ai.response",  # Vercel
     "gen_ai.completion",  # From OpenTelemetry AI semantic conventions
     "output.value",  # From OpenInference standard - highest priority
     "mlflow.spanOutputs",  # From MLFlow's tracking format
@@ -73,14 +75,23 @@ OUTPUT_KEYS = [
 # Never assume that the value is of a certain type or error, conventions provide no guarantees
 USAGE_KEYS = {
     # Maps Weave's "prompt_tokens" to keys from different standards
+    "input_tokens": [
+        ("gen_ai.usage.input_tokens", try_parse_int),
+    ],
+    # Maps Weave's "completion_tokens" to keys from different standards
+    "completion_tokens": [
+        ("gen_ai.usage.output_tokens", try_parse_int),
+    ],
     "prompt_tokens": [
         ("gen_ai.usage.prompt_tokens", try_parse_int),
         ("llm.token_count.prompt", try_parse_int),
+        ("ai.usage.promptTokens", try_parse_int),  # Vercel
     ],
     # Maps Weave's "completion_tokens" to keys from different standards
     "completion_tokens": [
         ("gen_ai.usage.completion_tokens", try_parse_int),
         ("llm.token_count.completion", try_parse_int),
+        ("ai.usage.completionTokens", try_parse_int),  # Vercel
     ],
     # Maps Weave's "total_tokens" to keys from different standards
     "total_tokens": [
@@ -105,10 +116,11 @@ ATTRIBUTE_KEYS = {
         "openinference.span.kind",  # OpenInference
     ],
     # Model name/identifier
-    "model": ["gen_ai.response.model", "llm.model_name"],
+    "model": ["gen_ai.response.model", "llm.model_name", "ai.model.id"],
     # Provider/vendor of the model
     "provider": [
         "llm.provider",  # Common across standards
+        "ai.model.provider",  # Vercel
     ],
     # Model generation parameters (temperature, max_tokens, etc.)
     "model_parameters": ["gen_ai.request", "llm.invocation_parameters"],


### PR DESCRIPTION
## Description

- Fixes WB-24612

Adds Input, Output, Usage, and Parameter parsing for Vercel style OTEL conventions

## Testing

Set up vercel example tracing repo and ensured keys are properly propogated into weave
