### PR TITLE
fix(weave): Uncomment validation check and fix table_query_stats query

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1047,8 +1047,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
         res = self.table_query_stats_batch(batch_req)
 
-        # if len(res.tables) != 1:
-        #     raise RuntimeError("Unexpected number of results", res)
+        if len(res.tables) != 1:
+            raise RuntimeError("Unexpected number of results", res)
 
         count = res.tables[0].count
         return tsi.TableQueryStatsRes(count=count)
@@ -1063,7 +1063,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
         query = """
         SELECT digest, length(row_digests)
-        FROM tables
+        FROM tables_deduped
         WHERE project_id = {project_id:String} AND digest IN {digests:Array(String)}
         """
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1048,7 +1048,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         res = self.table_query_stats_batch(batch_req)
 
         if len(res.tables) != 1:
-            raise RuntimeError("Unexpected number of results", res)
+            logger.exception(RuntimeError("Unexpected number of results", res))
 
         count = res.tables[0].count
         return tsi.TableQueryStatsRes(count=count)
@@ -1062,9 +1062,10 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         }
 
         query = """
-        SELECT digest, length(row_digests)
-        FROM tables_deduped
+        SELECT digest, any(length(row_digests))
+        FROM tables
         WHERE project_id = {project_id:String} AND digest IN {digests:Array(String)}
+        GROUP BY digest
         """
 
         if req.include_storage_size:


### PR DESCRIPTION
## Description

- Uncomments the error check in `table_query_stats` to ensure exactly one result is returned. The commenting was an expedited measure to quickly put prod errors out.

- Modifies the SQL query in `table_query_stats_batch` to:
  - Use `any(length(row_digests))` to pick one result instead of just `length(row_digests)`
  - Add a `GROUP BY digest` clause to properly aggregate results

- I have validated that the advanced form query generated by `make_table_stats_query_with_storage_size` does not return duplicated results.

## Testing

This change was tested by running the produced query against the impacted production data.