### PR TITLE
feat(ui): include trace ref in add to dataset

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
@@ -176,6 +176,7 @@ describe('createSourceSchema', () => {
     ];
 
     expect(createSourceSchema(calls)).toEqual([
+      {name: 'trace', type: 'string'},
       {name: 'inputs.prompt', type: 'string'},
       {name: 'inputs.options', type: 'object'},
       {name: 'output', type: 'string'},
@@ -201,6 +202,7 @@ describe('createSourceSchema', () => {
     ];
 
     expect(createSourceSchema(calls)).toEqual([
+      {name: 'trace', type: 'string'},
       {name: 'inputs.prompt', type: 'string'},
       {name: 'output.text', type: 'string'},
       {name: 'output.metadata', type: 'object'},
@@ -233,6 +235,7 @@ describe('createSourceSchema', () => {
     ];
 
     expect(createSourceSchema(calls)).toEqual([
+      {name: 'trace', type: 'string'},
       {name: 'inputs.prompt', type: 'string'},
       {name: 'output', type: 'string'},
     ]);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRefLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/smallRef/SmallRefLoaded.tsx
@@ -17,6 +17,7 @@ type SmallRefLoadedProps = {
   label?: string;
   error: Error | null;
   noLink?: boolean;
+  suffix?: React.ReactNode;
 };
 
 export const SmallRefLoaded = ({
@@ -25,6 +26,7 @@ export const SmallRefLoaded = ({
   label,
   error,
   noLink = false,
+  suffix,
 }: SmallRefLoadedProps) => {
   const content = (
     <div
@@ -42,6 +44,7 @@ export const SmallRefLoaded = ({
           {label}
         </div>
       )}
+      {suffix && <div className="ml-2 flex-shrink-0">{suffix}</div>}
     </div>
   );
   if (error) {


### PR DESCRIPTION
## Description
https://wandb.atlassian.net/browse/WB-24372

This PR adds the option to include a ref to the original call in the add call to dataset flow. There is now a `trace` field which contains a ref to the source call of each row.

The PR also modifies the `SmallWeaveRef` component to support call refs. Calls must be fetched with a different query than objects, so the `SmallWeaveRef` now wraps two children `SmallWeave{Object,Call}Ref` which in turn handle the querying and rendering for their respective data.

<img width="1088" alt="Screenshot 2025-04-24 at 6 01 10 PM" src="https://github.com/user-attachments/assets/02bea164-24f9-4477-9967-a9b81e48c683" />

<img width="1088" alt="Screenshot 2025-04-24 at 6 02 12 PM" src="https://github.com/user-attachments/assets/1c00b436-7fbc-4f53-857d-c9ff60d90e01" />

<img width="1088" alt="Screenshot 2025-04-24 at 6 02 43 PM" src="https://github.com/user-attachments/assets/bf2a972f-50fb-4aea-a04a-b58caa0acade" />

