### PR TITLE
fix(weave): fix incorrect bytes calculation

### DIFF
--- a/weave-js/src/util.ts
+++ b/weave-js/src/util.ts
@@ -66,12 +66,12 @@ export function convertBytes(result: any) {
   if (typeof result !== 'number') {
     return '';
   }
-  if (result > 10e9) {
-    return `${(result / 10e9).toFixed(1)}GB`;
-  } else if (result > 10e6) {
-    return `${(result / 10e6).toFixed(1)}MB`;
-  } else if (result > 10e3) {
-    return `${(result / 10e3).toFixed(1)}KB`;
+  if (result > 1e9) {
+    return `${(result / 1e9).toFixed(1)}GB`;
+  } else if (result > 1e6) {
+    return `${(result / 1e6).toFixed(1)}MB`;
+  } else if (result > 1000) {
+    return `${(result / 1000).toFixed(1)}kB`;
   }
   return `${result}B`;
 }


### PR DESCRIPTION
## Description

- Fixes a bug in the `convertBytes` function where byte conversion thresholds were incorrectly set

This PR corrects the byte conversion thresholds in the `convertBytes` utility function. The previous implementation used `10e9`, `10e6`, and `10e3` (which equal 10 billion, 10 million, and 10 thousand respectively) as thresholds. This has been fixed to use the correct values: `1e9` (1 billion), `1e6` (1 million), and `1000` for proper byte conversion to GB, MB, and KB.

## Testing

Manually tested on the UI