### PR TITLE
backend change for including storage size in the stats query

### DIFF
--- a/weave-js/src/util.ts
+++ b/weave-js/src/util.ts
@@ -66,12 +66,12 @@ export function convertBytes(result: any) {
   if (typeof result !== 'number') {
     return '';
   }
-  if (result > 10e9) {
-    return `${(result / 10e9).toFixed(1)}GB`;
-  } else if (result > 10e6) {
-    return `${(result / 10e6).toFixed(1)}MB`;
-  } else if (result > 10e3) {
-    return `${(result / 10e3).toFixed(1)}KB`;
+  if (result > 1e9) {
+    return `${(result / 1e9).toFixed(1)}GB`;
+  } else if (result > 1e6) {
+    return `${(result / 1e6).toFixed(1)}MB`;
+  } else if (result > 1000) {
+    return `${(result / 1000).toFixed(1)}kB`;
   }
   return `${result}B`;
 }

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -418,10 +418,12 @@ class CallsQueryStatsReq(BaseModel):
     project_id: str
     filter: Optional[CallsFilter] = None
     query: Optional[Query] = None
+    include_total_storage_size: Optional[bool] = False
 
 
 class CallsQueryStatsRes(BaseModel):
     count: int
+    total_storage_size_bytes: Optional[int] = None
 
 
 class CallUpdateReq(BaseModel):


### PR DESCRIPTION
## Description

- Adds support for retrieving total storage size in call query statistics
- Enhances `CallsQueryStatsReq` with an optional `include_total_storage_size` parameter
- Updates `CallsQueryStatsRes` to include an optional `total_storage_size_bytes` field
- Modifies the query construction to aggregate storage size data when requested

## Testing

This change was tested by verifying that:
- The existing functionality continues to work without the new parameter
- When `include_total_storage_size` is set to true, the response correctly includes the aggregated storage size
- The query properly handles null values in storage size with coalesce