### PR TITLE
feat(ui): add bulk object delete functionality

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionsTable.tsx
@@ -398,6 +398,7 @@ export const FilterableObjectVersionsTable: React.FC<{
   selectedVersions?: string[];
   setSelectedVersions?: (selected: string[]) => void;
 }> = props => {
+  const {setSelectedVersions} = props;
   const {useRootObjectVersions} = useWFHooks();
 
   const effectiveFilter = useMemo(() => {
@@ -422,6 +423,15 @@ export const FilterableObjectVersionsTable: React.FC<{
     undefined,
     effectivelyLatestOnly // metadata only when getting latest
   );
+
+  // When the table reloads, clear any selected versions.
+  // This is because we may be reloading because of a deletion, and
+  // we don't want the deleted version to remain in the selected state if it is there.
+  useEffect(() => {
+    if (filteredObjectVersions.loading && setSelectedVersions) {
+      setSelectedVersions([]);
+    }
+  }, [filteredObjectVersions.loading, setSelectedVersions]);
 
   if (filteredObjectVersions.loading) {
     return <Loading centered />;


### PR DESCRIPTION
## Description

Adds checkboxes and a delete button to the Object Versions page, allowing you to quickly delete an entire object (not just one version of it) or multiple selected objects.

![image](https://github.com/user-attachments/assets/99ebf66c-7351-486e-a2ca-c753696386d7)
![image](https://github.com/user-attachments/assets/7d9f6dbe-d4b9-4dea-abc2-cbfd54c40f60)

This UI follows the current backend permissions checks, which allow anyone with write access to the project to delete, even if they are not an admin / not the original creator of the version.

@Yangyi-wandb @m-rgba - design consult, do we want more of a warning about this irreversible action?

Fixes some additional bugs:
* Delete button only getting shown for site admins on version list page
* Row selection state not getting cleared when object versions are deleted through peek drawer.

## Testing

Manual through `wf` versions example.
