### PR TITLE
chore(weave): speed up image and sampling tests

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3379,7 +3379,7 @@ def test_op_sampling_child_follows_parent(client):
         parent_calls += 1
         return child_op(x)
 
-    num_runs = 100
+    num_runs = 5
     for i in range(num_runs):
         parent_op(i)
 

--- a/tests/trace/type_handlers/Image/image_test.py
+++ b/tests/trace/type_handlers/Image/image_test.py
@@ -30,7 +30,7 @@ Calls:
     ]
 )
 def test_img(request) -> Image.Image:
-    img = Image.new("RGB", (512, 512), "purple")
+    img = Image.new("RGB", (64, 64), "purple")
 
     if (fmt := request.param["format"]) is not None:
         buffer = io.BytesIO()
@@ -141,15 +141,15 @@ def test_image_as_file(client: WeaveClient) -> None:
         width, height = val.size
         return f"Image size: {width}x{height}"
 
-    Image.new("RGB", (100, 100), "purple").save(file_path)
+    Image.new("RGB", (64, 64), "purple").save(file_path)
     try:
         res = accept_image_jpg_pillow(return_image_jpg_pillow(file_path))
-        assert res == "Image size: 100x100"
+        assert res == "Image size: 64x64"
     finally:
         file_path.unlink()
 
 
-def make_random_image(image_size: tuple[int, int] = (1024, 1024)):
+def make_random_image(image_size: tuple[int, int] = (64, 64)):
     random_colour = (
         random.randint(0, 255),
         random.randint(0, 255),
@@ -161,7 +161,7 @@ def make_random_image(image_size: tuple[int, int] = (1024, 1024)):
 @pytest.fixture
 def dataset_ref(client):
     # This fixture represents a saved dataset containing images
-    N_ROWS = 50
+    N_ROWS = 5
     rows = [{"img": make_random_image()} for _ in range(N_ROWS)]
     dataset = weave.Dataset(rows=rows)
     ref = weave.publish(dataset)
@@ -205,7 +205,7 @@ async def test_many_images_will_consistently_log():
 
 
 def test_images_in_load_of_dataset(client):
-    N_ROWS = 50
+    N_ROWS = 5
     rows = [{"img": make_random_image()} for _ in range(N_ROWS)]
     dataset = weave.Dataset(rows=rows)
     ref = weave.publish(dataset)


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- reduces the sampling number of ops
- reduces image size and rows for image tests

## Testing

test!
