### PR TITLE
fix(ui): Saved Views view switch panel not refreshing

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsPage.tsx
@@ -193,7 +193,7 @@ export const CallsPage: FC<{
       onSaveNewView();
       return;
     }
-    onUpsertView(view, null, 'Successfully saved view.', false);
+    onUpsertView(view, null, 'Successfully saved view.', true);
   };
 
   const onRenameView = (newName: string) => {


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1745603003227869?thread_ts=1745595688.279219&cid=C03BSTEBD7F

When you save a view (as opposed to just renaming it) we need to refetch the latest data to make sure clicking around in the switch view gets the latest definition.
