### PR TITLE
fix(ui): don't show overview in nav sidebar twice

### DIFF
--- a/weave-js/src/components/FancyPage/useProjectSidebar.ts
+++ b/weave-js/src/components/FancyPage/useProjectSidebar.ts
@@ -139,14 +139,7 @@ export const useProjectSidebar = (
             type: 'menuPlaceholder' as const,
             isShown: isShowAll,
             key: 'moreModels',
-            menu: [
-              'jobs',
-              'automations',
-              'sweeps',
-              'reportlist',
-              'artifacts',
-              'overview',
-            ],
+            menu: ['jobs', 'automations', 'sweeps', 'reportlist', 'artifacts'],
           },
           {
             type: 'divider' as const,


### PR DESCRIPTION
## Description

In the case of an empty project or one that has both Models and Weave data we are showing the Overview page twice, once at the top of the nav bar and once in the Models overflow menu.

Before:
<img width="232" alt="Screenshot 2025-04-25 at 4 02 23 PM" src="https://github.com/user-attachments/assets/60c785a4-d7ed-49fb-a3a9-07a8b240838e" />

After:
<img width="229" alt="Screenshot 2025-04-25 at 4 02 36 PM" src="https://github.com/user-attachments/assets/682c81b4-518b-4166-ad98-9bbe6b281d4d" />
