### PR TITLE
chore(weave): Don't destroy type information when using op decorator

### DIFF
--- a/tests/integrations/bedrock/bedrock_guardrail_test.py
+++ b/tests/integrations/bedrock/bedrock_guardrail_test.py
@@ -126,7 +126,7 @@ class TestBedrockGuardrailScorer:
         mock_bedrock_client.apply_guardrail.return_value = MOCK_APPLY_GUARDRAIL_RESPONSE
 
         result = scorer.score(
-            "How should I think about retirement planning in general?"
+            output="How should I think about retirement planning in general?"
         )
 
         # Verify the result
@@ -170,7 +170,7 @@ class TestBedrockGuardrailScorer:
         )
 
         result = scorer.score(
-            "Give me specific investment advice for my retirement to generate $5,000 monthly."
+            output="Give me specific investment advice for my retirement to generate $5,000 monthly."
         )
 
         # Verify the result
@@ -202,7 +202,7 @@ class TestBedrockGuardrailScorer:
         # Configure the mock to raise an exception
         mock_bedrock_client.apply_guardrail.side_effect = Exception("Test error")
 
-        result = scorer.score("Test content")
+        result = scorer.score(output="Test content")
 
         # Verify the result
         assert result.passed is False
@@ -254,7 +254,7 @@ class TestBedrockGuardrailScorer:
         scorer._bedrock_runtime = None
 
         with pytest.raises(ValueError) as excinfo:
-            scorer.score("Test content")
+            scorer.score(output="Test content")
 
         assert "Bedrock runtime client is not initialized" in str(excinfo.value)
 
@@ -274,7 +274,7 @@ class TestBedrockGuardrailScorer:
         assert formatted["source"] == "INPUT"
 
         # Score the content and verify the client was called with source=INPUT
-        scorer.score("Test content")
+        scorer.score(output="Test content")
         call_args = mock_bedrock_client.apply_guardrail.call_args[1]
         assert call_args["source"] == "INPUT"
 
@@ -290,6 +290,6 @@ class TestBedrockGuardrailScorer:
         mock_bedrock_client.apply_guardrail.return_value = MOCK_APPLY_GUARDRAIL_RESPONSE
 
         # Score the content and verify the client was called with guardrailVersion=2
-        scorer.score("Test content")
+        scorer.score(output="Test content")
         call_args = mock_bedrock_client.apply_guardrail.call_args[1]
         assert call_args["guardrailVersion"] == "2"

--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -406,7 +406,7 @@ def test_bedrock_apply_guardrail(client: weave.trace.weave_client.WeaveClient) -
         new=mock_apply_guardrail_make_api_call,
     ):
         result = scorer.score(
-            "How should I think about retirement planning in general?"
+            output="How should I think about retirement planning in general?"
         )
 
         # Verify the result
@@ -443,7 +443,7 @@ def test_bedrock_apply_guardrail(client: weave.trace.weave_client.WeaveClient) -
         new=mock_apply_guardrail_make_api_call,
     ):
         result = scorer.score(
-            "Give me specific investment advice for my retirement to generate $5,000 monthly."
+            output="Give me specific investment advice for my retirement to generate $5,000 monthly."
         )
 
         # Verify the result shows intervention

--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, get_type_hints
+from typing import Any, Optional, get_type_hints
 
 import pytest
 
@@ -427,7 +427,7 @@ def test_op_preserves_type_information():
     def typed_func(
         a: int,
         b: str,
-        c: float | None,
+        c: Optional[float],
         d: list[int],
         e: dict[str, float],
         f: tuple[str, int],

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -137,7 +137,7 @@ class Evaluation(Object):
         if self.name is None and self.dataset.name is not None:
             self.name = self.dataset.name + "-evaluation"  # type: ignore
 
-    @weave.op()
+    @weave.op
     async def predict_and_score(self, model: Union[Op, Model], example: dict) -> dict:
         apply_model_result = await apply_model_async(
             model, example, self.preprocess_model_input

--- a/weave/scorers/bedrock_guardrails.py
+++ b/weave/scorers/bedrock_guardrails.py
@@ -60,7 +60,7 @@ class BedrockGuardrailScorer(weave.Scorer):
         return {"source": self.source, "content": [{"text": {"text": output}}]}
 
     @weave.op
-    def score(self, output: str) -> WeaveScorerResult:
+    def score(self, *, output: str, **kwargs: Any) -> WeaveScorerResult:
         if self._bedrock_runtime is None:
             raise ValueError("Bedrock runtime client is not initialized")
 

--- a/weave/scorers/classification_scorer.py
+++ b/weave/scorers/classification_scorer.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 import weave
 from weave.flow.util import transpose
@@ -79,7 +79,9 @@ class MultiTaskBinaryClassificationF1(weave.Scorer):
     # backwards compatibility.  In the future, this behavior may change to use the newer `output` key.
     # You can still pass a `column_map` to map to the new `output` key if preferred.
     @weave.op()
-    def score(self, target: dict, model_output: Optional[dict]) -> dict:
+    def score(
+        self, *, target: dict, model_output: Optional[dict], **kwargs: Any
+    ) -> dict:
         """
         Compare target labels with model outputs to determine correctness for each class.
 

--- a/weave/scorers/coherence_scorer.py
+++ b/weave/scorers/coherence_scorer.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from pydantic import Field, validate_call
 
@@ -82,10 +82,12 @@ class WeaveCoherenceScorerV1(HuggingFacePipelineScorer):
     @weave.op
     def score(
         self,
+        *,
         query: str,
         output: str,
         chat_history: Optional[list[dict[str, str]]] = None,
         context: Optional[Union[str, list[str]]] = None,
+        **kwargs: Any,
     ) -> WeaveScorerResult:
         """
         Score the Coherence of the query and output.

--- a/weave/scorers/context_relevance_scorer.py
+++ b/weave/scorers/context_relevance_scorer.py
@@ -155,6 +155,7 @@ class WeaveContextRelevanceScorerV1(HuggingFaceScorer):
         self,
         query: str,
         output: Union[str, list[str]],  # Pass the context to the `output` parameter
+        **kwargs: Any,
     ) -> WeaveScorerResult:
         all_spans: list[dict[str, Any]] = []
         total_weighted_score = 0.0

--- a/weave/scorers/fluency_scorer.py
+++ b/weave/scorers/fluency_scorer.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import Field, validate_call
 
 import weave
@@ -55,7 +57,7 @@ class WeaveFluencyScorerV1(HuggingFacePipelineScorer):
 
     @validate_call
     @weave.op
-    def score(self, output: str) -> WeaveScorerResult:
+    def score(self, *, output: str, **kwargs: Any) -> WeaveScorerResult:
         assert self._pipeline is not None
         pipeline_output = self._pipeline(output)[0]
         fluency_score = next(

--- a/weave/scorers/hallucination_scorer.py
+++ b/weave/scorers/hallucination_scorer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Any, Union
 
 from pydantic import BaseModel, Field, PrivateAttr, validate_call
 
@@ -148,7 +148,7 @@ class HallucinationFreeScorer(LLMScorer):
     )
 
     @weave.op
-    async def score(self, output: str, context: str) -> dict:
+    async def score(self, *, output: str, context: str, **kwargs: Any) -> dict:
         output = stringify(output)
         response = await self._acompletion(
             messages=[
@@ -279,7 +279,12 @@ class WeaveHallucinationScorerV1(HuggingFacePipelineScorer):
     @validate_call
     @weave.op
     def score(
-        self, query: str, context: Union[str, list[str]], output: str
+        self,
+        *,
+        query: str,
+        context: Union[str, list[str]],
+        output: str,
+        **kwargs: Any,
     ) -> WeaveScorerResult:
         """
         Score the hallucination of the query and context.

--- a/weave/scorers/json_scorer.py
+++ b/weave/scorers/json_scorer.py
@@ -8,7 +8,7 @@ class ValidJSONScorer(weave.Scorer):
     """Validate whether a string is valid JSON."""
 
     @weave.op
-    def score(self, output: Any) -> dict:
+    def score(self, *, output: Any, **kwargs: Any) -> dict:
         try:
             _ = json.loads(output)
         except json.JSONDecodeError:

--- a/weave/scorers/moderation_scorer.py
+++ b/weave/scorers/moderation_scorer.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from pydantic import Field, PrivateAttr, validate_call
 
@@ -31,7 +31,7 @@ class OpenAIModerationScorer(LLMScorer):
     )
 
     @weave.op
-    async def score(self, output: str) -> dict:
+    async def score(self, *, output: str, **kwargs: Any) -> dict:
         """
         Score the given text against the OpenAI moderation API.
 
@@ -156,7 +156,7 @@ class WeaveToxicityScorerV1(RollingWindowScorer):
 
     @validate_call
     @weave.op
-    def score(self, output: str) -> WeaveScorerResult:
+    def score(self, *, output: str, **kwargs: Any) -> WeaveScorerResult:
         passed: bool = True
         predictions: list[float] = self._predict(output)
         if (sum(predictions) >= self.total_threshold) or any(
@@ -246,7 +246,7 @@ class WeaveBiasScorerV1(RollingWindowScorer):
 
     @validate_call
     @weave.op
-    def score(self, output: str) -> WeaveScorerResult:
+    def score(self, *, output: str, **kwargs: Any) -> WeaveScorerResult:
         """
         Score the output.
 

--- a/weave/scorers/presidio_guardrail.py
+++ b/weave/scorers/presidio_guardrail.py
@@ -136,7 +136,7 @@ class PresidioScorer(weave.Scorer):
 
     @weave.op
     def score(
-        self, output: str, entities: Optional[list[str]] = None
+        self, *, output: str, entities: Optional[list[str]] = None, **kwargs: Any
     ) -> WeaveScorerResult:
         if self._analyzer is None:
             raise ValueError("Analyzer is not initialized")

--- a/weave/scorers/prompt_injection_guardrail.py
+++ b/weave/scorers/prompt_injection_guardrail.py
@@ -58,7 +58,7 @@ class PromptInjectionLLMGuardrail(LLMScorer):
             )
 
     @weave.op
-    async def score(self, output: str) -> WeaveScorerResult:
+    async def score(self, *, output: str, **kwargs: Any) -> WeaveScorerResult:
         user_prompt = PROMPT_INJECTION_GUARDRAIL_USER_PROMPT.format(
             research_paper_summary=PROMPT_INJECTION_SURVEY_PAPER_SUMMARY,
             prompt=output,

--- a/weave/scorers/pydantic_scorer.py
+++ b/weave/scorers/pydantic_scorer.py
@@ -11,7 +11,7 @@ class PydanticScorer(weave.Scorer):
     model: type[BaseModel]
 
     @weave.op
-    def score(self, output: Any) -> dict:
+    def score(self, *, output: Any, **kwargs: Any) -> dict:
         if isinstance(output, str):
             try:
                 self.model.model_validate_json(output)

--- a/weave/scorers/ragas_scorer.py
+++ b/weave/scorers/ragas_scorer.py
@@ -1,6 +1,7 @@
 # implementing metrics from ragas: https://github.com/explodinggradients/ragas
 
 from textwrap import dedent
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -72,7 +73,7 @@ class ContextEntityRecallScorer(LLMScorer):
         return entities
 
     @weave.op
-    async def score(self, output: str, context: str) -> dict:
+    async def score(self, *, output: str, context: str, **kwargs: Any) -> dict:
         expected_entities = await self._extract_entities(output)
         context_entities = await self._extract_entities(context)
         # Calculate recall
@@ -134,7 +135,7 @@ class ContextRelevancyScorer(LLMScorer):
     )
 
     @weave.op
-    async def score(self, output: str, context: str) -> dict:
+    async def score(self, *, output: str, context: str, **kwargs: Any) -> dict:
         prompt = self.relevancy_prompt.format(question=output, context=context)
         response = await self._acompletion(
             messages=[{"role": "user", "content": prompt}],

--- a/weave/scorers/similarity_scorer.py
+++ b/weave/scorers/similarity_scorer.py
@@ -28,7 +28,7 @@ class EmbeddingSimilarityScorer(LLMScorer):
     threshold: float = Field(0.5, description="The threshold for the similarity score")
 
     @weave.op
-    async def score(self, output: str, target: str) -> Any:
+    async def score(self, *, output: str, target: str, **kwargs: Any) -> Any:
         # Ensure the threshold is within the valid range for cosine similarity.
         assert (
             self.threshold >= -1 and self.threshold <= 1

--- a/weave/scorers/string_scorer.py
+++ b/weave/scorers/string_scorer.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Any, Callable
 
 from pydantic import Field, model_validator
 
@@ -9,7 +9,7 @@ class StringMatchScorer(weave.Scorer):
     """Scorer that checks if the model output string is found in the search columns of the dataset row."""
 
     @weave.op
-    def score(self, output: str, target: str) -> dict:
+    def score(self, *, output: str, target: str, **kwargs: Any) -> dict:
         string_in_input = output.lower() in target.lower()
         return {"string_in_input": string_in_input}
 
@@ -33,6 +33,6 @@ class LevenshteinScorer(weave.Scorer):
             return self
 
     @weave.op
-    def score(self, output: str, target: str) -> dict:
+    def score(self, *, output: str, target: str, **kwargs: Any) -> dict:
         distance = self.distance(output, target)
         return {"levenshtein_distance": distance}

--- a/weave/scorers/summarization_scorer.py
+++ b/weave/scorers/summarization_scorer.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -170,7 +170,7 @@ class SummarizationScorer(LLMScorer):
         return text.split()
 
     @weave.op
-    async def score(self, input: str, output: str) -> dict:
+    async def score(self, *, input: str, output: str, **kwargs: Any) -> dict:
         """
         Evaluate a summary by combining entity density and LLM quality evaluation.
 

--- a/weave/scorers/trust_scorer.py
+++ b/weave/scorers/trust_scorer.py
@@ -358,9 +358,11 @@ class WeaveTrustScorerV1(weave.Scorer):
     @weave.op
     def score(
         self,
+        *,
         query: str,
         context: Union[str, list[str]],
         output: str,  # Pass the output of a LLM to this parameter for example
+        **kwargs: Any,
     ) -> WeaveScorerResult:
         """
         Score the query, context and output against 5 different scorers.

--- a/weave/scorers/xml_scorer.py
+++ b/weave/scorers/xml_scorer.py
@@ -1,5 +1,5 @@
 import xml.etree.ElementTree as ET
-from typing import Union
+from typing import Any, Union
 
 import weave
 
@@ -8,7 +8,7 @@ class ValidXMLScorer(weave.Scorer):
     """Score an XML string."""
 
     @weave.op
-    def score(self, output: Union[str, dict]) -> dict:
+    def score(self, *, output: Union[str, dict], **kwargs: Any) -> dict:
         if isinstance(output, dict):
             xml_string = output.get("output", "")
         else:

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -197,7 +197,12 @@ class Op(Protocol[P, R]):
     _set_on_finish_handler: Callable[[OnFinishHandlerType], None]
     _on_finish_handler: OnFinishHandlerType | None
 
-    __call__: Callable[..., Any]
+    # __call__: Callable[..., Any]
+    @overload
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
+    @overload
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...  # pyright: ignore[reportOverlappingOverload]
+
     __self__: Any
 
     # `_tracing_enabled` is a runtime-only flag that can be used to disable

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -51,7 +51,7 @@ except ImportError:
     OPENAI_NOT_GIVEN = None  # type: ignore
 
 try:
-    from cohere.base_client import COHERE_NOT_GIVEN
+    from cohere.base_client import COHERE_NOT_GIVEN  # type: ignore
 except ImportError:
     COHERE_NOT_GIVEN = None
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -27,10 +27,7 @@ from typing import (
     runtime_checkable,
 )
 
-if sys.version_info >= (3, 10):
-    from typing import ParamSpec
-else:
-    from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec
 
 from weave.trace import box, settings
 from weave.trace.constants import TRACE_CALL_EMOJI
@@ -51,22 +48,22 @@ if TYPE_CHECKING:
 try:
     from openai._types import NOT_GIVEN as OPENAI_NOT_GIVEN
 except ImportError:
-    OPENAI_NOT_GIVEN = object()  # Use a sentinel object instead of None
+    OPENAI_NOT_GIVEN = None  # type: ignore
 
 try:
     from cohere.base_client import COHERE_NOT_GIVEN
 except ImportError:
-    COHERE_NOT_GIVEN = object()  # Use a sentinel object instead of None
+    COHERE_NOT_GIVEN = None
 
 try:
     from anthropic._types import NOT_GIVEN as ANTHROPIC_NOT_GIVEN
 except ImportError:
-    ANTHROPIC_NOT_GIVEN = object()  # Use a sentinel object instead of None
+    ANTHROPIC_NOT_GIVEN = None
 
 try:
     from cerebras.cloud.sdk._types import NOT_GIVEN as CEREBRAS_NOT_GIVEN
 except ImportError:
-    CEREBRAS_NOT_GIVEN = object()  # Use a sentinel object instead of None
+    CEREBRAS_NOT_GIVEN = None
 
 
 S = TypeVar("S")

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -27,6 +27,12 @@ from typing import (
     runtime_checkable,
 )
 
+# Add ParamSpec import
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
 from weave.trace import box, settings
 from weave.trace.constants import TRACE_CALL_EMOJI
 from weave.trace.context import call_context
@@ -66,6 +72,10 @@ except ImportError:
 
 S = TypeVar("S")
 V = TypeVar("V")
+
+# Define TypeVars for function signatures
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 if sys.version_info < (3, 10):
@@ -154,7 +164,7 @@ class WeaveKwargs(TypedDict):
 
 
 @runtime_checkable
-class Op(Protocol):
+class Op(Protocol[P, R]):
     """
     The interface for Op-ified functions and methods.
 
@@ -174,7 +184,7 @@ class Op(Protocol):
     name: str
     call_display_name: str | Callable[[Call], str]
     ref: ObjectRef | None
-    resolve_fn: Callable
+    resolve_fn: Callable[P, R]
 
     postprocess_inputs: Callable[[dict[str, Any]], dict[str, Any]] | None
     postprocess_output: Callable[..., Any] | None
@@ -192,7 +202,8 @@ class Op(Protocol):
     _set_on_finish_handler: Callable[[OnFinishHandlerType], None]
     _on_finish_handler: OnFinishHandlerType | None
 
-    __call__: Callable[..., Any]
+    # The critical field that preserves the callable signature
+    __call__: Callable[P, R]
     __self__: Any
 
     # `_tracing_enabled` is a runtime-only flag that can be used to disable
@@ -600,13 +611,13 @@ PostprocessOutputFunc = Callable[..., Any]
 
 @overload
 def op(
-    func: Callable,
+    func: Callable[P, R],
     *,
     name: str | None = None,
     call_display_name: str | CallDisplayNameFunc | None = None,
     postprocess_inputs: PostprocessInputsFunc | None = None,
     postprocess_output: PostprocessOutputFunc | None = None,
-) -> Op: ...
+) -> Op[P, R]: ...
 
 
 @overload
@@ -616,7 +627,7 @@ def op(
     call_display_name: str | CallDisplayNameFunc | None = None,
     postprocess_inputs: PostprocessInputsFunc | None = None,
     postprocess_output: PostprocessOutputFunc | None = None,
-) -> Callable[[Callable], Op]: ...
+) -> Callable[[Callable[P, R]], Op[P, R]]: ...
 
 
 @overload
@@ -624,11 +635,11 @@ def op(
     *,
     name: str | None = None,
     enable_code_capture: bool = True,
-) -> Callable[[Callable], Op]: ...
+) -> Callable[[Callable[P, R]], Op[P, R]]: ...
 
 
 def op(
-    func: Callable | None = None,
+    func: Callable[P, R] | None = None,
     *,
     name: str | None = None,
     call_display_name: str | CallDisplayNameFunc | None = None,
@@ -636,7 +647,7 @@ def op(
     postprocess_output: PostprocessOutputFunc | None = None,
     tracing_sample_rate: float = 1.0,
     enable_code_capture: bool = True,
-) -> Callable[[Callable], Op] | Op:
+) -> Callable[[Callable[P, R]], Op[P, R]] | Op[P, R]:
     """
     A decorator to weave op-ify a function or method. Works for both sync and async.
     Automatically detects iterator functions and applies appropriate behavior.
@@ -646,7 +657,7 @@ def op(
     if not 0 <= tracing_sample_rate <= 1:
         raise ValueError("tracing_sample_rate must be between 0 and 1")
 
-    def op_deco(func: Callable) -> Op:
+    def op_deco(func: Callable[P, R]) -> Op[P, R]:
         # Check function type
         is_method = _is_unbound_method(func)
         is_async = inspect.iscoroutinefunction(func)
@@ -654,23 +665,23 @@ def op(
         is_async_generator = inspect.isasyncgenfunction(func)
 
         # Create the appropriate wrapper based on function type
-        def create_wrapper(func: Callable) -> Op:
+        def create_wrapper(func: Callable[P, R]) -> Op[P, R]:
             if is_async:
 
                 @wraps(func)
-                async def wrapper(*args: Any, **kwargs: Any) -> Any:  # pyright: ignore[reportRedeclaration]
+                async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:  # pyright: ignore[reportRedeclaration]
                     res, _ = await _call_async_func(
                         cast(Op, wrapper), *args, __should_raise=True, **kwargs
                     )
-                    return res
+                    return cast(R, res)
             else:
 
                 @wraps(func)
-                def wrapper(*args: Any, **kwargs: Any) -> Any:
+                def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
                     res, _ = _call_sync_func(
                         cast(Op, wrapper), *args, __should_raise=True, **kwargs
                     )
-                    return res
+                    return cast(R, res)
 
             # Tack these helpers on to our wrapper
             wrapper.resolve_fn = func  # type: ignore
@@ -722,7 +733,7 @@ def op(
             wrapper._is_generator = is_generator  # type: ignore
             wrapper._is_async_generator = is_async_generator  # type: ignore
 
-            return cast(Op, wrapper)
+            return cast(Op[P, R], wrapper)
 
         # Create the wrapper
         return create_wrapper(func)
@@ -779,13 +790,17 @@ def maybe_unbind_method(oplike: Op | MethodType | partial) -> Op:
 
 
 def is_op(obj: Any) -> bool:
+    """Check if an object is an Op.
+
+    Works with both old-style Op instances and new-style generic Ops.
+    """
     if sys.version_info < (3, 12):
         return isinstance(obj, Op)
 
     return all(hasattr(obj, attr) for attr in Op.__annotations__)
 
 
-def as_op(fn: Callable) -> Op:
+def as_op(fn: Callable[P, R]) -> Op[P, R]:
     """Given a @weave.op() decorated function, return its Op.
 
     @weave.op() decorated functions are instances of Op already, so this
@@ -803,7 +818,7 @@ def as_op(fn: Callable) -> Op:
 
     # The unbinding is necessary for methods because `MethodType` is applied after the
     # func is decorated into an Op.
-    return maybe_unbind_method(cast(Op, fn))
+    return cast(Op[P, R], maybe_unbind_method(cast(Op, fn)))
 
 
 _OnYieldType = Callable[[V], None]

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -784,10 +784,7 @@ def maybe_unbind_method(oplike: Op | MethodType | partial) -> Op:
 
 
 def is_op(obj: Any) -> bool:
-    """Check if an object is an Op.
-
-    Works with both old-style Op instances and new-style generic Ops.
-    """
+    """Check if an object is an Op."""
     if sys.version_info < (3, 12):
         return isinstance(obj, Op)
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -48,10 +48,10 @@ if TYPE_CHECKING:
 try:
     from openai._types import NOT_GIVEN as OPENAI_NOT_GIVEN
 except ImportError:
-    OPENAI_NOT_GIVEN = None  # type: ignore
+    OPENAI_NOT_GIVEN = None
 
 try:
-    from cohere.base_client import COHERE_NOT_GIVEN  # type: ignore
+    from cohere.base_client import COHERE_NOT_GIVEN
 except ImportError:
     COHERE_NOT_GIVEN = None
 

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -27,7 +27,6 @@ from typing import (
     runtime_checkable,
 )
 
-# Add ParamSpec import
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
 else:
@@ -52,28 +51,27 @@ if TYPE_CHECKING:
 try:
     from openai._types import NOT_GIVEN as OPENAI_NOT_GIVEN
 except ImportError:
-    OPENAI_NOT_GIVEN = None
+    OPENAI_NOT_GIVEN = object()  # Use a sentinel object instead of None
 
 try:
     from cohere.base_client import COHERE_NOT_GIVEN
 except ImportError:
-    COHERE_NOT_GIVEN = None
+    COHERE_NOT_GIVEN = object()  # Use a sentinel object instead of None
 
 try:
     from anthropic._types import NOT_GIVEN as ANTHROPIC_NOT_GIVEN
 except ImportError:
-    ANTHROPIC_NOT_GIVEN = None
+    ANTHROPIC_NOT_GIVEN = object()  # Use a sentinel object instead of None
 
 try:
     from cerebras.cloud.sdk._types import NOT_GIVEN as CEREBRAS_NOT_GIVEN
 except ImportError:
-    CEREBRAS_NOT_GIVEN = None
+    CEREBRAS_NOT_GIVEN = object()  # Use a sentinel object instead of None
 
 
 S = TypeVar("S")
 V = TypeVar("V")
 
-# Define TypeVars for function signatures
 P = ParamSpec("P")
 R = TypeVar("R")
 
@@ -202,8 +200,7 @@ class Op(Protocol[P, R]):
     _set_on_finish_handler: Callable[[OnFinishHandlerType], None]
     _on_finish_handler: OnFinishHandlerType | None
 
-    # The critical field that preserves the callable signature
-    __call__: Callable[P, R]
+    __call__: Callable[..., Any]
     __self__: Any
 
     # `_tracing_enabled` is a runtime-only flag that can be used to disable


### PR DESCRIPTION
This adds better type hinting support for editors.

Resolves:
- https://github.com/wandb/weave/issues/3423
- https://github.com/wandb/weave/issues/3494

Before:
![image](https://github.com/user-attachments/assets/8770d1aa-6be2-48f5-b35d-a7f02f454379)

After:
![image](https://github.com/user-attachments/assets/d294f320-7e3e-4de6-9eb3-99caedf3281d)
![image](https://github.com/user-attachments/assets/37a24e0b-e28b-4dc9-9aee-54930ca8e467)
