### PR TITLE
chore(weave): Don't destroy type information for methods when using op decorator

### DIFF
--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -453,3 +453,22 @@ def test_op_preserves_type_information():
     }
     # Check that the function can be called with the correct types
     assert typed_func(**values) == decorated_func(**values) == values
+
+
+def test_op_preserves_type_information_method():
+    class A:
+        def method(self, a: int, b: str) -> dict[str, Any]:
+            return {"a": a, "b": b}
+
+        @op
+        def method_op(self, a: int, b: str) -> dict[str, Any]:
+            return {"a": a, "b": b}
+
+    assert get_type_hints(A.method) == get_type_hints(A.method_op)
+    assert inspect.signature(A.method) == inspect.signature(A.method_op)
+
+    a = A()
+
+    values = {"a": 1, "b": "hello"}
+    # Check that the function can be called with the correct types
+    assert a.method(**values) == a.method_op(**values) == values

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -199,6 +199,8 @@ class Op(Protocol[P, R]):
 
     # __call__: Callable[..., Any]
     @overload
+    def __call__(*args: P.args, **kwargs: P.kwargs) -> R: ...
+    @overload
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
     @overload
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...  # pyright: ignore[reportOverlappingOverload]


### PR DESCRIPTION
- **test**
- **test**
