### PR TITLE
fix(weave): Resolve datetime import conflict causing Pydantic error

### DIFF
--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
 import atexit
+import datetime
 import logging
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from datetime import datetime
 from types import MethodType
 from typing import Annotated, Any, TypeVar, Union, cast
 
-from pydantic import (
-    BaseModel,
-    BeforeValidator,
-    ConfigDict,
-    Field,
-    PrivateAttr,
-    validate_call,
-)
+from pydantic import (BaseModel, BeforeValidator, ConfigDict, Field,
+                      PrivateAttr, validate_call)
 
 import weave
 from weave.flow.dataset import Dataset
@@ -149,7 +143,7 @@ def _cast_to_imperative_dataset(value: Dataset | list[dict] | str) -> Dataset:
 
 
 def _default_dataset_name() -> str:
-    date = datetime.now().strftime("%Y-%m-%d")
+    date = datetime.datetime.now().strftime("%Y-%m-%d")
     unique_name = make_memorable_name()
     return f"{date}-{unique_name}-dataset"
 

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -9,8 +9,14 @@ from contextvars import ContextVar
 from types import MethodType
 from typing import Annotated, Any, TypeVar, Union, cast
 
-from pydantic import (BaseModel, BeforeValidator, ConfigDict, Field,
-                      PrivateAttr, validate_call)
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    validate_call,
+)
 
 import weave
 from weave.flow.dataset import Dataset


### PR DESCRIPTION
In `weave/flow/eval_imperative.py`, the use of `from datetime import datetime` (implicitly via `datetime.datetime.now()` in `_default_dataset_name`) caused the name `datetime` in the module scope to refer to the `datetime.datetime` class instead of the `datetime` module.

This led to an `AttributeError: type object 'datetime.datetime' has no attribute 'datetime'` when Pydantic attempted to parse the `ScoreLogger` model, specifically when resolving type annotations potentially involving the `datetime` module (likely within the `Call` type or its dependencies).



## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes #4307 

What does the PR do? Include a concise description of the PR contents.

This commit changes the import to `import datetime` at the top level and updates the usage in `_default_dataset_name` to `datetime.datetime.now()` to ensure `datetime` consistently refers to the module, resolving the Pydantic type resolution error.

## Testing

How was this PR tested?

Y