### PR TITLE
feat(weave): display trace size from the entire project

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -130,6 +130,7 @@ export type TraceCallsQueryStatsReq = {
 
 export type TraceCallsQueryStatsRes = {
   count: number;
+  total_storage_size_bytes?: number;
 };
 
 export type TraceCallsDeleteReq = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -495,7 +495,11 @@ const useCallsStats = (
   filter: CallFilter,
   query?: Query,
   limit?: number,
-  opts?: {skip?: boolean; refetchOnDelete?: boolean}
+  opts?: {
+    skip?: boolean;
+    refetchOnDelete?: boolean;
+    includeTotalStorageSize?: boolean;
+  }
 ): Loadable<traceServerTypes.TraceCallsQueryStatsRes> & Refetchable => {
   const getTsClient = useGetTraceServerClientContext();
   const loadingRef = useRef(false);
@@ -528,6 +532,9 @@ const useCallsStats = (
       },
       query,
       limit,
+      ...(!!opts?.includeTotalStorageSize
+        ? {include_total_storage_size: true}
+        : null),
     };
 
     getTsClient()
@@ -540,7 +547,16 @@ const useCallsStats = (
         loadingRef.current = false;
         setCallStatsRes({loading: false, result: null, error: err});
       });
-  }, [deepFilter, entity, project, query, limit, opts?.skip, getTsClient]);
+  }, [
+    opts?.skip,
+    opts?.includeTotalStorageSize,
+    entity,
+    project,
+    deepFilter,
+    query,
+    limit,
+    getTsClient,
+  ]);
 
   useEffect(() => {
     doFetch();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -202,7 +202,11 @@ export type WFDataModelHooksInterface = {
     filter: CallFilter,
     query?: Query,
     limit?: number,
-    opts?: {skip?: boolean; refetchOnDelete?: boolean}
+    opts?: {
+      skip?: boolean;
+      refetchOnDelete?: boolean;
+      includeTotalStorageSize?: boolean;
+    }
   ) => Loadable<traceServerClientTypes.TraceCallsQueryStatsRes> & Refetchable;
   useCallsDeleteFunc: () => (
     entity: string,


### PR DESCRIPTION
## Description

- Adds support for retrieving and displaying total storage size of all trace calls of a project
- Extends `TraceCallsQueryStatsRes` type to include optional `total_storage_size_bytes` field
- Adds `includeTotalStorageSize` option to `useCallsStats` hook to request storage size information
- In order to see the entire picture, please review the entire stack of PRs as suggested by Graphite comment below.

- The UI is surfaced up by this PR https://github.com/wandb/core/pull/29078

## Testing

Tested by verifying that the trace server client correctly requests and receives the total storage size when the new option is enabled, and that the UI components correctly display this information when available.