### PR TITLE
feat(weave): backend for getting all file size for a project

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -47,6 +47,7 @@ from weave.trace_server.sqlite_trace_server import (
 from weave.trace_server.trace_server_interface import (
     FileContentReadReq,
     FileCreateReq,
+    FilesStatsReq,
     RefsReadBatchReq,
     TableCreateReq,
     TableQueryReq,
@@ -3416,3 +3417,16 @@ def test_filter_calls_by_ref(client):
     # this as "no filter"
     calls = client.get_calls(filter={"input_refs": [], "output_refs": []})
     assert len(calls) == 1
+
+
+def test_files_stats(client):
+    if client_is_sqlite(client):
+        pytest.skip("Not implemented in SQLite")
+
+    f_bytes = b"0" * 10000005
+    client.server.file_create(
+        FileCreateReq(project_id="shawn/test-project", name="my-file", content=f_bytes)
+    )
+    read_res = client.server.files_stats(FilesStatsReq(project_id="shawn/test-project"))
+
+    assert read_res.total_size_bytes == 10000005

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -130,6 +130,7 @@ export type TraceCallsQueryStatsReq = {
 
 export type TraceCallsQueryStatsRes = {
   count: number;
+  total_storage_size_bytes?: number;
 };
 
 export type TraceCallsDeleteReq = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -495,7 +495,11 @@ const useCallsStats = (
   filter: CallFilter,
   query?: Query,
   limit?: number,
-  opts?: {skip?: boolean; refetchOnDelete?: boolean}
+  opts?: {
+    skip?: boolean;
+    refetchOnDelete?: boolean;
+    includeTotalStorageSize?: boolean;
+  }
 ): Loadable<traceServerTypes.TraceCallsQueryStatsRes> & Refetchable => {
   const getTsClient = useGetTraceServerClientContext();
   const loadingRef = useRef(false);
@@ -528,6 +532,9 @@ const useCallsStats = (
       },
       query,
       limit,
+      ...(!!opts?.includeTotalStorageSize
+        ? {include_total_storage_size: true}
+        : null),
     };
 
     getTsClient()
@@ -540,7 +547,16 @@ const useCallsStats = (
         loadingRef.current = false;
         setCallStatsRes({loading: false, result: null, error: err});
       });
-  }, [deepFilter, entity, project, query, limit, opts?.skip, getTsClient]);
+  }, [
+    opts?.skip,
+    opts?.includeTotalStorageSize,
+    entity,
+    project,
+    deepFilter,
+    query,
+    limit,
+    getTsClient,
+  ]);
 
   useEffect(() => {
     doFetch();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -202,7 +202,11 @@ export type WFDataModelHooksInterface = {
     filter: CallFilter,
     query?: Query,
     limit?: number,
-    opts?: {skip?: boolean; refetchOnDelete?: boolean}
+    opts?: {
+      skip?: boolean;
+      refetchOnDelete?: boolean;
+      includeTotalStorageSize?: boolean;
+    }
   ) => Loadable<traceServerClientTypes.TraceCallsQueryStatsRes> & Refetchable;
   useCallsDeleteFunc: () => (
     entity: string,

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -313,6 +313,10 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         # Special case where refs can never be part of the request
         return self._internal_trace_server.file_content_read(req)
 
+    def files_stats(self, req: tsi.FilesStatsReq) -> tsi.FilesStatsRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.files_stats, req)
+
     def feedback_create(self, req: tsi.FeedbackCreateReq) -> tsi.FeedbackCreateRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         original_user_id = req.wb_user_id

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1379,6 +1379,10 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             raise NotFoundError(f"File {req.digest} not found")
         return tsi.FileContentReadRes(content=query_result[0])
 
+    def files_stats(self, req: tsi.FilesStatsReq) -> tsi.FilesStatsRes:
+        print("files_stats is not implemented for SQLite trace server", req)
+        return tsi.FilesStatsRes(total_size_bytes=-1)
+
     def cost_create(self, req: tsi.CostCreateReq) -> tsi.CostCreateRes:
         print("COST CREATE is not implemented for local sqlite", req)
         return tsi.CostCreateRes()

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -898,8 +898,16 @@ class FileContentReadReq(BaseModel):
     digest: str
 
 
+class FilesStatsReq(BaseModel):
+    project_id: str
+
+
 class FileContentReadRes(BaseModel):
     content: bytes
+
+
+class FilesStatsRes(BaseModel):
+    total_size_bytes: int
 
 
 class EnsureProjectExistsRes(BaseModel):
@@ -1051,6 +1059,7 @@ class TraceServerInterface(Protocol):
     # File API
     def file_create(self, req: FileCreateReq) -> FileCreateRes: ...
     def file_content_read(self, req: FileContentReadReq) -> FileContentReadRes: ...
+    def files_stats(self, req: FilesStatsReq) -> FilesStatsRes: ...
 
     # Feedback API
     def feedback_create(self, req: FeedbackCreateReq) -> FeedbackCreateRes: ...

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -356,6 +356,13 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
             lambda content: tsi.FileContentReadRes(content=content),
         )
 
+    def files_stats(self, req: tsi.FilesStatsReq) -> tsi.FilesStatsRes:
+        return self._with_cache_pydantic(
+            self._next_trace_server.files_stats,
+            req,
+            tsi.FilesStatsRes,
+        )
+
     # Remaining Un-cacheable Methods:
 
     # Call API

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -495,6 +495,11 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         bytes.seek(0)
         return tsi.FileContentReadRes(content=bytes.read())
 
+    def files_stats(self, req: tsi.FilesStatsReq) -> tsi.FilesStatsRes:
+        return self._generic_request(
+            "/files/stats", req, tsi.FilesStatsReq, tsi.FilesStatsRes
+        )
+
     def feedback_create(
         self, req: Union[tsi.FeedbackCreateReq, dict[str, Any]]
     ) -> tsi.FeedbackCreateRes:


### PR DESCRIPTION
## Description

- Adds a new `files_stats` API endpoint to the trace server interface
- Implements the endpoint in the ClickHouse trace server to return total file size statistics
- Adds appropriate adapter implementations in middleware servers
- Includes a test case to verify functionality

The new endpoint allows clients to query for aggregate statistics about files in a project, specifically the total size in bytes of all files.

- In order to see the entire picture, please review the entire stack of PRs as suggested by Graphite comment below.

- There is also a server endpoint change snippet here: https://github.com/wandb/core/pull/29079

## Testing

Added a test case that creates a file of known size and verifies the `files_stats` endpoint returns the correct total size.