### PR TITLE
chore(weave): Revert "chore weave: Revert two fixes for when cost query returned n…

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -65,7 +65,14 @@ export const CallPage: FC<CallPageProps> = props => {
       project: props.project,
       callId: descendentCallId,
     },
-    {includeCosts: true, includeTotalStorageSize: true}
+    {
+      // Sadly we cannot include costs as unfinished calls will result
+      // in null response (bug on server side). As a result, the summary
+      // will not show costs. FIXME (This results in a second query in
+      // CallSummary.tsx)
+      // includeCosts: true,
+      includeTotalStorageSize: true,
+    }
   );
 
   // This is a little hack, but acceptable for now.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallSummary.tsx
@@ -9,6 +9,7 @@ import {Timestamp} from '../../../../../Timestamp';
 import {UserLink} from '../../../../../UserLink';
 import {SmallRef} from '../../smallRef/SmallRef';
 import {SimpleKeyValueTable} from '../common/SimplePageLayout';
+import {useWFHooks} from '../wfReactInterface/context';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
 import {CostTable} from './cost';
 import {ObjectViewerSection} from './ObjectViewerSection';
@@ -36,6 +37,7 @@ const StorageSizeDisplay: React.FC<{
 export const CallSummary: React.FC<{
   call: CallSchema;
 }> = ({call}) => {
+  const {useCall} = useWFHooks();
   const span = call.rawSpan;
   // Process attributes, only filtering out null values and keys starting with '_'
   const attributes = _.fromPairs(
@@ -53,8 +55,23 @@ export const CallSummary: React.FC<{
     )
   );
 
-  // Extract the costs from the trace call
-  const costData = call.traceCall?.summary?.weave?.costs;
+  // TODO: Once the server responds with costs even for unfinished calls,
+  // we can remove this second call. See the comment in CallPage.tsx.
+  // with `(This results in a second query in CallSummary.tsx)`
+  const callWithCosts = useCall(
+    {
+      entity: call.entity,
+      project: call.project,
+      callId: call.callId,
+    },
+    {
+      includeCosts: true,
+    }
+  );
+
+  const costData = useMemo(() => {
+    return callWithCosts.result?.traceCall?.summary?.weave?.costs;
+  }, [callWithCosts.result]);
 
   const storageSizeBytesRow = useMemo(() => {
     const size =

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooksTraces.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooksTraces.ts
@@ -27,33 +27,35 @@ export const useBareTraceCalls = (
       try {
         const client = getClient();
         const resProm = fetchBareTraceCalls(client, entity, project, traceId);
-        const resWithCostsProm = fetchBareTraceCallsWithCosts(
-          client,
-          entity,
-          project,
-          traceId
-        );
-
-        let firstDone = false;
-
-        // Create a race between the two promises
-        Promise.race([resProm, resWithCostsProm]).then(firstResult => {
-          // Only use result if nothing else has completed and component is mounted
-          if (!firstDone && mounted) {
-            firstDone = true;
-            setTraceCalls(firstResult);
-            setLoading(false);
-            setError(null);
-          }
-        });
-
-        // Always wait for costs version to complete
-        resWithCostsProm.then(withCostsResult => {
+        // The backend has a bug where calls that are unfinished do not return at all
+        // when requesting costs. Therefore, we have to do a second fetch to get costs
+        // and zip the results together - BAD!. FIXME.
+        resProm.then(res => {
           if (mounted) {
-            firstDone = true;
-            setTraceCalls(withCostsResult);
+            setTraceCalls(res);
             setLoading(false);
             setError(null);
+            const resWithCostsProm = fetchBareTraceCallsWithCosts(
+              client,
+              entity,
+              project,
+              traceId
+            );
+            resWithCostsProm.then(resWithCosts => {
+              if (mounted) {
+                setTraceCalls(currCalls => {
+                  // First, make a map of the calls with cost by id:
+                  const callsWithCosts = new Map<string, TraceCallSchema>();
+                  resWithCosts.forEach(call => {
+                    callsWithCosts.set(call.id, call);
+                  });
+                  // Then, update the calls in the current list with the costs:
+                  return currCalls.map(call => {
+                    return callsWithCosts.get(call.id) ?? call;
+                  });
+                });
+              }
+            });
           }
         });
       } catch (err) {


### PR DESCRIPTION
…ulls for unfinished calls (#4232)"

This reverts commit 6336dbe54c1aaca305ab5eee50b61f9e13309593.

## Description
Cost query is broken returning nulls, my last fix did not fully patch it in all cases

temporarily add the cost query hacks back in while trying to fix again

## Testing

How was this PR tested?
