### PR TITLE
feat(weave): backend change for including storage size in the stats query

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -55,6 +55,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     OrderField,
     QueryBuilderDynamicField,
     QueryBuilderField,
+    build_calls_query_stats_query,
     combine_conditions,
     optimized_project_contains_call_query,
 )
@@ -347,29 +348,37 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         """Returns a stats object for the given query. This is useful for counts or other
         aggregate statistics that are not directly queryable from the calls themselves.
         """
-        cq = CallsQuery(project_id=req.project_id)
-
-        cq.add_field("id")
-        if req.filter is not None:
-            cq.set_hardcoded_filter(HardCodedFilter(filter=req.filter))
-        if req.query is not None:
-            cq.add_condition(req.query.expr_)
-        if req.limit is not None:
-            cq.set_limit(req.limit)
-
         pb = ParamBuilder()
+
         # Special case when limit=1 and there is no filter or query,
         # construct highly optimized query that returns early
-        if req.limit == 1 and req.filter is None and req.query is None:
+        if (
+            req.limit == 1
+            and req.filter is None
+            and req.query is None
+            and not req.include_total_storage_size
+        ):
             query = optimized_project_contains_call_query(req.project_id, pb)
-        else:
-            query = f"SELECT count() FROM ({cq.as_sql(pb)})"
-        raw_res = self._query(query, pb.get_params())
-        rows = raw_res.result_rows
-        count = 0
-        if rows and len(rows) == 1 and len(rows[0]) == 1:
+            raw_res = self._query(query, pb.get_params())
+            rows = raw_res.result_rows
             count = rows[0][0]
-        return tsi.CallsQueryStatsRes(count=count)
+            return tsi.CallsQueryStatsRes(
+                count=count,
+                total_storage_size_bytes=None,
+            )
+
+        query, columns = build_calls_query_stats_query(req, pb)
+
+        raw_res = self._query(query, pb.get_params())
+
+        res_dict = (
+            dict(zip(columns, raw_res.result_rows[0])) if raw_res.result_rows else {}
+        )
+
+        return tsi.CallsQueryStatsRes(
+            count=res_dict.get("count", 0),
+            total_storage_size_bytes=res_dict.get("total_storage_size_bytes"),
+        )
 
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
         """Returns a stream of calls that match the given query."""

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -658,10 +658,16 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 filter=req.filter,
                 query=req.query,
                 limit=req.limit,
+                include_total_storage_size=req.include_total_storage_size,
             )
         ).calls
         return tsi.CallsQueryStatsRes(
             count=len(calls),
+            total_storage_size_bytes=sum(
+                call.total_storage_size_bytes
+                for call in calls
+                if call.total_storage_size_bytes is not None
+            ),
         )
 
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -419,10 +419,12 @@ class CallsQueryStatsReq(BaseModel):
     filter: Optional[CallsFilter] = None
     query: Optional[Query] = None
     limit: Optional[int] = None
+    include_total_storage_size: Optional[bool] = False
 
 
 class CallsQueryStatsRes(BaseModel):
     count: int
+    total_storage_size_bytes: Optional[int] = None
 
 
 class CallUpdateReq(BaseModel):


### PR DESCRIPTION
## Description

- Adds support for retrieving total storage size in call query statistics
- Enhances `CallsQueryStatsReq` with an optional `include_total_storage_size` parameter
- Updates `CallsQueryStatsRes` to include an optional `total_storage_size_bytes` field
- Modifies the query construction to aggregate storage size data when requested
- In order to see the entire picture, please review the entire stack of PRs as suggested by Graphite comment below.

## Testing

Added a test that:
- Creates calls with nested structure containing data
- Queries calls with the new `include_total_storage_size` flag
- Verifies the response includes the expected count and non-null storage size
- Handles ClickHouse-specific optimizations with materialized views

Also improved code formatting in an existing test by moving a multi-line assertion to a more readable format.