### PR TITLE
fix(ui): mid-word breaks in evaluation compare example section

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
@@ -1020,7 +1020,7 @@ const ICValueView: React.FC<{value: any}> = ({value}) => {
       style={{
         whiteSpace: 'pre-wrap',
         textAlign: 'left',
-        wordBreak: 'break-all',
+        overflowWrap: 'break-word',
         padding: 0,
         margin: 0,
         fontFamily: 'Inconsolata',


### PR DESCRIPTION
## Description

Fix https://wandb.atlassian.net/browse/WB-24661

Before:
<img width="553" alt="Screenshot 2025-04-28 at 2 09 16 PM" src="https://github.com/user-attachments/assets/8bdc22ea-7472-4b80-a334-1a85fc8f34ad" />

After:
<img width="562" alt="Screenshot 2025-04-28 at 2 08 41 PM" src="https://github.com/user-attachments/assets/7f0f2e32-c91e-4188-9f54-8ed663ad3f9e" />
