### PR TITLE
docs(weave): Clarify `preprocess_model_input behavior` i

### DIFF
--- a/docs/docs/guides/core-types/evaluations.md
+++ b/docs/docs/guides/core-types/evaluations.md
@@ -197,6 +197,11 @@ asyncio.run(evaluation.evaluate(function_to_evaluate))
 
 ### Using `preprocess_model_input` to format dataset rows before evaluating
 
+:::important
+The `preprocess_model_input` function is only applied to inputs before passing them to the model's prediction function.  
+Scorer functions always receive the original dataset example, without any preprocessing applied.
+:::
+
 The `preprocess_model_input` parameter allows you to transform your dataset examples before they are passed to your evaluation function. This is useful when you need to:
 
 - Rename fields to match your model's expected input

--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -354,6 +354,18 @@ For more information on how to use the `.call()` method, see the [Calling Ops](.
   </TabItem>
 </Tabs>
 
+### Use `preprocess_model_input` 
+
+You can use the `preprocess_model_input` parameter to modify dataset examples before they reach your model during evaluation. 
+
+:::important
+The `preprocess_model_input` function only transforms inputs before they are passed to the model’s prediction function.
+
+Scorer functions always receive the original dataset examples, without any preprocessing applied.
+:::
+
+For usage information and an example, see [Using `preprocess_model_input` to format dataset rows before evaluating](../core-types/evaluations.md#using-preprocess_model_input-to-format-dataset-rows-before-evaluating).
+
 ## Score Analysis
 
 In this section, we'll show you how to analyze the scores for a single call, multiple calls, and all calls scored by a specific scorer.


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1440

Clarify `preprocess_model_input behavior` in Scorers documentation

- Added a new "Use preprocess_model_input" subsection to the Scorers guide with link to example in Evaluations 
- Explained that preprocess_model_input only affects inputs passed to the model's prediction function, not scorer functions.
- In Evaluations, added an :::important callout to highlight this behavior and prevent potential confusion.

This change addresses user feedback https://github.com/wandb/weave/issues/4031

## Testing

yarn start on local
