### PR TITLE
fix(weave): fix ref filter optimization query construction

### DIFF
--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -2078,10 +2078,10 @@ def test_input_output_refs_filter():
             calls_merged.id AS id
         FROM calls_merged
         WHERE calls_merged.project_id = {pb_4:String}
-            AND ((hasAny(calls_merged.input_refs, {pb_2:Array(String)})
+            AND (((hasAny(calls_merged.input_refs, {pb_2:Array(String)})
                 OR length(calls_merged.input_refs) = 0)
             AND (hasAny(calls_merged.output_refs, {pb_3:Array(String)})
-                OR length(calls_merged.output_refs) = 0))
+                OR length(calls_merged.output_refs) = 0)))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.started_at) IS NULL))))

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1228,7 +1228,7 @@ def process_ref_filters_to_sql(
     if not ref_filters:
         return ""
 
-    return " AND " + combine_conditions(ref_filters, "AND")
+    return " AND (" + combine_conditions(ref_filters, "AND") + ")"
 
 
 def process_calls_filter_to_conditions(


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fix for a small but damaging parenthesis bug introduced in https://github.com/wandb/weave/pull/4198. Because this is implemented as a query optimization, it should not be impacting correctness, but for mega large projects is causing performance issues. 

We need to add the extra set of parentheses for when we are filtering by only one inputs/output ref set! 

[Example error](https://us5.datadoghq.com/logs?query=span_id%3A2612604084348452742&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZZ99ZZofjFJMwAAABhBWlo5OWFtZkFBQ3ZjeE4taEo3OWh3QUEAAAAkMDE5NjdkZjUtYmU1ZC00NGI3LTliOTQtOGJiOTQ4OWMyMWIxAAAifg&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1745869956939&to_ts=1745869970914&live=false)

## Testing

Fixed test
