### PR TITLE
refactor(ui): Create reusable helper for tracked loaders

### DIFF
--- a/weave-js/src/common/components/WandbLoader.tsx
+++ b/weave-js/src/common/components/WandbLoader.tsx
@@ -66,6 +66,36 @@ export const fireOnRandom = (
   }
 };
 
+const makeLoaderTracker =
+  ({
+    name,
+    profilingCb,
+    onComplete,
+    track,
+    samplingRate,
+    captureException,
+  }: TrackedWandbLoaderProps & {samplingRate: number}) =>
+  (data: ProfileData) => {
+    try {
+      // log the lifecycle for each loader to segment
+      const additionalData = profilingCb ? profilingCb() : {};
+      const trackedData = {
+        componentId: data.id,
+        duration: data.duration,
+        ...additionalData,
+      };
+      if (onComplete) {
+        onComplete(name, trackedData);
+      }
+      fireOnRandom(() => {
+        track('wandb-loader-onscreen', trackedData);
+      }, samplingRate);
+    } catch (e) {
+      // Tracking should be able to fail gracefully without breaking the app
+      captureException?.(e);
+    }
+  };
+
 export const TrackedWandbLoader = ({
   captureException,
   name,
@@ -78,26 +108,14 @@ export const TrackedWandbLoader = ({
 }: TrackedWandbLoaderProps & WandbLoaderProps) => {
   useLifecycleProfiling(
     name,
-    (data: ProfileData) => {
-      try {
-        // log the lifecycle for each loader to segment
-        const additionalData = profilingCb ? profilingCb() : {};
-        const trackedData = {
-          componentId: data.id,
-          duration: data.duration,
-          ...additionalData,
-        };
-        if (onComplete) {
-          onComplete(name, trackedData);
-        }
-        fireOnRandom(() => {
-          track('wandb-loader-onscreen', trackedData);
-        }, samplingRate);
-      } catch (e) {
-        // Tracking should be able to fail gracefully without breaking the app
-        captureException?.(e);
-      }
-    },
+    makeLoaderTracker({
+      name,
+      profilingCb,
+      onComplete,
+      track,
+      samplingRate,
+      captureException,
+    }),
     onStart
   );
 
@@ -120,26 +138,14 @@ export const TrackedWaveLoader = ({
 }) => {
   useLifecycleProfiling(
     name,
-    (data: ProfileData) => {
-      try {
-        // log the lifecycle for each loader to segment
-        const additionalData = profilingCb ? profilingCb() : {};
-        const trackedData = {
-          componentId: data.id,
-          duration: data.duration,
-          ...additionalData,
-        };
-        if (onComplete) {
-          onComplete(name, trackedData);
-        }
-        fireOnRandom(() => {
-          track('wandb-loader-onscreen', trackedData);
-        }, samplingRate);
-      } catch (e) {
-        // Tracking should be able to fail gracefully without breaking the app
-        captureException?.(e);
-      }
-    },
+    makeLoaderTracker({
+      name,
+      profilingCb,
+      onComplete,
+      track,
+      samplingRate,
+      captureException,
+    }),
     onStart
   );
 


### PR DESCRIPTION
Noticed an identical block of code between `TrackedWandbLoader` and `TrackedWaveLoader` comps. I'm about to add a third loader type so I figured I'd refactor a bit instead of copying into a third component