### PR TITLE
fix(weave): display name updates in call details page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -72,6 +72,7 @@ export const CallPage: FC<CallPageProps> = props => {
       // CallSummary.tsx)
       // includeCosts: true,
       includeTotalStorageSize: true,
+      refetchOnRename: true,
     }
   );
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -192,7 +192,7 @@ const useCall = (
   const [callRes, setCallRes] =
     useState<traceServerTypes.TraceCallReadRes | null>(null);
   const doFetch = useCallback(
-    (invalidateCache = false) => {
+    ({invalidateCache = false}: {invalidateCache?: boolean} = {}) => {
       if (deepKey) {
         if (invalidateCache) {
           callCache.del(deepKey);
@@ -218,14 +218,14 @@ const useCall = (
   );
 
   useEffect(() => {
-    doFetch(false);
+    doFetch({invalidateCache: false});
   }, [doFetch]);
 
   useEffect(() => {
     if (opts?.refetchOnRename) {
       const client = getTsClient();
       const unregisterRename = client.registerOnRenameListener(() =>
-        doFetch(true)
+        doFetch({invalidateCache: true})
       );
       return () => {
         unregisterRename();

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -172,7 +172,11 @@ export type Refetchable = {
 export type WFDataModelHooksInterface = {
   useCall: (
     key: CallKey | null,
-    opts?: {includeCosts?: boolean; includeTotalStorageSize?: boolean}
+    opts?: {
+      includeCosts?: boolean;
+      refetchOnRename?: boolean;
+      includeTotalStorageSize?: boolean;
+    }
   ) => Loadable<CallSchema | null>;
   useCalls: (
     entity: string,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24629](https://wandb.atlassian.net/browse/WB-24629)

This pr:
- adds a `refetchOnRename` opt to the `useCall` hook
- invalidates the cache to fetch the new `displayName` only on rename

## Testing

Prod:
![prod-display-name1](https://github.com/user-attachments/assets/f93f1049-3578-4554-aae6-8f464b1faaf1)

Branch:
![branch-display-name](https://github.com/user-attachments/assets/28f31ddc-bf91-4a68-9428-0d7e09d0ac4d)


[WB-24629]: https://wandb.atlassian.net/browse/WB-24629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ