### PR TITLE
fix(weave): tree navigator robust to missing parents

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/components/scrubbers.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceScrubber/components/scrubbers.ts
@@ -75,7 +75,7 @@ export const SiblingScrubber = createScrubber({
         .map(node => node.id);
     }
 
-    return traceTreeFlat[parentId].childrenIds;
+    return traceTreeFlat[parentId]?.childrenIds ?? [];
   },
 });
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/TreeView.tsx
@@ -268,7 +268,10 @@ export const FilterableTreeView: React.FC<TraceViewProps> = props => {
         if (node.parentId) {
           filteredCallIdsSet.add(node.parentId);
           if (!foundCallIds.has(node.parentId)) {
-            itemsToProcess.push(node.parentId);
+            // Check if the parent id exists before adding to the process queue
+            if (props.traceTreeFlat[node.parentId]) {
+              itemsToProcess.push(node.parentId);
+            }
           }
         }
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24729](https://wandb.atlassian.net/browse/WB-24729)

Trace tree crashes if call parents are nonexistent, probably a bigger issue but for now be more robust to errors. 

## Testing

Prod:
![Screenshot 2025-04-29 at 2 09 27 PM](https://github.com/user-attachments/assets/ea680dac-b7df-42cd-ac46-0d62cd9e5cf7)

Branch:
![Screenshot 2025-04-29 at 2 09 12 PM](https://github.com/user-attachments/assets/b7a4b45a-e44c-47b4-8558-4db5f1590161)



[WB-24729]: https://wandb.atlassian.net/browse/WB-24729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ