### PR TITLE
chore(weave): code cleanup for TS SDK test setup.

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -42,6 +42,10 @@
           "^.+\\.tsx?$": ["ts-jest", {
             "tsconfig": "<rootDir>/src/__tests__/legacy/tsconfig.json"
           }]
+        },
+        "moduleNameMapper": {
+          "^weave$": "<rootDir>/src/index.ts",
+          "^weave/(.+)$": "<rootDir>/src/$1"
         }
       },
       {
@@ -51,6 +55,10 @@
           "^.+\\.tsx?$": ["ts-jest", {
             "tsconfig": "<rootDir>/src/__tests__/modern/tsconfig.json"
           }]
+        },
+        "moduleNameMapper": {
+          "^weave$": "<rootDir>/src/index.ts",
+          "^weave/(.+)$": "<rootDir>/src/$1"
         }
       },
       {
@@ -65,8 +73,12 @@
         ],
         "transform": {
           "^.+\\.tsx?$": ["ts-jest", {
-            "tsconfig": "<rootDir>/tsconfig.json"
+            "tsconfig": "<rootDir>/src/__tests__/tsconfig.json"
           }]
+        },
+        "moduleNameMapper": {
+          "^weave$": "<rootDir>/src/index.ts",
+          "^weave/(.*)$": "<rootDir>/src/$1"
         }
       }
     ],
@@ -82,9 +94,6 @@
       "json",
       "node"
     ],
-    "moduleNameMapper": {
-      "^weave$": "<rootDir>/src/index.ts"
-    },
     "collectCoverage": true,
     "coveragePathIgnorePatterns": [
       "<rootDir>/src/generated",

--- a/sdks/node/src/__tests__/legacy/op.test.ts
+++ b/sdks/node/src/__tests__/legacy/op.test.ts
@@ -1,13 +1,22 @@
-import * as weave from '../../../src';
-import type {Op} from '../../../src/opType';
-import {getGlobalClient} from '../../../src/clientApi';
+import * as weave from 'weave';
+import {getGlobalClient} from 'weave/clientApi';
+import {Op} from 'weave/opType';
 
 // Mock the client to capture callDisplayName
 let capturedDisplayName: string | undefined;
-jest.mock('../../../src/clientApi', () => ({
+jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => ({
     pushNewCall: () => ({currentCall: {}, parentCall: null, newStack: []}),
-    createCall: (_: any, __: any, ___: any, ____: any, _____: any, ______: any, _______: any, displayName: string) => {
+    createCall: (
+      _: any,
+      __: any,
+      ___: any,
+      ____: any,
+      _____: any,
+      ______: any,
+      _______: any,
+      displayName: string
+    ) => {
       capturedDisplayName = displayName;
       return Promise.resolve();
     },
@@ -15,8 +24,8 @@ jest.mock('../../../src/clientApi', () => ({
     finishCall: () => Promise.resolve(),
     finishCallWithException: () => Promise.resolve(),
     settings: {shouldPrintCallLink: false},
-    waitForBatchProcessing: () => Promise.resolve()
-  }))
+    waitForBatchProcessing: () => Promise.resolve(),
+  })),
 }));
 
 describe('op legacy decorators', () => {
@@ -59,7 +68,7 @@ describe('op legacy decorators', () => {
 
       @weave.op({
         name: 'powerOp',
-        callDisplayName: (...args: any[]) => `Computing ${args[0]}^${args[1]}`
+        callDisplayName: (...args: any[]) => `Computing ${args[0]}^${args[1]}`,
       })
       static async power(base: number, exponent: number) {
         return Math.pow(base, exponent);
@@ -99,7 +108,7 @@ describe('op legacy decorators', () => {
       @weave.op({
         name: 'customOpName',
         callDisplayName: (...args: any[]) => `Processing: ${args[0]}`,
-        parameterNames: ['inputText']
+        parameterNames: ['inputText'],
       })
       async addPrefix(text: string) {
         return this.prefix + text;
@@ -127,10 +136,10 @@ describe('op legacy decorators', () => {
       }
 
       @weave.op({
-        name: 'multiplyAndAdd'
+        name: 'multiplyAndAdd',
       })
       async calculate(value: number, addend: number) {
-        return (value * this.multiplier) + addend;
+        return value * this.multiplier + addend;
       }
     }
 
@@ -138,4 +147,4 @@ describe('op legacy decorators', () => {
     const result = await instance.calculate(5, 3);
     expect(result).toBe(13); // (5 * 2) + 3
   });
-}); 
+});

--- a/sdks/node/src/__tests__/legacy/tsconfig.json
+++ b/sdks/node/src/__tests__/legacy/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.test.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "experimentalDecorators": true,
     "rootDir": "../../../src",

--- a/sdks/node/src/__tests__/modern/op.test.ts
+++ b/sdks/node/src/__tests__/modern/op.test.ts
@@ -1,13 +1,23 @@
-import * as weave from '../../../src';
-import type {Op, OpDecorator} from '../../../src/opType';
-import {getGlobalClient} from '../../../src/clientApi';
+import * as weave from 'weave';
+import {getGlobalClient} from 'weave/clientApi';
+import type {Op, OpDecorator} from 'weave/opType';
 
 // Mock the client to capture callDisplayName
 let capturedDisplayName: string | undefined;
-jest.mock('../../../src/clientApi', () => ({
+
+jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => ({
     pushNewCall: () => ({currentCall: {}, parentCall: null, newStack: []}),
-    createCall: (_: any, __: any, ___: any, ____: any, _____: any, ______: any, _______: any, displayName: string) => {
+    createCall: (
+      _: any,
+      __: any,
+      ___: any,
+      ____: any,
+      _____: any,
+      ______: any,
+      _______: any,
+      displayName: string
+    ) => {
       capturedDisplayName = displayName;
       return Promise.resolve();
     },
@@ -15,8 +25,8 @@ jest.mock('../../../src/clientApi', () => ({
     finishCall: () => Promise.resolve(),
     finishCallWithException: () => Promise.resolve(),
     settings: {shouldPrintCallLink: false},
-    waitForBatchProcessing: () => Promise.resolve()
-  }))
+    waitForBatchProcessing: () => Promise.resolve(),
+  })),
 }));
 
 describe('op modern decorators', () => {
@@ -54,7 +64,7 @@ describe('op modern decorators', () => {
     type PowerFn = (base: number, exponent: number) => Promise<number>;
     const customDecorator = weave.op({
       name: 'powerOp',
-      callDisplayName: (...args: any[]) => `Computing ${args[0]}^${args[1]}`
+      callDisplayName: (...args: any[]) => `Computing ${args[0]}^${args[1]}`,
     }) as unknown as OpDecorator<PowerFn>;
 
     class MathOps {
@@ -102,7 +112,7 @@ describe('op modern decorators', () => {
       @(weave.op({
         name: 'customOpName',
         callDisplayName: (...args: any[]) => `Processing: ${args[0]}`,
-        parameterNames: ['inputText']
+        parameterNames: ['inputText'],
       }) as any)
       async addPrefix(text: string): Promise<string> {
         return this.prefix + text;
@@ -133,7 +143,7 @@ describe('op modern decorators', () => {
 
   it('maintains correct this binding in decorated methods', async () => {
     type CalcFn = (value: number, addend: number) => Promise<number>;
-    
+
     class TestClass {
       private multiplier: number;
 
@@ -142,10 +152,10 @@ describe('op modern decorators', () => {
       }
 
       @(weave.op({
-        name: 'multiplyAndAdd'
+        name: 'multiplyAndAdd',
       }) as unknown as OpDecorator<CalcFn>)
       async calculate(value: number, addend: number): Promise<number> {
-        return (value * this.multiplier) + addend;
+        return value * this.multiplier + addend;
       }
     }
 
@@ -164,9 +174,12 @@ describe('op modern decorators', () => {
     }
 
     const instance = new TestClass();
-    const descriptor = Object.getOwnPropertyDescriptor(TestClass.prototype, 'method');
+    const descriptor = Object.getOwnPropertyDescriptor(
+      TestClass.prototype,
+      'method'
+    );
     expect(descriptor?.configurable).toBe(true);
     expect(descriptor?.enumerable).toBe(false);
     expect(typeof descriptor?.value).toBe('function');
   });
-}); 
+});

--- a/sdks/node/src/__tests__/modern/tsconfig.json
+++ b/sdks/node/src/__tests__/modern/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.test.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "target": "es2022",
     "experimentalDecorators": false,

--- a/sdks/node/src/__tests__/tsconfig.json
+++ b/sdks/node/src/__tests__/tsconfig.json
@@ -9,8 +9,12 @@
     "composite": true,
     "declaration": true,
     "sourceMap": true,
+    "baseUrl": ".",
+    "rootDir": "../",
     "paths": {
-      "weave": ["../../src/index.ts"]
+      "weave": ["../index.ts"],
+      "weave/*": ["../*"]
     }
-  }
+  },
+  "include": ["../**/*"]
 } 

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -8,7 +8,7 @@ export {Dataset} from './dataset';
 export {Evaluation} from './evaluation';
 export {CallSchema, CallsFilter} from './generated/traceServerApi';
 export {wrapOpenAI} from './integrations';
-export {weaveAudio, weaveImage} from './media';
+export {weaveAudio, weaveImage, WeaveAudio, WeaveImage} from './media';
 export {op} from './op';
 export * from './types';
 export {WeaveObject} from './weaveObject';

--- a/sdks/node/src/media.ts
+++ b/sdks/node/src/media.ts
@@ -10,7 +10,7 @@ type WeaveImageInput = {
   imageType?: ImageType;
 };
 
-interface WeaveImage extends WeaveImageInput {
+export interface WeaveImage extends WeaveImageInput {
   _weaveType: 'Image';
 }
 

--- a/sdks/node/src/types.ts
+++ b/sdks/node/src/types.ts
@@ -1,4 +1,2 @@
-import {Op} from './opType';
-import {WeaveClient} from './weaveClient';
-
-export {Op, WeaveClient};
+export {Op, OpDecorator} from './opType';
+export {WeaveClient} from './weaveClient';

--- a/sdks/node/src/urls.ts
+++ b/sdks/node/src/urls.ts
@@ -5,11 +5,18 @@ export function getUrls(host?: string) {
   const resolvedHost = host ?? defaultHost;
   const isDefault = resolvedHost === defaultHost;
 
+  let traceBaseUrl = process.env.WF_TRACE_SERVER_URL;
+
+  if (traceBaseUrl === undefined || traceBaseUrl === null) {
+    traceBaseUrl =isDefault
+      ? `https://trace.wandb.ai`
+      : `https://${resolvedHost}/traces`
+  }
+
+
   return {
     baseUrl: isDefault ? `https://api.wandb.ai` : `https://${resolvedHost}`,
-    traceBaseUrl: isDefault
-      ? `https://trace.wandb.ai`
-      : `https://${resolvedHost}/traces`,
+    traceBaseUrl,
     domain: isDefault ? defaultDomain : resolvedHost,
     host: isDefault ? defaultHost : resolvedHost,
   };

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -649,7 +649,6 @@ export class WeaveClient {
         response.data.digest
       );
 
-      // console.log('Saved op: ', ref.ui_url());
       return ref;
     })();
     return op.__savedRef;


### PR DESCRIPTION
## Description

This PR improves the Node SDK test infrastructure by:

1. Adding proper module path mapping for tests using the `moduleNameMapper` configuration in Jest
  a. Updating imports in test files to use the cleaner new path aliases (`weave` and `weave/*`). It looks more like how client side is going to consume the packages.
  b. Consolidating test TypeScript configuration files. "tsconfig.test.json" is ok to be used as base template, but my IDE doesn't seem to recognize it unless I renamed it to "tsconfig.json"
  c. Fixing mock implementations in tests

2. Adding environment variable support for trace server URL configuration.
3. Exporting additional types from the media module. (WeaveAudio, and WeaveImage) users should have a use of them.


This is a follow up of the TS decorator PR: https://github.com/wandb/weave/pull/4155
## Testing

Tested by running the Node SDK test suite to ensure all tests pass with the updated configuration.