### PR TITLE
chore(weave): make compare button primary + tooltip

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -900,6 +900,7 @@ export const CallsTable: FC<{
               </div>
               {isEvaluateTable ? (
                 <CompareEvaluationsTableButton
+                  tooltipText="Compare metrics and examples for selected evaluations"
                   onClick={() => {
                     history.push(
                       router.compareEvaluationsUri(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -437,7 +437,7 @@ export const CompareEvaluationsTableButton: FC<{
     }}>
     <Button
       size="medium"
-      variant="ghost"
+      variant="primary"
       disabled={disabled}
       onClick={onClick}
       icon="chart-scatterplot"


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

The compare view is so great, it deserves some love. Lets try it as primary for a bit. Also add some tooltip text. 

## Testing

Before: 
![Screenshot 2025-04-30 at 11 38 16 AM](https://github.com/user-attachments/assets/5376deba-619e-4899-a434-ba5a9b7a5b6c)

After:
![Screenshot 2025-04-30 at 11 37 55 AM](https://github.com/user-attachments/assets/b025f2f7-6abf-4b4b-b474-bb5ea9da91af)

