### PR TITLE
chore(weave): dont allow limit=0 in calls and calls stats query

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -4087,4 +4087,4 @@ def test_calls_query_stats_with_limit(client):
     assert calls_stats(filter={"trace_id": trace_id}).count == 2
 
     with pytest.raises(ValueError):
-        calls_stats(limit=-1)
+        calls_stats(limit=0)

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -459,7 +459,7 @@ class CallsQuery(BaseModel):
         return self
 
     def set_limit(self, limit: int) -> "CallsQuery":
-        if limit < 0:
+        if limit < 1:
             raise ValueError("Limit must be a positive integer")
         if self.limit is not None:
             raise ValueError("Limit can only be set once")


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

`limit=0` doesn't make sense, now we error if you try `limit=0`

## Testing

updates test
