### PR TITLE
chore(weave): restrict name filter type to string

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -74,9 +74,11 @@ export const getFieldLabel = (field: string): string => {
   return FIELD_LABELS[field] ?? field;
 };
 
+const STRING_LIKE = 'string-like';
 export const FIELD_TYPE: Record<string, string> = {
-  id: 'id',
+  id: STRING_LIKE,
   'summary.weave.status': 'status',
+  'summary.weave.trace_name': STRING_LIKE,
   wb_user_id: 'user',
   started_at: 'datetime',
 };
@@ -247,7 +249,7 @@ export const getOperatorValueType = (operatorValue: string): string => {
 
 export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
   const fieldType = getFieldType(field);
-  if ('id' === fieldType) {
+  if (STRING_LIKE === fieldType) {
     return [
       {
         value: '(string): equals',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -74,11 +74,10 @@ export const getFieldLabel = (field: string): string => {
   return FIELD_LABELS[field] ?? field;
 };
 
-const STRING_LIKE = 'string-like';
 export const FIELD_TYPE: Record<string, string> = {
-  id: STRING_LIKE,
+  id: 'id',
   'summary.weave.status': 'status',
-  'summary.weave.trace_name': STRING_LIKE,
+  'summary.weave.trace_name': 'string',
   wb_user_id: 'user',
   started_at: 'datetime',
 };
@@ -94,8 +93,7 @@ export type SelectOperatorOption = {
   group: OperatorGroup;
 };
 
-const allOperators: SelectOperatorOption[] = [
-  // String operators
+const stringOperators: SelectOperatorOption[] = [
   {
     value: '(string): contains',
     label: 'contains',
@@ -121,7 +119,9 @@ const allOperators: SelectOperatorOption[] = [
     label: 'does not contain',
     group: 'string',
   },
-  // Number operators
+];
+
+const numberOperators: SelectOperatorOption[] = [
   {
     value: '(number): =',
     label: '=',
@@ -152,13 +152,17 @@ const allOperators: SelectOperatorOption[] = [
     label: '≥',
     group: 'number',
   },
-  // Boolean operators
+];
+
+const booleanOperators: SelectOperatorOption[] = [
   {
     value: '(bool): is',
     label: 'is',
     group: 'boolean',
   },
-  // Date operators
+];
+
+const dateOperators: SelectOperatorOption[] = [
   {
     value: '(date): after',
     label: 'after',
@@ -169,7 +173,9 @@ const allOperators: SelectOperatorOption[] = [
     label: 'before',
     group: 'date',
   },
-  // Any operators
+];
+
+const anyOperators: SelectOperatorOption[] = [
   {
     value: '(any): isEmpty',
     label: 'is empty',
@@ -180,6 +186,14 @@ const allOperators: SelectOperatorOption[] = [
     label: 'is not empty',
     group: 'any',
   },
+];
+
+const allOperators: SelectOperatorOption[] = [
+  ...stringOperators,
+  ...numberOperators,
+  ...booleanOperators,
+  ...dateOperators,
+  ...anyOperators,
 ];
 
 // Display labels
@@ -249,7 +263,7 @@ export const getOperatorValueType = (operatorValue: string): string => {
 
 export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
   const fieldType = getFieldType(field);
-  if (STRING_LIKE === fieldType) {
+  if ('id' === fieldType) {
     return [
       {
         value: '(string): equals',
@@ -266,26 +280,13 @@ export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
         label: 'does not equal',
         group: 'string',
       },
-      {
-        value: '(string): notContains',
-        label: 'does not contain',
-        group: 'string',
-      },
     ];
   }
+  if ('string' === fieldType) {
+    return stringOperators;
+  }
   if ('datetime' === fieldType) {
-    return [
-      {
-        value: '(date): after',
-        label: 'after',
-        group: 'date',
-      },
-      {
-        value: '(date): before',
-        label: 'before',
-        group: 'date',
-      },
-    ];
+    return dateOperators;
   }
   if ('status' === fieldType) {
     return [

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -120,7 +120,6 @@ const stringOperators: SelectOperatorOption[] = [
     group: 'string',
   },
 ];
-
 const numberOperators: SelectOperatorOption[] = [
   {
     value: '(number): =',
@@ -153,7 +152,6 @@ const numberOperators: SelectOperatorOption[] = [
     group: 'number',
   },
 ];
-
 const booleanOperators: SelectOperatorOption[] = [
   {
     value: '(bool): is',
@@ -161,7 +159,6 @@ const booleanOperators: SelectOperatorOption[] = [
     group: 'boolean',
   },
 ];
-
 const dateOperators: SelectOperatorOption[] = [
   {
     value: '(date): after',
@@ -174,7 +171,6 @@ const dateOperators: SelectOperatorOption[] = [
     group: 'date',
   },
 ];
-
 const anyOperators: SelectOperatorOption[] = [
   {
     value: '(any): isEmpty',
@@ -187,7 +183,6 @@ const anyOperators: SelectOperatorOption[] = [
     group: 'any',
   },
 ];
-
 const allOperators: SelectOperatorOption[] = [
   ...stringOperators,
   ...numberOperators,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24755](https://wandb.atlassian.net/browse/WB-24755)

Restrict the name filter to just string operations. 

## Testing

Prod:
![Screenshot 2025-04-30 at 11 58 11 AM](https://github.com/user-attachments/assets/87ae116d-a15d-4965-a41b-95366e5071ab)


Branch:

![Screenshot 2025-04-30 at 11 57 54 AM](https://github.com/user-attachments/assets/57a19b73-6a8c-4e1a-85c9-e341286246b6)


[WB-24755]: https://wandb.atlassian.net/browse/WB-24755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ