### PR TITLE
fix(ui): treat json lists within uploaded dataset rows as lists, not strings

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/__tests__/jsonUtils.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/__tests__/jsonUtils.test.ts
@@ -1,38 +1,14 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {describe, expect, it} from 'vitest';
 
-import {
-  analyzeColumns,
-  castDataWithColumnTypes,
-  ParsedColumn,
-} from '../csvUtils';
 import {parseJSON, parseJSONL} from '../jsonUtils';
 
-// Mock the csvUtils functions
-vi.mock('../csvUtils', () => ({
-  analyzeColumns: vi.fn(),
-  castDataWithColumnTypes: vi.fn(),
-}));
-
 describe('jsonUtils', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   describe('parseJSON', () => {
     it('should parse a JSON array of objects', async () => {
       const mockData = [
         {name: 'John', age: 30, active: true},
         {name: 'Jane', age: 25, active: false},
       ];
-      const mockColumns: ParsedColumn[] = [
-        {name: 'name', type: 'string', sample: 'John'},
-        {name: 'age', type: 'number', sample: 30},
-        {name: 'active', type: 'boolean', sample: true},
-      ];
-      const mockCastedData = mockData;
-
-      (analyzeColumns as any).mockReturnValue(mockColumns);
-      (castDataWithColumnTypes as any).mockReturnValue(mockCastedData);
 
       const file = new File([JSON.stringify(mockData)], 'test.json', {
         type: 'application/json',
@@ -40,28 +16,11 @@ describe('jsonUtils', () => {
 
       const result = await parseJSON(file);
 
-      expect(result.data).toEqual(mockCastedData);
-      expect(result.errors).toHaveLength(0);
-      expect(result.meta.columns).toEqual(mockColumns);
-      expect(result.meta.totalRows).toBe(2);
-      expect(analyzeColumns).toHaveBeenCalledWith(mockData);
-      expect(castDataWithColumnTypes).toHaveBeenCalledWith(
-        mockData,
-        mockColumns
-      );
+      expect(result.data).toEqual(mockData);
     });
 
     it('should parse a single JSON object', async () => {
       const mockData = {name: 'John', age: 30, active: true};
-      const mockColumns: ParsedColumn[] = [
-        {name: 'name', type: 'string', sample: 'John'},
-        {name: 'age', type: 'number', sample: 30},
-        {name: 'active', type: 'boolean', sample: true},
-      ];
-      const mockCastedData = [mockData];
-
-      (analyzeColumns as any).mockReturnValue(mockColumns);
-      (castDataWithColumnTypes as any).mockReturnValue(mockCastedData);
 
       const file = new File([JSON.stringify(mockData)], 'test.json', {
         type: 'application/json',
@@ -69,15 +28,7 @@ describe('jsonUtils', () => {
 
       const result = await parseJSON(file);
 
-      expect(result.data).toEqual(mockCastedData);
-      expect(result.errors).toHaveLength(0);
-      expect(result.meta.columns).toEqual(mockColumns);
-      expect(result.meta.totalRows).toBe(1);
-      expect(analyzeColumns).toHaveBeenCalledWith([mockData]);
-      expect(castDataWithColumnTypes).toHaveBeenCalledWith(
-        [mockData],
-        mockColumns
-      );
+      expect(result.data).toEqual([mockData]);
     });
 
     it('should handle invalid JSON', async () => {
@@ -90,11 +41,6 @@ describe('jsonUtils', () => {
 
     it('should handle empty JSON array', async () => {
       const mockData: any[] = [];
-      const mockColumns: ParsedColumn[] = [];
-      const mockCastedData: any[] = [];
-
-      (analyzeColumns as any).mockReturnValue(mockColumns);
-      (castDataWithColumnTypes as any).mockReturnValue(mockCastedData);
 
       const file = new File([JSON.stringify(mockData)], 'test.json', {
         type: 'application/json',
@@ -102,10 +48,7 @@ describe('jsonUtils', () => {
 
       const result = await parseJSON(file);
 
-      expect(result.data).toEqual(mockCastedData);
-      expect(result.errors).toHaveLength(0);
-      expect(result.meta.columns).toEqual(mockColumns);
-      expect(result.meta.totalRows).toBe(0);
+      expect(result.data).toEqual([]);
     });
   });
 
@@ -115,15 +58,6 @@ describe('jsonUtils', () => {
         {name: 'John', age: 30, active: true},
         {name: 'Jane', age: 25, active: false},
       ];
-      const mockColumns: ParsedColumn[] = [
-        {name: 'name', type: 'string', sample: 'John'},
-        {name: 'age', type: 'number', sample: 30},
-        {name: 'active', type: 'boolean', sample: true},
-      ];
-      const mockCastedData = mockData;
-
-      (analyzeColumns as any).mockReturnValue(mockColumns);
-      (castDataWithColumnTypes as any).mockReturnValue(mockCastedData);
 
       const jsonlContent = mockData.map(obj => JSON.stringify(obj)).join('\n');
       const file = new File([jsonlContent], 'test.jsonl', {
@@ -132,15 +66,7 @@ describe('jsonUtils', () => {
 
       const result = await parseJSONL(file);
 
-      expect(result.data).toEqual(mockCastedData);
-      expect(result.errors).toHaveLength(0);
-      expect(result.meta.columns).toEqual(mockColumns);
-      expect(result.meta.totalRows).toBe(2);
-      expect(analyzeColumns).toHaveBeenCalledWith(mockData);
-      expect(castDataWithColumnTypes).toHaveBeenCalledWith(
-        mockData,
-        mockColumns
-      );
+      expect(result.data).toEqual(mockData);
     });
 
     it('should handle empty lines in JSONL file', async () => {
@@ -148,14 +74,6 @@ describe('jsonUtils', () => {
         {name: 'John', age: 30},
         {name: 'Jane', age: 25},
       ];
-      const mockColumns: ParsedColumn[] = [
-        {name: 'name', type: 'string', sample: 'John'},
-        {name: 'age', type: 'number', sample: 30},
-      ];
-      const mockCastedData = mockData;
-
-      (analyzeColumns as any).mockReturnValue(mockColumns);
-      (castDataWithColumnTypes as any).mockReturnValue(mockCastedData);
 
       const jsonlContent = [
         JSON.stringify(mockData[0]),
@@ -169,9 +87,7 @@ describe('jsonUtils', () => {
 
       const result = await parseJSONL(file);
 
-      expect(result.data).toEqual(mockCastedData);
-      expect(result.errors).toHaveLength(0);
-      expect(result.meta.totalRows).toBe(2);
+      expect(result.data).toEqual(mockData);
     });
 
     it('should handle invalid JSONL line', async () => {
@@ -188,22 +104,13 @@ describe('jsonUtils', () => {
     });
 
     it('should handle empty JSONL file', async () => {
-      const mockColumns: ParsedColumn[] = [];
-      const mockCastedData: any[] = [];
-
-      (analyzeColumns as any).mockReturnValue(mockColumns);
-      (castDataWithColumnTypes as any).mockReturnValue(mockCastedData);
-
       const file = new File([''], 'test.jsonl', {
         type: 'application/x-jsonlines',
       });
 
       const result = await parseJSONL(file);
 
-      expect(result.data).toEqual(mockCastedData);
-      expect(result.errors).toHaveLength(0);
-      expect(result.meta.columns).toEqual(mockColumns);
-      expect(result.meta.totalRows).toBe(0);
+      expect(result.data).toEqual([]);
     });
   });
 });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/jsonUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/jsonUtils.ts
@@ -1,4 +1,7 @@
-import {analyzeColumns, castDataWithColumnTypes, ParseResult} from './csvUtils';
+export interface JSONParseResult {
+  data: any[];
+  error?: string;
+}
 
 const unnestObject = (obj: any, prefix = ''): Record<string, any> => {
   const result: Record<string, any> = {};
@@ -16,7 +19,7 @@ const unnestObject = (obj: any, prefix = ''): Record<string, any> => {
   return result;
 };
 
-export const parseJSON = async (file: File): Promise<ParseResult> => {
+export const parseJSON = async (file: File): Promise<JSONParseResult> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = e => {
@@ -24,29 +27,37 @@ export const parseJSON = async (file: File): Promise<ParseResult> => {
         const text = e.target?.result as string;
         const data = JSON.parse(text);
 
-        // Handle both array of objects and single object
-        const rows = Array.isArray(data) ? data : [data];
+        if (!Array.isArray(data)) {
+          if (typeof data === 'object' && data !== null) {
+            // Single object case - wrap in array
+            const rows = [data];
+            resolve({
+              data: rows.map(row => unnestObject(row)),
+            });
+          } else {
+            reject(
+              new Error(
+                'JSON content must be an array of objects or a single object'
+              )
+            );
+          }
+          return;
+        }
+
+        if (data.length > 0 && typeof data[0] !== 'object') {
+          reject(new Error('JSON array must contain objects'));
+          return;
+        }
 
         // Unnest all objects in the rows
-        const unnestedRows = rows.map(row => unnestObject(row));
-
-        // Analyze columns and cast data types
-        const columns = analyzeColumns(unnestedRows);
-        const castedData = castDataWithColumnTypes(unnestedRows, columns);
-
+        const unnestedRows = data.map(row => unnestObject(row));
         resolve({
-          data: castedData,
-          errors: [],
-          meta: {
-            delimiter: '',
-            linebreak: '\n',
-            columns,
-            totalRows: rows.length,
-            encoding: 'UTF-8',
-          },
+          data: unnestedRows,
         });
       } catch (error) {
-        reject(error);
+        reject(
+          error instanceof Error ? error : new Error('Failed to parse JSON')
+        );
       }
     };
     reader.onerror = () => reject(new Error('Failed to read file'));
@@ -54,7 +65,7 @@ export const parseJSON = async (file: File): Promise<ParseResult> => {
   });
 };
 
-export const parseJSONL = async (file: File): Promise<ParseResult> => {
+export const parseJSONL = async (file: File): Promise<JSONParseResult> => {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = e => {
@@ -63,28 +74,30 @@ export const parseJSONL = async (file: File): Promise<ParseResult> => {
         const rows = text
           .split('\n')
           .filter(line => line.trim())
-          .map(line => JSON.parse(line));
+          .map(line => {
+            try {
+              return JSON.parse(line);
+            } catch (error) {
+              throw new Error(
+                `Invalid JSONL: Each line must be valid JSON. Error at line: ${line}`
+              );
+            }
+          });
+
+        if (rows.length > 0 && typeof rows[0] !== 'object') {
+          reject(new Error('JSONL must contain objects on each line'));
+          return;
+        }
 
         // Unnest all objects in the rows
         const unnestedRows = rows.map(row => unnestObject(row));
-
-        // Analyze columns and cast data types
-        const columns = analyzeColumns(unnestedRows);
-        const castedData = castDataWithColumnTypes(unnestedRows, columns);
-
         resolve({
-          data: castedData,
-          errors: [],
-          meta: {
-            delimiter: '',
-            linebreak: '\n',
-            columns,
-            totalRows: rows.length,
-            encoding: 'UTF-8',
-          },
+          data: unnestedRows,
         });
       } catch (error) {
-        reject(error);
+        reject(
+          error instanceof Error ? error : new Error('Failed to parse JSONL')
+        );
       }
     };
     reader.onerror = () => reject(new Error('Failed to read file'));


### PR DESCRIPTION
## Description

Remove dependency of `jsonUtils.ts` for parsing json datasets on logic for csv files in `csvUtils.ts`. This led to a bad bug where list values were treated as strings. Now the json parsing logic has its own interfaces and is logically separate from the csv parser. And the bug is fixed.
