### PR TITLE
fix(weave): Fixes User and Run ID filters

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1,4 +1,3 @@
-from unittest import mock
 import dataclasses
 import datetime
 import json
@@ -12,6 +11,7 @@ from contextvars import copy_context
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, Callable
+from unittest import mock
 
 import pytest
 import wandb
@@ -661,8 +661,9 @@ def test_trace_call_query_filter_wb_run_ids(client):
     run_name = "test-run-name"
     full_wb_run_id = f"{client.entity}/{client.project}/{run_name}"
     from weave.trace import weave_client
-    with mock.patch.object(weave_client, "safe_current_wb_run_id", 
-                           lambda: full_wb_run_id
+
+    with mock.patch.object(
+        weave_client, "safe_current_wb_run_id", lambda: full_wb_run_id
     ):
         call_spec_1 = simple_line_call_bootstrap()
     call_spec_2 = simple_line_call_bootstrap()
@@ -681,6 +682,7 @@ def test_trace_call_query_filter_wb_run_ids(client):
         )
 
         assert len(inner_res.calls) == exp_count
+
 
 def test_trace_call_query_filter_wb_user_ids(client):
     call_spec_1 = simple_line_call_bootstrap()
@@ -704,6 +706,7 @@ def test_trace_call_query_filter_wb_user_ids(client):
         )
 
         assert len(inner_res.calls) == exp_count
+
 
 def test_trace_call_query_limit(client):
     call_spec = simple_line_call_bootstrap()

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1272,12 +1272,12 @@ def process_calls_filter_to_conditions(
 
     if filter.wb_user_ids:
         conditions.append(
-            f"{get_field_by_name('wb_user_id').as_sql(param_builder, table_alias)} IN {param_slot(param_builder.add_param(filter.wb_user_ids), 'Array(String)')})"
+            f"{get_field_by_name('wb_user_id').as_sql(param_builder, table_alias)} IN {param_slot(param_builder.add_param(filter.wb_user_ids), 'Array(String)')}"
         )
 
     if filter.wb_run_ids:
         conditions.append(
-            f"{get_field_by_name('wb_run_id').as_sql(param_builder, table_alias)} IN {param_slot(param_builder.add_param(filter.wb_run_ids), 'Array(String)')})"
+            f"{get_field_by_name('wb_run_id').as_sql(param_builder, table_alias)} IN {param_slot(param_builder.add_param(filter.wb_run_ids), 'Array(String)')}"
         )
 
     return conditions

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -325,6 +325,9 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             if filter.wb_run_ids:
                 in_expr = ", ".join(f"'{x}'" for x in filter.wb_run_ids)
                 conds += [f"wb_run_id IN ({in_expr})"]
+            if filter.wb_user_ids:
+                in_expr = ", ".join(f"'{x}'" for x in filter.wb_user_ids)
+                conds += [f"wb_user_id IN ({in_expr})"]
 
         if req.query:
             # This is the mongo-style query


### PR DESCRIPTION
The Run and User id filters had an extra paren at the end of the query causing invalid query generation