### PR TITLE
chore(weave): use tmp_path builtin and remove redundant test in audio_test.py

### DIFF
--- a/tests/trace/type_handlers/Audio/audio_test.py
+++ b/tests/trace/type_handlers/Audio/audio_test.py
@@ -1,6 +1,6 @@
 import math
-import tempfile
 import wave
+from pathlib import Path
 from typing import Optional
 
 import weave
@@ -25,45 +25,32 @@ def make_audio_file(filename: str, nframes: Optional[int] = None) -> None:
         wav_file.writeframes(bytes(sound_wave(440, 2.5)))
 
 
-def test_audio_publish(client: WeaveClient) -> None:
+def test_audio_publish(client: WeaveClient, tmp_path: Path) -> None:
     client.project = "test_audio_publish"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_file:
-        make_audio_file(temp_file.name)
-        audio = wave.open(temp_file.name, "rb")
-        weave.publish(audio)
+    temp_file = str(tmp_path / "audio.wav")
+    make_audio_file(temp_file)
+    audio = wave.open(temp_file, "rb")
+    weave.publish(audio)
 
-        ref = get_ref(audio)
-        assert ref is not None
-        gotten_audio = weave.ref(ref.uri()).get()
-        assert audio.readframes(10) == gotten_audio.readframes(10)
-
-
-def test_audio_as_property(client: WeaveClient) -> None:
-    client.project = "test_audio_as_property"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_file:
-        make_audio_file(temp_file.name)
-        audio = wave.open(temp_file.name, "rb")
-        weave.publish(audio)
-
-        ref = get_ref(audio)
-        assert ref is not None
-        gotten_audio = weave.ref(ref.uri()).get()
-        assert audio.readframes(10) == gotten_audio.readframes(10)
+    ref = get_ref(audio)
+    assert ref is not None
+    gotten_audio = weave.ref(ref.uri()).get()
+    assert audio.readframes(10) == gotten_audio.readframes(10)
 
 
-def test_audio_as_dataset_cell(client: WeaveClient) -> None:
+def test_audio_as_dataset_cell(client: WeaveClient, tmp_path) -> None:
     client.project = "test_audio_as_dataset_cell"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_file:
-        make_audio_file(temp_file.name)
-        audio = wave.open(temp_file.name, "rb")
-        dataset = weave.Dataset(rows=[{"audio": audio}])
-        weave.publish(dataset)
+    temp_file = str(tmp_path / "audio.wav")
+    make_audio_file(temp_file)
+    audio = wave.open(temp_file, "rb")
+    dataset = weave.Dataset(rows=weave.Table([{"audio": audio}]))
+    weave.publish(dataset)
 
-        ref = get_ref(dataset)
-        assert ref is not None
+    ref = get_ref(dataset)
+    assert ref is not None
 
-        gotten_dataset = weave.ref(ref.uri()).get()
-        assert audio.readframes(10) == gotten_dataset.rows[0]["audio"].readframes(10)
+    gotten_dataset = weave.ref(ref.uri()).get()
+    assert audio.readframes(10) == gotten_dataset.rows[0]["audio"].readframes(10)
 
 
 @weave.op
@@ -71,46 +58,46 @@ def audio_as_input_and_output_part(in_audio: wave.Wave_read) -> dict:
     return {"out_audio": in_audio}
 
 
-def test_audio_as_call_io(client: WeaveClient) -> None:
+def test_audio_as_call_io(client: WeaveClient, tmp_path: Path) -> None:
     client.project = "test_audio_as_call_io"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_file:
-        make_audio_file(temp_file.name)
-        audio = wave.open(temp_file.name, "rb")
+    temp_file = str(tmp_path / "audio.wav")
+    make_audio_file(temp_file)
+    audio = wave.open(temp_file, "rb")
 
-        exp_bytes = audio.readframes(5)
-        audio.rewind()
+    exp_bytes = audio.readframes(5)
+    audio.rewind()
 
-        audio_dict = audio_as_input_and_output_part(audio)
+    audio_dict = audio_as_input_and_output_part(audio)
 
-        assert type(audio_dict["out_audio"]) is wave.Wave_read
-        assert audio_dict["out_audio"].getparams() == audio.getparams()
-        assert audio_dict["out_audio"].readframes(5) == exp_bytes
+    assert type(audio_dict["out_audio"]) is wave.Wave_read
+    assert audio_dict["out_audio"].getparams() == audio.getparams()
+    assert audio_dict["out_audio"].readframes(5) == exp_bytes
 
-        input_output_part_call = audio_as_input_and_output_part.calls()[0]
+    input_output_part_call = audio_as_input_and_output_part.calls()[0]
 
-        assert input_output_part_call.inputs["in_audio"].readframes(5) == exp_bytes
-        assert input_output_part_call.output["out_audio"].readframes(5) == exp_bytes
+    assert input_output_part_call.inputs["in_audio"].readframes(5) == exp_bytes
+    assert input_output_part_call.output["out_audio"].readframes(5) == exp_bytes
 
 
-def test_audio_with_max_nframes(client: WeaveClient) -> None:
+def test_audio_with_max_nframes(client: WeaveClient, tmp_path: Path) -> None:
     client.project = "test_audio_with_max_nframes"
-    with tempfile.NamedTemporaryFile(delete=False, suffix=".wav") as temp_file:
-        two_gb_nframes = (1 * 1024 * 1024 * 1024) - 1
-        make_audio_file(temp_file.name, nframes=two_gb_nframes)
-        audio = wave.open(temp_file.name, "rb")
-        weave.publish(audio)
+    temp_file = str(tmp_path / "audio.wav")
+    two_gb_nframes = (1 * 1024 * 1024 * 1024) - 1
+    make_audio_file(temp_file, nframes=two_gb_nframes)
+    audio = wave.open(temp_file, "rb")
+    weave.publish(audio)
 
-        ref = get_ref(audio)
-        assert ref is not None
-        gotten_audio = weave.ref(ref.uri()).get()
-        assert audio.readframes(10) == gotten_audio.readframes(10)
+    ref = get_ref(audio)
+    assert ref is not None
+    gotten_audio = weave.ref(ref.uri()).get()
+    assert audio.readframes(10) == gotten_audio.readframes(10)
 
-        # now with 0 nframes
-        make_audio_file(temp_file.name, nframes=0)
-        audio = wave.open(temp_file.name, "rb")
-        weave.publish(audio)
+    # now with 0 nframes
+    make_audio_file(temp_file, nframes=0)
+    audio = wave.open(temp_file, "rb")
+    weave.publish(audio)
 
-        ref = get_ref(audio)
-        assert ref is not None
-        gotten_audio = weave.ref(ref.uri()).get()
-        assert audio.readframes(10) == gotten_audio.readframes(10)
+    ref = get_ref(audio)
+    assert ref is not None
+    gotten_audio = weave.ref(ref.uri()).get()
+    assert audio.readframes(10) == gotten_audio.readframes(10)


### PR DESCRIPTION
## Description

`audio_test.py` currently has two tests doing the same thing and uses tempfile with the delete=False option. This PR removes the redundant test and revises all tests to use the built in temporary test directory fixture provided by pytest.