### PR TITLE
fix(ui): saved view modified state incorrect when contains filter in use

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/savedViewUtil.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/savedViewUtil.ts
@@ -228,6 +228,7 @@ const filterToClause = (item: Filter): Record<string, any> => {
       $contains: {
         input: {$getField: item.field},
         substr: {$literal: item.value},
+        case_insensitive: false,
       },
     };
   } else if (item.operator === '(string): notContains') {
@@ -237,6 +238,7 @@ const filterToClause = (item: Filter): Record<string, any> => {
           $contains: {
             input: {$getField: item.field},
             substr: {$literal: item.value},
+            case_insensitive: false,
           },
         },
       ],


### PR DESCRIPTION
## Description

Fix https://wandb.atlassian.net/browse/WB-24737

When a saved view had a filter with a "contains" operation the representation of that clause didn't match what was saved, causing freshly loaded views to appear to be in the "modified" state.

## Testing

Tested with Adam's project