### PR TITLE
chore(app): hide customRunNames variable in weave suggestions

### DIFF
--- a/weave-js/src/core/suggest.ts
+++ b/weave-js/src/core/suggest.ts
@@ -528,7 +528,8 @@ async function autosuggestNodes(
     if (node.nodeType === 'void') {
       const frame = toFrame(stack);
       const variableNames = Object.keys(frame).filter(
-        key => !key.includes('runColors') // runColors is used to color the row index in the table, but we don't want to suggest it (see WB-21774)
+        // runColors (see WB-21774) and customRunNames are only used internally within the panels
+        key => !key.includes('runColors') && !key.includes('customRunNames')
       );
       if (variableNames.length > 0) {
         for (const varName of variableNames) {


### PR DESCRIPTION
## Description

Also filter out `customRunNames` variable before showing weave suggestions. The variable defines the mapping from run ID to a custom run name (if one is set) and is causing [confusion with users](https://weightsandbiases.slack.com/archives/C02DQUT83SR/p1738324755752539) who are trying to use it to display their run's custom name inside the query panel. With this issue being fixed via https://github.com/wandb/weave/pull/4360, which defines a special path for the `run.name` op to account for custom run names, we should hide this variable, as it is otherwise only used internally within the query panel code.

The change in this PR will not break functionality for users that are currently using the variable. 

## Testing

Local FE

https://github.com/user-attachments/assets/27e19baf-50dd-47c5-907b-874ce890d580

