### PR TITLE
chore(weave): force min width even if set incorrectly

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/useDrawerResize.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/useDrawerResize.tsx
@@ -115,8 +115,12 @@ export const useDrawerResize = (
     debouncedHandleResize();
   }, [windowSize.width, debouncedHandleResize]);
 
+  // Ensure the drawer width is at least MIN_DRAWER_WIDTH, this can get
+  // messed up by resizing the browser weirdly.
+  const drawerWidthPx = Math.max(currentWidthRef.current, MIN_DRAWER_WIDTH);
+
   return {
     handleMousedown,
-    drawerWidthPx: currentWidthRef.current,
+    drawerWidthPx,
   };
 };


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24735](https://wandb.atlassian.net/browse/WB-24735)

Resizing the browser and/or opening up the console and/or connecting to external displays can cause the drawer width to get set less than the minimum allowed. Strictly enforce a minimum drawer width. 

## Testing

Prod
![Screenshot 2025-05-01 at 9 54 45 AM](https://github.com/user-attachments/assets/28f68a37-0349-4c2d-9b55-e20e2d73878f)

Branch
![Screenshot 2025-05-01 at 9 55 25 AM](https://github.com/user-attachments/assets/85eab15e-0418-4e7a-97b2-bbe909f4f0bd)


[WB-24735]: https://wandb.atlassian.net/browse/WB-24735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ