### PR TITLE
chore(weave): better display name with small drawer width

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -14,7 +14,15 @@ import {OverflowMenu} from './OverflowMenu';
 export const Overview = styled.div`
   display: flex;
   align-items: center;
-  gap: 8px;
+  & > * {
+    margin-right: 4px;
+  }
+  & > *:first-child {
+    margin-right: 4px;
+  }
+  & > *:last-child {
+    margin-right: 0px;
+  }
 `;
 Overview.displayName = 'S.Overview';
 
@@ -23,8 +31,8 @@ export const CallName = styled.div<{$isEditing?: boolean}>`
   font-size: 16px;
   font-weight: 600;
   text-align: left;
-  word-break: break-all;
-  width: ${props => (props.$isEditing ? '100%' : 'max-content%')};
+  min-width: 0;
+  width: 100%;
 `;
 CallName.displayName = 'S.CallName';
 
@@ -35,7 +43,6 @@ Spacer.displayName = 'S.Spacer';
 
 export const OverflowBin = styled.div`
   align-items: right;
-  margin-left: auto;
 `;
 OverflowBin.displayName = 'S.OverflowBin';
 
@@ -45,13 +52,13 @@ export const CallOverview: React.FC<{
   const statusCode = call.rawSpan.status_code;
   const refCall = makeRefCall(call.entity, call.project, call.callId);
   const editableCallDisplayNameRef = React.useRef<EditableField>(null);
-  const [isEditing, setIsEditing] = React.useState(false);
+  const [, setIsEditing] = React.useState(false);
 
   return (
     <>
       <Overview>
         <StatusChip value={statusCode} iconOnly />
-        <CallName $isEditing={isEditing}>
+        <CallName>
           <EditableCallName call={call} onEditingChange={setIsEditing} />
         </CallName>
         <CopyableId id={call.callId} type="Call" />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -32,9 +32,17 @@ export const CallName = styled.div<{$isEditing?: boolean}>`
   font-weight: 600;
   text-align: left;
   min-width: 0;
-  width: 100%;
+  display: inline-block;
 `;
 CallName.displayName = 'S.CallName';
+
+export const NameIdContainer = styled.div`
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  margin-right: 4px;
+`;
+NameIdContainer.displayName = 'S.NameIdContainer';
 
 export const Spacer = styled.div`
   flex: 1 1 auto;
@@ -58,10 +66,12 @@ export const CallOverview: React.FC<{
     <>
       <Overview>
         <StatusChip value={statusCode} iconOnly />
-        <CallName>
-          <EditableCallName call={call} onEditingChange={setIsEditing} />
-        </CallName>
-        <CopyableId id={call.callId} type="Call" />
+        <NameIdContainer>
+          <CallName>
+            <EditableCallName call={call} onEditingChange={setIsEditing} />
+          </CallName>
+          <CopyableId id={call.callId} type="Call" />
+        </NameIdContainer>
         <Spacer />
         <div>
           <Reactions weaveRef={refCall} forceVisible={true} />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OverflowMenu.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/OverflowMenu.tsx
@@ -86,7 +86,6 @@ export const OverflowMenu: FC<{
             icon="overflow-horizontal"
             size="medium"
             variant="ghost"
-            style={{marginLeft: '4px'}}
           />
         }
         offset="-178px, -16px"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
@@ -130,7 +130,7 @@ export const EditableCallName: React.FC<{
           placeholder={defaultDisplayName}
           autoGrow={true}
           rows={1}
-          className="w-full overflow-hidden text-ellipsis whitespace-nowrap px-[8px] py-[4px]"
+          className="w-full px-[8px] py-[4px]"
         />
       </div>
     </Tailwind>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
@@ -98,7 +98,7 @@ export const EditableCallName: React.FC<{
         <div
           className="group flex cursor-pointer items-center rounded px-[8px] py-[4px] hover:bg-moon-100 dark:hover:bg-moon-800"
           onClick={() => setIsEditing(true)}>
-          {currNameToDisplay}
+          <span className="truncate">{currNameToDisplay}</span>
           <Icon
             name="pencil-edit"
             width={16}
@@ -130,7 +130,7 @@ export const EditableCallName: React.FC<{
           placeholder={defaultDisplayName}
           autoGrow={true}
           rows={1}
-          className="w-full px-[8px] py-[4px]"
+          className="w-full overflow-hidden text-ellipsis whitespace-nowrap px-[8px] py-[4px]"
         />
       </div>
     </Tailwind>


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24780](https://wandb.atlassian.net/browse/WB-24780)

Fix call display with small widths. 

## Testing

### Prod
Normal width:
![Screenshot 2025-05-01 at 10 48 04 AM](https://github.com/user-attachments/assets/4a148aeb-c562-482e-b1d6-df5ff84ee8be)

Smallest width:
![Screenshot 2025-05-01 at 10 48 14 AM](https://github.com/user-attachments/assets/d7ffd153-00e0-4865-be85-9f5647cfa874)

Smallish width:
![Screenshot 2025-05-01 at 10 53 04 AM](https://github.com/user-attachments/assets/2a3e9324-4c88-4aeb-b048-a73c3c42cc13)


### Branch
Normal width:
![image](https://github.com/user-attachments/assets/684c5379-b278-43ad-a0af-e7fb1daf612e)


Smallest width:
![Screenshot 2025-05-01 at 10 44 43 AM](https://github.com/user-attachments/assets/6e6cc6a8-8089-4785-9cef-80538eda8cee)

Smallish width:
![Screenshot 2025-05-01 at 10 52 40 AM](https://github.com/user-attachments/assets/586e0bab-54d4-4d47-bf08-b2bbe30341bd)

Smallest width editing:
![image](https://github.com/user-attachments/assets/b2442105-7977-4350-ba57-f251d4449993)


[WB-24780]: https://wandb.atlassian.net/browse/WB-24780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ