### PR TITLE
chore(weave): fix small width CompositionView in TraceNavigator

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/CompositionView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/CompositionView.tsx
@@ -39,7 +39,8 @@ const NodeContainer = styled.div<{$level: number; $isSelected?: boolean}>`
   background: ${props =>
     props.$isSelected ? `${Colors.TEAL_300}52` : Colors.WHITE};
   transition: all 0.1s ease-in-out;
-  flex: 1 1 100px;
+  width: 100%;
+  min-width: 0;
 
   &:hover {
     ${props =>
@@ -65,6 +66,7 @@ const NodeHeader = styled.button`
   cursor: pointer;
   min-height: 32px;
   user-select: none;
+  min-width: 0;
 `;
 NodeHeader.displayName = 'NodeHeader';
 
@@ -72,6 +74,8 @@ const NodeContent = styled.div<{$isExpanded: boolean}>`
   display: ${props => (props.$isExpanded ? 'flex' : 'none')};
   flex-wrap: wrap;
   gap: 4px;
+  width: 100%;
+  min-width: 0;
 `;
 NodeContent.displayName = 'NodeContent';
 
@@ -197,8 +201,10 @@ const CodeMapNodeComponent: React.FC<CodeMapNodeProps> = ({
     <NodeContainer $level={level} $isSelected={isSelected}>
       <NodeHeader onClick={handleClick}>
         <div className="flex min-w-0 flex-1 flex-col">
-          <div className="flex w-full items-center ">
-            <div className="truncate text-sm font-medium">{node.opName}</div>
+          <div className="flex w-full items-center">
+            <div className="truncate text-sm font-medium" title={node.opName}>
+              {node.opName}
+            </div>
           </div>
           <div className="flex items-center gap-2 text-[11px] text-moon-500">
             <span>{stats.finishedCallCount} finished</span>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/CompositionView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/CompositionView.tsx
@@ -206,16 +206,18 @@ const CodeMapNodeComponent: React.FC<CodeMapNodeProps> = ({
               {node.opName}
             </div>
           </div>
-          <div className="flex items-center gap-2 text-[11px] text-moon-500">
-            <span>{stats.finishedCallCount} finished</span>
-            {stats.unfinishedCallCount > 0 && (
-              <span>• {stats.unfinishedCallCount} running</span>
-            )}
-            {stats.errorCount > 0 && <span>• {stats.errorCount} errors</span>}
-            {stats.finishedCallCount > 0 && (
-              <span>• {formatDuration(avgDuration)} avg</span>
-            )}
-            <div className="ml-auto whitespace-nowrap text-[11px] text-moon-500">
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-moon-500">
+            <div className="flex min-w-[110px] flex-1 flex-wrap items-center gap-2">
+              <span>{stats.finishedCallCount} finished</span>
+              {stats.unfinishedCallCount > 0 && (
+                <span>• {stats.unfinishedCallCount} running</span>
+              )}
+              {stats.errorCount > 0 && <span>• {stats.errorCount} errors</span>}
+              {stats.finishedCallCount > 0 && (
+                <span>• {formatDuration(avgDuration)} avg</span>
+              )}
+            </div>
+            <div className="whitespace-nowrap">
               {stats.finishedCallCount > 0
                 ? stats.minDuration === stats.maxDuration
                   ? formatDuration(stats.minDuration)

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/CompositionView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/components/TraceNavigator/TraceViews/CompositionView.tsx
@@ -40,6 +40,7 @@ const NodeContainer = styled.div<{$level: number; $isSelected?: boolean}>`
     props.$isSelected ? `${Colors.TEAL_300}52` : Colors.WHITE};
   transition: all 0.1s ease-in-out;
   width: 100%;
+  flex: 1 1 150px;
   min-width: 0;
 
   &:hover {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -264,7 +264,7 @@ export const SimplePageLayoutWithHeader: FC<{
       </Box>
       <div style={{flex: '1 1 auto', overflow: 'hidden'}}>
         <SplitPanelLeft
-          minWidth={150}
+          minWidth={200}
           defaultWidth={200}
           maxWidth="50%"
           isDrawerOpen={props.isLeftSidebarOpen ?? false}


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24781](https://wandb.atlassian.net/browse/WB-24781)

Fixes TraceComposition rendering in small width drawers.

This pr:
- truncates very long op names
- adds better flex handling for the ms timings
- increases the minimum drawer size (old view was simpler, this one needs more space)

## Testing

### Prod
![composition-view-prod-2](https://github.com/user-attachments/assets/d7a23ca7-b8fc-4a0e-8d9b-e0f34e258717)


### Branch
![composition-view-branch-1](https://github.com/user-attachments/assets/7be08dce-6bd1-47ec-a925-52524270c76e)


[WB-24781]: https://wandb.atlassian.net/browse/WB-24781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ