### PR TITLE
chore(weave): WeaveStatsSummarySection

### DIFF
--- a/weave-js/src/common/components/WeaveStatsSummarySection.tsx
+++ b/weave-js/src/common/components/WeaveStatsSummarySection.tsx
@@ -1,0 +1,70 @@
+import {LoadingDots} from '@wandb/weave/components/LoadingDots';
+import {useWFHooks} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context';
+import {
+  projectIdFromParts,
+  useFilesStats,
+} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks';
+import {convertBytes} from '@wandb/weave/util';
+import React, {useMemo} from 'react';
+
+export const WeaveStatsSummarySection = ({
+  entity,
+  project,
+}: {
+  entity: string;
+  project: string;
+}) => {
+  const {useCallsStats} = useWFHooks();
+  const {result, loading: callsStatsLoading} = useCallsStats(
+    entity,
+    project,
+    {}, // filter
+    undefined, // query
+    undefined, // limit
+    {includeTotalStorageSize: true}
+  );
+
+  const {value: filesStatsResult, loading: filesStatsLoading} = useFilesStats(
+    projectIdFromParts({entity, project})
+  );
+
+  const traceCount = useMemo(
+    () => <div>{callsStatsLoading ? <LoadingDots /> : result?.count ?? 0}</div>,
+    [callsStatsLoading, result]
+  );
+  const totalStorageSize = useMemo(
+    () =>
+      callsStatsLoading ? (
+        <LoadingDots />
+      ) : (
+        convertBytes(result?.total_storage_size_bytes ?? 0)
+      ),
+    [callsStatsLoading, result]
+  );
+  const fileStorageSize = useMemo(
+    () =>
+      filesStatsLoading ? (
+        <LoadingDots />
+      ) : (
+        convertBytes(filesStatsResult?.total_size_bytes ?? 0)
+      ),
+    [filesStatsLoading, filesStatsResult]
+  );
+
+  return (
+    <>
+      <div className="overview-item">
+        <div className="overview-key">Total traces</div>
+        <div className="overview-value">{traceCount}</div>
+      </div>
+      <div className="overview-item">
+        <div className="overview-key">Total traces size</div>
+        <div className="overview-value">{totalStorageSize}</div>
+      </div>
+      <div className="overview-item">
+        <div className="overview-key">File storage size</div>
+        <div className="overview-value">{fileStorageSize}</div>
+      </div>
+    </>
+  );
+};


### PR DESCRIPTION
## Description


Added a new `WeaveStatsSummarySection` component that displays statistics for Weave projects. The component shows:
- Total number of traces
- Total size of traces
- File storage size

The component fetches data using `useCallsStats` and `useFilesStats` hooks, and displays loading indicators while data is being retrieved.

This component is supposed to replace the \<TraceCountDisplay /> component created in https://github.com/wandb/weave/pull/4341/files
and will be consumed by \<ProjectOverview /> in https://github.com/wandb/core/pull/29080/files

Preview:
Before:
<img width="449" alt="image" src="https://github.com/user-attachments/assets/f7fc796d-a97f-45e8-95e7-97e89f260cd3" />

After:
<img width="452" alt="image" src="https://github.com/user-attachments/assets/4aaff53f-469d-4f73-9979-ba0ae8acc0c7" />


## Testing

Tested locally.