### PR TITLE
fix(ui): min size and truncation of call name

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallOverview.tsx
@@ -20,13 +20,13 @@ export const Overview = styled.div`
 `;
 Overview.displayName = 'S.Overview';
 
-export const CallName = styled.div<{$isEditing?: boolean}>`
+export const CallName = styled.div`
   font-family: Source Sans Pro;
   font-size: 16px;
   font-weight: 600;
   text-align: left;
   word-break: break-all;
-  width: ${props => (props.$isEditing ? '100%' : 'max-content%')};
+  width: 100%;
 `;
 CallName.displayName = 'S.CallName';
 
@@ -46,7 +46,6 @@ export const CallOverview: React.FC<{
 }> = ({call}) => {
   const refCall = makeRefCall(call.entity, call.project, call.callId);
   const editableCallDisplayNameRef = React.useRef<EditableField>(null);
-  const [isEditing, setIsEditing] = React.useState(false);
 
   const status = call.traceCall
     ? traceCallStatusCode(call.traceCall)
@@ -56,8 +55,8 @@ export const CallOverview: React.FC<{
     <>
       <Overview>
         <StatusChip value={status} iconOnly />
-        <CallName $isEditing={isEditing}>
-          <EditableCallName call={call} onEditingChange={setIsEditing} />
+        <CallName>
+          <EditableCallName call={call} />
         </CallName>
         <CopyableId id={call.callId} type="Call" />
         <Spacer />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EditableCallName.tsx
@@ -9,8 +9,7 @@ import {opNiceName} from './opNiceName';
 
 export const EditableCallName: React.FC<{
   call: CallSchema;
-  onEditingChange?: (isEditing: boolean) => void;
-}> = ({call, onEditingChange}) => {
+}> = ({call}) => {
   const defaultDisplayName = opNiceName(call.spanName);
   const displayNameIsEmpty =
     call.displayName == null || call.displayName === '';
@@ -34,8 +33,6 @@ export const EditableCallName: React.FC<{
   }, [nameToDisplay]);
 
   useEffect(() => {
-    onEditingChange?.(isEditing);
-
     // Fire height recalculation specifically when going from isEditing.
     if (isEditing && textAreaRef.current) {
       const el = textAreaRef.current;
@@ -51,7 +48,7 @@ export const EditableCallName: React.FC<{
         el.setSelectionRange(textLength, textLength);
       }, 0);
     }
-  }, [isEditing, onEditingChange]);
+  }, [isEditing]);
 
   const saveName = useCallback(
     (newName: string) => {
@@ -105,16 +102,27 @@ export const EditableCallName: React.FC<{
   if (!isEditing) {
     return (
       <Tailwind>
-        <div
-          className="group flex cursor-pointer items-center rounded px-[8px] py-[4px] hover:bg-moon-100 dark:hover:bg-moon-800"
-          onClick={() => setIsEditing(true)}>
-          {currNameToDisplay}
-          <Icon
-            name="pencil-edit"
-            width={16}
-            height={16}
-            className="ml-[8px] min-w-[16px] text-moon-500 opacity-0 group-hover:opacity-100"
-          />
+        <div className="group flex items-center">
+          <div
+            title={`Click to edit: ${currNameToDisplay}`}
+            className="flex min-w-[150px] cursor-pointer items-center overflow-hidden rounded px-[8px] py-[4px] hover:bg-moon-100 dark:hover:bg-moon-800"
+            style={{
+              display: '-webkit-box',
+              WebkitBoxOrient: 'vertical',
+              WebkitLineClamp: 2,
+              lineClamp: 2 /* Not supported in all browsers yet, but added for future compatibility */,
+            }}
+            onClick={() => setIsEditing(true)}>
+            {currNameToDisplay}
+          </div>
+          <div>
+            <Icon
+              name="pencil-edit"
+              width={16}
+              height={16}
+              className="ml-[8px] min-w-[16px] text-moon-500 opacity-0 group-hover:opacity-100"
+            />
+          </div>
         </div>
       </Tailwind>
     );
@@ -140,7 +148,7 @@ export const EditableCallName: React.FC<{
           placeholder={defaultDisplayName}
           autoGrow={true}
           rows={1}
-          className="w-full px-[8px] py-[4px]"
+          className="w-full min-w-[150px] px-[8px] py-[4px]"
         />
       </div>
     </Tailwind>


### PR DESCRIPTION
## Description

Fix https://wandb.atlassian.net/browse/WB-24780

Before - as width available for title gets small the height gets huge
<img width="610" alt="Screenshot 2025-05-01 at 2 51 18 PM" src="https://github.com/user-attachments/assets/fc467f41-0014-4edc-afba-47f7df2c01ce" />

After:
We start truncating with ellipsis after 4 (arbitrarily chosen) lines of text. Full text is in tooltip.
<img width="564" alt="Screenshot 2025-05-01 at 2 51 31 PM" src="https://github.com/user-attachments/assets/47502be7-d3eb-4986-83e5-7923ad8836fe" />

Set a minimum width so that name is still at least somewhat visible. This will cause horizontal scrolling but seems better than alternative?
<img width="699" alt="Screenshot 2025-05-01 at 2 51 41 PM" src="https://github.com/user-attachments/assets/44551596-e4a8-4502-9c45-a822b80595a0" />

## Testing

How was this PR tested?
