### PR TITLE
fix(ui): do not expand weave objects when moving from schema mapping to confirm step

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/AddToDatasetDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/AddToDatasetDrawer.tsx
@@ -9,6 +9,7 @@ import {useWeaveflowRouteContext} from '../context';
 import {ResizableDrawer} from '../pages/common/ResizableDrawer';
 import {useWFHooks} from '../pages/wfReactInterface/context';
 import {useClientSideCallRefExpansion} from '../pages/wfReactInterface/tsDataModelHooksCallRefExpansion';
+import {CustomWeaveTypeProjectContext} from '../typeViews/CustomWeaveTypeDispatcher';
 import {
   ACTION_TYPES,
   DatasetDrawerProvider,
@@ -39,7 +40,13 @@ export const AddToDatasetDrawer: React.FC<AddToDatasetDrawerProps> = props => {
       onClose={props.onClose}
       entity={props.entity}
       project={props.project}>
-      <AddToDatasetDrawerInner {...props} />
+      <CustomWeaveTypeProjectContext.Provider
+        value={{
+          entity: props.entity,
+          project: props.project,
+        }}>
+        <AddToDatasetDrawerInner {...props} />
+      </CustomWeaveTypeProjectContext.Provider>
     </DatasetDrawerProvider>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetDrawerContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetDrawerContext.tsx
@@ -312,7 +312,6 @@ function datasetDrawerReducer(
       }
 
       const {selectedCalls} = action.payload;
-      const isNewDataset = state.selectedDataset === null;
 
       try {
         // Map calls to dataset rows
@@ -320,23 +319,6 @@ function datasetDrawerReducer(
           selectedCalls,
           state.fieldMappings
         );
-
-        // Apply filtering for new datasets
-        if (isNewDataset) {
-          const targetFields = new Set(
-            state.fieldMappings.map(m => m.targetField)
-          );
-          mappedRows = mappedRows.map(row => {
-            const {___weave, ...rest} = row;
-            const filteredData = Object.fromEntries(
-              Object.entries(rest).filter(([key]) => targetFields.has(key))
-            );
-            return {
-              ___weave,
-              ...filteredData,
-            };
-          });
-        }
 
         // Process rows with schema-based filtering
         const processedRowsMap = createProcessedRowsMap(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/__tests__/DatasetDrawerContext.test.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/__tests__/DatasetDrawerContext.test.tsx
@@ -31,7 +31,6 @@ vi.mock('../schemaUtils', () => ({
   createProcessedRowsMap: vi.fn(() => {
     return new Map([['call1', {text: 'Sample text'}]]);
   }),
-  filterRowsForNewDataset: vi.fn(rows => rows),
   createTargetSchema: vi.fn(() => []),
 }));
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.test.ts
@@ -3,7 +3,6 @@ import {
   createProcessedRowsMap,
   createSourceSchema,
   createTargetSchema,
-  extractTopLevelFields,
   inferType,
   mapCallsToDatasetRows,
   unwrapRefValue,
@@ -33,38 +32,6 @@ describe('inferType', () => {
     expect(inferType(42)).toBe('number');
     expect(inferType(true)).toBe('boolean');
     expect(inferType(undefined)).toBe('undefined');
-  });
-});
-
-describe('extractTopLevelFields', () => {
-  test('extracts only top-level fields', () => {
-    const obj = {
-      user: {
-        name: 'Alice',
-        address: {
-          city: 'Paris',
-        },
-      },
-      age: 30,
-    };
-
-    expect(extractTopLevelFields(obj)).toEqual([
-      {name: 'user', type: 'object'},
-      {name: 'age', type: 'number'},
-    ]);
-  });
-
-  test('handles arrays as single fields', () => {
-    const obj = {tags: ['a', 'b', 'c']};
-    expect(extractTopLevelFields(obj)).toEqual([{name: 'tags', type: 'array'}]);
-  });
-
-  test('handles prefix correctly', () => {
-    const obj = {name: 'Alice', age: 30};
-    expect(extractTopLevelFields(obj, 'user')).toEqual([
-      {name: 'user.name', type: 'string'},
-      {name: 'user.age', type: 'number'},
-    ]);
   });
 });
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/schemaUtils.ts
@@ -44,6 +44,7 @@ export const FIELD_NAMES = {
   IS_NEW: 'isNew',
   SERVER_VALUE: 'serverValue',
   SELF: 'self',
+  MODEL: 'model',
 };
 
 // Weave metadata namespace
@@ -98,57 +99,6 @@ export const denestData = (
   });
 
   return nestedObject;
-};
-
-/**
- * Extracts only the top-level fields from an object without deep flattening.
- * Used primarily for source/call schema where we only want the top-level structure.
- */
-export const extractTopLevelFields = (obj: any, prefix = ''): SchemaField[] => {
-  const fields: SchemaField[] = [];
-
-  // Return empty array for null or undefined inputs
-  if (obj == null) {
-    return fields;
-  }
-
-  if (Array.isArray(obj)) {
-    fields.push({
-      name: prefix,
-      type: 'array',
-    });
-    return fields;
-  }
-
-  // Special handling for __ref__ and __val__ pattern
-  if (
-    typeof obj === 'object' &&
-    WEAVE_EXPANDED_REF_PROPS.REF in obj &&
-    WEAVE_EXPANDED_REF_PROPS.VAL in obj
-  ) {
-    if (
-      typeof obj[WEAVE_EXPANDED_REF_PROPS.VAL] === 'object' &&
-      !Array.isArray(obj[WEAVE_EXPANDED_REF_PROPS.VAL])
-    ) {
-      // For object values, extract its top-level fields
-      return extractTopLevelFields(obj[WEAVE_EXPANDED_REF_PROPS.VAL], prefix);
-    } else {
-      // For primitive or array values, return as is
-      return [
-        {name: prefix, type: inferType(obj[WEAVE_EXPANDED_REF_PROPS.VAL])},
-      ];
-    }
-  }
-
-  for (const [key, value] of Object.entries(obj)) {
-    const newKey = prefix ? `${prefix}.${key}` : key;
-    fields.push({
-      name: newKey,
-      type: inferType(value),
-    });
-  }
-
-  return fields;
 };
 
 /**
@@ -320,7 +270,8 @@ export const createSourceSchema = (calls: CallData[]): SchemaField[] => {
       if (
         output !== null &&
         typeof output === 'object' &&
-        !Array.isArray(output)
+        !Array.isArray(output) &&
+        output._type === undefined
       ) {
         Object.entries(output).forEach(([key, value]) => {
           allFields.push({
@@ -387,7 +338,8 @@ export const createSourceSchema = (calls: CallData[]): SchemaField[] => {
   return allFields
     .filter(
       field =>
-        !field.name.startsWith(`${FIELD_PREFIX.INPUTS}${FIELD_NAMES.SELF}`)
+        !field.name.startsWith(`${FIELD_PREFIX.INPUTS}${FIELD_NAMES.SELF}`) &&
+        !field.name.startsWith(`${FIELD_PREFIX.INPUTS}${FIELD_NAMES.MODEL}`)
     )
     .reduce((acc, field) => {
       if (!acc.some(f => f.name === field.name)) {
@@ -547,11 +499,12 @@ export const mapCallsToDatasetRows = (
       const value = obj[key];
       const newPrefix = prefix ? `${prefix}.${key}` : key;
 
-      // If it's an object and not an array, recurse and merge results
+      // If it's an object and not an array or weave object, recurse and merge results
       if (
         typeof value === 'object' &&
         value !== null &&
-        !Array.isArray(value)
+        !Array.isArray(value) &&
+        value?._type === undefined
       ) {
         Object.assign(result, flattenObject(value, newPrefix));
       } else {
@@ -572,11 +525,9 @@ export const mapCallsToDatasetRows = (
       const summary = call.val.summary || {};
 
       let sourceValue: any;
-      if (
-        mapping.sourceField === FIELD_NAMES.OUTPUT &&
-        typeof output === 'string'
-      ) {
-        sourceValue = output;
+      if (mapping.sourceField === FIELD_NAMES.OUTPUT) {
+        // Case where output is a primitive value or array
+        sourceValue = unwrapRefValue(output);
       } else {
         sourceValue = resolveValue(
           {
@@ -589,21 +540,17 @@ export const mapCallsToDatasetRows = (
           mapping.sourceField
         );
       }
-
       if (sourceValue !== undefined) {
         if (
           typeof sourceValue === 'object' &&
           sourceValue !== null &&
-          !Array.isArray(sourceValue)
+          !Array.isArray(sourceValue) &&
+          sourceValue._type === undefined
         ) {
-          // Flatten nested objects into path-based keys
-          const flattenedValues = flattenObject(sourceValue);
-          Object.keys(flattenedValues).forEach(key => {
-            const fullKey = `${mapping.targetField}.${key}`;
-            rowData[fullKey] = flattenedValues[key];
+          Object.entries(flattenObject(sourceValue)).forEach(([key, value]) => {
+            rowData[`${mapping.targetField}.${key}`] = value;
           });
         } else {
-          // For primitive values and arrays, add directly
           rowData[mapping.targetField] = sourceValue;
         }
       }
@@ -618,40 +565,6 @@ export const mapCallsToDatasetRows = (
     } as WeaveRow;
   });
 };
-
-/**
- * Filters row data for new datasets based on target fields.
- *
- * @param mappedRows - The rows mapped from calls
- * @param targetFields - Set of target field names to include
- * @returns Filtered rows containing only the specified target fields
- */
-export function filterRowsForNewDataset(
-  mappedRows: WeaveRow[],
-  targetFields: Set<string>
-): WeaveRow[] {
-  return mappedRows
-    .map(row => {
-      try {
-        if (!row || typeof row !== 'object' || !row[WEAVE_NAMESPACE]) {
-          return undefined;
-        }
-
-        const {[WEAVE_NAMESPACE]: weaveData, ...rest} = row;
-        const filteredData = Object.fromEntries(
-          Object.entries(rest).filter(([key]) => targetFields.has(key))
-        );
-        return {
-          [WEAVE_NAMESPACE]: weaveData,
-          ...filteredData,
-        } as WeaveRow;
-      } catch (rowError) {
-        console.error('Error processing row:', rowError);
-        return undefined;
-      }
-    })
-    .filter((row): row is WeaveRow => row !== undefined);
-}
 
 /**
  * Creates a map of processed rows with schema-based filtering.
@@ -671,13 +584,28 @@ export function createProcessedRowsMap(
         // If datasetObject has a schema, filter row properties to match schema fields
         if (datasetObject?.schema && Array.isArray(datasetObject.schema)) {
           const schemaFields = new Set(
-            datasetObject.schema.map((f: {name: string}) => f.name)
+            datasetObject.schema.map((f: {name: string}) => {
+              // Remove inputs. or output. prefix if present
+              const name = f.name;
+              if (name.startsWith(FIELD_PREFIX.INPUTS)) {
+                return name.slice(FIELD_PREFIX.INPUTS.length);
+              }
+              if (name.startsWith(FIELD_PREFIX.OUTPUT)) {
+                return name.slice(FIELD_PREFIX.OUTPUT.length);
+              }
+              return name;
+            })
           );
-          const {[WEAVE_NAMESPACE]: weaveData, ...rest} = row;
 
+          const {[WEAVE_NAMESPACE]: weaveData, ...rest} = row;
           // Only include fields that are in the schema
           const filteredData = Object.fromEntries(
-            Object.entries(rest).filter(([key]) => schemaFields.has(key))
+            Object.entries(rest).filter(([key]) =>
+              Array.from(schemaFields).some(
+                schemaField =>
+                  key === schemaField || key.startsWith(`${schemaField}.`)
+              )
+            )
           );
 
           return [


### PR DESCRIPTION
## Description

1. Don't flatten dataset columns if the nested data is a weave object, like an image. 
2. Include fields from the flattened objects in the resulting dataset if they have an included field as a prefix of their name.
3. Put a `CustomWeaveTypeProjectContext` in the add to dataset drawer scope so weave objects will render.

https://github.com/user-attachments/assets/037463d4-6ffa-4c8d-a7b0-76930de7ce59

