### PR TITLE
chore(weave): add option+click support to Name and Latency

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/CellFilterWrapper.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/CellFilterWrapper.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 
-export type OnAddFilter = (
+export type OnUpdateFilter = (
   field: string,
   operator: string | null,
   value: any,
@@ -13,7 +13,7 @@ export type OnAddFilter = (
 ) => void;
 type CellFilterWrapperProps = {
   children: React.ReactNode;
-  onAddFilter?: OnAddFilter;
+  onUpdateFilter?: OnUpdateFilter;
   field: string;
   operation: string | null;
   value: any;
@@ -23,20 +23,20 @@ type CellFilterWrapperProps = {
 
 export const CellFilterWrapper = ({
   children,
-  onAddFilter,
+  onUpdateFilter,
   field,
   operation,
   value,
   rowId,
   style,
 }: CellFilterWrapperProps) => {
-  const onClickCapture = onAddFilter
+  const onClickCapture = onUpdateFilter
     ? (e: React.MouseEvent) => {
         // event.altKey - pressed Option key on Macs
         if (e.altKey) {
           e.stopPropagation();
           e.preventDefault();
-          onAddFilter(field, operation, value, rowId);
+          onUpdateFilter(field, operation, value, rowId);
         }
       }
     : undefined;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -57,7 +57,7 @@ import {
   convertFeedbackFieldToBackendFilter,
   parseFeedbackType,
 } from '../../feedback/HumanFeedback/tsHumanFeedback';
-import {OnAddFilter} from '../../filters/CellFilterWrapper';
+import {OnUpdateFilter} from '../../filters/CellFilterWrapper';
 import {getDefaultOperatorForValue} from '../../filters/common';
 import {FilterPanel} from '../../filters/FilterPanel';
 import {flattenObjectPreservingWeaveTypes} from '../../flattenObject';
@@ -372,9 +372,7 @@ export const CallsTable: FC<{
     [callsResult, columnIsRefExpanded, expandedRefCols]
   );
 
-  // TODO: Despite the name, this has changed to be slightly more sophisticated,
-  //       where it may replace or toggle a filter off. We should consider renaming.
-  const onAddFilter: OnAddFilter | undefined =
+  const onUpdateFilter: OnUpdateFilter | undefined =
     filterModel && setFilterModel
       ? (field: string, operator: string | null, value: any, rowId: string) => {
           // This condition is used to filter by the parent ref itself, not the child cell.
@@ -463,7 +461,7 @@ export const CallsTable: FC<{
     onExpand,
     columnIsRefExpanded,
     allowedColumnPatterns,
-    onAddFilter,
+    onUpdateFilter,
     calls.costsLoading,
     !!calls.costsError,
     shouldIncludeTotalStorageSize,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -316,7 +316,11 @@ function buildCallsTableColumns(
             field="summary.weave.trace_name"
             rowId={rowParams.id.toString()}
             operation={'(string): equals'}
-            value={name}>
+            value={name}
+            style={{
+              display: 'flex',
+              width: '100%',
+            }}>
             <CallLinkCell
               rowParams={rowParams}
               entity={entity}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -718,7 +718,7 @@ function buildCallsTableColumns(
         // Displaying nothing seems preferable to being misleading.
         return null;
       }
-      const timeMs = traceCallLatencyMs(cellParams.row) * 1.0001;
+      const timeMs = traceCallLatencyMs(cellParams.row);
       const timeString = monthRoundedTime(traceCallLatencyS(cellParams.row));
       return (
         <CellFilterWrapper

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -40,7 +40,10 @@ import {
   RUNNABLE_FEEDBACK_OUTPUT_PART,
 } from '../../feedback/HumanFeedback/tsScorerFeedback';
 import {Reactions} from '../../feedback/Reactions';
-import {CellFilterWrapper, OnAddFilter} from '../../filters/CellFilterWrapper';
+import {
+  CellFilterWrapper,
+  OnUpdateFilter,
+} from '../../filters/CellFilterWrapper';
 import {isWeaveRef} from '../../filters/common';
 import {
   getCostsFromCellParams,
@@ -53,6 +56,7 @@ import {buildDynamicColumns} from '../common/tabularListViews/columnBuilder';
 import {TraceCallSchema} from '../wfReactInterface/traceServerClientTypes';
 import {
   convertISOToDate,
+  traceCallLatencyMs,
   traceCallLatencyS,
   traceCallStatusCode,
 } from '../wfReactInterface/tsDataModelHooks';
@@ -82,7 +86,7 @@ export const useCallsTableColumns = (
   onExpand: (col: string) => void,
   columnIsRefExpanded: (col: string) => boolean,
   allowedColumnPatterns?: string[],
-  onAddFilter?: OnAddFilter,
+  onUpdateFilter?: OnUpdateFilter,
   costsLoading: boolean = false,
   costsHasError: boolean = false,
   includeTotalStorageSizeBytes: boolean = false,
@@ -164,7 +168,7 @@ export const useCallsTableColumns = (
         columnIsRefExpanded,
         userDefinedColumnWidths,
         allowedColumnPatterns,
-        onAddFilter,
+        onUpdateFilter,
         costsLoading,
         costsHasError,
         includeTotalStorageSizeBytes
@@ -189,7 +193,7 @@ export const useCallsTableColumns = (
       columnIsRefExpanded,
       userDefinedColumnWidths,
       allowedColumnPatterns,
-      onAddFilter,
+      onUpdateFilter,
       costsLoading,
       includeTotalStorageSizeBytes,
       storageSizeResults,
@@ -255,7 +259,7 @@ function buildCallsTableColumns(
   columnIsRefExpanded: (col: string) => boolean,
   userDefinedColumnWidths: Record<string, number>,
   allowedColumnPatterns?: string[],
-  onAddFilter?: OnAddFilter,
+  onUpdateFilter?: OnUpdateFilter,
   costsLoading: boolean = false,
   costsHasError: boolean = false,
   storageSizeInfo: {
@@ -301,13 +305,25 @@ function buildCallsTableColumns(
         return opVersionRefOpName(op_name);
       },
       renderCell: rowParams => {
+        const name =
+          rowParams.row.display_name ??
+          // Rows are flattened at this point, they DO NOT strictly
+          // follow the TraceCallSchema!
+          (rowParams.row as any)['summary.weave.trace_name'];
         return (
-          <CallLinkCell
-            rowParams={rowParams}
-            entity={entity}
-            project={project}
-            preservePath={preservePath}
-          />
+          <CellFilterWrapper
+            onUpdateFilter={onUpdateFilter}
+            field="summary.weave.trace_name"
+            rowId={rowParams.id.toString()}
+            operation={'(string): equals'}
+            value={name}>
+            <CallLinkCell
+              rowParams={rowParams}
+              entity={entity}
+              project={project}
+              preservePath={preservePath}
+            />
+          </CellFilterWrapper>
         );
       },
     },
@@ -369,7 +385,7 @@ function buildCallsTableColumns(
         const valueFilter = STATUS_TO_FILTER[valueStatus];
         return (
           <CellFilterWrapper
-            onAddFilter={onAddFilter}
+            onUpdateFilter={onUpdateFilter}
             field="summary.weave.status"
             rowId={cellParams.id.toString()}
             operation={'(string): in'}
@@ -397,7 +413,7 @@ function buildCallsTableColumns(
     // TODO (Tim) - (BackendExpansion): This can be removed once we support backend expansion!
     key => !columnIsRefExpanded(key) && !columnsWithRefs.has(key),
     (key, operator, value, rowId) => {
-      onAddFilter?.(key, operator, value, rowId);
+      onUpdateFilter?.(key, operator, value, rowId);
     }
   );
   cols.push(...newCols);
@@ -547,7 +563,7 @@ function buildCallsTableColumns(
             renderCell: (params: GridRenderCellParams<TraceCallSchema>) => {
               return (
                 <CellFilterWrapper
-                  onAddFilter={onAddFilter}
+                  onUpdateFilter={onUpdateFilter}
                   field={field}
                   rowId={params.id.toString()}
                   operation={null}
@@ -579,7 +595,7 @@ function buildCallsTableColumns(
       }
       return (
         <CellFilterWrapper
-          onAddFilter={onAddFilter}
+          onUpdateFilter={onUpdateFilter}
           field="wb_user_id"
           rowId={cellParams.id.toString()}
           operation="(string): equals"
@@ -607,7 +623,7 @@ function buildCallsTableColumns(
       const value = date.getTime() / 1000;
       return (
         <CellFilterWrapper
-          onAddFilter={onAddFilter}
+          onUpdateFilter={onUpdateFilter}
           field="started_at"
           rowId={cellParams.id.toString()}
           operation="(date): after"
@@ -702,7 +718,18 @@ function buildCallsTableColumns(
         // Displaying nothing seems preferable to being misleading.
         return null;
       }
-      return monthRoundedTime(traceCallLatencyS(cellParams.row));
+      const timeMs = traceCallLatencyMs(cellParams.row) * 1.0001;
+      const timeString = monthRoundedTime(traceCallLatencyS(cellParams.row));
+      return (
+        <CellFilterWrapper
+          onUpdateFilter={onUpdateFilter}
+          field="summary.weave.latency_ms"
+          rowId={cellParams.id.toString()}
+          operation={'(number): >='}
+          value={timeMs}>
+          <div>{timeString}</div>
+        </CellFilterWrapper>
+      );
     },
   });
 
@@ -765,7 +792,7 @@ function buildCallsTableColumns(
       // that far would be if we had an "ends with" operator.
       return (
         <CellFilterWrapper
-          onAddFilter={onAddFilter}
+          onUpdateFilter={onUpdateFilter}
           field="wb_run_id"
           rowId={cellParams.id.toString()}
           operation="(string): contains"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/columnBuilder.tsx
@@ -12,7 +12,7 @@ import {ErrorBoundary} from '../../../../../../ErrorBoundary';
 import {CellValue} from '../../../../Browse2/CellValue';
 import {
   CellFilterWrapper,
-  OnAddFilter,
+  OnUpdateFilter,
 } from '../../../filters/CellFilterWrapper';
 import {isWeaveRef} from '../../../filters/common';
 import {flattenObjectPreservingWeaveTypes} from '../../../flattenObject';
@@ -206,7 +206,7 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
   onCollapse?: (col: string) => void,
   onExpand?: (col: string) => void,
   columnIsSortable?: (col: string) => boolean,
-  onAddFilter?: OnAddFilter
+  onUpdateFilter?: OnUpdateFilter
 ) => {
   const cols: Array<GridColDef<T>> = [];
 
@@ -287,7 +287,7 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
         if (val === undefined) {
           return (
             <CellFilterWrapper
-              onAddFilter={onAddFilter}
+              onUpdateFilter={onUpdateFilter}
               field={key}
               rowId={cellParams.id.toString()}
               operation={'(any): isEmpty'}
@@ -299,7 +299,7 @@ export const buildDynamicColumns = <T extends GridValidRowModel>(
         return (
           <ErrorBoundary>
             <CellFilterWrapper
-              onAddFilter={onAddFilter}
+              onUpdateFilter={onUpdateFilter}
               field={key}
               rowId={cellParams.id.toString()}
               operation={null}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -3,6 +3,8 @@ import _ from 'lodash';
 
 import {Query} from '../../wfReactInterface/traceServerClientInterface/query';
 
+const FIELDS_NO_FLOAT_CONVERT = ['summary.weave.latency_ms'];
+
 // Convert one Material GridFilterItem to our Mongo-like query format.
 export const operationConverter = (
   item: GridFilterItem
@@ -58,79 +60,115 @@ export const operationConverter = (
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $eq: [
-        {$convert: {input: {$getField: item.field}, to: 'double'}},
-        {$literal: val},
-      ],
-    };
+    if (FIELDS_NO_FLOAT_CONVERT.includes(item.field)) {
+      return {
+        $eq: [{$getField: item.field}, {$literal: val}],
+      };
+    } else {
+      return {
+        $eq: [
+          {$convert: {input: {$getField: item.field}, to: 'double'}},
+          {$literal: val},
+        ],
+      };
+    }
   } else if (item.operator === '(number): !=') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $not: [
-        {
-          $eq: [
-            {$convert: {input: {$getField: item.field}, to: 'double'}},
-            {$literal: val},
-          ],
-        },
-      ],
-    };
+    if (FIELDS_NO_FLOAT_CONVERT.includes(item.field)) {
+      return {
+        $not: [{$eq: [{$getField: item.field}, {$literal: val}]}],
+      };
+    } else {
+      return {
+        $not: [
+          {
+            $eq: [
+              {$convert: {input: {$getField: item.field}, to: 'double'}},
+              {$literal: val},
+            ],
+          },
+        ],
+      };
+    }
   } else if (item.operator === '(number): >') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $gt: [
-        {$convert: {input: {$getField: item.field}, to: 'double'}},
-        {$literal: val},
-      ],
-    };
+    if (FIELDS_NO_FLOAT_CONVERT.includes(item.field)) {
+      return {
+        $gt: [{$getField: item.field}, {$literal: val}],
+      };
+    } else {
+      return {
+        $gt: [
+          {$convert: {input: {$getField: item.field}, to: 'double'}},
+          {$literal: val},
+        ],
+      };
+    }
   } else if (item.operator === '(number): >=') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $gte: [
-        {$convert: {input: {$getField: item.field}, to: 'double'}},
-        {$literal: val},
-      ],
-    };
+    if (FIELDS_NO_FLOAT_CONVERT.includes(item.field)) {
+      return {
+        $gte: [{$getField: item.field}, {$literal: val}],
+      };
+    } else {
+      return {
+        $gte: [
+          {$convert: {input: {$getField: item.field}, to: 'double'}},
+          {$literal: val},
+        ],
+      };
+    }
   } else if (item.operator === '(number): <') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $not: [
-        {
-          $gte: [
-            {$convert: {input: {$getField: item.field}, to: 'double'}},
-            {$literal: val},
-          ],
-        },
-      ],
-    };
+    if (FIELDS_NO_FLOAT_CONVERT.includes(item.field)) {
+      return {
+        $not: [{$gte: [{$getField: item.field}, {$literal: val}]}],
+      };
+    } else {
+      return {
+        $not: [
+          {
+            $gte: [
+              {$convert: {input: {$getField: item.field}, to: 'double'}},
+              {$literal: val},
+            ],
+          },
+        ],
+      };
+    }
   } else if (item.operator === '(number): <=') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $not: [
-        {
-          $gt: [
-            {$convert: {input: {$getField: item.field}, to: 'double'}},
-            {$literal: val},
-          ],
-        },
-      ],
-    };
+    if (FIELDS_NO_FLOAT_CONVERT.includes(item.field)) {
+      return {
+        $not: [{$gt: [{$getField: item.field}, {$literal: val}]}],
+      };
+    } else {
+      return {
+        $not: [
+          {
+            $gt: [
+              {$convert: {input: {$getField: item.field}, to: 'double'}},
+              {$literal: val},
+            ],
+          },
+        ],
+      };
+    }
   } else if (item.operator === '(bool): is') {
     if (item.value === '') {
       return null;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -73,56 +73,49 @@ export const operationConverter = (
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $eq: [getFieldExpression(item.field), {$literal: val}],
-    };
+    const field = getFieldExpression(item.field);
+    return {$eq: [field, {$literal: val}]};
   } else if (item.operator === '(number): !=') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $not: [{$eq: [getFieldExpression(item.field), {$literal: val}]}],
-    };
+    const field = getFieldExpression(item.field);
+    return {$not: [{$eq: [field, {$literal: val}]}]};
   } else if (item.operator === '(number): >') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $gt: [getFieldExpression(item.field), {$literal: val}],
-    };
+    const field = getFieldExpression(item.field);
+    return {$gt: [field, {$literal: val}]};
   } else if (item.operator === '(number): >=') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $gte: [getFieldExpression(item.field), {$literal: val}],
-    };
+    const field = getFieldExpression(item.field);
+    return {$gte: [field, {$literal: val}]};
   } else if (item.operator === '(number): <') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $not: [{$gte: [getFieldExpression(item.field), {$literal: val}]}],
-    };
+    const field = getFieldExpression(item.field);
+    return {$not: [{$gte: [field, {$literal: val}]}]};
   } else if (item.operator === '(number): <=') {
     if (item.value === '') {
       return null;
     }
     const val = parseFloat(item.value);
-    return {
-      $not: [{$gt: [getFieldExpression(item.field), {$literal: val}]}],
-    };
+    const field = getFieldExpression(item.field);
+    return {$not: [{$gt: [field, {$literal: val}]}]};
   } else if (item.operator === '(bool): is') {
     if (item.value === '') {
       return null;
     }
-    return {
-      $eq: [{$getField: item.field}, {$literal: `${item.value}`}],
-    };
+    const field = getFieldExpression(item.field);
+    return {$eq: [field, {$literal: `${item.value}`}]};
   } else if (item.operator === '(date): after') {
     if (item.value === '') {
       return null;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -1959,11 +1959,10 @@ export const traceCallLatencyMs = (
   const endDate = traceCall.ended_at
     ? convertISOToDate(traceCall.ended_at)
     : null;
-  let latencyMs = 0;
-  if (startDate && endDate) {
-    latencyMs = endDate.getTime() - startDate.getTime();
+  if (startDate == null || endDate == null) {
+    return 0;
   }
-  return latencyMs;
+  return endDate.getTime() - startDate.getTime();
 };
 
 const traceCallToLegacySpan = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -1949,15 +1949,21 @@ export const traceCallStatusCode = (
 export const traceCallLatencyS = (
   traceCall: traceServerTypes.TraceCallSchema
 ) => {
+  return traceCallLatencyMs(traceCall) / 1000;
+};
+
+export const traceCallLatencyMs = (
+  traceCall: traceServerTypes.TraceCallSchema
+) => {
   const startDate = convertISOToDate(traceCall.started_at);
   const endDate = traceCall.ended_at
     ? convertISOToDate(traceCall.ended_at)
     : null;
-  let latencyS = 0;
+  let latencyMs = 0;
   if (startDate && endDate) {
-    latencyS = (endDate.getTime() - startDate.getTime()) / 1000;
+    latencyMs = endDate.getTime() - startDate.getTime();
   }
-  return latencyS;
+  return latencyMs;
 };
 
 const traceCallToLegacySpan = (

--- a/weave/flow/saved_view.py
+++ b/weave/flow/saved_view.py
@@ -753,8 +753,7 @@ class SavedView:
     def ui_url(self) -> str | None:
         """URL to show this saved view in the UI.
 
-        Note this is the "result" page with traces etc, not the URL for the view object.
-        """
+        Note this is the "result" page with traces etc, not the URL for the view object."""
         if self.ref and self.entity and self.project:
             weave_root = urls.project_weave_root_url(self.entity, self.project)
             return f"{weave_root}/{self.view_type}?view={self.ref.name}"

--- a/weave/flow/saved_view.py
+++ b/weave/flow/saved_view.py
@@ -162,10 +162,6 @@ def py_to_api_filter(filter: tsi.CallsFilter | None) -> tsi.CallsFilter | None:
     )
 
 
-def make_convert_getfield_query(field: str, value: Any, to: str) -> dict[str, Any]:
-    return {"$convert": {"input": {"$getField": field}, "to": to}}
-
-
 # See operationConverter in weave-js
 def get_field_expression(field: str) -> dict[str, Any]:
     """Helper function to get field expression based on whether it needs float conversion."""

--- a/weave/flow/saved_view.py
+++ b/weave/flow/saved_view.py
@@ -146,6 +146,9 @@ OPERATOR_MAP = {
 
 VALUELESS_OPERATORS = {"(any): isEmpty", "(any): isNotEmpty"}
 
+# We return a real float from the backend! do not convert to double!
+FIELDS_NO_FLOAT_CONVERT = {"summary.weave.latency_ms"}
+
 
 def py_to_api_filter(filter: tsi.CallsFilter | None) -> tsi.CallsFilter | None:
     """Convert Saved View Filter to API Filter"""
@@ -212,79 +215,99 @@ def filter_to_clause(item: Filter) -> dict[str, Any]:
         return {"$or": clauses}
     elif item.operator == "(number): =":
         value = float(item.value)
-        return {
-            "$eq": [
-                {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
-                {"$literal": value},
-            ],
-        }
+        if item.field in FIELDS_NO_FLOAT_CONVERT:
+            return {"$eq": [{"$getField": item.field}, {"$literal": value}]}
+        else:
+            return {
+                "$eq": [
+                    {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
+                    {"$literal": value},
+                ],
+            }
     elif item.operator == "(number): !=":
         value = float(item.value)
-        return {
-            "$not": [
-                {
-                    "$eq": [
-                        {
-                            "$convert": {
-                                "input": {"$getField": item.field},
-                                "to": "double",
-                            }
-                        },
-                        {"$literal": value},
-                    ],
-                },
-            ],
-        }
+        if item.field in FIELDS_NO_FLOAT_CONVERT:
+            return {"$not": [{"$eq": [{"$getField": item.field}, {"$literal": value}]}]}
+        else:
+            return {
+                "$not": [
+                    {
+                        "$eq": [
+                            {
+                                "$convert": {
+                                    "input": {"$getField": item.field},
+                                    "to": "double",
+                                }
+                            },
+                            {"$literal": value},
+                        ],
+                    },
+                ],
+            }
     elif item.operator == "(number): >":
         value = float(item.value)
-        return {
-            "$gt": [
-                {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
-                {"$literal": value},
-            ],
-        }
+        if item.field in FIELDS_NO_FLOAT_CONVERT:
+            return {"$gt": [{"$getField": item.field}, {"$literal": value}]}
+        else:
+            return {
+                "$gt": [
+                    {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
+                    {"$literal": value},
+                ],
+            }
     elif item.operator == "(number): >=":
         value = float(item.value)
-        return {
-            "$gte": [
-                {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
-                {"$literal": value},
-            ],
-        }
+        if item.field in FIELDS_NO_FLOAT_CONVERT:
+            return {"$gte": [{"$getField": item.field}, {"$literal": value}]}
+        else:
+            return {
+                "$gte": [
+                    {"$convert": {"input": {"$getField": item.field}, "to": "double"}},
+                    {"$literal": value},
+                ],
+            }
     elif item.operator == "(number): <":
         value = float(item.value)
-        return {
-            "$not": [
-                {
-                    "$gte": [
-                        {
-                            "$convert": {
-                                "input": {"$getField": item.field},
-                                "to": "double",
-                            }
-                        },
-                        {"$literal": value},
-                    ],
-                }
-            ],
-        }
+        if item.field in FIELDS_NO_FLOAT_CONVERT:
+            return {
+                "$not": [{"$gte": [{"$getField": item.field}, {"$literal": value}]}]
+            }
+        else:
+            return {
+                "$not": [
+                    {
+                        "$gte": [
+                            {
+                                "$convert": {
+                                    "input": {"$getField": item.field},
+                                    "to": "double",
+                                }
+                            },
+                            {"$literal": value},
+                        ],
+                    }
+                ],
+            }
     elif item.operator == "(number): <=":
         value = float(item.value)
-        return {
-            "$not": [
-                {
-                    "$gt": [
-                        {
-                            "$convert": {
-                                "input": {"$getField": item.field},
-                                "to": "double",
-                            }
-                        },
-                        {"$literal": value},
-                    ],
-                }
-            ],
-        }
+        if item.field in FIELDS_NO_FLOAT_CONVERT:
+            return {"$not": [{"$gt": [{"$getField": item.field}, {"$literal": value}]}]}
+        else:
+            return {
+                "$not": [
+                    {
+                        "$gt": [
+                            {
+                                "$convert": {
+                                    "input": {"$getField": item.field},
+                                    "to": "double",
+                                }
+                            },
+                            {"$literal": value},
+                        ],
+                    }
+                ],
+            }
     elif item.operator == "(bool): is":
         return {
             "$eq": [{"$getField": item.field}, {"$literal": str(item.value)}],
@@ -791,7 +814,8 @@ class SavedView:
     def ui_url(self) -> str | None:
         """URL to show this saved view in the UI.
 
-        Note this is the "result" page with traces etc, not the URL for the view object."""
+        Note this is the "result" page with traces etc, not the URL for the view object.
+        """
         if self.ref and self.entity and self.project:
             weave_root = urls.project_weave_root_url(self.entity, self.project)
             return f"{weave_root}/{self.view_type}?view={self.ref.name}"


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-24782](https://wandb.atlassian.net/browse/WB-24782)

This pr:
- refactor the "onAddFilter" to "onUpdateFilter" (just a name change, per the TODO comment)
- Add support for "option+click" filtering by trace name. 
- Add support for "option+click" filtering for `latency_ms`. When option clicking latency, the default is "greater than or equal to". Because we are generating this field manually on the backend, it is actually a float, not a string stored in json, so we need to omit the conversion params from the filter. 

## Testing

![filter-name-1](https://github.com/user-attachments/assets/0cf57690-3570-4cd3-b711-2a7fb6cf6d8e)



[WB-24782]: https://wandb.atlassian.net/browse/WB-24782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ