### PR TITLE
chore(ui): replace MUI Chip with RemovableTag

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -6,13 +6,7 @@
  *    * (BackendExpansion) Move Expansion to Backend, and support filter/sort
  */
 
-import {
-  Autocomplete,
-  Chip,
-  FormControl,
-  ListItem,
-  Tooltip,
-} from '@mui/material';
+import {Autocomplete, FormControl, ListItem, Tooltip} from '@mui/material';
 import {
   GridColDef,
   GridColumnVisibilityModel,
@@ -47,6 +41,8 @@ import React, {
 import {useHistory} from 'react-router-dom';
 
 import {useViewerInfo} from '../../../../../../common/hooks/useViewerInfo';
+import {RemovableTag} from '../../../../../Tag';
+import {RemoveAction} from '../../../../../Tag/RemoveAction';
 import {TailwindContents} from '../../../../../Tailwind';
 import {TableRowSelectionContext} from '../../../TableRowSelectionContext';
 import {
@@ -69,11 +65,7 @@ import {StyledTextField} from '../../StyledTextField';
 import {ConfirmDeleteModal} from '../CallPage/OverflowMenu';
 import {FilterLayoutTemplate} from '../common/SimpleFilterableDataTable';
 import {prepareFlattenedDataForTable} from '../common/tabularListViews/columnBuilder';
-import {
-  truncateID,
-  useControllableState,
-  useURLSearchParamsDict,
-} from '../util';
+import {useControllableState, useURLSearchParamsDict} from '../util';
 import {useWFHooks} from '../wfReactInterface/context';
 import {TraceCallSchema} from '../wfReactInterface/traceServerClientTypes';
 import {traceCallToUICallSchema} from '../wfReactInterface/tsDataModelHooks';
@@ -979,40 +971,60 @@ export const CallsTable: FC<{
           )}
           <div className="ml-auto flex items-center gap-8">
             {selectedInputObjectVersion && (
-              <Chip
+              <RemovableTag
+                color="moon"
                 label={`Input: ${objectVersionNiceString(
                   selectedInputObjectVersion
                 )}`}
-                onDelete={() => {
-                  setFilter({
-                    ...filter,
-                    inputObjectVersionRefs: undefined,
-                  });
-                }}
+                removeAction={
+                  <RemoveAction
+                    onClick={(e: React.SyntheticEvent) => {
+                      e.stopPropagation();
+                      setFilter({
+                        ...filter,
+                        inputObjectVersionRefs: undefined,
+                      });
+                    }}
+                  />
+                }
               />
             )}
             {selectedOutputObjectVersion && (
-              <Chip
+              <RemovableTag
+                color="moon"
                 label={`Output: ${objectVersionNiceString(
                   selectedOutputObjectVersion
                 )}`}
-                onDelete={() => {
-                  setFilter({
-                    ...filter,
-                    outputObjectVersionRefs: undefined,
-                  });
-                }}
+                removeAction={
+                  <RemoveAction
+                    onClick={(e: React.SyntheticEvent) => {
+                      e.stopPropagation();
+                      setFilter({
+                        ...filter,
+                        outputObjectVersionRefs: undefined,
+                      });
+                    }}
+                  />
+                }
               />
             )}
             {selectedParentId && (
-              <Chip
+              <RemovableTag
+                maxChars={48}
+                truncatedPart="middle"
+                color="moon"
                 label={`Parent: ${selectedParentId}`}
-                onDelete={() => {
-                  setFilter({
-                    ...filter,
-                    parentId: undefined,
-                  });
-                }}
+                removeAction={
+                  <RemoveAction
+                    onClick={(e: React.SyntheticEvent) => {
+                      e.stopPropagation();
+                      setFilter({
+                        ...filter,
+                        parentId: undefined,
+                      });
+                    }}
+                  />
+                }
               />
             )}
             <div className="flex items-center gap-6">
@@ -1265,10 +1277,11 @@ const useParentIdOptions = (
     if (parentCall.loading || parentCall.result == null) {
       return {};
     }
+    const call = parentCall.result;
+    const truncatedId = call.callId.slice(-4);
+    const label = `${call.displayName} (${truncatedId})`;
     return {
-      [parentCall.result.callId]: `${parentCall.result.spanName} (${truncateID(
-        parentCall.result.callId
-      )})`,
+      [call.callId]: label,
     };
   }, [parentCall.loading, parentCall.result]);
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Links.tsx
@@ -163,9 +163,6 @@ export const ObjectVersionLink: React.FC<{
   hideVersionSuffix?: boolean;
 }> = props => {
   const {peekingRouter} = useWeaveflowRouteContext();
-  // const text = props.hideName
-  //   ? props.version
-  //   : props.objectName + ': ' + truncateID(props.version);
   const text = props.hideVersionSuffix
     ? props.objectName
     : objectVersionText(props.objectName, props.versionIndex);
@@ -231,9 +228,6 @@ export const OpVersionLink: React.FC<{
   color?: string;
 }> = props => {
   const {peekingRouter} = useWeaveflowRouteContext();
-  // const text = props.hideName
-  //   ? props.version
-  //   : props.opName + ': ' + truncateID(props.version);
   const text = opVersionText(props.opName, props.versionIndex);
   const to = peekingRouter.opVersionUIUrl(
     props.entityName,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/util.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/util.tsx
@@ -15,15 +15,6 @@ export const useURLSearchParamsDict = () => {
   }, [search]);
 };
 
-export const truncateID = (id: string, maxLen: number = 9) => {
-  if (id.length < maxLen) {
-    return id;
-  }
-  const startLen = Math.floor((maxLen - 3) / 2);
-  const endLen = maxLen - 3 - startLen;
-  return `${id.slice(0, startLen)}...${id.slice(-endLen)}`;
-};
-
 /**
  * A hook that returns a state that can be controlled by an external component.
  * The usage is the same as useState, but with an additional optional parameter


### PR DESCRIPTION
## Description

Replace the UI for the parentId filter value, from one using a Material UI Chip to one using a W&B common component removable tag.

Besides a more consistent look with the rest of the UI, changes/improvements are:
* Use the display name of the parent call, which might have been changed
* Use the "trailing 4 char" form of id abbreviation instead of an older approach.
* The component automatically has a tooltip if the call name is truncated.

Before:
<img width="304" alt="Screenshot 2025-05-02 at 2 53 47 PM" src="https://github.com/user-attachments/assets/038cd76c-ee6f-4a33-af7a-7e47c073b8cd" />

After:
<img width="318" alt="Screenshot 2025-05-02 at 2 54 11 PM" src="https://github.com/user-attachments/assets/2e0efb77-5a2e-4ba5-b617-95857cccd9e0" />
<img width="866" alt="Screenshot 2025-05-02 at 2 57 11 PM" src="https://github.com/user-attachments/assets/b6e3f2b7-3742-43f1-862d-7a0d26ac0612" />

@Yangyi-wandb @m-rgba - if we go with this we should also replace the Chips used for input/output filters but wanted to get your opinions on it first.

----

Update - have replace Chip component for the input/output object link too.


## Testing

How was this PR tested?
