### PR TITLE
chore(ui): Minor nits - multi-chat playground update

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
@@ -211,7 +211,9 @@ export const PlaygroundChat = ({
                 className={`relative m-[8px] flex w-full min-w-[520px] ${
                   playgroundStates.length === 1 ? 'lg:min-w-[800px]' : ''
                 } max-w-[800px] flex-col rounded-[4px] border ${
-                  settingsTab === idx ? 'outline outline-[1.5px] outline-teal-400 border-teal-400' : 'border-moon-200'
+                  settingsTab === idx
+                    ? 'border-teal-400 outline outline-[1.5px] outline-teal-400'
+                    : 'border-moon-200'
                 }`}>
                 {state.loading && (
                   <div
@@ -222,7 +224,7 @@ export const PlaygroundChat = ({
                     <WaveLoader size="small" />
                   </div>
                 )}
-                <div className="absolute top-0 z-[10] w-full bg-white px-[16px] py-[8px] rounded-t-[4px]">
+                <div className="absolute top-0 z-[10] w-full rounded-t-[4px] bg-white px-[16px] py-[8px]">
                   <PlaygroundChatTopBar
                     idx={idx}
                     settingsTab={settingsTab}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
@@ -1,9 +1,9 @@
-import {CircularProgress} from '@mui/material';
 import {WHITE} from '@wandb/weave/common/css/color.styles';
 import {hexToRGB} from '@wandb/weave/common/css/utils';
 import {useIsTeamAdmin} from '@wandb/weave/common/hooks/useIsTeamAdmin';
 import {useViewerInfo} from '@wandb/weave/common/hooks/useViewerInfo';
 import {Button} from '@wandb/weave/components/Button';
+import {WaveLoader} from '@wandb/weave/components/Loaders/WaveLoader';
 import React, {Dispatch, SetStateAction, useMemo, useState} from 'react';
 
 import {CallChat} from '../../CallPage/CallChat';
@@ -208,8 +208,10 @@ export const PlaygroundChat = ({
           {playgroundStates.map((state, idx) => (
             <React.Fragment key={idx}>
               <div
-                className={`relative m-[8px] flex w-full min-w-[520px] max-w-[800px] flex-col rounded-[4px] border-2 ${
-                  settingsTab === idx ? 'border-teal-400' : 'border-moon-200'
+                className={`relative m-[8px] flex w-full min-w-[520px] ${
+                  playgroundStates.length === 1 ? 'lg:min-w-[800px]' : ''
+                } max-w-[800px] flex-col rounded-[4px] border ${
+                  settingsTab === idx ? 'outline outline-[1.5px] outline-teal-400 border-teal-400' : 'border-moon-200'
                 }`}>
                 {state.loading && (
                   <div
@@ -217,10 +219,10 @@ export const PlaygroundChat = ({
                       WHITE,
                       0.7
                     )}]`}>
-                    <CircularProgress />
+                    <WaveLoader size="small" />
                   </div>
                 )}
-                <div className="absolute top-0 z-[10] w-full bg-white px-[16px] py-[8px]">
+                <div className="absolute top-0 z-[10] w-full bg-white px-[16px] py-[8px] rounded-t-[4px]">
                   <PlaygroundChatTopBar
                     idx={idx}
                     settingsTab={settingsTab}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -86,7 +86,7 @@ export const PlaygroundPage = (props: PlaygroundPageProps) => {
               JSON.parse(JSON.stringify(playgroundStates[settingsTab ?? 0])),
             ]);
           }}>
-          Add chat
+          Add model
         </Button>
       }
     />


### PR DESCRIPTION
## Description

- Switched to `WaveLoader` instead of CircularLoader (trying to deprecate usage across app).
- Tried this: `playgroundStates.length === 1 ? 'lg:min-w-[800px]' : ''` as a fix for the card collapsing in to ~740px on larger screens... pretty annoying visual OCD issue -- this is a bit of a hack, but it improves it.
- Used a single px border + `outline outline-[1.5px] outline-teal-400` for the setting active state (and the rounded the top corner of the card header)
  - We do this somewhere else as a fix as well, it would be preferable to use Tailwind's `ring` but I think box-shadow is set to none in dark mode which is what it uses for the active ring border.
- Updated `Add chat` to `Add model` copy - my bad (since that's the actual unit we're adding - and `Add chat` could make the user think they're creating a new entire chat instance).