### PR TITLE
refactor(ui): move OpDefCode out of Browse2

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewer.tsx
@@ -3,9 +3,9 @@ import {useHistory} from 'react-router-dom';
 import styled from 'styled-components';
 
 import {Button} from '../../../Button';
-import {Browse2OpDefCode} from '../Browse2/Browse2OpDefCode';
 import {useWeaveflowCurrentRouteContext} from './context';
 import {OpCodeViewerDiff} from './OpCodeViewerDiff';
+import {OpDefCode} from './OpDefCode';
 import {opVersionKeyToRefUri} from './pages/wfReactInterface/utilities';
 import {OpVersionSchema} from './pages/wfReactInterface/wfDataModelHooksInterface';
 import {SelectOpVersion} from './SelectOpVersion';
@@ -155,7 +155,7 @@ export const OpCodeViewer = ({
     <OpCodeViewerContainer>
       {diffBar}
       {diffState.left == null || diffState.right == null ? (
-        <Browse2OpDefCode uri={currentVersionURI} />
+        <OpDefCode uri={currentVersionURI} />
       ) : (
         <>
           <SelectVersionBar>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/OpDefCode.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/OpDefCode.tsx
@@ -5,7 +5,7 @@ import React, {FC} from 'react';
 
 import {sanitizeString} from '../../../../util/sanitizeSecrets';
 import {Alert} from '../../../Alert';
-import {useWFHooks} from '../Browse3/pages/wfReactInterface/context';
+import {useWFHooks} from './pages/wfReactInterface/context';
 
 function detectLanguage(uri: string, code: string) {
   // Simple language detection based on file extension or content
@@ -24,7 +24,7 @@ function detectLanguage(uri: string, code: string) {
   return 'plaintext';
 }
 
-export const Browse2OpDefCode: FC<{uri: string; maxRowsInView?: number}> = ({
+export const OpDefCode: FC<{uri: string; maxRowsInView?: number}> = ({
   uri,
   maxRowsInView,
 }) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/CodeView.tsx
@@ -11,7 +11,7 @@ import {Loading} from '../../../../Loading';
 import {useWFHooks} from '../pages/wfReactInterface/context';
 
 // Simple language detection based on file extension or content
-// TODO: Unify this utility method with Browse2OpDefCode.tsx
+// TODO: Unify this utility method with OpDefCode.tsx
 export const detectLanguage = (uri: string, code: string) => {
   if (uri.endsWith('.py')) {
     return 'python';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -6,7 +6,6 @@ import React, {FC, useCallback, useContext, useEffect, useRef} from 'react';
 import {makeRefCall} from '../../../../../../util/refs';
 import {Button} from '../../../../../Button';
 import {Tailwind} from '../../../../../Tailwind';
-import {Browse2OpDefCode} from '../../../Browse2/Browse2OpDefCode';
 import {TableRowSelectionContext} from '../../../TableRowSelectionContext';
 import {TraceNavigator} from '../../components/TraceNavigator/TraceNavigator';
 import {WeaveflowPeekContext} from '../../context';
@@ -15,6 +14,7 @@ import {ScorerFeedbackGrid} from '../../feedback/ScorerFeedbackGrid';
 import {FeedbackSidebar} from '../../feedback/StructuredFeedback/FeedbackSidebar';
 import {useHumanAnnotationSpecs} from '../../feedback/StructuredFeedback/tsHumanFeedback';
 import {NotFoundPanel} from '../../NotFoundPanel';
+import {OpDefCode} from '../../OpDefCode';
 import {isCallChat} from '../ChatView/hooks';
 import {isEvaluateOp} from '../common/heuristics';
 import {CenteredAnimatedLoader} from '../common/Loader';
@@ -191,7 +191,7 @@ const useCallTabs = (call: CallSchema) => {
       ? [
           {
             label: 'Code',
-            content: <Browse2OpDefCode uri={codeURI} />,
+            content: <OpDefCode uri={codeURI} />,
           },
         ]
       : []),

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -21,8 +21,8 @@ import React, {
 
 import {parseRefMaybe} from '../../../../../../react';
 import {LoadingDots} from '../../../../../LoadingDots';
-import {Browse2OpDefCode} from '../../../Browse2/Browse2OpDefCode';
 import {isWeaveRef} from '../../filters/common';
+import {OpDefCode} from '../../OpDefCode';
 import {objectRefDisplayName} from '../../smallRef/SmallWeaveRef';
 import {StyledDataGrid} from '../../StyledDataGrid';
 import {
@@ -351,7 +351,7 @@ export const ObjectViewer = ({
                   width: '100%',
                   height: '100%',
                 }}>
-                <Browse2OpDefCode uri={row.value} maxRowsInView={20} />
+                <OpDefCode uri={row.value} maxRowsInView={20} />
               </Box>
             );
           }


### PR DESCRIPTION
## Description

Continuing towards goal of eliminating Browse2, this just relocates and renames `Browse2OpDefCode` to `OpDefCode`.

## Testing

How was this PR tested?
