### PR TITLE
fix(weave): do not retry call inserts that fail with a non retryable status code

### DIFF
--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -11,7 +11,7 @@ from weave.trace.settings import max_calls_queue_size
 from weave.trace_server import requests
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
-from weave.utils.retry import with_retry
+from weave.utils.retry import _is_retryable_exception, with_retry
 from weave.wandb_interface import project_creator
 
 logger = logging.getLogger(__name__)
@@ -43,6 +43,29 @@ class ServerInfoRes(BaseModel):
 REMOTE_REQUEST_BYTES_LIMIT = (
     (32 - 1) * 1024 * 1024
 )  # 32 MiB (real limit) - 1 MiB (buffer)
+
+
+def _log_dropped_call_batch(
+    batch: list[Union[StartBatchItem, EndBatchItem]], e: Exception
+) -> None:
+    logger.error(f"Error sending batch of {len(batch)} call events to server")
+    dropped_start_ids = []
+    dropped_end_ids = []
+    for item in batch:
+        if isinstance(item, StartBatchItem):
+            dropped_start_ids.append(item.req.start.id)
+        elif isinstance(item, EndBatchItem):
+            dropped_end_ids.append(item.req.end.id)
+    if dropped_start_ids:
+        logger.error(f"dropped call start ids: {dropped_start_ids}")
+    if dropped_end_ids:
+        logger.error(f"dropped call end ids: {dropped_end_ids}")
+    if isinstance(e, requests.HTTPError) and e.response is not None:
+        logger.error(f"status code: {e.response.status_code}")
+        logger.error(f"reason: {e.response.reason}")
+        logger.error(f"text: {e.response.text}")
+    else:
+        logger.error(f"error: {e}")
 
 
 class RemoteHTTPTraceServer(tsi.TraceServerInterface):
@@ -148,22 +171,25 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
 
         try:
             self._send_batch_to_server(encoded_data)
-        except Exception:
-            # Add items back to the queue for later processing
-            logger.warning(
-                f"Batch failed after max retries, requeueing batch with {len(batch)=} for later processing",
-            )
+        except Exception as e:
+            if not _is_retryable_exception(e):
+                _log_dropped_call_batch(batch, e)
+            else:
+                # Add items back to the queue for later processing
+                logger.warning(
+                    f"Batch failed after max retries, requeueing batch with {len(batch)=} for later processing",
+                )
 
-            # only if debug mode
-            if logger.isEnabledFor(logging.DEBUG):
-                ids = []
-                for item in batch:
-                    if isinstance(item, StartBatchItem):
-                        ids.append(f"{item.req.start.id}-start")
-                    elif isinstance(item, EndBatchItem):
-                        ids.append(f"{item.req.end.id}-end")
-                logger.debug(f"Requeueing batch with {ids=}")
-            self.call_processor.enqueue(batch)
+                # only if debug mode
+                if logger.isEnabledFor(logging.DEBUG):
+                    ids = []
+                    for item in batch:
+                        if isinstance(item, StartBatchItem):
+                            ids.append(f"{item.req.start.id}-start")
+                        elif isinstance(item, EndBatchItem):
+                            ids.append(f"{item.req.end.id}-end")
+                    logger.debug(f"Requeueing batch with {ids=}")
+                self.call_processor.enqueue(batch)
 
     @with_retry
     def _generic_request_executor(


### PR DESCRIPTION
Modifies the retry logic in `_flush_calls` to prevent infinite retries of non-retyable errors. Previously we requeued all batches that failed. Now we requeue batches that fail with a retryable exception (ie 4XX). If a batch failsfails with with 4XX, we `logger.error` the response code, text, and reason, the dropped start and end event ids that were dropped, and proceed.

Example script that would infinitely retry 400:

```python
import weave

weave.init("testing")

@weave.op()
def get_artifact_url() -> str:  # Malformed ref in output causes a 400 error on request validation
    return "weave:///artifact/bcanfieldsherman/testing/toxic-extra-path/run-4cinli05-test.py:v0"

get_artifact_url()
```

Previously running this generated an infinite loop of:
```
Batch failed after max retries, requeueing batch with len(batch)=2 for later processing
```

and now the output is:
```
Logged in as Weights & Biases user: bcanfieldsherman.
View Weave data at https://wandb.ai/bcanfieldsherman/testing/weave
Error sending batch of 1 call events to server
dropped call end ids: ['01969356-77a1-7441-a4f4-4180c4335465']
status code: 400
reason: Bad Request
text: {"reason":"1 validation error for CallEndCHInsertable\noutput_refs\n  Value error, Unknown ref kind: toxic-extra-path [type=value_error, input_value=['weave-trace-internal://...un-4cinli05-test.py:v0'], input_type=list]\n    For further information visit https://errors.pydantic.dev/2.7/v/value_error"}
```
