### PR TITLE
chore(weave): trace server does not 400 for malformed refs in call inputs or output

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -51,6 +51,21 @@ from weave.trace_server.trace_server_interface_util import (
 
 ## Hacky interface compatibility helpers
 
+
+def extract_weave_refs_from_value(value):
+    """Extract all strings that start with 'weave:///' from a value."""
+    refs = []
+    if isinstance(value, str) and value.startswith("weave:///"):
+        refs.append(value)
+    elif isinstance(value, dict):
+        for v in value.values():
+            refs.extend(extract_weave_refs_from_value(v))
+    elif isinstance(value, list):
+        for v in value:
+            refs.extend(extract_weave_refs_from_value(v))
+    return refs
+
+
 ClientType = weave_client.WeaveClient
 
 
@@ -444,7 +459,11 @@ def test_trace_call_query_filter_input_object_version_refs(client):
     res = get_all_calls_asserting_finished(client, call_spec)
 
     input_object_version_refs = unique_vals(
-        [ref for call in res.calls for ref in extract_refs_from_values(call.inputs)]
+        [
+            ref
+            for call in res.calls
+            for ref in extract_weave_refs_from_value(call.inputs)
+        ]
     )
     assert len(input_object_version_refs) > 3  # > 3
 
@@ -461,7 +480,7 @@ def test_trace_call_query_filter_input_object_version_refs(client):
                     call
                     for call in res.calls
                     if has_any(
-                        extract_refs_from_values(call.inputs),
+                        extract_weave_refs_from_value(call.inputs),
                         input_object_version_refs[:1],
                     )
                 ]
@@ -475,7 +494,7 @@ def test_trace_call_query_filter_input_object_version_refs(client):
                     call
                     for call in res.calls
                     if has_any(
-                        extract_refs_from_values(call.inputs),
+                        extract_weave_refs_from_value(call.inputs),
                         input_object_version_refs[:3],
                     )
                 ]
@@ -498,7 +517,11 @@ def test_trace_call_query_filter_output_object_version_refs(client):
     res = get_all_calls_asserting_finished(client, call_spec)
 
     output_object_version_refs = unique_vals(
-        [ref for call in res.calls for ref in extract_refs_from_values(call.output)]
+        [
+            ref
+            for call in res.calls
+            for ref in extract_weave_refs_from_value(call.output)
+        ]
     )
     assert len(output_object_version_refs) > 3
 
@@ -515,7 +538,7 @@ def test_trace_call_query_filter_output_object_version_refs(client):
                     call
                     for call in res.calls
                     if has_any(
-                        extract_refs_from_values(call.output),
+                        extract_weave_refs_from_value(call.output),
                         output_object_version_refs[:1],
                     )
                 ]
@@ -529,7 +552,7 @@ def test_trace_call_query_filter_output_object_version_refs(client):
                     call
                     for call in res.calls
                     if has_any(
-                        extract_refs_from_values(call.output),
+                        extract_weave_refs_from_value(call.output),
                         output_object_version_refs[:3],
                     )
                 ]

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -3451,3 +3451,27 @@ def test_files_stats(client):
     read_res = client.server.files_stats(FilesStatsReq(project_id="shawn/test-project"))
 
     assert read_res.total_size_bytes == 10000005
+
+
+def test_no_400_on_invalid_artifact_url(client):
+    @weave.op()
+    def test() -> str:
+        # This url is too long, should be wandb-artifact:///entity/project/name:version
+        return "wandb-artifact:///entity/project/toxic-extra-path/artifact:latest"
+
+    _, call = test.call()
+    id = call.id
+    server_call = client.get_call(id)
+    assert server_call.id == id
+
+
+def test_no_400_on_invalid_refs(client):
+    @weave.op()
+    def test() -> str:
+        # This ref is too long, should be weave:///entity/project/object/name:version
+        return "weave:///entity/project/object/toxic-extra-path/object:latest"
+
+    _, call = test.call()
+    id = call.id
+    server_call = client.get_call(id)
+    assert server_call.id == id

--- a/weave/trace_server/refs_internal.py
+++ b/weave/trace_server/refs_internal.py
@@ -173,14 +173,6 @@ def parse_internal_uri(
             raise InvalidInternalRef(f"Invalid URI: {uri}. Must have at least 2 parts")
         project_id, kind = parts[:2]
         remaining = parts[2:]
-    elif uri.startswith(f"{WEAVE_SCHEME}:///"):
-        path = uri[len(f"{WEAVE_SCHEME}:///") :]
-        parts = path.split("/")
-        if len(parts) < 3:
-            raise InvalidInternalRef(f"Invalid URI: {uri}. Must have at least 3 parts")
-        entity, project, kind = parts[:3]
-        project_id = f"{entity}/{project}"
-        remaining = parts[3:]
     elif uri.startswith(f"{ARTIFACT_REF_SCHEME}:///"):
         path = uri[len(f"{ARTIFACT_REF_SCHEME}:///") :]
         parts = path.split("/")

--- a/weave/trace_server/trace_server_interface_util.py
+++ b/weave/trace_server/trace_server_interface_util.py
@@ -28,8 +28,7 @@ def _order_dict(dictionary: dict) -> dict:
     }
 
 
-valid_schemes = [
-    TRACE_REF_SCHEME,
+valid_internal_schemes = [
     ARTIFACT_REF_SCHEME,
     refs_internal.WEAVE_INTERNAL_SCHEME,
 ]
@@ -47,10 +46,16 @@ def extract_refs_from_values(
         elif isinstance(val, list):
             for v in val:
                 _visit(v)
-        elif isinstance(val, str) and any(
-            val.startswith(scheme + "://") for scheme in valid_schemes
-        ):
-            refs.append(val)
+        elif isinstance(val, str):
+            if any(
+                val.startswith(scheme + ":///") for scheme in valid_internal_schemes
+            ):
+                try:
+                    parsed = refs_internal.parse_internal_uri(val)
+                    if parsed.uri() == val:
+                        refs.append(val)
+                except Exception:
+                    pass
 
     _visit(vals)
     return refs


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-24747



If these are included in the `input_refs` and `output_refs` field for a `CHInsertable`, it will lead to a validation error on the pydantic class and then a 400 bad request back to the client. This PR modifies `extract_refs_from_values` to attempt a parse of each of our special uri prefixes before we construct the `CHInsertable` and perform the validation there:
- `weave:///`
- `weave-trace-internal:///`
- `wandb-artifact:///`

If the parse fails, we omit the value from the refs list, since this will lead to a downstream validation error and 400. The result is that our backend treats these malformed uris in call i/o and objects as strings and our queries will not attempt to resolve those refs.