### PR TITLE
fix(weave): Correct timestamps for langfuse OTEL

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -23,7 +23,9 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.constants import MAX_OP_NAME_LENGTH
 from weave.trace_server.opentelemetry.attributes import (
+    get_span_overrides,
     get_wandb_attributes,
     get_weave_attributes,
     get_weave_inputs,
@@ -38,6 +40,7 @@ from weave.trace_server.opentelemetry.helpers import (
     get_attribute,
     shorten_name,
     to_json_serializable,
+    try_parse_timestamp,
     unflatten_key_values,
 )
 from weave.trace_server.opentelemetry.python_spans import (
@@ -243,9 +246,6 @@ class TestPythonSpans:
 
     def test_span_to_call_long_name(self):
         """Test that span names are properly shortened when too long."""
-        from weave.trace_server.constants import MAX_OP_NAME_LENGTH
-        from weave.trace_server.opentelemetry.helpers import shorten_name
-
         # Create a test span with a very long name
         pb_span = create_test_span()
         long_name = "a" * (MAX_OP_NAME_LENGTH + 10)
@@ -933,8 +933,6 @@ class TestHelpers:
         """Test parsing timestamps from various formats."""
         from datetime import datetime
 
-        from weave.trace_server.opentelemetry.helpers import try_parse_timestamp
-
         # Test parsing ISO 8601 format string
         iso_timestamp = "2023-01-01T12:00:00"
         result = try_parse_timestamp(iso_timestamp)
@@ -981,9 +979,6 @@ class TestSpanOverrides:
         """Test extracting span overrides from attributes."""
         from datetime import datetime
 
-        from weave.trace_server.opentelemetry.attributes import get_span_overrides
-        from weave.trace_server.opentelemetry.helpers import expand_attributes
-
         # Create attribute dictionary with timestamp overrides in ISO format
         iso_start = "2023-01-01T10:00:00"
         iso_end = "2023-01-01T10:01:30"
@@ -1006,9 +1001,6 @@ class TestSpanOverrides:
     def test_get_span_overrides_with_timestamps(self):
         """Test extracting span overrides with different timestamp formats."""
         from datetime import datetime
-
-        from weave.trace_server.opentelemetry.attributes import get_span_overrides
-        from weave.trace_server.opentelemetry.helpers import expand_attributes
 
         # Create attribute dictionary with epoch timestamps
         start_ns = 1672574400000000000  # 2023-01-01T12:00:00 in nanoseconds
@@ -1045,9 +1037,6 @@ class TestSpanOverrides:
 
     def test_get_span_overrides_with_missing_attributes(self):
         """Test get_span_overrides when no override attributes are present."""
-        from weave.trace_server.opentelemetry.attributes import get_span_overrides
-        from weave.trace_server.opentelemetry.helpers import expand_attributes
-
         # Create attribute dictionary without overrides
         attributes = expand_attributes(
             [

--- a/weave/trace_server/opentelemetry/attributes.py
+++ b/weave/trace_server/opentelemetry/attributes.py
@@ -5,6 +5,7 @@ from weave.trace_server.opentelemetry.constants import (
     ATTRIBUTE_KEYS,
     INPUT_KEYS,
     OUTPUT_KEYS,
+    SPAN_OVERRIDES,
     USAGE_KEYS,
     WB_KEYS,
 )
@@ -114,3 +115,8 @@ def get_weave_outputs(_: list[SpanEvent], attributes: dict[str, Any]) -> dict[st
 # Custom attributes for weave to enable setting fields like wb_user_id otherwise unavailable in OTEL Traces
 def get_wandb_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
     return parse_weave_values(attributes, WB_KEYS)
+
+
+# Pass events here even though they are unused because some libraries put input in event attribtes
+def get_span_overrides(attributes: dict[str, Any]) -> dict[str, Any]:
+    return parse_weave_values(attributes, SPAN_OVERRIDES)

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -135,6 +135,6 @@ WB_KEYS = {
 # These represent fields that are set by a provider which override top level span information
 # Langfuse relies on these attributes to give the real start and end time for spans
 SPAN_OVERRIDES = {
-    "start_time": ['langfuse.startTime', try_parse_timestamp],
-    "end_time": ['langfuse.endTime', try_parse_timestamp],
+    "start_time": [("langfuse.startTime", try_parse_timestamp)],
+    "end_time": [("langfuse.endTime", try_parse_timestamp)],
 }

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -1,4 +1,4 @@
-from weave.trace_server.opentelemetry.helpers import try_parse_int
+from weave.trace_server.opentelemetry.helpers import try_parse_int, try_parse_timestamp
 
 """
 The constants defined in this file map attribute keys from various telemetry standards
@@ -130,4 +130,11 @@ ATTRIBUTE_KEYS = {
 WB_KEYS = {
     # Custom display name for the call in the UI
     "display_name": ["wandb.display_name"],
+}
+
+# These represent fields that are set by a provider which override top level span information
+# Langfuse relies on these attributes to give the real start and end time for spans
+SPAN_OVERRIDES = {
+    "start_time": ['langfuse.startTime', try_parse_timestamp],
+    "end_time": ['langfuse.endTime', try_parse_timestamp],
 }

--- a/weave/trace_server/opentelemetry/helpers.py
+++ b/weave/trace_server/opentelemetry/helpers.py
@@ -453,6 +453,7 @@ def shorten_name(
         i += 1
     return shortened_name
 
+
 def try_parse_timestamp(x: Any) -> Any:
     """
     Try to parse a timestamp from various formats.

--- a/weave/trace_server/opentelemetry/helpers.py
+++ b/weave/trace_server/opentelemetry/helpers.py
@@ -452,3 +452,23 @@ def shorten_name(
             shortened_name += next_part
         i += 1
     return shortened_name
+
+def try_parse_timestamp(x: Any) -> Any:
+    """
+    Try to parse a timestamp from various formats.
+    Args:
+        x: The input value to parse as a timestamp.
+    Returns:
+        A datetime object if parsing is successful, otherwise returns None.
+    """
+    try:
+        if isinstance(x, str):
+            # Try to parse as ISO 8601 format
+            return datetime.fromisoformat(x)
+        elif isinstance(x, int):
+            # Try to parse from unix_ns
+            return datetime.fromtimestamp(x / 1_000_000_000)
+        elif isinstance(x, float):
+            return datetime.fromtimestamp(x)
+    except (ValueError, TypeError):
+        return None


### PR DESCRIPTION
## Description

- Fixes WB-24778

OTEL spans from langfuse don't display latency correctly because the start and end time of the spans are not the actual start and end time. Instead, the real start and end time are under:

`langfuse.startTime`
`langfuse.endTime`

This PR checks for these values and parses them out.

## Testing

Added test cases for datetime conversion handler and override fields parser.
