### PR TITLE
feat(weave): Adds Dataset.map and progress bars

### DIFF
--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -1,4 +1,5 @@
 import pytest
+import asyncio
 
 import weave
 from tests.trace.test_evaluate import Dataset
@@ -222,3 +223,377 @@ def test_add_rows_to_unsaved_dataset(client):
     ds = weave.Dataset(rows=[{"a": i} for i in range(10)])
     with pytest.raises(TypeError):
         ds.add_rows([{"a": 10}])
+
+
+# Dataset.map tests
+
+def test_dataset_map_basic(client):
+    original_rows = [{"id": i, "val": i * 2} for i in range(5)]
+    ds = weave.Dataset(rows=original_rows)
+
+    # Use named parameters instead of row dictionary
+    def add_doubled_val(val):
+        return {"val_doubled": val * 2}
+
+    mapped_ds = ds.map(add_doubled_val)
+
+    assert len(mapped_ds) == 5
+    expected_rows = [
+        {"id": 0, "val": 0, "val_doubled": 0},
+        {"id": 1, "val": 2, "val_doubled": 4},
+        {"id": 2, "val": 4, "val_doubled": 8},
+        {"id": 3, "val": 6, "val_doubled": 12},
+        {"id": 4, "val": 8, "val_doubled": 16},
+    ]
+    assert list(mapped_ds) == expected_rows
+    assert set(mapped_ds.columns_names) == {"id", "val", "val_doubled"}
+
+
+async def add_tripled_val_async(val):
+    await asyncio.sleep(0.01)  # Simulate async work
+    return {"val_tripled": val * 3}
+
+
+def test_dataset_map_async(client):
+    original_rows = [{"id": i, "val": i * 2} for i in range(3)]
+    ds = weave.Dataset(rows=original_rows)
+
+    mapped_ds = ds.map(add_tripled_val_async)
+
+    assert len(mapped_ds) == 3
+    expected_rows = [
+        {"id": 0, "val": 0, "val_tripled": 0},
+        {"id": 1, "val": 2, "val_tripled": 6},
+        {"id": 2, "val": 4, "val_tripled": 12},
+    ]
+    assert list(mapped_ds) == expected_rows
+    assert set(mapped_ds.columns_names) == {"id", "val", "val_tripled"}
+
+
+def test_dataset_map_failing_row(client):
+    original_rows = [{"id": i, "val": i} for i in range(5)]
+    ds = weave.Dataset(rows=original_rows)
+
+    def fail_on_three(id):
+        if id == 3:
+            raise ValueError("ID cannot be 3!")
+        return {"processed": True}
+
+    with pytest.raises(ValueError, match="ID cannot be 3!"):
+        ds.map(fail_on_three)
+
+
+def test_dataset_map_uneven_dicts(client):
+    original_rows = [{"id": i} for i in range(4)]
+    ds = weave.Dataset(rows=original_rows)
+
+    def add_conditional_cols(id):
+        if id % 2 == 0:
+            return {"is_even": True, "even_val": id * 10}
+        else:
+            return {"is_odd": True}
+
+    # Note: weave.Table currently doesn't enforce strict schemas or fill missing vals with None
+    # The behavior here reflects how weave.Table handles lists of dicts with varying keys.
+    mapped_ds = ds.map(add_conditional_cols)
+
+    assert len(mapped_ds) == 4
+    expected_rows = [
+        {"id": 0, "is_even": True, "even_val": 0}, # missing is_odd
+        {"id": 1, "is_odd": True},               # missing is_even, even_val
+        {"id": 2, "is_even": True, "even_val": 20},# missing is_odd
+        {"id": 3, "is_odd": True},               # missing is_even, even_val
+    ]
+    assert list(mapped_ds) == expected_rows
+    # The columns_names property gets the keys from the *first* row.
+    assert set(mapped_ds.columns_names) == {"id", "is_even", "even_val"}
+
+
+def test_dataset_map_immutability(client):
+    original_rows = [{"id": i, "val": i} for i in range(3)]
+    original_rows_copy = [r.copy() for r in original_rows] # Deep copy for comparison
+    ds = weave.Dataset(rows=original_rows)
+
+    # Use named parameters instead of row dictionary
+    def add_square(val):
+        return {"val_squared": val ** 2}
+
+    mapped_ds = ds.map(add_square)
+
+    # Assert mapped_ds is different
+    assert len(mapped_ds) == 3
+    assert list(mapped_ds)[0] == {"id": 0, "val": 0, "val_squared": 0}
+
+    # Assert original dataset (ds) and its rows are unchanged
+    assert len(ds) == 3
+    assert list(ds) == original_rows_copy
+    # Ensure the dictionaries within the original dataset were not mutated
+    assert ds.rows[0] is original_rows[0] # Check object identity if rows were passed directly
+    assert ds.rows[0] == original_rows_copy[0]
+
+
+def test_dataset_map_with_specific_params(client):
+    """Test mapping a function that takes specific parameters instead of a row dictionary."""
+    original_rows = [{"id": i, "val": i * 2, "name": f"Item {i}"} for i in range(5)]
+    ds = weave.Dataset(rows=original_rows)
+
+    # Function that takes specific columns as parameters
+    def multiply_val(val, id):
+        return {"product": val * id}
+
+    mapped_ds = ds.map(multiply_val)
+
+    assert len(mapped_ds) == 5
+    expected_rows = [
+        {"id": 0, "val": 0, "name": "Item 0", "product": 0},
+        {"id": 1, "val": 2, "name": "Item 1", "product": 2},
+        {"id": 2, "val": 4, "name": "Item 2", "product": 8},
+        {"id": 3, "val": 6, "name": "Item 3", "product": 18},
+        {"id": 4, "val": 8, "name": "Item 4", "product": 32},
+    ]
+    assert list(mapped_ds) == expected_rows
+
+
+def test_dataset_map_with_scalar_return(client):
+    """Test mapping a function that returns a scalar value instead of a dictionary."""
+    original_rows = [{"id": i, "val": i * 2} for i in range(5)]
+    ds = weave.Dataset(rows=original_rows)
+
+    # Function that takes specific columns and returns a scalar
+    def sum_values(id, val):
+        return id + val
+
+    # The function's name "sum_values" should be used as the key
+    mapped_ds = ds.map(sum_values)
+
+    assert len(mapped_ds) == 5
+    expected_rows = [
+        {"id": 0, "val": 0, "sum_values": 0},
+        {"id": 1, "val": 2, "sum_values": 3},
+        {"id": 2, "val": 4, "sum_values": 6},
+        {"id": 3, "val": 6, "sum_values": 9},
+        {"id": 4, "val": 8, "sum_values": 12},
+    ]
+    assert list(mapped_ds) == expected_rows
+
+
+def test_dataset_map_with_default_param(client):
+    """Test mapping a function with default parameter values."""
+    original_rows = [{"id": i, "val": i * 2} for i in range(5)]
+    ds = weave.Dataset(rows=original_rows)
+
+    # Function with a default parameter
+    def process_with_default(val, multiplier=10):
+        return {"scaled": val * multiplier}
+
+    mapped_ds = ds.map(process_with_default)
+
+    assert len(mapped_ds) == 5
+    expected_rows = [
+        {"id": 0, "val": 0, "scaled": 0},
+        {"id": 1, "val": 2, "scaled": 20},
+        {"id": 2, "val": 4, "scaled": 40},
+        {"id": 3, "val": 6, "scaled": 60},
+        {"id": 4, "val": 8, "scaled": 80},
+    ]
+    assert list(mapped_ds) == expected_rows
+
+
+def test_dataset_map_missing_param(client):
+    """Test mapping a function that expects a parameter not in the dataset."""
+    original_rows = [{"id": i, "val": i * 2} for i in range(5)]
+    ds = weave.Dataset(rows=original_rows)
+
+    # Function expecting a parameter not in the dataset
+    def needs_missing_param(val, missing_param):
+        return {"result": val + missing_param}
+
+    # Should raise an error because missing_param is not in the dataset
+    with pytest.raises(ValueError, match="Function expects parameter 'missing_param'"):
+        ds.map(needs_missing_param)
+
+
+def test_dataset_map_with_lambda(client):
+    """Test mapping with lambda functions."""
+    ds = weave.Dataset(rows=[{"a": i, "b": i * 2} for i in range(5)])
+    
+    # Lambda that takes specific params
+    mapped_ds = ds.map(lambda a, b: {"sum": a + b})
+    assert len(mapped_ds) == 5
+    assert mapped_ds[0] == {"a": 0, "b": 0, "sum": 0}
+    assert mapped_ds[2] == {"a": 2, "b": 4, "sum": 6}
+    
+    # Lambda with a scalar return value (should get a generic key)
+    mapped_ds = ds.map(lambda a, b: a * b)
+    assert len(mapped_ds) == 5
+    assert "<lambda>" in mapped_ds[0]  # Should use "<lambda>" as key
+    assert mapped_ds[2]["<lambda>"] == 8  # 2 * 4
+
+
+def test_dataset_map_parameter_reuse(client):
+    """Test mapping when a function uses the same parameter in multiple ways."""
+    ds = weave.Dataset(rows=[{"id": i, "val": i * 2} for i in range(3)])
+    
+    # Function that uses a parameter in multiple ways
+    def reuse_param(id, val):
+        return {
+            "identity": id,
+            "id_plus_val": id + val,
+            "id_times_val": id * val,
+        }
+    
+    mapped_ds = ds.map(reuse_param)
+    
+    assert len(mapped_ds) == 3
+    assert mapped_ds[2] == {
+        "id": 2, 
+        "val": 4, 
+        "identity": 2, 
+        "id_plus_val": 6,  # 2 + 4
+        "id_times_val": 8,  # 2 * 4
+    }
+
+
+def test_dataset_map_error_handling(client):
+    """Test error handling in more complex scenarios."""
+    ds = weave.Dataset(rows=[{"id": i, "val": i} for i in range(5)])
+    
+    # Function that raises different errors based on input
+    def problematic_func(id, val):
+        if id == 0:
+            return {"ok": True}
+        elif id == 1:
+            return None  # Should be wrapped in a dict
+        elif id == 2:
+            # Type error when converting val to a list
+            return {"error": list(val)}
+        elif id == 3:
+            # KeyError
+            d = {}
+            return {"error": d["nonexistent"]}
+        else:
+            # Should not get here in this test
+            return {"ok": False}
+    
+    # Test None return value is handled
+    mapped_ds = ds.map(lambda id, val: None if id == 3 else {"ok": id})
+    assert "problematic_func" not in mapped_ds[1]
+    assert mapped_ds[3]["<lambda>"] is None
+    
+    # Test list return is wrapped
+    list_ds = ds.map(lambda id, val: [id, val] if id == 2 else {"ok": id})
+    assert isinstance(list_ds[2]["<lambda>"], list)
+    assert list_ds[2]["<lambda>"] == [2, 2]
+
+
+def test_dataset_map_empty_dataset(client):
+    """Test mapping on an empty dataset (should fail)."""
+    # Create an empty dataset
+    with pytest.raises(ValueError, match="empty list"):
+        # This should fail during dataset creation, not during map
+        ds = weave.Dataset(rows=[])
+        ds.map(lambda x: x + 1)
+
+
+def test_dataset_map_return_types(client):
+    """Test mapping with different return types."""
+    ds = weave.Dataset(rows=[{"id": i} for i in range(3)])
+    
+    # Test returning various data types
+    def return_types(id):
+        return {
+            "str_val": str(id),
+            "bool_val": bool(id),
+            "list_val": [0, id],
+            "dict_val": {"x": id},
+            "none_val": None,
+            "float_val": float(id),
+        }
+    
+    types_ds = ds.map(return_types)
+    
+    # Check all types are preserved
+    assert types_ds[1]["str_val"] == "1"
+    assert types_ds[1]["bool_val"] is True
+    assert types_ds[1]["list_val"] == [0, 1]
+    assert types_ds[1]["dict_val"] == {"x": 1}
+    assert types_ds[1]["none_val"] is None
+    assert types_ds[1]["float_val"] == 1.0
+    
+    # Test returning a complex object directly
+    class CustomClass:
+        def __init__(self, value):
+            self.value = value
+    
+    custom_ds = ds.map(lambda id: CustomClass(id + 100))
+    
+    # The CustomClass object should be stored under the function name
+    assert custom_ds[1]["<lambda>"].value == 101
+
+
+def test_dataset_map_typed_params(client):
+    """Test mapping with type hints in function parameters."""
+    ds = weave.Dataset(rows=[{"id": i, "num": str(i), "flag": i % 2 == 0} for i in range(5)])
+    
+    # Function with type annotations
+    def typed_func(id: int, num: str, flag: bool) -> dict:
+        # Convert num to int and add to id if flag is True
+        result = int(num) + id if flag else id
+        return {"result": result}
+    
+    mapped_ds = ds.map(typed_func)
+    
+    assert len(mapped_ds) == 5
+    assert mapped_ds[0]["result"] == 0  # 0 + 0, flag=True
+    assert mapped_ds[1]["result"] == 1  # Just id, flag=False
+    assert mapped_ds[2]["result"] == 4  # 2 + 2, flag=True
+    assert mapped_ds[3]["result"] == 3  # Just id, flag=False
+    assert mapped_ds[4]["result"] == 8  # 4 + 4, flag=True
+
+
+def test_dataset_map_empty_function(client):
+    """Test mapping with an empty function (no parameters)."""
+    ds = weave.Dataset(rows=[{"id": i, "val": i} for i in range(5)])
+    
+    # Function with no parameters
+    def constant_func():
+        return {"constant": 42}
+    
+    mapped_ds = ds.map(constant_func)
+    
+    # Should add the constant to every row
+    assert len(mapped_ds) == 5
+    for i in range(5):
+        assert mapped_ds[i] == {"id": i, "val": i, "constant": 42}
+
+
+def test_dataset_map_error_handling(client):
+    """Test error handling in more complex scenarios."""
+    ds = weave.Dataset(rows=[{"id": i, "val": i} for i in range(5)])
+    
+    # Function that raises different errors based on input
+    def problematic_func(id, val):
+        if id == 0:
+            return {"ok": True}
+        elif id == 1:
+            return None  # Should be wrapped in a dict
+        elif id == 2:
+            # Type error when converting val to a list
+            return {"error": list(val)}
+        elif id == 3:
+            # KeyError
+            d = {}
+            return {"error": d["nonexistent"]}
+        else:
+            # Should not get here in this test
+            return {"ok": False}
+    
+    # Test None return value is handled
+    mapped_ds = ds.map(lambda id, val: None if id == 3 else {"ok": id})
+    assert "problematic_func" not in mapped_ds[1]
+    assert mapped_ds[3]["<lambda>"] is None
+    
+    # Test list return is wrapped
+    list_ds = ds.map(lambda id, val: [id, val] if id == 2 else {"ok": id})
+    assert isinstance(list_ds[2]["<lambda>"], list)
+    assert list_ds[2]["<lambda>"] == [2, 2]

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -8,6 +8,16 @@ from typing import Any, Callable, Literal, Optional, Union
 from pydantic import PrivateAttr
 from rich import print
 from rich.console import Console
+from rich.panel import Panel
+from rich.pretty import Pretty
+from rich.progress import (
+    Progress,
+    TextColumn,
+    MofNCompleteColumn,
+    TaskProgressColumn,
+    BarColumn,
+    TimeElapsedColumn,
+)
 from typing_extensions import Self
 
 import weave
@@ -192,7 +202,9 @@ class Evaluation(Object):
                     summary[name] = model_output_summary
         return summary
 
-    async def get_eval_results(self, model: Union[Op, Model]) -> EvaluationResults:
+    async def get_eval_results(
+        self, model: Union[Op, Model], verbose: bool = False
+    ) -> EvaluationResults:
         if not is_valid_model(model):
             raise ValueError(INVALID_MODEL_ERROR)
         eval_rows = []
@@ -211,33 +223,55 @@ class Evaluation(Object):
         n_complete = 0
         dataset = self.dataset
         _rows = dataset.rows
-        num_rows = len(_rows) * self.trials
+        trial_rows_list = list(chain.from_iterable(repeat(_rows, self.trials)))
+        num_rows = len(trial_rows_list)
 
-        trial_rows = chain.from_iterable(repeat(_rows, self.trials))
-        async for example, eval_row in util.async_foreach(
-            trial_rows, eval_example, get_weave_parallelism()
-        ):
-            n_complete += 1
-            print(f"Evaluated {n_complete} of {num_rows} examples")
-            if eval_row is None:
-                eval_row = {self._output_key: None, "scores": {}}
-            else:
-                eval_row["scores"] = eval_row.get("scores", {})
-            if self.scorers:
-                for scorer in self.scorers:
-                    scorer_attributes = get_scorer_attributes(scorer)
-                    scorer_name = scorer_attributes.scorer_name
-                    if scorer_name not in eval_row["scores"]:
-                        eval_row["scores"][scorer_name] = {}
-            eval_rows.append(eval_row)
+        with Progress(
+            TextColumn("[progress.description]{task.description}"),
+            MofNCompleteColumn(),
+            TaskProgressColumn(),
+            BarColumn(),
+            util.IterationSpeedColumn(),
+            TimeElapsedColumn(),
+            console=console,
+            transient=True,
+        ) as progress:
+            async for example, eval_row in util.async_foreach(
+                trial_rows_list,
+                eval_example,
+                get_weave_parallelism(),
+                progress=progress,
+                progress_desc="Evaluating model",
+            ):
+                n_complete += 1
+                if verbose:
+                    console.print(f"Evaluated {n_complete} of {num_rows} examples")
+                if eval_row is None:
+                    eval_row = {self._output_key: None, "scores": {}}
+                else:
+                    eval_row["scores"] = eval_row.get("scores", {})
+                if self.scorers:
+                    for scorer in self.scorers:
+                        scorer_attributes = get_scorer_attributes(scorer)
+                        scorer_name = scorer_attributes.scorer_name
+                        if scorer_name not in eval_row["scores"]:
+                            eval_row["scores"][scorer_name] = {}
+                eval_rows.append(eval_row)
         return EvaluationResults(rows=weave.Table(eval_rows))
 
     @weave.op(call_display_name=default_evaluation_display_name)
-    async def evaluate(self, model: Union[Op, Model]) -> dict:
-        eval_results = await self.get_eval_results(model)
+    async def evaluate(self, model: Union[Op, Model], verbose: bool = False) -> dict:
+        """
+        Evaluate the model on the dataset.
+
+        Args:
+            model: The model to evaluate.
+            verbose: Whether to print verbose progress updates.
+        """
+        eval_results = await self.get_eval_results(model, verbose=verbose)
         summary = await self.summarize(eval_results)
 
-        print("Evaluation summary", summary)
+        console.print(Panel(Pretty(summary), title="Evaluation Summary", expand=False))
 
         return summary
 

--- a/weave/flow/util.py
+++ b/weave/flow/util.py
@@ -4,7 +4,10 @@ import multiprocessing
 import random
 from collections import defaultdict
 from collections.abc import AsyncIterator, Awaitable, Iterable
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, TypeVar, Optional
+
+from rich.progress import Progress, TaskID, ProgressColumn, Text
+from rich.text import Text
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -24,6 +27,8 @@ async def async_foreach(
     sequence: Iterable[T],
     func: Callable[[T], Awaitable[U]],
     max_concurrent_tasks: int,
+    progress: Optional[Progress] = None,
+    progress_desc: str = "Processing items",
 ) -> AsyncIterator[tuple[T, U]]:
     """Process items from a sequence concurrently with a maximum number of parallel tasks.
 
@@ -34,6 +39,8 @@ async def async_foreach(
         sequence: An iterable of items to process. Items are loaded lazily.
         func: An async function that processes each item from the sequence.
         max_concurrent_tasks: Maximum number of items to process concurrently.
+        progress: Optional rich Progress object to display progress.
+        progress_desc: Description to show in the progress bar.
 
     Yields:
         Tuples of (original_item, processed_result) in the same order as the input sequence.
@@ -56,6 +63,17 @@ async def async_foreach(
     """
     semaphore = asyncio.Semaphore(max_concurrent_tasks)
     active_tasks: list[asyncio.Task] = []
+    task_id: Optional[TaskID] = None
+    total: Optional[int] = None
+    processed_count = 0
+
+    if progress:
+        try:
+            total = len(sequence) # type: ignore
+        except TypeError:
+            # Sequence doesn't have a defined length (e.g., generator)
+            total = None
+        task_id = progress.add_task(progress_desc, total=total)
 
     async def process_item(item: T) -> tuple[T, U]:
         """Process a single item using the provided function with semaphore control."""
@@ -85,6 +103,9 @@ async def async_foreach(
             task = active_tasks.pop(0)  # Remove completed task from front of list
             try:
                 item, result = await task
+                processed_count += 1
+                if progress and task_id is not None:
+                    progress.update(task_id, advance=1, refresh=True)
                 yield item, result
 
                 # Add a new task if there are more items
@@ -102,6 +123,15 @@ async def async_foreach(
             task.cancel()
         await asyncio.gather(*active_tasks, return_exceptions=True)
         raise
+    finally:
+        if progress and task_id is not None:
+            # Ensure progress bar stops cleanly, even if total wasn't known
+            final_description = f"{progress_desc} (Completed)"
+            if progress.tasks[task_id].total is None:
+                progress.update(task_id, total=processed_count, completed=processed_count, description=final_description)
+            else:
+                 progress.update(task_id, description=final_description)
+            progress.stop_task(task_id)
 
 
 def _subproc(
@@ -249,3 +279,14 @@ def short_str(obj: Any, limit: int = 25) -> str:
     if len(str_val) > limit:
         return str_val[:limit] + "..."
     return str_val
+
+class IterationSpeedColumn(ProgressColumn):
+    """Renders human readable iteration speed."""
+
+    def render(self, task: "Task") -> Text:
+        """Show iteration speed."""
+        speed = task.finished_speed or task.speed
+        if speed is None:
+            return Text("?", style="progress.data.speed")
+        it_speed = int(speed)
+        return Text(f"{it_speed}/s", style="progress.data.speed")


### PR DESCRIPTION
- Modifies `async_foreach` to support rich progressbar
- Enables `weave.Evaluation` with progress bar, also `verbose=False` to silence printing per row
- Adds `Dataset.map` that uses `async_foreach` to process each example
- Same `inspect` convention as with evaluations.

```py
ds = weave.Dataset(rows=[
    {"id": i, "val": i} for i in range(1000)
])

@weave.op
def double_value(val):
    time.sleep(.001)  # Simulate work
    return {"new": val * 2}

new_ds1 = ds.map(double_value)
```