### PR TITLE
fix(ui): wrap long markdown lines

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewMarkdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewMarkdown.tsx
@@ -83,7 +83,11 @@ export const ValueViewMarkdown = ({value}: ValueViewMarkdownProps) => {
 
   let content: ReactNode = trimmed;
   if (format === 'Markdown') {
-    content = <Markdown content={trimmed} />;
+    content = (
+      <PreserveWrapping>
+        <Markdown content={trimmed} />
+      </PreserveWrapping>
+    );
   } else if (format === 'Code') {
     content = <CodeEditor value={trimmed} language="markdown" readOnly />;
   } else {


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-24852

Wrap long lines when displaying a `weave.Markdown` as an input in the object viewer.

Before:
<img width="640" alt="Screenshot 2025-05-05 at 11 58 41 PM" src="https://github.com/user-attachments/assets/6ef99332-9705-460d-b64b-f4691408fb31" />

After:
<img width="836" alt="Screenshot 2025-05-05 at 11 58 54 PM" src="https://github.com/user-attachments/assets/fb379f37-8106-46a2-8987-08d9c5f52db2" />

## Testing

Added an example to `wf`.