### PR TITLE
chore(dev): bump Node to v20 in WeaveJS Lint and Compile check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/setup-node@v1
         if: steps.check_run.outputs.should_lint_and_compile == 'true'
         with:
-          node-version: "18.x"
+          node-version: "20.x"
       - name: Configure npm for GitHub Packages
         run: |
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc


### PR DESCRIPTION
## Description

Node 18 is past its [EOL](https://github.com/nodejs/release#release-schedule) of 2025-04-30. Let's use v20 in our WeaveJS Lint and Compile check.
