### PR TITLE
chore(dev): make notify wandb core rerun-able on the same commit

### DIFF
--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -29,10 +29,11 @@ jobs:
           yarn generate
           cp package.json README.md .npmrc src/
           cd src
+          # E409 means the package already exists, in which case we don't want to fail this job
           if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            npm publish
+            npm publish 2>&1 | tee publish_output.log || grep -q "E409" publish_output.log
           else
-            npm publish --tag prerelease
+            npm publish --tag prerelease 2>&1 | tee publish_output.log || grep -q "E409" publish_output.log
           fi
   check-which-tests-to-run:
     uses: ./.github/workflows/check-which-tests-to-run.yaml


### PR DESCRIPTION
## Description

- Fixes issue with npm publish failing when package already exists

Updates the npm publish commands in the notify-wandb-core workflow to handle E409 errors (package already exists) gracefully. The workflow now captures the output of npm publish and checks for E409 errors, preventing the job from failing when the package version already exists in the registry.

Example fail:
https://github.com/wandb/weave/actions/runs/14871415503/job/41760432377

## Testing

Tested by verifying that the workflow continues successfully when npm publish returns an E409 error code.