### PR TITLE
feat(weave): Saved models frontend

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
@@ -1,16 +1,25 @@
 import {Box} from '@mui/material';
 import {Select} from '@wandb/weave/components/Form/Select';
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 
 import {AddProviderDrawer} from '../../OverviewPage/AddProviderDrawer';
 import {TraceObjSchemaForBaseObjectClass} from '../../wfReactInterface/objectClassQuery';
 import {LLMMaxTokensKey} from '../llmMaxTokens';
-import {CustomOption, ProviderOption} from './LLMDropdownOptions';
+import {SavedPlaygroundModelState} from '../types';
+import {
+  CustomOption,
+  LLMOption,
+  LLMOptionToSavedPlaygroundModelState,
+  ProviderOption,
+} from './LLMDropdownOptions';
 import {ProviderConfigDrawer} from './ProviderConfigDrawer';
-
 interface LLMDropdownProps {
-  value: LLMMaxTokensKey;
-  onChange: (value: LLMMaxTokensKey, maxTokens: number) => void;
+  value: LLMMaxTokensKey | string;
+  onChange: (
+    value: LLMMaxTokensKey | string,
+    maxTokens: number,
+    savedModel?: SavedPlaygroundModelState
+  ) => void;
   entity: string;
   project: string;
   isTeamAdmin: boolean;
@@ -57,20 +66,47 @@ export const LLMDropdown: React.FC<LLMDropdownProps> = ({
     refetchConfiguredProviders();
   }, [refetchConfiguredProviders]);
 
-  const isValueAvailable = llmDropdownOptions.find(
-    option =>
-      'llms' in option && option.llms?.some(llm => llm && llm.value === value)
-  );
+  const isValueAvailable = useMemo(() => {
+    return llmDropdownOptions.some(
+      (option: ProviderOption) =>
+        'llms' in option && option.llms?.some(llm => llm && llm.value === value)
+    );
+  }, [llmDropdownOptions, value]);
 
   useEffect(() => {
     if (!isValueAvailable && !areProvidersLoading) {
-      for (const option of llmDropdownOptions) {
-        for (const llm of option.llms) {
-          if (llm && llm.value && llm.max_tokens) {
-            onChange(llm.value, llm.max_tokens);
+      let firstAvailableLlm: LLMOption | null = null;
+
+      // Check if the value is a saved model
+      const savedModelOption = llmDropdownOptions.find(
+        option => option.value === 'saved-models'
+      );
+      if (savedModelOption) {
+        firstAvailableLlm =
+          savedModelOption.llms.find(
+            llm => llm.objectId === value && llm.isLatest
+          ) ?? null;
+      }
+
+      // If the value is not a saved model, check if theres any available LLM
+      if (!firstAvailableLlm) {
+        for (const option of llmDropdownOptions) {
+          if (
+            'llms' in option &&
+            !option.isDisabled &&
+            option.llms.length > 0
+          ) {
+            firstAvailableLlm = option.llms[0];
             break;
           }
         }
+      }
+      if (firstAvailableLlm) {
+        onChange(
+          firstAvailableLlm.value,
+          firstAvailableLlm.max_tokens,
+          LLMOptionToSavedPlaygroundModelState(firstAvailableLlm)
+        );
       }
     }
   }, [

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
@@ -11,6 +11,7 @@ import {
   LLMOption,
   LLMOptionToSavedPlaygroundModelState,
   ProviderOption,
+  SAVED_MODEL_OPTION_VALUE,
 } from './LLMDropdownOptions';
 import {ProviderConfigDrawer} from './ProviderConfigDrawer';
 interface LLMDropdownProps {
@@ -66,12 +67,15 @@ export const LLMDropdown: React.FC<LLMDropdownProps> = ({
     refetchConfiguredProviders();
   }, [refetchConfiguredProviders]);
 
-  const isValueAvailable = useMemo(() => {
-    return llmDropdownOptions.some(
-      (option: ProviderOption) =>
-        'llms' in option && option.llms?.some(llm => llm && llm.value === value)
-    );
-  }, [llmDropdownOptions, value]);
+  const isValueAvailable = useMemo(
+    () =>
+      llmDropdownOptions.some(
+        (option: ProviderOption) =>
+          'llms' in option &&
+          option.llms?.some(llm => llm && llm.value === value)
+      ),
+    [llmDropdownOptions, value]
+  );
 
   useEffect(() => {
     if (!isValueAvailable && !areProvidersLoading) {
@@ -79,7 +83,7 @@ export const LLMDropdown: React.FC<LLMDropdownProps> = ({
 
       // Check if the value is a saved model
       const savedModelOption = llmDropdownOptions.find(
-        option => option.value === 'saved-models'
+        option => option.value === SAVED_MODEL_OPTION_VALUE
       );
       if (savedModelOption) {
         firstAvailableLlm =

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
@@ -132,7 +132,7 @@ const SubMenu = ({
           }}>
           {llm.label}
           {llm.subLabel && (
-            <Box sx={{fontSize: '12px', color: MOON_500}}>{llm.subLabel}</Box>
+            <div className="text-sm text-moon-500">{llm.subLabel}</div>
           )}
         </Box>
       ))}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
@@ -2,31 +2,48 @@ import {Box} from '@mui/material';
 import {
   MOON_100,
   MOON_200,
+  MOON_500,
   MOON_800,
   OBLIVION,
 } from '@wandb/weave/common/css/color.styles';
 import {hexToRGB} from '@wandb/weave/common/css/utils';
 import {Button} from '@wandb/weave/components/Button';
 import {Icon} from '@wandb/weave/components/Icon';
+import {Pill} from '@wandb/weave/components/Tag';
 import {Tooltip} from '@wandb/weave/components/Tooltip';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import ReactDOM from 'react-dom';
 import {components, OptionProps} from 'react-select';
 
+import {LlmStructuredCompletionModel} from '../../wfReactInterface/generatedBuiltinObjectClasses.zod';
 import {TraceObjSchemaForBaseObjectClass} from '../../wfReactInterface/objectClassQuery';
 import {
+  findMaxTokensByModelName,
   LLM_MAX_TOKENS,
   LLM_PROVIDER_LABELS,
   LLMMaxTokensKey,
 } from '../llmMaxTokens';
+import {
+  OptionalSavedPlaygroundModelParams,
+  SavedPlaygroundModelState,
+} from '../types';
 import {ProviderStatus} from '../useConfiguredProviders';
+import {convertDefaultParamsToOptionalPlaygroundModelParams} from '../useSaveModelConfiguration';
 
 export interface LLMOption {
   label: string;
-  value: LLMMaxTokensKey;
+  subLabel?: string | React.ReactNode;
+  value: LLMMaxTokensKey | string;
   max_tokens: number;
-  provider?: string;
+
+  // Saved LLM options
+  baseModelId?: LLMMaxTokensKey | null;
+  defaultParams?: OptionalSavedPlaygroundModelParams;
+  versionIndex?: number | null;
+  isLatest?: boolean;
+  objectId?: string;
 }
+
 export interface ProviderOption {
   label: string | React.ReactNode;
   value: string;
@@ -36,7 +53,11 @@ export interface ProviderOption {
 }
 
 export interface CustomOptionProps extends OptionProps<ProviderOption, false> {
-  onChange: (value: LLMMaxTokensKey, maxTokens: number) => void;
+  onChange: (
+    value: LLMMaxTokensKey,
+    maxTokens: number,
+    savedModel?: SavedPlaygroundModelState
+  ) => void;
   entity: string;
   project: string;
   isAdmin?: boolean;
@@ -53,7 +74,11 @@ const SubMenu = ({
   providers,
 }: {
   llms: Array<LLMOption>;
-  onChange: (value: LLMMaxTokensKey, maxTokens: number) => void;
+  onChange: (
+    value: LLMMaxTokensKey,
+    maxTokens: number,
+    savedModel?: SavedPlaygroundModelState
+  ) => void;
   position: {top: number; left: number};
   onSelect: () => void;
   isAdmin?: boolean;
@@ -78,11 +103,17 @@ const SubMenu = ({
       }}>
       {llms.map(llm => (
         <Box
-          key={llm.value}
+          key={llm.value + llm.versionIndex}
           onClick={e => {
             e.preventDefault();
             e.stopPropagation();
-            onChange(llm.value, llm.max_tokens);
+            onChange(
+              llm.value as LLMMaxTokensKey,
+              llm.max_tokens,
+              llm.defaultParams && llm.baseModelId
+                ? LLMOptionToSavedPlaygroundModelState(llm)
+                : undefined
+            );
             onSelect();
           }}
           sx={{
@@ -98,6 +129,9 @@ const SubMenu = ({
             },
           }}>
           {llm.label}
+          {llm.subLabel && (
+            <Box sx={{fontSize: '12px', color: MOON_500}}>{llm.subLabel}</Box>
+          )}
         </Box>
       ))}
       {providers?.map(provider => {
@@ -258,21 +292,31 @@ export const CustomOption = ({
   project,
   isAdmin,
   onConfigureProvider,
+  data,
   ...props
 }: CustomOptionProps) => {
   const {inputValue} = props.selectProps;
   // If searching, show nested structure
   if (inputValue) {
-    const {llms, isDisabled} = props.data;
+    const isDisabled = data.isDisabled;
     if (isDisabled) {
       return null;
     }
 
-    const filteredLLMs = llms.filter(
-      llm =>
-        llm.value.toLowerCase().includes(inputValue.toLowerCase()) ||
-        llm.label.toLowerCase().includes(inputValue.toLowerCase())
-    );
+    const filteredLLMs = data.llms
+      .filter(
+        llm =>
+          llm.value.toLowerCase().includes(inputValue.toLowerCase()) ||
+          llm.label.toLowerCase().includes(inputValue.toLowerCase()) ||
+          (llm.subLabel &&
+            llm.subLabel
+              .toString()
+              .toLowerCase()
+              .includes(inputValue.toLowerCase()))
+      )
+      .sort((a, b) => {
+        return a.label.localeCompare(b.label);
+      });
 
     return (
       <Box>
@@ -290,7 +334,7 @@ export const CustomOption = ({
             wordWrap: 'break-word',
             whiteSpace: 'normal',
           }}>
-          <span>{props.data.label}</span>
+          <span>{data.label}</span>
         </Box>
         <Box
           sx={{
@@ -301,9 +345,15 @@ export const CustomOption = ({
           }}>
           {filteredLLMs.map(llm => (
             <Box
-              key={llm.value}
+              key={llm.value + llm.versionIndex}
               onClick={() => {
-                onChange(llm.value as LLMMaxTokensKey, llm.max_tokens);
+                onChange(
+                  llm.value as LLMMaxTokensKey,
+                  llm.max_tokens,
+                  llm.defaultParams && llm.baseModelId
+                    ? LLMOptionToSavedPlaygroundModelState(llm)
+                    : undefined
+                );
                 props.selectProps.onInputChange?.('', {
                   action: 'set-value',
                   prevInputValue: props.selectProps.inputValue,
@@ -317,18 +367,35 @@ export const CustomOption = ({
                 '&:hover': {
                   backgroundColor: MOON_100,
                 },
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
               }}>
-              {llm.label}
+              <Box>
+                {llm.label}
+                {llm.subLabel && (
+                  <Box sx={{fontSize: '12px', color: MOON_500}}>
+                    {llm.subLabel}
+                  </Box>
+                )}
+              </Box>
+              {llm.isLatest && <Pill label="Latest" color="moon" />}
             </Box>
           ))}
         </Box>
       </Box>
     );
   }
+
+  const filteredData = {
+    ...data,
+    llms: data.llms.filter(llm => !!llm.isLatest),
+  };
   // If not searching, use the hover submenu
   return (
     <SubMenuOption
       {...props}
+      data={data.value === 'saved-models' ? filteredData : data}
       onChange={onChange}
       entity={entity}
       project={project}
@@ -361,15 +428,18 @@ export const addProviderOption = (
   ],
 });
 
-export const getLLMDropdownOptions = (
+export const useLLMDropdownOptions = (
   configuredProviders: Record<string, ProviderStatus>,
   configuredProvidersLoading: boolean,
   customProvidersResult: TraceObjSchemaForBaseObjectClass<'Provider'>[],
   customProviderModelsResult: TraceObjSchemaForBaseObjectClass<'ProviderModel'>[],
-  customLoading: boolean
+  customLoading: boolean,
+  savedModelsResult: TraceObjSchemaForBaseObjectClass<'LLMStructuredCompletionModel'>[],
+  savedModelsLoading: boolean
 ) => {
   const options: ProviderOption[] = [];
   const disabledOptions: ProviderOption[] = [];
+  const savedModelsOptions: ProviderOption[] = [];
 
   if (configuredProvidersLoading) {
     options.push({
@@ -433,13 +503,93 @@ export const getLLMDropdownOptions = (
     });
   }
 
+  const savedModels = useMemo(() => {
+    const savedModels: LLMOption[] = [];
+
+    if (savedModelsResult) {
+      savedModelsResult.forEach(savedModelObj => {
+        const savedModelVal = savedModelObj.val as LlmStructuredCompletionModel;
+        const baseModelId = savedModelVal.llm_model_id;
+        const savedModelName =
+          savedModelVal.name ?? savedModelObj.object_id ?? 'Unnamed Model';
+
+        let maxTokens: number | undefined;
+
+        // Try to determine max tokens from built-in model list
+        if (baseModelId in LLM_MAX_TOKENS) {
+          const baseModelConfig =
+            LLM_MAX_TOKENS[baseModelId as LLMMaxTokensKey];
+          maxTokens = baseModelConfig.max_tokens;
+        } else {
+          // Try to determine from custom provider models
+          const customModelMatch = customProviderModelsResult?.find(
+            customModel => {
+              const customProviderMatch = customProvidersResult?.find(
+                p => p.digest === customModel.val.provider
+              );
+              return (
+                `${customProviderMatch?.val.name}/${customModel.val.name}` ===
+                baseModelId
+              );
+            }
+          );
+          if (customModelMatch) {
+            maxTokens = customModelMatch.val.max_tokens;
+          }
+        }
+        // Fallback max tokens determination
+        if (maxTokens === undefined) {
+          maxTokens = findMaxTokensByModelName(baseModelId);
+        }
+
+        // Add the saved model to the list
+        savedModels.push({
+          label: savedModelName + `:v${savedModelObj.version_index}`,
+          value: savedModelName + `:v${savedModelObj.version_index}`,
+          subLabel: baseModelId,
+          baseModelId: baseModelId as LLMMaxTokensKey,
+          max_tokens: maxTokens,
+          defaultParams: convertDefaultParamsToOptionalPlaygroundModelParams(
+            savedModelVal.default_params ?? {messages_template: []}
+          ),
+          objectId: savedModelName,
+          versionIndex: savedModelObj.version_index ?? null,
+          isLatest: !!savedModelObj.is_latest,
+        });
+      });
+    }
+
+    return savedModels;
+  }, [savedModelsResult, customProviderModelsResult, customProvidersResult]);
+
+  if (!savedModelsLoading && savedModels.length > 0) {
+    savedModelsOptions.push({
+      label: 'Saved Models',
+      value: 'saved-models',
+      llms: savedModels,
+    });
+  }
+
   // Combine options
   // Add a divider option before the add provider option
   const allOptions = [
     ...options,
+    ...savedModelsOptions,
     dividerOption,
     addProviderOption(disabledOptions),
   ];
 
   return allOptions;
+};
+
+export const LLMOptionToSavedPlaygroundModelState = (
+  llmOption: LLMOption
+): SavedPlaygroundModelState => {
+  return {
+    llmModelId: llmOption.baseModelId ?? null,
+    objectId: llmOption.objectId ?? null,
+    savedModelParams: llmOption.defaultParams ?? null,
+    isLatest: llmOption.isLatest ?? false,
+    versionIndex: llmOption.versionIndex ?? null,
+  };
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
@@ -2,7 +2,6 @@ import {Box} from '@mui/material';
 import {
   MOON_100,
   MOON_200,
-  MOON_500,
   MOON_800,
   OBLIVION,
 } from '@wandb/weave/common/css/color.styles';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
@@ -105,7 +105,7 @@ const SubMenu = ({
       }}>
       {llms.map(llm => (
         <Box
-          key={llm.value + llm.versionIndex}
+          key={`${llm.value}${llm.versionIndex}`}
           onClick={e => {
             e.preventDefault();
             e.stopPropagation();
@@ -373,14 +373,12 @@ export const CustomOption = ({
                 alignItems: 'center',
                 justifyContent: 'space-between',
               }}>
-              <Box>
+              <div>
                 {llm.label}
                 {llm.subLabel && (
-                  <Box sx={{fontSize: '12px', color: MOON_500}}>
-                    {llm.subLabel}
-                  </Box>
+                  <div className="text-sm text-moon-500">{llm.subLabel}</div>
                 )}
-              </Box>
+              </div>
               {llm.isLatest && <Pill label="Latest" color="moon" />}
             </Box>
           ))}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
@@ -17,7 +17,7 @@ import {TraceCallSchema} from '../../wfReactInterface/traceServerClientTypes';
 import {PlaygroundContext} from '../PlaygroundContext';
 import {PlaygroundMessageRole, PlaygroundState} from '../types';
 import {ProviderStatus} from '../useConfiguredProviders';
-import {getLLMDropdownOptions} from './LLMDropdownOptions';
+import {useLLMDropdownOptions} from './LLMDropdownOptions';
 import {PlaygroundCallStats} from './PlaygroundCallStats';
 import {PlaygroundChatInput} from './PlaygroundChatInput';
 import {PlaygroundChatTopBar} from './PlaygroundChatTopBar';
@@ -82,6 +82,8 @@ export type PlaygroundChatProps = {
   refetchConfiguredProviders: () => void;
   configuredProvidersLoading: boolean;
   configuredProviders: Record<string, ProviderStatus>;
+  savedModelsResult: TraceObjSchemaForBaseObjectClass<'LLMStructuredCompletionModel'>[];
+  savedModelsLoading: boolean;
 };
 
 export const PlaygroundChat = ({
@@ -100,6 +102,8 @@ export const PlaygroundChat = ({
   refetchConfiguredProviders,
   configuredProvidersLoading,
   configuredProviders,
+  savedModelsResult,
+  savedModelsLoading,
 }: PlaygroundChatProps) => {
   const [chatText, setChatText] = useState('');
 
@@ -129,12 +133,14 @@ export const PlaygroundChat = ({
   );
   const isTeamAdmin = maybeTeamAdmin ?? false;
 
-  const llmDropdownOptions = getLLMDropdownOptions(
+  const llmDropdownOptions = useLLMDropdownOptions(
     configuredProviders,
     configuredProvidersLoading,
     customProvidersResult,
     customProviderModelsResult,
-    areCustomProvidersLoading
+    areCustomProvidersLoading,
+    savedModelsResult,
+    savedModelsLoading
   );
 
   // Check if any chat is loading
@@ -239,7 +245,9 @@ export const PlaygroundChat = ({
                     refetchCustomLLMs={refetchCustomLLMs}
                     llmDropdownOptions={llmDropdownOptions}
                     areProvidersLoading={
-                      configuredProvidersLoading || areCustomProvidersLoading
+                      configuredProvidersLoading ||
+                      areCustomProvidersLoading ||
+                      savedModelsLoading
                     }
                     customProvidersResult={customProvidersResult}
                   />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatTopBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChatTopBar.tsx
@@ -14,11 +14,21 @@ import styled from 'styled-components';
 import {CopyableId} from '../../common/Id';
 import {TraceObjSchemaForBaseObjectClass} from '../../wfReactInterface/objectClassQuery';
 import {LLMMaxTokensKey} from '../llmMaxTokens';
-import {OptionalTraceCallSchema, PlaygroundState} from '../types';
-import {DEFAULT_SYSTEM_MESSAGE} from '../usePlaygroundState';
+import {
+  OptionalTraceCallSchema,
+  PlaygroundState,
+  SavedPlaygroundModelState,
+} from '../types';
+import {
+  DEFAULT_SAVED_MODEL,
+  DEFAULT_SYSTEM_MESSAGE,
+} from '../usePlaygroundState';
 import {LLMDropdown} from './LLMDropdown';
 import {ProviderOption} from './LLMDropdownOptions';
-import {SetPlaygroundStateFieldFunctionType} from './useChatFunctions';
+import {
+  SetPlaygroundStateFieldFunctionType,
+  TraceCallOutput,
+} from './useChatFunctions';
 
 type PlaygroundChatTopBarProps = {
   idx: number;
@@ -78,11 +88,62 @@ export const PlaygroundChatTopBar: React.FC<PlaygroundChatTopBarProps> = ({
   const handleModelChange = (
     index: number,
     model: LLMMaxTokensKey,
-    maxTokens: number
+    maxTokens: number,
+    savedModel?: SavedPlaygroundModelState
   ) => {
-    setPlaygroundStateField(index, 'model', model);
-    setPlaygroundStateField(index, 'maxTokensLimit', maxTokens);
-    setPlaygroundStateField(index, 'maxTokens', Math.floor(maxTokens / 2));
+    if (!savedModel) {
+      setPlaygroundStates(
+        playgroundStates.map((state, i) => {
+          if (i === index) {
+            return {
+              ...state,
+              model,
+              maxTokensLimit: maxTokens,
+              maxTokens: Math.floor(maxTokens / 2),
+            };
+          }
+          return state;
+        })
+      );
+      return;
+    }
+
+    const {messagesTemplate, ...defaultParams} =
+      savedModel?.savedModelParams ?? {};
+
+    setPlaygroundStates(
+      playgroundStates.map((state, i) => {
+        if (i === index) {
+          return {
+            ...state,
+            model,
+            maxTokensLimit: maxTokens,
+            maxTokens: Math.floor(maxTokens / 2),
+
+            // Update the state to show we are using a saved model
+            savedModel: savedModel ?? DEFAULT_SAVED_MODEL,
+            traceCall: {
+              ...state.traceCall,
+              inputs: {
+                ...state.traceCall?.inputs,
+                // If the saved model has messages, use them, otherwise use the current messages
+                messages: messagesTemplate ?? state.traceCall?.inputs?.messages,
+              },
+              output: {
+                ...(state.traceCall?.output as TraceCallOutput),
+                // If the saved model has messages, clear the choices, otherwise use the current choices
+                choices: messagesTemplate
+                  ? undefined
+                  : (state.traceCall?.output as TraceCallOutput)?.choices,
+              },
+            },
+            // Update the other params
+            ...defaultParams,
+          };
+        }
+        return state;
+      })
+    );
   };
 
   const ConfirmClearModal: React.FC<{
@@ -125,8 +186,13 @@ export const PlaygroundChatTopBar: React.FC<PlaygroundChatTopBarProps> = ({
         <Tag label={`${idx + 1}`} />
         <LLMDropdown
           value={playgroundStates[idx].model}
-          onChange={(model, maxTokens) =>
-            handleModelChange(idx, model, maxTokens)
+          onChange={(model, maxTokens, savedModel) =>
+            handleModelChange(
+              idx,
+              model as LLMMaxTokensKey,
+              maxTokens,
+              savedModel
+            )
           }
           entity={entity}
           project={project}
@@ -177,8 +243,10 @@ export const PlaygroundChatTopBar: React.FC<PlaygroundChatTopBarProps> = ({
           disabled={onlyOneChat}
           tooltip={onlyOneChat ? 'Cannot remove last chat' : 'Remove chat'}
           onClick={() => {
-            if (settingsTab === idx) {
-              setSettingsTab(0);
+            // If the settings tab is set to length that is going to be removed,
+            // we need to set the settings tab to the previous chat.
+            if (settingsTab && settingsTab < playgroundStates.length + 1) {
+              setSettingsTab(settingsTab - 1);
             }
             setPlaygroundStates(
               playgroundStates.filter((_, index) => index !== idx)

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatFunctions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatFunctions.tsx
@@ -4,7 +4,7 @@ import {SetStateAction} from 'react';
 import {Message} from '../../ChatView/types';
 import {OptionalTraceCallSchema, PlaygroundState} from '../types';
 
-type TraceCallOutput = {
+export type TraceCallOutput = {
   choices?: any[];
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundPage.tsx
@@ -169,6 +169,14 @@ export const PlaygroundPageInner = ({
     },
   });
 
+  const {
+    result: savedModelsResult,
+    loading: savedModelsLoading,
+    refetch: refetchSavedModels,
+  } = useBaseObjectInstances('LLMStructuredCompletionModel', {
+    project_id: projectId,
+  });
+
   const refetchCustomLLMs = useCallback(() => {
     refetchCustomProviders();
     refetchCustomProviderModels();
@@ -248,6 +256,8 @@ export const PlaygroundPageInner = ({
           customProvidersResult={customProvidersResult || []}
           customProviderModelsResult={customProviderModelsResult || []}
           configuredProviders={configuredProviders}
+          savedModelsResult={savedModelsResult || []}
+          savedModelsLoading={savedModelsLoading}
         />
       )}
       {settingsTab !== null && (
@@ -256,6 +266,8 @@ export const PlaygroundPageInner = ({
           setPlaygroundStateField={setPlaygroundStateField}
           settingsTab={settingsTab}
           setSettingsTab={setSettingsTab}
+          projectId={projectId}
+          refetchSavedModels={refetchSavedModels}
         />
       )}
     </div>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundSettings/PlaygroundSettings.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundSettings/PlaygroundSettings.tsx
@@ -1,8 +1,8 @@
-import {Box, TextField, Tooltip} from '@mui/material';
-import {MOON_250} from '@wandb/weave/common/css/color.styles';
+import {TextField} from '@mui/material';
 import {Button, Switch} from '@wandb/weave/components';
 import * as Tabs from '@wandb/weave/components/Tabs';
 import {Tag} from '@wandb/weave/components/Tag';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
 import React, {useEffect, useState} from 'react';
 
 import {SetPlaygroundStateFieldFunctionType} from '../PlaygroundChat/useChatFunctions';
@@ -56,42 +56,20 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
   );
 
   return (
-    <Box
-      sx={{
-        padding: '0 0 8px',
-        height: '100%',
-        borderLeft: `1px solid ${MOON_250}`,
-        display: 'flex',
-        flexDirection: 'column',
-        width: '320px',
-        flexShrink: 0,
-        position: 'relative',
-      }}>
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: '8px',
-          justifyContent: 'space-between',
-          borderBottom: `1px solid ${MOON_250}`,
-          padding: '8px 16px',
-        }}>
+    <div className="relative flex h-full w-[320px] shrink-0 flex-col border-l border-moon-250 pb-4">
+      <div className="flex items-center justify-between gap-8 border-b border-moon-250 px-16 py-8">
         {/* Header */}
-        <Box sx={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+        <div className="flex items-center gap-8">
           <Tag label={`${settingsTab + 1}`} />
-          <Tooltip title={playgroundStates[settingsTab].model}>
-            <Box
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                fontSize: '16px',
-                fontWeight: '600',
-              }}>
-              {playgroundStates[settingsTab].model}
-            </Box>
-          </Tooltip>
-        </Box>
+          <Tooltip
+            content={playgroundStates[settingsTab].model}
+            trigger={
+              <div className="overflow-hidden text-ellipsis whitespace-nowrap text-base font-semibold">
+                {playgroundStates[settingsTab].model}
+              </div>
+            }
+          />
+        </div>
         <Button
           tooltip={'Close settings drawer'}
           variant="ghost"
@@ -101,21 +79,15 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
             setSettingsTab(null);
           }}
         />
-      </Box>
-      <Box sx={{padding: '0 16px', overflowY: 'scroll', height: '100%'}}>
+      </div>
+      <div className="h-full overflow-y-scroll px-16">
         <Tabs.Root value={settingsTab.toString()}>
           {playgroundStates.map((playgroundState, idx) => (
             <Tabs.Content key={idx} value={idx.toString()}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: '16px',
-                  my: 2,
-                }}>
+              <div className="my-8 flex flex-col gap-16">
                 {/* Model Name Input */}
                 <div className="flex w-full flex-col gap-2">
-                  <span style={{fontSize: '14px'}}>Model Name</span>
+                  <span className="text-sm">Model Name</span>
                   <div className="flex w-full flex-col rounded-md border border-moon-250">
                     <TextField
                       value={currentModelName}
@@ -242,12 +214,7 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                   value={playgroundState.presencePenalty}
                 />
 
-                <Box
-                  sx={{
-                    width: '100%',
-                    display: 'flex',
-                    alignItems: 'center',
-                  }}>
+                <div className="flex w-full items-center">
                   <Switch.Root
                     id="trackWithWeaveSwitch"
                     size="small"
@@ -269,19 +236,14 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                     htmlFor="trackWithWeaveSwitch">
                     Track this LLM call with Weave
                   </label>
-                </Box>
-              </Box>
+                </div>
+              </div>
             </Tabs.Content>
           ))}
         </Tabs.Root>
-      </Box>
+      </div>
 
-      <Box
-        sx={{
-          p: 2,
-          borderTop: `1px solid ${MOON_250}`,
-          backgroundColor: 'white',
-        }}>
+      <div className="border-t border-moon-250 bg-white p-16">
         <Button
           variant="primary"
           onClick={() => saveModelConfiguration(currentModelName)}
@@ -293,8 +255,8 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
           }>
           {isUpdatingPublishedModel ? 'Update model' : 'Publish model'}
         </Button>
-      </Box>
-    </Box>
+      </div>
+    </div>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundSettings/PlaygroundSettings.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundSettings/PlaygroundSettings.tsx
@@ -6,11 +6,7 @@ import {Tag} from '@wandb/weave/components/Tag';
 import React, {useEffect, useState} from 'react';
 
 import {SetPlaygroundStateFieldFunctionType} from '../PlaygroundChat/useChatFunctions';
-import {
-  JSON_PLAYGROUND_MODEL_PARAMS_KEYS,
-  PLAYGROUND_MODEL_PARAMS_KEYS,
-  PlaygroundState,
-} from '../types';
+import {PLAYGROUND_MODEL_PARAMS_KEYS, PlaygroundState} from '../types';
 import {useSaveModelConfiguration} from '../useSaveModelConfiguration';
 import {FunctionEditor} from './FunctionEditor';
 import {PlaygroundSlider} from './PlaygroundSlider';
@@ -118,22 +114,9 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                   my: 2,
                 }}>
                 {/* Model Name Input */}
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '4px',
-                    width: '100%',
-                  }}>
+                <div className="flex w-full flex-col gap-2">
                   <span style={{fontSize: '14px'}}>Model Name</span>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      border: `1px solid ${MOON_250}`,
-                      borderRadius: '4px',
-                      width: '100%',
-                    }}>
+                  <div className="flex w-full flex-col rounded-md border border-moon-250">
                     <TextField
                       value={currentModelName}
                       onChange={e => setCurrentModelName(e.target.value)}
@@ -157,15 +140,13 @@ export const PlaygroundSettings: React.FC<PlaygroundSettingsProps> = ({
                         },
                       }}
                     />
-                  </Box>
-                </Box>
+                  </div>
+                </div>
 
                 {/* Parameters */}
-                <Box sx={{display: 'flex', flexDirection: 'column'}}>
-                  <div className="font-[Source Sans Pro] mb-[-16px] text-sm font-semibold text-moon-500">
-                    PARAMETERS
-                  </div>
-                </Box>
+                <div className="font-[Source Sans Pro] mb-[-16px] text-sm font-semibold text-moon-500">
+                  PARAMETERS
+                </div>
 
                 {/* Response Format Editor */}
                 <ResponseFormatEditor
@@ -336,7 +317,9 @@ const arePlaygroundSettingsEqual = (
     return false;
   }
 
+  // Check each key in the saved params for equality
   for (const key of PLAYGROUND_MODEL_PARAMS_KEYS) {
+    // messagesTemplate is a special case, because its stored in the trace call state
     if (key === 'messagesTemplate') {
       const messagesTemplate = savedParams.messagesTemplate;
       const messages = currentPlaygroundState.traceCall?.inputs?.messages;
@@ -349,21 +332,12 @@ const arePlaygroundSettingsEqual = (
     const currentValue = currentPlaygroundState[key];
     const savedValue = savedParams[key];
 
-    if (JSON_PLAYGROUND_MODEL_PARAMS_KEYS.includes(key)) {
-      const currentValueObject = currentValue ?? {};
-      const savedValueObject = savedValue ?? {};
-      if (
-        JSON.stringify(currentValueObject) !== JSON.stringify(savedValueObject)
-      ) {
-        return false;
-      }
-    } else {
-      // For other primitive types, direct comparison
-      if (currentValue !== savedValue) {
-        return false;
-      }
+    // We compare the JSON strings of the current and saved values, since some values are not primitive types
+    if (JSON.stringify(currentValue) !== JSON.stringify(savedValue)) {
+      return false;
     }
   }
 
-  return true; // All compared keys are equal
+  // All compared keys are equal
+  return true;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/types.ts
@@ -8,23 +8,63 @@ export enum PlaygroundResponseFormats {
   // JsonSchema = 'json_schema',
 }
 
+export type SavedPlaygroundModelState = {
+  llmModelId: string | null;
+  versionIndex: number | null;
+  isLatest: boolean;
+  savedModelParams: OptionalSavedPlaygroundModelParams | null;
+  objectId: string | null;
+};
+
 export type PlaygroundState = {
   traceCall: OptionalTraceCallSchema;
   trackLLMCall: boolean;
   loading: boolean;
-  functions: Array<{name: string; [key: string]: any}>;
-  responseFormat: PlaygroundResponseFormats;
-  temperature: number;
+  model: LLMMaxTokensKey;
+  selectedChoiceIndex: number;
+  maxTokensLimit: number;
+  savedModel: SavedPlaygroundModelState;
+} & PlaygroundModelParams;
+
+export type PlaygroundModelParams = {
   maxTokens: number;
-  stopSequences: string[];
+  temperature: number;
   topP: number;
   frequencyPenalty: number;
   presencePenalty: number;
   nTimes: number;
-  maxTokensLimit: number;
-  model: LLMMaxTokensKey;
-  selectedChoiceIndex: number;
+  responseFormat: PlaygroundResponseFormats;
+  functions: Array<{
+    name: string;
+    [key: string]: any;
+  }>;
+  stopSequences: string[];
+  responseFormatSchema?: Record<string, any>;
 };
+
+export const JSON_PLAYGROUND_MODEL_PARAMS_KEYS: Array<
+  keyof PlaygroundModelParams | 'messagesTemplate'
+> = ['functions', 'stopSequences', 'responseFormatSchema', 'messagesTemplate'];
+
+// Define the keys from PlaygroundModelParams to iterate and compare
+export const PLAYGROUND_MODEL_PARAMS_KEYS: Array<
+  keyof PlaygroundModelParams | 'messagesTemplate'
+> = [
+  'maxTokens',
+  'temperature',
+  'topP',
+  'frequencyPenalty',
+  'presencePenalty',
+  'nTimes',
+  ...JSON_PLAYGROUND_MODEL_PARAMS_KEYS,
+];
+
+export type SavedPlaygroundModelParams = PlaygroundModelParams & {
+  messagesTemplate: Array<Record<string, any>>;
+};
+
+export type OptionalSavedPlaygroundModelParams =
+  Partial<SavedPlaygroundModelParams>;
 
 export type PlaygroundStateKey = keyof PlaygroundState;
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/types.ts
@@ -42,10 +42,6 @@ export type PlaygroundModelParams = {
   responseFormatSchema?: Record<string, any>;
 };
 
-export const JSON_PLAYGROUND_MODEL_PARAMS_KEYS: Array<
-  keyof PlaygroundModelParams | 'messagesTemplate'
-> = ['functions', 'stopSequences', 'responseFormatSchema', 'messagesTemplate'];
-
 // Define the keys from PlaygroundModelParams to iterate and compare
 export const PLAYGROUND_MODEL_PARAMS_KEYS: Array<
   keyof PlaygroundModelParams | 'messagesTemplate'
@@ -56,7 +52,10 @@ export const PLAYGROUND_MODEL_PARAMS_KEYS: Array<
   'frequencyPenalty',
   'presencePenalty',
   'nTimes',
-  ...JSON_PLAYGROUND_MODEL_PARAMS_KEYS,
+  'functions',
+  'stopSequences',
+  'responseFormat',
+  'messagesTemplate',
 ];
 
 export type SavedPlaygroundModelParams = PlaygroundModelParams & {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/usePlaygroundState.ts
@@ -26,6 +26,14 @@ export const DEFAULT_SYSTEM_MESSAGE = {
   content: DEFAULT_SYSTEM_MESSAGE_CONTENT,
 };
 
+export const DEFAULT_SAVED_MODEL = {
+  llmModelId: null,
+  versionIndex: null,
+  isLatest: false,
+  objectId: null,
+  savedModelParams: null,
+};
+
 const DEFAULT_PLAYGROUND_STATE = {
   traceCall: {
     inputs: {
@@ -46,6 +54,7 @@ const DEFAULT_PLAYGROUND_STATE = {
   maxTokensLimit: 16384,
   model: DEFAULT_LLM_MODEL,
   selectedChoiceIndex: 0,
+  savedModel: DEFAULT_SAVED_MODEL,
 };
 
 type NumericPlaygroundStateKey =
@@ -186,7 +195,9 @@ export const getInputFromPlaygroundState = (state: PlaygroundState) => {
     key: Math.random() * 1000,
 
     messages: state.traceCall?.inputs?.messages,
-    model: state.model,
+    model: state.savedModel.llmModelId
+      ? state.savedModel.llmModelId
+      : state.model,
     temperature: state.temperature,
     max_tokens: state.maxTokens,
     stop: state.stopSequences.length > 0 ? state.stopSequences : undefined,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/useSaveModelConfiguration.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/useSaveModelConfiguration.ts
@@ -1,0 +1,183 @@
+import {toast} from '@wandb/weave/common/components/elements/Toast';
+
+import {
+  LlmStructuredCompletionModel,
+  LlmStructuredCompletionModelDefaultParams,
+  LlmStructuredCompletionModelDefaultParamsSchema,
+  Message,
+  ResponseFormatSchema,
+} from '../wfReactInterface/generatedBuiltinObjectClasses.zod';
+import {useCreateBuiltinObjectInstance} from '../wfReactInterface/objectClassQuery';
+import {LLMMaxTokensKey} from './llmMaxTokens';
+import {
+  SetPlaygroundStateFieldFunctionType,
+  TraceCallOutput,
+} from './PlaygroundChat/useChatFunctions';
+import {
+  OptionalSavedPlaygroundModelParams,
+  PlaygroundResponseFormats,
+  PlaygroundState,
+} from './types';
+
+type UseSaveModelConfigurationArgs = {
+  setPlaygroundStateField: SetPlaygroundStateFieldFunctionType;
+  playgroundStates: PlaygroundState[];
+  settingsTab: number;
+  projectId: string;
+  refetchSavedModels: () => void;
+};
+
+export const useSaveModelConfiguration = ({
+  setPlaygroundStateField,
+  playgroundStates,
+  settingsTab,
+  projectId,
+  refetchSavedModels,
+}: UseSaveModelConfigurationArgs) => {
+  const createLLMStructuredCompletionModel = useCreateBuiltinObjectInstance(
+    'LLMStructuredCompletionModel'
+  );
+
+  const saveModelConfiguration = async (modelName: string) => {
+    const finalModelName = modelName.trim();
+    // This should never happen(button is disabled), but just in case
+    if (!finalModelName) {
+      toast('Model name cannot be empty.', {type: 'error'});
+      return;
+    }
+
+    const state = playgroundStates[settingsTab];
+    if (!state) {
+      toast('Cannot find current playground state.', {type: 'error'});
+      return;
+    }
+
+    const defaultParams: LlmStructuredCompletionModel['default_params'] = {
+      temperature: state.temperature,
+      top_p: state.topP,
+      max_tokens: state.maxTokens,
+      presence_penalty: state.presencePenalty,
+      frequency_penalty: state.frequencyPenalty,
+      stop: state.stopSequences ?? [],
+      response_format:
+        state.responseFormat === PlaygroundResponseFormats.JsonObject
+          ? ResponseFormatSchema.parse('json')
+          : state.responseFormat === PlaygroundResponseFormats.Text
+          ? ResponseFormatSchema.parse('text')
+          : undefined,
+      functions: state.functions,
+      n_times: state.nTimes,
+      messages_template: [],
+    };
+
+    const addMessageToTemplate = (message: Message) => {
+      defaultParams.messages_template.push({
+        content: message.content,
+        function_call: message.function_call ?? null,
+        name: message.name ?? null,
+        role: message.role,
+        tool_call_id: message.tool_call_id ?? null,
+      });
+    };
+
+    if (state.traceCall?.inputs?.messages) {
+      state.traceCall.inputs.messages.forEach(addMessageToTemplate);
+    }
+
+    const choice = (state.traceCall?.output as TraceCallOutput)?.choices?.[
+      state.selectedChoiceIndex ?? 0
+    ];
+    if (choice) {
+      addMessageToTemplate(choice.message);
+    }
+
+    // Validate the default parameters
+    const validatedParams =
+      LlmStructuredCompletionModelDefaultParamsSchema.safeParse(defaultParams);
+    if (!validatedParams.success) {
+      console.error('Parameter validation failed:', validatedParams.error);
+      toast(`Invalid parameters: ${validatedParams.error.message}`, {
+        type: 'error',
+      });
+      return;
+    }
+
+    // Get the base model id (if resaving llmModelId, otherwise use the current model)
+    const baseModelId = state.savedModel?.llmModelId
+      ? state.savedModel.llmModelId
+      : state.model;
+
+    // Create payload for the new model
+    const modelToSave: Omit<LlmStructuredCompletionModel, 'ref'> & {
+      name: string;
+    } = {
+      name: finalModelName,
+      llm_model_id: baseModelId,
+      default_params: validatedParams.data,
+    };
+
+    // Save the new model
+    try {
+      await createLLMStructuredCompletionModel({
+        obj: {
+          project_id: projectId,
+          object_id: finalModelName,
+          val: modelToSave,
+        },
+      });
+      toast(`Model "${finalModelName}" saved successfully!`, {
+        type: 'success',
+      });
+
+      refetchSavedModels();
+
+      // Update state so LLM dropdown shows the new model
+      setPlaygroundStateField(settingsTab, 'savedModel', {
+        name: baseModelId,
+        savedModelParams: convertDefaultParamsToOptionalPlaygroundModelParams(
+          validatedParams.data
+        ),
+      });
+      setPlaygroundStateField(
+        settingsTab,
+        'model',
+        finalModelName as LLMMaxTokensKey
+      );
+    } catch (error) {
+      console.error('Failed to save model:', error);
+      toast(`Failed to save model: ${error}`, {
+        type: 'error',
+      });
+    }
+  };
+
+  return {saveModelConfiguration};
+};
+
+// Helper function to convert backend saved model parameters to playground state format
+export const convertDefaultParamsToOptionalPlaygroundModelParams = (
+  defaultParams: LlmStructuredCompletionModelDefaultParams | null | undefined
+): OptionalSavedPlaygroundModelParams => {
+  if (!defaultParams) return {};
+
+  // Helper function to convert null or undefined to undefined
+  const nullToUndefined = (value: any) => {
+    return value === null || value === undefined ? undefined : value;
+  };
+
+  // We want undefined instead of null for the default params
+  return {
+    temperature: nullToUndefined(defaultParams.temperature),
+    topP: nullToUndefined(defaultParams.top_p),
+    maxTokens: nullToUndefined(defaultParams.max_tokens),
+    frequencyPenalty: nullToUndefined(defaultParams.frequency_penalty),
+    presencePenalty: nullToUndefined(defaultParams.presence_penalty),
+    nTimes: nullToUndefined(defaultParams.n_times) ?? 1,
+    responseFormat: nullToUndefined(
+      defaultParams.response_format as PlaygroundResponseFormats
+    ),
+    functions: nullToUndefined(defaultParams.functions),
+    stopSequences: nullToUndefined(defaultParams.stop),
+    messagesTemplate: nullToUndefined(defaultParams.messages_template),
+  };
+};


### PR DESCRIPTION
## Description

Frontend for saved models

Main Changes
LLM Dropdown
- We fetch saved models
- Add them to the LLM Dropdown
- Add support within the playgrounds state to select and search for them
Playground Settings
- On selection we load the settings
- We can save or update a model
- Adds a text field, for model name, and button for publishing

https://github.com/user-attachments/assets/22ed9045-58d3-4dde-b2e5-2c0c0ad30608


## Testing

How was this PR tested?
