### PR TITLE
chore(weave): trace server does not 400 for malformed refs in objects, call inputs or output

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -3451,3 +3451,27 @@ def test_files_stats(client):
     read_res = client.server.files_stats(FilesStatsReq(project_id="shawn/test-project"))
 
     assert read_res.total_size_bytes == 10000005
+
+
+def test_no_400_on_invalid_artifact_url(client):
+    @weave.op()
+    def test() -> str:
+        # This url is too long, should be wandb-artifact:///entity/project/name:version
+        return "wandb-artifact:///entity/project/toxic-extra-path/artifact:latest"
+
+    _, call = test.call()
+    id = call.id
+    server_call = client.get_call(id)
+    assert server_call.id == id
+
+
+def test_no_400_on_invalid_refs(client):
+    @weave.op()
+    def test() -> str:
+        # This ref is too long, should be weave:///entity/project/object/name:version
+        return "weave:///entity/project/object/toxic-extra-path/object:latest"
+
+    _, call = test.call()
+    id = call.id
+    server_call = client.get_call(id)
+    assert server_call.id == id


### PR DESCRIPTION
## Description

- Fixes WB-12345

This PR adds robustness to the reference extraction logic by validating URIs before adding them to the refs list. It now properly handles invalid artifact URLs and reference paths by attempting to parse them first and only including them if they match the expected format.

Two new tests were added to verify that invalid artifact URLs and references don't cause 400 errors, ensuring the system gracefully handles malformed inputs.

## Testing

Added two test cases that verify the system doesn't return 400 errors when encountering invalid artifact URLs and references with extra path components.