### PR TITLE
feat(weave): backend for the project stats API

### DIFF
--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -399,3 +399,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         res = self._ref_apply(self._internal_trace_server.completions_create, req)
         return res
+
+    def project_stats(self, req: tsi.ProjectStatsReq) -> tsi.ProjectStatsRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.project_stats, req)

--- a/weave/trace_server/project_query_builder.py
+++ b/weave/trace_server/project_query_builder.py
@@ -1,0 +1,75 @@
+from weave.trace_server.orm import ParamBuilder
+
+
+def make_project_stats_query(
+    project_id: str,
+    pb: ParamBuilder,
+    include_trace_storage_size: bool,
+    include_objects_storage_size: bool,
+    include_tables_storage_size: bool,
+    include_files_storage_size: bool,
+) -> tuple[str, list[str]]:
+    if (
+        not include_trace_storage_size
+        and not include_objects_storage_size
+        and not include_tables_storage_size
+        and not include_files_storage_size
+    ):
+        raise ValueError(
+            "At least one of include_trace_storage_size, include_objects_storage_size, include_table_storage_size, or include_files_storage_size must be True"
+        )
+    project_id = pb.add_param(project_id)
+
+    columns = []
+    sub_sqls = []
+    if include_trace_storage_size:
+        columns.append("trace_storage_size_bytes")
+        sub_sqls.append(
+            f"""
+            (SELECT sum(
+                COALESCE(attributes_size_bytes, 0) +
+                COALESCE(inputs_size_bytes, 0) +
+                COALESCE(output_size_bytes, 0) +
+                COALESCE(summary_size_bytes, 0)
+                )
+                FROM calls_merged_stats
+                WHERE project_id = {{{project_id}: String}}
+            ) AS {columns[-1]}
+            """
+        )
+    if include_objects_storage_size:
+        columns.append("objects_storage_size_bytes")
+        sub_sqls.append(
+            f"""
+            (SELECT sum(size_bytes)
+                FROM object_versions_stats
+                WHERE project_id = {{{project_id}: String}}
+            ) AS {columns[-1]}
+        """
+        )
+    if include_tables_storage_size:
+        columns.append("tables_storage_size_bytes")
+        sub_sqls.append(
+            f"""
+            (SELECT sum(size_bytes)
+                FROM table_rows_stats
+                WHERE project_id = {{{project_id}: String}}
+            ) AS {columns[-1]}
+        """
+        )
+    if include_files_storage_size:
+        columns.append("files_storage_size_bytes")
+        sub_sqls.append(
+            f"""
+            (SELECT sum(size_bytes)
+                FROM files_stats
+                WHERE project_id = {{{project_id}: String}}
+            ) AS {columns[-1]}
+        """
+        )
+
+    sql = f"""
+        SELECT {", ".join(sub_sqls)}
+    """
+
+    return sql, columns

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1432,6 +1432,11 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         # Return the empty ExportTraceServiceResponse as per the OTLP spec
         return tsi.OtelExportRes()
 
+    def project_stats(self, req: tsi.ProjectStatsReq) -> tsi.ProjectStatsRes:
+        raise NotImplementedError(
+            "project_stats is not implemented for SQLite trace server"
+        )
+
     def _table_row_read(self, project_id: str, row_digest: str) -> tsi.TableRowSchema:
         conn, cursor = get_conn_cursor(self.db_path)
         # Now get the rows

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1007,6 +1007,21 @@ class ActionsExecuteBatchRes(BaseModel):
     pass
 
 
+class ProjectStatsReq(BaseModel):
+    project_id: str
+    include_trace_storage_size: Optional[bool] = True
+    include_object_storage_size: Optional[bool] = True
+    include_table_storage_size: Optional[bool] = True
+    include_file_storage_size: Optional[bool] = True
+
+
+class ProjectStatsRes(BaseModel):
+    trace_storage_size_bytes: int
+    objects_storage_size_bytes: int
+    tables_storage_size_bytes: int
+    files_storage_size_bytes: int
+
+
 class TraceServerInterface(Protocol):
     def ensure_project_exists(
         self, entity: str, project: str
@@ -1074,3 +1089,6 @@ class TraceServerInterface(Protocol):
 
     # Execute LLM API
     def completions_create(self, req: CompletionsCreateReq) -> CompletionsCreateRes: ...
+
+    # Project statistics API
+    def project_stats(self, req: ProjectStatsReq) -> ProjectStatsRes: ...

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -455,3 +455,6 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         self, req: tsi.CompletionsCreateReq
     ) -> tsi.CompletionsCreateRes:
         return self._next_trace_server.completions_create(req)
+
+    def project_stats(self, req: tsi.ProjectStatsReq) -> tsi.ProjectStatsRes:
+        return self._next_trace_server.project_stats(req)

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -596,6 +596,11 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             tsi.CompletionsCreateRes,
         )
 
+    def project_stats(self, req: tsi.ProjectStatsReq) -> tsi.ProjectStatsRes:
+        return self._generic_request(
+            "/project/stats", req, tsi.ProjectStatsReq, tsi.ProjectStatsRes
+        )
+
 
 __docspec__ = [
     RemoteHTTPTraceServer,


### PR DESCRIPTION
## Description

- Adds a new `project_stats` API endpoint to retrieve storage usage statistics for a project
- Implements the endpoint for ClickHouse trace server with statistics for trace, object, table, and file storage sizes
- Adds a test case to verify the functionality with direct ClickHouse data insertion

- This PR depends on [https://github.com/wandb/core/pull/29316](https://github.com/wandb/core/pull/29316)

## Why the New `project_stats` Endpoint is Superior

The new `project_stats` endpoint provides a unified, accurate, and efficient way to retrieve all relevant storage statistics for a project—including trace, object, table, and file storage sizes—in a single atomic query. Unlike the previous approach, which required separate calls to endpoints like `calls_query_stats` (for traces) and `files_stats` (for files), and still lacked object and table storage coverage, this endpoint:

- **Ensures Consistency:** All statistics are fetched together in one query, guaranteeing they reflect the same point in time and eliminating inconsistencies that can arise from multiple, separate requests.
- **Covers All Storage Types:** Aggregates data from all relevant tables (`calls_merged_stats`, `object_versions_stats`, `table_rows_stats`, `files_stats`), providing a complete picture of project storage.
- **Improves Performance:** Reduces network and database overhead by combining multiple queries into a single, optimized SQL statement. Unlike the current `calls_query_stats()`, which uses complex per-call roll-up queries, the new endpoint efficiently aggregates data directly from the `calls_merged_stats` table.
- **Simplifies Client Logic:** Clients only need to call one endpoint and handle one response, reducing complexity and the risk of integration errors.
- **Future-Proof and Extensible:** New statistics can be added to the unified response without proliferating new endpoints or changing client code.
- **Easier for Future Enhancements:** If we need to add a date-range filter or other common filters in the future, implementing it in the unified `project_stats` endpoint will be much easier and more efficient than having to update and coordinate multiple separate endpoints and queries.

This approach is more robust, maintainable, and user-friendly for both backend and client applications, and sets a solid foundation for future feature expansion.

## Testing

- Added a comprehensive test that inserts test data directly into ClickHouse stats tables and verifies the API returns the expected storage size values
- Added appropriate interface implementations across all trace server implementations