### PR TITLE
chore(weave): Zero out call stack before each test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from fastapi.testclient import TestClient
 import weave
 from tests.trace.util import DummyTestException, client_is_sqlite
 from weave.trace import autopatch, weave_client, weave_init
+from weave.trace.context.call_context import set_call_stack
 from weave.trace_server import (
     clickhouse_trace_server_batched,
     external_to_internal_trace_server_adapter,
@@ -601,8 +602,14 @@ def create_client(
     return inited_client
 
 
+@pytest.fixture
+def zero_stack():
+    with set_call_stack([]):
+        yield
+
+
 @pytest.fixture()
-def client(request):
+def client(zero_stack, request):
     """This is the standard fixture used everywhere in tests to test end to end
     client functionality"""
     inited_client = create_client(request)
@@ -614,7 +621,7 @@ def client(request):
 
 
 @pytest.fixture()
-def client_creator(request):
+def client_creator(zero_stack, request):
     """This fixture is useful for delaying the creation of the client (ex. when you want to set settings first)"""
 
     @contextlib.contextmanager


### PR DESCRIPTION
This helps resolves some CI issues where a straggling test that incorrectly cleaned up could cause a cascade of test failures.

We should still be on the look out for those stragglers