### PR TITLE
fix(ui): extra newlines in markdown rendering

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewMarkdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ValueViewMarkdown.tsx
@@ -46,6 +46,11 @@ const PreserveWrapping = styled.div`
 `;
 PreserveWrapping.displayName = 'S.PreserveWrapping';
 
+const EnableWrapping = styled.div`
+  white-space: normal;
+`;
+EnableWrapping.displayName = 'S.EnableWrapping';
+
 export const ValueViewMarkdown = ({value}: ValueViewMarkdownProps) => {
   const trimmed = value.trim();
 
@@ -84,9 +89,9 @@ export const ValueViewMarkdown = ({value}: ValueViewMarkdownProps) => {
   let content: ReactNode = trimmed;
   if (format === 'Markdown') {
     content = (
-      <PreserveWrapping>
+      <EnableWrapping>
         <Markdown content={trimmed} />
-      </PreserveWrapping>
+      </EnableWrapping>
     );
   } else if (format === 'Code') {
     content = <CodeEditor value={trimmed} language="markdown" readOnly />;


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-24881

The fix in https://github.com/wandb/weave/pull/4406 wasn't good. While it did wrap long lines in lists, our markdown renderer is inserting a large number of newlines at the start of HTML generated for a simple table. `break-spaces` would preserve these newlines, causing the table to not even be visible without scrolling. Setting `white-space` to `normal` collapses the whitespace. (It takes precedence over the `white-space: nowrap` on `.MuiDataGrid-cell` that was the cause of the original issue.)

## Testing

Tested on customer reported trace.
