### PR TITLE
fix(weave): Grid locale can error

### DIFF
--- a/weave/trace/grid.py
+++ b/weave/trace/grid.py
@@ -22,7 +22,11 @@ if TYPE_CHECKING:
 
 
 # Set locale to user's default setting
-locale.setlocale(locale.LC_ALL, "")
+try:
+    locale.setlocale(locale.LC_ALL, "")
+except locale.Error:
+    # Fall back to default C locale if user's locale is not supported
+    locale.setlocale(locale.LC_ALL, "C")
 
 # TODO: Add support for other types, e.g. float, datetime, etc.
 ColumnType = Literal["str", "int", "bool"]


### PR DESCRIPTION
## Description

Fix for https://github.com/wandb/weave/issues/4444

## Testing

I haven't been able to reproduce the problem on my machine when passing `''`. I can get the locale error if I do:
`import locale; locale.setlocale(locale.LC_ALL, 'invalid_locale')`

I thought it might be because I have `LANG=en_US.UTF-8` in my environment, but it doesn't error for me even if I unset that, so maybe this is OS or Python version specific? In any case, I believe this should resolve the error for the user.