### PR TITLE
chore(weave): Azure bucket store: Allow for default credentials

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ trace_server = [
   "boto3>=1.34.0",
   # BYOB - Azure
   "azure-storage-blob>=12.24.0",
+  "azure-identity>=1.22.0",
   # BYOB - GCP
   "google-cloud-storage>=2.7.0",
   # LLM Support

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -46,6 +46,7 @@ from abc import abstractmethod
 from typing import Any, Callable, Optional, Union, cast
 
 import boto3
+from azure.identity import DefaultAzureCredential
 from azure.storage.blob import BlobServiceClient
 from botocore.config import Config
 from google.cloud import storage
@@ -292,9 +293,13 @@ class AzureStorageClient(FileStorageClient):
                 account_url = account_creds["account_url"]
             else:
                 account_url = f"https://{account}.blob.core.windows.net/"
+            if "access_key" in account_creds and account_creds["access_key"]:
+                credential = account_creds["access_key"]
+            else:
+                credential = DefaultAzureCredential()
             return BlobServiceClient(
                 account_url=account_url,
-                credential=account_creds["access_key"],
+                credential=credential,
                 connection_timeout=DEFAULT_CONNECT_TIMEOUT,
                 read_timeout=DEFAULT_READ_TIMEOUT,
             )

--- a/weave/trace_server/file_storage_credentials.py
+++ b/weave/trace_server/file_storage_credentials.py
@@ -27,7 +27,7 @@ class AzureConnectionCredentials(TypedDict):
 class AzureAccountCredentials(TypedDict):
     """Azure authentication using account-based credentials."""
 
-    access_key: str
+    access_key: NotRequired[Optional[str]]
     account_url: NotRequired[Optional[str]]
 
 
@@ -110,7 +110,5 @@ def get_azure_credentials() -> (
     if connection_string is not None:
         return AzureConnectionCredentials(connection_string=connection_string)
     access_key = environment.wf_storage_bucket_azure_access_key()
-    if access_key is None:
-        raise ValueError("Azure access key not set")
     account_url = environment.wf_storage_bucket_azure_account_url()
     return AzureAccountCredentials(access_key=access_key, account_url=account_url)


### PR DESCRIPTION
Supports default credentials via env: https://learn.microsoft.com/en-us/azure/developer/python/sdk/authentication/overview#use-defaultazurecredential-in-an-application.

Depends on https://github.com/wandb/core/pull/29334