### PR TITLE
docs: small nit remove "in weave"

### DIFF
--- a/docs/docs/guides/tracking/otel.md
+++ b/docs/docs/guides/tracking/otel.md
@@ -1,4 +1,4 @@
-# Send OpenTelemetry Traces to Weave
+# Send OpenTelemetry Traces
 
 ## Overview
 Weave supports ingestion of OpenTelemetry compatible trace data through a dedicated endpoint. This endpoint allows you to send OTLP (OpenTelemetry Protocol) formatted trace data directly to your Weave project.

--- a/docs/docs/guides/tracking/video.md
+++ b/docs/docs/guides/tracking/video.md
@@ -1,9 +1,9 @@
-# Video Support in Weave
+# Video Support
 
-Weave now supports video tracing using [`moviepy`](https://zulko.github.io/moviepy/). This allows you to pass video inputs and outputs to traced functions, and Weave will automatically handle uploading and storing video data.
+Weave automatically logs videos that using [`moviepy`](https://zulko.github.io/moviepy/). This allows you to pass video inputs and outputs to traced functions, and Weave will automatically handle uploading and storing video data.
 
 :::note
-Video support in Weave is currently only available in Python.
+Video support is currently only available in Python.
 :::
 
 ## Supported video types


### PR DESCRIPTION
Small changes to titles of 2 docs pages to remove "in weave"/"to weave"