### PR TITLE
chore(weave): Decompose useExampleCompareData for Eval Compare Page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSection.tsx
@@ -47,7 +47,7 @@ import {
 } from '../ScorecardSection/ScorecardSection';
 import {
   PivotedRow,
-  useExampleCompareData,
+  useExampleCompareDataAndPrefetch,
   useFilteredAggregateRows,
 } from './exampleCompareSectionUtil';
 
@@ -223,11 +223,8 @@ export const ExampleCompareSection: React.FC<{
     return filteredRows[targetIndex];
   }, [filteredRows, targetIndex]);
 
-  const {targetRowValue, loading: loadingInputValue} = useExampleCompareData(
-    props.state,
-    filteredRows,
-    targetIndex
-  );
+  const {targetRowValue, loading: loadingInputValue} =
+    useExampleCompareDataAndPrefetch(props.state, filteredRows, targetIndex);
 
   const inputColumnKeys = useMemo(() => {
     return Object.keys(targetRowValue ?? {});

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/exampleCompareSectionUtil.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/exampleCompareSectionUtil.ts
@@ -412,8 +412,7 @@ function useExampleCompareData(
       partialTableRequest
     ).then(rows => {
       if (mounted) {
-        const data = rows[0]?.val;
-        // If the value is already loaded, don't fetch again
+        const data = rows[0];
         if (data != null) {
           setTargetRowValue(flattenObjectPreservingWeaveTypes(data));
         }


### PR DESCRIPTION
Recently @chance-wnb did some great work to improve the loading and caching of our eval compare page. I am reusing some of these methods in an upcoming UI enhancement. In particular, rending a list-view instead of a detail view. 

The current implementation of useExampleCompareData couples data caching, fetching, and prefetching into a single hook. While i wanted to reuse this logic, the current interface was not well suited for my new use case.

This PR is a non-functional change, but decouples the different functionalities and makes it a bit easier to reuse. Specifically:

`useExampleCompareData` is renamed to `useExampleCompareDataAndPrefetch` and:

```
/**
 * The following functions are used to fetch data rows (and cache them in the state - Note: caching them in
 * the state is a little hacky since it is not reactive, but it does work for our use case)
 *
 * Anyway, there are the following methods:
 * * `useExampleCompareDataAndPrefetch` - This is used to fetch a target row and prefetch the adjacent rows.
 *   * This is the primary exported hook from this section.
 * * `useExampleCompareData` - This is used to fetch a single row.
 * * `loadMissingRowDataIntoCache` - This is used to asynchronously load rows that are not yet in our cache.
 * * Then there are a few helper functions that are used to make the above hooks work:
 *   * `makePartialTableReq` - This is used to make a partial table request for a dataset.
 *   * `usePartialTableRequest` - This is used to wrap the `makePartialTableReq` hook and provide a reactive partial table request.
 *   * `loadRowDataIntoCache` - This is used to directly load rows into our cache.
 *   * `getCachedRowData` - This is used to directly get a row from our cache.
 */

```