### PR TITLE
docs(weave): Update scorer examples to use output

### DIFF
--- a/docs/docs/guides/core-types/evaluations.md
+++ b/docs/docs/guides/core-types/evaluations.md
@@ -20,7 +20,7 @@ examples = [
 @weave.op()
 def match_score1(expected: str, output: dict) -> dict:
     # Here is where you'd define the logic to score the model output
-    return {'match': expected == model_output['generated_text']}
+    return {'match': expected == output['generated_text']}
 
 @weave.op()
 def function_to_evaluate(question: str):
@@ -55,9 +55,9 @@ First, define a [Dataset](/guides/core-types/datasets) or list of dictionaries w
 
 ### Defining scoring functions
 
-Then, create a list of scoring functions. These are used to score each example. Each function should have a `model_output` and optionally, other inputs from your examples, and return a dictionary with the scores.
+Then, create a list of scoring functions. These are used to score each example. Each function should have a `output` and optionally, other inputs from your examples, and return a dictionary with the scores.
 
-Scoring functions need to have a `model_output` keyword argument, but the other arguments are user defined and are taken from the dataset examples. It will only take the necessary keys by using a dictionary key based on the argument name.
+Scoring functions need to have a `output` keyword argument, but the other arguments are user defined and are taken from the dataset examples. It will only take the necessary keys by using a dictionary key based on the argument name.
 
 This will take `expected` from the dictionary for scoring.
 
@@ -75,7 +75,7 @@ examples = [
 @weave.op()
 def match_score1(expected: str, output: dict) -> dict:
     # Here is where you'd define the logic to score the model output
-    return {'match': expected == model_output['generated_text']}
+    return {'match': expected == output['generated_text']}
 ```
 
 ### Optional: Define a custom `Scorer` class
@@ -165,11 +165,11 @@ examples = [
 
 @weave.op()
 def match_score1(expected: str, output: dict) -> dict:
-    return {'match': expected == model_output['generated_text']}
+    return {'match': expected == output['generated_text']}
 
 @weave.op()
 def match_score2(expected: dict, output: dict) -> dict:
-    return {'match': expected == model_output['generated_text']}
+    return {'match': expected == output['generated_text']}
 
 class MyModel(Model):
     prompt: str
@@ -231,7 +231,7 @@ def preprocess_example(example):
 
 @weave.op()
 def match_score(expected: str, output: dict) -> dict:
-    return {'match': expected == model_output['generated_text']}
+    return {'match': expected == output['generated_text']}
 
 @weave.op()
 def function_to_evaluate(question: str):

--- a/docs/docs/guides/integrations/dspy.md
+++ b/docs/docs/guides/integrations/dspy.md
@@ -106,8 +106,8 @@ import weave
 os.environ["OPENAI_API_KEY"] = "<YOUR-OPENAI-API-KEY>"
 weave.init(project_name="<YOUR-WANDB-PROJECT-NAME>")
 
-def accuracy_metric(answer, model_output, trace=None):
-    predicted_answer = model_output["answer"].lower()
+def accuracy_metric(answer, output, trace=None):
+    predicted_answer = output["answer"].lower()
     return answer["answer"].lower() == predicted_answer
 
 module = dspy.ChainOfThought("question -> answer: str, explanation: str")

--- a/docs/docs/guides/integrations/langchain.md
+++ b/docs/docs/guides/integrations/langchain.md
@@ -248,7 +248,7 @@ examples = [
 
 @weave.op()
 def fruit_name_score(target: dict, output: dict) -> dict:
-    return {"correct": target["fruit"] == model_output["fruit"]}
+    return {"correct": target["fruit"] == output["fruit"]}
 
 
 evaluation = weave.Evaluation(

--- a/docs/docs/guides/integrations/llamaindex.md
+++ b/docs/docs/guides/integrations/llamaindex.md
@@ -179,7 +179,7 @@ evaluator = CorrectnessEvaluator(llm=llm_judge)
 @weave.op()
 def correctness_evaluator(query: str, ground_truth: str, output: dict):
     result = evaluator.evaluate(
-        query=query, reference=ground_truth, response=model_output["response"]
+        query=query, reference=ground_truth, response=output["response"]
     )
     return {"correctness": float(result.score)}
 
@@ -196,7 +196,7 @@ This evaluation builds on the example in the earlier section. Evaluating using `
 
 - Make sure that the keys of the evaluation sample dicts matches the arguments of the scorer function and of the `weave.Model`'s `predict` method.
 - The `weave.Model` should have a method with the name `predict` or `infer` or `forward`. Decorate this method with `weave.op()` for tracing.
-- The scorer function should be decorated with `weave.op()` and should have `model_output` as named argument.
+- The scorer function should be decorated with `weave.op()` and should have `output` as named argument.
 
 [![llamaindex_evaluation.png](imgs/llamaindex_evaluation.png)](https://wandb.ai/wandbot/llamaindex-weave/weave/calls?filter=%7B%22opVersionRefs%22%3A%5B%22weave%3A%2F%2F%2Fwandbot%2Fllamaindex-weave%2Fop%2FEvaluation.predict_and_score%3ANmwfShfFmgAhDGLXrF6Xn02T9MIAsCXBUcifCjyKpOM%22%5D%2C%22parentId%22%3A%2233491e66-b580-47fa-9d43-0cd6f1dc572a%22%7D&peekPath=%2Fwandbot%2Fllamaindex-weave%2Fcalls%2F33491e66-b580-47fa-9d43-0cd6f1dc572a%3Ftracetree%3D1)
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1505

The scorer code samples in the following files still had `model_output` in some places:

docs/guides/core-types/evaluations.md
docs/guides/integrations/dspy.md
docs/guides/integrations/langchain.md
docs/guides/integrations/llamaindex.md

## Testing

yarn start on local
