### PR TITLE
fix(ui): ellipsis in copyable text

### DIFF
--- a/weave-js/src/components/CopyableText.tsx
+++ b/weave-js/src/components/CopyableText.tsx
@@ -39,6 +39,8 @@ const Wrapper = styled.div<{isMultiline?: boolean}>`
   padding: 8px;
   border-radius: 8px;
   margin-top: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   &:hover {
     background-color: ${MOON_150};
     & > .button_copy {


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-24950

Truncate text with ellipsis rather than having overflow be visible in CopyableText. (If the full text is needed it's just a click to copy away.)

Before: 
<img width="785" alt="Screenshot 2025-05-12 at 2 37 46 PM" src="https://github.com/user-attachments/assets/05bed791-a50f-400d-adde-8d06f4c17212" />

After:
<img width="773" alt="Screenshot 2025-05-12 at 2 37 19 PM" src="https://github.com/user-attachments/assets/f57020ce-45c7-4d44-b173-fe0b3b8ac5ae" />

## Testing

How was this PR tested?
