### PR TITLE
chore(app): Add optional setting to use Right Handed System

### DIFF
--- a/weave-js/src/common/util/render_babylon.ts
+++ b/weave-js/src/common/util/render_babylon.ts
@@ -234,7 +234,8 @@ export function renderJsonPoints<T>(
   pointCloud: BabylonPointCloud,
   request: RenderRequest<T>,
   meta?: Camera3DControl,
-  backgroundColor?: RgbaColor
+  backgroundColor?: RgbaColor,
+  useRightHandedSystem?: boolean
 ): RenderResult<T> {
   const context = request.fullscreen
     ? getFullscreenContext()
@@ -250,7 +251,8 @@ export function renderJsonPoints<T>(
     context,
     size,
     meta,
-    backgroundColor
+    backgroundColor,
+    useRightHandedSystem
   );
   const cleanup = () => scene.dispose();
   const camera = scene.cameras[0];
@@ -266,7 +268,8 @@ const pointCloudScene = (
   {engine}: RenderContext,
   {width, height}: {width: number; height: number},
   meta?: Camera3DControl,
-  backgroundColor?: RgbaColor
+  backgroundColor?: RgbaColor,
+  useRightHandedSystem: boolean = false // default to false because that is the existing behavior
 ): Scene => {
   // these dimensions did not have a lot of thought put into them,
   // so they may need fine tuning. The idea is that table & media previews
@@ -280,6 +283,9 @@ const pointCloudScene = (
       backgroundColor.b / 255,
       backgroundColor.a
     );
+  }
+  if (useRightHandedSystem) {
+    scene.useRightHandedSystem = true;
   }
 
   const target = [0, 0, 0];


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-24590

BabylonJS defaults to a left handed axes system for some reason which isn't the standard https://forum.babylonjs.com/t/left-and-right-handed-shenanagins/17049. But since this has been our default so far, we're just going to add this as a media setting if someone wants to switch to right handed to avoid sudden user confusion with all axes mirrored.

## Testing

How was this PR tested?

Tested in https://github.com/wandb/core/pull/29413
