### PR TITLE
chore(ui): update Run filter label

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -51,6 +51,7 @@ export const FIELD_LABELS: Record<string, string> = {
   'summary.weave.status': 'Status',
   'summary.weave.trace_name': 'Name',
   started_at: 'Called',
+  wb_run_id: 'Run',
   wb_user_id: 'User',
 };
 


### PR DESCRIPTION
## Description

Override filter field label to hide the internal field name and make it match the column display.

Before:
<img width="329" alt="Screenshot 2025-05-13 at 9 45 58 AM" src="https://github.com/user-attachments/assets/fbaa4186-1673-493e-802a-5a1f63ddca52" />

After:
<img width="293" alt="Screenshot 2025-05-13 at 9 45 31 AM" src="https://github.com/user-attachments/assets/8987db5f-df28-4abd-b97b-9080a9577f8f" />


## Testing

How was this PR tested?
