### PR TITLE
extract meaningful errors when calls to the traceServerApi fail (#4487)

### DIFF
--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -236,12 +236,12 @@ export class WeaveClient {
     limit: number = 1000
   ): AsyncIterableIterator<CallSchema> {
     const resp =
-      await this.traceServerApi.calls.callsQueryStreamCallsStreamQueryPost({
+      await debugResponse( () => this.traceServerApi.calls.callsQueryStreamCallsStreamQueryPost({
         project_id: this.projectId,
         filter,
         include_costs: includeCosts,
         limit,
-      });
+      }));
 
     const reader = resp.body!.getReader();
     const decoder = new TextDecoder();
@@ -361,13 +361,13 @@ export class WeaveClient {
       }
 
       const serializedObj = await this.serializedVal(obj);
-      const response = await this.traceServerApi.obj.objCreateObjCreatePost({
+      const response = await debugResponse( () => this.traceServerApi.obj.objCreateObjCreatePost({
         obj: {
           project_id: this.projectId,
-          object_id: objId,
+          object_id: objId!,
           val: serializedObj,
         },
-      });
+      }));
       return new ObjectRef(this.projectId, objId, response.data.digest);
     })();
 
@@ -403,13 +403,13 @@ export class WeaveClient {
         _bases: classChain.slice(1),
         ...saveAttrs,
       };
-      const response = await this.traceServerApi.obj.objCreateObjCreatePost({
+      const response = await debugResponse( () => this.traceServerApi.obj.objCreateObjCreatePost({
         obj: {
           project_id: this.projectId,
-          object_id: objId,
+          object_id: objId!,
           val: saveValue,
         },
-      });
+      }));
       const ref = new ObjectRef(this.projectId, objId, response.data.digest);
       return ref;
     })();
@@ -428,22 +428,22 @@ export class WeaveClient {
       });
       const rows = await this.serializedVal(rowsWithoutRefs);
       const response =
-        await this.traceServerApi.table.tableCreateTableCreatePost({
+        await debugResponse( () => this.traceServerApi.table.tableCreateTableCreatePost({
           table: {
             project_id: this.projectId,
             rows,
           },
-        });
+        }));
       const ref = new TableRef(this.projectId, response.data.digest);
       return ref;
     })();
     const tableQueryPromise = (async () => {
       const tableRef = await table.__savedRef;
       const tableQueryRes =
-        await this.traceServerApi.table.tableQueryTableQueryPost({
+        await debugResponse( () => this.traceServerApi.table.tableQueryTableQueryPost({
           project_id: this.projectId,
           digest: tableRef?.digest!,
-        });
+        }));
       return {
         tableDigest: tableRef?.digest!,
         tableQueryResult: tableQueryRes.data,
@@ -636,13 +636,13 @@ export class WeaveClient {
         'obj.py',
         new Blob([formattedOpFn])
       );
-      const response = await this.traceServerApi.obj.objCreateObjCreatePost({
+      const response = await debugResponse( () => this.traceServerApi.obj.objCreateObjCreatePost({
         obj: {
           project_id: this.projectId,
           object_id: resolvedObjId,
           val: saveValue,
         },
-      });
+      }));
       const ref = new OpRef(
         this.projectId,
         resolvedObjId,
@@ -847,4 +847,36 @@ function sanitizeObjectName(name: string): string {
   }
 
   return res;
+}
+
+// Wrapper of last-resort for traceServerApi requests that occasionally throw
+// Response objects
+function debugResponse<R>( fn: () => Promise<R> ) {
+  return fn().catch( async e => {
+    // If it's a real error, rethrow it
+    if ( e instanceof Error ) {
+      throw e;
+    }
+
+    // Does it look response-y?
+    else if ( e && typeof e === 'object' && 'bodyUsed' in e ) {
+      const url = e.url ??  'unknown url';
+      const status = e.status ?? 'unknown status';
+
+      let body : string = 'no body';
+      try {
+        const eCopy = e.clone();
+        body = await eCopy.text();
+      } catch (e) {
+
+      }
+
+      throw new Error(`Trace Server API returned ${status} for ${url}: ${body.substring(0, 256)}`);
+    }
+
+    // wrap it in a real error so it has a stack trace and send it on its way
+    else {
+      throw new Error("Uncaught error thrown in traceServerApi: " + String(e));
+    }
+  })
 }


### PR DESCRIPTION
# Description

Adds debugging messages of last-resort to HTTP Responses thrown as errors inside [src/weaveClient.ts](). This is obviously a band-aid patch: the better fix would be to lobby the `swagger-typescript-api` not to throw a Response object, and to also add proper error handling to each of the call sites in [src/weaveClient.ts](). HOWEVER, the Node SDK is essentially unusable without this in its current form (see: #4487).

# Testing

I ran the test suite, it passed.