### PR TITLE
fix(ui): empty email in user popup

### DIFF
--- a/weave-js/src/components/UserLink.tsx
+++ b/weave-js/src/components/UserLink.tsx
@@ -106,11 +106,12 @@ const UserContent = ({user, mode, onClose, hasPopover}: UserContentProps) => {
   ) : (
     user.username
   );
-  const email = isPopover ? (
-    <A href={`mailto:${user.email}`}>{user.email}</A>
-  ) : (
-    user.email
-  );
+  const email =
+    user.email && isPopover ? (
+      <A href={`mailto:${user.email}`}>{user.email}</A>
+    ) : (
+      user.email
+    );
   const bodyStyle = isPopover ? {fontSize: '0.9em'} : undefined;
   const onCloseClick = onClose ? () => onClose() : undefined;
   return (
@@ -134,8 +135,12 @@ const UserContent = ({user, mode, onClose, hasPopover}: UserContentProps) => {
         <Grid>
           <Label>Username</Label>
           <div>{username}</div>
-          <Label>Email</Label>
-          <div>{email}</div>
+          {email != null && (
+            <>
+              <Label>Email</Label>
+              <div>{email}</div>
+            </>
+          )}
         </Grid>
       </UserContentBody>
       {hasPopover && !isPopover && (


### PR DESCRIPTION
## Description

Internal Jira: https://wandb.atlassian.net/browse/WB-24992

Quick fix, we may want a more comprehensive design review of this component. If the viewer does not have permission to view a user's email we shouldn't show a blank row in the information table in the user popup.

Before:
<img width="224" alt="Screenshot 2025-05-14 at 10 17 40 AM" src="https://github.com/user-attachments/assets/b9210d73-13c6-42f1-95e6-0428bd4720ef" />

After:
<img width="223" alt="Screenshot 2025-05-14 at 10 16 11 AM" src="https://github.com/user-attachments/assets/cb5b3734-8973-4e5f-99db-89e142b5e882" />


## Testing

How was this PR tested?
