### PR TITLE
chore(weave_query): Add orjson package and use for JSON parsing of tables

### DIFF
--- a/weave_query/requirements.legacy.txt
+++ b/weave_query/requirements.legacy.txt
@@ -63,3 +63,5 @@ flask_cors
 
 
 anyio==3.6.2
+
+orjson >= 3.10,<4

--- a/weave_query/weave_query/ops_domain/table.py
+++ b/weave_query/weave_query/ops_domain/table.py
@@ -20,6 +20,7 @@ from weave_query import weave_types as types
 from weave_query.api import op, weave_class
 from weave_query.ops_domain import trace_tree, wbmedia
 
+
 @dataclasses.dataclass(frozen=True)
 class TableType(types.ObjectType):
     name = "table"
@@ -677,14 +678,20 @@ def _get_table_data_from_file(file: artifact_fs.FilesystemArtifactFile) -> dict:
         raise errors.WeaveInternalError("File is None or a directory")
     with file.open() as f:
         with tracer.trace("get_table:jsonload"):
-            data = json.load(f)
+            import orjson
+
+            data = orjson.loads(f.read())
     return data
 
+
 def _get_incremental_table_awl_from_file(
-    data: dict,
-    file: artifact_fs.FilesystemArtifactFile
+    data: dict, file: artifact_fs.FilesystemArtifactFile
 ) -> ops_arrow.ArrowWeaveList:
-    from weave_query.ops_domain.wb_util import escape_artifact_path, _filesystem_artifact_file_from_artifact_path
+    from weave_query.ops_domain.wb_util import (
+        _filesystem_artifact_file_from_artifact_path,
+        escape_artifact_path,
+    )
+
     all_awls: list[ops_arrow.ArrowWeaveList] = []
     files = {}
     if "previous_increments_paths" in data:
@@ -692,20 +699,26 @@ def _get_incremental_table_awl_from_file(
         # If we have more than 100, otherwise use all increments
         all_increment_paths = data["previous_increments_paths"]
         MAX_PREVIOUS_INCREMENTS = 99
-        increment_paths = all_increment_paths[-MAX_PREVIOUS_INCREMENTS:] if len(all_increment_paths) > MAX_PREVIOUS_INCREMENTS else all_increment_paths
+        increment_paths = (
+            all_increment_paths[-MAX_PREVIOUS_INCREMENTS:]
+            if len(all_increment_paths) > MAX_PREVIOUS_INCREMENTS
+            else all_increment_paths
+        )
         escaped_paths = [escape_artifact_path(path) for path in increment_paths]
         for path in escaped_paths:
             fs_art_file = _filesystem_artifact_file_from_artifact_path(path)
             files[fs_art_file.path] = fs_art_file
 
     files[file.path] = file
-    
+
     asyncio.run(ensure_files(files))
     rrows: list[list] = []
     object_types: list[types.Type] = []
     for incremental_file in files.values():
         incremental_data = _get_table_data_from_file(incremental_file)
-        rows, object_type = _get_rows_and_object_type_awl_from_file(incremental_data, file)
+        rows, object_type = _get_rows_and_object_type_awl_from_file(
+            incremental_data, file
+        )
         rrows.append(rows)
         object_types.append(object_type)
 
@@ -716,8 +729,6 @@ def _get_incremental_table_awl_from_file(
 
     arrow_weave_list = ops_arrow.ops.concat.raw_resolve_fn(all_awls)
     return arrow_weave_list
-
-
 
 
 def _get_table_like_awl_from_file(
@@ -838,7 +849,7 @@ async def ensure_files(files: dict[str, artifact_fs.FilesystemArtifactFile]):
     client = io_service.get_async_client()
     loop = asyncio.get_running_loop()
     tasks = set()
-    
+
     async with client.connect() as conn:
         for file in files.values():
             if (


### PR DESCRIPTION
## Description

`orjson` is faster at JSON parsing than the native `json` package and should help us shave another 2-3 seconds on the load time of large tables (e.g. [This 1.7GB table parse took ~7s](https://us5.datadoghq.com/apm/traces?query=%40duration%3A%3E5s%20-customer-ns%3Awandb-qa-%2A%20%40customer-ns%3Awandb-cohere%20service%3Aweave-python&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&shouldShowLegend=true&sort=time&sort_by=%40duration&sort_order=desc&spanID=11545485965206133566&spanType=all&storage=hot&timeHint=1747167777574&trace=AwAAAZbLUJMmVU2BMQAAABhBWmJMVUp6OEFBQnprVU0yWXRwWWprb1kAAAAkMDE5NmNiNTQtZjVkZS00MzNkLWFjYTItMTExZjZiM2VlNjg3AAhNXg&traceID=1750480686073508918&view=spans&start=1747156897471&end=1747243297471&paused=false))


## Testing

Local Invoker