### PR TITLE
docs(weave): update basic eval logger example

### DIFF
--- a/docs/docs/guides/evaluation/evaluation_logger.md
+++ b/docs/docs/guides/evaluation/evaluation_logger.md
@@ -40,7 +40,9 @@ Finally, `log_summary` records any aggregate metrics and triggers automatic scor
 ```python
 import weave
 from openai import OpenAI
-from weave.flow.eval_imperative import EvaluationLogger
+from weave import EvaluationLogger 
+
+weave.init('my-project')
 
 # Initialize the logger (model/dataset names are optional metadata)
 eval_logger = EvaluationLogger(


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1492

In https://weave-docs.wandb.ai/guides/evaluation/evaluation_logger/#basic-example
1. Adds missing `weave.init`
2. Replaces `weave.flow.eval_imperative` with `from weave import EvaluationLogger` since we don't want to expose internal structures in user facing code 


## Testing

yarn start on local
