### PR TITLE
fix(weave): only perform trace to chat conversion when underlying data changes

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/hooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/hooks.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React from 'react';
+import React, {useMemo} from 'react';
 
 import {isWeaveRef} from '../../filters/common';
 import {mapObject, traverse, TraverseContext} from '../CallPage/traverse';
@@ -564,7 +564,7 @@ export const useCallAsChat = (
 } & Chat => {
   // Memoize the call data processing to prevent unnecessary recalculations
   // when the component re-renders but the call data hasn't changed
-  const refs = React.useMemo(
+  const refs = useMemo(
     // Traverse the data and find all ref URIs.
     () => getRefs(call),
     [call]

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/hooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/hooks.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, {useMemo} from 'react';
+import {useMemo} from 'react';
 
 import {isWeaveRef} from '../../filters/common';
 import {mapObject, traverse, TraverseContext} from '../CallPage/traverse';
@@ -573,7 +573,7 @@ export const useCallAsChat = (
   const refsData = useRefsData({refUris: refs});
 
   // Only recalculate when refs data or call data changes
-  const result = React.useMemo(() => {
+  const result = useMemo(() => {
     const refsMap = _.zipObject(refs, refsData.result ?? []);
     const request = normalizeChatRequest(deref(call.inputs, refsMap));
     const result = call.output

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/hooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/hooks.ts
@@ -559,17 +559,16 @@ export const normalizeChatCompletion = (
 
 export const useCallAsChat = (
   call: TraceCallSchema
- ): {
-   loading: boolean;
- } & Chat => {
+): {
+  loading: boolean;
+} & Chat => {
   // Memoize the call data processing to prevent unnecessary recalculations
   // when the component re-renders but the call data hasn't changed
-  const callId = call.id;
-  const callInputs = JSON.stringify(call.inputs);
-  const callOutput = call.output ? JSON.stringify(call.output) : null;
-
-  // Traverse the data and find all ref URIs.
-  const refs = React.useMemo(() => getRefs(call), [callId, callInputs, callOutput]);
+  const refs = React.useMemo(
+    // Traverse the data and find all ref URIs.
+    () => getRefs(call),
+    [call]
+  );
   const {useRefsData} = useWFHooks();
   const refsData = useRefsData({refUris: refs});
 
@@ -595,13 +594,13 @@ export const useCallAsChat = (
       request,
       result,
     };
-  }, [callId, callInputs, callOutput, refsData.result]);
+  }, [refsData.result, call, refs]);
 
-   return {
-     loading: refsData.loading,
+  return {
+    loading: refsData.loading,
     ...result,
-   };
-}
+  };
+};
 
 export const isMistralChatCompletionChoice = (choice: any): boolean => {
   if (!_.isPlainObject(choice)) {


### PR DESCRIPTION
## Description

- Fixes WB-25009

Currently normalizing the call trace into a Chat occurs on every keypress when the user types into the playground prompt box and multiple times every time the chat is rendered in playground and trace view.

With this change it is only re-parsed when the underlying data changes.

## Testing

tested in playground
