### PR TITLE
chore(weave): Add top level get_client function

### DIFF
--- a/tests/trace/test_top_level.py
+++ b/tests/trace/test_top_level.py
@@ -1,0 +1,10 @@
+import weave
+from weave.trace.weave_client import WeaveClient
+
+
+def test_get_client(client: WeaveClient):
+    assert weave.get_client() is client
+
+
+def test_get_client_no_client():
+    assert weave.get_client() is None

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -84,6 +84,10 @@ def init(
     return initialized_client.client
 
 
+def get_client() -> weave_client.WeaveClient | None:
+    return weave_client_context.get_weave_client()
+
+
 @contextlib.contextmanager
 def remote_client(project_name: str) -> Iterator[weave_init.weave_client.WeaveClient]:
     inited_client = weave_init.init_weave(project_name)
@@ -293,4 +297,5 @@ __all__ = [
     "weave_client_context",
     "require_current_call",
     "get",
+    "get_client",
 ]


### PR DESCRIPTION
This is helpful for users who do:
```py
weave.init(project)
```

but then need to retrieve the client later (perhaps in a different context).  Now they can:
```py
client = weave.get_client()
```