### PR TITLE
chore(ui): Add id prop to TextField

### DIFF
--- a/weave-js/src/components/Form/TextField.tsx
+++ b/weave-js/src/components/Form/TextField.tsx
@@ -19,6 +19,8 @@ export type TextFieldSize =
   (typeof TextFieldSizes)[keyof typeof TextFieldSizes];
 
 type TextFieldProps = {
+  /** id to assign to the input element */
+  id?: string;
   size?: TextFieldSize;
   placeholder?: string;
   value?: string;
@@ -43,6 +45,7 @@ type TextFieldProps = {
 };
 
 export const TextField = ({
+  id,
   size,
   variant = 'default',
   placeholder,
@@ -129,6 +132,7 @@ export const TextField = ({
             </div>
           )}
           <input
+            id={id}
             className={classNames(
               'h-full w-full flex-1 rounded-[5px] bg-inherit pr-8',
               'appearance-none border-none',


### PR DESCRIPTION
## Description

Add `id` prop to `TextField` common comp, which will be assigned to the input element. This allows us to associate accessible labels to the input.

## Testing

Used here: https://github.com/wandb/core/pull/29499