### PR TITLE
feat(ui): Improve run links and filtering

### DIFF
--- a/wb_schema.gql
+++ b/wb_schema.gql
@@ -236,6 +236,12 @@ type ParquetHistory {
   parquetUrls: [String!]!
 }
 
+type RunTag @internal(method: "ProjectID() teams.ProjectID") {
+  id: ID!
+  name: String!
+  colorIndex: Int!
+}
+
 type Run implements Node {
   createdAt: DateTime!
   name: String!
@@ -254,6 +260,9 @@ type Run implements Node {
   historyKeys: JSON
   computeSeconds: Duration!
   parquetHistory(liveKeys: [String!]!): ParquetHistory!
+  notes: String
+  state: String
+  tagColors: [RunTag!]!
 }
 
 type RunConnection {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -340,6 +340,8 @@ export const FilterBar = ({
           {combinedItems.map(f => (
             <FilterTagItem
               key={f.id}
+              entity={entity}
+              project={project}
               item={f}
               onRemoveFilter={onRemoveFilter}
               isEditing={activeEditIds.has(f.id) || f.id === activeEditId}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -64,7 +64,7 @@ export const FilterRow = ({
 
   const isOperatorDisabled =
     isWeaveRef(item.value) ||
-    ['id', 'status', 'user'].includes(getFieldType(item.field));
+    ['id', 'status', 'run', 'user'].includes(getFieldType(item.field));
 
   return (
     <>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -7,6 +7,7 @@ import {RemoveAction} from '@wandb/weave/components/Tag';
 import React from 'react';
 
 import {parseRef} from '../../../../../react';
+import {RunLink} from '../../../../RunLink';
 import {Timestamp, TimestampRange, TimestampSmall} from '../../../../Timestamp';
 import {UserLink} from '../../../../UserLink';
 import {SmallRef} from '../smallRef/SmallRef';
@@ -26,6 +27,8 @@ import {FilterTagStatus} from './FilterTagStatus';
 import {IdList} from './IdList';
 
 type FilterTagItemProps = {
+  entity: string;
+  project: string;
   item: GridFilterItem;
   onRemoveFilter: (id: FilterId) => void;
   isEditing?: boolean;
@@ -39,6 +42,8 @@ const quoteValue = (valueType: string, value: string): string => {
 };
 
 export const FilterTagItem = ({
+  entity,
+  project,
   item,
   onRemoveFilter,
   isEditing = false,
@@ -53,6 +58,11 @@ export const FilterTagItem = ({
   const fieldType = getFieldType(item.field);
   if (fieldType === 'id') {
     value = <IdList ids={getStringList(item.value)} type="Call" />;
+  } else if (fieldType === 'run') {
+    const runName = item.value.split(':')[1]; // Value is e.g. UHJvamVjdEludGVybmFsSWQ6NDE2OTQ4MDc=:qels1cvj
+    value = (
+      <RunLink entityName={entity} projectName={project} runName={runName} />
+    );
   } else if (fieldType === 'user') {
     // This additional night-aware is unfortunate, necessary to counteract
     // the night-aware in FilterTag's useTagClasses call.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 
 import {parseRef} from '../../../../../react';
+import {RunOption, SelectRun} from '../../../../SelectRun';
 import {UserLink} from '../../../../UserLink';
 import {SmallRef} from '../smallRef/SmallRef';
 import {
@@ -61,6 +62,23 @@ export const SelectValue = ({
   }
   if (fieldType === 'user') {
     return <UserLink userId={value} includeName={true} hasPopover={false} />;
+  }
+  if (fieldType === 'run') {
+    return (
+      <SelectRun
+        entityName={entity}
+        projectName={project}
+        runName={
+          typeof value === 'string' && value.includes(':')
+            ? value.split(':')[1]
+            : value
+        }
+        onSelectRun={(run: RunOption) => {
+          const value = `${run.projectInternalId}:${run.value}`;
+          onSetValue(value);
+        }}
+      />
+    );
   }
   if (fieldType === 'datetime') {
     // For date range, only show active state for the last filter

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -37,7 +37,6 @@ export const UNFILTERABLE_FIELDS = [
   'tokens',
   'cost',
   'wb_user_id', // Option+Click works
-  'wb_run_id', // Option+Click works
   'total_storage_size_bytes',
 ];
 
@@ -79,6 +78,7 @@ export const FIELD_TYPE: Record<string, string> = {
   id: 'id',
   'summary.weave.status': 'status',
   'summary.weave.trace_name': 'string',
+  wb_run_id: 'run',
   wb_user_id: 'user',
   started_at: 'datetime',
 };
@@ -289,6 +289,15 @@ export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
       {
         value: '(string): in',
         label: 'in',
+        group: 'string',
+      },
+    ];
+  }
+  if ('run' === fieldType) {
+    return [
+      {
+        value: '(string): equals',
+        label: 'equals',
         group: 'string',
       },
     ];

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -801,24 +801,14 @@ function buildCallsTableColumns(
         return <span>{runId}</span>;
       }
       const [entityName, projectName, runName] = parts;
-      // The filtering here is kind of hacky.
-      // We would need the project internal id to construct an equals filter,
-      // or we need to pass the restriction in as part of the "filter" argument
-      // instead of the "query" argument. A slight improvement that wouldn't go
-      // that far would be if we had an "ends with" operator.
       return (
-        <CellFilterWrapper
+        <CellValueRun
+          entity={entityName}
+          project={projectName}
+          run={runName}
           onUpdateFilter={onUpdateFilter}
-          field="wb_run_id"
           rowId={cellParams.id.toString()}
-          operation="(string): contains"
-          value={':' + runName}>
-          <CellValueRun
-            entity={entityName}
-            project={projectName}
-            run={runName}
-          />
-        </CellFilterWrapper>
+        />
       );
     },
   });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableFilter.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableFilter.ts
@@ -24,6 +24,7 @@ export type WFHighLevelCallFilter = {
   inputObjectVersionRefs?: string[];
   outputObjectVersionRefs?: string[];
   parentId?: string | null;
+  runIds?: string[];
   // This really doesn't belong here. We are using it to indicate that the
   // filter is frozen and should not be updated by the user. However, this
   // control should really be managed outside of the filter itself.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -294,6 +294,7 @@ export const convertHighLevelFilterToLowLevelFilter = (
     parentIds: effectiveFilter.parentId
       ? [effectiveFilter.parentId]
       : undefined,
+    runIds: effectiveFilter.runIds,
   };
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context.tsx
@@ -12,7 +12,10 @@ import React, {createContext, FC, useContext, useMemo} from 'react';
 
 import {useHasTraceServerClientContext} from './traceServerClientContext';
 import {tsWFDataModelHooks} from './tsDataModelHooks';
-import {WFDataModelHooksInterface} from './wfDataModelHooksInterface';
+import {
+  CallFilter,
+  WFDataModelHooksInterface,
+} from './wfDataModelHooksInterface';
 
 const WFDataModelHooksContext = createContext<WFDataModelHooksInterface | null>(
   null
@@ -67,4 +70,26 @@ export const useProjectHasTraceServerData = (
     }),
     [loading, objs.result, calls.result]
   );
+};
+
+/**
+ * Returns trace count for a Run if the client can connect to trace server.
+ */
+export const useRunTraceStats = (
+  entity: string,
+  project: string,
+  runName: string
+) => {
+  const filter: CallFilter = {
+    runIds: [`${entity}/${project}/${runName}`],
+    traceRootsOnly: true,
+  };
+  const hasTraceServer = useHasTraceServerClientContext();
+  const callStats = tsWFDataModelHooks.useCallsStats({
+    entity,
+    project,
+    filter,
+    skip: !hasTraceServer,
+  });
+  return callStats;
 };

--- a/weave-js/src/components/RunLink.tsx
+++ b/weave-js/src/components/RunLink.tsx
@@ -1,0 +1,217 @@
+/**
+ * Show information about one W&B Run.
+ */
+
+import {gql, useApolloClient} from '@apollo/client';
+import {TooltipProps} from '@mui/material';
+import * as Colors from '@wandb/weave/common/css/color.styles';
+import React, {useEffect, useState} from 'react';
+import styled from 'styled-components';
+
+import {DraggableHandle, StyledTooltip} from './DraggablePopups';
+import {Link} from './PagePanelComponents/Home/Browse3/pages/common/Links';
+import {RunState} from './RunState';
+import {getTagContrastColor, Tag} from './Tag';
+import {Tailwind} from './Tailwind';
+import {Timestamp} from './Timestamp';
+
+type RunLinkProps = {
+  entityName: string;
+  projectName: string;
+  runName: string; // e.g. "qd58mkmj"
+  placement?: TooltipProps['placement'];
+
+  to?: string;
+};
+
+type TagColor = {
+  id: string;
+  name: string;
+  colorIndex: number;
+};
+
+type RunData = {
+  name: string;
+  displayName: string;
+  createdAt: string;
+  notes: string;
+  state: string;
+  tagColors: TagColor[];
+};
+
+const FETCH_PROJECT_RUN_QUERY = gql`
+  query FetchProjectRun(
+    $entityName: String!
+    $projectName: String!
+    $runName: String!
+  ) {
+    project(entityName: $entityName, name: $projectName) {
+      id
+      internalId
+      run(name: $runName) {
+        id
+        name
+        displayName
+        createdAt
+        notes
+        state
+        tagColors {
+          id
+          name
+          colorIndex
+        }
+      }
+    }
+  }
+`;
+
+type RunResult = 'load' | 'loading' | 'error' | RunData;
+
+const RunContentHeader = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 2px 2px 2px 8px;
+  background-color: ${Colors.MOON_100};
+`;
+RunContentHeader.displayName = 'S.RunContentHeader';
+
+const RunDisplayName = styled.div`
+  font-weight: 600;
+  flex: 1 1 auto;
+`;
+RunDisplayName.displayName = 'S.RunDisplayName';
+
+const RunContentBody = styled.div`
+  padding: 4px;
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+`;
+RunContentBody.displayName = 'S.RunContentBody';
+
+type RunContentProps = {run: RunData};
+
+const RunContent = ({run}: RunContentProps) => {
+  return (
+    <Tailwind>
+      <DraggableHandle>
+        <RunContentHeader>
+          <RunDisplayName>{run.displayName}</RunDisplayName>
+        </RunContentHeader>
+      </DraggableHandle>
+      <RunContentBody>
+        <div className="grid grid-cols-[auto_auto] gap-4">
+          {run.notes && (
+            <>
+              <div className="text-right font-semibold">Notes</div>
+              <div>{run.notes}</div>
+            </>
+          )}
+          {run.tagColors.length > 0 && (
+            <>
+              <div className="text-right font-semibold">Tags</div>
+              <div className="flex items-center gap-4">
+                {run.tagColors.map(tag => (
+                  <Tag
+                    key={tag.id}
+                    label={tag.name}
+                    color={getTagContrastColor(tag.colorIndex)}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+          <div className="text-right font-semibold">State</div>
+          <div>
+            <RunState value={run.state} />
+          </div>
+          <div className="text-right font-semibold">Start time</div>
+          <div>
+            <Timestamp value={run.createdAt} />
+          </div>
+        </div>
+      </RunContentBody>
+    </Tailwind>
+  );
+};
+
+export const useProjectRun = (
+  entityName: string,
+  projectName: string,
+  runName: string
+) => {
+  const apolloClient = useApolloClient();
+
+  const [runData, setRunData] = useState<RunResult>('load');
+  useEffect(() => {
+    let mounted = true;
+    setRunData('loading');
+    apolloClient
+      .query({
+        query: FETCH_PROJECT_RUN_QUERY as any,
+        variables: {
+          entityName,
+          projectName,
+          runName,
+        },
+      })
+      .then(runRes => {
+        if (!mounted) {
+          return;
+        }
+        const run = runRes.data.project.run;
+        const {name, displayName, createdAt, notes, state, tagColors} = run;
+        setRunData({
+          name,
+          displayName,
+          createdAt,
+          notes,
+          state,
+          tagColors,
+        });
+      })
+      .catch(err => {
+        console.error({err});
+        if (!mounted) {
+          return;
+        }
+        setRunData('error');
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [apolloClient, entityName, projectName, runName]);
+
+  return runData;
+};
+
+export const RunLink = ({
+  entityName,
+  projectName,
+  runName,
+  placement,
+  to,
+}: RunLinkProps) => {
+  const runData = useProjectRun(entityName, projectName, runName);
+  if (runData === 'load' || runData === 'loading' || runData === 'error') {
+    return null;
+  }
+
+  let content = <span className="font-semibold">{runData.displayName}</span>;
+  if (to) {
+    content = <Link to={to}>{content}</Link>;
+  }
+  const tooltipContent = <RunContent run={runData} />;
+
+  return (
+    <Tailwind>
+      <StyledTooltip
+        enterDelay={500}
+        title={tooltipContent}
+        placement={placement ?? 'right'}
+        padding={0}>
+        {content}
+      </StyledTooltip>
+    </Tailwind>
+  );
+};

--- a/weave-js/src/components/RunState.tsx
+++ b/weave-js/src/components/RunState.tsx
@@ -1,0 +1,140 @@
+/**
+ * Colored chip representing Run / Run Queue Item / Sweep state.
+ *
+ * TODO: Split into multiple components for the different use cases?
+ *
+ * See https://www.notion.so/wandbai/Run-Run-Queue-Item-and-Sweep-States-61c84c5d0f0a40c19046f1c58db5bb19?pvs=4
+ * for documentation on the meaning of each state.
+ */
+import {IconName} from '@wandb/weave/components/Icon';
+import {Pill, TagColorName} from '@wandb/weave/components/Tag';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
+import React from 'react';
+
+export const RUN_STATE = [
+  'idle',
+  'preempting',
+  'preempted',
+  'pending',
+  'queued',
+  'starting',
+  'running',
+  'finished',
+  'failed',
+  'crashed',
+  'stopping',
+  'stopped',
+  'killed',
+] as const;
+export type RunStateType = (typeof RUN_STATE)[number];
+
+type RunStateProps = {
+  value: string;
+  // By default we will show an icon, but you can turn it off.
+  noIcon?: boolean;
+  tooltip?: boolean;
+};
+
+type RunStateInfo = {
+  icon: IconName;
+  color: TagColorName;
+  tooltip?: string;
+};
+const RUN_STATE_INFO: Record<RunStateType, RunStateInfo> = {
+  idle: {
+    icon: 'idle',
+    color: 'red',
+    tooltip:
+      'The run cannot start because there are no active agents on the queue.',
+  },
+  preempting: {
+    icon: 'loading',
+    color: 'sienna',
+  },
+  preempted: {
+    icon: 'failed',
+    color: 'sienna',
+  },
+  pending: {
+    icon: 'loading', // sweep state
+    color: 'moon',
+    tooltip:
+      'The run has been picked up by an agent but has not yet started. This could be due to resources being unavailable on the cluster.',
+  },
+  queued: {
+    icon: 'queued',
+    color: 'moon',
+    tooltip: 'The run is waiting for an agent to process it.',
+  },
+  starting: {
+    icon: 'run',
+    color: 'teal',
+  },
+  running: {
+    icon: 'run',
+    color: 'teal',
+    tooltip: 'The run is currently executing.',
+  },
+  finished: {
+    icon: 'checkmark-circle',
+    color: 'green',
+    tooltip: 'The job completed successfully.',
+  },
+  failed: {
+    icon: 'failed',
+    color: 'red',
+    tooltip:
+      'The run ended with a non-zero exit code or the run failed to start.',
+  },
+  crashed: {
+    icon: 'warning',
+    color: 'red',
+    tooltip: 'The run stopped sending data or did not successfully start.',
+  },
+  stopping: {
+    icon: 'loading',
+    color: 'sienna',
+  },
+  stopped: {
+    icon: 'failed',
+    color: 'sienna',
+  },
+  killed: {
+    icon: 'failed',
+    color: 'sienna',
+    tooltip: 'The job was killed by the user.',
+  },
+};
+
+export const RunState = ({value, noIcon, tooltip}: RunStateProps) => {
+  if (!value) {
+    return null;
+  }
+
+  const stateStr = value.toLowerCase() as RunStateType;
+  const label = stateStr.charAt(0).toUpperCase() + stateStr.slice(1);
+
+  const stateInfo = RUN_STATE_INFO[stateStr];
+  if (stateInfo == null) {
+    return <Pill color="moon" label={label} />;
+  }
+
+  const pill = (
+    <Pill
+      icon={noIcon ? undefined : stateInfo.icon}
+      color={stateInfo.color}
+      label={label}
+    />
+  );
+
+  if (!tooltip || stateInfo.tooltip == null) {
+    return pill;
+  }
+  return (
+    <Tooltip
+      position="top center"
+      content={stateInfo.tooltip}
+      trigger={<div>{pill}</div>}
+    />
+  );
+};

--- a/weave-js/src/components/SelectRun.tsx
+++ b/weave-js/src/components/SelectRun.tsx
@@ -1,0 +1,132 @@
+/**
+ * Select a Run from within a Project.
+ */
+import {gql, useApolloClient} from '@apollo/client';
+import {Select} from '@wandb/weave/components/Form/Select';
+import _ from 'lodash';
+import React, {useEffect, useState} from 'react';
+
+export type RunOption = {
+  // e.g. "UHJvamVjdEludGVybmFsSWQ6NDE2OTQ4MDc= which decodes to "ProjectInternalId:41694807"
+  // This is useful for constructing the value we store in ClickHouse.
+  // Since this query is project scoped, this value should be constant across options,
+  // but is repeated for ease of use.
+  projectInternalId: string;
+
+  value: string; // run name, e.g. "qd58mkmj"
+
+  displayName: string; // e.g. "restful-glitter-3"
+};
+
+type SelectRunProps = {
+  entityName: string;
+  projectName: string;
+  runName?: string;
+  onSelectRun: (run: RunOption) => void;
+};
+
+const FETCH_PROJECT_RUNS_QUERY = gql`
+  query FetchProjectRuns($entityName: String!, $projectName: String!) {
+    project(entityName: $entityName, name: $projectName) {
+      id
+      internalId
+      runs {
+        edges {
+          node {
+            id
+            name
+            displayName
+          }
+        }
+      }
+    }
+  }
+`;
+
+const getRunOptions = (result: any): RunOption[] => {
+  const projectInternalId = result?.data?.project?.internalId ?? '';
+  const edges = result?.data?.project?.runs?.edges ?? [];
+  const options = edges.map((edge: any) => {
+    const run = edge.node;
+    return {
+      value: run.name,
+      displayName: run.displayName,
+      projectInternalId,
+    };
+  });
+  return options;
+};
+
+const labelStyle = {
+  whiteSpace: 'nowrap' as const,
+};
+
+const formatOptionLabel = (option: RunOption) => {
+  return <div style={labelStyle}>{option.displayName}</div>;
+};
+
+type RunResult = 'load' | 'loading' | 'error' | RunOption[];
+
+export const useProjectRuns = (entityName: string, projectName: string) => {
+  const apolloClient = useApolloClient();
+
+  const [runs, setRuns] = useState<RunResult>('load');
+  useEffect(() => {
+    let mounted = true;
+    setRuns('loading');
+    apolloClient
+      .query({
+        query: FETCH_PROJECT_RUNS_QUERY as any,
+        variables: {
+          entityName,
+          projectName,
+        },
+      })
+      .then(runRes => {
+        if (!mounted) {
+          return;
+        }
+        setRuns(getRunOptions(runRes));
+      })
+      .catch(err => {
+        if (!mounted) {
+          return;
+        }
+        setRuns('error');
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [apolloClient, entityName, projectName]);
+
+  return runs;
+};
+
+export const SelectRun = ({
+  entityName,
+  projectName,
+  runName,
+  onSelectRun,
+}: SelectRunProps) => {
+  const runs = useProjectRuns(entityName, projectName);
+  if (runs === 'load' || runs === 'loading' || runs === 'error') {
+    return null;
+  }
+
+  const selectedOption = _.find(runs, o => o.value === runName);
+  const onChange = (option: RunOption | null) => {
+    if (option) {
+      onSelectRun(option);
+    }
+  };
+
+  return (
+    <Select<RunOption>
+      options={runs}
+      placeholder="Select a run..."
+      value={selectedOption}
+      formatOptionLabel={formatOptionLabel}
+      onChange={onChange}
+    />
+  );
+};


### PR DESCRIPTION
## Description

* When the user hovers over a value in the Run column we show a little popup summary.
* Option+Click to add a filter still works, but is less hacky because we can query for the project's internal ID.
* We don't have to show the confusing run name in the filter bar, we can show the display name and give it the same hover treatment as the cell value.
* Users can select Run as the field in the filter popup, and a new Select widget allows them to pick one.

A follow up PR in the core repo will link from the Run Overview to the filtered traces page using code in this PR.

I also copied the `RunState` component from the core repo so we could use it in Weave. Follow up PRs will point core uses at this location and then delete the core version to finish that migration.

Before:

<img width="704" alt="Screenshot 2025-05-15 at 2 23 56 PM" src="https://github.com/user-attachments/assets/e2bbd294-9463-4ebf-a412-6783b1660820" />

After:

Hover over the run display name shows more information
<img width="333" alt="Screenshot 2025-05-15 at 2 21 41 PM" src="https://github.com/user-attachments/assets/e2fc8e90-2166-4b0f-87b9-719f22332438" />

Filter bar shows display name instead of name
<img width="291" alt="Screenshot 2025-05-15 at 2 21 54 PM" src="https://github.com/user-attachments/assets/4599a07c-1353-445c-b14c-f562f3bcee0f" />

Users can now easily switch between runs using the filter dialog
<img width="661" alt="Screenshot 2025-05-15 at 2 22 03 PM" src="https://github.com/user-attachments/assets/8f7a6da7-a57b-4112-9186-6ff160c8b6e8" />


## Testing

How was this PR tested?
