### PR TITLE
refactor(ui): move ModelRefLabel into its own file

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
@@ -13,11 +13,7 @@ import {
 import {useEvaluationsFilter} from '../../../CallsPage/evaluationsFilter';
 import {Id} from '../../../common/Id';
 import {opNiceName} from '../../../common/opNiceName';
-import {useWFHooks} from '../../../wfReactInterface/context';
-import {
-  CallSchema,
-  ObjectVersionKey,
-} from '../../../wfReactInterface/wfDataModelHooksInterface';
+import {CallSchema} from '../../../wfReactInterface/wfDataModelHooksInterface';
 import {useCompareEvaluationsState} from '../../compareEvaluationsContext';
 import {
   EvaluationComparisonState,
@@ -29,6 +25,7 @@ import {HorizontalBox} from '../../Layout';
 import {ItemDef} from '../DraggableSection/DraggableItem';
 import {DraggableSection} from '../DraggableSection/DraggableSection';
 import {VerticalBar} from './EvaluationDefinition';
+import {ModelRefLabel} from './ModelRefLabel';
 
 export const ComparisonDefinitionSection: React.FC<{
   state: EvaluationComparisonState;
@@ -87,39 +84,6 @@ export const ComparisonDefinitionSection: React.FC<{
         </HorizontalBox>
       </div>
     </Tailwind>
-  );
-};
-
-const ModelRefLabel: React.FC<{modelRef: string}> = props => {
-  const {useObjectVersion} = useWFHooks();
-  const objRef = useMemo(
-    () => parseRef(props.modelRef) as WeaveObjectRef,
-    [props.modelRef]
-  );
-  const objVersionKey = useMemo(() => {
-    return {
-      scheme: 'weave',
-      entity: objRef.entityName,
-      project: objRef.projectName,
-      weaveKind: objRef.weaveKind,
-      objectId: objRef.artifactName,
-      versionHash: objRef.artifactVersion,
-      path: '',
-      refExtra: objRef.artifactRefExtra,
-    } as ObjectVersionKey;
-  }, [
-    objRef.artifactName,
-    objRef.artifactRefExtra,
-    objRef.artifactVersion,
-    objRef.entityName,
-    objRef.projectName,
-    objRef.weaveKind,
-  ]);
-  const objectVersion = useObjectVersion({key: objVersionKey});
-  return (
-    <span className="ml-2">
-      {objectVersion.result?.objectId}:v{objectVersion.result?.versionIndex}
-    </span>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ModelRefLabel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ModelRefLabel.tsx
@@ -1,0 +1,43 @@
+/**
+ * Takes a ref string like "weave:///entity/project/op/op_name:digest"
+ * and displays the model name and numeric version.
+ */
+
+import {parseRef, WeaveObjectRef} from '@wandb/weave/react';
+import React, {useMemo} from 'react';
+
+import {useWFHooks} from '../../../wfReactInterface/context';
+import {ObjectVersionKey} from '../../../wfReactInterface/wfDataModelHooksInterface';
+
+export const ModelRefLabel: React.FC<{modelRef: string}> = props => {
+  const {useObjectVersion} = useWFHooks();
+  const objRef = useMemo(
+    () => parseRef(props.modelRef) as WeaveObjectRef,
+    [props.modelRef]
+  );
+  const objVersionKey = useMemo(() => {
+    return {
+      scheme: 'weave',
+      entity: objRef.entityName,
+      project: objRef.projectName,
+      weaveKind: objRef.weaveKind,
+      objectId: objRef.artifactName,
+      versionHash: objRef.artifactVersion,
+      path: '',
+      refExtra: objRef.artifactRefExtra,
+    } as ObjectVersionKey;
+  }, [
+    objRef.artifactName,
+    objRef.artifactRefExtra,
+    objRef.artifactVersion,
+    objRef.entityName,
+    objRef.projectName,
+    objRef.weaveKind,
+  ]);
+  const objectVersion = useObjectVersion({key: objVersionKey});
+  return (
+    <span className="ml-2">
+      {objectVersion.result?.objectId}:v{objectVersion.result?.versionIndex}
+    </span>
+  );
+};


### PR DESCRIPTION
## Description

The first of some small refactors - the larger goal is extracting this evaluation selector component from the evaluation comparison page as part of allowing people to swap evaluations when viewing the predict_and_score traces.

<img width="424" alt="Screenshot 2025-05-16 at 9 14 57 AM" src="https://github.com/user-attachments/assets/9d93265f-cfcc-403d-9f8c-0cba20c99506" />

## Testing

How was this PR tested?
