### PR TITLE
feat(weave): TS SDK: allows call handle to be returned

### DIFF
--- a/sdks/node/src/__tests__/call.manipulation.test.ts
+++ b/sdks/node/src/__tests__/call.manipulation.test.ts
@@ -1,0 +1,54 @@
+import * as weave from 'weave';
+import {op, Op} from 'weave';
+import {CallState, InternalCall} from 'weave/call';
+import {getGlobalClient} from 'weave/clientApi';
+
+const mockCallId = 'test-call-id';
+const mockProjectId = 'test-project-id';
+
+const mockUpdateCall = jest.fn();
+
+jest.mock('weave/clientApi', () => ({
+  getGlobalClient: jest.fn(() => {
+    const weaveClient = new weave.WeaveClient(
+      null as any,
+      null as any,
+      mockProjectId
+    );
+
+    Object.assign(weaveClient, {
+      getCall: async (callId: string) => {
+        const internalCall = new InternalCall();
+        internalCall.updateWithCallSchemaData({
+          id: callId,
+        });
+
+        internalCall.state = CallState.finished;
+
+        return internalCall.proxy;
+      },
+      updateCall: mockUpdateCall,
+    });
+    return weaveClient;
+  }),
+}));
+
+beforeEach(() => {
+  mockUpdateCall.mockClear();
+});
+
+describe('get call handle', () => {
+  it('can use the handle to reset display name', async () => {
+    const client = getGlobalClient();
+    const call = await client!.getCall(mockCallId);
+
+    expect(call.id).toBe(mockCallId);
+
+    await call.setDisplayName('test-display-name');
+
+    expect(mockUpdateCall).toHaveBeenCalledWith(
+      mockCallId,
+      'test-display-name'
+    );
+  });
+});

--- a/sdks/node/src/__tests__/call.test.ts
+++ b/sdks/node/src/__tests__/call.test.ts
@@ -1,0 +1,85 @@
+import * as weave from 'weave';
+import {op, Op} from 'weave';
+
+const mockOpName = 'weave://test-project-id/op/test-op';
+const mockCallId = 'test-call-id';
+const mockProjectId = 'test-project-id';
+
+jest.mock('weave/clientApi', () => ({
+  getGlobalClient: jest.fn(() => {
+    const weaveClient = new weave.WeaveClient(
+      null as any,
+      null as any,
+      mockProjectId
+    );
+
+    Object.assign(weaveClient, {
+      pushNewCall: () => ({
+        currentCall: {
+          callId: mockCallId,
+        },
+        parentCall: null,
+        newStack: [],
+      }),
+      createCall: (...args: any) => {
+        return weave.WeaveClient.prototype.createCall.apply(weaveClient, args);
+      },
+      startCall: (...args: any[]) => {
+        return Promise.resolve();
+      },
+      saveOp: (op: any, ...rest: any) => {
+        op.__savedRef = Promise.resolve(op);
+        op.uri = () => 'weave://test-project-id/op/test-op';
+        return Promise.resolve();
+      },
+      runWithCallStack: async (stack: any, fn: () => any) => fn(),
+      finishCall: () => Promise.resolve(),
+      finishCallWithException: () => Promise.resolve(),
+      settings: {shouldPrintCallLink: false},
+      waitForBatchProcessing: () => Promise.resolve(),
+      processBatch: () => Promise.resolve(),
+    });
+    return weaveClient;
+  }),
+}));
+
+describe('standalone function call', () => {
+  it('can use call method to get call object', async () => {
+    async function myStandaloneFunction() {
+      return 42;
+    }
+    const callDisplayName = 'test-myStandaloneFunction';
+
+    const wrappedFn = weave.op(myStandaloneFunction, {
+      callDisplayName: () => callDisplayName,
+    });
+
+    const [result, call] = await wrappedFn.invoke();
+    expect(result).toBe(42);
+    expect(call.op_name).toBe(mockOpName);
+    expect(call.display_name).toBe(callDisplayName);
+    expect(call.id).toBe(mockCallId);
+    expect(call.project_id).toBe(mockProjectId);
+  });
+});
+
+describe('class method call', () => {
+  it('can use call method to get call object', async () => {
+    class TestClass {
+      @weave.op
+      async myMethod() {
+        return 42;
+      }
+    }
+    const testInstance = new TestClass();
+
+    const typedOp = testInstance.myMethod as Op<typeof testInstance.myMethod>;
+
+    const [result, call] = await typedOp.invoke();
+
+    expect(result).toBe(42);
+    expect(call.op_name).toBe(mockOpName);
+    expect(call.id).toBe(mockCallId);
+    expect(call.project_id).toBe(mockProjectId);
+  });
+});

--- a/sdks/node/src/__tests__/legacy/op.test.ts
+++ b/sdks/node/src/__tests__/legacy/op.test.ts
@@ -7,17 +7,8 @@ let capturedDisplayName: string | undefined;
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => ({
     pushNewCall: () => ({currentCall: {}, parentCall: null, newStack: []}),
-    createCall: (
-      _: any,
-      __: any,
-      ___: any,
-      ____: any,
-      _____: any,
-      ______: any,
-      _______: any,
-      displayName: string
-    ) => {
-      capturedDisplayName = displayName;
+    createCall: (...args: any[]) => {
+      capturedDisplayName = args.length > 0 ? args[args.length - 1] : undefined;
       return Promise.resolve();
     },
     runWithCallStack: async (stack: any, fn: () => any) => fn(),

--- a/sdks/node/src/__tests__/modern/op.test.ts
+++ b/sdks/node/src/__tests__/modern/op.test.ts
@@ -8,17 +8,8 @@ let capturedDisplayName: string | undefined;
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => ({
     pushNewCall: () => ({currentCall: {}, parentCall: null, newStack: []}),
-    createCall: (
-      _: any,
-      __: any,
-      ___: any,
-      ____: any,
-      _____: any,
-      ______: any,
-      _______: any,
-      displayName: string
-    ) => {
-      capturedDisplayName = displayName;
+    createCall: (...args: any[]) => {
+      capturedDisplayName = args.length > 0 ? args[args.length - 1] : undefined;
       return Promise.resolve();
     },
     runWithCallStack: async (stack: any, fn: () => any) => fn(),

--- a/sdks/node/src/__tests__/op.test.ts
+++ b/sdks/node/src/__tests__/op.test.ts
@@ -10,15 +10,13 @@ const createFreshMockClient = () => ({
     parentCall: null,
     newStack: [],
   })),
-  createCall: jest.fn(
-    (_, __, ___, ____, _____, ______, _______, displayName: string) => {
-      // We still need a way to capture this if tests rely on it.
-      // Maybe pass a shared object or use a different mechanism?
-      // For now, let's remove the direct capture here.
-      // capturedDisplayName = displayName;
-      return Promise.resolve();
-    }
-  ),
+  createCall: jest.fn((...args: any[]) => {
+    // We still need a way to capture this if tests rely on it.
+    // Maybe pass a shared object or use a different mechanism?
+    // For now, let's remove the direct capture here.
+    // capturedDisplayName = displayName;
+    return Promise.resolve();
+  }),
   runWithCallStack: jest.fn(async (stack: any, fn: () => any) => fn()),
   finishCall: jest.fn(() => Promise.resolve()),
   finishCallWithException: jest.fn(() => Promise.resolve()),
@@ -193,13 +191,17 @@ describe('op wrappers', () => {
     expect(getGlobalClientSpy).toHaveBeenCalledTimes(1);
 
     // Assertions on the specific mock instance returned for this test
-    expect(mockClientInstance.finishCallWithException).toHaveBeenCalledWith(
+    expect(mockClientInstance.finishCallWithException).toHaveBeenCalled();
+    const args = mockClientInstance.finishCallWithException.mock.lastCall;
+    // The first arg is internal, so we shift it off and not check it
+    args?.shift();
+    expect(args).toEqual([
       error,
       expect.objectContaining({callId: 'mockCallId'}), // currentCall
       null, // parentCall
       expect.any(Date), // endTime
-      expect.any(Promise) // startCallPromise
-    );
+      expect.any(Promise), // startCallPromise
+    ]);
     expect(mockClientInstance.finishCall).not.toHaveBeenCalled();
   });
 });

--- a/sdks/node/src/call.ts
+++ b/sdks/node/src/call.ts
@@ -1,0 +1,80 @@
+import {getGlobalClient} from './clientApi';
+import {CallSchema} from './generated/traceServerApi';
+
+export enum CallState {
+  uninitialized,
+  pending,
+  finished,
+  failed,
+}
+
+export class InternalCall {
+  _state: CallState = CallState.uninitialized;
+
+  public callSchema: Partial<CallSchema> = {};
+
+  constructor() {}
+
+  public async setDisplayName(displayName: string) {
+    this.callSchema.display_name = displayName;
+
+    if ([CallState.pending, CallState.uninitialized].includes(this._state)) {
+      // nothing needs to be done here, the call will be updated when it is finished
+      return;
+    }
+
+    const client = getGlobalClient();
+    if (!client) {
+      throw new Error('Weave is not initialized');
+    }
+    await client.updateCall(this.callSchema.id!, displayName);
+  }
+
+  public updateWithCallSchemaData(callSchemaExchangeData: Partial<CallSchema>) {
+    Object.assign(this.callSchema, callSchemaExchangeData);
+  }
+
+  // This proxy is used to access the call schema properties, we don't directly expose the InternalCall instance
+  get proxy(): Call {
+    return new Proxy(
+      this.callSchema,
+      buildProxyHandlers(this.callSchema, this)
+    ) as unknown as Call;
+  }
+
+  set state(state: CallState) {
+    this._state = state;
+  }
+}
+
+function buildProxyHandlers(
+  callSchema: Partial<CallSchema>,
+  internalCall: InternalCall
+) {
+  return {
+    get(target: Partial<CallSchema>, prop: string) {
+      if (prop === 'toJSON') {
+        return (...args: any[]) => JSON.stringify(callSchema, ...args);
+      }
+
+      if (prop === 'setDisplayName') {
+        return internalCall.setDisplayName.bind(internalCall);
+      }
+
+      // If the property exists on the call schema, return it
+      if (Reflect.has(internalCall.callSchema, prop)) {
+        return Reflect.get(internalCall.callSchema, prop);
+      }
+
+      return undefined;
+    },
+    set(target: Partial<CallSchema>, prop: string, value: any) {
+      // Disallow setting properties on the call schema
+      return false;
+    },
+  };
+}
+
+export interface Call extends CallSchema {
+  setDisplayName(displayName: string): Promise<void>;
+}

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -242,8 +242,7 @@ function createOpWrapper<T extends (...args: any[]) => any>(
     });
   }
 
-  // Override the native call method to use the weave call style
-  opWrapper.call = createCallMethod<T>(opWrapper, call.proxy) as any;
+  opWrapper.invoke = createCallMethod<T>(opWrapper, call.proxy) as any;
 
   return opWrapper;
 }

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -1,6 +1,7 @@
+import {Call, InternalCall} from './call';
 import {getGlobalClient} from './clientApi';
 import {TRACE_CALL_EMOJI} from './constants';
-import {Op, OpOptions, OpRef} from './opType';
+import {Op, OpOptions, OpRef, CallMethod} from './opType';
 import {getGlobalDomain} from './urls';
 import {warnOnce} from './utils/warnOnce';
 
@@ -113,6 +114,8 @@ function createOpWrapper<T extends (...args: any[]) => any>(
 ): Op<T> {
   const {context, ...options} = optionsAndContext;
 
+  const call = new InternalCall();
+
   const opWrapper = async function (
     this: any,
     ...params: Parameters<T>
@@ -143,6 +146,7 @@ function createOpWrapper<T extends (...args: any[]) => any>(
     const opRefForCall: Op<any> | OpRef = opWrapper as Op<any>;
 
     const startCallPromise = client.createCall(
+      call,
       opRefForCall,
       params,
       options?.parameterNames,
@@ -179,6 +183,7 @@ function createOpWrapper<T extends (...args: any[]) => any>(
               if (client) {
                 const endTime = new Date();
                 await client.finishCall(
+                  call,
                   state,
                   currentCall,
                   parentCall,
@@ -195,6 +200,7 @@ function createOpWrapper<T extends (...args: any[]) => any>(
         // Non-stream handling
         const endTime = new Date();
         await client.finishCall(
+          call,
           result,
           currentCall,
           parentCall,
@@ -207,6 +213,7 @@ function createOpWrapper<T extends (...args: any[]) => any>(
     } catch (error) {
       const endTime = new Date();
       await client.finishCallWithException(
+        call,
         error,
         currentCall,
         parentCall,
@@ -234,6 +241,9 @@ function createOpWrapper<T extends (...args: any[]) => any>(
       opWrapper.__name = `${actualClassName}.${String(context.name)}`;
     });
   }
+
+  // Override the native call method to use the weave call style
+  opWrapper.call = createCallMethod<T>(opWrapper, call.proxy) as any;
 
   return opWrapper;
 }
@@ -406,4 +416,19 @@ export function op(...args: any[]): any {
 
 export function isOp(fn: any): fn is Op<any> {
   return fn?.__isOp === true;
+}
+
+export function createCallMethod<F extends (...args: any[]) => any>(
+  opWrapper: (
+    this: any,
+    ...args: Parameters<F>
+  ) => Promise<Awaited<ReturnType<F>>>,
+  callProxy: Call
+): CallMethod<F> {
+  return async function call(this: any, ...args: Parameters<F>) {
+    return [await opWrapper.apply(this, args), callProxy] as [
+      Awaited<ReturnType<F>>,
+      Call,
+    ];
+  };
 }

--- a/sdks/node/src/opType.ts
+++ b/sdks/node/src/opType.ts
@@ -11,7 +11,7 @@ export type Op<T extends (...args: any[]) => any> = {
   __name: string;
   __savedRef?: OpRef | Promise<OpRef>;
   __parameterNames?: ParameterNamesOption;
-  call: CallMethod<T>;
+  invoke: CallMethod<T>;
 } & T &
   ((
     ...args: Parameters<T>

--- a/sdks/node/src/opType.ts
+++ b/sdks/node/src/opType.ts
@@ -1,3 +1,4 @@
+import {Call} from './call';
 import {getGlobalDomain} from './urls';
 import {WeaveObject} from './weaveObject';
 
@@ -10,6 +11,7 @@ export type Op<T extends (...args: any[]) => any> = {
   __name: string;
   __savedRef?: OpRef | Promise<OpRef>;
   __parameterNames?: ParameterNamesOption;
+  call: CallMethod<T>;
 } & T &
   ((
     ...args: Parameters<T>
@@ -59,6 +61,21 @@ export interface OpOptions<T extends (...args: any[]) => any> {
   bindThis?: WeaveObject;
   isDecorator?: boolean;
   parameterNames?: ParameterNamesOption;
+}
+
+type AsyncResult<F extends (...args: any[]) => any> = Promise<
+  Awaited<ReturnType<F>>
+>;
+
+export interface OpWrapper<F extends (...args: any[]) => any> {
+  (this: any, ...params: Parameters<F>): AsyncResult<F>;
+}
+
+export interface CallMethod<F extends (...args: any[]) => any> {
+  (
+    this: any,
+    ...params: Parameters<F>
+  ): Promise<[Awaited<ReturnType<F>>, Call]>;
 }
 
 export function isOp(value: any): value is Op<any> {


### PR DESCRIPTION
## Description

Adds a new `invoke` method to ops that returns both the result and a Call object, allowing users to update call metadata after execution. The Call object provides a `setDisplayName` method to change the display name of a call even after it has completed.

## Testing

Tested by creating ops, calling them with the new `invoke` method, and verifying that the returned Call object can be used to update the display name both during and after execution.

Some unit tests scenarios are authored as well.