### PR TITLE
Unit tests for the call handle feature

### DIFF
--- a/sdks/node/src/__tests__/call.manipulation.test.ts
+++ b/sdks/node/src/__tests__/call.manipulation.test.ts
@@ -1,0 +1,54 @@
+import * as weave from 'weave';
+import {op, Op} from 'weave';
+import {CallState, InternalCall} from 'weave/call';
+import {getGlobalClient} from 'weave/clientApi';
+
+const mockCallId = 'test-call-id';
+const mockProjectId = 'test-project-id';
+
+const mockUpdateCall = jest.fn();
+
+jest.mock('weave/clientApi', () => ({
+  getGlobalClient: jest.fn(() => {
+    const weaveClient = new weave.WeaveClient(
+      null as any,
+      null as any,
+      mockProjectId
+    );
+
+    Object.assign(weaveClient, {
+      getCall: async (callId: string) => {
+        const internalCall = new InternalCall();
+        internalCall.updateWithCallSchemaData({
+          id: callId,
+        });
+
+        internalCall.state = CallState.finished;
+
+        return internalCall.proxy;
+      },
+      updateCall: mockUpdateCall,
+    });
+    return weaveClient;
+  }),
+}));
+
+beforeEach(() => {
+  mockUpdateCall.mockClear();
+});
+
+describe('get call handle', () => {
+  it('can use the handle to reset display name', async () => {
+    const client = getGlobalClient();
+    const call = await client!.getCall(mockCallId);
+
+    expect(call.id).toBe(mockCallId);
+
+    await call.setDisplayName('test-display-name');
+
+    expect(mockUpdateCall).toHaveBeenCalledWith(
+      mockCallId,
+      'test-display-name'
+    );
+  });
+});

--- a/sdks/node/src/__tests__/call.test.ts
+++ b/sdks/node/src/__tests__/call.test.ts
@@ -1,0 +1,85 @@
+import * as weave from 'weave';
+import {op, Op} from 'weave';
+
+const mockOpName = 'weave://test-project-id/op/test-op';
+const mockCallId = 'test-call-id';
+const mockProjectId = 'test-project-id';
+
+jest.mock('weave/clientApi', () => ({
+  getGlobalClient: jest.fn(() => {
+    const weaveClient = new weave.WeaveClient(
+      null as any,
+      null as any,
+      mockProjectId
+    );
+
+    Object.assign(weaveClient, {
+      pushNewCall: () => ({
+        currentCall: {
+          callId: mockCallId,
+        },
+        parentCall: null,
+        newStack: [],
+      }),
+      createCall: (...args: any) => {
+        return weave.WeaveClient.prototype.createCall.apply(weaveClient, args);
+      },
+      startCall: (...args: any[]) => {
+        return Promise.resolve();
+      },
+      saveOp: (op: any, ...rest: any) => {
+        op.__savedRef = Promise.resolve(op);
+        op.uri = () => 'weave://test-project-id/op/test-op';
+        return Promise.resolve();
+      },
+      runWithCallStack: async (stack: any, fn: () => any) => fn(),
+      finishCall: () => Promise.resolve(),
+      finishCallWithException: () => Promise.resolve(),
+      settings: {shouldPrintCallLink: false},
+      waitForBatchProcessing: () => Promise.resolve(),
+      processBatch: () => Promise.resolve(),
+    });
+    return weaveClient;
+  }),
+}));
+
+describe('standalone function call', () => {
+  it('can use call method to get call object', async () => {
+    async function myStandaloneFunction() {
+      return 42;
+    }
+    const callDisplayName = 'test-myStandaloneFunction';
+
+    const wrappedFn = weave.op(myStandaloneFunction, {
+      callDisplayName: () => callDisplayName,
+    });
+
+    const [result, call] = await wrappedFn.invoke();
+    expect(result).toBe(42);
+    expect(call.op_name).toBe(mockOpName);
+    expect(call.display_name).toBe(callDisplayName);
+    expect(call.id).toBe(mockCallId);
+    expect(call.project_id).toBe(mockProjectId);
+  });
+});
+
+describe('class method call', () => {
+  it('can use call method to get call object', async () => {
+    class TestClass {
+      @weave.op
+      async myMethod() {
+        return 42;
+      }
+    }
+    const testInstance = new TestClass();
+
+    const typedOp = testInstance.myMethod as Op<typeof testInstance.myMethod>;
+
+    const [result, call] = await typedOp.invoke();
+
+    expect(result).toBe(42);
+    expect(call.op_name).toBe(mockOpName);
+    expect(call.id).toBe(mockCallId);
+    expect(call.project_id).toBe(mockProjectId);
+  });
+});

--- a/sdks/node/src/__tests__/legacy/op.test.ts
+++ b/sdks/node/src/__tests__/legacy/op.test.ts
@@ -7,17 +7,8 @@ let capturedDisplayName: string | undefined;
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => ({
     pushNewCall: () => ({currentCall: {}, parentCall: null, newStack: []}),
-    createCall: (
-      _: any,
-      __: any,
-      ___: any,
-      ____: any,
-      _____: any,
-      ______: any,
-      _______: any,
-      displayName: string
-    ) => {
-      capturedDisplayName = displayName;
+    createCall: (...args: any[]) => {
+      capturedDisplayName = args.length > 0 ? args[args.length - 1] : undefined;
       return Promise.resolve();
     },
     runWithCallStack: async (stack: any, fn: () => any) => fn(),

--- a/sdks/node/src/__tests__/modern/op.test.ts
+++ b/sdks/node/src/__tests__/modern/op.test.ts
@@ -8,17 +8,8 @@ let capturedDisplayName: string | undefined;
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => ({
     pushNewCall: () => ({currentCall: {}, parentCall: null, newStack: []}),
-    createCall: (
-      _: any,
-      __: any,
-      ___: any,
-      ____: any,
-      _____: any,
-      ______: any,
-      _______: any,
-      displayName: string
-    ) => {
-      capturedDisplayName = displayName;
+    createCall: (...args: any[]) => {
+      capturedDisplayName = args.length > 0 ? args[args.length - 1] : undefined;
       return Promise.resolve();
     },
     runWithCallStack: async (stack: any, fn: () => any) => fn(),

--- a/sdks/node/src/__tests__/op.test.ts
+++ b/sdks/node/src/__tests__/op.test.ts
@@ -10,15 +10,13 @@ const createFreshMockClient = () => ({
     parentCall: null,
     newStack: [],
   })),
-  createCall: jest.fn(
-    (_, __, ___, ____, _____, ______, _______, displayName: string) => {
-      // We still need a way to capture this if tests rely on it.
-      // Maybe pass a shared object or use a different mechanism?
-      // For now, let's remove the direct capture here.
-      // capturedDisplayName = displayName;
-      return Promise.resolve();
-    }
-  ),
+  createCall: jest.fn((...args: any[]) => {
+    // We still need a way to capture this if tests rely on it.
+    // Maybe pass a shared object or use a different mechanism?
+    // For now, let's remove the direct capture here.
+    // capturedDisplayName = displayName;
+    return Promise.resolve();
+  }),
   runWithCallStack: jest.fn(async (stack: any, fn: () => any) => fn()),
   finishCall: jest.fn(() => Promise.resolve()),
   finishCallWithException: jest.fn(() => Promise.resolve()),
@@ -193,13 +191,17 @@ describe('op wrappers', () => {
     expect(getGlobalClientSpy).toHaveBeenCalledTimes(1);
 
     // Assertions on the specific mock instance returned for this test
-    expect(mockClientInstance.finishCallWithException).toHaveBeenCalledWith(
+    expect(mockClientInstance.finishCallWithException).toHaveBeenCalled();
+    const args = mockClientInstance.finishCallWithException.mock.lastCall;
+    // The first arg is internal, so we shift it off and not check it
+    args?.shift();
+    expect(args).toEqual([
       error,
       expect.objectContaining({callId: 'mockCallId'}), // currentCall
       null, // parentCall
       expect.any(Date), // endTime
-      expect.any(Promise) // startCallPromise
-    );
+      expect.any(Promise), // startCallPromise
+    ]);
     expect(mockClientInstance.finishCall).not.toHaveBeenCalled();
   });
 });

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -242,8 +242,7 @@ function createOpWrapper<T extends (...args: any[]) => any>(
     });
   }
 
-  // Override the native call method to use the weave call style
-  opWrapper.call = createCallMethod<T>(opWrapper, call.proxy) as any;
+  opWrapper.invoke = createCallMethod<T>(opWrapper, call.proxy) as any;
 
   return opWrapper;
 }

--- a/sdks/node/src/opType.ts
+++ b/sdks/node/src/opType.ts
@@ -11,7 +11,7 @@ export type Op<T extends (...args: any[]) => any> = {
   __name: string;
   __savedRef?: OpRef | Promise<OpRef>;
   __parameterNames?: ParameterNamesOption;
-  call: CallMethod<T>;
+  invoke: CallMethod<T>;
 } & T &
   ((
     ...args: Parameters<T>


### PR DESCRIPTION
## Description

- Adds a new `invoke` method to the `Op` type that returns both the result and the call object
- Replaces the existing `call` method with `invoke` in the op wrapper
- Adds tests for retrieving call objects from standalone functions and class methods
- Adds tests for call manipulation (setting display name)
- Simplifies mock implementations in tests to use rest parameters

## Testing

Tested with new unit tests that verify:
- Getting call objects from standalone function calls
- Getting call objects from class method calls
- Using call handles to manipulate calls (e.g., setting display names)