### PR TITLE
fix(weave_query): Make mapped file-table_with_increments op parallel

### DIFF
--- a/weave_query/weave_query/derive_op.py
+++ b/weave_query/weave_query/derive_op.py
@@ -246,6 +246,7 @@ class MappedDeriveOpHandler(DeriveOpHandler):
             # more generally in the future.
             if (
                 orig_op.name.endswith("file-table")
+                or orig_op.name.endswith("file-table_with_increments")
                 or orig_op.name.endswith("file-joinedTable")
                 or orig_op.name.endswith("file-partitionedTable")
                 or orig_op.name.endswith("run-history")


### PR DESCRIPTION
## Description

Without this line, we call `mapped_file-table_with_increments` which means the `file-table_with_increments` op is never called individually and therefore not cached. This adds it to the list so it can be parallelized and cached.

## Testing

How was this PR tested?
