### PR TITLE
fix(weave): User sentry not respected depending on import order

### DIFF
--- a/tests/trace/test_trace_sentry.py
+++ b/tests/trace/test_trace_sentry.py
@@ -1,0 +1,192 @@
+"""Tests for the trace_sentry module."""
+
+import unittest
+from unittest import mock
+
+import sentry_sdk
+
+from weave.trace import trace_sentry
+
+
+class TestDualSentryReporting(unittest.TestCase):
+    """Test that events are sent to both Weave's Sentry endpoint and user's endpoint when configured."""
+
+    def setUp(self):
+        # Mock Hub and Client to avoid actual Sentry calls
+        self.mock_hub_patcher = mock.patch("sentry_sdk.Hub")
+        self.mock_hub = self.mock_hub_patcher.start()
+
+        # Mock Hub.current to simulate user-configured Sentry
+        self.mock_hub.current = mock.MagicMock()
+        self.mock_hub.current.client = mock.MagicMock()
+
+        # Mock event_from_exception
+        self.mock_event_from_exception_patcher = mock.patch(
+            "sentry_sdk.utils.event_from_exception"
+        )
+        self.mock_event_from_exception = self.mock_event_from_exception_patcher.start()
+        self.mock_event_from_exception.return_value = (
+            {"event": "data"},
+            {"hint": "data"},
+        )
+
+        # Mock exc_info_from_error
+        self.mock_exc_info_patcher = mock.patch("sentry_sdk.utils.exc_info_from_error")
+        self.mock_exc_info = self.mock_exc_info_patcher.start()
+
+        # Reset the global Sentry instance to ensure clean test state
+        self.original_sentry = trace_sentry.global_trace_sentry
+        trace_sentry.global_trace_sentry = trace_sentry.Sentry()
+
+        # Store original is_sentry_configured function
+        self.original_is_sentry_configured = trace_sentry._is_sentry_configured
+
+    def tearDown(self):
+        self.mock_hub_patcher.stop()
+        self.mock_event_from_exception_patcher.stop()
+        self.mock_exc_info_patcher.stop()
+        # Restore the global Sentry instance
+        trace_sentry.global_trace_sentry = self.original_sentry
+        # Restore the original is_sentry_configured function
+        trace_sentry._is_sentry_configured = self.original_is_sentry_configured
+
+    def test_setup_creates_both_hubs_when_user_configured(self):
+        """Test that setup creates both hubs when user has configured Sentry."""
+        # Mock _is_sentry_configured to return True
+        trace_sentry._is_sentry_configured = mock.MagicMock(return_value=True)
+
+        # Setup Sentry
+        sentry = trace_sentry.Sentry()
+        sentry.setup()
+
+        # Verify that setup used the existing hub and created a new weave hub
+        self.assertEqual(sentry.hub, sentry_sdk.Hub.current)
+        self.assertTrue(sentry._using_global_hub)
+        self.assertIsNotNone(sentry.weave_hub)
+
+    def test_setup_creates_single_hub_when_no_user_config(self):
+        """Test that setup creates a single hub when user has not configured Sentry."""
+        # Mock _is_sentry_configured to return False
+        trace_sentry._is_sentry_configured = mock.MagicMock(return_value=False)
+
+        # Setup Sentry
+        sentry = trace_sentry.Sentry()
+        sentry.setup()
+
+        # Verify that setup created a new hub and did not create a separate weave hub
+        self.assertIsNotNone(sentry.hub)
+        self.assertFalse(sentry._using_global_hub)
+        self.assertIsNone(sentry.weave_hub)
+
+    def test_exception_reports_to_both_hubs_when_user_configured(self):
+        """Test that exception is reported to both hubs when user has configured Sentry."""
+        # Mock _is_sentry_configured to return True
+        trace_sentry._is_sentry_configured = mock.MagicMock(return_value=True)
+
+        # Create a sentry instance with mocked components
+        sentry = trace_sentry.Sentry()
+
+        # Set up the hub and weave_hub manually with proper mocks
+        sentry.hub = mock.MagicMock()
+        sentry.hub._stack = [(mock.MagicMock(), mock.MagicMock())]
+        sentry.hub.client.options = {}
+        sentry.hub.capture_event = mock.MagicMock()
+
+        sentry.weave_hub = mock.MagicMock()
+        sentry.weave_hub._stack = [(mock.MagicMock(), mock.MagicMock())]
+        sentry.weave_hub.capture_event = mock.MagicMock()
+
+        # Mark as using global hub
+        sentry._using_global_hub = True
+
+        # Report an exception
+        test_error = ValueError("Test error")
+        sentry.exception(test_error)
+
+        # Verify that exception was captured by both hubs
+        self.assertEqual(sentry.hub.capture_event.call_count, 1)
+        self.assertEqual(sentry.weave_hub.capture_event.call_count, 1)
+
+    def test_track_event_reports_to_both_hubs_when_user_configured(self):
+        """Test that track_event reports to both hubs when user has configured Sentry."""
+        # Mock _is_sentry_configured to return True
+        trace_sentry._is_sentry_configured = mock.MagicMock(return_value=True)
+
+        # Create a sentry instance
+        sentry = trace_sentry.Sentry()
+
+        # Set up the hub and weave_hub manually
+        sentry.hub = mock.MagicMock()
+        sentry.hub.capture_event = mock.MagicMock()
+
+        sentry.weave_hub = mock.MagicMock()
+        sentry.weave_hub.capture_event = mock.MagicMock()
+
+        # Track an event
+        sentry.track_event("test_event", {"tag": "value"}, "test_user")
+
+        # Verify that event was captured by both hubs
+        self.assertEqual(sentry.hub.capture_event.call_count, 1)
+        self.assertEqual(sentry.weave_hub.capture_event.call_count, 1)
+
+    def test_configure_scope_sets_up_both_hubs_when_user_configured(self):
+        """Test that configure_scope sets up both hubs when user has configured Sentry."""
+        # Mock _is_sentry_configured to return True
+        trace_sentry._is_sentry_configured = mock.MagicMock(return_value=True)
+
+        # Create a sentry instance
+        sentry = trace_sentry.Sentry()
+
+        # Set up the hub and weave_hub manually
+        sentry.hub = mock.MagicMock()
+        sentry.hub._stack = [(mock.MagicMock(), mock.MagicMock())]
+
+        # Mock configure_scope context managers
+        user_scope = mock.MagicMock()
+        sentry.hub.configure_scope.return_value.__enter__.return_value = user_scope
+
+        sentry.weave_hub = mock.MagicMock()
+        sentry.weave_hub._stack = [(mock.MagicMock(), mock.MagicMock())]
+
+        weave_scope = mock.MagicMock()
+        sentry.weave_hub.configure_scope.return_value.__enter__.return_value = (
+            weave_scope
+        )
+
+        # Configure scope with tags
+        test_tags = {
+            "entity_name": "test_entity",
+            "project_name": "test_project",
+            "user": {"username": "test_user"},
+        }
+        sentry.configure_scope(test_tags)
+
+        # Verify that tags were set on both scopes
+        for tag, value in test_tags.items():
+            if tag != "user":
+                user_scope.set_tag.assert_any_call(tag, value)
+                weave_scope.set_tag.assert_any_call(tag, value)
+
+        # Verify that user was set on both scopes if present
+        if "user" in test_tags:
+            self.assertEqual(user_scope.user, test_tags["user"])
+            self.assertEqual(weave_scope.user, test_tags["user"])
+
+    def test_initialize_sentry_respects_user_config_and_adds_weave(self):
+        """Test that initialize_sentry respects user config and adds Weave reporting."""
+        # Mock _is_sentry_configured to return True
+        trace_sentry._is_sentry_configured = mock.MagicMock(return_value=True)
+
+        # Create a mock for setup and configure_scope
+        with (
+            mock.patch.object(trace_sentry.global_trace_sentry, "setup") as mock_setup,
+            mock.patch.object(
+                trace_sentry.global_trace_sentry, "configure_scope"
+            ) as mock_configure_scope,
+        ):
+            # Call initialize_sentry
+            trace_sentry.initialize_sentry()
+
+            # Verify that setup and configure_scope were called
+            mock_setup.assert_called_once()
+            mock_configure_scope.assert_called_once()

--- a/weave/trace/trace_sentry.py
+++ b/weave/trace/trace_sentry.py
@@ -68,6 +68,7 @@ class Sentry:
         self.dsn = SENTRY_DEFAULT_DSN
 
         self.hub: sentry_sdk.Hub | None = None
+        self.weave_hub: sentry_sdk.Hub | None = None
         self._using_global_hub = False
 
         self._disabled = False
@@ -94,17 +95,26 @@ class Sentry:
     def setup(self) -> None:
         """Setup Sentry SDK.
 
-        If the user has already configured Sentry SDK, we'll use their hub configuration.
-        Otherwise, we'll create our own hub with weave's default settings.
-        This ensures we don't interfere with the user's Sentry configuration.
+        If the user has already configured Sentry SDK, we'll use their hub configuration
+        and also create our own hub with weave's default settings.
+        This ensures we send events to both the user's Sentry and Weave's Sentry.
         """
         from weave import version
 
-        # Check if Sentry has already been configured
+        # Check if Sentry has already been configured by the user
         if _is_sentry_configured():
-            # Use the existing global hub
+            # Use the existing global hub for user's configuration
             self.hub = sentry_sdk.Hub.current
             self._using_global_hub = True
+
+            # Create a separate hub for Weave's reporting
+            weave_client = sentry_sdk.Client(
+                dsn=self.dsn,
+                default_integrations=False,
+                environment=self.environment,
+                release=version.VERSION,
+            )
+            self.weave_hub = sentry_sdk.Hub(weave_client)
         else:
             # Create a new client and hub with weave's settings
             client = sentry_sdk.Client(
@@ -114,6 +124,7 @@ class Sentry:
                 release=version.VERSION,
             )
             self.hub = sentry_sdk.Hub(client)
+            self.weave_hub = None  # No need for a separate hub
             self._using_global_hub = False
 
     @_safe_noop
@@ -136,25 +147,40 @@ class Sentry:
             client_options=self.hub.client.options,  # type: ignore
             mechanism={"type": "generic", "handled": handled},
         )
+
+        # Send to the primary hub (user's hub if configured, or Weave's hub)
         try:
             self.hub.capture_event(event, hint=hint)  # type: ignore
         except Exception:
             pass
+
+        # Also send to Weave's dedicated hub if we're using the user's global hub
+        if self.weave_hub is not None:
+            try:
+                self.weave_hub.capture_event(event, hint=hint)  # type: ignore
+            except Exception:
+                pass
 
         # if the status is not explicitly set, we'll set it to "crashed" if the exception
         # was unhandled, or "errored" if it was handled
         status = status or ("crashed" if not handled else "errored")  # type: ignore
         self.mark_session(status=status)
 
+        # Flush both hubs
         client, _ = self.hub._stack[-1]  # type: ignore
         if client is not None:
             client.flush()
+
+        if self.weave_hub is not None:
+            weave_client, _ = self.weave_hub._stack[-1]  # type: ignore
+            if weave_client is not None:
+                weave_client.flush()
 
         return None
 
     @_safe_noop
     def start_session(self) -> None:
-        """Start a new session."""
+        """Start a new session on both hubs if needed."""
         assert self.hub is not None
         # get the current client and scope
         _, scope = self.hub._stack[-1]
@@ -164,15 +190,29 @@ class Sentry:
         if session is None:
             self.hub.start_session()
 
+        # Also start a session on the Weave hub if it exists
+        if self.weave_hub is not None:
+            _, weave_scope = self.weave_hub._stack[-1]
+            weave_session = weave_scope._session
+            if weave_session is None:
+                self.weave_hub.start_session()
+
     @_safe_noop
     def end_session(self) -> None:
-        """End the current session."""
+        """End the current session on both hubs."""
         if self.hub is None:
             return
 
         # If we're using the global hub (user's Sentry configuration),
         # we don't want to close their session since that should be managed by them
         if self._using_global_hub:
+            # Only end the Weave hub session
+            if self.weave_hub is not None:
+                weave_client, weave_scope = self.weave_hub._stack[-1]
+                weave_session = weave_scope._session
+                if weave_session is not None and weave_client is not None:
+                    self.weave_hub.end_session()
+                    weave_client.flush()
             return
 
         # get the current client and scope
@@ -185,7 +225,7 @@ class Sentry:
 
     @_safe_noop
     def mark_session(self, status: SessionStatus | None = None) -> None:
-        """Mark the current session with a status."""
+        """Mark the current session with a status on both hubs."""
         assert self.hub is not None
         _, scope = self.hub._stack[-1]
         session = scope._session
@@ -193,12 +233,19 @@ class Sentry:
         if session is not None:
             session.update(status=status)
 
+        # Also mark the Weave hub session if it exists
+        if self.weave_hub is not None:
+            _, weave_scope = self.weave_hub._stack[-1]
+            weave_session = weave_scope._session
+            if weave_session is not None:
+                weave_session.update(status=status)
+
     @_safe_noop
     def configure_scope(
         self,
         tags: dict[str, Any] | None = None,
     ) -> None:
-        """Configure the Sentry scope for the current thread.
+        """Configure the Sentry scope for the current thread on both hubs.
 
         This function should be called at the beginning of every thread that
         will send events to Sentry. It sets the tags that will be applied to
@@ -216,9 +263,26 @@ class Sentry:
                     if tag == "user":
                         scope.user = val
 
+        # Also configure the Weave hub if it exists
+        if self.weave_hub is not None:
+            with self.weave_hub.configure_scope() as weave_scope:
+                if tags is not None:
+                    for tag in tags:
+                        val = tags.get(tag, None)
+                        if val not in (None, ""):
+                            weave_scope.set_tag(tag, val)
+                        if tag == "user":
+                            weave_scope.user = val
+
         # Only start a session if we're not using the global hub
         if not self._using_global_hub:
             self.start_session()
+        elif self.weave_hub is not None:
+            # Start a session on the Weave hub if we're using the global hub
+            _, weave_scope = self.weave_hub._stack[-1]
+            weave_session = weave_scope._session
+            if weave_session is None:
+                self.weave_hub.start_session()
 
     # Not in the original WandB Sentry module
     def watch(self) -> Callable:
@@ -244,7 +308,7 @@ class Sentry:
         tags: dict[str, Any] | None = None,
         username: str | None = None,
     ) -> None:
-        """Track an event to Sentry."""
+        """Track an event to Sentry on both hubs."""
         assert self.hub is not None
 
         event_data: Event = {
@@ -256,7 +320,12 @@ class Sentry:
             },
         }
 
+        # Send to the primary hub
         self.hub.capture_event(event_data)
+
+        # Also send to the Weave hub if it exists
+        if self.weave_hub is not None:
+            self.weave_hub.capture_event(event_data)
 
 
 def _is_local_dev_install(module: Any) -> bool:
@@ -282,7 +351,8 @@ def initialize_sentry() -> None:
 
     This function should be called from weave.init rather than automatically
     when this module is imported. This ensures that if the user has already
-    initialized Sentry, we'll properly respect that configuration.
+    initialized Sentry, we'll properly respect that configuration while
+    also reporting to Weave's Sentry endpoint.
     """
     global_trace_sentry.setup()
     global_trace_sentry.configure_scope()

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -163,6 +163,11 @@ def init_weave(
         username, entity_name, project_name, read_only=not ensure_project_exists
     )
 
+    # Initialize Sentry with our configuration, but respecting any existing user config
+    # This calls trace_sentry.initialize_sentry() which ensures we don't override a
+    # user's existing Sentry configuration
+    trace_sentry.initialize_sentry()
+
     user_context = {"username": username} if username else None
     trace_sentry.global_trace_sentry.configure_scope(
         {


### PR DESCRIPTION
## Description

- Fixes WB-25064

1. Added dual Sentry reporting to both user and Weave hubs
2. Added tests for the Sentry functionality
3. Added function to check if user has already configured Sentry
4. Modified initialization to respect user's Sentry configuration

## Testing

Added integration tests with mocked endpoints to verify sentry works properly
