### PR TITLE
fix(weave): fix breaking dspy test runner

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,7 +15,7 @@ PY313_INCOMPATIBLE_SHARDS = [
     "notdiamond",
     "crewai",
 ]
-PY39_INCOMPATIBLE_SHARDS = ["crewai", "google_genai", "mcp", "smolagents"]
+PY39_INCOMPATIBLE_SHARDS = ["crewai", "google_genai", "mcp", "smolagents", "dspy"]
 
 
 @nox.session


### PR DESCRIPTION
## Description

- Fixes WB-25094

Temporarily moves DSPY to 3.9 incompatible shards. Their dependency `json_repair` pushed some changes yesterday which are 3.9 incompatible.
We can open a PR upstream to fix this but in the mean time CI shouldn't be broken over it.
