### PR TITLE
fix(weave): Speed up EvaluationLogger

### DIFF
--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -186,14 +186,16 @@ def _validate_class_name(name: str) -> str:
 class ScorerCache:
     _cached_scorers: dict[str, Scorer]
     _cached_scorers_lock: Any
-
-    def __init__(self) -> None:
+    _max_size: int
+    def __init__(self, max_size: int = 1000) -> None:
         self._cached_scorers = {}
         self._cached_scorers_lock = Lock()
-
+        self._max_size = max_size
     def get_scorer(self, scorer_id: str, default_factory: Callable[[], Scorer]) -> Scorer:
         with self._cached_scorers_lock:
             if scorer_id not in self._cached_scorers:
+                if len(self._cached_scorers) >= self._max_size:
+                    self._cached_scorers.popitem()
                 self._cached_scorers[scorer_id] = default_factory()
         return self._cached_scorers[scorer_id]
 

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import atexit
 import datetime
+import json
 import logging
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from multiprocessing import Lock
 from types import MethodType
 from typing import Annotated, Any, TypeVar, Union, cast
 
@@ -181,6 +183,22 @@ def _validate_class_name(name: str) -> str:
     return name
 
 
+class ScorerCache:
+    _cached_scorers: dict[str, Scorer]
+    _cached_scorers_lock: Any
+
+    def __init__(self) -> None:
+        self._cached_scorers = {}
+        self._cached_scorers_lock = Lock()
+
+    def get_scorer(self, scorer_id: str, default_factory: Callable[[], Scorer]) -> Scorer:
+        with self._cached_scorers_lock:
+            if scorer_id not in self._cached_scorers:
+                self._cached_scorers[scorer_id] = default_factory()
+        return self._cached_scorers[scorer_id]
+
+global_scorer_cache = ScorerCache()
+
 class ScoreLogger(BaseModel):
     """This class provides an imperative interface for logging scores."""
 
@@ -234,12 +252,10 @@ class ScoreLogger(BaseModel):
             # No event loop exists, create one with asyncio.run
             return asyncio.run(self.alog_score(scorer, score))
 
-    @validate_call
     async def alog_score(
         self,
         scorer: Annotated[
             Scorer | dict | str,
-            BeforeValidator(_cast_to_cls(Scorer)),
             Field(
                 description="A metadata-only scorer used for comparisons."
                 "Alternatively, you can pass a dict of attributes or just a string"
@@ -248,6 +264,9 @@ class ScoreLogger(BaseModel):
         ],
         score: ScoreType,
     ) -> None:
+        if not isinstance(scorer, Scorer):
+            scorer_id = json.dumps(scorer)
+            scorer = global_scorer_cache.get_scorer(scorer_id, lambda: _cast_to_cls(Scorer)(scorer))
         if self._has_finished:
             raise ValueError("Cannot log score after finish has been called")
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -693,8 +693,7 @@ class Call:
                 # then scorer_ref_uri will be None, and we will use the op_name from
                 # the score_call instead.
                 scorer_ref = get_ref(scorer)
-                scorer_ref_uri = scorer_ref.uri() if scorer_ref else None
-            wc._send_score_call(self, score_call, scorer_ref_uri)
+            wc._send_score_call(self, score_call, scorer_ref)
         return apply_scorer_result
 
     def to_dict(self) -> CallDict:
@@ -1634,7 +1633,7 @@ class WeaveClient:
         self,
         predict_call: Call,
         score_call: Call,
-        scorer_object_ref_uri: str | None = None,
+        scorer_object_ref: ObjectRef | None = None,
     ) -> Future[str]:
         """(Private) Adds a score to a call. This is particularly useful
         for adding evaluation metrics to a call.
@@ -1650,9 +1649,10 @@ class WeaveClient:
                 raise ValueError("Score call must have a ref")
             scorer_call_ref_uri = scorer_call_ref.uri()
 
-            # If scorer_object_ref_uri is provided, it is used as the runnable_ref_uri
+            # If scorer_object_ref is provided, it is used as the runnable_ref_uri
             # Otherwise, we use the op_name from the score_call. This should happen
             # when there is a Scorer subclass that is the source of the score call.
+            scorer_object_ref_uri = scorer_object_ref.uri() if scorer_object_ref else None
             runnable_ref_uri = scorer_object_ref_uri or score_call.op_name
             score_results = score_call.output
 


### PR DESCRIPTION
The current EvaluationLogger suffers from a number of problems:
1. The `predict_and_score` virtualized call accidentally blocks on uploading the Scorer
2. Each time you log a score, a new scorer is minted, meaning it uploads a new one every time!

This PR implements the following improvements:
1. Modifies the score sending logic to be non-blocking on the main process and backgrounded. This will only block therefore if the user process is about to quit and we need to upload the data.
2. Maintains an id-based LRU cache of scorers so we don't mint new ones!