### PR TITLE
chore(weave): Re-organize eval compare page closer to long-term design

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -7,15 +7,7 @@ import {Alert} from '@mui/material';
 import {WaveLoader} from '@wandb/weave/components/Loaders/WaveLoader';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
-import React, {
-  FC,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, {FC, useCallback, useContext, useMemo, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 import {AutoSizer} from 'react-virtualized';
 
@@ -35,7 +27,7 @@ import {EvaluationComparisonState} from './ecpState';
 import {ComparisonDimensionsType} from './ecpState';
 import {EvaluationCall} from './ecpTypes';
 import {EVALUATION_NAME_DEFAULT} from './ecpUtil';
-import {HorizontalBox, VerticalBox} from './Layout';
+import {VerticalBox} from './Layout';
 import {ComparisonDefinitionSection} from './sections/ComparisonDefinitionSection/ComparisonDefinitionSection';
 import {ExampleCompareSectionDetail} from './sections/ExampleCompareSection/ExampleCompareSectionDetail';
 import {ExampleCompareSectionTable} from './sections/ExampleCompareSection/ExampleCompareSectionTable';
@@ -216,14 +208,14 @@ const CompareEvaluationsPageInner: React.FC<{
         }}
         tabs={[
           {
-            value: 'report',
-            label: 'Report',
+            value: 'summary',
+            label: 'Summary',
             content: (
               <VerticalBox
                 sx={{
                   height: '100%',
                   overflow: 'auto',
-                  paddingTop: STANDARD_PADDING,
+                  paddingTop: STANDARD_PADDING / 2,
                   alignItems: 'flex-start',
                   gridGap: STANDARD_PADDING,
                 }}>
@@ -368,64 +360,6 @@ const ResultExplorer: React.FC<{
         </Box>
       </Box>
     </VerticalBox>
-  );
-};
-
-/**
- * This component should behave as follows:
- * 1. It accepts a maxHeight prop which is the maximum height of the component.
- * 2. It accepts children to display inside the component.
- * 3. The children component's parent element should be no taller than the maxHeight, BUT
- *    IMPORTANTLY: should be contrainted to the visible bounding region.
- *
- * In other words: the parent's height is:
- *    * > 0
- *    * <= maxHeight
- *    * <= the visible height of the parent's parent element (bounded by the window or the next visible parent with a height constraint and overflow: hidden)
- */
-const AdaptiveHeightParent: React.FC<{
-  maxHeight: number;
-  children: React.ReactNode;
-  style?: React.CSSProperties;
-  className?: string;
-}> = ({maxHeight, children, style, className}) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [height, setHeight] = useState(maxHeight);
-
-  useEffect(() => {
-    const updateHeight = () => {
-      if (!containerRef.current) return;
-
-      // Get the container's bounding rect
-      const containerRect = containerRef.current.getBoundingClientRect();
-
-      // Find the visible height (distance from top of element to bottom of viewport)
-      const visibleHeight = Math.min(
-        window.innerHeight - containerRect.top,
-        containerRef.current.parentElement?.getBoundingClientRect().height ||
-          Infinity
-      );
-
-      // Set the height to the minimum of maxHeight and visibleHeight
-      const newHeight = Math.max(0, Math.min(maxHeight, visibleHeight));
-      setHeight(newHeight);
-    };
-
-    const interval = setInterval(updateHeight, 100);
-
-    return () => clearInterval(interval);
-  }, [maxHeight]);
-
-  return (
-    <div
-      ref={containerRef}
-      style={{
-        height: maxHeight,
-        overflow: 'hidden',
-      }}
-      className={className}>
-      <div style={{height, ...style}}>{children}</div>
-    </div>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -25,7 +25,7 @@ import {
   WeaveflowPeekContext,
 } from '../../context';
 import {CustomWeaveTypeProjectContext} from '../../typeViews/CustomWeaveTypeDispatcher';
-import {SimplePageLayout} from '../common/SimplePageLayout';
+import {BetterTabView, SimplePageLayout} from '../common/SimplePageLayout';
 import {
   CompareEvaluationsProvider,
   useCompareEvaluationsState,
@@ -192,6 +192,7 @@ const CompareEvaluationsPageInner: React.FC<{
     Object.keys(state.loadableComparisonResults.result?.resultRows ?? {})
       .length > 0;
   const resultsLoading = state.loadableComparisonResults.loading;
+  const [tabValue, setTabValue] = useState('report');
   return (
     <Box
       sx={{
@@ -199,58 +200,91 @@ const CompareEvaluationsPageInner: React.FC<{
         width: '100%',
         overflow: 'auto',
       }}>
-      <VerticalBox
-        sx={{
-          paddingTop: STANDARD_PADDING,
-          alignItems: 'flex-start',
-          gridGap: STANDARD_PADDING * 2,
-        }}>
-        <InvalidEvaluationBanner
-          evaluationCalls={Object.values(state.summary.evaluationCalls)}
-        />
-        <ComparisonDefinitionSection state={state} />
-        <SummaryPlots state={state} setSelectedMetrics={setSelectedMetrics} />
-        <ScorecardSection state={state} />
-        {resultsLoading ? (
-          <Box
-            sx={{
-              width: '100%',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              height: '50px',
-            }}>
-            <WaveLoader size="small" />
-          </Box>
-        ) : showExamples ? (
+      <BetterTabView
+        headerContent={
           <>
-            {showExampleFilter && <ExampleFilterSection state={state} />}
-            <ResultExplorer state={state} height={props.height} />
+            <InvalidEvaluationBanner
+              evaluationCalls={Object.values(state.summary.evaluationCalls)}
+            />
+            <ComparisonDefinitionSection state={state} />
           </>
-        ) : (
-          <VerticalBox
-            sx={{
-              // alignItems: '',
-              paddingLeft: STANDARD_PADDING,
-              paddingRight: STANDARD_PADDING,
-              width: '100%',
-              overflow: 'auto',
-            }}>
-            <Box
-              sx={{
-                fontSize: '1.5em',
-                fontWeight: 'bold',
-              }}>
-              Examples
-            </Box>
-            <Alert severity="info">
-              The selected evaluations' datasets have 0 rows in common, try
-              comparing evaluations with datasets that have at least one row in
-              common.
-            </Alert>
-          </VerticalBox>
-        )}
-      </VerticalBox>
+        }
+        tabs={[
+          {
+            value: 'report',
+            label: 'Report',
+            content: (
+              <VerticalBox
+                sx={{
+                  paddingTop: STANDARD_PADDING,
+                  alignItems: 'flex-start',
+                  gridGap: STANDARD_PADDING * 2,
+                }}>
+                <SummaryPlots
+                  state={state}
+                  setSelectedMetrics={setSelectedMetrics}
+                />
+                <ScorecardSection state={state} />
+              </VerticalBox>
+            ),
+          },
+          {
+            value: 'results',
+            label: 'Results',
+            content: (
+              <VerticalBox
+                sx={{
+                  paddingTop: STANDARD_PADDING,
+                  alignItems: 'flex-start',
+                  gridGap: STANDARD_PADDING * 2,
+                }}>
+                {resultsLoading ? (
+                  <Box
+                    sx={{
+                      width: '100%',
+                      display: 'flex',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      height: '50px',
+                    }}>
+                    <WaveLoader size="small" />
+                  </Box>
+                ) : showExamples ? (
+                  <>
+                    {showExampleFilter && (
+                      <ExampleFilterSection state={state} />
+                    )}
+                    <ResultExplorer state={state} height={props.height} />
+                  </>
+                ) : (
+                  <VerticalBox
+                    sx={{
+                      // alignItems: '',
+                      paddingLeft: STANDARD_PADDING,
+                      paddingRight: STANDARD_PADDING,
+                      width: '100%',
+                      overflow: 'auto',
+                    }}>
+                    <Box
+                      sx={{
+                        fontWeight: 'bold',
+                      }}>
+                      Examples
+                    </Box>
+                    <Alert severity="info">
+                      The selected evaluations' datasets have 0 rows in common,
+                      try comparing evaluations with datasets that have at least
+                      one row in common.
+                    </Alert>
+                  </VerticalBox>
+                )}
+              </VerticalBox>
+            ),
+          },
+        ]}
+        tabValue={tabValue}
+        handleTabChange={setTabValue}
+      />
     </Box>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -186,8 +186,8 @@ const CompareEvaluationsPageInner: React.FC<{
   height: number;
 }> = props => {
   const {state, setSelectedMetrics} = useCompareEvaluationsState();
-  const showExampleFilter =
-    Object.keys(state.summary.evaluationCalls).length === 2;
+  const showExampleFilter = false;
+  // Object.keys(state.summary.evaluationCalls).length === 2;
   const showExamples =
     Object.keys(state.loadableComparisonResults.result?.resultRows ?? {})
       .length > 0;
@@ -209,6 +209,11 @@ const CompareEvaluationsPageInner: React.FC<{
             <ComparisonDefinitionSection state={state} />
           </>
         }
+        headerContainerSx={{
+          // Nice scrolling behavior
+          pr: 0,
+          pl: 0,
+        }}
         tabs={[
           {
             value: 'report',
@@ -216,9 +221,11 @@ const CompareEvaluationsPageInner: React.FC<{
             content: (
               <VerticalBox
                 sx={{
+                  height: '100%',
+                  overflow: 'auto',
                   paddingTop: STANDARD_PADDING,
                   alignItems: 'flex-start',
-                  gridGap: STANDARD_PADDING * 2,
+                  gridGap: STANDARD_PADDING,
                 }}>
                 <SummaryPlots
                   state={state}
@@ -234,6 +241,8 @@ const CompareEvaluationsPageInner: React.FC<{
             content: (
               <VerticalBox
                 sx={{
+                  height: '100%',
+                  overflow: 'auto',
                   paddingTop: STANDARD_PADDING,
                   alignItems: 'flex-start',
                   gridGap: STANDARD_PADDING * 2,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -17,7 +17,7 @@ import {
   WeaveflowPeekContext,
 } from '../../context';
 import {CustomWeaveTypeProjectContext} from '../../typeViews/CustomWeaveTypeDispatcher';
-import {BetterTabView, SimplePageLayout} from '../common/SimplePageLayout';
+import {SimplePageLayout, SimpleTabView} from '../common/SimplePageLayout';
 import {
   CompareEvaluationsProvider,
   useCompareEvaluationsState,
@@ -184,7 +184,7 @@ const CompareEvaluationsPageInner: React.FC<{
     Object.keys(state.loadableComparisonResults.result?.resultRows ?? {})
       .length > 0;
   const resultsLoading = state.loadableComparisonResults.loading;
-  const [tabValue, setTabValue] = useState('report');
+  const [tabValue, setTabValue] = useState('summary');
   return (
     <Box
       sx={{
@@ -192,7 +192,7 @@ const CompareEvaluationsPageInner: React.FC<{
         width: '100%',
         overflow: 'auto',
       }}>
-      <BetterTabView
+      <SimpleTabView
         headerContent={
           <>
             <InvalidEvaluationBanner

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -243,7 +243,6 @@ const CompareEvaluationsPageInner: React.FC<{
                 sx={{
                   height: '100%',
                   overflow: 'auto',
-                  paddingTop: STANDARD_PADDING,
                   alignItems: 'flex-start',
                   gridGap: STANDARD_PADDING * 2,
                 }}>
@@ -303,7 +302,7 @@ const ResultExplorer: React.FC<{
   height: number;
 }> = ({state, height}) => {
   const [viewMode, setViewMode] = useState<'detail' | 'table' | 'split'>(
-    'detail'
+    'split'
   );
 
   return (
@@ -313,7 +312,7 @@ const ResultExplorer: React.FC<{
         width: '100%',
         overflow: 'hidden',
       }}>
-      <HorizontalBox
+      {/* <HorizontalBox
         sx={{
           flex: '0 0 auto',
           paddingLeft: STANDARD_PADDING,
@@ -330,46 +329,44 @@ const ResultExplorer: React.FC<{
           }}>
           Output Comparison
         </Box>
-      </HorizontalBox>
-      <AdaptiveHeightParent maxHeight={height}>
+      </HorizontalBox> */}
+      <Box
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          height: '100%',
+          borderTop: '1px solid #e0e0e0',
+        }}>
         <Box
           style={{
-            display: 'flex',
-            flexDirection: 'row',
-            height: '100%',
-            borderTop: '1px solid #e0e0e0',
+            flex: 1,
+            width: '50%',
+            display: viewMode !== 'detail' ? 'block' : 'none',
           }}>
-          <Box
-            style={{
-              flex: 1,
-              width: '50%',
-              display: viewMode !== 'detail' ? 'block' : 'none',
-            }}>
-            <ExampleCompareSectionTable
-              state={state}
-              shouldHighlightSelectedRow={viewMode === 'split'}
-              onShowSplitView={() => setViewMode('split')}
-            />
-          </Box>
-
-          <Box
-            style={{
-              flex: 1,
-              width: '50%',
-              borderLeft: '1px solid #e0e0e0',
-              display: viewMode !== 'table' ? 'block' : 'none',
-            }}>
-            <ExampleCompareSectionDetail
-              state={state}
-              onClose={() => setViewMode('table')}
-              onExpandToggle={() =>
-                setViewMode(viewMode === 'detail' ? 'split' : 'detail')
-              }
-              isExpanded={viewMode === 'detail'}
-            />
-          </Box>
+          <ExampleCompareSectionTable
+            state={state}
+            shouldHighlightSelectedRow={viewMode === 'split'}
+            onShowSplitView={() => setViewMode('split')}
+          />
         </Box>
-      </AdaptiveHeightParent>
+
+        <Box
+          style={{
+            flex: 1,
+            width: '50%',
+            borderLeft: '1px solid #e0e0e0',
+            display: viewMode !== 'table' ? 'block' : 'none',
+          }}>
+          <ExampleCompareSectionDetail
+            state={state}
+            onClose={() => setViewMode('table')}
+            onExpandToggle={() =>
+              setViewMode(viewMode === 'detail' ? 'split' : 'detail')
+            }
+            isExpanded={viewMode === 'detail'}
+          />
+        </Box>
+      </Box>
     </VerticalBox>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
@@ -66,7 +66,7 @@ export const ComparisonDefinitionSection: React.FC<{
 
   return (
     <Tailwind>
-      <div className="flex w-full items-end gap-4 overflow-x-auto pl-16">
+      <div className="flex w-full items-center gap-4 overflow-x-auto pl-16">
         <HorizontalBox>
           <DraggableSection
             useDragHandle
@@ -170,10 +170,7 @@ const AddEvaluationButton: React.FC<{
 
   return (
     <>
-      <div
-        ref={refBar}
-        className="flex cursor-pointer items-center gap-4 rounded px-8 py-4 outline outline-moon-250 hover:outline-2 hover:outline-teal-500/40"
-        onClick={onClick}>
+      <div ref={refBar} onClick={onClick}>
         <div ref={refLabel}>
           <Button variant="ghost" size="large" icon="add-new">
             Add evaluation

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
@@ -66,7 +66,7 @@ export const ComparisonDefinitionSection: React.FC<{
 
   return (
     <Tailwind>
-      <div className="flex w-full items-center gap-4 overflow-x-auto px-16">
+      <div className="flex w-full items-end gap-4 overflow-x-auto pl-16">
         <HorizontalBox>
           <DraggableSection
             useDragHandle

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -928,8 +928,6 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
     outputWidths,
   ]);
 
-  console.log(compositeMetrics);
-
   const columnGroupingModel: GridColumnGroupingModel = useMemo(() => {
     return [
       {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -1189,8 +1189,6 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
     outputWidths,
   ]);
 
-  console.log(compositeMetrics);
-
   const columnGroupingModel: GridColumnGroupingModel = useMemo(() => {
     return [
       {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleFilterSection/ExampleFilterSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleFilterSection/ExampleFilterSection.tsx
@@ -50,7 +50,6 @@ export const ExampleFilterSection: React.FC<{
         }}>
         <Box
           sx={{
-            fontSize: '1.5em',
             fontWeight: 'bold',
           }}>
           Example Filter

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
@@ -157,7 +157,6 @@ export const ScorecardSection: React.FC<{
         }}>
         <Box
           sx={{
-            fontSize: '1.5em',
             fontWeight: 'bold',
           }}>
           Scorecard

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
@@ -148,20 +148,6 @@ export const ScorecardSection: React.FC<{
         paddingRight: STANDARD_PADDING,
         overflow: 'auto',
       }}>
-      <HorizontalBox
-        sx={{
-          width: '100%',
-          alignItems: 'center',
-          justifyContent: 'flex-start',
-          marginBottom: '8px',
-        }}>
-        <Box
-          sx={{
-            fontWeight: 'bold',
-          }}>
-          Scorecard
-        </Box>
-      </HorizontalBox>
       <div
         style={{
           display: 'grid',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
@@ -91,26 +91,16 @@ export const SummaryPlots: React.FC<{
       <HorizontalBox
         sx={{
           alignItems: 'center',
-          justifyContent: 'flex-start',
+          justifyContent: 'space-between',
         }}>
-        <Box
-          sx={{
-            fontWeight: 'bold',
-            flex: '1 1 auto',
-          }}>
-          Summary Metrics
-        </Box>
-        <HorizontalBox>
-          <div style={{display: 'flex', alignItems: 'center'}}>
-            <div style={{marginRight: '4px', whiteSpace: 'nowrap'}}>
-              Configure metrics
-            </div>
-            <MetricsSelector
-              selectedMetrics={selectedMetrics}
-              setSelectedMetrics={setSelectedMetrics}
-              allMetrics={Array.from(allMetricNames)}
-            />
-          </div>
+        <div style={{display: 'flex', alignItems: 'center'}}>
+          <MetricsSelector
+            selectedMetrics={selectedMetrics}
+            setSelectedMetrics={setSelectedMetrics}
+            allMetrics={Array.from(allMetricNames)}
+          />
+        </div>
+        <div style={{display: 'flex', alignItems: 'center'}}>
           <PaginationControls
             currentPage={currentPage}
             totalPages={totalPages}
@@ -122,7 +112,7 @@ export const SummaryPlots: React.FC<{
               setCurrentPage(prev => Math.min(prev + 1, totalPages - 1))
             }
           />
-        </HorizontalBox>
+        </div>
       </HorizontalBox>
 
       <div ref={containerRef} style={{width: '100%'}}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
@@ -123,7 +123,6 @@ const SectionHeader: React.FC<{
     }}>
     <Box
       sx={{
-        fontSize: '1.5em',
         fontWeight: 'bold',
       }}>
       Summary Metrics

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
@@ -84,70 +84,63 @@ export const SummaryPlots: React.FC<{
       sx={{
         paddingLeft: STANDARD_PADDING,
         paddingRight: STANDARD_PADDING,
-        flex: '1 1 auto',
+        // flex: '1 1 auto',
         width: '100%',
+        gridGap: STANDARD_PADDING / 2,
       }}>
-      <SectionHeader
-        selectedMetrics={selectedMetrics}
-        setSelectedMetrics={setSelectedMetrics}
-        allMetrics={Array.from(allMetricNames)}
-      />
-      <div ref={containerRef} style={{width: '100%', display: 'flex'}}>
+      <HorizontalBox
+        sx={{
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+        }}>
+        <Box
+          sx={{
+            fontWeight: 'bold',
+            flex: '1 1 auto',
+          }}>
+          Summary Metrics
+        </Box>
+        <HorizontalBox>
+          <div style={{display: 'flex', alignItems: 'center'}}>
+            <div style={{marginRight: '4px', whiteSpace: 'nowrap'}}>
+              Configure metrics
+            </div>
+            <MetricsSelector
+              selectedMetrics={selectedMetrics}
+              setSelectedMetrics={setSelectedMetrics}
+              allMetrics={Array.from(allMetricNames)}
+            />
+          </div>
+          <PaginationControls
+            currentPage={currentPage}
+            totalPages={totalPages}
+            startIndex={startIndex}
+            endIndex={endIndex}
+            totalPlots={totalPlots}
+            onPrevPage={() => setCurrentPage(prev => Math.max(prev - 1, 0))}
+            onNextPage={() =>
+              setCurrentPage(prev => Math.min(prev + 1, totalPages - 1))
+            }
+          />
+        </HorizontalBox>
+      </HorizontalBox>
+
+      <div ref={containerRef} style={{width: '100%'}}>
         <HorizontalBox>{plotsToShow}</HorizontalBox>
       </div>
-      <PaginationControls
-        currentPage={currentPage}
-        totalPages={totalPages}
-        startIndex={startIndex}
-        endIndex={endIndex}
-        totalPlots={totalPlots}
-        onPrevPage={() => setCurrentPage(prev => Math.max(prev - 1, 0))}
-        onNextPage={() =>
-          setCurrentPage(prev => Math.min(prev + 1, totalPages - 1))
-        }
-      />
     </VerticalBox>
   );
 };
-
-const SectionHeader: React.FC<{
-  selectedMetrics: Record<string, boolean> | undefined;
-  setSelectedMetrics: (newModel: Record<string, boolean>) => void;
-  allMetrics: string[];
-}> = ({selectedMetrics, setSelectedMetrics, allMetrics}) => (
-  <HorizontalBox
-    sx={{
-      width: '100%',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-    }}>
-    <Box
-      sx={{
-        fontWeight: 'bold',
-      }}>
-      Summary Metrics
-    </Box>
-    <Box sx={{marginLeft: 'auto'}}>
-      <div style={{display: 'flex', alignItems: 'center'}}>
-        <div style={{marginRight: '4px'}}>Configure displayed metrics</div>
-        <MetricsSelector
-          selectedMetrics={selectedMetrics}
-          setSelectedMetrics={setSelectedMetrics}
-          allMetrics={allMetrics}
-        />
-      </div>
-    </Box>
-  </HorizontalBox>
-);
 
 const RadarPlotBox: React.FC<{data: RadarPlotData}> = ({data}) => (
   <Box
     sx={{
       height: PLOT_HEIGHT,
-      width: PLOT_HEIGHT * 2,
+      width: PLOT_HEIGHT * 1.5,
       borderRadius: BOX_RADIUS,
       border: STANDARD_BORDER,
       padding: PLOT_PADDING,
+      flex: '1 0 auto',
     }}>
     <PlotlyRadarPlot height={PLOT_HEIGHT} data={data} />
   </Box>
@@ -168,6 +161,7 @@ const BarPlotBox: React.FC<{
       paddingBottom: PLOT_PADDING,
       paddingLeft: PLOT_PADDING,
       paddingRight: PLOT_PADDING,
+      flex: '1 1 auto',
     }}>
     <Button
       variant="ghost"
@@ -214,7 +208,6 @@ const PaginationControls: React.FC<{
   <HorizontalBox sx={{width: '100%'}}>
     <Box
       sx={{
-        marginLeft: 'auto',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -313,6 +313,31 @@ const SimpleTabView: FC<{
   hideTabsIfSingle?: boolean;
   handleTabChange: (newValue: string) => void;
 }> = props => {
+  const tabValueString = props.tabs[props.tabValue].label;
+  return (
+    <BetterTabView
+      {...props}
+      tabs={props.tabs.map(t => ({...t, value: t.label}))}
+      tabValue={tabValueString}
+    />
+  );
+};
+
+export const BetterTabView: FC<{
+  headerContent: ReactNode;
+  tabs: Array<{
+    value: string;
+    label: string;
+    content: ReactNode;
+  }>;
+  tabValue: string;
+  hideTabsIfSingle?: boolean;
+  handleTabChange: (newValue: string) => void;
+}> = props => {
+  const selectedTab = useMemo(
+    () => props.tabs.find(t => t.value === props.tabValue),
+    [props.tabs, props.tabValue]
+  );
   return (
     <Box
       sx={{
@@ -339,13 +364,13 @@ const SimpleTabView: FC<{
       {(!props.hideTabsIfSingle || props.tabs.length > 1) && (
         <Tabs.Root
           style={{margin: '12px 16px 0 16px'}}
-          value={props.tabs[props.tabValue].label}
+          value={props.tabValue}
           onValueChange={props.handleTabChange}>
           <Tabs.List style={{overflowX: 'scroll', scrollbarWidth: 'none'}}>
             {props.tabs.map(tab => (
               <Tabs.Trigger
                 key={tab.label}
-                value={tab.label}
+                value={tab.value}
                 className="h-[30px] whitespace-nowrap text-sm">
                 {tab.label}
               </Tabs.Trigger>
@@ -360,7 +385,9 @@ const SimpleTabView: FC<{
           flexDirection: 'column',
           flex: '1 1 auto',
         }}>
-        <ErrorBoundary key={props.tabId}>{props.tabContent}</ErrorBoundary>
+        <ErrorBoundary key={props.tabValue}>
+          {selectedTab?.content}
+        </ErrorBoundary>
       </Box>
     </Box>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -325,6 +325,7 @@ const SimpleTabView: FC<{
 
 export const BetterTabView: FC<{
   headerContent: ReactNode;
+  headerContainerSx?: SxProps<Theme>;
   tabs: Array<{
     value: string;
     label: string;
@@ -357,16 +358,25 @@ export const BetterTabView: FC<{
             pt: 1,
             px: 2,
             alignContent: 'center',
+            ...(props.headerContainerSx ?? {}),
           }}>
           {props.headerContent}
         </Box>
       )}
       {(!props.hideTabsIfSingle || props.tabs.length > 1) && (
         <Tabs.Root
-          style={{padding: '12px 16px 0 16px', borderBottom: `1px solid ${MOON_200}`}}
+          style={{
+            padding: '12px 16px 0 16px',
+            borderBottom: `1px solid ${MOON_200}`,
+          }}
           value={props.tabValue}
           onValueChange={props.handleTabChange}>
-          <Tabs.List style={{overflowX: 'scroll', scrollbarWidth: 'none', borderBottom: `0px solid white`}}>
+          <Tabs.List
+            style={{
+              overflowX: 'scroll',
+              scrollbarWidth: 'none',
+              borderBottom: `0px solid white`,
+            }}>
             {props.tabs.map(tab => (
               <Tabs.Trigger
                 key={tab.label}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -217,8 +217,11 @@ export const SimplePageLayoutWithHeader: FC<{
       setAndNotifyTab(tabs[0].label);
     }
   }, [tabs, idxSelected, userSelectedTab, setAndNotifyTab]);
-  const tabContent = useMemo(() => tabs[tabValue].content, [tabs, tabValue]);
-
+  const tabValueString = props.tabs[tabValue].label;
+  const tabsWithValues = useMemo(
+    () => props.tabs.map(t => ({...t, value: t.label})),
+    [props.tabs]
+  );
   return (
     <Box
       sx={{
@@ -285,10 +288,8 @@ export const SimplePageLayoutWithHeader: FC<{
               main={
                 <SimpleTabView
                   headerContent={props.headerContent}
-                  tabContent={tabContent}
-                  tabs={props.tabs}
-                  tabId={tabId}
-                  tabValue={tabValue}
+                  tabs={tabsWithValues}
+                  tabValue={tabValueString}
                   hideTabsIfSingle={props.hideTabsIfSingle}
                   handleTabChange={handleTabChange}
                 />
@@ -301,29 +302,7 @@ export const SimplePageLayoutWithHeader: FC<{
   );
 };
 
-const SimpleTabView: FC<{
-  headerContent: ReactNode;
-  tabs: Array<{
-    label: string;
-    content: ReactNode;
-  }>;
-  tabContent: ReactNode;
-  tabId: string;
-  tabValue: number;
-  hideTabsIfSingle?: boolean;
-  handleTabChange: (newValue: string) => void;
-}> = props => {
-  const tabValueString = props.tabs[props.tabValue].label;
-  return (
-    <BetterTabView
-      {...props}
-      tabs={props.tabs.map(t => ({...t, value: t.label}))}
-      tabValue={tabValueString}
-    />
-  );
-};
-
-export const BetterTabView: FC<{
+export const SimpleTabView: FC<{
   headerContent: ReactNode;
   headerContainerSx?: SxProps<Theme>;
   tabs: Array<{

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -366,7 +366,7 @@ export const BetterTabView: FC<{
       {(!props.hideTabsIfSingle || props.tabs.length > 1) && (
         <Tabs.Root
           style={{
-            padding: '12px 16px 0 16px',
+            padding: '8px 16px 0 16px',
             borderBottom: `1px solid ${MOON_200}`,
           }}
           value={props.tabValue}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout.tsx
@@ -363,10 +363,10 @@ export const BetterTabView: FC<{
       )}
       {(!props.hideTabsIfSingle || props.tabs.length > 1) && (
         <Tabs.Root
-          style={{margin: '12px 16px 0 16px'}}
+          style={{padding: '12px 16px 0 16px', borderBottom: `1px solid ${MOON_200}`}}
           value={props.tabValue}
           onValueChange={props.handleTabChange}>
-          <Tabs.List style={{overflowX: 'scroll', scrollbarWidth: 'none'}}>
+          <Tabs.List style={{overflowX: 'scroll', scrollbarWidth: 'none', borderBottom: `0px solid white`}}>
             {props.tabs.map(tab => (
               <Tabs.Trigger
                 key={tab.label}

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -186,14 +186,16 @@ def _validate_class_name(name: str) -> str:
 class ScorerCache:
     _cached_scorers: dict[str, Scorer]
     _cached_scorers_lock: Any
-
-    def __init__(self) -> None:
+    _max_size: int
+    def __init__(self, max_size: int = 1000) -> None:
         self._cached_scorers = {}
         self._cached_scorers_lock = Lock()
-
+        self._max_size = max_size
     def get_scorer(self, scorer_id: str, default_factory: Callable[[], Scorer]) -> Scorer:
         with self._cached_scorers_lock:
             if scorer_id not in self._cached_scorers:
+                if len(self._cached_scorers) >= self._max_size:
+                    self._cached_scorers.popitem()
                 self._cached_scorers[scorer_id] = default_factory()
         return self._cached_scorers[scorer_id]
 

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import atexit
 import datetime
+import json
 import logging
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
+from multiprocessing import Lock
 from types import MethodType
 from typing import Annotated, Any, TypeVar, Union, cast
 
@@ -181,6 +183,22 @@ def _validate_class_name(name: str) -> str:
     return name
 
 
+class ScorerCache:
+    _cached_scorers: dict[str, Scorer]
+    _cached_scorers_lock: Any
+
+    def __init__(self) -> None:
+        self._cached_scorers = {}
+        self._cached_scorers_lock = Lock()
+
+    def get_scorer(self, scorer_id: str, default_factory: Callable[[], Scorer]) -> Scorer:
+        with self._cached_scorers_lock:
+            if scorer_id not in self._cached_scorers:
+                self._cached_scorers[scorer_id] = default_factory()
+        return self._cached_scorers[scorer_id]
+
+global_scorer_cache = ScorerCache()
+
 class ScoreLogger(BaseModel):
     """This class provides an imperative interface for logging scores."""
 
@@ -234,12 +252,10 @@ class ScoreLogger(BaseModel):
             # No event loop exists, create one with asyncio.run
             return asyncio.run(self.alog_score(scorer, score))
 
-    @validate_call
     async def alog_score(
         self,
         scorer: Annotated[
             Scorer | dict | str,
-            BeforeValidator(_cast_to_cls(Scorer)),
             Field(
                 description="A metadata-only scorer used for comparisons."
                 "Alternatively, you can pass a dict of attributes or just a string"
@@ -248,6 +264,9 @@ class ScoreLogger(BaseModel):
         ],
         score: ScoreType,
     ) -> None:
+        if not isinstance(scorer, Scorer):
+            scorer_id = json.dumps(scorer)
+            scorer = global_scorer_cache.get_scorer(scorer_id, lambda: _cast_to_cls(Scorer)(scorer))
         if self._has_finished:
             raise ValueError("Cannot log score after finish has been called")
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -687,10 +687,10 @@ class Call:
 
         wc = weave_client_context.get_weave_client()
         if wc:
-            scorer_ref_uri = None
+            scorer_ref = None
             if weave_isinstance(scorer, Scorer):
                 # Very important: if the score is generated from a Scorer subclass,
-                # then scorer_ref_uri will be None, and we will use the op_name from
+                # then scorer_ref will be None, and we will use the op_name from
                 # the score_call instead.
                 scorer_ref = get_ref(scorer)
             wc._send_score_call(self, score_call, scorer_ref)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -693,8 +693,7 @@ class Call:
                 # then scorer_ref_uri will be None, and we will use the op_name from
                 # the score_call instead.
                 scorer_ref = get_ref(scorer)
-                scorer_ref_uri = scorer_ref.uri() if scorer_ref else None
-            wc._send_score_call(self, score_call, scorer_ref_uri)
+            wc._send_score_call(self, score_call, scorer_ref)
         return apply_scorer_result
 
     def to_dict(self) -> CallDict:
@@ -1634,7 +1633,7 @@ class WeaveClient:
         self,
         predict_call: Call,
         score_call: Call,
-        scorer_object_ref_uri: str | None = None,
+        scorer_object_ref: ObjectRef | None = None,
     ) -> Future[str]:
         """(Private) Adds a score to a call. This is particularly useful
         for adding evaluation metrics to a call.
@@ -1650,9 +1649,10 @@ class WeaveClient:
                 raise ValueError("Score call must have a ref")
             scorer_call_ref_uri = scorer_call_ref.uri()
 
-            # If scorer_object_ref_uri is provided, it is used as the runnable_ref_uri
+            # If scorer_object_ref is provided, it is used as the runnable_ref_uri
             # Otherwise, we use the op_name from the score_call. This should happen
             # when there is a Scorer subclass that is the source of the score call.
+            scorer_object_ref_uri = scorer_object_ref.uri() if scorer_object_ref else None
             runnable_ref_uri = scorer_object_ref_uri or score_call.op_name
             score_results = score_call.output
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1652,7 +1652,9 @@ class WeaveClient:
             # If scorer_object_ref is provided, it is used as the runnable_ref_uri
             # Otherwise, we use the op_name from the score_call. This should happen
             # when there is a Scorer subclass that is the source of the score call.
-            scorer_object_ref_uri = scorer_object_ref.uri() if scorer_object_ref else None
+            scorer_object_ref_uri = (
+                scorer_object_ref.uri() if scorer_object_ref else None
+            )
             runnable_ref_uri = scorer_object_ref_uri or score_call.op_name
             score_results = score_call.output
 


### PR DESCRIPTION
This PR basically just splits the eval compare page into 2 tabs and makes a bunch of minor style adjustments to match the aesthetics of the updated ux from design team