### PR TITLE
fix(weave): Fix deprecated usage of include in Field

### DIFF
--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -210,7 +210,7 @@ class ObjSchemaForInsert(BaseModel):
     builtin_object_class: Optional[str] = None
     # Keeping `set_base_object_class` here until it is successfully removed from UI client
     set_base_object_class: Optional[str] = Field(
-        include=False, default=None, deprecated=True
+        exclude=True, default=None, deprecated=True
     )
 
     wb_user_id: Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)


### PR DESCRIPTION
## Description

- Fixes WB-20574
- Fixes #4533


Changes deprecated `include=True` to `exclude=False`

## Testing

Importing no longer results in pydantic warning
