### PR TITLE
feat(weave): document call attribute immutability and summary editing

### DIFF
--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -97,6 +97,13 @@ There are three main ways to create Calls in Weave:
   </TabItem>
 </Tabs>
 
+#### Summary
+
+You can store metrics or other post-call values in the `summary`
+dictionary of a Call. Modify `call.summary` during execution and any
+values you add will be merged with Weave's computed summary data when
+the call finishes.
+
 ### 2. Decorating and wrapping functions
 
 However, often LLM applications have additional logic (such as pre/post processing, prompts, etc.) that you want to track.
@@ -380,6 +387,11 @@ However, often LLM applications have additional logic (such as pre/post processi
     with weave.attributes({'env': 'production'}):
         print(my_function.call("World"))
     ```
+
+    :::tip
+    `call.attributes` cannot be modified once the call starts. Use this
+    context manager to set any metadata before invoking the op.
+    :::
 
   </TabItem>
   <TabItem value="typescript" label="TypeScript">
@@ -906,12 +918,12 @@ Please see the [schema](../../reference/python-sdk/weave/trace_server/weave.trac
 | trace_id | string (uuid) | Identifier for the trace this call belongs to |
 | parent_id | string (uuid) | Identifier of the parent call |
 | started_at | datetime | Timestamp when the call started |
-| attributes | Dict[str, Any] | User-defined metadata about the call |
+| attributes | Dict[str, Any] | User-defined metadata about the call *(read-only during execution)* |
 | inputs | Dict[str, Any] | Input parameters for the call |
 | ended_at | datetime (optional) | Timestamp when the call ended |
 | exception | string (optional) | Error message if the call failed |
 | output | Any (optional) | Result of the call |
-| summary | Optional[SummaryMap] | Post-execution summary information |
+| summary | Optional[SummaryMap] | Post-execution summary information. You can modify this during execution to record custom metrics. |
 | wb_user_id | Optional[str] | Associated Weights & Biases user ID |
 | wb_run_id | Optional[str] | Associated Weights & Biases run ID |
 | deleted_at | datetime (optional) | Timestamp of call deletion, if applicable |
@@ -920,7 +932,7 @@ The table above outlines the key properties of a Call in Weave. Each property pl
 
 - The `id`, `trace_id`, and `parent_id` fields help in organizing and relating calls within the system.
 - Timing information (`started_at`, `ended_at`) allows for performance analysis.
-- The `attributes` and `inputs` fields provide context for the call, while `output` and `summary` capture the results.
+- The `attributes` and `inputs` fields provide context for the call. Attributes are frozen once the call starts, so set them before invocation with `weave.attributes`. `output` and `summary` capture the results, and you can update `summary` during execution to log additional metrics.
 - Integration with Weights & Biases is facilitated through `wb_user_id` and `wb_run_id`.
 
 This comprehensive set of properties enables detailed tracking and analysis of function calls throughout your project.

--- a/docs/docs/reference/python-sdk/weave/index.md
+++ b/docs/docs/reference/python-sdk/weave/index.md
@@ -253,7 +253,10 @@ A decorator to weave op-ify a function or method. Works for both sync and async.
 attributes(attributes: 'dict[str, Any]') → Iterator
 ```
 
-Context manager for setting attributes on a call. 
+Context manager for setting attributes on a call.
+
+Attributes become immutable once a call begins execution. Use this
+context manager to provide metadata before the call starts.
 
 
 

--- a/tests/trace/test_current_call.py
+++ b/tests/trace/test_current_call.py
@@ -35,3 +35,37 @@ def test_call_summary_editable(client):
     assert summary["foo"] == 1
     assert summary["bar"] == 2
     assert summary[RESERVED_SUMMARY_STATUS_COUNTS_KEY][tsi.TraceStatus.SUCCESS] == 1
+
+
+def test_call_attributes_update_and_delete_forbidden(client):
+    @weave.op()
+    def my_op():
+        call = call_context.get_current_call()
+        with pytest.raises(TypeError):
+            call.attributes.update({"extra": 1})
+        with pytest.raises(TypeError):
+            del call.attributes["weave"]
+        return 1
+
+    with weave.attributes({"env": "prod"}):
+        my_op()
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    # Original attribute is preserved
+    assert calls[0].attributes["env"] == "prod"
+    assert "extra" not in calls[0].attributes
+
+
+def test_call_summary_deep_merge(client):
+    @weave.op()
+    def my_op():
+        call = call_context.get_current_call()
+        call.summary["nested"] = {"foo": 1}
+        return "done"
+
+    my_op()
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    summary = calls[0].summary
+    assert summary["nested"]["foo"] == 1
+    assert summary[RESERVED_SUMMARY_STATUS_COUNTS_KEY][tsi.TraceStatus.SUCCESS] == 1

--- a/weave/trace/context/call_context.py
+++ b/weave/trace/context/call_context.py
@@ -118,6 +118,13 @@ def get_current_call() -> Call | None:
         The Call object for the currently executing Op, or
         None if tracking has not been initialized or this method is
         invoked outside an Op.
+
+    Note:
+        The returned Call's ``attributes`` dictionary becomes immutable
+        once the call starts. Use :func:`weave.attributes` to set
+        call metadata before invoking an Op. The ``summary`` field may
+        be updated while the Op executes and will be merged with
+        computed summary information when the call finishes.
     """
     return _call_stack.get()[-1] if _call_stack.get() else None
 


### PR DESCRIPTION
## Summary
- describe immutability of call attributes in docs and code comments
- allow user edits to call.summary and mention merge behavior
- test attribute immutability edge cases and summary merge

## Testing
- `nox --no-install -e lint` *(fails: Failed to fetch packages)*
- `nox --no-install -e "tests-3.12(shard='trace')"` *(fails: pytest errors)*