### PR TITLE
chore(weave): Move logger configuration to init so that it doesn't affect non-SDK usage

### DIFF
--- a/tests/trace/test_call_behaviours.py
+++ b/tests/trace/test_call_behaviours.py
@@ -3,6 +3,9 @@ import pytest
 import weave
 from tests.trace.util import capture_output, flushing_callback
 from weave.trace.constants import TRACE_CALL_EMOJI
+from weave.trace.term import configure_logger
+
+configure_logger()
 
 
 @weave.op

--- a/tests/trace_server_bindings/test_remote_http_trace_server_binding.py
+++ b/tests/trace_server_bindings/test_remote_http_trace_server_binding.py
@@ -11,6 +11,7 @@ import pytest
 import requests
 import tenacity
 
+from weave.trace.term import configure_logger
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
 from weave.trace_server_bindings.remote_http_trace_server import (
@@ -300,6 +301,7 @@ def test_post_timeout(mock_post, success_response, server, log_collector):
     This test modifies the retry mechanism to use a short wait time and limited retries
     to verify behavior when retries are exhausted.
     """
+    configure_logger()
     # Configure mock to timeout twice to exhaust retries
     mock_post.side_effect = [
         # First batch times out twice

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -19,7 +19,6 @@ from weave.flow.prompt.prompt import EasyPrompt, MessagesPrompt, Prompt, StringP
 from weave.flow.saved_view import SavedView
 from weave.flow.scorer import Scorer
 from weave.initialization import *
-from weave.trace.term import configure_logger
 from weave.trace.util import Thread as Thread
 from weave.trace.util import ThreadPoolExecutor as ThreadPoolExecutor
 from weave.type_handlers.Audio.audio import Audio
@@ -28,8 +27,6 @@ from weave.type_handlers.Markdown.markdown import Markdown
 
 # Alias for succinct code
 P = EasyPrompt
-
-configure_logger()
 
 # Special object informing doc generation tooling which symbols
 # to document & to associate with this module.

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -24,6 +24,7 @@ from weave.trace.settings import (
     should_disable_weave,
 )
 from weave.trace.table import Table
+from weave.trace.term import configure_logger
 from weave.trace_server.interface.builtin_object_classes import leaderboard
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,8 @@ def init(
     Returns:
         A Weave client.
     """
+    configure_logger()
+
     parse_and_apply_settings(settings)
 
     global _global_postprocess_inputs


### PR DESCRIPTION
## Description

Now that the full weave code is in the server image, `configure_logger` affects any logger whose name starts with `"weave."`. By default these logger will propagate to the parent logger, which leads to double printing.

Moving `configure_logger()` to `init` ensures that the configuration only affects real SDK usage, not all imports of the `weave` module.

## Testing

- Not yet tested in the scoring worker, but will do in the morning.