### PR TITLE
chore(ui): Video thumbnail enhancement

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/moviepy.video.VideoClip/VideoPlayer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/moviepy.video.VideoClip/VideoPlayer.tsx
@@ -5,9 +5,14 @@ import {CustomLink} from '@wandb/weave/components/PagePanelComponents/Home/Brows
 import {useWFHooks} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context';
 import {CustomWeaveTypePayload} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/typeViews/customWeaveType.types';
 import {CustomWeaveTypeProjectContext} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/typeViews/CustomWeaveTypeDispatcher';
+import {WeaveflowPeekContext} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/context';
 import VideoViewer from '@wandb/weave/components/Panel2/VideoViewer';
-import React, {useContext, useEffect, useMemo, useState} from 'react';
+import {IconPlay} from '@wandb/weave/components/Icon';
+import {Tailwind} from '@wandb/weave/components/Tailwind';
+import {Pill} from '@wandb/weave/components/Tag';
+import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {AutoSizer} from 'react-virtualized';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
 
 type VideoFormat = 'gif' | 'mp4' | 'webm';
 type VideoFileKeys = `video.${VideoFormat}`;
@@ -66,7 +71,9 @@ const VideoPlayerWithSize: React.FC<VideoPlayerWithSizeProps> = ({
   const [showPopup, setShowPopup] = useState(false);
   const {useFileContent} = useWFHooks();
   const context = useContext(CustomWeaveTypeProjectContext);
+  const {isPeeking} = useContext(WeaveflowPeekContext);
   const mode = propMode ?? context?.mode;
+  const videoRef = useRef<HTMLVideoElement>(null);
 
   // Find the first available video format
   const videoKey = Object.keys(data.files).find(key => key in VIDEO_TYPES) as
@@ -94,36 +101,106 @@ const VideoPlayerWithSize: React.FC<VideoPlayerWithSizeProps> = ({
 
   // Link mode (default view)
   if (!mode || mode !== 'object_viewer' || containerHeight < 50) {
-    const videoText = `${fileExt.toUpperCase()} Video`;
+    const videoText = `${fileExt.toUpperCase()}`;
 
-    return (
-      <>
-        <div className="flex h-full w-full items-center justify-start">
-          <CustomLink
-            text={videoText}
-            fontWeight={400}
+    // Show thumbnail in drawer view, link in list view
+    if (isPeeking) {
+      const thumbnailHeight = Math.min(containerHeight, 38); // Default height of the cell row
+      const thumbnailWidth = Math.min(containerWidth, 68); // 16:9-ish ratio
+
+      const thumbnailContent = (
+        <Tailwind>
+          <div 
+            className="flex h-full w-full items-center justify-start relative"
+            style={{cursor: 'pointer'}}
             onClick={() => setShowPopup(true)}
-          />
-        </div>
+          >
+            <div style={{height: thumbnailHeight, width: thumbnailWidth}} className="relative">
+              {videoBinary.result ? (
+                <>
+                  <VideoContent
+                    fileExt={fileExt}
+                    buffer={videoBinary.result}
+                    containerWidth={thumbnailWidth}
+                    containerHeight={thumbnailHeight}
+                    title={title}
+                    isThumbnail={true}
+                    videoRef={videoRef}
+                  />
+                  <div className="absolute inset-0 flex items-center justify-center bg-oblivion/30 hover:bg-oblivion/10 transition-all duration-200">
+                    <IconPlay className="text-white" />
+                  </div>
+                </>
+              ) : (
+                <LoadingDots />
+              )}
+            </div>
+          </div>
+        </Tailwind>
+      );
 
-        {showPopup && videoBinary.result && (
-          <Dialog.Root open={showPopup} onOpenChange={setShowPopup}>
-            <Dialog.Portal>
-              <Dialog.Overlay />
-              <Dialog.Content className="h-[60vh] w-[60vw] p-0">
-                <VideoContent
-                  fileExt={fileExt}
-                  buffer={videoBinary.result}
-                  containerWidth={containerWidth}
-                  containerHeight={containerHeight}
-                  title={title}
-                />
-              </Dialog.Content>
-            </Dialog.Portal>
-          </Dialog.Root>
-        )}
-      </>
-    );
+      return (
+        <>
+          <Tooltip 
+            trigger={thumbnailContent}
+            content={`${fileExt.toUpperCase()} Video - Click to play`}
+          />
+
+          {showPopup && videoBinary.result && (
+            <Dialog.Root open={showPopup} onOpenChange={setShowPopup}>
+              <Dialog.Portal>
+                <Dialog.Overlay />
+                <Dialog.Content className="h-[60vh] w-[60vw] p-0">
+                  <VideoContent
+                    fileExt={fileExt}
+                    buffer={videoBinary.result}
+                    containerWidth={containerWidth}
+                    containerHeight={containerHeight}
+                    title={title}
+                    videoRef={videoRef}
+                  />
+                </Dialog.Content>
+              </Dialog.Portal>
+            </Dialog.Root>
+          )}
+        </>
+      );
+    } else {
+      // List view - show simple link
+      return (
+        <div className="flex h-full w-full items-center justify-start">
+          <div 
+            className="cursor-pointer" 
+            onClick={() => setShowPopup(true)}
+          >
+            <Pill
+              label={videoText}
+              icon="play"
+              color="moon"
+              isInteractive={true}
+            />
+          </div>
+
+          {showPopup && videoBinary.result && (
+            <Dialog.Root open={showPopup} onOpenChange={setShowPopup}>
+              <Dialog.Portal>
+                <Dialog.Overlay />
+                <Dialog.Content className="h-[60vh] w-[60vw] p-0">
+                  <VideoContent
+                    fileExt={fileExt}
+                    buffer={videoBinary.result}
+                    containerWidth={containerWidth}
+                    containerHeight={containerHeight}
+                    title={title}
+                    videoRef={videoRef}
+                  />
+                </Dialog.Content>
+              </Dialog.Portal>
+            </Dialog.Root>
+          )}
+        </div>
+      );
+    }
   }
 
   // Full viewer mode
@@ -142,6 +219,7 @@ const VideoPlayerWithSize: React.FC<VideoPlayerWithSizeProps> = ({
       containerWidth={containerWidth}
       containerHeight={containerHeight}
       title={title}
+      videoRef={videoRef}
     />
   );
 };
@@ -153,6 +231,8 @@ type VideoContentProps = {
   containerHeight: number;
   title: string;
   previewImageUrl?: string;
+  isThumbnail?: boolean;
+  videoRef: React.RefObject<HTMLVideoElement>;
 };
 
 const VideoContent: React.FC<VideoContentProps> = ({
@@ -162,6 +242,8 @@ const VideoContent: React.FC<VideoContentProps> = ({
   containerHeight,
   title,
   previewImageUrl,
+  isThumbnail,
+  videoRef,
 }) => {
   const [url, setUrl] = useState<string>('');
 
@@ -179,10 +261,34 @@ const VideoContent: React.FC<VideoContentProps> = ({
   }
 
   return containerHeight >= 1 ? (
-    <VideoViewer
-      videoSrc={url}
-      width={containerWidth}
-      height={containerHeight}
-    />
+    <div style={{
+      width: '100%',
+      height: '100%',
+      overflow: 'hidden',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center'
+    }}>
+      <video
+        ref={videoRef}
+        src={url}
+        style={{
+          width: '100%',
+          height: '100%',
+          objectFit: 'contain'
+        }}
+        controls={!isThumbnail}
+        autoPlay={false}
+        muted={true}
+        loop={isThumbnail}
+        onLoadedData={() => {
+          if (isThumbnail && videoRef.current) {
+            // For thumbnails, seek to 1 second or 25% of the video duration
+            const seekTime = Math.min(1, videoRef.current.duration * 0.25);
+            videoRef.current.currentTime = seekTime;
+          }
+        }}
+      />
+    </div>
   ) : null;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/moviepy.video.VideoClip/VideoPlayer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/moviepy.video.VideoClip/VideoPlayer.tsx
@@ -108,12 +108,13 @@ const VideoPlayerWithSize: React.FC<VideoPlayerWithSizeProps> = ({
 
       const thumbnailContent = (
         <Tailwind>
-          <div 
-            className="flex h-full w-full items-center justify-start relative"
+          <div
+            className="relative flex h-full w-full items-center justify-start"
             style={{cursor: 'pointer'}}
-            onClick={() => setShowPopup(true)}
-          >
-            <div style={{height: thumbnailHeight, width: thumbnailWidth}} className="relative">
+            onClick={() => setShowPopup(true)}>
+            <div
+              style={{height: thumbnailHeight, width: thumbnailWidth}}
+              className="relative">
               {videoBinary.result ? (
                 <>
                   <VideoContent
@@ -125,7 +126,7 @@ const VideoPlayerWithSize: React.FC<VideoPlayerWithSizeProps> = ({
                     isThumbnail={true}
                     videoRef={videoRef}
                   />
-                  <div className="absolute inset-0 flex items-center justify-center bg-oblivion/30 hover:bg-oblivion/10 transition-all duration-200">
+                  <div className="absolute inset-0 flex items-center justify-center bg-oblivion/30 transition-all duration-200 hover:bg-oblivion/10">
                     <IconPlay className="text-white" />
                   </div>
                 </>
@@ -139,7 +140,7 @@ const VideoPlayerWithSize: React.FC<VideoPlayerWithSizeProps> = ({
 
       return (
         <>
-          <Tooltip 
+          <Tooltip
             trigger={thumbnailContent}
             content={`${fileExt.toUpperCase()} Video - Click to play`}
           />
@@ -167,10 +168,7 @@ const VideoPlayerWithSize: React.FC<VideoPlayerWithSizeProps> = ({
       // List view - show simple link
       return (
         <div className="flex h-full w-full items-center justify-start">
-          <div 
-            className="cursor-pointer" 
-            onClick={() => setShowPopup(true)}
-          >
+          <div className="cursor-pointer" onClick={() => setShowPopup(true)}>
             <Pill
               label={videoText}
               icon="play"
@@ -259,21 +257,22 @@ const VideoContent: React.FC<VideoContentProps> = ({
   }
 
   return containerHeight >= 1 ? (
-    <div style={{
-      width: '100%',
-      height: '100%',
-      overflow: 'hidden',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center'
-    }}>
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
       <video
         ref={videoRef}
         src={url}
         style={{
           width: '100%',
           height: '100%',
-          objectFit: 'contain'
+          objectFit: 'contain',
         }}
         controls={!isThumbnail}
         autoPlay={false}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/moviepy.video.VideoClip/VideoPlayer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/typeViews/moviepy.video.VideoClip/VideoPlayer.tsx
@@ -1,18 +1,16 @@
 import * as Dialog from '@wandb/weave/components/Dialog/Dialog';
+import {IconPlay} from '@wandb/weave/components/Icon';
 import {LoadingDots} from '@wandb/weave/components/LoadingDots';
+import {WeaveflowPeekContext} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/context';
 import {NotApplicable} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/NotApplicable';
-import {CustomLink} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/Links';
 import {useWFHooks} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context';
 import {CustomWeaveTypePayload} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/typeViews/customWeaveType.types';
 import {CustomWeaveTypeProjectContext} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/typeViews/CustomWeaveTypeDispatcher';
-import {WeaveflowPeekContext} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/context';
-import VideoViewer from '@wandb/weave/components/Panel2/VideoViewer';
-import {IconPlay} from '@wandb/weave/components/Icon';
-import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {Pill} from '@wandb/weave/components/Tag';
+import {Tailwind} from '@wandb/weave/components/Tailwind';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
 import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {AutoSizer} from 'react-virtualized';
-import {Tooltip} from '@wandb/weave/components/Tooltip';
 
 type VideoFormat = 'gif' | 'mp4' | 'webm';
 type VideoFileKeys = `video.${VideoFormat}`;


### PR DESCRIPTION
## Description

| Before | After |
| -------- | ------- |
| ![image](https://github.com/user-attachments/assets/d5baa9c3-419d-40c1-8cef-3c4137c8ca33) | ![image](https://github.com/user-attachments/assets/e7fb22fe-ebe0-48a8-890f-f30e698f6d40) |
| ![image](https://github.com/user-attachments/assets/eacb9170-51fc-4448-b780-65b1187c32a3) | ![image](https://github.com/user-attachments/assets/ebaa7990-3981-4678-bc1c-4a9a79dee97f) |

- Loads video to 1s, removes controls, and adds a play button overlay if loaded in the peek drawer.
- Uses pill w/ MP4 extension if the video is referenced in the list view (emulates design of MP3 waveform).