### PR TITLE
fix(weave): Streaming mode is broken for mistral endpoints

### DIFF
--- a/tests/integrations/openai/test_openai_sdk.py
+++ b/tests/integrations/openai/test_openai_sdk.py
@@ -1,0 +1,75 @@
+import pytest
+
+from weave.integrations.openai.openai_sdk import (
+    create_wrapper_async,
+    create_wrapper_sync,
+)
+from weave.trace.autopatch import OpSettings
+
+
+class DummyClient:
+    def __init__(self, base_url: str):
+        self._base_url = base_url
+
+
+class DummyCompletion:
+    def __init__(self, base_url: str):
+        self._client = DummyClient(base_url)
+
+
+def test_stream_options_injected_for_openai_base_url_sync() -> None:
+    captured = {}
+
+    def dummy_fn(completion, **kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    wrapped = create_wrapper_sync(OpSettings())(dummy_fn)
+
+    wrapped(DummyCompletion("https://api.openai.com"), stream=True)
+
+    assert captured.get("stream_options") == {"include_usage": True}
+
+
+def test_stream_options_not_injected_for_non_openai_base_url_sync() -> None:
+    captured = {}
+
+    def dummy_fn(completion, **kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    wrapped = create_wrapper_sync(OpSettings())(dummy_fn)
+
+    wrapped(DummyCompletion("https://api.mistral.ai"), stream=True)
+
+    assert "stream_options" not in captured
+
+
+@pytest.mark.asyncio
+async def test_stream_options_injected_for_openai_base_url_async() -> None:
+    captured = {}
+
+    async def dummy_fn(completion, **kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    wrapped = create_wrapper_async(OpSettings())(dummy_fn)
+
+    await wrapped(DummyCompletion("https://api.openai.com"), stream=True)
+
+    assert captured.get("stream_options") == {"include_usage": True}
+
+
+@pytest.mark.asyncio
+async def test_stream_options_not_injected_for_non_openai_base_url_async() -> None:
+    captured = {}
+
+    async def dummy_fn(completion, **kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    wrapped = create_wrapper_async(OpSettings())(dummy_fn)
+
+    await wrapped(DummyCompletion("https://api.mistral.ai"), stream=True)
+
+    assert "stream_options" not in captured

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -328,14 +328,14 @@ def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
 
         def _add_stream_options(fn: Callable) -> Callable:
             @wraps(fn)
-            def _wrapper(*args: Any, **kwargs: Any) -> Any:
+            def _wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
                 if kwargs.get("stream") and kwargs.get("stream_options") is None:
-                    completion = args[0]
+                    completion = self
                     base_url = str(completion._client._base_url)
                     # Only set stream_options if it targets the OpenAI endpoints
                     if urlparse(base_url).hostname == "api.openai.com":
                         kwargs["stream_options"] = {"include_usage": True}
-                return fn(*args, **kwargs)
+                return fn(self, *args, **kwargs)
 
             return _wrapper
 
@@ -369,14 +369,14 @@ def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]
 
         def _add_stream_options(fn: Callable) -> Callable:
             @wraps(fn)
-            async def _wrapper(*args: Any, **kwargs: Any) -> Any:
+            async def _wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
                 if kwargs.get("stream") and kwargs.get("stream_options") is None:
-                    completion = args[0]
+                    completion = self
                     base_url = str(completion._client._base_url)
                     # Only set stream_options if it targets the OpenAI endpoints
                     if urlparse(base_url).hostname == "api.openai.com":
                         kwargs["stream_options"] = {"include_usage": True}
-                return await fn(*args, **kwargs)
+                return await fn(self, *args, **kwargs)
 
             return _wrapper
 

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -346,6 +346,7 @@ def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
 
         op_kwargs = settings.model_dump()
         op = weave.op(_add_stream_options(fn), **op_kwargs)
+
         op._set_on_input_handler(openai_on_input_handler)
         return _add_accumulator(
             op,  # type: ignore


### PR DESCRIPTION
## Description

Fix [WB-25044](https://wandb.atlassian.net/browse/WB-25044)

- Fixes issue with stream_options being set for non-OpenAI endpoints
### What problem does it fix?

`stream_options` currently only happen for Completion series API, because that's the only occasion we would attach {stream: true}

For non-OpenAI endpoints, eg mistral, the `stream_options` config is not supported and will be rejected. 

So we can't just add `stream_options` indiscriminately.

This PR modifies the `_add_stream_options` function to only set `stream_options` when the API endpoint is specifically targeting OpenAI's official API (`api.openai.com`). It checks the hostname from the client's base URL before applying the stream options, preventing these options from being incorrectly applied to other compatible APIs.

## Testing

added tests in [openai_sdk.py](https://github.com/wandb/weave/pull/4563/files#diff-4ca40709ac141a5367973a7d99334b63f415ebaf67f8af4cc096a41080b667d2)

[WB-25044]: https://wandb.atlassian.net/browse/WB-25044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ