### PR TITLE
chore(ui): Added callout area to eval compare page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -4,7 +4,6 @@
 
 import {Box} from '@material-ui/core';
 import {Alert} from '@mui/material';
-import {Typography} from '@mui/material';
 import {Icon} from '@wandb/weave/components/Icon';
 import {WaveLoader} from '@wandb/weave/components/Loaders/WaveLoader';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
@@ -223,11 +222,15 @@ const CompareEvaluationsPageInner: React.FC<{}> = props => {
                 <ScorecardSection state={state} />
                 <Tailwind style={{width: '100%'}}>
                   <div className="px-16">
-                    <div className="w-full p-16 border border-dashed border-moon-300 rounded-lg bg-moon-50 flex flex-col items-center gap-3">
+                    <div className="flex w-full flex-col items-center gap-3 rounded-lg border border-dashed border-moon-300 bg-moon-50 p-16">
                       <Icon name="table" size="large" color="moon-500 mb-4" />
-                      <div className="flex flex-col items-center mb-4">
-                        <p className="font-semibold text-center">Looking for your evaluation results?</p>
-                        <p className="text-center text-moon-500">You can find it in our new results tab.</p>
+                      <div className="mb-4 flex flex-col items-center">
+                        <p className="text-center font-semibold">
+                          Looking for your evaluation results?
+                        </p>
+                        <p className="text-center text-moon-500">
+                          You can find it in our new results tab.
+                        </p>
                       </div>
                       <Button
                         variant="secondary"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -4,6 +4,8 @@
 
 import {Box} from '@material-ui/core';
 import {Alert} from '@mui/material';
+import {Typography} from '@mui/material';
+import {Icon} from '@wandb/weave/components/Icon';
 import {WaveLoader} from '@wandb/weave/components/Loaders/WaveLoader';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
@@ -219,6 +221,23 @@ const CompareEvaluationsPageInner: React.FC<{}> = props => {
                   setSelectedMetrics={setSelectedMetrics}
                 />
                 <ScorecardSection state={state} />
+                <Tailwind style={{width: '100%'}}>
+                  <div className="px-16">
+                    <div className="w-full p-16 border border-dashed border-moon-300 rounded-lg bg-moon-50 flex flex-col items-center gap-3">
+                      <Icon name="table" size="large" color="moon-500 mb-4" />
+                      <div className="flex flex-col items-center mb-4">
+                        <p className="font-semibold text-center">Looking for your evaluation results?</p>
+                        <p className="text-center text-moon-500">You can find it in our new results tab.</p>
+                      </div>
+                      <Button
+                        variant="secondary"
+                        onClick={() => setTabValue('results')}>
+                        Review evaluation results
+                      </Button>
+                    </div>
+                    <div className="h-16"></div>
+                  </div>
+                </Tailwind>
               </VerticalBox>
             ),
           },


### PR DESCRIPTION
## Description

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/db80a72f-49a6-4fa2-ad75-6c63b487d108" />

- Callout area for eval compare page.
- Reduce moving-the-cheese effect for moving results to new page.