### PR TITLE
fix(weave): Remove reference to deleted type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ google_genai = ["google-genai>=1.0.0", "pillow>=11.1.0"]
 groq = ["groq>=0.13.0"]
 huggingface = ["huggingface-hub>=0.28.1"]
 smolagents = [
-  "openai>=1.0.0,<1.82.0",
+  "openai>=1.0.0",
   "litellm>=1.58",
   "smolagents>=1.8.1",
   "huggingface-hub>=0.28.1",
@@ -143,7 +143,7 @@ scorers = [
   "presidio-anonymizer>=2.2.0",
 ]
 notdiamond = ["notdiamond>=0.3.21", "litellm<=1.49.1"]
-openai = ["openai>=1.0.0,<1.82.0"]
+openai = ["openai>=1.0.0"]
 openai_agents = ["openai-agents>=0.0.4"]
 pandas-test = ["pandas>=2.2.3"]
 presidio = ["presidio-analyzer==2.2.357", "presidio-anonymizer==2.2.357"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ google_genai = ["google-genai>=1.0.0", "pillow>=11.1.0"]
 groq = ["groq>=0.13.0"]
 huggingface = ["huggingface-hub>=0.28.1"]
 smolagents = [
-  "openai>=1.0.0",
+  "openai>=1.0.0,<1.82.0",
   "litellm>=1.58",
   "smolagents>=1.8.1",
   "huggingface-hub>=0.28.1",
@@ -143,7 +143,7 @@ scorers = [
   "presidio-anonymizer>=2.2.0",
 ]
 notdiamond = ["notdiamond>=0.3.21", "litellm<=1.49.1"]
-openai = ["openai>=1.0.0"]
+openai = ["openai>=1.0.0,<1.82.0"]
 openai_agents = ["openai-agents>=0.0.4"]
 pandas-test = ["pandas>=2.2.3"]
 presidio = ["presidio-analyzer==2.2.357", "presidio-anonymizer==2.2.357"]

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -424,6 +424,7 @@ def responses_accumulator(acc: Response | None, value: ResponseStreamEvent) -> R
         ResponseOutputItemDoneEvent,
         ResponseRefusalDeltaEvent,
         ResponseRefusalDoneEvent,
+        ResponseTextAnnotationDeltaEvent,
         ResponseTextDeltaEvent,
         ResponseTextDoneEvent,
         ResponseWebSearchCallCompletedEvent,
@@ -488,6 +489,10 @@ def responses_accumulator(acc: Response | None, value: ResponseStreamEvent) -> R
         if not acc.output:
             acc.output = [""]
         acc.output[0] += value.delta
+
+    elif isinstance(value, ResponseTextAnnotationDeltaEvent):
+        # Not obvious how to handle this since there is no delta
+        ...
 
     # Everything else
     elif isinstance(

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -424,7 +424,6 @@ def responses_accumulator(acc: Response | None, value: ResponseStreamEvent) -> R
         ResponseOutputItemDoneEvent,
         ResponseRefusalDeltaEvent,
         ResponseRefusalDoneEvent,
-        ResponseTextAnnotationDeltaEvent,
         ResponseTextDeltaEvent,
         ResponseTextDoneEvent,
         ResponseWebSearchCallCompletedEvent,
@@ -485,14 +484,12 @@ def responses_accumulator(acc: Response | None, value: ResponseStreamEvent) -> R
             ResponseAudioTranscriptDeltaEvent,
         ),
     ):
+        # Note: Audio unrelated events are being sent as ResponseAudioDeltaEvent by some tool calls in 1.82.0
         # Not obvious how to handle these since there is no output_index
         if not acc.output:
             acc.output = [""]
-        acc.output[0] += value.delta
-
-    elif isinstance(value, ResponseTextAnnotationDeltaEvent):
-        # Not obvious how to handle this since there is no delta
-        ...
+        if value.delta is not None:
+            acc.output[0] += value.delta
 
     # Everything else
     elif isinstance(

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -424,7 +424,6 @@ def responses_accumulator(acc: Response | None, value: ResponseStreamEvent) -> R
         ResponseOutputItemDoneEvent,
         ResponseRefusalDeltaEvent,
         ResponseRefusalDoneEvent,
-        ResponseTextAnnotationDeltaEvent,
         ResponseTextDeltaEvent,
         ResponseTextDoneEvent,
         ResponseWebSearchCallCompletedEvent,
@@ -489,10 +488,6 @@ def responses_accumulator(acc: Response | None, value: ResponseStreamEvent) -> R
         if not acc.output:
             acc.output = [""]
         acc.output[0] += value.delta
-
-    elif isinstance(value, ResponseTextAnnotationDeltaEvent):
-        # Not obvious how to handle this since there is no delta
-        ...
 
     # Everything else
     elif isinstance(

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -491,9 +491,13 @@ def responses_accumulator(acc: Response | None, value: ResponseStreamEvent) -> R
         # Not obvious how to handle these since there is no output_index
         if not acc.output:
             acc.output = [""]
-        if value.delta is None:
-            logger.warn(f"Could not determine delta for value: {value}")
-        acc.output[0] += value.delta
+
+        if value.delta != None:
+            acc.output[0] += value.delta
+        else:
+            # Can't use value.delta is None because it should never be None and linter removes it
+            logger.warning(f"Could not determine delta for value: {value}")
+            return acc
 
     # Everything else
     elif isinstance(

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import logging
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -8,6 +9,8 @@ import weave
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import Op, ProcessedInputs, _add_accumulator
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from openai.types.chat import ChatCompletionChunk
@@ -488,8 +491,9 @@ def responses_accumulator(acc: Response | None, value: ResponseStreamEvent) -> R
         # Not obvious how to handle these since there is no output_index
         if not acc.output:
             acc.output = [""]
-        if value.delta is not None:
-            acc.output[0] += value.delta
+        if value.delta is None:
+            logger.warn(f"Could not determine delta for value: {value}")
+        acc.output[0] += value.delta
 
     # Everything else
     elif isinstance(


### PR DESCRIPTION
## Description

OpenAI's last release causes test failures for two reasons:
1. They removed `ResponseTextAnnotationDeltaEvent` from their types (unhandled so it's safe to just delete that block)
2. Their web search tool is sending invalid `ResponseAudioDeltaEvent` (has no delta field despite being required)

This PR removes the import and adds a warning message informing the user that we could not process the response.

