### PR TITLE
chore(ui): Eval compare design enhancements

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -42,7 +42,6 @@ type CellValueStringProps = {
 const Collapsed = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
   cursor: pointer;
 `;
 Collapsed.displayName = 'S.Collapsed';
@@ -87,7 +86,7 @@ Spacer.displayName = 'S.Spacer';
 const CellValueStringWithPopup = ({value, style}: CellValueStringProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const onClick = (event: React.MouseEvent<HTMLElement>) => {
+  const onClick = (_event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(anchorEl ? null : ref.current);
   };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -305,7 +305,7 @@ const ResultExplorer: React.FC<{
   height: number;
 }> = ({state, height}) => {
   const [viewMode, setViewMode] = useState<'detail' | 'table' | 'split'>(
-    'split'
+    'table'
   );
   const regressionFinderEnabled = state.evaluationCallIdsOrdered.length === 2;
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -61,8 +61,8 @@ export const CompareEvaluationsPage: React.FC<
     <SimplePageLayout
       title={
         props.evaluationCallIds.length === 1
-          ? 'Evaluation Results'
-          : 'Compare Evaluations'
+          ? 'Evaluation results'
+          : 'Compare evaluations'
       }
       hideTabsIfSingle
       tabs={[

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -8,7 +8,15 @@ import {Icon} from '@wandb/weave/components/Icon';
 import {WaveLoader} from '@wandb/weave/components/Loaders/WaveLoader';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
-import React, {FC, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
+import React, {
+  FC,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {useHistory} from 'react-router-dom';
 import {AutoSizer} from 'react-virtualized';
 
@@ -312,14 +320,19 @@ const ResultExplorer: React.FC<{
   const containerRef = useRef<HTMLDivElement>(null);
   const regressionFinderEnabled = state.evaluationCallIdsOrdered.length === 2;
 
-  const handleMouseMove = useCallback((e: MouseEvent) => {
-    if (isResizing && containerRef.current) {
-      e.preventDefault();
-      const containerRect = containerRef.current.getBoundingClientRect();
-      const newWidthPx = containerRect.right - e.clientX;
-      setSidebarWidth(Math.min(Math.max(newWidthPx, 200), containerRect.width - 160)); // Constrain between 200px and container width - 2
-    }
-  }, [isResizing]);
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (isResizing && containerRef.current) {
+        e.preventDefault();
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const newWidthPx = containerRect.right - e.clientX;
+        setSidebarWidth(
+          Math.min(Math.max(newWidthPx, 200), containerRect.width - 160)
+        ); // Constrain between 200px and container width - 2
+      }
+    },
+    [isResizing]
+  );
 
   const handleMouseUp = useCallback(() => {
     setIsResizing(false);
@@ -371,7 +384,9 @@ const ResultExplorer: React.FC<{
           }}>
           <ExampleCompareSectionTable
             state={state}
-            shouldHighlightSelectedRow={viewMode === 'split' || viewMode === 'detail'}
+            shouldHighlightSelectedRow={
+              viewMode === 'split' || viewMode === 'detail'
+            }
             onShowSplitView={() => setViewMode('split')}
           />
         </Box>
@@ -382,10 +397,14 @@ const ResultExplorer: React.FC<{
               position: 'absolute',
               top: 0,
               right: 0,
-              width: sidebarWidth !== null ? `${sidebarWidth}px` : 'calc(100% - 160px)',
+              width:
+                sidebarWidth !== null
+                  ? `${sidebarWidth}px`
+                  : 'calc(100% - 160px)',
               height: '100%',
               backgroundColor: 'white',
-              boxShadow: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+              boxShadow:
+                '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
               display: 'flex',
               flexDirection: 'row',
               zIndex: 1000,
@@ -403,12 +422,13 @@ const ResultExplorer: React.FC<{
                 zIndex: 1001,
               }}
               onMouseDown={handleMouseDown}
-              onMouseEnter={(e) => {
+              onMouseEnter={e => {
                 if (!isResizing) {
-                  e.currentTarget.style.backgroundColor = 'rgba(169, 237, 242, 0.5)';
+                  e.currentTarget.style.backgroundColor =
+                    'rgba(169, 237, 242, 0.5)';
                 }
               }}
-              onMouseLeave={(e) => {
+              onMouseLeave={e => {
                 if (!isResizing) {
                   e.currentTarget.style.backgroundColor = 'transparent';
                 }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -327,7 +327,7 @@ const ResultExplorer: React.FC<{
   const [isResizing, setIsResizing] = useState(false);
   const [wasAutoExpanded, setWasAutoExpanded] = useState(false); // Track if expansion was automatic
   const containerRef = useRef<HTMLDivElement>(null);
-  
+
   // Only enable regression finder if exactly 2 evaluations are visible
   const visibleEvaluationCount = state.evaluationCallIdsOrdered.filter(
     id => !hiddenEvaluationIds.has(id)

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -315,12 +315,14 @@ const ResultExplorer: React.FC<{
 }> = ({state, height}) => {
   const peekLocation = usePeekLocation();
   const isPeekDrawerOpen = peekLocation != null;
-  
+
   const [viewMode, setViewMode] = useState<'detail' | 'table' | 'split'>(
     'table'
   );
   const [sidebarWidth, setSidebarWidth] = useState<number | null>(null); // null means use default calc(100% - 160px)
-  const [previousSidebarWidth, setPreviousSidebarWidth] = useState<number | null>(null); // Store width before expanding
+  const [previousSidebarWidth, setPreviousSidebarWidth] = useState<
+    number | null
+  >(null); // Store width before expanding
   const [isResizing, setIsResizing] = useState(false);
   const [wasAutoExpanded, setWasAutoExpanded] = useState(false); // Track if expansion was automatic
   const containerRef = useRef<HTMLDivElement>(null);
@@ -339,7 +341,13 @@ const ResultExplorer: React.FC<{
       setSidebarWidth(previousSidebarWidth);
       setWasAutoExpanded(false);
     }
-  }, [isPeekDrawerOpen, viewMode, sidebarWidth, previousSidebarWidth, wasAutoExpanded]);
+  }, [
+    isPeekDrawerOpen,
+    viewMode,
+    sidebarWidth,
+    previousSidebarWidth,
+    wasAutoExpanded,
+  ]);
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -22,9 +22,9 @@ import {AutoSizer} from 'react-virtualized';
 
 import {Button} from '../../../../../Button';
 import {
+  usePeekLocation,
   useWeaveflowCurrentRouteContext,
   WeaveflowPeekContext,
-  usePeekLocation,
 } from '../../context';
 import {CustomWeaveTypeProjectContext} from '../../typeViews/CustomWeaveTypeDispatcher';
 import {SimplePageLayout, SimpleTabView} from '../common/SimplePageLayout';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -8,7 +8,7 @@ import {Icon} from '@wandb/weave/components/Icon';
 import {WaveLoader} from '@wandb/weave/components/Loaders/WaveLoader';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
-import React, {FC, useCallback, useContext, useMemo, useState} from 'react';
+import React, {FC, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {useHistory} from 'react-router-dom';
 import {AutoSizer} from 'react-virtualized';
 
@@ -307,14 +307,53 @@ const ResultExplorer: React.FC<{
   const [viewMode, setViewMode] = useState<'detail' | 'table' | 'split'>(
     'table'
   );
+  const [sidebarWidth, setSidebarWidth] = useState<number | null>(null); // null means use default calc(100% - 160px)
+  const [isResizing, setIsResizing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
   const regressionFinderEnabled = state.evaluationCallIdsOrdered.length === 2;
 
+  const handleMouseMove = useCallback((e: MouseEvent) => {
+    if (isResizing && containerRef.current) {
+      e.preventDefault();
+      const containerRect = containerRef.current.getBoundingClientRect();
+      const newWidthPx = containerRect.right - e.clientX;
+      setSidebarWidth(Math.min(Math.max(newWidthPx, 200), containerRect.width - 160)); // Constrain between 200px and container width - 2
+    }
+  }, [isResizing]);
+
+  const handleMouseUp = useCallback(() => {
+    setIsResizing(false);
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  }, []);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsResizing(true);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  useEffect(() => {
+    if (isResizing) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+    }
+    return undefined;
+  }, [isResizing, handleMouseMove, handleMouseUp]);
+
   return (
-    <VerticalBox
-      sx={{
+    <div
+      ref={containerRef}
+      style={{
         height: '100%',
         width: '100%',
         overflow: 'auto',
+        position: 'relative',
       }}>
       {regressionFinderEnabled && <ExampleFilterSection state={state} />}
       <Box
@@ -323,38 +362,72 @@ const ResultExplorer: React.FC<{
           flexDirection: 'row',
           height: height,
           borderTop: '1px solid #e0e0e0',
+          position: 'relative',
         }}>
         <Box
           style={{
             flex: 1,
-            width: '50%',
-            display: viewMode !== 'detail' ? 'block' : 'none',
+            width: '100%',
           }}>
           <ExampleCompareSectionTable
             state={state}
-            shouldHighlightSelectedRow={viewMode === 'split'}
+            shouldHighlightSelectedRow={viewMode === 'split' || viewMode === 'detail'}
             onShowSplitView={() => setViewMode('split')}
           />
         </Box>
 
-        <Box
-          style={{
-            flex: 1,
-            width: '50%',
-            borderLeft: '1px solid #e0e0e0',
-            display: viewMode !== 'table' ? 'block' : 'none',
-          }}>
-          <ExampleCompareSectionDetail
-            state={state}
-            onClose={() => setViewMode('table')}
-            onExpandToggle={() =>
-              setViewMode(viewMode === 'detail' ? 'split' : 'detail')
-            }
-            isExpanded={viewMode === 'detail'}
-          />
-        </Box>
+        {viewMode !== 'table' && (
+          <Box
+            style={{
+              position: 'absolute',
+              top: 0,
+              right: 0,
+              width: sidebarWidth !== null ? `${sidebarWidth}px` : 'calc(100% - 160px)',
+              height: '100%',
+              backgroundColor: 'white',
+              boxShadow: '0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+              display: 'flex',
+              flexDirection: 'row',
+              zIndex: 1000,
+            }}>
+            <div
+              style={{
+                position: 'absolute',
+                left: -3,
+                top: 0,
+                bottom: 0,
+                width: 5,
+                cursor: 'col-resize',
+                backgroundColor: isResizing ? '#13A9BA' : 'transparent',
+                transition: isResizing ? 'none' : 'background-color 0.2s',
+                zIndex: 1001,
+              }}
+              onMouseDown={handleMouseDown}
+              onMouseEnter={(e) => {
+                if (!isResizing) {
+                  e.currentTarget.style.backgroundColor = 'rgba(169, 237, 242, 0.5)';
+                }
+              }}
+              onMouseLeave={(e) => {
+                if (!isResizing) {
+                  e.currentTarget.style.backgroundColor = 'transparent';
+                }
+              }}
+            />
+            <Box style={{flex: 1, overflow: 'hidden'}}>
+              <ExampleCompareSectionDetail
+                state={state}
+                onClose={() => setViewMode('table')}
+                onExpandToggle={() =>
+                  setViewMode(viewMode === 'detail' ? 'split' : 'detail')
+                }
+                isExpanded={viewMode === 'detail'}
+              />
+            </Box>
+          </Box>
+        )}
       </Box>
-    </VerticalBox>
+    </div>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -313,6 +313,7 @@ const ResultExplorer: React.FC<{
   state: EvaluationComparisonState;
   height: number;
 }> = ({state, height}) => {
+  const {hiddenEvaluationIds} = useCompareEvaluationsState();
   const peekLocation = usePeekLocation();
   const isPeekDrawerOpen = peekLocation != null;
 
@@ -326,7 +327,12 @@ const ResultExplorer: React.FC<{
   const [isResizing, setIsResizing] = useState(false);
   const [wasAutoExpanded, setWasAutoExpanded] = useState(false); // Track if expansion was automatic
   const containerRef = useRef<HTMLDivElement>(null);
-  const regressionFinderEnabled = state.evaluationCallIdsOrdered.length === 2;
+  
+  // Only enable regression finder if exactly 2 evaluations are visible
+  const visibleEvaluationCount = state.evaluationCallIdsOrdered.filter(
+    id => !hiddenEvaluationIds.has(id)
+  ).length;
+  const regressionFinderEnabled = visibleEvaluationCount === 2;
 
   // When peek drawer opens and we're in split view, automatically expand to detail view
   // When peek drawer closes and we're in detail view, automatically collapse back to split view

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -409,7 +409,6 @@ const ResultExplorer: React.FC<{
           display: 'flex',
           flexDirection: 'row',
           height: height,
-          borderTop: '1px solid #e0e0e0',
           position: 'relative',
         }}>
         <Box

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -7,6 +7,7 @@ import {Alert} from '@mui/material';
 import {Icon} from '@wandb/weave/components/Icon';
 import {WaveLoader} from '@wandb/weave/components/Loaders/WaveLoader';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
+import {Pill} from '@wandb/weave/components/Tag';
 import {maybePluralizeWord} from '@wandb/weave/core/util/string';
 import React, {
   FC,
@@ -255,7 +256,14 @@ const CompareEvaluationsPageInner: React.FC<{}> = props => {
           },
           {
             value: 'results',
-            label: 'Results',
+            label: (
+              <>
+                Results
+                <Tailwind>
+                  <Pill label="New" color="purple" className="ml-2" />
+                </Tailwind>
+              </>
+            ) as any,
             loading: resultsLoading,
             content: (
               <VerticalBox

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -316,6 +316,7 @@ const ResultExplorer: React.FC<{
     'table'
   );
   const [sidebarWidth, setSidebarWidth] = useState<number | null>(null); // null means use default calc(100% - 160px)
+  const [previousSidebarWidth, setPreviousSidebarWidth] = useState<number | null>(null); // Store width before expanding
   const [isResizing, setIsResizing] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const regressionFinderEnabled = state.evaluationCallIdsOrdered.length === 2;
@@ -398,7 +399,9 @@ const ResultExplorer: React.FC<{
               top: 0,
               right: 0,
               width:
-                sidebarWidth !== null
+                viewMode === 'detail'
+                  ? '100%'
+                  : sidebarWidth !== null
                   ? `${sidebarWidth}px`
                   : 'calc(100% - 160px)',
               height: '100%',
@@ -409,38 +412,49 @@ const ResultExplorer: React.FC<{
               flexDirection: 'row',
               zIndex: 1000,
             }}>
-            <div
-              style={{
-                position: 'absolute',
-                left: -3,
-                top: 0,
-                bottom: 0,
-                width: 5,
-                cursor: 'col-resize',
-                backgroundColor: isResizing ? '#13A9BA' : 'transparent',
-                transition: isResizing ? 'none' : 'background-color 0.2s',
-                zIndex: 1001,
-              }}
-              onMouseDown={handleMouseDown}
-              onMouseEnter={e => {
-                if (!isResizing) {
-                  e.currentTarget.style.backgroundColor =
-                    'rgba(169, 237, 242, 0.5)';
-                }
-              }}
-              onMouseLeave={e => {
-                if (!isResizing) {
-                  e.currentTarget.style.backgroundColor = 'transparent';
-                }
-              }}
-            />
+            {viewMode !== 'detail' && (
+              <div
+                style={{
+                  position: 'absolute',
+                  left: -3,
+                  top: 0,
+                  bottom: 0,
+                  width: 5,
+                  cursor: 'col-resize',
+                  backgroundColor: isResizing ? '#13A9BA' : 'transparent',
+                  transition: isResizing ? 'none' : 'background-color 0.2s',
+                  zIndex: 1001,
+                }}
+                onMouseDown={handleMouseDown}
+                onMouseEnter={e => {
+                  if (!isResizing) {
+                    e.currentTarget.style.backgroundColor =
+                      'rgba(169, 237, 242, 0.5)';
+                  }
+                }}
+                onMouseLeave={e => {
+                  if (!isResizing) {
+                    e.currentTarget.style.backgroundColor = 'transparent';
+                  }
+                }}
+              />
+            )}
             <Box style={{flex: 1, overflow: 'hidden'}}>
               <ExampleCompareSectionDetail
                 state={state}
                 onClose={() => setViewMode('table')}
-                onExpandToggle={() =>
-                  setViewMode(viewMode === 'detail' ? 'split' : 'detail')
-                }
+                onExpandToggle={() => {
+                  if (viewMode === 'detail') {
+                    // Collapsing from detail mode back to split mode
+                    setViewMode('split');
+                    // Restore the previous width
+                    setSidebarWidth(previousSidebarWidth);
+                  } else {
+                    // Expanding to detail mode
+                    setPreviousSidebarWidth(sidebarWidth);
+                    setViewMode('detail');
+                  }
+                }}
                 isExpanded={viewMode === 'detail'}
               />
             </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -232,18 +232,16 @@ const CompareEvaluationsPageInner: React.FC<{}> = props => {
                 <ScorecardSection state={state} />
                 <Tailwind style={{width: '100%'}}>
                   <div className="px-16">
-                    <div className="flex w-full flex-col items-center gap-3 rounded-lg border border-dashed border-moon-300 bg-moon-50 p-16">
+                    <div className="flex w-full flex items-center gap-3 rounded-lg bg-moon-100 px-16 py-8">
                       <Icon name="table" size="large" color="moon-500 mb-4" />
-                      <div className="mb-4 flex flex-col items-center">
-                        <p className="text-center font-semibold">
-                          Looking for your evaluation results?
-                        </p>
-                        <p className="text-center text-moon-500">
-                          You can find it in our new results tab.
-                        </p>
-                      </div>
+                      <p className="text-[14px] ml-[8px] font-semibold">
+                        Looking for your evaluation results?
+                      </p>
+                      <p className="text-[14px] ml-[8px] mr-auto text-moon-500">
+                        You can find it in our new results tab.
+                      </p>
                       <Button
-                        variant="secondary"
+                        variant="ghost"
                         onClick={() => setTabValue('results')}>
                         Review evaluation results
                       </Button>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/compareEvaluationsContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/compareEvaluationsContext.tsx
@@ -70,7 +70,7 @@ export const CompareEvaluationsProvider: React.FC<{
   const [hiddenEvaluationIds, setHiddenEvaluationIds] = useState<Set<string>>(
     new Set()
   );
-  
+
   useEffect(() => {
     setEvaluationCallIds(initialEvaluationCallIdsMemo);
   }, [initialEvaluationCallIdsMemo]);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/compareEvaluationsContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/compareEvaluationsContext.tsx
@@ -18,6 +18,8 @@ export type CompareEvaluationContext = {
   addEvaluationCall: (newCallId: string) => void;
   removeEvaluationCall: (callId: string) => void;
   setEvaluationCallOrder: (newCallIdOrder: string[]) => void;
+  hiddenEvaluationIds: Set<string>;
+  toggleHideEvaluation: (callId: string) => void;
 
   getCachedRowData: (digest: string) => any;
   setCachedRowData: (digest: string, data: any) => void;
@@ -65,6 +67,10 @@ export const CompareEvaluationsProvider: React.FC<{
   const [evaluationCallIds, setEvaluationCallIds] = useState(
     initialEvaluationCallIdsMemo
   );
+  const [hiddenEvaluationIds, setHiddenEvaluationIds] = useState<Set<string>>(
+    new Set()
+  );
+  
   useEffect(() => {
     setEvaluationCallIds(initialEvaluationCallIdsMemo);
   }, [initialEvaluationCallIdsMemo]);
@@ -96,6 +102,17 @@ export const CompareEvaluationsProvider: React.FC<{
         ]?.rawDataRow
       );
     };
+    const toggleHideEvaluation = (callId: string) => {
+      setHiddenEvaluationIds(prev => {
+        const next = new Set(prev);
+        if (next.has(callId)) {
+          next.delete(callId);
+        } else {
+          next.add(callId);
+        }
+        return next;
+      });
+    };
     return {
       state: initialState.result,
       setComparisonDimensions,
@@ -117,6 +134,8 @@ export const CompareEvaluationsProvider: React.FC<{
         setEvaluationCallIds(newCallIdOrder);
         onEvaluationCallIdsUpdate(newCallIdOrder);
       },
+      hiddenEvaluationIds,
+      toggleHideEvaluation,
       getCachedRowData,
       setCachedRowData,
     };
@@ -127,6 +146,7 @@ export const CompareEvaluationsProvider: React.FC<{
     setSelectedInputDigest,
     setSelectedMetrics,
     evaluationCallIds,
+    hiddenEvaluationIds,
     onEvaluationCallIdsUpdate,
   ]);
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/ComparisonDefinitionSection.tsx
@@ -162,7 +162,7 @@ const AddEvaluationButton: React.FC<{
   const refBar = useRef<HTMLDivElement>(null);
   const refLabel = useRef<HTMLDivElement>(null);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const onClick = (event: React.MouseEvent<HTMLElement>) => {
+  const onClick = () => {
     setAnchorEl(anchorEl ? null : refBar.current);
   };
   const open = Boolean(anchorEl);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/EvaluationDefinition.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/EvaluationDefinition.tsx
@@ -3,12 +3,10 @@ import React, {useMemo} from 'react';
 
 import {
   MOON_300,
-  MOON_600,
   MOON_800,
 } from '../../../../../../../../common/css/color.styles';
-import {hexToRGB} from '../../../../../../../../common/css/utils';
 import {parseRef, WeaveObjectRef} from '../../../../../../../../react';
-import {Icon, IconNames} from '../../../../../../../Icon';
+import {Icon} from '../../../../../../../Icon';
 import {SmallRef} from '../../../../smallRef/SmallRef';
 import {objectRefDisplayName} from '../../../../smallRef/SmallWeaveRef';
 import {CallLink, ObjectVersionLink} from '../../../common/Links';
@@ -116,26 +114,6 @@ export const EvaluationDatasetLink: React.FC<{
     return null;
   }
   return <SmallRef objRef={parsed} />;
-};
-
-const ModelIcon: React.FC<{color?: string}> = ({color}) => {
-  return (
-    <Box
-      mr="4px"
-      bgcolor={hexToRGB(MOON_300, 0.48)}
-      sx={{
-        height: '22px',
-        width: '22px',
-        borderRadius: '16px',
-        display: 'flex',
-        flex: '0 0 22px',
-        justifyContent: 'center',
-        alignItems: 'center',
-        color: color ?? MOON_600,
-      }}>
-      <Icon name={IconNames.Model} width={14} height={14} />
-    </Box>
-  );
 };
 
 export const VerticalBar: React.FC = () => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/EvaluationDefinition.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ComparisonDefinitionSection/EvaluationDefinition.tsx
@@ -84,7 +84,7 @@ export const EvaluationModelLink: React.FC<{
           textDecoration: 'line-through',
         }}>
         <Box display="flex" alignItems="center">
-          <ModelIcon />
+          <Icon name="filled-circle" color={evaluationCall.color} />
           {objectRefDisplayName(objRef).label}
         </Box>
       </Box>
@@ -99,7 +99,7 @@ export const EvaluationModelLink: React.FC<{
       version={objRef.artifactVersion}
       versionIndex={objectVersion.result?.versionIndex ?? 0}
       color={MOON_800}
-      icon={<ModelIcon color={evaluationCall.color} />}
+      icon={<Icon name="filled-circle" color={evaluationCall.color} />}
     />
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/DraggableSection/DraggableItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/DraggableSection/DraggableItem.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 import React, {useState} from 'react';
 import {SortableElement, SortableHandle} from 'react-sortable-hoc';
 
+import {useCompareEvaluationsState} from '../../compareEvaluationsContext';
 import {EvaluationComparisonState} from '../../ecpState';
 import {EvaluationCallLink} from '../ComparisonDefinitionSection/EvaluationDefinition';
 
@@ -34,8 +35,10 @@ export const DraggableItem = SortableElement(
     onRemoveItem,
     onSetBaseline,
   }: DraggableItemProps) => {
+    const {hiddenEvaluationIds, toggleHideEvaluation} = useCompareEvaluationsState();
     const isDeletable = numItems > 1;
     const isBaseline = idx === 0;
+    const isHidden = hiddenEvaluationIds.has(item.value);
     const [isOpen, setIsOpen] = useState(false);
 
     const onMakeBaselinePropagated = (e: React.MouseEvent) => {
@@ -48,17 +51,26 @@ export const DraggableItem = SortableElement(
       onRemoveItem(item.value);
     };
 
+    const onToggleHidePropagated = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      toggleHideEvaluation(item.value);
+    };
+
     return (
       <Tailwind>
         <div
           className={classNames(
-            'flex select-none items-center gap-4 whitespace-nowrap rounded-[4px] border-[1px] border-moon-250 bg-white px-4 py-8 text-sm font-semibold hover:border-moon-350 hover:bg-moon-100'
+            'flex select-none items-center gap-4 whitespace-nowrap rounded-[4px] border-[1px] border-moon-250 bg-white px-4 py-8 text-sm font-semibold hover:border-moon-350 hover:bg-moon-100',
+            isHidden && 'opacity-50'
           )}>
           <DragHandle />
           <div className="flex items-center">
             <EvaluationCallLink callId={item.value} state={state} />
             {isBaseline && (
               <Pill color="teal" label="Baseline" className="ml-8" />
+            )}
+            {isHidden && (
+              <Pill color="moon" label="Hidden" className="ml-8" />
             )}
           </div>
           <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
@@ -77,6 +89,10 @@ export const DraggableItem = SortableElement(
                   disabled={isBaseline}>
                   <Icon name="baseline-alt" />
                   Make baseline
+                </DropdownMenu.Item>
+                <DropdownMenu.Item onClick={onToggleHidePropagated}>
+                  <Icon name={isHidden ? "show-visible" : "hide-hidden"} />
+                  {isHidden ? "Unhide evaluation" : "Hide evaluation"}
                 </DropdownMenu.Item>
                 {isDeletable && (
                   <>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/DraggableSection/DraggableItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/DraggableSection/DraggableItem.tsx
@@ -36,7 +36,8 @@ export const DraggableItem = SortableElement(
     onRemoveItem,
     onSetBaseline,
   }: DraggableItemProps) => {
-    const {hiddenEvaluationIds, toggleHideEvaluation} = useCompareEvaluationsState();
+    const {hiddenEvaluationIds, toggleHideEvaluation} =
+      useCompareEvaluationsState();
     const isDeletable = numItems > 1;
     const isBaseline = idx === 0;
     const isHidden = hiddenEvaluationIds.has(item.value);
@@ -71,7 +72,7 @@ export const DraggableItem = SortableElement(
               <Pill color="teal" label="Baseline" className="ml-8" />
             )}
             {isHidden && (
-              <Tooltip 
+              <Tooltip
                 content="This evaluation is hidden"
                 trigger={
                   <Icon name="hide-hidden" className="ml-8 text-moon-500" />
@@ -97,8 +98,8 @@ export const DraggableItem = SortableElement(
                   Make baseline
                 </DropdownMenu.Item>
                 <DropdownMenu.Item onClick={onToggleHidePropagated}>
-                  <Icon name={isHidden ? "show-visible" : "hide-hidden"} />
-                  {isHidden ? "Unhide evaluation" : "Hide evaluation"}
+                  <Icon name={isHidden ? 'show-visible' : 'hide-hidden'} />
+                  {isHidden ? 'Unhide evaluation' : 'Hide evaluation'}
                 </DropdownMenu.Item>
                 {isDeletable && (
                   <>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/DraggableSection/DraggableItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/DraggableSection/DraggableItem.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenu from '@wandb/weave/components/DropdownMenu';
 import {Icon} from '@wandb/weave/components/Icon';
 import {Pill} from '@wandb/weave/components/Tag/Pill';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
 import classNames from 'classnames';
 import React, {useState} from 'react';
 import {SortableElement, SortableHandle} from 'react-sortable-hoc';
@@ -70,7 +71,12 @@ export const DraggableItem = SortableElement(
               <Pill color="teal" label="Baseline" className="ml-8" />
             )}
             {isHidden && (
-              <Pill color="moon" label="Hidden" className="ml-8" />
+              <Tooltip 
+                content="This evaluation is hidden"
+                trigger={
+                  <Icon name="hide-hidden" className="ml-8 text-moon-500" />
+                }
+              />
             )}
           </div>
           <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ColumnsManagementPanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ColumnsManagementPanel.tsx
@@ -81,9 +81,7 @@ const ColumnGroup: FC<{
           checked={isGroupIndeterminate ? 'indeterminate' : isGroupChecked}
           onCheckedChange={toggleColumnGroup}
         />
-        <label
-          htmlFor={idCheckboxGroup}
-          className="ml-4 cursor-pointer">
+        <label htmlFor={idCheckboxGroup} className="ml-4 cursor-pointer">
           {group.headerName ?? group.groupId}
         </label>
       </div>
@@ -94,7 +92,7 @@ const ColumnGroup: FC<{
               const idCheckbox = `toggle-vis_${child.field}`;
               const checked = columnVisibilityModel[child.field] !== false;
               const label = columnLookup[child.field].headerName ?? child.field;
-              
+
               return (
                 <div key={child.field} className="flex items-center py-2">
                   <Checkbox
@@ -103,9 +101,7 @@ const ColumnGroup: FC<{
                     checked={checked}
                     onCheckedChange={() => toggleColumn(child.field, !checked)}
                   />
-                  <label
-                    htmlFor={idCheckbox}
-                    className="ml-4 cursor-pointer">
+                  <label htmlFor={idCheckbox} className="ml-4 cursor-pointer">
                     {label}
                   </label>
                 </div>
@@ -148,8 +144,10 @@ export const ColumnsManagementPanel: FC<GridColumnsPanelProps> = props => {
 
   return (
     <Tailwind>
-      <div className="min-w-[360px] p-12" style={{fontFamily: 'Source Sans Pro', fontSize: '14px'}}>
-        <div className="font-semibold mb-4">Manage columns</div>
+      <div
+        className="min-w-[360px] p-12"
+        style={{fontFamily: 'Source Sans Pro', fontSize: '14px'}}>
+        <div className="mb-4 font-semibold">Manage columns</div>
         <div>
           {columnGroupingModel.map(group => (
             <ColumnGroup

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ColumnsManagementPanel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ColumnsManagementPanel.tsx
@@ -1,4 +1,3 @@
-import {Box, Checkbox, FormControlLabel, Stack} from '@mui/material';
 import {
   GridApi,
   GridColumnGroup,
@@ -13,6 +12,8 @@ import {
   useGridRootProps,
   useGridSelector,
 } from '@mui/x-data-grid-pro';
+import {Checkbox} from '@wandb/weave/components/Checkbox';
+import {Tailwind} from '@wandb/weave/components/Tailwind';
 import React, {FC, useMemo} from 'react';
 
 const getColumnGroupLeaves = (
@@ -69,50 +70,59 @@ const ColumnGroup: FC<{
     return !!(group as any)[CUSTOM_GROUP_KEY_TO_CONTROL_CHILDREN_VISIBILITY];
   }, [group]);
 
+  const idCheckboxGroup = `toggle-group-vis_${group.groupId}`;
+
   return (
-    <div>
-      <FormControlLabel
-        control={
-          <Checkbox
-            checked={isGroupChecked}
-            indeterminate={isGroupIndeterminate}
-            size="small"
-            sx={{p: 1}}
-          />
-        }
-        label={group.headerName ?? group.groupId}
-        onChange={(_, newValue) => toggleColumnGroup(newValue)}
-      />
+    <div className="mb-2">
+      <div className="flex items-center py-2">
+        <Checkbox
+          id={idCheckboxGroup}
+          size="small"
+          checked={isGroupIndeterminate ? 'indeterminate' : isGroupChecked}
+          onCheckedChange={toggleColumnGroup}
+        />
+        <label
+          htmlFor={idCheckboxGroup}
+          className="ml-4 cursor-pointer">
+          {group.headerName ?? group.groupId}
+        </label>
+      </div>
       {!groupControlsChildrenVisibility && (
-        <Box sx={{pl: 3.5}}>
+        <div className="ml-18">
           {group.children.map(child => {
-            return isLeaf(child) ? (
-              <Stack direction="row" key={child.field}>
-                <FormControlLabel
-                  control={
-                    <Checkbox
-                      checked={columnVisibilityModel[child.field] !== false}
-                      size="small"
-                      sx={{p: 1}}
-                    />
-                  }
-                  label={columnLookup[child.field].headerName ?? child.field}
-                  onChange={(_, newValue) =>
-                    toggleColumn(child.field, newValue)
-                  }
+            if (isLeaf(child)) {
+              const idCheckbox = `toggle-vis_${child.field}`;
+              const checked = columnVisibilityModel[child.field] !== false;
+              const label = columnLookup[child.field].headerName ?? child.field;
+              
+              return (
+                <div key={child.field} className="flex items-center py-2">
+                  <Checkbox
+                    id={idCheckbox}
+                    size="small"
+                    checked={checked}
+                    onCheckedChange={() => toggleColumn(child.field, !checked)}
+                  />
+                  <label
+                    htmlFor={idCheckbox}
+                    className="ml-4 cursor-pointer">
+                    {label}
+                  </label>
+                </div>
+              );
+            } else {
+              return (
+                <ColumnGroup
+                  group={child}
+                  columnLookup={columnLookup}
+                  key={child.groupId}
+                  apiRef={apiRef}
+                  columnVisibilityModel={columnVisibilityModel}
                 />
-              </Stack>
-            ) : (
-              <ColumnGroup
-                group={child}
-                columnLookup={columnLookup}
-                key={child.groupId}
-                apiRef={apiRef}
-                columnVisibilityModel={columnVisibilityModel}
-              />
-            );
+              );
+            }
           })}
-        </Box>
+        </div>
       )}
     </div>
   );
@@ -137,16 +147,21 @@ export const ColumnsManagementPanel: FC<GridColumnsPanelProps> = props => {
   }
 
   return (
-    <Box sx={{px: 2, py: 0.5}}>
-      {columnGroupingModel.map(group => (
-        <ColumnGroup
-          group={group}
-          columnLookup={columnLookup}
-          columnVisibilityModel={columnVisibilityModel}
-          key={group.groupId}
-          apiRef={apiRef}
-        />
-      ))}
-    </Box>
+    <Tailwind>
+      <div className="min-w-[360px] p-12" style={{fontFamily: 'Source Sans Pro', fontSize: '14px'}}>
+        <div className="font-semibold mb-4">Manage columns</div>
+        <div>
+          {columnGroupingModel.map(group => (
+            <ColumnGroup
+              group={group}
+              columnLookup={columnLookup}
+              columnVisibilityModel={columnVisibilityModel}
+              key={group.groupId}
+              apiRef={apiRef}
+            />
+          ))}
+        </div>
+      </div>
+    </Tailwind>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -674,7 +674,9 @@ export const ExampleCompareSectionDetail: React.FC<{
             <IconButton
               // disabled={targetIndex === 0}
               onClick={() => {
-                setSelectedInputDigest(filteredRows[targetIndex - 1].inputDigest);
+                setSelectedInputDigest(
+                  filteredRows[targetIndex - 1].inputDigest
+                );
               }}>
               <Icon name="chevron-up" />
             </IconButton>
@@ -686,7 +688,9 @@ export const ExampleCompareSectionDetail: React.FC<{
             <IconButton
               // disabled={targetIndex === filteredRows.length - 1}
               onClick={() => {
-                setSelectedInputDigest(filteredRows[targetIndex + 1].inputDigest);
+                setSelectedInputDigest(
+                  filteredRows[targetIndex + 1].inputDigest
+                );
               }}>
               <Icon name="chevron-down" />
             </IconButton>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -658,6 +658,7 @@ export const ExampleCompareSectionDetail: React.FC<{
         alignItems: 'center',
         bgcolor: MOON_50,
         padding: '16px',
+        borderLeft: '1px solid #e0e0e0',
         height: HEADER_HIEGHT_PX,
       }}>
       <HorizontalBox

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -700,17 +700,30 @@ export const ExampleCompareSectionDetail: React.FC<{
       </HorizontalBox>
 
       <HorizontalBox>
-        <Tooltip title={props.isExpanded ? (props.isPeekDrawerOpen ? "Cannot collapse while peek drawer is open" : "Collapse") : "Full Screen"}>
+        <Tooltip
+          title={
+            props.isExpanded
+              ? props.isPeekDrawerOpen
+                ? 'Cannot collapse while peek drawer is open'
+                : 'Collapse'
+              : 'Full Screen'
+          }>
           <IconButton
             style={{
-              ...(props.isExpanded && props.isPeekDrawerOpen ? { opacity: 0.5, cursor: 'not-allowed' } : {})
+              ...(props.isExpanded && props.isPeekDrawerOpen
+                ? {opacity: 0.5, cursor: 'not-allowed'}
+                : {}),
             }}
             onClick={() => {
               if (!(props.isExpanded && props.isPeekDrawerOpen)) {
                 props.onExpandToggle();
               }
             }}>
-            <Icon name={props.isExpanded ? "minimize-mode" : "full-screen-mode-expand"} />
+            <Icon
+              name={
+                props.isExpanded ? 'minimize-mode' : 'full-screen-mode-expand'
+              }
+            />
           </IconButton>
         </Tooltip>
         <Tooltip title="Close">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -209,6 +209,7 @@ export const ExampleCompareSectionDetail: React.FC<{
   onClose: () => void;
   onExpandToggle: () => void;
   isExpanded: boolean;
+  isPeekDrawerOpen?: boolean;
 }> = props => {
   const ctx = useCompareEvaluationsState();
   // Prefer the method below (since `state` diverging from the
@@ -699,10 +700,15 @@ export const ExampleCompareSectionDetail: React.FC<{
       </HorizontalBox>
 
       <HorizontalBox>
-        <Tooltip title={props.isExpanded ? "Collapse" : "Full Screen"}>
+        <Tooltip title={props.isExpanded ? (props.isPeekDrawerOpen ? "Cannot collapse while peek drawer is open" : "Collapse") : "Full Screen"}>
           <IconButton
+            style={{
+              ...(props.isExpanded && props.isPeekDrawerOpen ? { opacity: 0.5, cursor: 'not-allowed' } : {})
+            }}
             onClick={() => {
-              props.onExpandToggle();
+              if (!(props.isExpanded && props.isPeekDrawerOpen)) {
+                props.onExpandToggle();
+              }
             }}>
             <Icon name={props.isExpanded ? "minimize-mode" : "full-screen-mode-expand"} />
           </IconButton>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -717,8 +717,7 @@ export const ExampleCompareSectionDetail: React.FC<{
       <HorizontalBox
         sx={{
           gridGap: '8px',
-        }}
-      >
+        }}>
         <Tooltip
           content={
             props.isExpanded

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -1,7 +1,8 @@
-import {Box, Tooltip} from '@material-ui/core';
+import {Box} from '@material-ui/core';
 import {WarningAmberOutlined} from '@mui/icons-material';
 import {IconButton} from '@wandb/weave/components/IconButton';
 import {LoadingDots} from '@wandb/weave/components/LoadingDots';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 import styled from 'styled-components';
@@ -619,13 +620,13 @@ export const ExampleCompareSectionDetail: React.FC<{
     } else {
       inner = (
         <Tooltip
-          title={
+          content={
             SCORER_VARIATION_WARNING_TITLE +
             ': ' +
             SCORER_VARIATION_WARNING_EXPLANATION
-          }>
-          <WarningAmberOutlined color="warning" />
-        </Tooltip>
+          }
+          trigger={<WarningAmberOutlined color="warning" />}
+        />
       );
     }
 
@@ -667,24 +668,30 @@ export const ExampleCompareSectionDetail: React.FC<{
           alignItems: 'center',
           flex: 1,
         }}>
-        <Tooltip title="Previous Example">
-          <IconButton
-            // disabled={targetIndex === 0}
-            onClick={() => {
-              setSelectedInputDigest(filteredRows[targetIndex - 1].inputDigest);
-            }}>
-            <Icon name="chevron-up" />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Next Example">
-          <IconButton
-            // disabled={targetIndex === filteredRows.length - 1}
-            onClick={() => {
-              setSelectedInputDigest(filteredRows[targetIndex + 1].inputDigest);
-            }}>
-            <Icon name="chevron-down" />
-          </IconButton>
-        </Tooltip>
+        <Tooltip
+          content="Previous Example"
+          trigger={
+            <IconButton
+              // disabled={targetIndex === 0}
+              onClick={() => {
+                setSelectedInputDigest(filteredRows[targetIndex - 1].inputDigest);
+              }}>
+              <Icon name="chevron-up" />
+            </IconButton>
+          }
+        />
+        <Tooltip
+          content="Next Example"
+          trigger={
+            <IconButton
+              // disabled={targetIndex === filteredRows.length - 1}
+              onClick={() => {
+                setSelectedInputDigest(filteredRows[targetIndex + 1].inputDigest);
+              }}>
+              <Icon name="chevron-down" />
+            </IconButton>
+          }
+        />
         <Box
           style={{
             flex: 0,
@@ -701,39 +708,44 @@ export const ExampleCompareSectionDetail: React.FC<{
 
       <HorizontalBox>
         <Tooltip
-          title={
+          content={
             props.isExpanded
               ? props.isPeekDrawerOpen
                 ? 'Cannot collapse while peek drawer is open'
                 : 'Collapse'
               : 'Full Screen'
-          }>
-          <IconButton
-            style={{
-              ...(props.isExpanded && props.isPeekDrawerOpen
-                ? {opacity: 0.5, cursor: 'not-allowed'}
-                : {}),
-            }}
-            onClick={() => {
-              if (!(props.isExpanded && props.isPeekDrawerOpen)) {
-                props.onExpandToggle();
-              }
-            }}>
-            <Icon
-              name={
-                props.isExpanded ? 'minimize-mode' : 'full-screen-mode-expand'
-              }
-            />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Close">
-          <IconButton
-            onClick={() => {
-              props.onClose();
-            }}>
-            <Icon name={'close'} />
-          </IconButton>
-        </Tooltip>
+          }
+          trigger={
+            <IconButton
+              style={{
+                ...(props.isExpanded && props.isPeekDrawerOpen
+                  ? {opacity: 0.5, cursor: 'not-allowed'}
+                  : {}),
+              }}
+              onClick={() => {
+                if (!(props.isExpanded && props.isPeekDrawerOpen)) {
+                  props.onExpandToggle();
+                }
+              }}>
+              <Icon
+                name={
+                  props.isExpanded ? 'minimize-mode' : 'full-screen-mode-expand'
+                }
+              />
+            </IconButton>
+          }
+        />
+        <Tooltip
+          content="Close"
+          trigger={
+            <IconButton
+              onClick={() => {
+                props.onClose();
+              }}>
+              <Icon name={'close'} />
+            </IconButton>
+          }
+        />
       </HorizontalBox>
     </HorizontalBox>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -662,11 +662,13 @@ export const ExampleCompareSectionDetail: React.FC<{
         padding: '16px',
         borderLeft: '1px solid #e0e0e0',
         height: HEADER_HIEGHT_PX,
+        gridGap: '8px',
       }}>
       <HorizontalBox
         sx={{
           alignItems: 'center',
           flex: 1,
+          gridGap: '8px',
         }}>
         <Tooltip
           content="Previous Example"
@@ -712,7 +714,11 @@ export const ExampleCompareSectionDetail: React.FC<{
         </Box>
       </HorizontalBox>
 
-      <HorizontalBox>
+      <HorizontalBox
+        sx={{
+          gridGap: '8px',
+        }}
+      >
         <Tooltip
           content={
             props.isExpanded

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -8,7 +8,7 @@ import React, {useCallback, useEffect, useMemo, useRef} from 'react';
 import styled from 'styled-components';
 
 import {
-  MOON_50,
+  MOON_100,
   MOON_200,
   MOON_300,
   MOON_800,
@@ -133,7 +133,7 @@ const stickyHeaderStyleMixin: React.CSSProperties = {
   position: 'sticky',
   top: 0,
   zIndex: 1,
-  backgroundColor: MOON_50,
+  backgroundColor: MOON_100,
   fontWeight: 'bold',
 };
 
@@ -141,7 +141,7 @@ const stickySidebarStyleMixin: React.CSSProperties = {
   position: 'sticky',
   left: 0,
   zIndex: 1,
-  backgroundColor: MOON_50,
+  backgroundColor: MOON_100,
   fontWeight: 'bold',
 };
 
@@ -658,7 +658,7 @@ export const ExampleCompareSectionDetail: React.FC<{
       sx={{
         justifyContent: 'space-between',
         alignItems: 'center',
-        bgcolor: MOON_50,
+        bgcolor: MOON_100,
         padding: '16px',
         borderLeft: '1px solid #e0e0e0',
         height: HEADER_HIEGHT_PX,
@@ -974,7 +974,7 @@ export const ExampleCompareSectionDetail: React.FC<{
                       <GridCell
                         key={metricIndex}
                         style={{
-                          backgroundColor: MOON_50,
+                          backgroundColor: MOON_100,
                         }}>
                         {scorerMetricKeyComp(scorerIndex, metricIndex)}
                       </GridCell>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -699,12 +699,12 @@ export const ExampleCompareSectionDetail: React.FC<{
       </HorizontalBox>
 
       <HorizontalBox>
-        <Tooltip title={props.isExpanded ? 'Collapse' : 'Expand'}>
+        <Tooltip title={props.isExpanded ? "Collapse" : "Full Screen"}>
           <IconButton
             onClick={() => {
               props.onExpandToggle();
             }}>
-            <Icon name={props.isExpanded ? 'expand-right' : 'contract-left'} />
+            <Icon name={props.isExpanded ? "minimize-mode" : "full-screen-mode-expand"} />
           </IconButton>
         </Tooltip>
         <Tooltip title="Close">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionDetail.tsx
@@ -705,6 +705,8 @@ export const ExampleCompareSectionDetail: React.FC<{
         <Box
           style={{
             flex: 1,
+            fontSize: '16px',
+            fontWeight: '600',
           }}>
           {`Example ${targetIndex + 1} of ${filteredRows.length}`}
         </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -326,6 +326,7 @@ export const ExampleCompareSectionTable: React.FC<
     });
     setLineClamp(v => Math.min(v + 1, 8));
   }, []);
+
   const decreaseRowHeight = useCallback(() => {
     setRowHeight(v => {
       const newHeight = Math.max(v - 17, 32); // Min 1 line
@@ -733,12 +734,16 @@ const expansionField = (
   renderHeader: (params: GridColumnHeaderParams<RowData>) => {
     return (
       <Tooltip
-        content={defaultExpandState === 'expanded' ? 'Hide trials' : 'Show trials'}
+        content={
+          defaultExpandState === 'expanded' ? 'Hide trials' : 'Show trials'
+        }
         trigger={
           <IconButton onClick={toggleDefaultExpansionState}>
             <Icon
               name={
-                defaultExpandState === 'expanded' ? 'collapse' : 'expand-uncollapse'
+                defaultExpandState === 'expanded'
+                  ? 'collapse'
+                  : 'expand-uncollapse'
               }
             />
           </IconButton>
@@ -926,17 +931,21 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
           if (params.row._pivot === 'modelsAsColumns') {
             return null;
           }
-          
+
           // For trial rows, we have direct access to predictAndScore
-          if (params.row._type === 'trial' && params.row._pivot === 'modelsAsRows') {
-            const trialPredict = params.row.predictAndScore._rawPredictTraceData;
+          if (
+            params.row._type === 'trial' &&
+            params.row._pivot === 'modelsAsRows'
+          ) {
+            const trialPredict =
+              params.row.predictAndScore._rawPredictTraceData;
             const [trialEntity, trialProject] =
               trialPredict?.project_id.split('/') ?? [];
             const trialOpName = parseRefMaybe(
               trialPredict?.op_name ?? ''
             )?.artifactName;
             const trialCallId = params.row.predictAndScore.callId;
-            
+
             if (trialEntity && trialProject && trialOpName && trialCallId) {
               return (
                 <Box
@@ -957,7 +966,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
               );
             }
           }
-          
+
           // For summary rows, we need to get the first trial from filteredRows
           if (params.row._type === 'summary') {
             // Find the corresponding filtered row
@@ -966,26 +975,28 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
             );
             if (correspondingFilteredRow) {
               // For modelsAsRows, we can use evaluationCallId directly
-              const evalCallId = (params.row as RowData)._pivot === 'modelsAsRows' 
-                ? (params.row as ModelAsRowsRowData).evaluationCallId 
-                : (params.row as RowData)._pivot === 'modelsAsColumns' 
+              const evalCallId =
+                (params.row as RowData)._pivot === 'modelsAsRows'
+                  ? (params.row as ModelAsRowsRowData).evaluationCallId
+                  : (params.row as RowData)._pivot === 'modelsAsColumns'
                   ? props.state.evaluationCallIdsOrdered[0] // Use first evaluation for modelsAsColumns
                   : null;
-              
+
               if (!evalCallId) return null;
-              
+
               const firstTrial = correspondingFilteredRow.originalRows.find(
                 row => row.evaluationCallId === evalCallId
               );
               if (firstTrial) {
-                const trialPredict = firstTrial.predictAndScore._rawPredictTraceData;
+                const trialPredict =
+                  firstTrial.predictAndScore._rawPredictTraceData;
                 const [trialEntity, trialProject] =
                   trialPredict?.project_id.split('/') ?? [];
                 const trialOpName = parseRefMaybe(
                   trialPredict?.op_name ?? ''
                 )?.artifactName;
                 const trialCallId = firstTrial.predictAndScore.callId;
-                
+
                 if (trialEntity && trialProject && trialOpName && trialCallId) {
                   return (
                     <Box
@@ -1008,7 +1019,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
               }
             }
           }
-          
+
           return null;
         },
       },
@@ -1300,14 +1311,15 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
             fr => fr.inputDigest === params.row.inputDigest
           );
           if (correspondingFilteredRow) {
-            const trial = params.row._type === 'trial'
-              ? correspondingFilteredRow.originalRows.filter(
-                  row => row.evaluationCallId === evaluationCallId
-                )[params.row._trialNdx]
-              : correspondingFilteredRow.originalRows.find(
-                  row => row.evaluationCallId === evaluationCallId
-                );
-                
+            const trial =
+              params.row._type === 'trial'
+                ? correspondingFilteredRow.originalRows.filter(
+                    row => row.evaluationCallId === evaluationCallId
+                  )[params.row._trialNdx]
+                : correspondingFilteredRow.originalRows.find(
+                    row => row.evaluationCallId === evaluationCallId
+                  );
+
             if (trial) {
               const trialPredict = trial.predictAndScore._rawPredictTraceData;
               const [trialEntity, trialProject] =
@@ -1316,7 +1328,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
                 trialPredict?.op_name ?? ''
               )?.artifactName;
               const trialCallId = trial.predictAndScore.callId;
-              
+
               if (trialEntity && trialProject && trialOpName && trialCallId) {
                 return (
                   <Box
@@ -1473,9 +1485,11 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
       {
         groupId: 'predictCalls',
         headerName: 'Calls',
-        children: props.state.evaluationCallIdsOrdered.map(evaluationCallId => ({
-          field: `predictCall.${evaluationCallId}`,
-        })),
+        children: props.state.evaluationCallIdsOrdered.map(
+          evaluationCallId => ({
+            field: `predictCall.${evaluationCallId}`,
+          })
+        ),
       },
       {
         groupId: 'output',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -153,7 +153,7 @@ const CustomFooter: React.FC<CustomFooterProps> = props => {
           height: '40px',
         }}>
         <Tooltip
-          content="Increase Row Height"
+          content="Increase row height"
           trigger={
             <IconButton onClick={props.increaseRowHeight}>
               <Icon name="row-height-small" />
@@ -161,24 +161,32 @@ const CustomFooter: React.FC<CustomFooterProps> = props => {
           }
         />
         <Tooltip
-          content="Decrease Row Height"
+          content="Decrease row height"
           trigger={
             <IconButton onClick={props.decreaseRowHeight}>
               <Icon name="row-height-large" />
             </IconButton>
           }
         />
+        <Tooltip
+          content="Show/hide columns"
+          trigger={
+            <IconButton onClick={handleColumnMenuOpen}>
+              <Icon name="column" />
+            </IconButton>
+          }
+        />
         {!props.onlyOneModel && (
           <Tooltip
-            content="Pivot on Model"
+            content="Pivot on eval"
             trigger={
               <IconButton onClick={() => props.setModelsAsRows(v => !v)}>
-                <Icon name="table" />
+                <Icon name="retry" />
               </IconButton>
             }
           />
         )}
-        {!props.shouldHighlightSelectedRow && (
+        {/* {!props.shouldHighlightSelectedRow && (
           <Tooltip
             content="Show Detail Panel"
             trigger={
@@ -187,15 +195,7 @@ const CustomFooter: React.FC<CustomFooterProps> = props => {
               </IconButton>
             }
           />
-        )}
-        <Tooltip
-          content="Show/Hide Columns"
-          trigger={
-            <IconButton onClick={handleColumnMenuOpen}>
-              <Icon name="column" />
-            </IconButton>
-          }
-        />
+        )} */}
       </HorizontalBox>
       <GridFooter sx={{border: 'none'}} />
       <Popover

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -1174,7 +1174,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
       },
       {
         groupId: 'predictCall',
-        headerName: 'Predict Call',
+        headerName: 'Calls',
         children: [{field: 'predictCall'}],
       },
       {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -61,6 +61,12 @@ const styledDataGridStyleOverrides: SxProps = {
     backgroundColor: 'white',
     zIndex: '7 !important',
   },
+  '& .MuiDataGrid-footerContainer': {
+    minHeight: '40px !important',
+  },
+  '& .MuiTablePagination-root': {
+    minHeight: '40px !important',
+  },
   width: '100%',
 };
 
@@ -84,6 +90,8 @@ const CustomFooter: React.FC<CustomFooterProps> = props => {
           justifyContent: 'flex-start',
           alignItems: 'center',
           padding: '0 16px',
+          minHeight: '40px',
+          height: '40px',
         }}>
         <Tooltip
           content="Increase Row Height"
@@ -1220,6 +1228,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
       pinnedColumns={{
         left: ['inputDigest'],
       }}
+      columnHeaderHeight={36}
       rowHeight={props.rowHeight}
       rowSelectionModel={selectedRowInputDigest}
       unstable_rowSpanning={true}
@@ -1616,6 +1625,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
       pinnedColumns={{
         left: ['inputDigest'],
       }}
+      columnHeaderHeight={36}
       rowHeight={props.rowHeight}
       rowSelectionModel={selectedRowInputDigest}
       unstable_rowSpanning={true}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -778,12 +778,17 @@ const expansionField = (
           height: '100%',
           width: '100%',
         }}>
-        <IconButton
-          onClick={() => {
-            toggleExpansion(params.row._expansionId);
-          }}>
-          <Icon name={itemIsExpanded ? 'collapse' : 'expand-uncollapse'} />
-        </IconButton>
+        <Tooltip
+          content={itemIsExpanded ? 'Hide trials' : 'Show trials'}
+          trigger={
+            <IconButton
+              onClick={() => {
+                toggleExpansion(params.row._expansionId);
+              }}>
+              <Icon name={itemIsExpanded ? 'collapse' : 'expand-uncollapse'} />
+            </IconButton>
+          }
+        />
       </Box>
     );
   },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -81,6 +81,12 @@ const styledDataGridStyleOverrides: SxProps = {
   '& .input-digest-cell:hover': {
     backgroundColor: '#E9F8FB !important',
   },
+  '& .call-id-cell': {
+    padding: '0px !important',
+  },
+  '& .call-id-cell:hover': {
+    backgroundColor: '#E9F8FB !important',
+  },
   width: '100%',
 };
 
@@ -1084,6 +1090,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                   width: '100%',
                   display: 'flex',
                   alignItems: 'center',
+                  justifyContent: 'center',
                   cursor: 'pointer',
                 }}
                 onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
@@ -1110,6 +1117,8 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
         sortable: false,
         filterable: false,
         hideable: false,
+        headerAlign: 'center',
+        cellClassName: 'call-id-cell',
         ...DISABLED_ROW_SPANNING,
         renderCell: (params: GridRenderCellParams<RowData>) => {
           if (params.row._pivot === 'modelsAsColumns') {
@@ -1139,6 +1148,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                     width: '100%',
                     display: 'flex',
                     alignItems: 'center',
+                    justifyContent: 'center',
                     cursor: 'pointer',
                   }}
                   onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
@@ -1193,6 +1203,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                         width: '100%',
                         display: 'flex',
                         alignItems: 'center',
+                        justifyContent: 'center',
                         cursor: 'pointer',
                       }}
                       onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
@@ -1511,6 +1522,8 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
         disableReorder: true,
         sortable: false,
         filterable: false,
+        headerAlign: 'center',
+        cellClassName: 'call-id-cell',
         ...DISABLED_ROW_SPANNING,
         renderHeader: (params: GridColumnHeaderParams<RowData>) => {
           return (
@@ -1553,6 +1566,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
                       width: '100%',
                       display: 'flex',
                       alignItems: 'center',
+                      justifyContent: 'center',
                       cursor: 'pointer',
                     }}
                     onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -1,4 +1,4 @@
-import {Box, SxProps, Tooltip} from '@mui/material';
+import {Box, SxProps} from '@mui/material';
 import {
   GridColDef,
   GridColumnGroupingModel,
@@ -11,6 +11,7 @@ import {MOON_50} from '@wandb/weave/common/css/color.styles';
 import {Icon} from '@wandb/weave/components/Icon';
 import {IconButton} from '@wandb/weave/components/IconButton';
 import {LoadingDots} from '@wandb/weave/components/LoadingDots';
+import {Tooltip} from '@wandb/weave/components/Tooltip';
 import {CellValue} from '@wandb/weave/components/PagePanelComponents/Home/Browse2/CellValue';
 import {parseRefMaybe} from '@wandb/weave/react';
 import _ from 'lodash';
@@ -276,22 +277,31 @@ export const ExampleCompareSectionTable: React.FC<
           justifyContent: 'flex-start',
           alignItems: 'center',
         }}>
-        <Tooltip title="Increase Row Height">
-          <IconButton onClick={increaseRowHeight}>
-            <Icon name="expand-uncollapse" />
-          </IconButton>
-        </Tooltip>
-        <Tooltip title="Decrease Row Height">
-          <IconButton onClick={decreaseRowHeight}>
-            <Icon name="collapse" />
-          </IconButton>
-        </Tooltip>
-        {!onlyOneModel && (
-          <Tooltip title="Pivot on Model">
-            <IconButton onClick={() => setModelsAsRows(v => !v)}>
-              <Icon name="table" />
+        <Tooltip
+          content="Increase Row Height"
+          trigger={
+            <IconButton onClick={increaseRowHeight}>
+              <Icon name="expand-uncollapse" />
             </IconButton>
-          </Tooltip>
+          }
+        />
+        <Tooltip
+          content="Decrease Row Height"
+          trigger={
+            <IconButton onClick={decreaseRowHeight}>
+              <Icon name="collapse" />
+            </IconButton>
+          }
+        />
+        {!onlyOneModel && (
+          <Tooltip
+            content="Pivot on Model"
+            trigger={
+              <IconButton onClick={() => setModelsAsRows(v => !v)}>
+                <Icon name="table" />
+              </IconButton>
+            }
+          />
         )}
       </HorizontalBox>
       <HorizontalBox
@@ -300,11 +310,14 @@ export const ExampleCompareSectionTable: React.FC<
           alignItems: 'center',
         }}>
         {!props.shouldHighlightSelectedRow && (
-          <Tooltip title="Show Detail Panel">
-            <IconButton onClick={props.onShowSplitView}>
-              <Icon name="panel" />
-            </IconButton>
-          </Tooltip>
+          <Tooltip
+            content="Show Detail Panel"
+            trigger={
+              <IconButton onClick={props.onShowSplitView}>
+                <Icon name="panel" />
+              </IconButton>
+            }
+          />
         )}
       </HorizontalBox>
     </HorizontalBox>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -132,6 +132,16 @@ interface CustomFooterProps {
 }
 
 const CustomFooter: React.FC<CustomFooterProps> = props => {
+  const [columnMenuAnchorEl, setColumnMenuAnchorEl] = useState<HTMLElement | null>(null);
+
+  const handleColumnMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setColumnMenuAnchorEl(event.currentTarget);
+  };
+
+  const handleColumnMenuClose = () => {
+    setColumnMenuAnchorEl(null);
+  };
+
   return (
     <GridFooterContainer>
       <HorizontalBox
@@ -178,8 +188,38 @@ const CustomFooter: React.FC<CustomFooterProps> = props => {
             }
           />
         )}
+        <Tooltip
+          content="Show/Hide Columns"
+          trigger={
+            <IconButton onClick={handleColumnMenuOpen}>
+              <Icon name="column" />
+            </IconButton>
+          }
+        />
       </HorizontalBox>
       <GridFooter sx={{border: 'none'}} />
+      <Popover
+        open={Boolean(columnMenuAnchorEl)}
+        anchorEl={columnMenuAnchorEl}
+        onClose={handleColumnMenuClose}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        slotProps={{
+          paper: {
+            sx: {
+              maxHeight: '400px',
+              overflow: 'auto',
+            },
+          },
+        }}>
+        <ColumnsManagementPanel />
+      </Popover>
     </GridFooterContainer>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -17,17 +17,16 @@ import {Tooltip} from '@wandb/weave/components/Tooltip';
 import {parseRefMaybe} from '@wandb/weave/react';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-
 import {useHistory} from 'react-router-dom';
 
-import {NotApplicable} from '../../../../NotApplicable';
-import {StyledDataGrid} from '../../../../StyledDataGrid';
 import {
-  useWeaveflowRouteContext,
-  usePeekLocation,
   HIDE_TRACETREE_PARAM,
   SHOW_FEEDBACK_PARAM,
+  usePeekLocation,
+  useWeaveflowRouteContext,
 } from '../../../../context';
+import {NotApplicable} from '../../../../NotApplicable';
+import {StyledDataGrid} from '../../../../StyledDataGrid';
 import {IdPanel} from '../../../common/Id';
 import {CallLink} from '../../../common/Links';
 import {
@@ -114,26 +113,39 @@ const useCallNavigation = () => {
   const history = useHistory();
   const {peekingRouter} = useWeaveflowRouteContext();
   const peekLoc = usePeekLocation();
-  
-  return useCallback((entityName: string, projectName: string, callId: string) => {
-    const peekParams = new URLSearchParams(peekLoc?.search ?? '');
-    const traceTreeParam = peekParams.get(HIDE_TRACETREE_PARAM);
-    const hideTraceTree = traceTreeParam === '1' ? true : traceTreeParam === '0' ? false : undefined;
-    const showFeedbackParam = peekParams.get(SHOW_FEEDBACK_PARAM);
-    const showFeedbackExpand = showFeedbackParam === '1' ? true : showFeedbackParam === '0' ? false : undefined;
-    
-    const url = peekingRouter.callUIUrl(
-      entityName,
-      projectName,
-      '',
-      callId,
-      undefined,
-      hideTraceTree,
-      showFeedbackExpand
-    );
-    
-    history.push(url);
-  }, [history, peekingRouter, peekLoc]);
+
+  return useCallback(
+    (entityName: string, projectName: string, callId: string) => {
+      const peekParams = new URLSearchParams(peekLoc?.search ?? '');
+      const traceTreeParam = peekParams.get(HIDE_TRACETREE_PARAM);
+      const hideTraceTree =
+        traceTreeParam === '1'
+          ? true
+          : traceTreeParam === '0'
+          ? false
+          : undefined;
+      const showFeedbackParam = peekParams.get(SHOW_FEEDBACK_PARAM);
+      const showFeedbackExpand =
+        showFeedbackParam === '1'
+          ? true
+          : showFeedbackParam === '0'
+          ? false
+          : undefined;
+
+      const url = peekingRouter.callUIUrl(
+        entityName,
+        projectName,
+        '',
+        callId,
+        undefined,
+        hideTraceTree,
+        showFeedbackExpand
+      );
+
+      history.push(url);
+    },
+    [history, peekingRouter, peekLoc]
+  );
 };
 
 /**
@@ -149,7 +161,8 @@ interface CustomFooterProps {
 }
 
 const CustomFooter: React.FC<CustomFooterProps> = props => {
-  const [columnMenuAnchorEl, setColumnMenuAnchorEl] = useState<HTMLElement | null>(null);
+  const [columnMenuAnchorEl, setColumnMenuAnchorEl] =
+    useState<HTMLElement | null>(null);
 
   const handleColumnMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     setColumnMenuAnchorEl(event.currentTarget);
@@ -624,24 +637,24 @@ export const ExampleCompareSectionTable: React.FC<
     });
     setLineClamp(v => Math.max(v - 1, 1));
   }, []);
-  
+
   // Filter out hidden evaluations
   const visibleEvaluationCallIds = useMemo(() => {
     return props.state.evaluationCallIdsOrdered.filter(
       id => !hiddenEvaluationIds.has(id)
     );
   }, [props.state.evaluationCallIdsOrdered, hiddenEvaluationIds]);
-  
+
   const onlyOneModel = visibleEvaluationCallIds.length === 1;
-  
+
   // Create a modified state with filtered evaluation call IDs
   const filteredState = useMemo(() => {
     return {
       ...props.state,
-      evaluationCallIdsOrdered: visibleEvaluationCallIds
+      evaluationCallIdsOrdered: visibleEvaluationCallIds,
     };
   }, [props.state, visibleEvaluationCallIds]);
-  
+
   const inner =
     modelsAsRows || onlyOneModel ? (
       <ExampleCompareSectionTableModelsAsRows
@@ -935,7 +948,8 @@ const inputFields = (
             setSelectedInputDigest(params.row.inputDigest);
             onShowSplitView();
           }}>
-          <span style={{flexShrink: 1, marginLeft: 'auto', marginRight: 'auto'}}>
+          <span
+            style={{flexShrink: 1, marginLeft: 'auto', marginRight: 'auto'}}>
             <IdPanel clickable>{params.row.inputDigest.slice(-4)}</IdPanel>
           </span>
         </Box>
@@ -1072,7 +1086,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
     outputColumnKeys,
     rows
   );
-  
+
   const navigateToCall = useCallNavigation();
 
   const columns: GridColDef<RowData>[] = useMemo(() => {
@@ -1170,7 +1184,9 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                   justifyContent: 'center',
                   cursor: 'pointer',
                 }}
-                onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
+                onClick={() =>
+                  navigateToCall(trialEntity, trialProject, trialCallId)
+                }>
                 <CallLink
                   entityName={trialEntity}
                   projectName={trialProject}
@@ -1228,7 +1244,9 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                     justifyContent: 'center',
                     cursor: 'pointer',
                   }}
-                  onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
+                  onClick={() =>
+                    navigateToCall(trialEntity, trialProject, trialCallId)
+                  }>
                   <CallLink
                     entityName={trialEntity}
                     projectName={trialProject}
@@ -1283,7 +1301,9 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                         justifyContent: 'center',
                         cursor: 'pointer',
                       }}
-                      onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
+                      onClick={() =>
+                        navigateToCall(trialEntity, trialProject, trialCallId)
+                      }>
                       <CallLink
                         entityName={trialEntity}
                         projectName={trialProject}
@@ -1566,7 +1586,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
     outputColumnKeys,
     rows
   );
-  
+
   const navigateToCall = useCallNavigation();
 
   const columns: GridColDef<RowData>[] = useMemo(() => {
@@ -1646,7 +1666,9 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
                       justifyContent: 'center',
                       cursor: 'pointer',
                     }}
-                    onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
+                    onClick={() =>
+                      navigateToCall(trialEntity, trialProject, trialCallId)
+                    }>
                     <CallLink
                       entityName={trialEntity}
                       projectName={trialProject}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -587,6 +587,7 @@ const DenseCellValue: React.FC<
 export const ExampleCompareSectionTable: React.FC<
   ExampleCompareSectionTableProps
 > = props => {
+  const {hiddenEvaluationIds} = useCompareEvaluationsState();
   const [modelsAsRows, setModelsAsRows] = useState(false);
   const [rowHeight, setRowHeight] = useState(32);
   const [lineClamp, setLineClamp] = useState(1);
@@ -606,11 +607,29 @@ export const ExampleCompareSectionTable: React.FC<
     });
     setLineClamp(v => Math.max(v - 1, 1));
   }, []);
-  const onlyOneModel = props.state.evaluationCallIdsOrdered.length === 1;
+  
+  // Filter out hidden evaluations
+  const visibleEvaluationCallIds = useMemo(() => {
+    return props.state.evaluationCallIdsOrdered.filter(
+      id => !hiddenEvaluationIds.has(id)
+    );
+  }, [props.state.evaluationCallIdsOrdered, hiddenEvaluationIds]);
+  
+  const onlyOneModel = visibleEvaluationCallIds.length === 1;
+  
+  // Create a modified state with filtered evaluation call IDs
+  const filteredState = useMemo(() => {
+    return {
+      ...props.state,
+      evaluationCallIdsOrdered: visibleEvaluationCallIds
+    };
+  }, [props.state, visibleEvaluationCallIds]);
+  
   const inner =
     modelsAsRows || onlyOneModel ? (
       <ExampleCompareSectionTableModelsAsRows
         {...props}
+        state={filteredState}
         rowHeight={rowHeight}
         lineClamp={lineClamp}
         increaseRowHeight={increaseRowHeight}
@@ -621,6 +640,7 @@ export const ExampleCompareSectionTable: React.FC<
     ) : (
       <ExampleCompareSectionTableModelsAsColumns
         {...props}
+        state={filteredState}
         rowHeight={rowHeight}
         lineClamp={lineClamp}
         increaseRowHeight={increaseRowHeight}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -18,8 +18,16 @@ import {parseRefMaybe} from '@wandb/weave/react';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
+import {useHistory} from 'react-router-dom';
+
 import {NotApplicable} from '../../../../NotApplicable';
 import {StyledDataGrid} from '../../../../StyledDataGrid';
+import {
+  useWeaveflowRouteContext,
+  usePeekLocation,
+  HIDE_TRACETREE_PARAM,
+  SHOW_FEEDBACK_PARAM,
+} from '../../../../context';
 import {IdPanel} from '../../../common/Id';
 import {CallLink} from '../../../common/Links';
 import {
@@ -68,6 +76,35 @@ const styledDataGridStyleOverrides: SxProps = {
     minHeight: '40px !important',
   },
   width: '100%',
+};
+
+/**
+ * Hook to handle navigation to a call
+ */
+const useCallNavigation = () => {
+  const history = useHistory();
+  const {peekingRouter} = useWeaveflowRouteContext();
+  const peekLoc = usePeekLocation();
+  
+  return useCallback((entityName: string, projectName: string, callId: string) => {
+    const peekParams = new URLSearchParams(peekLoc?.search ?? '');
+    const traceTreeParam = peekParams.get(HIDE_TRACETREE_PARAM);
+    const hideTraceTree = traceTreeParam === '1' ? true : traceTreeParam === '0' ? false : undefined;
+    const showFeedbackParam = peekParams.get(SHOW_FEEDBACK_PARAM);
+    const showFeedbackExpand = showFeedbackParam === '1' ? true : showFeedbackParam === '0' ? false : undefined;
+    
+    const url = peekingRouter.callUIUrl(
+      entityName,
+      projectName,
+      '',
+      callId,
+      undefined,
+      hideTraceTree,
+      showFeedbackExpand
+    );
+    
+    history.push(url);
+  }, [history, peekingRouter, peekLoc]);
 };
 
 /**
@@ -802,6 +839,7 @@ const inputFields = (
             display: 'flex',
             alignItems: 'center',
             gap: '4px',
+            cursor: 'pointer',
           }}
           onClick={() => {
             setSelectedInputDigest(params.row.inputDigest);
@@ -944,6 +982,8 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
     outputColumnKeys,
     rows
   );
+  
+  const navigateToCall = useCallNavigation();
 
   const columns: GridColDef<RowData>[] = useMemo(() => {
     const res: GridColDef<RowData>[] = [
@@ -1034,9 +1074,12 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                 style={{
                   overflow: 'hidden',
                   height: '100%',
+                  width: '100%',
                   display: 'flex',
                   alignItems: 'center',
-                }}>
+                  cursor: 'pointer',
+                }}
+                onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
                 <CallLink
                   entityName={trialEntity}
                   projectName={trialProject}
@@ -1086,9 +1129,12 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                   style={{
                     overflow: 'hidden',
                     height: '100%',
+                    width: '100%',
                     display: 'flex',
                     alignItems: 'center',
-                  }}>
+                    cursor: 'pointer',
+                  }}
+                  onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
                   <CallLink
                     entityName={trialEntity}
                     projectName={trialProject}
@@ -1137,9 +1183,12 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                       style={{
                         overflow: 'hidden',
                         height: '100%',
+                        width: '100%',
                         display: 'flex',
                         alignItems: 'center',
-                      }}>
+                        cursor: 'pointer',
+                      }}
+                      onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
                       <CallLink
                         entityName={trialEntity}
                         projectName={trialProject}
@@ -1270,6 +1319,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
     outputWidths,
     filteredRows,
     props.lineClamp,
+    navigateToCall,
   ]);
 
   const columnGroupingModel: GridColumnGroupingModel = useMemo(() => {
@@ -1421,6 +1471,8 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
     outputColumnKeys,
     rows
   );
+  
+  const navigateToCall = useCallNavigation();
 
   const columns: GridColDef<RowData>[] = useMemo(() => {
     const res: GridColDef<RowData>[] = [
@@ -1491,9 +1543,12 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
                     style={{
                       overflow: 'hidden',
                       height: '100%',
+                      width: '100%',
                       display: 'flex',
                       alignItems: 'center',
-                    }}>
+                      cursor: 'pointer',
+                    }}
+                    onClick={() => navigateToCall(trialEntity, trialProject, trialCallId)}>
                     <CallLink
                       entityName={trialEntity}
                       projectName={trialProject}
@@ -1629,6 +1684,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
     outputWidths,
     filteredRows,
     props.lineClamp,
+    navigateToCall,
   ]);
 
   const columnGroupingModel: GridColumnGroupingModel = useMemo(() => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -75,6 +75,12 @@ const styledDataGridStyleOverrides: SxProps = {
   '& .MuiTablePagination-root': {
     minHeight: '40px !important',
   },
+  '& .input-digest-cell': {
+    padding: '0px !important',
+  },
+  '& .input-digest-cell:hover': {
+    backgroundColor: '#E9F8FB !important',
+  },
   width: '100%',
 };
 
@@ -829,6 +835,7 @@ const inputFields = (
     filterable: false,
     sortable: false,
     hideable: false,
+    cellClassName: 'input-digest-cell',
     renderCell: params => {
       return (
         <Box
@@ -845,7 +852,7 @@ const inputFields = (
             setSelectedInputDigest(params.row.inputDigest);
             onShowSplitView();
           }}>
-          <span style={{flexShrink: 1}}>
+          <span style={{flexShrink: 1, marginLeft: 'auto', marginRight: 'auto'}}>
             <IdPanel clickable>{params.row.inputDigest.slice(-4)}</IdPanel>
           </span>
         </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -57,6 +57,7 @@ import {
 } from './exampleCompareSectionUtil';
 
 const styledDataGridStyleOverrides: SxProps = {
+  borderTop: 0,
   '& .MuiDataGrid-row:hover': {
     backgroundColor: 'white',
   },

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -957,26 +957,29 @@ const inputFields = (
       );
     },
   },
-  ...inputSubFields.map(key => ({
-    field: `inputs.${key}`,
-    headerName: key,
-    sortable: false,
-    filterable: false,
-    width: columnWidths[key],
-    maxWidth: DYNAMIC_COLUMN_MAX_WIDTH,
-    valueGetter: (value: any, row: RowData) => {
-      return row.inputDigest;
-    },
-    renderCell: (params: GridRenderCellParams<RowData>) => {
-      return (
-        <DatasetRowItemRenderer
-          digest={params.row.inputDigest}
-          inputKey={key}
-          lineClamp={lineClamp}
-        />
-      );
-    },
-  } as GridColDef<RowData>)),
+  ...inputSubFields.map(
+    key =>
+      ({
+        field: `inputs.${key}`,
+        headerName: key,
+        sortable: false,
+        filterable: false,
+        width: columnWidths[key],
+        maxWidth: DYNAMIC_COLUMN_MAX_WIDTH,
+        valueGetter: (value: any, row: RowData) => {
+          return row.inputDigest;
+        },
+        renderCell: (params: GridRenderCellParams<RowData>) => {
+          return (
+            <DatasetRowItemRenderer
+              digest={params.row.inputDigest}
+              inputKey={key}
+              lineClamp={lineClamp}
+            />
+          );
+        },
+      } as GridColDef<RowData>)
+  ),
 ];
 
 const expansionField = (
@@ -1322,41 +1325,46 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
           return null;
         },
       },
-      ...outputColumnKeys.map(key => ({
-        field: `output.${key}`,
-        headerName: key,
-        renderHeader: () => removePrefix(key, 'output.'),
-        width: outputWidths[key],
-        maxWidth: DYNAMIC_COLUMN_MAX_WIDTH,
-        ...DISABLED_ROW_SPANNING,
-        disableReorder: true,
-        valueGetter: (value: any, row: RowData) => {
-          if (row._pivot === 'modelsAsColumns') {
-            return null;
-          }
-          return row.output[key]?.[row.evaluationCallId];
-        },
-        renderCell: (params: GridRenderCellParams<RowData>) => {
-          if (params.row._pivot === 'modelsAsColumns') {
-            return null;
-          }
-          if (params.row._type === 'summary') {
-            // TODO: Should we indicate that this is just the first trial?
-            return (
-              <DenseCellValue
-                value={params.row.output[key]?.[params.row.evaluationCallId]}
-                lineClamp={props.lineClamp}
-              />
-            );
-          }
-          return (
-            <DenseCellValue
-              value={params.row.output[key]?.[params.row.evaluationCallId]}
-              lineClamp={props.lineClamp}
-            />
-          );
-        },
-      } as GridColDef<RowData>)),
+      ...outputColumnKeys.map(
+        key =>
+          ({
+            field: `output.${key}`,
+            headerName: key,
+            renderHeader: () => removePrefix(key, 'output.'),
+            width: outputWidths[key],
+            maxWidth: DYNAMIC_COLUMN_MAX_WIDTH,
+            ...DISABLED_ROW_SPANNING,
+            disableReorder: true,
+            valueGetter: (value: any, row: RowData) => {
+              if (row._pivot === 'modelsAsColumns') {
+                return null;
+              }
+              return row.output[key]?.[row.evaluationCallId];
+            },
+            renderCell: (params: GridRenderCellParams<RowData>) => {
+              if (params.row._pivot === 'modelsAsColumns') {
+                return null;
+              }
+              if (params.row._type === 'summary') {
+                // TODO: Should we indicate that this is just the first trial?
+                return (
+                  <DenseCellValue
+                    value={
+                      params.row.output[key]?.[params.row.evaluationCallId]
+                    }
+                    lineClamp={props.lineClamp}
+                  />
+                );
+              }
+              return (
+                <DenseCellValue
+                  value={params.row.output[key]?.[params.row.evaluationCallId]}
+                  lineClamp={props.lineClamp}
+                />
+              );
+            },
+          } as GridColDef<RowData>)
+      ),
       ...Object.entries(compositeMetrics).flatMap(
         ([metricGroupKey, metricGroupDef]) => {
           return Object.entries(metricGroupDef.metrics).map(
@@ -1610,81 +1618,90 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
           ]
         : []),
       // Add predict call columns for each evaluation
-      ...props.state.evaluationCallIdsOrdered.map(evaluationCallId => ({
-        field: `predictCall.${evaluationCallId}`,
-        headerName: 'Call',
-        width: 100,
-        maxWidth: 150,
-        resizable: true,
-        disableColumnMenu: false,
-        disableReorder: true,
-        sortable: false,
-        filterable: false,
-        headerAlign: 'center',
-        cellClassName: 'call-id-cell',
-        ...DISABLED_ROW_SPANNING,
-        renderHeader: (params: GridColumnHeaderParams<RowData>) => {
-          return (
-            <EvaluationModelLink
-              callId={evaluationCallId}
-              state={props.state}
-            />
-          );
-        },
-        renderCell: (params: GridRenderCellParams<RowData>) => {
-          // Find the corresponding filtered row
-          const correspondingFilteredRow = filteredRows.find(
-            fr => fr.inputDigest === params.row.inputDigest
-          );
-          if (correspondingFilteredRow) {
-            const trial =
-              params.row._type === 'trial'
-                ? correspondingFilteredRow.originalRows.filter(
-                    row => row.evaluationCallId === evaluationCallId
-                  )[params.row._trialNdx]
-                : correspondingFilteredRow.originalRows.find(
-                    row => row.evaluationCallId === evaluationCallId
-                  );
+      ...props.state.evaluationCallIdsOrdered.map(
+        evaluationCallId =>
+          ({
+            field: `predictCall.${evaluationCallId}`,
+            headerName: 'Call',
+            width: 100,
+            maxWidth: 150,
+            resizable: true,
+            disableColumnMenu: false,
+            disableReorder: true,
+            sortable: false,
+            filterable: false,
+            headerAlign: 'center',
+            cellClassName: 'call-id-cell',
+            ...DISABLED_ROW_SPANNING,
+            renderHeader: (params: GridColumnHeaderParams<RowData>) => {
+              return (
+                <EvaluationModelLink
+                  callId={evaluationCallId}
+                  state={props.state}
+                />
+              );
+            },
+            renderCell: (params: GridRenderCellParams<RowData>) => {
+              // Find the corresponding filtered row
+              const correspondingFilteredRow = filteredRows.find(
+                fr => fr.inputDigest === params.row.inputDigest
+              );
+              if (correspondingFilteredRow) {
+                const trial =
+                  params.row._type === 'trial'
+                    ? correspondingFilteredRow.originalRows.filter(
+                        row => row.evaluationCallId === evaluationCallId
+                      )[params.row._trialNdx]
+                    : correspondingFilteredRow.originalRows.find(
+                        row => row.evaluationCallId === evaluationCallId
+                      );
 
-            if (trial) {
-              const trialPredict = trial.predictAndScore._rawPredictTraceData;
-              const [trialEntity, trialProject] =
-                trialPredict?.project_id.split('/') ?? [];
-              const trialOpName = parseRefMaybe(
-                trialPredict?.op_name ?? ''
-              )?.artifactName;
-              const trialCallId = trial.predictAndScore.callId;
+                if (trial) {
+                  const trialPredict =
+                    trial.predictAndScore._rawPredictTraceData;
+                  const [trialEntity, trialProject] =
+                    trialPredict?.project_id.split('/') ?? [];
+                  const trialOpName = parseRefMaybe(
+                    trialPredict?.op_name ?? ''
+                  )?.artifactName;
+                  const trialCallId = trial.predictAndScore.callId;
 
-              if (trialEntity && trialProject && trialOpName && trialCallId) {
-                return (
-                  <Box
-                    style={{
-                      overflow: 'hidden',
-                      height: '100%',
-                      width: '100%',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      cursor: 'pointer',
-                    }}
-                    onClick={() =>
-                      navigateToCall(trialEntity, trialProject, trialCallId)
-                    }>
-                    <CallLink
-                      entityName={trialEntity}
-                      projectName={trialProject}
-                      opName={trialOpName}
-                      callId={trialCallId}
-                      noName
-                    />
-                  </Box>
-                );
+                  if (
+                    trialEntity &&
+                    trialProject &&
+                    trialOpName &&
+                    trialCallId
+                  ) {
+                    return (
+                      <Box
+                        style={{
+                          overflow: 'hidden',
+                          height: '100%',
+                          width: '100%',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          cursor: 'pointer',
+                        }}
+                        onClick={() =>
+                          navigateToCall(trialEntity, trialProject, trialCallId)
+                        }>
+                        <CallLink
+                          entityName={trialEntity}
+                          projectName={trialProject}
+                          opName={trialOpName}
+                          callId={trialCallId}
+                          noName
+                        />
+                      </Box>
+                    );
+                  }
+                }
               }
-            }
-          }
-          return null;
-        },
-      } as GridColDef<RowData>)),
+              return null;
+            },
+          } as GridColDef<RowData>)
+      ),
       ...outputColumnKeys.flatMap(key => {
         return props.state.evaluationCallIdsOrdered.map(evaluationCallId => {
           return {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -74,6 +74,23 @@ const styledDataGridStyleOverrides: SxProps = {
   },
   '& .MuiTablePagination-root': {
     minHeight: '40px !important',
+    fontFamily: 'Source Sans Pro',
+    color: '#79808A', // moon-500
+  },
+  '& .MuiTablePagination-displayedRows': {
+    fontFamily: 'Source Sans Pro',
+    color: '#79808A', // moon-500
+  },
+  '& .MuiTablePagination-selectLabel': {
+    fontFamily: 'Source Sans Pro',
+    color: '#79808A', // moon-500
+  },
+  '& .MuiTablePagination-select': {
+    fontFamily: 'Source Sans Pro',
+    color: '#79808A', // moon-500
+  },
+  '& .MuiTablePagination-actions': {
+    color: '#79808A', // moon-500
   },
   '& .input-digest-cell': {
     padding: '0px !important',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -196,7 +196,7 @@ const DISABLED_ROW_SPANNING = {
 
 const SCORE_COLUMN_SETTINGS = {
   flex: 1,
-  minWidth: 120,
+  minWidth: 162,
 };
 
 // Constants for column width calculations

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -9,7 +9,6 @@ import {
   GridFooterContainer,
   GridRenderCellParams,
 } from '@mui/x-data-grid-pro';
-import {MOON_50} from '@wandb/weave/common/css/color.styles';
 import {Icon} from '@wandb/weave/components/Icon';
 import {IconButton} from '@wandb/weave/components/IconButton';
 import {LoadingDots} from '@wandb/weave/components/LoadingDots';
@@ -32,7 +31,7 @@ import {
   DERIVED_SCORER_REF_PLACEHOLDER,
 } from '../../compositeMetricsUtil';
 import {EvaluationComparisonState} from '../../ecpState';
-import {HorizontalBox, VerticalBox} from '../../Layout';
+import {HorizontalBox} from '../../Layout';
 import {EvaluationModelLink} from '../ComparisonDefinitionSection/EvaluationDefinition';
 import {
   ColumnsManagementPanel,
@@ -85,7 +84,6 @@ const CustomFooter: React.FC<CustomFooterProps> = props => {
           justifyContent: 'flex-start',
           alignItems: 'center',
           padding: '0 16px',
-          gap: 1,
         }}>
         <Tooltip
           content="Increase Row Height"
@@ -124,7 +122,7 @@ const CustomFooter: React.FC<CustomFooterProps> = props => {
           />
         )}
       </HorizontalBox>
-      <GridFooter sx={{ border: 'none' }} />
+      <GridFooter sx={{border: 'none'}} />
     </GridFooterContainer>
   );
 };
@@ -290,9 +288,12 @@ const DenseCellValue: React.FC<
   if (props.value == null) {
     return <NotApplicable />;
   }
-  
+
   // For string values, render directly with line-clamp
-  if (typeof props.value === 'string' && !props.value.startsWith('data:image/')) {
+  if (
+    typeof props.value === 'string' &&
+    !props.value.startsWith('data:image/')
+  ) {
     return (
       <Box
         sx={{
@@ -322,7 +323,7 @@ const DenseCellValue: React.FC<
       </Box>
     );
   }
-  
+
   // For objects/arrays that will be JSON stringified, also apply line-clamp
   if (typeof props.value === 'object') {
     const stringified = JSON.stringify(props.value);
@@ -357,7 +358,7 @@ const DenseCellValue: React.FC<
       </Box>
     );
   }
-  
+
   // For non-string values, use the default CellValue component
   return (
     <Box
@@ -1145,6 +1146,8 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
     outputColumnKeys,
     compositeMetrics,
     outputWidths,
+    filteredRows,
+    props.lineClamp,
   ]);
 
   const columnGroupingModel: GridColumnGroupingModel = useMemo(() => {
@@ -1501,6 +1504,8 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
     outputColumnKeys,
     compositeMetrics,
     outputWidths,
+    filteredRows,
+    props.lineClamp,
   ]);
 
   const columnGroupingModel: GridColumnGroupingModel = useMemo(() => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -657,13 +657,18 @@ const expansionField = (
   headerAlign: 'center',
   renderHeader: (params: GridColumnHeaderParams<RowData>) => {
     return (
-      <IconButton onClick={toggleDefaultExpansionState}>
-        <Icon
-          name={
-            defaultExpandState === 'expanded' ? 'collapse' : 'expand-uncollapse'
-          }
-        />
-      </IconButton>
+      <Tooltip
+        content={defaultExpandState === 'expanded' ? 'Hide trials' : 'Show trials'}
+        trigger={
+          <IconButton onClick={toggleDefaultExpansionState}>
+            <Icon
+              name={
+                defaultExpandState === 'expanded' ? 'collapse' : 'expand-uncollapse'
+              }
+            />
+          </IconButton>
+        }
+      />
     );
   },
   valueGetter: (value: any, row: RowData) => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -976,7 +976,7 @@ const inputFields = (
         />
       );
     },
-  })),
+  } as GridColDef<RowData>)),
 ];
 
 const expansionField = (
@@ -1122,7 +1122,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                   />
                 );
               },
-            },
+            } as GridColDef<RowData>,
           ]),
       ...(hasTrials
         ? [
@@ -1356,7 +1356,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
             />
           );
         },
-      })),
+      } as GridColDef<RowData>)),
       ...Object.entries(compositeMetrics).flatMap(
         ([metricGroupKey, metricGroupDef]) => {
           return Object.entries(metricGroupDef.metrics).map(
@@ -1411,7 +1411,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
                     baselineValue
                   );
                 },
-              };
+              } as GridColDef<RowData>;
             }
           );
         }
@@ -1684,7 +1684,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
           }
           return null;
         },
-      })),
+      } as GridColDef<RowData>)),
       ...outputColumnKeys.flatMap(key => {
         return props.state.evaluationCallIdsOrdered.map(evaluationCallId => {
           return {
@@ -1723,7 +1723,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
                 />
               );
             },
-          };
+          } as GridColDef<RowData>;
         });
       }),
       ...Object.entries(compositeMetrics).flatMap(
@@ -1779,7 +1779,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
                         baselineValue
                       );
                     },
-                  };
+                  } as GridColDef<RowData>;
                 }
               );
             }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
@@ -59,6 +59,7 @@ const GridCell = styled.div<{
 }>`
   padding: 6px 16px;
   min-width: 100px;
+  font-size: 14px;
   ${props =>
     props.button &&
     `
@@ -249,8 +250,8 @@ export const ScorecardSection: React.FC<{
           style={{
             gridColumnEnd: 'span ' + (evalCallIds.length + 2),
             backgroundColor: MOON_100,
-            color: MOON_600,
-            fontWeight: 'bold',
+            fontWeight: 600,
+            fontSize: '16px',
             borderTop: '1px solid #ccc',
             borderBottom: '1px solid #ccc',
             display: 'flex',
@@ -265,7 +266,7 @@ export const ScorecardSection: React.FC<{
               flexDirection: 'row',
               gap: '8px',
             }}>
-            <span>diff only</span>
+            <span style={{fontSize: '14px'}}>Diff only</span>
             <Checkbox checked={diffOnly} onClick={() => setDiffOnly(v => !v)} />
           </div>
         </GridCell>
@@ -319,8 +320,8 @@ export const ScorecardSection: React.FC<{
           style={{
             gridColumnEnd: 'span ' + (evalCallIds.length + 2),
             backgroundColor: MOON_100,
-            color: MOON_600,
-            fontWeight: 'bold',
+            fontWeight: 600,
+            fontSize: '16px',
             borderTop: '1px solid #ccc',
             borderBottom: '1px solid #ccc',
           }}>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ScorecardSection/ScorecardSection.tsx
@@ -7,7 +7,6 @@ import styled from 'styled-components';
 import {
   MOON_100,
   MOON_300,
-  MOON_600,
 } from '../../../../../../../../common/css/color.styles';
 import {parseRefMaybe, WeaveObjectRef} from '../../../../../../../../react';
 import {Checkbox} from '../../../../../../..';
@@ -33,7 +32,6 @@ import {
 } from '../../ecpConstants';
 import {
   EvaluationComparisonState,
-  getBaselineCallId,
   getOrderedCallIds,
   getOrderedModelRefs,
 } from '../../ecpState';
@@ -76,20 +74,27 @@ export const ScorecardSection: React.FC<{
   state: EvaluationComparisonState;
 }> = props => {
   const {hiddenEvaluationIds} = useCompareEvaluationsState();
-  
+
   const evalCallIds = useMemo(
-    () => getOrderedCallIds(props.state).filter(id => !hiddenEvaluationIds.has(id)),
+    () =>
+      getOrderedCallIds(props.state).filter(id => !hiddenEvaluationIds.has(id)),
     [props.state, hiddenEvaluationIds]
   );
-  
+
   const modelRefs = useMemo(() => {
     // Get all model refs from visible evaluations only
-    const visibleEvalCalls = evalCallIds.map(id => props.state.summary.evaluationCalls[id]);
-    const visibleModelRefs = new Set(visibleEvalCalls.map(call => call.modelRef));
+    const visibleEvalCalls = evalCallIds.map(
+      id => props.state.summary.evaluationCalls[id]
+    );
+    const visibleModelRefs = new Set(
+      visibleEvalCalls.map(call => call.modelRef)
+    );
     // Keep the ordering from getOrderedModelRefs but filter to only visible ones
-    return getOrderedModelRefs(props.state).filter(ref => visibleModelRefs.has(ref));
+    return getOrderedModelRefs(props.state).filter(ref =>
+      visibleModelRefs.has(ref)
+    );
   }, [props.state, evalCallIds]);
-  
+
   const datasetRefs = useMemo(
     () => Object.values(props.state.summary.evaluations).map(e => e.datasetRef),
     [props.state]

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/PlotlyBarPlot.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/PlotlyBarPlot.tsx
@@ -40,7 +40,7 @@ export const PlotlyBarPlot: React.FC<{
       title: {
         multiline: true,
         text: props.plotlyData.name ?? '',
-        font: {size: 12},
+        font: {size: 10},
         xref: 'paper',
         x: 0.5,
         y: 1,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/PlotlyBarPlot.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/PlotlyBarPlot.tsx
@@ -40,7 +40,7 @@ export const PlotlyBarPlot: React.FC<{
       title: {
         multiline: true,
         text: props.plotlyData.name ?? '',
-        font: {size: 10},
+        font: {size: 12},
         xref: 'paper',
         x: 0.5,
         y: 1,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/PlotlyRadarPlot.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/PlotlyRadarPlot.tsx
@@ -51,6 +51,9 @@ export const PlotlyRadarPlot: React.FC<{
           linecolor: PLOT_GRID_COLOR,
           gridcolor: PLOT_GRID_COLOR,
           ticklen: 3,
+          tickfont: {
+            size: 10,
+          },
         },
       },
     };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
@@ -351,7 +351,7 @@ const useBarPlotData = (filteredData: RadarPlotData) =>
           Number.isInteger(value) ? value.toString() : value.toFixed(3)
         ),
         textposition: 'outside',
-        textfont: {size: 14, color: 'black'},
+        textfont: {size: 12, color: 'black'},
         name: metric,
         marker: {color: metricBin.colors},
       };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/SummaryPlotsSection/SummaryPlotsSection.tsx
@@ -3,6 +3,7 @@ import {Button} from '@wandb/weave/components/Button';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 
+import {useCompareEvaluationsState} from '../../compareEvaluationsContext';
 import {buildCompositeMetricsMap} from '../../compositeMetricsUtil';
 import {
   BOX_RADIUS,
@@ -451,12 +452,13 @@ const usePaginatedPlots = (
 const usePlotDataFromMetrics = (
   state: EvaluationComparisonState
 ): {radarData: RadarPlotData; allMetricNames: Set<string>} => {
+  const {hiddenEvaluationIds} = useCompareEvaluationsState();
   const compositeMetrics = useMemo(() => {
     return buildCompositeMetricsMap(state.summary, 'summary');
   }, [state]);
   const callIds = useMemo(() => {
-    return getOrderedCallIds(state);
-  }, [state]);
+    return getOrderedCallIds(state).filter(id => !hiddenEvaluationIds.has(id));
+  }, [state, hiddenEvaluationIds]);
 
   return useMemo(() => {
     const metrics = Object.values(compositeMetrics)

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Id.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Id.tsx
@@ -2,7 +2,11 @@
  * Show truncated ID with full value in a tooltip.
  */
 
-import {GREEN_600, TEAL_500, MOON_150} from '@wandb/weave/common/css/color.styles';
+import {
+  GREEN_600,
+  MOON_150,
+  TEAL_500,
+} from '@wandb/weave/common/css/color.styles';
 import {IconCheckmark} from '@wandb/weave/components/Icon';
 import {Tooltip} from '@wandb/weave/components/Tooltip';
 import {TooltipDeprecated} from '@wandb/weave/components/TooltipDeprecated';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Id.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Id.tsx
@@ -19,7 +19,7 @@ export const IdPanel = styled.div<{clickable?: boolean}>`
   font-family: monospace;
   font-size: 10px;
   line-height: 20px;
-  cursor: ${props => (props.clickable ? 'pointer' : 'default')};
+  cursor: pointer;
   &:hover {
     color: ${TEAL_500};
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Id.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/Id.tsx
@@ -2,7 +2,7 @@
  * Show truncated ID with full value in a tooltip.
  */
 
-import {GREEN_600, MOON_150} from '@wandb/weave/common/css/color.styles';
+import {GREEN_600, TEAL_500, MOON_150} from '@wandb/weave/common/css/color.styles';
 import {IconCheckmark} from '@wandb/weave/components/Icon';
 import {Tooltip} from '@wandb/weave/components/Tooltip';
 import {TooltipDeprecated} from '@wandb/weave/components/TooltipDeprecated';
@@ -20,6 +20,9 @@ export const IdPanel = styled.div<{clickable?: boolean}>`
   font-size: 10px;
   line-height: 20px;
   cursor: ${props => (props.clickable ? 'pointer' : 'default')};
+  &:hover {
+    color: ${TEAL_500};
+  }
 `;
 IdPanel.displayName = 'S.IdPanel';
 


### PR DESCRIPTION
## Description

Latest updated Featurebee:
https://beta.wandb.ai/?betaVersion=d45e5e0da0d2ba389f06b7bdc4dcd4b830e5a0db

| List view | Detail view | Detail + list |
| -------- | ------- | ------- |
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/63839d2a-1d36-48ff-8c84-95078876d4b1" /> | <img width="1469" alt="image" src="https://github.com/user-attachments/assets/816a3517-2e73-4443-a7a2-28c20796a9bd" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/b3b85ef4-c1cf-4d2a-9406-b2b804d03ba1" /> |

### User story
User story we're designing for:
- User comes to view the compare / expanded table.
- They review lines for the ones which are important to them.
- They did into those lines for further review.

Changes made:
- Start off at the table view to allow users to glance to review the example line-items.
- Started with the rows in a single line state.
- When the user needs to dig in for more details, they can:
  - Expand rows to get more lines to review.
    - Tweaked formatting and line-clamps.
  - Open the example details popover.
    - Made nearly full-screen - since reviewing needs more space, it's very busy.
  - Open the call peek-drawer.
    - Made call links available from example list.

---

### Larger updates
- Added call ID pills to the table.
- Updated the example detail card to be nearly full-width (needs more space for reviewing in that format).
  - Updated example detail card to make it resizeable.
- Added logic to make the example detail card full width when the calls peek-drawer is open when they're open at the same time (and then revert when the peek-drawer is closed).
- Adjusted row-size logic to add line-clamps (adding space adds lines and then we truncate as needed).
- Added the ability to Show/Hide (toggle) evals from header area. 
- Added the ability to show and hide columns (/ sets of columns).

### Smaller updates
- Using filled-circle indicator instead of model icon with color.
  - Does add some visual noise, but we'd take that trade-off to allow the user to visually understand which eval is mapped to which column quickly (interpreting the change in icon color is more difficult). 
Make hit points better for opening calls / example detail view
- Loads with example detail pane being closed.
- Loads with a single-row row-size per dataset example.
- Moved header row to footer area.
  - Space saving until we add filtering section above.
  - Will probably shift some of that back up when we have a filter / column adjustment section.
  - Hid "Open Details" button for simplicity / allowing user to select from rows.
- Adjusted header heights (more compact).
- Increased scorer column size (probably need to normalize the change percentages and values).
- Added trials tooltips for expand/contract icons.
- Updated tooltips to use design system (vs. MUI).
- Small design tweaks
  - Font sizes on summary page
  - Table footer pagination (size / font / colors)
  - Detail view header design tweaks (size, gap, color)
  - Double border table header
  - Pivot icon

### ToDo
ToDos:
- [ ] Use better popover display (from dataset cell renderer)
- [ ] Use small medium large sizing for height (similar to models)
- [ ] Add some nice stuff like search for column, cleanup "Calls" showing multiple times
- [ ] Make resize design nicer

Design feedback:
- [ ] Chart numbers - adjust sizes
- [ ] Try removing selected evals when in table view
- [ ] Add animations to detail drawer
- [ ] More aggressive drop-shadow detail drawer
- [ ] Full-screen drawer
- [ ] Close button tooltip remove

Additional feedback:
- [ ] Show hide all buttons for columns
- [ ] Multi-sort call-out
- [ ] Ctrl+click count on rows