### PR TITLE
fix(weave): Don't cause EvaluationLogger instances to stomp on each other when logging in parallel

### DIFF
--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -463,9 +463,9 @@ class EvaluationLogger(BaseModel):
 
         self._cleanup_predictions()
 
-        assert self._evaluate_call is not None, (
-            "Evaluation call should exist for finalization"
-        )
+        assert (
+            self._evaluate_call is not None
+        ), "Evaluation call should exist for finalization"
 
         # Finish the evaluation call
         wc = require_weave_client()
@@ -547,9 +547,9 @@ class EvaluationLogger(BaseModel):
             final_summary = {**final_summary, **summary}
 
         # Call the summarize op
-        assert self._evaluate_call is not None, (
-            "Evaluation call should exist for summary"
-        )
+        assert (
+            self._evaluate_call is not None
+        ), "Evaluation call should exist for summary"
 
         # Use set_call_stack to temporarily set the evaluation as the parent
         with call_context.set_call_stack([self._evaluate_call]):

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -549,9 +549,9 @@ class EvaluationLogger(BaseModel):
             final_summary = {**final_summary, **summary}
 
         # Call the summarize op
-        assert self._evaluate_call is not None, (
-            "Evaluation call should exist for summary"
-        )
+        assert (
+            self._evaluate_call is not None
+        ), "Evaluation call should exist for summary"
 
         # Use set_call_stack to temporarily set the evaluation as the parent
         with call_context.set_call_stack([self._evaluate_call]):

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -439,9 +439,11 @@ class EvaluationLogger(BaseModel):
                 "model": self.model,
             },
             attributes=IMPERATIVE_EVAL_MARKER,
+            use_stack=False,  # Don't push to global stack to prevent nesting
         )
         assert self._evaluate_call is not None
-        call_context.push_call(self._evaluate_call)
+        # Don't push the evaluation call to the global context to prevent nesting
+        # We'll use set_call_stack when needed instead
 
     def _cleanup_predictions(self) -> None:
         if self._is_finalized:
@@ -463,9 +465,9 @@ class EvaluationLogger(BaseModel):
 
         self._cleanup_predictions()
 
-        assert (
-            self._evaluate_call is not None
-        ), "Evaluation call should exist for finalization"
+        assert self._evaluate_call is not None, (
+            "Evaluation call should exist for finalization"
+        )
 
         # Finish the evaluation call
         wc = require_weave_client()
@@ -478,13 +480,6 @@ class EvaluationLogger(BaseModel):
                 "Failed to finish evaluation call during finalization.", exc_info=True
             )
 
-        # Pop the call regardless of finish success
-        try:
-            call_context.pop_call(self._evaluate_call.id)
-        except Exception:
-            # If popping fails (e.g., context already unwound), log and ignore
-            logger.warning("Failed to pop evaluation call from context.", exc_info=True)
-
         self._is_finalized = True
 
     def log_prediction(self, inputs: dict, output: Any) -> ScoreLogger:
@@ -492,31 +487,34 @@ class EvaluationLogger(BaseModel):
 
         The reference can be used to log scores which are attached to the specific
         prediction instance."""
-        # Make the prediction call
-        with _set_current_output(output):
-            with weave.attributes(IMPERATIVE_EVAL_MARKER):
-                _, predict_and_score_call = (
-                    self._pseudo_evaluation.predict_and_score.call(
-                        self._pseudo_evaluation,
-                        self.model,
-                        inputs,
-                        __require_explicit_finish=True,
-                    )
-                )
-
-        # Get the predict_call from the context variable
-        predict_call = current_predict_call.get()
-        if predict_call is None:
-            raise ValueError("predict_call should not be None")
-
+        # Use set_call_stack to temporarily set the evaluation as the parent
         assert self._evaluate_call is not None
-        pred = ScoreLogger(
-            predict_and_score_call=predict_and_score_call,
-            evaluate_call=self._evaluate_call,
-            predict_call=predict_call,
-        )
-        self._accumulated_predictions.append(pred)
-        return pred
+
+        with call_context.set_call_stack([self._evaluate_call]):
+            # Make the prediction call
+            with _set_current_output(output):
+                with weave.attributes(IMPERATIVE_EVAL_MARKER):
+                    _, predict_and_score_call = (
+                        self._pseudo_evaluation.predict_and_score.call(
+                            self._pseudo_evaluation,
+                            self.model,
+                            inputs,
+                            __require_explicit_finish=True,
+                        )
+                    )
+
+            # Get the predict_call from the context variable
+            predict_call = current_predict_call.get()
+            if predict_call is None:
+                raise ValueError("predict_call should not be None")
+
+            pred = ScoreLogger(
+                predict_and_score_call=predict_and_score_call,
+                evaluate_call=self._evaluate_call,
+                predict_call=predict_call,
+            )
+            self._accumulated_predictions.append(pred)
+            return pred
 
     def log_summary(
         self,
@@ -551,16 +549,19 @@ class EvaluationLogger(BaseModel):
             final_summary = {**final_summary, **summary}
 
         # Call the summarize op
-        assert (
-            self._evaluate_call is not None
-        ), "Evaluation call should exist for summary"
-        try:
-            with _set_current_summary(final_summary):
-                with weave.attributes(IMPERATIVE_EVAL_MARKER):
-                    self._pseudo_evaluation.summarize()
-        except Exception:
-            logger.error("Error during execution of summarize op.", exc_info=True)
-            # Even if summarize fails, try to finalize with the calculated summary
+        assert self._evaluate_call is not None, (
+            "Evaluation call should exist for summary"
+        )
+
+        # Use set_call_stack to temporarily set the evaluation as the parent
+        with call_context.set_call_stack([self._evaluate_call]):
+            try:
+                with _set_current_summary(final_summary):
+                    with weave.attributes(IMPERATIVE_EVAL_MARKER):
+                        self._pseudo_evaluation.summarize()
+            except Exception:
+                logger.error("Error during execution of summarize op.", exc_info=True)
+                # Even if summarize fails, try to finalize with the calculated summary
 
         self._finalize_evaluation(output=final_summary)
 

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -441,7 +441,8 @@ class EvaluationLogger(BaseModel):
             attributes=IMPERATIVE_EVAL_MARKER,
             use_stack=False,  # Don't push to global stack to prevent nesting
         )
-        assert self._evaluate_call is not None
+        if self._evaluate_call is None:
+            raise RuntimeError("Evaluation call does not exist, something went wrong!")
 
     def _cleanup_predictions(self) -> None:
         if self._is_finalized:
@@ -463,9 +464,10 @@ class EvaluationLogger(BaseModel):
 
         self._cleanup_predictions()
 
-        assert (
-            self._evaluate_call is not None
-        ), "Evaluation call should exist for finalization"
+        if self._evaluate_call is None:
+            raise RuntimeError(
+                "Evaluation call should exist for finalization, something went wrong!"
+            )
 
         # Finish the evaluation call
         wc = require_weave_client()
@@ -547,9 +549,9 @@ class EvaluationLogger(BaseModel):
             final_summary = {**final_summary, **summary}
 
         # Call the summarize op
-        assert (
-            self._evaluate_call is not None
-        ), "Evaluation call should exist for summary"
+        assert self._evaluate_call is not None, (
+            "Evaluation call should exist for summary"
+        )
 
         # Use set_call_stack to temporarily set the evaluation as the parent
         with call_context.set_call_stack([self._evaluate_call]):

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -442,8 +442,6 @@ class EvaluationLogger(BaseModel):
             use_stack=False,  # Don't push to global stack to prevent nesting
         )
         assert self._evaluate_call is not None
-        # Don't push the evaluation call to the global context to prevent nesting
-        # We'll use set_call_stack when needed instead
 
     def _cleanup_predictions(self) -> None:
         if self._is_finalized:


### PR DESCRIPTION
Resolves: https://wandb.atlassian.net/browse/WB-25510

This PR prevents instances from stomping on each other when logging in parallel by explicitly not using the global stack

This snippet will generate the following topology:
```py
def log_evals():
    ev = weave.EvaluationLogger()
    for x in range(3):
        pred = ev.log_prediction(inputs={"a": x, "b": x+1}, output=x+2)
        pred.log_score(scorer="scorer1", score=x+2)
        pred.log_score(scorer="scorer2", score=x+3)

for x in range(3):
    log_evals()
```

Before:
<img width="808" alt="image" src="https://github.com/user-attachments/assets/568bf822-045c-401e-b51f-0734021ee7c8" />


After:
<img width="803" alt="image" src="https://github.com/user-attachments/assets/7c6d1876-9c33-4403-8060-bc58cf786717" />
