### PR TITLE
feat(weave): Filter by feedback

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -17,6 +17,7 @@ import {
 } from '../feedback/HumanFeedback/tsHumanFeedback';
 import {ColumnInfo} from '../types';
 import {
+  FEEDBACK_EMOJI_FIELD,
   FIELD_DESCRIPTIONS,
   FIELD_LABELS,
   FilterId,
@@ -133,6 +134,11 @@ export const FilterBar = ({
       (options[2] as GroupedOption).options.push({
         value: col.field,
         label: col.headerName ?? col.field,
+      });
+    } else if (col.field === 'feedback') {
+      (options[0] as GroupedOption).options.push({
+        value: FEEDBACK_EMOJI_FIELD,
+        label: 'Feedback',
       });
     } else if (col.field.startsWith('output.')) {
       (options[2] as GroupedOption).options.push({

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterTagItem.tsx
@@ -88,6 +88,8 @@ export const FilterTagItem = ({
     } else {
       value = <Timestamp value={item.value} dropTimeWhenDefault />;
     }
+  } else if (fieldType === 'emoji') {
+    value = item.value === ':thumbs_up:' ? '👍' : '👎';
   } else {
     const valueType = getOperatorValueType(item.operator);
     value = ' ' + quoteValue(valueType, item.value);

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectValue.tsx
@@ -2,6 +2,7 @@
  * Select the value for a filter. Depends on the operator.
  */
 
+import {Select} from '@wandb/weave/components/Form/Select';
 import React from 'react';
 
 import {parseRef} from '../../../../../react';
@@ -97,6 +98,21 @@ export const SelectValue = ({
           isActive={shouldBeActive}
         />
       </div>
+    );
+  }
+
+  if (fieldType === 'emoji') {
+    return (
+      <Select<{emoji: string; detonedAlias: string}>
+        placeholder="Select a reaction..."
+        options={[
+          {emoji: '👍', detonedAlias: ':thumbs_up:'},
+          {emoji: '👎', detonedAlias: ':thumbs_down:'},
+        ]}
+        formatOptionLabel={option => <>{option.emoji}</>}
+        value={value}
+        onChange={v => onSetValue(v?.detonedAlias ?? '')}
+      />
     );
   }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -32,7 +32,7 @@ export type FilterId = number | string | undefined;
 // These are columns we won't allow the user to filter on.
 // For most of these it would be great if we could enable filtering in the future.
 export const UNFILTERABLE_FIELDS = [
-  'feedback',
+  //'feedback',
   'summary.weave.latency_ms',
   'tokens',
   'cost',
@@ -45,6 +45,9 @@ export type ColumnInfo = {
   colGroupingModel: GridColumnGroupingModel;
 };
 
+export const FEEDBACK_EMOJI_FIELD: string =
+  'feedback.[wandb.reaction.1].payload.detoned_alias';
+
 export const FIELD_LABELS: Record<string, string> = {
   id: 'Call ID',
   'summary.weave.status': 'Status',
@@ -52,6 +55,7 @@ export const FIELD_LABELS: Record<string, string> = {
   started_at: 'Called',
   wb_run_id: 'Run',
   wb_user_id: 'User',
+  [FEEDBACK_EMOJI_FIELD]: 'Feedback',
 };
 
 export const getFieldLabel = (field: string): string => {
@@ -81,13 +85,21 @@ export const FIELD_TYPE: Record<string, string> = {
   wb_run_id: 'run',
   wb_user_id: 'user',
   started_at: 'datetime',
+  [FEEDBACK_EMOJI_FIELD]: 'emoji',
 };
 
 export const getFieldType = (field: string): string => {
   return FIELD_TYPE[field] ?? 'text';
 };
 
-export type OperatorGroup = 'string' | 'number' | 'boolean' | 'date' | 'any';
+export type OperatorGroup =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'date'
+  | 'any'
+  | 'emoji';
+
 export type SelectOperatorOption = {
   label: string;
   value: string;
@@ -199,6 +211,7 @@ const GROUP_LABELS: Record<OperatorGroup, string> = {
   boolean: 'Boolean',
   date: 'Date',
   any: 'Other',
+  emoji: 'Emoji',
 };
 
 export function getGroupedOperatorOptions(
@@ -308,6 +321,15 @@ export const getOperatorOptions = (field: string): SelectOperatorOption[] => {
         value: '(string): equals',
         label: 'equals',
         group: 'string',
+      },
+    ];
+  }
+  if ('emoji' === fieldType) {
+    return [
+      {
+        value: '(emoji): is',
+        label: 'is',
+        group: 'emoji',
       },
     ];
   }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/common.ts
@@ -32,7 +32,6 @@ export type FilterId = number | string | undefined;
 // These are columns we won't allow the user to filter on.
 // For most of these it would be great if we could enable filtering in the future.
 export const UNFILTERABLE_FIELDS = [
-  //'feedback',
   'summary.weave.latency_ms',
   'tokens',
   'cost',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/savedViewUtil.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/SavedViews/savedViewUtil.ts
@@ -349,6 +349,10 @@ const filterToClause = (item: Filter): Record<string, any> => {
         },
       ],
     };
+  } else if (item.operator === '(emoji): is') {
+    return {
+      $eq: [{$getField: item.field}, {$literal: item.value}],
+    };
   }
   throw new Error(`Unsupported operator: ${item.operator}`);
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/tabularListViews/operators.ts
@@ -137,6 +137,10 @@ export const operationConverter = (
         },
       ],
     };
+  } else if (item.operator === '(emoji): is') {
+    return {
+      $eq: [{$getField: item.field}, {$literal: item.value}],
+    };
   } else {
     throw new Error(`Unsupported operator: ${item.operator}`);
   }


### PR DESCRIPTION
## Description

Only 👍 and 👎 are supported at this time.

Follow-ups:
- Support for arbitrary emojis (easy)
- Support for arbitrary feedbacks submitted with SDK (hard)

![Screenshot 2025-05-25 at 9 12 08 PM](https://github.com/user-attachments/assets/0a5f492c-57bc-439d-8aba-afe884cb0b7b)

## Testing

How was this PR tested?
