### PR TITLE
chore(weave): dont pass empty filter in stats query

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -496,17 +496,19 @@ const useCallsStats = (
         entity: params.entity,
         project: params.project,
       }),
-      filter: {
-        op_names: deepFilter?.opVersionRefs,
-        input_refs: deepFilter?.inputObjectVersionRefs,
-        output_refs: deepFilter?.outputObjectVersionRefs,
-        parent_ids: deepFilter?.parentIds,
-        trace_ids: deepFilter?.traceId ? [deepFilter.traceId] : undefined,
-        call_ids: deepFilter?.callIds,
-        trace_roots_only: deepFilter?.traceRootsOnly,
-        wb_run_ids: deepFilter?.runIds,
-        wb_user_ids: deepFilter?.userIds,
-      },
+      filter: deepFilter
+        ? {
+            op_names: deepFilter?.opVersionRefs,
+            input_refs: deepFilter?.inputObjectVersionRefs,
+            output_refs: deepFilter?.outputObjectVersionRefs,
+            parent_ids: deepFilter?.parentIds,
+            trace_ids: deepFilter?.traceId ? [deepFilter.traceId] : undefined,
+            call_ids: deepFilter?.callIds,
+            trace_roots_only: deepFilter?.traceRootsOnly,
+            wb_run_ids: deepFilter?.runIds,
+            wb_user_ids: deepFilter?.userIds,
+          }
+        : undefined,
       query: params.query,
       limit: params.limit,
       ...(!!params.includeTotalStorageSize
@@ -568,7 +570,6 @@ const useProjectHasCalls = (
   const callsStats = useCallsStats({
     entity: params.entity,
     project: params.project,
-    filter: {},
     limit: 1,
     skip: params.skip,
   });


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

The backend checks the filter against `None` to trigger a special performant stats query. In the frontend, we are actually passing an empty filter, which is not the same as `None`.

## Testing

Prod:
![Screenshot 2025-05-27 at 3 33 56 PM](https://github.com/user-attachments/assets/fe2d2595-cbe4-4805-b7ff-83e4541cb722)

Branch:
![Screenshot 2025-05-27 at 3 33 44 PM](https://github.com/user-attachments/assets/7d539e28-3be4-450c-80ab-94256a4ce37b)

![Screenshot 2025-05-27 at 3 34 56 PM](https://github.com/user-attachments/assets/868e3000-2a7b-407a-a810-93d1bec0e143)

![Screenshot 2025-05-27 at 3 34 44 PM](https://github.com/user-attachments/assets/520d373c-0293-41eb-9dc3-65edd9f6c35b)

