### PR TITLE
fix(weave): Updating smollagents test for new version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ huggingface = ["huggingface-hub>=0.28.1"]
 smolagents = [
   "openai>=1.0.0",
   "litellm>=1.58",
-  "smolagents>=1.8.1",
+  "smolagents>=1.17.0",
   "huggingface-hub>=0.28.1",
   "SQLAlchemy>=2.0.38",
 ]

--- a/tests/integrations/smolagents/test_smolagents.py
+++ b/tests/integrations/smolagents/test_smolagents.py
@@ -97,7 +97,7 @@ def test_tool_calling_agent_search(client):
     )
 
     calls = client.calls()
-    assert len(calls) == 20
+    assert len(calls) == 17
 
     call = calls[0]
     assert call.started_at < call.ended_at
@@ -136,7 +136,7 @@ def test_tool_calling_agent_weather(client):
 
     assert answer == "The weather in Tokyo is sunny with temperatures around 7°C."
     calls = client.calls()
-    assert len(calls) == 12
+    assert len(calls) == 10
 
     call = calls[0]
     assert call.started_at < call.ended_at

--- a/weave/integrations/smolagents/smolagents_sdk.py
+++ b/weave/integrations/smolagents/smolagents_sdk.py
@@ -107,6 +107,7 @@ def get_smolagents_patcher(
             # Patch model-related classes
             get_symbol_patcher("smolagents", "TransformersModel.__call__", base),
             get_symbol_patcher("smolagents", "HfApiModel.__call__", base),
+            get_symbol_patcher("smolagents", "InferenceClientModel.__call__", base),
             get_symbol_patcher("smolagents", "LiteLLMModel.__call__", base),
             get_symbol_patcher("smolagents", "OpenAIServerModel.__call__", base),
             get_symbol_patcher("smolagents", "AzureOpenAIServerModel.__call__", base),


### PR DESCRIPTION
## Description

`smolagents` got a new version (1.17.0). Which changes its internal logic a bit so that we don't get exactly the same number of runs.
