### PR TITLE
chore(weave): fix pill icon alignment in trace navigator

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/StatusChip.tsx
@@ -65,7 +65,7 @@ export const StatusChip = ({
   const {icon, color, label, tooltip} = statusInfo;
 
   const pill = iconOnly ? (
-    <IconOnlyPill icon={icon} color={color} />
+    <IconOnlyPill icon={icon} color={color} style={{flexShrink: 1}} />
   ) : (
     <Pill icon={icon} color={color} label={label} />
   );

--- a/weave-js/src/components/Tag/Pill.tsx
+++ b/weave-js/src/components/Tag/Pill.tsx
@@ -53,17 +53,24 @@ export type IconOnlyPillProps = {
   icon: IconName;
   color?: TagColorName;
   isInteractive?: boolean;
+  style?: React.CSSProperties;
 };
 export const IconOnlyPill: FC<IconOnlyPillProps> = ({
   icon,
   color,
   isInteractive,
+  style,
 }) => {
   const classes = useTagClasses({color, isInteractive});
   return (
     <Tailwind>
       <div className={twMerge(classes, 'rounded-2xl', 'max-w-[22px]')}>
-        <Icon role="presentation" className="m-4 h-14 w-14" name={icon} />
+        <Icon
+          role="presentation"
+          className="m-4 h-14 w-14"
+          name={icon}
+          style={style}
+        />
       </div>
     </Tailwind>
   );


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->


[This](https://github.com/wandb/weave/pull/4559) recent pr now causes an alignment issue with the pill. There may be a better way of fixing this, but this restores previous functionality. 

## Testing

Before:
![Screenshot 2025-05-28 at 9 42 01 AM](https://github.com/user-attachments/assets/28274c5e-c6e4-4998-af19-c5b1e19e4a44)


After:
![Screenshot 2025-05-28 at 9 41 21 AM](https://github.com/user-attachments/assets/a7168c61-23b8-45d1-9381-a12dbade8a85)

