### PR TITLE
chore(weave): move comment out of query to remove from logs

### DIFF
--- a/tests/trace/test_objects_query_builder.py
+++ b/tests/trace/test_objects_query_builder.py
@@ -178,11 +178,6 @@ FROM (
         ) AS row_num,
         if (row_num = 1, 1, 0) AS is_latest
     FROM (
-        --
-        -- Object versions are uniquely identified by (kind, project_id, object_id, digest).
-        -- This subquery selects a row to represent each object version. There are multiple rows
-        -- for each object version if it has been deleted or recreated prior to a table merge.
-        --
         SELECT
             project_id,
             object_id,
@@ -199,14 +194,6 @@ FROM (
                 kind,
                 object_id,
                 digest
-                --
-                -- Prefer the most recent row. If there is a tie, prefer the row
-                -- with non-null deleted_at, which represents the deletion event.
-                --
-                -- Rows for the same object version may have the same created_at
-                -- because deletion events inherit the created_at of the last
-                -- non-deleted row for the object version.
-                --
                 ORDER BY created_at DESC, (deleted_at IS NULL) ASC
             ) AS rn
         FROM object_versions"""


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Comments in queries get logged to dd which makes it ugly(er) and [bloated](t&cols=host%2Cservice&event=AwAAAZcY6gOY-FsCgAAAABhBWmNZNmhXZ0FBQ044NDVJZEJfQWdRQUoAAAAkMDE5NzE4ZWYtNWFiMy00MDA5LWJhZmEtNGRiNmZiMTU2MzdhAAP9Qw&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1748469677884&to_ts=1748469680926&live=false), lets just pull it out. 