### PR TITLE
fix(weave): default Icon to inline block

### DIFF
--- a/weave-js/src/components/Icon/Icon.tsx
+++ b/weave-js/src/components/Icon/Icon.tsx
@@ -293,6 +293,7 @@ const updateIconProps = (props: SVGIconProps) => {
     ...props,
     style: {
       flexShrink: 0,
+      display: 'inline-block',
       ...props.style,
     },
   };


### PR DESCRIPTION
## Description

Icons should by default appear next to elements rather than consume the block. For example: 
<img width="405" alt="image" src="https://github.com/user-attachments/assets/f49767d2-f560-4ebc-85db-8afb01fb2cbe" />
rather than
![image](https://github.com/user-attachments/assets/5b9a32c7-5097-41db-a32f-e4e20441a482)
