### PR TITLE
fix(weave): Do not attempt to read .netrc when API key is set in env

### DIFF
--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -90,9 +90,7 @@ def _wandb_api_key_via_netrc_file(filepath: str) -> str | None:
 
 def weave_wandb_api_key() -> str | None:
     env_api_key = _wandb_api_key_via_env()
-    netrc_api_key = _wandb_api_key_via_netrc()
-    if env_api_key and netrc_api_key and env_api_key != netrc_api_key:
-        logger.warning(
-            "There are different credentials in the netrc file and the environment. Using the environment value."
-        )
-    return env_api_key or netrc_api_key
+    if env_api_key is not None:
+        return env_api_key
+
+    return _wandb_api_key_via_netrc()

--- a/weave_query/weave_query/environment.py
+++ b/weave_query/weave_query/environment.py
@@ -252,8 +252,7 @@ def weave_wandb_api_key() -> typing.Optional[str]:
     if env_api_key is not None:
         return env_api_key
 
-    netrc_api_key = _wandb_api_key_via_netrc()
-    return env_api_key or netrc_api_key
+    return _wandb_api_key_via_netrc()
 
 
 def projection_timeout_sec() -> typing.Optional[typing.Union[int, float]]:

--- a/weave_query/weave_query/environment.py
+++ b/weave_query/weave_query/environment.py
@@ -249,16 +249,10 @@ def _wandb_api_key_via_netrc_file(filepath: str) -> typing.Optional[str]:
 
 def weave_wandb_api_key() -> typing.Optional[str]:
     env_api_key = _wandb_api_key_via_env()
+    if env_api_key is not None:
+        return env_api_key
+
     netrc_api_key = _wandb_api_key_via_netrc()
-    if env_api_key and netrc_api_key:
-        if wandb_production():
-            raise errors.WeaveConfigurationError(
-                "WANDB_API_KEY should not be set in both ~/.netrc and the environment."
-            )
-        elif env_api_key != netrc_api_key:
-            print(
-                "There are different credentials in the netrc file and the environment. Using the environment value."
-            )
     return env_api_key or netrc_api_key
 
 


### PR DESCRIPTION
## Description

- Fixes 25242

Attempting to read an unavailable netrc file was reported to cause a large delay in execution.

This changes the code to just return the env key if found (which is prioritized anyways) which is how the node SDK already handles this.
