### PR TITLE
Update evaluation_logger.md

### DIFF
--- a/docs/docs/guides/evaluation/evaluation_logger.md
+++ b/docs/docs/guides/evaluation/evaluation_logger.md
@@ -16,6 +16,10 @@ The `EvaluationLogger` offers flexibility while the standard framework offers st
 ## Basic workflow
 
 1. _Initialize the logger:_ Create an instance of `EvaluationLogger`, optionally providing metadata about the `model` and `dataset`. Defaults will be used if omitted.
+    :::important Track token usage and cost
+    To capture token usage and cost for LLM calls (e.g. OpenAI), initialize `EvaluationLogger` before any LLM invocations**. 
+    If you call your LLM first and then log predictions afterward, token and cost data are not be captured.
+    :::
 2. _Log predictions:_ Call `log_prediction` for each input/output pair from your system.
 3. _Log scores:_ Use the returned `ScoreLogger` to `log_score` for the prediction. Multiple scores per prediction are supported.
 4. _Finish prediction:_ Always call `finish()` after logging scores for a prediction to finalize it.


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1555

updates eval logger docs to address common point of confusion: token and cost tracking only occurs for LLM calls made after the logger is initialized.

## Testing

yarn start on local
