### PR TITLE
chore(weave): Bump TS SDK version and update docs

### DIFF
--- a/docs/docs/guides/tracking/tracing.mdx
+++ b/docs/docs/guides/tracking/tracing.mdx
@@ -69,13 +69,13 @@ There are three main ways to create Calls in Weave:
 
   </TabItem>
   <TabItem value="typescript" label="TypeScript">
-    Weave automatically tracks [calls to common LLM libraries](../integrations/index.md) like `openai`. Simply call [`await weave.init('project_name')`](../../reference/typescript-sdk/weave/functions/init.md) and wrap your OpenAI client with [`weave.wrapOpenAI`](../../reference/typescript-sdk/weave/functions/wrapOpenAI.md) at the start of your program:
+    Weave automatically tracks [calls to common LLM libraries](../integrations/index.md) like `openai`.
 
     ```typescript showLineNumbers
     import OpenAI from 'openai'
     import * as weave from 'weave'
 
-    const client = weave.wrapOpenAI(new OpenAI())
+    const client = new OpenAI()
 
     // Initialize Weave Tracing
     await weave.init('intro-example')
@@ -93,6 +93,8 @@ There are three main ways to create Calls in Weave:
       top_p: 1,
     });
     ```
+
+    Please also see [TypeScript SDK: Third-Party Integration Guide](../integrations/js.md) for complete setup guide for JS/TS projects.
 
   </TabItem>
 </Tabs>

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -94,13 +94,9 @@ _In this example, we're using openai so you will need to add an OpenAI [API key]
     // highlight-next-line
     import * as weave from 'weave';
     
-    With the new change this manual wrapping is no longer needed. We might need to add a link to the full set up guide.
     // highlight-next-line
     const openai = new OpenAI();
-    // In some cases, you may still need to use manual instrumentation:
-    // const openai = wrapOpenAI(new OpenAI());
-    // See the JS Integration guide for more information
-
+  
     async function extractDinos(input: string) {
       const response = await openai.chat.completions.create({
         model: 'gpt-4o',

--- a/sdks/node/README.md
+++ b/sdks/node/README.md
@@ -125,10 +125,8 @@ await testClassInstance.logImage(image);
 Weave provides an integration with OpenAI, allowing you to trace API calls made to OpenAI's services seamlessly.
 
 ```javascript
-import {wrapOpenAI} from 'weave/integrations/openai';
-
 // Create a patched instance of OpenAI
-const openai = wrapOpenAI();
+const openai = new OpenAI();
 
 // Use the OpenAI instance as usual
 openai.chat.completions.create({
@@ -145,6 +143,8 @@ openai.images.generate({
   response_format: 'b64_json',
 });
 ```
+
+Please also see [TypeScript SDK: Third-Party Integration Guide](https://weave-docs.wandb.ai/guides/integrations/js) for setup guide for ESM projects.
 
 ### Evaluations
 

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weave",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "AI development toolkit",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

- Updates TypeScript SDK documentation to reflect automatic instrumentation of OpenAI
- Removes references to `wrapOpenAI()` which is no longer needed
- Adds links to the TypeScript SDK integration guide for complete setup instructions
- Updates code examples in quickstart and tracing guides to use the simplified approach
- Bumps Node SDK version from 0.8.0 to 0.9.0

## Testing

Verified all documentation examples are consistent with the current SDK behavior and that links to the TypeScript integration guide are correct.