### PR TITLE
fix(weave): Calls incorrectly being dropped if batch is too large

### DIFF
--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -169,9 +169,6 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
                 f"The maximum size is {self.remote_request_bytes_limit} bytes."
             )
             logger.error(error_message)
-            # If we get down to here we have recursed to size 1
-            # We don't want to error the whole process, just drop the call that is too large
-            return
 
         try:
             self._send_batch_to_server(encoded_data)
@@ -197,6 +194,10 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
                 # Only requeue if the processor is still accepting work
                 if self.call_processor and self.call_processor.is_accepting_new_work():
                     self.call_processor.enqueue(batch)
+                else:
+                    logger.error(
+                        f"Failed to enqueue batch of size {len(batch)} - Processor is shutting down"
+                    )
 
     @with_retry
     def _generic_request_executor(


### PR DESCRIPTION
## Description

Reverts an added return which caused calls to drop based on heurestic rather than a an actual error.
Also logs an error if batch fails to enqueue due to the call processor shutting down.

