### PR TITLE
fix(weave): fix logger warnings

### DIFF
--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -221,7 +221,7 @@ class ScoreLogger(BaseModel):
 
     def finish(self) -> None:
         if self._has_finished:
-            logger.warn("(NO-OP): Already called finish, returning.")
+            logger.warning("(NO-OP): Already called finish, returning.")
             return
 
         scores = self._captured_scores
@@ -529,7 +529,7 @@ class EvaluationLogger(BaseModel):
         the evaluation, meaning no more predictions or scores can be logged.
         """
         if self._is_finalized:
-            logger.warn("(NO-OP): Evaluation already finalized, cannot log summary.")
+            logger.warning("(NO-OP): Evaluation already finalized, cannot log summary.")
             return
 
         if summary is None:

--- a/weave_query/weave_query/artifact_wandb.py
+++ b/weave_query/weave_query/artifact_wandb.py
@@ -228,7 +228,7 @@ def _collection_and_alias_id_mapping_to_uri(
             # never uploaded, so the client id doesn't exist in the W&B server.
 
             collection = None
-            logging.warn(
+            logging.warning(
                 f"Artifact collection with client id {client_collection_id} not present in W&B server."
             )
 
@@ -1208,7 +1208,7 @@ class WeaveWBArtifactByIDURI(uris.WeaveURI):
 
 
 # This is a wrapper around an artifact that acts like a list of files.
-# It fetchs a file from the manifest on __getItem__ and can return a count without fetching all files
+# It fetches a file from the manifest on __getItem__ and can return a count without fetching all files
 @dataclasses.dataclass
 class FilesystemArtifactFileIterator(list[artifact_fs.FilesystemArtifactFile]):
     data: list[str]

--- a/weave_query/weave_query/ecosystem/langchain/util.py
+++ b/weave_query/weave_query/ecosystem/langchain/util.py
@@ -31,7 +31,7 @@ def safely_convert_lc_run_to_wb_span(run: Run) -> Optional["trace_tree.Span"]:
         return _convert_lc_run_to_wb_span(run)
     except Exception as e:
         if PRINT_WARNINGS:
-            logging.warn(
+            logging.warning(
                 f"Skipping trace saving - unable to safely convert LangChain Run into W&B Trace due to: {e}"
             )
         return None

--- a/weave_query/weave_query/execute.py
+++ b/weave_query/weave_query/execute.py
@@ -161,7 +161,7 @@ _top_level_stats_ctx: contextvars.ContextVar[
 
 @contextlib.contextmanager
 def top_level_stats():
-    """Will keep stats for nodes executed within this context, including recurisvely."""
+    """Will keep stats for nodes executed within this context, including recursively."""
     stats = _top_level_stats_ctx.get()
     token = None
     if stats is None:
@@ -603,7 +603,7 @@ def execute_forward_node(
                                 # Sometimes we experience a FileNotFoundError when loading up the AWL instance.
                                 # Unsure how/why this happens in the first place, but handle it by deleting the
                                 # corrupted artifact and sending execution down the cache miss path.
-                                logging.warn(f"AWL local artifact not found: {output_ref.artifact.uri}")
+                                logging.warning(f"AWL local artifact not found: {output_ref.artifact.uri}")
                                 output_ref.artifact.delete()
                 # otherwise, the run's output was not saveable, so we need
                 # to recompute it.

--- a/weave_query/weave_query/wandb_client_api.py
+++ b/weave_query/weave_query/wandb_client_api.py
@@ -46,7 +46,7 @@ def query_with_retry(
         except exceptions.Timeout as e:
             if attempt_no == num_timeout_retries:
                 raise
-            logging.warn(
+            logging.warning(
                 f'wandb GQL query timed out: "{e}", retrying (num_attempts={attempt_no + 1})'
             )
 


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

What does the PR do? Include a concise description of the PR contents.

## Testing

How was this PR tested?
