### PR TITLE
chore(weave): Correctly annotate async pytests

### DIFF
--- a/tests/trace/test_tracing_resilience.py
+++ b/tests/trace/test_tracing_resilience.py
@@ -420,6 +420,7 @@ def test_resilience_to_accumulator_on_finish_post_processor_errors(
         assert log.msg.startswith("Error closing iterator, call data may be incomplete")
 
 
+@pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
     client, log_collector

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -2747,6 +2747,7 @@ def test_calls_query_sort_by_display_name_prioritized(client):
     assert call_list[0].op_name == call_list[1].op_name == call_list[2].op_name
 
 
+@pytest.mark.asyncio
 async def test_tracing_enabled_context(client):
     """Test that gc.create_call() and gc.finish_call() respect the _tracing_enabled context variable."""
     from weave.trace.weave_client import Call


### PR DESCRIPTION
I'm not sure why this started failing recently, but these async tests are now failing due to lack of asyncio annotations 