### PR TITLE
chore(weave): Fix margin top on add provider drawer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OverviewPage/AddProviderDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OverviewPage/AddProviderDrawer.tsx
@@ -212,7 +212,7 @@ export const AddProviderDrawer: React.FC<AddProviderDrawerProps> = ({
       open={isOpen}
       onClose={handleClose}
       // if the navbar is visible, we need to offset the drawer by the height of the navbar
-      marginTop={Math.min(60 - scrollWidth, 60)}
+      marginTop={Math.max(60 - scrollWidth, 0)}
       defaultWidth={isFullscreen ? window.innerWidth - 73 : drawerWidth}
       setWidth={width => !isFullscreen && setDrawerWidth(width)}
       headerContent={


### PR DESCRIPTION
## Description

Top margin was going negative on scroll

before
<img width="505" alt="Screenshot 2025-06-02 at 1 04 23 PM" src="https://github.com/user-attachments/assets/89abd714-64d2-4948-8ece-66dacf78b7d6" />

after
<img width="459" alt="Screenshot 2025-06-02 at 1 04 41 PM" src="https://github.com/user-attachments/assets/404d5212-7f95-4a51-945e-699d8f7489d5" />
