### PR TITLE
fix: revert display inline block

### DIFF
--- a/weave-js/src/components/Icon/Icon.tsx
+++ b/weave-js/src/components/Icon/Icon.tsx
@@ -297,7 +297,6 @@ const updateIconProps = (props: SVGIconProps) => {
     ...props,
     style: {
       flexShrink: 0,
-      display: 'inline-block',
       ...props.style,
     },
   };


### PR DESCRIPTION
## Description

This reverts the display inline block to prevent any potential side effects. the original intent was to resolve the block display of the group by dropdown but that has been resolved in core now so we don't need this:

<img width="607" alt="image" src="https://github.com/user-attachments/assets/9e4a316e-7b3d-4163-96fb-1924b5150696" />

