### PR TITLE
chore(weave): Fix double stream loading

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
@@ -258,7 +258,7 @@ export const PlaygroundChat = ({
                       <PlaygroundContext.Provider
                         value={{
                           isPlayground: true,
-                          isStreaming: isAnyLoading,
+                          isStreaming: state.loading,
                           deleteMessage: (messageIndex, responseIndexes) =>
                             deleteMessage(idx, messageIndex, responseIndexes),
                           editMessage: (messageIndex, newMessage) =>


### PR DESCRIPTION
## Description
Separate the loading states
Before even if one chat finished it wouldnt show the whole text because the other was still loading

Before

https://github.com/user-attachments/assets/db82a54a-32c1-49df-b8f4-053564e60ff9



after


https://github.com/user-attachments/assets/b3888198-719c-4f11-9465-8cec5831ccab

