### PR TITLE
chore(weave): lock the datetime filter field

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterRow.tsx
@@ -66,6 +66,10 @@ export const FilterRow = ({
     isWeaveRef(item.value) ||
     ['id', 'status', 'run', 'user'].includes(getFieldType(item.field));
 
+  // Encourage users to create a new filter instead of modifying the datetime
+  // filter by locking the selection. Still deletable.
+  const isFieldDisabled = item.field === 'started_at';
+
   return (
     <>
       <div className="min-w-[250px]">
@@ -73,6 +77,7 @@ export const FilterRow = ({
           options={options}
           value={item.field}
           onSelectField={onSelectField}
+          isDisabled={isFieldDisabled}
         />
       </div>
       <div className="w-[165px]">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectField.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectField.tsx
@@ -26,6 +26,7 @@ export type SelectFieldOption = FieldOption | GroupedOption;
 type SelectFieldProps = {
   options: SelectFieldOption[];
   value: string;
+  isDisabled?: boolean;
   onSelectField: (name: string) => void;
 };
 
@@ -57,18 +58,19 @@ const SingleValue = ({
 export const SelectField = ({
   options,
   value,
+  isDisabled,
   onSelectField,
 }: SelectFieldProps) => {
   const internalOptions = _.cloneDeep(options);
   const allOptions: FieldOption[] = internalOptions.flatMap(
     (groupOption: SelectFieldOption) => (groupOption as GroupedOption).options
   );
-  let isDisabled = false;
+  let isDisabledOverride = isDisabled ?? false;
   let selectedOption = allOptions.find(o => o.value === value);
 
   // Handle the case of a filter that we let the user create but not edit.
   if (value && !selectedOption) {
-    isDisabled = true;
+    isDisabledOverride = true;
     selectedOption = {
       value,
       label: getFieldLabel(value),
@@ -90,7 +92,7 @@ export const SelectField = ({
       onChange={onReactSelectChange}
       components={{Option, SingleValue}}
       formatOptionLabel={OptionLabel}
-      isDisabled={isDisabled}
+      isDisabled={isDisabledOverride}
       autoFocus
     />
   );


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Encourage users to add a new filter instead of clobbering the datetime default. It is still possible to remove the filter with the "x" button, and change the date to expand the range. 

## Testing

Prod:
![Screenshot 2025-06-03 at 11 35 14 AM](https://github.com/user-attachments/assets/a6c2129d-5c2d-4fb4-af75-b8ca77c208f5)

This branch:

![Screenshot 2025-06-03 at 11 29 32 AM](https://github.com/user-attachments/assets/4c5c2278-fcf2-46f0-a9ba-bfe39dc73bea)

![Screenshot 2025-06-03 at 11 30 02 AM](https://github.com/user-attachments/assets/50310ce3-0f6e-4d7c-b26d-b98723d4fe9f)

![Screenshot 2025-06-03 at 11 29 26 AM](https://github.com/user-attachments/assets/011d2e81-7e58-410f-9942-f771bd1a7558)
