### PR TITLE
chore(weave): Design - default eval compare view results to table instead of split view

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/CompareEvaluationsPage.tsx
@@ -305,7 +305,7 @@ const ResultExplorer: React.FC<{
   height: number;
 }> = ({state, height}) => {
   const [viewMode, setViewMode] = useState<'detail' | 'table' | 'split'>(
-    'split'
+    'table'
   );
   const regressionFinderEnabled = state.evaluationCallIdsOrdered.length === 2;
 


### PR DESCRIPTION
Modifies default view to be table instead of split