### PR TITLE
chore(weave): fancy page content as main with id

### DIFF
--- a/weave-js/src/components/FancyPage/FancyPage.tsx
+++ b/weave-js/src/components/FancyPage/FancyPage.tsx
@@ -35,10 +35,10 @@ export const FancyPage = React.memo(
           selectedItem={activeItem}
           baseUrl={baseUrl}
         />
-        <div className="fancy-page__content">
+        <main id="main-content" className="fancy-page__content">
           {children ??
             (activeItem && 'render' in activeItem && activeItem.render?.())}
-        </div>
+        </main>
       </div>
     );
   }


### PR DESCRIPTION
## Description

makes the fancy page's content a `main` element and applies the `main-content` id on it so the skip to content link can jump straight to it.

https://wandb.atlassian.net/browse/WB-25111
