### PR TITLE
chore(app): Updating tag to support icon only display

### DIFF
--- a/weave-js/src/components/Tag/Tag.tsx
+++ b/weave-js/src/components/Tag/Tag.tsx
@@ -43,7 +43,7 @@ export function useTagClasses({
     () =>
       classNames(
         'night-aware',
-        'min-h-22 flex max-h-22 w-fit items-center rounded-[3px] text-[14px]',
+        'min-h-22 flex h-22 max-h-22 w-fit items-center rounded-[3px] text-[14px] flex items-center gap-4 space-around px-4',
         getTagColorClass(tagColor),
         isInteractive ? getTagHoverClass(tagColor) : ''
       ),
@@ -76,19 +76,19 @@ export const Tag: FC<TagProps> = ({
   return (
     <TruncateByCharsWithTooltip {...truncationProps}>
       {({truncatedText}) => (
-        <div className={twMerge(classes, showIcon ? 'pl-4 pr-6' : 'px-6')}>
+        <div className={classes}>
           {showIcon && (
             <Icon
               role="presentation"
-              className="mr-4 h-14 w-14"
+              className=" h-14 w-14"
               name={iconName ?? DEFAULT_TAG_ICON}
             />
           )}
-          <span>{truncatedText}</span>
+          {truncatedText && <span>{truncatedText}</span>}
           {endIconName && (
             <Icon
               role="presentation"
-              className="ml-4 h-14 w-14"
+              className="h-14 w-14"
               name={endIconName}
             />
           )}


### PR DESCRIPTION
- gap spacing preferred to explicit since it automatically handles different numbers of items
- setting explicit height so it doesn't require line-height from `truncatedText`
- removing spacing cheat since it unbalances no-text versions

## Description
I require a single icon version of a tag:
![image](https://github.com/user-attachments/assets/e68730a0-1c33-4c76-88e6-66ec44861d3e)

This looks awful in existing implementations:
<img width="394" alt="Screenshot 2025-06-05 at 1 17 44 PM" src="https://github.com/user-attachments/assets/fdb375d0-acba-4042-8976-df412dae919c" />

So I made it not awful:
<img width="403" alt="Screenshot 2025-06-05 at 1 18 36 PM" src="https://github.com/user-attachments/assets/fa99fc45-2307-4045-95ba-1b0c65ec16ba" />
