### PR TITLE
chore(weave): only show feedback hover with reactions

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/ReactionsLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/feedback/ReactionsLoaded.tsx
@@ -138,7 +138,10 @@ export const ReactionsLoaded = ({
 
   const onMouseEnter = () => setIsMouseOver(true);
   const onMouseLeave = () => setIsMouseOver(false);
-  const showContent = forceVisible || isMouseOver || reactions.length > 0;
+  const legacyReactions = reactions.filter(r =>
+    feedbackIsLegacy(r.feedback_type)
+  );
+  const showContent = forceVisible || isMouseOver || legacyReactions.length > 0;
 
   const wrapperStyles = {
     overflow: 'auto',
@@ -273,3 +276,10 @@ export const ReactionsLoaded = ({
     </Tailwind>
   );
 };
+
+function feedbackIsLegacy(feedbackType: string) {
+  return (
+    feedbackType.startsWith('wandb.note') ||
+    feedbackType.startsWith('wandb.reaction')
+  );
+}


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Only show the popup when hovered or actually has existing reactions, not all feedback (which is now more broad). 

## Testing

Prod
<img width="500" alt="Screenshot 2025-06-05 at 2 20 05 PM" src="https://github.com/user-attachments/assets/1f82636a-a52b-40a2-9777-eed987d4bb88" />


Branch
<img width="498" alt="image" src="https://github.com/user-attachments/assets/aff8c906-2bdb-42ea-b75f-cda344da842a" />


