### PR TITLE
chore(weave): force flush in test to reduce flake

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -733,6 +733,7 @@ def test_dataset_calls(client):
     for row in ref.rows:
         call = client.create_call("x", {"a": row["doc"]})
         client.finish_call(call, None)
+    client.finish()
 
     calls = list(client.get_calls(filter={"op_name": "x"}))
     assert calls[0].inputs["a"] == "xx"

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1808,6 +1808,8 @@ def test_long_display_names_are_elided(client):
     _, call = func.call()
     assert len(call.display_name) <= MAX_DISPLAY_NAME_LENGTH
 
+    client.finish()
+
     # The display name is correct server side
     calls = list(func.calls())
     call = calls[0]

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1922,12 +1922,16 @@ def test_delete_op_version(client):
     with pytest.raises(weave.trace_server.errors.ObjectDeletedError):
         op_ref.get()
 
+    client.finish()
+
     # lets get the calls
     calls = list(my_op.calls())
     assert len(calls) == 1
 
     # call the deleted op, this should still work (?)
     my_op(1)
+
+    client.finish()
 
     calls = list(my_op.calls())
     assert len(calls) == 2


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->
1. [Flaky test](https://github.com/wandb/weave/actions/runs/15479515889/job/43582535913?pr=4150)
2. [Flaky test](https://github.com/wandb/weave/actions/runs/15495765966/job/43632028424?pr=4620)
3. [Flaky test](https://github.com/wandb/weave/actions/runs/15497940251/job/43639064319?pr=4647)

## Testing

Flush before reading to be more sure the client has at least sent the items. 
