### PR TITLE
perf(weave): truncate strings in table display

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -139,7 +139,7 @@ const CellValueStringWithPopup = ({value, style}: CellValueStringProps) => {
   ) : (
     <TooltipContent onClick={onClick}>
       <TooltipText isJSON={json}>{displayTrimmed}</TooltipText>
-      <TooltipHint>Click for complete content</TooltipHint>
+      <TooltipHint>Click to view full content</TooltipHint>
     </TooltipContent>
   );
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse2/CellValueString.tsx
@@ -84,6 +84,8 @@ const Spacer = styled.div`
 `;
 Spacer.displayName = 'S.Spacer';
 
+const MAX_DISPLAY_LENGTH = 500;
+
 const CellValueStringWithPopup = ({value, style}: CellValueStringProps) => {
   const ref = useRef<HTMLDivElement>(null);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
@@ -95,6 +97,10 @@ const CellValueStringWithPopup = ({value, style}: CellValueStringProps) => {
   const id = open ? 'simple-popper' : undefined;
 
   const trimmed = value.trim();
+  const displayTrimmed =
+    trimmed.length > MAX_DISPLAY_LENGTH
+      ? trimmed.substring(0, MAX_DISPLAY_LENGTH) + '...'
+      : trimmed;
   const json = isJSON(trimmed);
   const [format, setFormat] = useState('Text');
 
@@ -132,8 +138,8 @@ const CellValueStringWithPopup = ({value, style}: CellValueStringProps) => {
     '' // Suppress tooltip when popper is open.
   ) : (
     <TooltipContent onClick={onClick}>
-      <TooltipText isJSON={json}>{trimmed}</TooltipText>
-      <TooltipHint>Click for more details</TooltipHint>
+      <TooltipText isJSON={json}>{displayTrimmed}</TooltipText>
+      <TooltipHint>Click for complete content</TooltipHint>
     </TooltipContent>
   );
 
@@ -144,7 +150,7 @@ const CellValueStringWithPopup = ({value, style}: CellValueStringProps) => {
     <>
       <StyledTooltip enterDelay={500} title={title}>
         <Collapsed ref={ref} onClick={onClick} style={style}>
-          {trimmed}
+          {displayTrimmed}
         </Collapsed>
       </StyledTooltip>
       <Popover


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25400](https://wandb.atlassian.net/browse/WB-25400)

Limit the number of characters to display in the table and in the hover state. Update the "click" description to reference missing material. This improves loading time to first paint and performance of navigating around the table. 


## Testing

prod
![preview-table-string-prod2](https://github.com/user-attachments/assets/6c6595a1-80fd-4799-97e1-bbf27231327f)


branch
![preview-table-string-branch3](https://github.com/user-attachments/assets/da45e5dc-f4d0-4789-9f50-813312b332f7)



[WB-25400]: https://wandb.atlassian.net/browse/WB-25400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ