### PR TITLE
chore(weave): sort eval predict call table first

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallDetails.tsx
@@ -9,6 +9,7 @@ import {Button} from '../../../../../Button';
 import {useWeaveflowRouteContext, WeaveflowPeekContext} from '../../context';
 import {CustomWeaveTypeProjectContext} from '../../typeViews/CustomWeaveTypeDispatcher';
 import {CallsTable} from '../CallsPage/CallsTable';
+import {isPredictAndScoreOp} from '../common/heuristics';
 import {CallLink} from '../common/Links';
 import {useWFHooks} from '../wfReactInterface/context';
 import {CallSchema} from '../wfReactInterface/wfDataModelHooksInterface';
@@ -101,10 +102,18 @@ export const CallDetails: FC<{
     columns,
   });
 
-  const {multipleChildCallOpRefs} = useMemo(
-    () => callGrouping(!childCalls.loading ? childCalls.result ?? [] : []),
-    [childCalls.loading, childCalls.result]
-  );
+  const {multipleChildCallOpRefs} = useMemo(() => {
+    const result = callGrouping(
+      !childCalls.loading ? childCalls.result ?? [] : []
+    );
+    // Sort them so predict_and_score ops appear first
+    result.multipleChildCallOpRefs.sort((a, b) => {
+      if (isPredictAndScoreOp(a)) return -1;
+      if (isPredictAndScoreOp(b)) return 1;
+      return 0;
+    });
+    return result;
+  }, [childCalls.loading, childCalls.result]);
   const {baseRouter} = useWeaveflowRouteContext();
   const {isPeeking} = useContext(WeaveflowPeekContext);
   const history = useHistory();


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25314](https://wandb.atlassian.net/browse/WB-25314)

Make sure the predict and score table is visible before other children in the call display page. 

## Testing

Branch
![Screenshot 2025-06-09 at 12 57 46 PM](https://github.com/user-attachments/assets/7f16bf2b-c4a2-4c60-82d5-1fb38e6aff00)


[WB-25314]: https://wandb.atlassian.net/browse/WB-25314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ