### PR TITLE
chore(weave): update client types to allow primatives

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -587,7 +587,7 @@ def test_calls_delete(client):
 
     assert len(list(client.get_calls())) == 4
 
-    result = list(client.get_calls(filter=tsi.CallsFilter(op_names=[call0.op_name])))
+    result = list(client.get_calls(filter={"op_names": [call0.op_name]}))
     assert len(result) == 3
 
     # should deleted call0_child1, _call0_child2, call1, but not call0

--- a/weave/flow/casting.py
+++ b/weave/flow/casting.py
@@ -10,6 +10,7 @@ from weave.flow.scorer import Scorer, _validate_scorer_signature
 from weave.trace.op import Op, as_op, is_op
 from weave.trace.refs import ObjectRef, OpRef
 from weave.trace.vals import WeaveObject
+from weave.trace_server.trace_server_interface import CallsFilter, Query, SortBy
 
 
 def cast_to_dataset(obj: Any) -> Dataset:
@@ -50,5 +51,55 @@ def cast_to_scorer(obj: Any) -> Scorer | Op:
     return res
 
 
+def cast_to_calls_filter(obj: Any) -> CallsFilter:
+    if isinstance(obj, CallsFilter):
+        return obj
+
+    if isinstance(obj, dict):
+        return CallsFilter(**obj)
+
+    if obj is None:
+        return CallsFilter()
+
+    raise TypeError("Unable to cast to CallsFilter")
+
+
+def cast_to_sort_by(obj: Any) -> SortBy:
+    if isinstance(obj, SortBy):
+        return obj
+
+    if isinstance(obj, dict):
+        return SortBy(**obj)
+
+    if isinstance(obj, str):
+        # Handle simple string format like "started_at desc"
+        parts = obj.split()
+        if len(parts) == 2:
+            field, direction = parts
+            return SortBy(field=field, direction=direction)
+        else:
+            return SortBy(field=obj, direction="asc")
+
+    raise TypeError(f"Unable to cast to SortBy: {obj}")
+
+
+def cast_to_query(obj: Any) -> Query | None:
+    if isinstance(obj, Query):
+        return obj
+
+    if isinstance(obj, dict):
+        return Query(**obj)
+
+    if obj is None:
+        return None
+
+    raise TypeError("Unable to cast to Query")
+
+
 DatasetLike = Annotated[Dataset, BeforeValidator(cast_to_dataset)]
 ScorerLike = Annotated[Union[Op, Scorer], BeforeValidator(cast_to_scorer)]
+
+# calls query parameter types
+CallsFilterLike = Annotated[CallsFilter, BeforeValidator(cast_to_calls_filter)]
+SortByLike = Annotated[SortBy, BeforeValidator(cast_to_sort_by)]
+QueryLike = Annotated[Query | None, BeforeValidator(cast_to_query)]

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -31,6 +31,7 @@ import pydantic
 from requests import HTTPError
 
 from weave import version
+from weave.flow.casting import CallsFilterLike, QueryLike, SortByLike
 from weave.trace import trace_sentry, urls
 from weave.trace.concurrent.futures import FutureExecutor
 from weave.trace.context import call_context
@@ -1036,14 +1037,15 @@ class WeaveClient:
     ################ Query API ################
 
     @trace_sentry.global_trace_sentry.watch()
+    @pydantic.validate_call
     def get_calls(
         self,
         *,
-        filter: CallsFilter | None = None,
+        filter: CallsFilterLike | None = None,
         limit: int | None = None,
         offset: int | None = None,
-        sort_by: list[SortBy] | None = None,
-        query: Query | None = None,
+        sort_by: list[SortByLike] | None = None,
+        query: QueryLike | None = None,
         include_costs: bool = False,
         include_feedback: bool = False,
         columns: list[str] | None = None,
@@ -1501,9 +1503,10 @@ class WeaveClient:
             )
         )
 
+    @pydantic.validate_call
     def get_feedback(
         self,
-        query: Query | str | None = None,
+        query: QueryLike | None = None,
         *,
         reaction: str | None = None,
         offset: int = 0,
@@ -1577,9 +1580,10 @@ class WeaveClient:
         )
 
     @deprecated(new_name="get_feedback")
+    @pydantic.validate_call
     def feedback(
         self,
-        query: Query | str | None = None,
+        query: QueryLike | None = None,
         *,
         reaction: str | None = None,
         offset: int = 0,
@@ -1661,9 +1665,10 @@ class WeaveClient:
             CostPurgeReq(project_id=self._project_id(), query=Query(**{"$expr": expr}))
         )
 
+    @pydantic.validate_call
     def query_costs(
         self,
-        query: Query | str | None = None,
+        query: QueryLike | None = None,
         llm_ids: list[str] | None = None,
         offset: int = 0,
         limit: int = 100,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25421](https://wandb.atlassian.net/browse/WB-25421)

Fix typing for `client.get_calls` (and others) to allow type hints to validate primetives. 

Example:

```python
import weave

client = weave.init("prod-evals-aug")
calls = client.get_calls(
    filter={"trace_roots_only": True},
    sort_by=[{"field":"started_at","direction":"desc"}],
)
```

## Testing

Existing test coverage should be sufficient, tweaked one test explicitly. 
