### PR TITLE
chore(weave): better datetime filter ergonomics

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -32,6 +32,8 @@ import {combineRangeFilters, getNextFilterId} from './filterUtils';
 import {GroupedOption, SelectFieldOption} from './SelectField';
 import {VariableChildrenDisplay} from './VariableChildrenDisplayer';
 
+export const FILTER_INPUT_DEBOUNCE_MS = 1000;
+
 type FilterBarProps = {
   entity: string;
   project: string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -4,7 +4,6 @@
 
 import {Popover} from '@mui/material';
 import {GridFilterItem, GridFilterModel} from '@mui/x-data-grid-pro';
-import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {useViewerInfo} from '../../../../../common/hooks/useViewerInfo';
@@ -32,8 +31,6 @@ import {FilterTagItem} from './FilterTagItem';
 import {combineRangeFilters, getNextFilterId} from './filterUtils';
 import {GroupedOption, SelectFieldOption} from './SelectField';
 import {VariableChildrenDisplay} from './VariableChildrenDisplayer';
-
-const DEBOUNCE_MS = 1_000;
 
 type FilterBarProps = {
   entity: string;
@@ -72,7 +69,7 @@ export const FilterBar = ({
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   // local filter model is used to avoid triggering a re-render of the trace
-  // table on every keystroke. debounced DEBOUNCE_MS ms
+  // table on every keystroke.
   const [localFilterModel, setLocalFilterModel] = useState(filterModel);
   const [activeEditId, setActiveEditId] = useState<FilterId | null>(null);
 
@@ -224,14 +221,8 @@ export const FilterBar = ({
     [setFilterModel]
   );
 
-  const debouncedSetFilterModel = useMemo(
-    () => _.debounce(applyCompletedFilters, DEBOUNCE_MS),
-    [applyCompletedFilters]
-  );
-
   const onUpdateFilter = useCallback(
     (item: GridFilterItem) => {
-      debouncedSetFilterModel.cancel();
       const oldItems = localFilterModel.items;
       const index = oldItems.findIndex(f => f.id === item.id);
 
@@ -241,7 +232,7 @@ export const FilterBar = ({
       if (index === -1) {
         const newModel = {...localFilterModel, items: [item]};
         setLocalFilterModel(newModel);
-        debouncedSetFilterModel(newModel);
+        applyCompletedFilters(newModel);
         return;
       }
 
@@ -252,9 +243,9 @@ export const FilterBar = ({
       ];
       const newItemsModel = {...localFilterModel, items: newItems};
       setLocalFilterModel(newItemsModel);
-      debouncedSetFilterModel(newItemsModel);
+      applyCompletedFilters(newItemsModel);
     },
-    [localFilterModel, debouncedSetFilterModel]
+    [localFilterModel, applyCompletedFilters]
   );
 
   const onRemoveFilter = useCallback(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -210,10 +210,22 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
     if (inputRef.current) {
       inputRef.current.blur();
     }
-    if (date) {
-      const formattedDate = formatDate(date);
-      parseAndUpdateDate(formattedDate, true);
+    // Clear any pending debounced parse first
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
     }
+
+    // Defer the date parsing to the next event loop cycle to allow calendar to close first
+    setTimeout(() => {
+      if (date) {
+        // When OK is clicked, use the provided date
+        const formattedDate = formatDate(date);
+        parseAndUpdateDate(formattedDate, true);
+      } else {
+        // When clicking outside, immediately parse the current input value
+        parseAndUpdateDate(inputValue, true);
+      }
+    }, 1);
   };
 
   const handleSuggestionClick = useCallback(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -192,7 +192,7 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
 
   const handleIconClick = (event: React.MouseEvent) => {
     event.stopPropagation();
-    setIsCalendarOpen(true);
+    setIsCalendarOpen(prev => !prev);
   };
 
   // Add handler for closing when Ok button is clicked
@@ -345,6 +345,7 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
             value={new Date(inputValue) ?? null}
             onChange={handleDateChange}
             onAccept={handleAccept}
+            reduceAnimations
             slotProps={{
               textField: {
                 style: {display: 'none'},

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -17,6 +17,7 @@ import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import * as userEvents from '../../../../../integrations/analytics/userEvents';
 import {formatDate, formatDateOnly, parseDate} from '../../../../../util/date';
+import {FILTER_INPUT_DEBOUNCE_MS} from './FilterBar';
 
 type PredefinedSuggestion = {
   abbreviation: string;
@@ -51,7 +52,6 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
   isActive,
 }) => {
   const [inputValue, setInputValue] = useState('');
-  console.log('inputValue', inputValue);
   const [isDropdownVisible, setDropdownVisible] = useState(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [selectedSuggestion, setSelectedSuggestion] = useState<string | null>(
@@ -146,7 +146,7 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
       }
       debounceTimeoutRef.current = setTimeout(() => {
         parseAndUpdateDate(newInputValue);
-      }, 1000);
+      }, FILTER_INPUT_DEBOUNCE_MS);
     },
     [parseAndUpdateDate]
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -50,7 +50,8 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
   onChange,
   isActive,
 }) => {
-  const [inputValue, setInputValue] = useState(value);
+  const [inputValue, setInputValue] = useState('');
+  console.log('inputValue', inputValue);
   const [isDropdownVisible, setDropdownVisible] = useState(false);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const [selectedSuggestion, setSelectedSuggestion] = useState<string | null>(
@@ -66,13 +67,20 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
   const dropdownRef = useRef<HTMLUListElement>(null);
   const debounceTimeoutRef = useRef<NodeJS.Timeout>();
 
-  // Initialize input value from prop value
+  // Format and set input value whenever the value prop changes
   useEffect(() => {
-    if (value && value !== inputValue) {
-      setInputValue(value);
+    if (value) {
+      const date = parseDate(value);
+      if (date) {
+        const formattedDate = formatDate(date);
+        setInputValue(formattedDate);
+      } else {
+        // If parseDate fails, use the raw value as fallback
+        setInputValue(value);
+      }
+    } else {
+      setInputValue('');
     }
-    // Only run when value changes from parent
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   // Add analytics hook
@@ -310,7 +318,9 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
               if (debounceTimeoutRef.current) {
                 clearTimeout(debounceTimeoutRef.current);
               }
-              parseAndUpdateDate(inputValue, true);
+              if (inputValue !== value) {
+                parseAndUpdateDate(inputValue, true);
+              }
             }}
             onMouseEnter={() => setIsInputHovered(true)}
             onMouseLeave={() => setIsInputHovered(false)}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -178,11 +178,6 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
       if (inputRef.current) {
         inputRef.current.blur();
       }
-    } else if (event.key === 'Escape') {
-      setDropdownVisible(false);
-      if (inputRef.current) {
-        inputRef.current.blur();
-      }
     }
   };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -193,8 +193,8 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
     if (date) {
       const formattedDate = formatDate(date);
       setInputValue(formattedDate);
-      onChange(formattedDate);
       setIsInvalid(false);
+      // Don't auto update the date until the calendar is closed
     }
   };
 
@@ -204,9 +204,15 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
   };
 
   // Add handler for closing when Ok button is clicked
-  const handleAccept = (date: Date | null) => {
+  const handleClose = (date: Date | null) => {
+    setIsCalendarOpen(false);
+    setDropdownVisible(false);
+    if (inputRef.current) {
+      inputRef.current.blur();
+    }
     if (date) {
-      setIsCalendarOpen(false);
+      const formattedDate = formatDate(date);
+      parseAndUpdateDate(formattedDate, true);
     }
   };
 
@@ -351,11 +357,12 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
           />
           <DateTimePicker
             open={isCalendarOpen}
-            onClose={() => setIsCalendarOpen(false)}
+            onClose={() => handleClose(null)}
             value={new Date(inputValue) ?? null}
             onChange={handleDateChange}
-            onAccept={handleAccept}
+            onAccept={handleClose}
             reduceAnimations
+            closeOnSelect={false}
             slotProps={{
               textField: {
                 style: {display: 'none'},

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -215,17 +215,14 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
       clearTimeout(debounceTimeoutRef.current);
     }
 
-    // Defer the date parsing to the next event loop cycle to allow calendar to close first
-    setTimeout(() => {
-      if (date) {
-        // When OK is clicked, use the provided date
-        const formattedDate = formatDate(date);
-        parseAndUpdateDate(formattedDate, true);
-      } else {
-        // When clicking outside, immediately parse the current input value
-        parseAndUpdateDate(inputValue, true);
-      }
-    }, 1);
+    if (date) {
+      // When OK is clicked, use the provided date
+      const formattedDate = formatDate(date);
+      parseAndUpdateDate(formattedDate, true);
+    } else {
+      // When clicking outside, immediately parse the current input value
+      parseAndUpdateDate(inputValue, true);
+    }
   };
 
   const handleSuggestionClick = useCallback(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/TextValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/TextValue.tsx
@@ -15,12 +15,43 @@ export const TextValue = ({
   type,
   isActive,
 }: TextValueProps) => {
+  const [localValue, setLocalValue] = React.useState(value);
+  const debounceTimeoutRef = React.useRef<NodeJS.Timeout>();
+
+  // Update local value when prop value changes
+  React.useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  // Cleanup debounce timeout on unmount
+  React.useEffect(() => {
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleChange = (newValue: string) => {
+    setLocalValue(newValue);
+
+    // Clear existing timeout
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
+    }
+
+    // Set new timeout
+    debounceTimeoutRef.current = setTimeout(() => {
+      onSetValue(newValue);
+    }, 1000);
+  };
+
   return (
     <div className="ml-1 min-w-[200px]">
       <TextField
         type={type}
-        value={value}
-        onChange={onSetValue}
+        value={localValue}
+        onChange={handleChange}
         size="small"
         autoFocus={isActive}
       />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/TextValue.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/TextValue.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {TextField} from '../../../../Form/TextField';
+import {FILTER_INPUT_DEBOUNCE_MS} from './FilterBar';
 
 type TextValueProps = {
   value: string;
@@ -43,7 +44,7 @@ export const TextValue = ({
     // Set new timeout
     debounceTimeoutRef.current = setTimeout(() => {
       onSetValue(newValue);
-    }, 1000);
+    }, FILTER_INPUT_DEBOUNCE_MS);
   };
 
   return (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25435](https://wandb.atlassian.net/browse/WB-25435)
[WB-25311](https://wandb.atlassian.net/browse/WB-25311)

Changes in this pr:

**debounce**
- Increases debounce delay from 500ms to 1000ms to give users more typing time for dates
- Remove the global filter state debounce, so now selecting from dropdown and calendar execute immediately.
- Adds 1000ms debounce to the TextValue component to maintain existing text input functionality.
- Adds Enter key support to immediately parse and confirm input
- Enhances blur behavior to immediately parse input when focus is lost

**input field**
- Removes automatic "1mo" default - component no longer forces a default value
- Prevents invalid input from updating filter state - invalid input shows red highlight but doesn't change the actual filter
- Clicking the calendar icon when its displayed should hide it
- Default datetime filter properly formatted

**calendar**
- Remove the calendar transition in and out, which should improve performance under load
- Don't auto-accept calendar input when selecting minutes
- When in calendar, only update the filter state on close or accept
- When exiting calendar, hide the dropdown

## Testing
prod
![ergo-datefilter-prod](https://github.com/user-attachments/assets/f951d5de-157e-4cdf-8b72-864ce0a55507)


branch
![ergo-datefilter-branch-final](https://github.com/user-attachments/assets/d0fb82b2-5e87-4674-aab5-90c3e1e78339)


[WB-25435]: https://wandb.atlassian.net/browse/WB-25435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WB-25311]: https://wandb.atlassian.net/browse/WB-25311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ