### PR TITLE
fix(weave): get_feedback accepts custom queries in mongo format

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1534,6 +1534,22 @@ class WeaveClient:
 
             # Find all feedback objects with a specific reaction.
             client.get_feedback(reaction="👍", limit=10)
+
+            # Find all feedback objects with a specific feedback type with
+            # mongo-style query.
+            from weave.trace_server.interface.query import Query
+
+            query = Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "feedback_type"},
+                            {"$literal": "wandb.reaction.1"},
+                        ],
+                    }
+                }
+            )
+            client.get_feedback(query=query)
             ```
 
         Args:
@@ -1559,7 +1575,7 @@ class WeaveClient:
                 ],
             }
         elif isinstance(query, Query):
-            expr = query.expr_.dict()
+            expr = query.expr_
 
         if reaction:
             expr = {


### PR DESCRIPTION
## Description

Remove the `.dict` attribute read when using a custom user query- this was causing the final query to always fail pydantic validation. The `expr_` key stores the query expression in a usable format. Also `.dict` is deprecated.

Also adds an example to the docstring for `get_feedback` and some test cases to `test_feedback.py` to verify that these queries work.