### PR TITLE
fix(weave): allow unspecified leaf_object_class on objreadres for backcompat

### DIFF
--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -199,7 +199,7 @@ class ObjSchema(BaseModel):
     is_latest: int
     kind: str
     base_object_class: Optional[str]
-    leaf_object_class: Optional[str]
+    leaf_object_class: Optional[str] = None
     val: Any
 
     wb_user_id: Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)


### PR DESCRIPTION
## Description

Allow `leaf_object_class` to be unset on `ObjReadRes` for backwards compatibility with trace server versions that do not include this key in the response.