### PR TITLE
fix(weave): Fixes flushing mechanics when using server cache

### DIFF
--- a/weave/scripts/prerelease_dry_run.py
+++ b/weave/scripts/prerelease_dry_run.py
@@ -24,7 +24,7 @@ def main() -> None:
     client = weave.init("test-project")
     res = func(42)
 
-    client._flush()
+    client.flush()
     calls = func.calls()
 
     assert len(calls) == 1

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -19,6 +19,7 @@ from weave.trace.settings import (
     use_server_cache,
 )
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.caches import DiskCache, LRUCache, StackedCache
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,15 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
             self._cache.close()
         except Exception as e:
             logger.exception(f"Error closing cache: {e}")
+
+    def get_call_processor(self) -> AsyncBatchProcessor | None:
+        """
+        Custom method not defined on the formal TraceServerInterface to expose
+        the underlying call processor. Should be formalized in a client-side interface.
+        """
+        if hasattr(self._next_trace_server, "get_call_processor"):
+            return self._next_trace_server.get_call_processor()
+        return None
 
     @classmethod
     def from_env(cls, next_trace_server: tsi.TraceServerInterface) -> Self:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -199,6 +199,13 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
                         f"Failed to enqueue batch of size {len(batch)} - Processor is shutting down"
                     )
 
+    def get_call_processor(self) -> AsyncBatchProcessor | None:
+        """
+        Custom method not defined on the formal TraceServerInterface to expose
+        the underlying call processor. Should be formalized in a client-side interface.
+        """
+        return self.call_processor
+
     @with_retry
     def _generic_request_executor(
         self,


### PR DESCRIPTION
Our WeaveClient has some hacky code that allows it to access the `call_processor` of the internal server when that server is of the `RemoteHTTPTraceServer` class. This is a violation of interface rules (since the interface does not define such a member - and nor should it!). With the caching enabled, we wrap the server in a caching layer that makes the instance check to perform the above hack invalid. This PR simply exposes the `call_processor` through the caching layer. Frankly, I don't love this. The correct solution would be for us to finally bite the bullet and split up our trace interface. But let's do the quick thing to unblock deploys.