### PR TITLE
fix(weave): better resizing of model details

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/DetailTile.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/DetailTile.tsx
@@ -7,14 +7,22 @@ type DetailTileProps = {
   header: string;
   children?: React.ReactNode;
   footer?: string;
+  tooltip?: string;
 };
 
 // Used to preserve spacing when no footer is provided.
 const NON_BREAKING_SPACE = '\u00A0';
 
-export const DetailTile = ({header, footer, children}: DetailTileProps) => {
+export const DetailTile = ({
+  header,
+  children,
+  footer,
+  tooltip,
+}: DetailTileProps) => {
   return (
-    <div className="flex h-[96px] w-[170px] flex-col rounded-lg border border-moon-250 p-8">
+    <div
+      className="flex h-[96px] flex-[1_0_auto] flex-col whitespace-nowrap rounded-lg border border-moon-250 p-8"
+      title={tooltip}>
       <div className="text-center text-sm font-semibold text-moon-600">
         {header}
       </div>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelDetailsLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelDetailsLoaded.tsx
@@ -199,17 +199,15 @@ export const ModelDetailsLoaded = ({
       </div>
       <div className="mb-8 mt-16 text-lg font-semibold">Model overview</div>
 
-      <div className="mb-16 flex gap-10">
-        <Tooltip
-          trigger={
-            <DetailTile header="Price" footer="Input - Output">
-              <div className="text-xl font-semibold">
-                {getPriceString(model, false, '-')}
-              </div>
-            </DetailTile>
-          }
-          content="Price per million tokens"
-        />
+      <div className="mb-16 flex flex-wrap gap-10">
+        <DetailTile
+          header="Price"
+          footer="Input - Output"
+          tooltip="Price per million tokens">
+          <div className="text-xl font-semibold">
+            {getPriceString(model, false, '-')}
+          </div>
+        </DetailTile>
         {model.contextWindow && (
           <DetailTile header="Context window">
             <div className="text-xl font-semibold">
@@ -310,14 +308,13 @@ export const ModelDetailsLoaded = ({
           <Button variant="ghost" icon="copy" onClick={onClickCopy} />
         </div>
       </div>
-      <div>
+      <div className="[&_.monaco-editor]:!absolute">
         <CodeEditor
           value={codeExample}
           language={CODE_LANGUAGE_MAP[selectedLanguage]}
           readOnly
           handleMouseWheel
           alwaysConsumeMouseWheel={false}
-          // wrapLines={wrapLines}
         />
       </div>
     </div>


### PR DESCRIPTION
## Description

This improves the layout of the model details page when you reduce the width of the browser window. Before, the code component wouldn't shrink, detail tiles wouldn't wrap, etc. causing content to be clipped in a bad way.

Before:
![image](https://github.com/user-attachments/assets/2ca6669c-57c9-4e5c-90f1-9a3ca6420499)

After:
![image](https://github.com/user-attachments/assets/970bd7b1-c3eb-42a9-b9f2-1b5bff597be0)


## Testing

How was this PR tested?
