### PR TITLE
chore(ui): Add multi-select for compare to Leaderboard

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -428,7 +428,8 @@ export const CompareEvaluationsTableButton: FC<{
   onClick: () => void;
   disabled?: boolean;
   tooltipText?: string;
-}> = ({onClick, disabled, tooltipText}) => (
+  buttonText?: string;
+}> = ({onClick, disabled, tooltipText, buttonText = 'Compare'}) => (
   <Box
     sx={{
       height: '100%',
@@ -442,7 +443,7 @@ export const CompareEvaluationsTableButton: FC<{
       onClick={onClick}
       icon="chart-scatterplot"
       tooltip={tooltipText}>
-      Compare
+      {buttonText}
     </Button>
   </Box>
 );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/LeaderboardPage/LeaderboardPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/LeaderboardPage/LeaderboardPage.tsx
@@ -261,7 +261,9 @@ export const LeaderboardPageContentInner: React.FC<
                 selected:
               </div>
               <CompareEvaluationsTableButton
-                buttonText={selectedEvaluations.length === 1 ? 'View' : 'Compare'}
+                buttonText={
+                  selectedEvaluations.length === 1 ? 'View' : 'Compare'
+                }
                 tooltipText="Compare metrics and examples for selected evaluations"
                 onClick={() => {
                   history.push(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/views/Leaderboard/LeaderboardGrid.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/views/Leaderboard/LeaderboardGrid.tsx
@@ -196,27 +196,28 @@ export const LeaderboardGrid: React.FC<LeaderboardGridProps> = ({
             selectedEvaluations.length < allAvailableEvaluationIds.length;
 
           return (
-              <Checkbox
-                size="small"
-                checked={
-                  selectedEvaluations.length === 0
-                    ? false
-                    : selectedEvaluations.length === allAvailableEvaluationIds.length
-                    ? true
-                    : 'indeterminate'
+            <Checkbox
+              size="small"
+              checked={
+                selectedEvaluations.length === 0
+                  ? false
+                  : selectedEvaluations.length ===
+                    allAvailableEvaluationIds.length
+                  ? true
+                  : 'indeterminate'
+              }
+              onCheckedChange={() => {
+                if (isAllSelected || isSomeSelected) {
+                  // Deselect all
+                  setSelectedEvaluations([]);
+                } else {
+                  // Select all (up to MAX_SELECT)
+                  setSelectedEvaluations(
+                    allAvailableEvaluationIds.slice(0, MAX_SELECT)
+                  );
                 }
-                onCheckedChange={() => {
-                  if (isAllSelected || isSomeSelected) {
-                    // Deselect all
-                    setSelectedEvaluations([]);
-                  } else {
-                    // Select all (up to MAX_SELECT)
-                    setSelectedEvaluations(
-                      allAvailableEvaluationIds.slice(0, MAX_SELECT)
-                    );
-                  }
-                }}
-              />
+              }}
+            />
           );
         },
         renderCell: (params: GridRenderCellParams) => {


### PR DESCRIPTION
## Description

<img width="1469" alt="image" src="https://github.com/user-attachments/assets/73568a3a-51b1-46a9-b839-eef5716f35e5" />

- Adds multi-select checkboxes to Leaderboard - pushes the user to a multi-eval compare experience.
- Modifies the compare button to allow a custom label (so we can say View vs. Compare with 1/more selected models).