### PR TITLE
chore(weave): remove the exposed API key

### DIFF
--- a/tests/integrations/langchain/cassettes/langchain_test/test_langchain_google_genai_usage.yaml
+++ b/tests/integrations/langchain/cassettes/langchain_test/test_langchain_google_genai_usage.yaml
@@ -18,7 +18,7 @@ interactions:
           - langchain-google-genai/2.1.5-ChatGoogleGenerativeAI:models/gemini-1.5-pro
             gl-python/3.12.9 grpc/1.71.0 gax/2.24.2 gccl/2.1.5-ChatGoogleGenerativeAI:models/gemini-1.5-pro
         x-goog-api-key:
-          - AIzaSyBMFtq5UrvJTtFw20Zjh3Oy1rhKpj-zQ3U
+          - SUPER_FAKE_API-KEY
         x-goog-request-params:
           - model=models/gemini-1.5-pro
       method: POST

--- a/tests/integrations/langchain/langchain_test.py
+++ b/tests/integrations/langchain/langchain_test.py
@@ -709,7 +709,7 @@ def test_weave_attributes_in_call(client: WeaveClient) -> None:
 
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
-    filter_headers=["authorization", "x-api-key"],
+    filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
     allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai", "*.googleapis.com"],
     before_record_request=filter_body,
     match_on=["method", "scheme", "path", "query"],


### PR DESCRIPTION
## Description

This PR updates the VCR configuration in the langchain test to filter out the Google API key from the recorded cassettes. It replaces a real API key with a fake one in the test cassette file.

## Testing

This change was tested by running the langchain integration tests to ensure they still pass with the updated VCR configuration.