### PR TITLE
feat(ui): add learn more and clipboard copy buttons to model tile

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelTile.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelTile.tsx
@@ -3,8 +3,10 @@
  * and a very brief description.
  */
 import {Tooltip} from '@wandb/weave/components/Tooltip';
-import React from 'react';
+import copyToClipboard from 'copy-to-clipboard';
+import React, {useCallback} from 'react';
 
+import {toast} from '../../../../../common/components/elements/Toast';
 import {Button} from '../../../../Button';
 import {IconOnlyPill} from '../../../../Tag';
 import {Link} from '../pages/common/Links';
@@ -61,6 +63,8 @@ export const ModelTile = ({
       }
     : undefined;
 
+  const urlDetails = urlInference(model.provider, model.id);
+
   const hasPlayground = !!model.idPlayground && inferenceContext.isLoggedIn;
   const textPlayground =
     selected && selected.selectedWithPlayground.length > 1 && hasPlayground
@@ -89,6 +93,11 @@ export const ModelTile = ({
     e.stopPropagation();
   };
 
+  const onClickCopy = useCallback(() => {
+    copyToClipboard(model.idPlayground ?? '');
+    toast('Copied to clipboard');
+  }, [model.idPlayground]);
+
   return (
     <div
       className={`group w-[500px] cursor-pointer rounded-lg border border-moon-250 bg-white px-16 pb-6 pt-12  ${
@@ -100,7 +109,7 @@ export const ModelTile = ({
       <div className="mb-8 flex items-center gap-8">
         {logoImg}
         <div className="text-lg font-semibold text-teal-600">
-          <Link to={urlInference(model.provider, model.id)}>{label}</Link>
+          <Link to={urlDetails}>{label}</Link>
         </div>
         {model.modalities && <Modalities modalities={model.modalities} />}
       </div>
@@ -158,6 +167,18 @@ export const ModelTile = ({
             tooltip={tooltipPlayground}>
             {textPlayground}
           </Button>
+          <Link to={urlDetails}>
+            <Button size="small" variant="secondary">
+              Learn more
+            </Button>
+          </Link>
+          <Button
+            size="small"
+            icon="copy"
+            variant="ghost"
+            onClick={onClickCopy}
+            tooltip="Copy ID for API use to clipboard"
+          />
         </div>
       )}
       {hint && (


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C08RU04P36G/p1749683637172539

Adds two buttons to "Learn more" and "Copy" to the model tile, requested by design.

<img width="518" alt="Screenshot 2025-06-11 at 7 48 33 PM" src="https://github.com/user-attachments/assets/e4b55afb-f5ea-4c07-93f1-b52811c5bd7d" />


## Testing

How was this PR tested?
