### PR TITLE
chore(ui): Monitor: Form components 

### DIFF
--- a/weave-js/.claude/settings.local.json
+++ b/weave-js/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(rg:*)"
-    ],
-    "deny": []
-  }
-}

--- a/weave-js/.claude/settings.local.json
+++ b/weave-js/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(rg:*)"
+    ],
+    "deny": []
+  }
+}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -9,7 +9,6 @@ import {validateDatasetName} from '@wandb/weave/components/PagePanelComponents/H
 import {FilterPanel} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/filters/FilterPanel';
 import {prepareFlattenedCallDataForTable} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable';
 import {useCallsTableColumns} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns';
-import {LLMAsAJudgeScorerForm} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm';
 import {
   useOpVersionOptions,
   WFHighLevelCallFilter,
@@ -23,6 +22,11 @@ import {
   Autocomplete,
   OpSelector,
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/CallsPage/OpSelector';
+import {
+  FieldName,
+  typographyStyle,
+} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/FormComponents';
+import {LLMAsAJudgeScorerForm} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm';
 import {queryToGridFilterModel} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/SavedViews/savedViewUtil';
 import {useWFHooks} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context';
 import {
@@ -41,10 +45,6 @@ import {parseRef} from '@wandb/weave/react';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {toast} from 'react-toastify';
-import {
-  FieldName,
-  typographyStyle,
-} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/FormComponents';
 
 const PAGE_SIZE = 10;
 const PAGE_OFFSET = 0;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -46,7 +46,6 @@ import {
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {parseRef} from '@wandb/weave/react';
-import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {toast} from 'react-toastify';
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -43,8 +43,8 @@ import {
   ObjectVersionSchema,
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
 import {Radio} from '@wandb/weave/components';
+import {Switch} from '@wandb/weave/components';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
-import {ToggleButtonGroup} from '@wandb/weave/components/ToggleButtonGroup';
 import {parseRef} from '@wandb/weave/react';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
@@ -554,13 +554,16 @@ export const CreateMonitorDrawer = ({
                     />
                   </Box>
                   <Box>
-                    <FieldName name="Active" />
-                    <ToggleButtonGroup
-                      value={active ? 'active' : 'inactive'}
-                      options={[{value: 'active'}, {value: 'inactive'}]}
-                      onValueChange={value => setActive(value === 'active')}
-                      size="medium"
-                    />
+                    <Box className="flex items-center gap-8">
+                      <Switch.Root
+                        checked={active}
+                        onCheckedChange={setActive}
+                        size="medium"
+                      >
+                        <Switch.Thumb size="medium" checked={active} />
+                      </Switch.Root>
+                      <span className="font-semibold">Active monitor</span>
+                    </Box>
                   </Box>
                 </Box>
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -1,12 +1,14 @@
 import {Box, Drawer, Typography} from '@mui/material';
-import {GridFilterModel} from '@mui/x-data-grid-pro';
 import {styled} from '@mui/material/styles';
+import {GridFilterModel} from '@mui/x-data-grid-pro';
 import SliderInput from '@wandb/weave/common/components/elements/SliderInput';
 import {
   MOON_250,
   MOON_350,
   TEAL_500,
 } from '@wandb/weave/common/css/color.styles';
+import {Radio} from '@wandb/weave/components';
+import {Switch} from '@wandb/weave/components';
 import {Button} from '@wandb/weave/components/Button';
 import {TextArea} from '@wandb/weave/components/Form/TextArea';
 import {TextField} from '@wandb/weave/components/Form/TextField';
@@ -42,8 +44,6 @@ import {
   ObjectVersionKey,
   ObjectVersionSchema,
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
-import {Radio} from '@wandb/weave/components';
-import {Switch} from '@wandb/weave/components';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {parseRef} from '@wandb/weave/react';
 import _ from 'lodash';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -416,7 +416,7 @@ export const CreateMonitorDrawer = ({
                       </Typography>
                     )}
                     <Typography
-                      className="mt-1 text-sm font-normal"
+                      className="mt-4 text-sm font-normal"
                       sx={{
                         ...typographyStyle,
                         color: 'text.secondary',
@@ -449,10 +449,10 @@ export const CreateMonitorDrawer = ({
                 <Box className="flex flex-col pt-16 gap-8">
                   <Typography
                     sx={typographyStyle}
-                    className="py-16 px-20 border-t border-moon-250 uppercase tracking-wide text-moon-500 font-semibold">
+                    className="pt-16 pb-8 px-20 border-t border-moon-250 uppercase tracking-wide text-moon-500 font-semibold">
                     Calls to monitor
                   </Typography>
-                  <Box className="flex flex-col gap-16">
+                  <Box className="flex flex-col gap-16 px-20">
                     <Box>
                       <FieldName name="Operations" />
                       <OpSelector
@@ -507,13 +507,14 @@ export const CreateMonitorDrawer = ({
                     </Box>
                   </Box>
                 </Box>
-                <Box className="flex flex-col gap-8">
+
+                <Box className="flex flex-col pt-16 gap-8">
                   <Typography
                     sx={typographyStyle}
-                    className="text-lg font-semibold">
-                    Scorers to apply to selected calls
+                    className="pt-16 pb-8 px-20 border-t border-moon-250 uppercase tracking-wide text-moon-500 font-semibold">
+                    Scorers
                   </Typography>
-                  <Box className="flex flex-col gap-16">
+                  <Box className="flex flex-col gap-16 px-20">
                     <Box>
                       <FieldName name="Scorers" />
                       <Autocomplete
@@ -552,9 +553,10 @@ export const CreateMonitorDrawer = ({
                         }}
                       />
                     </Box>
-                    {scorerForms}
                   </Box>
                 </Box>
+
+                {scorerForms}
               </Box>
             )}
           </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -587,27 +587,26 @@ export const CreateMonitorDrawer = ({
                         frozenFilter={undefined}
                         sx={{width: '100%', height: undefined}}
                       />
-                    </Box>
-                    <Box>
-                      <FieldName name="Additional filters" />
                       {selectedOpVersionOption.length > 0 ? (
-                        <FilterPanel
-                          entity={entity}
-                          project={project}
-                          filterModel={filterModel}
-                          setFilterModel={setFilterModel}
-                          columnInfo={columns}
-                          selectedCalls={[]}
-                          clearSelectedCalls={() => {}}
-                        />
+                        <Box className="mt-4">
+                          <FilterPanel
+                            entity={entity}
+                            project={project}
+                            filterModel={filterModel}
+                            setFilterModel={setFilterModel}
+                            columnInfo={columns}
+                            selectedCalls={[]}
+                            clearSelectedCalls={() => {}}
+                          />
+                        </Box>
                       ) : (
                         <Typography
-                          className="mt-1 text-sm font-normal"
+                          className="mt-4 text-sm font-normal"
                           sx={{
                             ...typographyStyle,
                             color: 'text.secondary',
                           }}>
-                          Select an op to add filters.
+                          Select an op to add additional filters.
                         </Typography>
                       )}
                     </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -40,7 +40,7 @@ import {
   ObjectVersionSchema,
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
-import {ToggleButtonGroup} from '@wandb/weave/components/ToggleButtonGroup';
+import * as Switch from '@wandb/weave/components/Switch';
 import {parseRef} from '@wandb/weave/react';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
@@ -435,14 +435,15 @@ export const CreateMonitorDrawer = ({
                       onChange={e => setDescription(e.target.value)}
                     />
                   </Box>
-                  <Box>
-                    <FieldName name="Active" />
-                    <ToggleButtonGroup
-                      value={active ? 'active' : 'inactive'}
-                      options={[{value: 'active'}, {value: 'inactive'}]}
-                      onValueChange={value => setActive(value === 'active')}
+                  <Box className="flex items-center gap-8">
+                  <Switch.Root
+                      checked={active}
+                      onCheckedChange={setActive}
                       size="medium"
-                    />
+                    >
+                      <Switch.Thumb size="medium" checked={active} />
+                    </Switch.Root>
+                    <span className="font-semibold">Active</span>
                   </Box>
                 </Box>
 
@@ -466,9 +467,6 @@ export const CreateMonitorDrawer = ({
                         frozenFilter={undefined}
                         sx={{width: '100%', height: undefined}}
                       />
-                    </Box>
-                    <Box>
-                      <FieldName name="Additional filters" />
                       {selectedOpVersionOption.length > 0 ? (
                         <FilterPanel
                           entity={entity}
@@ -481,7 +479,7 @@ export const CreateMonitorDrawer = ({
                         />
                       ) : (
                         <Typography
-                          className="mt-1 text-sm font-normal"
+                          className="mt-4 text-sm font-normal"
                           sx={{
                             ...typographyStyle,
                             color: 'text.secondary',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -219,55 +219,80 @@ export const CreateMonitorDrawer = ({
   }, [scorers.length]);
 
   useEffect(() => {
-    const newScorers: ObjectVersionSchema[] = [];
-    
-    if (validationType === 'json') {
-      newScorers.push({
-        scheme: 'weave',
-        weaveKind: 'object',
-        entity,
-        project,
-        objectId: '',
-        versionHash: '',
-        path: '',
-        versionIndex: 0,
-        baseObjectClass: 'ValidJSONScorer',
-        createdAtMs: Date.now(),
-        val: {_type: 'ValidJSONScorer'},
-      });
-    } else if (validationType === 'xml') {
-      newScorers.push({
-        scheme: 'weave',
-        weaveKind: 'object',
-        entity,
-        project,
-        objectId: '',
-        versionHash: '',
-        path: '',
-        versionIndex: 0,
-        baseObjectClass: 'ValidXMLScorer',
-        createdAtMs: Date.now(),
-        val: {_type: 'ValidXMLScorer'},
-      });
-    }
+    setScorers(currentScorers => {
+      const newScorers: ObjectVersionSchema[] = [];
+      
+      // Find existing scorers to preserve their configurations
+      const existingJSONScorer = currentScorers.find(s => s.val['_type'] === 'ValidJSONScorer');
+      const existingXMLScorer = currentScorers.find(s => s.val['_type'] === 'ValidXMLScorer');
+      const existingLLMScorer = currentScorers.find(s => s.val['_type'] === 'LLMAsAJudgeScorer');
+      
+      if (validationType === 'json') {
+        if (existingJSONScorer) {
+          // Preserve existing JSON scorer configuration
+          newScorers.push(existingJSONScorer);
+        } else {
+          // Create new JSON scorer with default configuration
+          newScorers.push({
+            scheme: 'weave',
+            weaveKind: 'object',
+            entity,
+            project,
+            objectId: '',
+            versionHash: '',
+            path: '',
+            versionIndex: 0,
+            baseObjectClass: 'ValidJSONScorer',
+            createdAtMs: Date.now(),
+            val: {_type: 'ValidJSONScorer'},
+          });
+        }
+      } else if (validationType === 'xml') {
+        if (existingXMLScorer) {
+          // Preserve existing XML scorer configuration
+          newScorers.push(existingXMLScorer);
+        } else {
+          // Create new XML scorer with default configuration
+          newScorers.push({
+            scheme: 'weave',
+            weaveKind: 'object',
+            entity,
+            project,
+            objectId: '',
+            versionHash: '',
+            path: '',
+            versionIndex: 0,
+            baseObjectClass: 'ValidXMLScorer',
+            createdAtMs: Date.now(),
+            val: {_type: 'ValidXMLScorer'},
+          });
+        }
+      }
 
-    if (llmAsJudgeEnabled) {
-      newScorers.push({
-        scheme: 'weave',
-        weaveKind: 'object',
-        entity,
-        project,
-        objectId: '',
-        versionHash: '',
-        path: '',
-        versionIndex: 0,
-        baseObjectClass: 'LLMAsAJudgeScorer',
-        createdAtMs: Date.now(),
-        val: {_type: 'LLMAsAJudgeScorer'},
-      });
-    }
+      if (llmAsJudgeEnabled) {
+        if (existingLLMScorer) {
+          // Preserve existing LLM-as-a-judge scorer configuration
+          newScorers.push(existingLLMScorer);
+        } else {
+          // Create new LLM-as-a-judge scorer with default configuration
+          newScorers.push({
+            scheme: 'weave',
+            weaveKind: 'object',
+            entity,
+            project,
+            objectId: '',
+            versionHash: '',
+            path: '',
+            versionIndex: 0,
+            baseObjectClass: 'LLMAsAJudgeScorer',
+            createdAtMs: Date.now(),
+            val: {_type: 'LLMAsAJudgeScorer'},
+          });
+        }
+      }
 
-    setScorers(newScorers);
+      return newScorers;
+    });
   }, [validationType, llmAsJudgeEnabled, entity, project]);
 
   const {result: callsResults, loading: callsLoading} = useCalls({

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -688,13 +688,6 @@ export const CreateMonitorDrawer = ({
           </Box>
           <Box className="flex gap-8 border-t border-moon-250 p-20 py-16">
             <Button
-              variant="secondary"
-              onClick={onClose}
-              twWrapperStyles={{flexGrow: 1}}
-              className="w-full">
-              Cancel
-            </Button>
-            <Button
               disabled={!enableCreateButton}
               variant="primary"
               onClick={createMonitor}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -44,7 +44,7 @@ import {
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
 import {Radio} from '@wandb/weave/components';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
-import * as Switch from '@wandb/weave/components/Switch';
+import {ToggleButtonGroup} from '@wandb/weave/components/ToggleButtonGroup';
 import {parseRef} from '@wandb/weave/react';
 import _ from 'lodash';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
@@ -553,15 +553,14 @@ export const CreateMonitorDrawer = ({
                       onChange={e => setDescription(e.target.value)}
                     />
                   </Box>
-                  <Box className="flex items-center gap-8">
-                  <Switch.Root
-                      checked={active}
-                      onCheckedChange={setActive}
+                  <Box>
+                    <FieldName name="Active" />
+                    <ToggleButtonGroup
+                      value={active ? 'active' : 'inactive'}
+                      options={[{value: 'active'}, {value: 'inactive'}]}
+                      onValueChange={value => setActive(value === 'active')}
                       size="medium"
-                    >
-                      <Switch.Thumb size="medium" checked={active} />
-                    </Switch.Root>
-                    <span className="font-semibold">Active</span>
+                    />
                   </Box>
                 </Box>
 
@@ -585,6 +584,9 @@ export const CreateMonitorDrawer = ({
                         frozenFilter={undefined}
                         sx={{width: '100%', height: undefined}}
                       />
+                    </Box>
+                    <Box>
+                      <FieldName name="Additional filters" />
                       {selectedOpVersionOption.length > 0 ? (
                         <FilterPanel
                           entity={entity}
@@ -597,7 +599,7 @@ export const CreateMonitorDrawer = ({
                         />
                       ) : (
                         <Typography
-                          className="mt-4 text-sm font-normal"
+                          className="mt-1 text-sm font-normal"
                           sx={{
                             ...typographyStyle,
                             color: 'text.secondary',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -382,7 +382,7 @@ export const CreateMonitorDrawer = ({
               />
             </Box>
           </Box>
-          <Box className="flex flex-1 flex-col overflow-y-scroll pt-20 pb-60">
+          <Box className="flex flex-1 flex-col overflow-y-scroll pb-60 pt-20">
             {isCreating ? (
               <Box className="flex h-full flex-1 flex-col items-center justify-center">
                 <WaveLoader size="huge" />
@@ -446,10 +446,10 @@ export const CreateMonitorDrawer = ({
                   </Box>
                 </Box>
 
-                <Box className="flex flex-col pt-16 gap-8">
+                <Box className="flex flex-col gap-8 pt-16">
                   <Typography
                     sx={typographyStyle}
-                    className="pt-16 pb-8 px-20 border-t border-moon-250 uppercase tracking-wide text-moon-500 font-semibold">
+                    className="border-t border-moon-250 px-20 pb-8 pt-16 font-semibold uppercase tracking-wide text-moon-500">
                     Calls to monitor
                   </Typography>
                   <Box className="flex flex-col gap-16 px-20">
@@ -508,10 +508,10 @@ export const CreateMonitorDrawer = ({
                   </Box>
                 </Box>
 
-                <Box className="flex flex-col pt-16 gap-8">
+                <Box className="flex flex-col gap-8 pt-16">
                   <Typography
                     sx={typographyStyle}
-                    className="pt-16 pb-8 px-20 border-t border-moon-250 uppercase tracking-wide text-moon-500 font-semibold">
+                    className="border-t border-moon-250 px-20 pb-8 pt-16 font-semibold uppercase tracking-wide text-moon-500">
                     Scorers
                   </Typography>
                   <Box className="flex flex-col gap-16 px-20">
@@ -560,7 +560,7 @@ export const CreateMonitorDrawer = ({
               </Box>
             )}
           </Box>
-          <Box className="flex gap-8 p-20 py-16 border-t border-moon-250">
+          <Box className="flex gap-8 border-t border-moon-250 p-20 py-16">
             <Button
               variant="secondary"
               onClick={onClose}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -363,7 +363,7 @@ export const CreateMonitorDrawer = ({
       <Tailwind style={{height: '100%'}}>
         <Box className="flex h-full flex-col pt-60">
           <Box
-            className="flex h-56 items-center justify-between border-b px-20 py-8"
+            className="flex h-44 items-center justify-between border-b px-20"
             sx={{
               borderColor: 'divider',
             }}>
@@ -371,7 +371,7 @@ export const CreateMonitorDrawer = ({
               variant="h6"
               className="text-xl font-semibold"
               sx={typographyStyle}>
-              Create monitor
+              Create new monitor
             </Typography>
             <Box className="flex gap-2">
               <Button
@@ -382,22 +382,22 @@ export const CreateMonitorDrawer = ({
               />
             </Box>
           </Box>
-          <Box className="flex flex-1 flex-col overflow-y-scroll px-20 pb-24 pt-12">
+          <Box className="flex flex-1 flex-col overflow-y-scroll pt-20 pb-60">
             {isCreating ? (
               <Box className="flex h-full flex-1 flex-col items-center justify-center">
                 <WaveLoader size="huge" />
               </Box>
             ) : (
               <Box className="flex flex-grow flex-col gap-16">
-                <Box className="flex flex-col gap-16">
+                <Box className="flex flex-col gap-16 px-20">
                   {error && (
                     <Box
-                      className="mb-2 rounded-sm bg-red-300 text-red-600"
+                      className="rounded-sm bg-red-300 text-red-600"
                       sx={typographyStyle}>
                       {error}
                     </Box>
                   )}
-                  <Box className="mb-2">
+                  <Box>
                     <FieldName name="Name" />
                     <TextField
                       value={monitorName}
@@ -426,7 +426,7 @@ export const CreateMonitorDrawer = ({
                       underscores.
                     </Typography>
                   </Box>
-                  <Box className="mb-2">
+                  <Box>
                     <FieldName name="Description" />
                     <TextArea
                       value={description}
@@ -435,7 +435,7 @@ export const CreateMonitorDrawer = ({
                       onChange={e => setDescription(e.target.value)}
                     />
                   </Box>
-                  <Box className="mb-2">
+                  <Box>
                     <FieldName name="Active" />
                     <ToggleButtonGroup
                       value={active ? 'active' : 'inactive'}
@@ -445,10 +445,11 @@ export const CreateMonitorDrawer = ({
                     />
                   </Box>
                 </Box>
-                <Box className="flex flex-col gap-8">
+
+                <Box className="flex flex-col pt-16 gap-8">
                   <Typography
                     sx={typographyStyle}
-                    className="text-lg font-semibold">
+                    className="py-16 px-20 border-t border-moon-250 uppercase tracking-wide text-moon-500 font-semibold">
                     Calls to monitor
                   </Typography>
                   <Box className="flex flex-col gap-16">
@@ -557,7 +558,7 @@ export const CreateMonitorDrawer = ({
               </Box>
             )}
           </Box>
-          <Box className="flex gap-16 px-24 py-20">
+          <Box className="flex gap-8 p-20 py-16 border-t border-moon-250">
             <Button
               variant="secondary"
               onClick={onClose}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -1,6 +1,12 @@
 import {Box, Drawer, Typography} from '@mui/material';
 import {GridFilterModel} from '@mui/x-data-grid-pro';
+import {styled} from '@mui/material/styles';
 import SliderInput from '@wandb/weave/common/components/elements/SliderInput';
+import {
+  MOON_250,
+  MOON_350,
+  TEAL_500,
+} from '@wandb/weave/common/css/color.styles';
 import {Button} from '@wandb/weave/components/Button';
 import {TextArea} from '@wandb/weave/components/Form/TextArea';
 import {TextField} from '@wandb/weave/components/Form/TextField';
@@ -48,6 +54,60 @@ import {toast} from 'react-toastify';
 
 const PAGE_SIZE = 10;
 const PAGE_OFFSET = 0;
+
+const StyledSliderInput = styled('div')<{progress: number}>(({progress}) => ({
+  '& .slider-input': {
+    '& input[type="range"]': {
+      appearance: 'none',
+      width: '100%',
+      height: '8px',
+      borderRadius: '4px',
+      background: `linear-gradient(to right, ${TEAL_500} 0%, ${TEAL_500} ${progress}%, ${MOON_250} ${progress}%, ${MOON_250} 100%)`,
+      outline: 'none',
+      padding: 0,
+      margin: '8px 0',
+      '&::-webkit-slider-track': {
+        width: '100%',
+        height: '8px',
+        borderRadius: '4px',
+        background: 'transparent',
+      },
+      '&::-moz-range-track': {
+        width: '100%',
+        height: '8px',
+        borderRadius: '4px',
+        background: 'transparent',
+      },
+      '&::-webkit-slider-thumb': {
+        appearance: 'none',
+        width: '16px',
+        height: '16px',
+        borderRadius: '50%',
+        background: '#fff',
+        cursor: 'pointer',
+        border: `1px solid ${MOON_350}`,
+        boxShadow: '0 0 2px 0px rgba(0, 0, 0, 0.1)',
+        transition: 'box-shadow 0.2s',
+        '&:hover': {
+          boxShadow: '0 0 8px 0px rgba(0, 0, 0, 0.2)',
+        },
+      },
+      '&::-moz-range-thumb': {
+        width: '12px',
+        height: '12px',
+        borderRadius: '50%',
+        background: '#fff',
+        cursor: 'pointer',
+        border: `1px solid ${MOON_350}`,
+        boxShadow: '0 0 2px 0px rgba(0, 0, 0, 0.1)',
+        transition: 'box-shadow 0.2s',
+        '&:hover': {
+          boxShadow: '0 0 8px 0px rgba(0, 0, 0, 0.2)',
+        },
+      },
+    },
+  },
+}));
 
 const SCORER_FORMS: Map<
   string,
@@ -491,15 +551,17 @@ export const CreateMonitorDrawer = ({
                     <Box>
                       <FieldName name="Sampling rate" />
                       <Box className="flex items-center gap-12">
-                        <SliderInput
-                          value={samplingRate}
-                          onChange={setSamplingRate}
-                          min={0}
-                          max={100}
-                          step={1}
-                          hasInput
-                          className="w-full"
-                        />
+                        <StyledSliderInput className="w-full" progress={samplingRate}>
+                          <SliderInput
+                            value={samplingRate}
+                            onChange={setSamplingRate}
+                            min={0}
+                            max={100}
+                            step={1}
+                            hasInput
+                            className="w-full"
+                          />
+                        </StyledSliderInput>
                         <span style={typographyStyle}>%</span>
                       </Box>
                     </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer.tsx
@@ -557,9 +557,9 @@ export const CreateMonitorDrawer = ({
                       <Switch.Root
                         checked={active}
                         onCheckedChange={setActive}
-                        size="medium"
+                        size="small"
                       >
-                        <Switch.Thumb size="medium" checked={active} />
+                        <Switch.Thumb size="small" checked={active} />
                       </Switch.Root>
                       <span className="font-semibold">Active monitor</span>
                     </Box>
@@ -672,9 +672,9 @@ export const CreateMonitorDrawer = ({
                       <Switch.Root
                         checked={llmAsJudgeEnabled}
                         onCheckedChange={setLlmAsJudgeEnabled}
-                        size="medium"
+                        size="small"
                       >
-                        <Switch.Thumb size="medium" checked={llmAsJudgeEnabled} />
+                        <Switch.Thumb size="small" checked={llmAsJudgeEnabled} />
                       </Switch.Root>
                       <span className="font-semibold">Enable LLM-as-a-judge scoring</span>
                     </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorPage.tsx
@@ -12,6 +12,7 @@ import {
   SimpleKeyValueTable,
   SimplePageLayoutWithHeader,
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout';
+import {SafeOpRef} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorsPage';
 import {DeleteObjectButtonWithModal} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectDeleteButtons';
 import {ObjectIcon} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage';
 import {queryToGridFilterModel} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/SavedViews/savedViewUtil';
@@ -23,7 +24,6 @@ import {
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks';
 import {objectVersionKeyToRefUri} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/utilities';
 import {ObjectVersionSchema} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
-import {SafeOpRef} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorsPage';
 import {SmallRef} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/smallRef/SmallRef';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
 import {Timestamp} from '@wandb/weave/components/Timestamp';

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorsPage.tsx
@@ -236,7 +236,7 @@ const MonitorsPageHeaderExtra: React.FC<{
           variant="ghost"
           onClick={onCreateMonitor}
           tooltip="Create a new monitor">
-          Create monitor
+          New monitor
         </Button>
       </div>
     </Tailwind>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorsPage.tsx
@@ -1,4 +1,3 @@
-import {Box} from '@mui/material';
 import {PopupDropdown} from '@wandb/weave/common/components/PopupDropdown';
 import {Button} from '@wandb/weave/components/Button';
 import {IconPencilEdit} from '@wandb/weave/components/Icon';
@@ -6,6 +5,7 @@ import {LoadingDots} from '@wandb/weave/components/LoadingDots';
 import {CellValue} from '@wandb/weave/components/PagePanelComponents/Home/Browse2/CellValue';
 import {ALL_TRACES_OR_CALLS_REF_KEY} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableFilter';
 import {EMPTY_PROPS_MONITORS} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent';
+import {SimplePageLayout} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/common/SimplePageLayout';
 import {MonitorDrawerRouter} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/CreateMonitorDrawer';
 import {FilterableObjectVersionsTable} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionsTable';
 import {Query} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientInterface/query';
@@ -30,146 +30,158 @@ export const MonitorsPage = ({
   const [selectedMonitor, setSelectedMonitor] = useState<
     ObjectVersionSchema | undefined
   >();
+
+  const handleCreateMonitor = () => {
+    setSelectedMonitor(undefined);
+    setIsCreateDrawerOpen(true);
+  };
+
+  const handleCloseDrawer = () => {
+    setIsCreateDrawerOpen(false);
+  };
+
   return (
-    <Tailwind>
-      <Box>
-        <Box className="mx-16 my-16 flex items-center justify-between">
-          <h1 className="text-2xl font-bold">Monitors</h1>
-          <Button
-            icon="add-new"
-            variant="ghost"
-            tooltip="Create a new monitor"
-            onClick={() => {
-              setSelectedMonitor(undefined);
-              setIsCreateDrawerOpen(true);
-            }}>
-            Create monitor
-          </Button>
-        </Box>
-        <FilterableObjectVersionsTable
-          entity={entity}
-          project={project}
-          objectTitle="Monitor"
-          hideCategoryColumn
-          frozenFilter={{
-            baseObjectClass: 'Monitor',
-          }}
-          metadataOnly={false}
-          propsEmpty={EMPTY_PROPS_MONITORS}
-          keepNestedVal={['query']}
-          hidePeerVersionsColumn
-          hideVersionSuffix
-          actionMenu={obj => (
-            <PopupDropdown
-              sections={[
-                [
+    <>
+      <SimplePageLayout
+        title="Monitors"
+        hideTabsIfSingle
+        headerExtra={
+          <MonitorsPageHeaderExtra onCreateMonitor={handleCreateMonitor} />
+        }
+        tabs={[
+          {
+            label: '',
+            content: (
+              <FilterableObjectVersionsTable
+                entity={entity}
+                project={project}
+                objectTitle="Monitor"
+                hideCategoryColumn
+                frozenFilter={{
+                  baseObjectClass: 'Monitor',
+                }}
+                metadataOnly={false}
+                propsEmpty={EMPTY_PROPS_MONITORS}
+                keepNestedVal={['query']}
+                hidePeerVersionsColumn
+                hideVersionSuffix
+                actionMenu={obj => (
+                  <PopupDropdown
+                    sections={[
+                      [
+                        {
+                          key: 'edit',
+                          text: 'Edit',
+                          icon: <IconPencilEdit style={{marginRight: '8px'}} />,
+                          onClick: () => setIsCreateDrawerOpen(true),
+                        },
+                      ],
+                    ]}
+                    trigger={
+                      <Button icon="overflow-horizontal" variant="ghost" />
+                    }
+                    offset="0px, -20px"
+                    onOpen={() => setSelectedMonitor(obj)}
+                  />
+                )}
+                customColumns={[
                   {
-                    key: 'edit',
-                    text: 'Edit',
-                    icon: <IconPencilEdit style={{marginRight: '8px'}} />,
-                    onClick: () => setIsCreateDrawerOpen(true),
+                    field: 'description',
+                    headerName: 'Description',
+                    flex: 1,
+                    valueGetter: (_, row) => row.obj.val['description'],
+                    renderCell: params => <CellValue value={params.value} />,
                   },
-                ],
-              ]}
-              trigger={<Button icon="overflow-horizontal" variant="ghost" />}
-              offset="0px, -20px"
-              onOpen={() => setSelectedMonitor(obj)}
-            />
-          )}
-          customColumns={[
-            {
-              field: 'description',
-              headerName: 'Description',
-              flex: 1,
-              valueGetter: (_, row) => row.obj.val['description'],
-              renderCell: params => <CellValue value={params.value} />,
-            },
-            {
-              field: 'samplingRate',
-              headerName: 'Sampling rate',
-              width: 120,
-              valueGetter: (_, row) => row.obj.val['sampling_rate'],
-              renderCell: params => (
-                <CellValue value={`${params.value * 100}%`} />
-              ),
-            },
-            {
-              field: 'ops',
-              headerName: 'Ops',
-              flex: 1,
-              valueGetter: (_, row) => row.obj.val['op_names'],
-              renderCell: params => {
-                const opRefs: string[] = params.value;
-                if (opRefs.length === 0) {
-                  return null;
-                }
-                return (
-                  <div className="flex items-center gap-2">
-                    {opRefs[0] !== ALL_TRACES_OR_CALLS_REF_KEY ? (
-                      <SafeOpRef opRef={opRefs[0]} />
-                    ) : null}
-                    {opRefs[0] === ALL_TRACES_OR_CALLS_REF_KEY ? (
-                      <span>All calls</span>
-                    ) : null}
-                    {opRefs.length > 1 ? (
-                      <span>{`+${opRefs.length - 1}`}</span>
-                    ) : null}
-                  </div>
-                );
-              },
-            },
-            {
-              field: 'scorers',
-              headerName: 'Scorers',
-              flex: 1,
-              valueGetter: (_, row) => row.obj.val['scorers'],
-              renderCell: params => {
-                const scorerRefs: string[] = params.value;
-                return scorerRefs.length > 0 ? (
-                  <div className="flex items-center gap-2">
-                    <CellValue value={scorerRefs[0]} />
-                    {scorerRefs.length > 1 ? (
-                      <span>{`+${scorerRefs.length - 1}`}</span>
-                    ) : null}
-                  </div>
-                ) : null;
-              },
-            },
-            {
-              field: 'active',
-              headerName: 'Active',
-              valueGetter: (_, row) => {
-                return row.obj.val['active'];
-              },
-              renderCell: params => {
-                return <CellValue value={params.value} />;
-              },
-            },
-            {
-              field: 'callCount',
-              headerName: 'Calls',
-              valueGetter: (_, row) => {
-                return row.id;
-              },
-              renderCell: params => (
-                <CallCountCell
-                  monitorRef={params.value}
-                  entity={entity}
-                  project={project}
-                />
-              ),
-            },
-          ]}
-        />
-      </Box>
+                  {
+                    field: 'samplingRate',
+                    headerName: 'Sampling rate',
+                    width: 120,
+                    valueGetter: (_, row) => row.obj.val['sampling_rate'],
+                    renderCell: params => (
+                      <CellValue value={`${params.value * 100}%`} />
+                    ),
+                  },
+                  {
+                    field: 'ops',
+                    headerName: 'Ops',
+                    flex: 1,
+                    valueGetter: (_, row) => row.obj.val['op_names'],
+                    renderCell: params => {
+                      const opRefs: string[] = params.value;
+                      if (opRefs.length === 0) {
+                        return null;
+                      }
+                      return (
+                        <div className="flex items-center gap-2">
+                          {opRefs[0] !== ALL_TRACES_OR_CALLS_REF_KEY ? (
+                            <SafeOpRef opRef={opRefs[0]} />
+                          ) : null}
+                          {opRefs[0] === ALL_TRACES_OR_CALLS_REF_KEY ? (
+                            <span>All calls</span>
+                          ) : null}
+                          {opRefs.length > 1 ? (
+                            <span>{`+${opRefs.length - 1}`}</span>
+                          ) : null}
+                        </div>
+                      );
+                    },
+                  },
+                  {
+                    field: 'scorers',
+                    headerName: 'Scorers',
+                    flex: 1,
+                    valueGetter: (_, row) => row.obj.val['scorers'],
+                    renderCell: params => {
+                      const scorerRefs: string[] = params.value;
+                      return scorerRefs.length > 0 ? (
+                        <div className="flex items-center gap-2">
+                          <CellValue value={scorerRefs[0]} />
+                          {scorerRefs.length > 1 ? (
+                            <span>{`+${scorerRefs.length - 1}`}</span>
+                          ) : null}
+                        </div>
+                      ) : null;
+                    },
+                  },
+                  {
+                    field: 'active',
+                    headerName: 'Active',
+                    valueGetter: (_, row) => {
+                      return row.obj.val['active'];
+                    },
+                    renderCell: params => {
+                      return <CellValue value={params.value} />;
+                    },
+                  },
+                  {
+                    field: 'callCount',
+                    headerName: 'Calls',
+                    valueGetter: (_, row) => {
+                      return row.id;
+                    },
+                    renderCell: params => (
+                      <CallCountCell
+                        monitorRef={params.value}
+                        entity={entity}
+                        project={project}
+                      />
+                    ),
+                  },
+                ]}
+              />
+            ),
+          },
+        ]}
+      />
+
       <MonitorDrawerRouter
         entity={entity}
         project={project}
         open={isCreateDrawerOpen}
-        onClose={() => setIsCreateDrawerOpen(false)}
+        onClose={handleCloseDrawer}
         monitor={selectedMonitor}
       />
-    </Tailwind>
+    </>
   );
 };
 
@@ -210,6 +222,24 @@ const CallCountCell = ({
         'call'
       )}`}
     />
+  );
+};
+
+const MonitorsPageHeaderExtra: React.FC<{
+  onCreateMonitor: () => void;
+}> = ({onCreateMonitor}) => {
+  return (
+    <Tailwind>
+      <div className="mr-16 flex gap-8">
+        <Button
+          icon="add-new"
+          variant="ghost"
+          onClick={onCreateMonitor}
+          tooltip="Create a new monitor">
+          Create monitor
+        </Button>
+      </div>
+    </Tailwind>
   );
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
@@ -107,40 +107,87 @@ export const LLMAsAJudgeScorerForm = ({
   );
 
   return (
-    <Box className="mb-2 flex flex-col gap-8">
-      <Typography sx={typographyStyle} className="font-semibold">
+    <Box className="flex flex-col pt-16 gap-8">
+      <Typography sx={typographyStyle} 
+        className="pt-16 pb-8 px-20 border-t border-moon-250 uppercase tracking-wide text-moon-500 font-semibold"
+      >
         LLM-as-a-Judge configuration
       </Typography>
-      <Box>
-        <FieldName name="Name" />
-        <TextField value={scorerName} onChange={onScorerNameChange} />
-        {nameError && (
+
+      <Box className="flex flex-col gap-16 px-20">
+        <Box>
+          <FieldName name="Name" />
+          <TextField value={scorerName} onChange={onScorerNameChange} />
+          {nameError && (
+            <Typography
+              className="mt-1 text-sm"
+              sx={{
+                ...typographyStyle,
+                color: 'error.main',
+              }}>
+              {nameError}
+            </Typography>
+          )}
           <Typography
-            className="mt-1 text-sm"
+            className="mt-4 text-sm font-normal"
             sx={{
               ...typographyStyle,
-              color: 'error.main',
+              color: 'text.secondary',
             }}>
-            {nameError}
+            Valid names must start with a letter or number and can only contain
+            letters, numbers, hyphens, and underscores.
           </Typography>
-        )}
-        <Typography
-          className="mt-1 text-sm font-normal"
-          sx={{
-            ...typographyStyle,
-            color: 'text.secondary',
-          }}>
-          Valid names must start with a letter or number and can only contain
-          letters, numbers, hyphens, and underscores.
-        </Typography>
-      </Box>
-      <Box>
-        <FieldName name="Judge Model" />
-        {!savedModelsLoading && modelOptions.length === 0 ? (
-          <Typography sx={typographyStyle} className="text-sm">
-            No saved models found. Create one in the Playground.
-            <br />
-            See{' '}
+        </Box>
+
+        <Box>
+          <FieldName name="Judge Model" />
+          {!savedModelsLoading && modelOptions.length === 0 ? (
+            <Typography sx={typographyStyle} className="text-sm">
+              No saved models found. Create one in the Playground.
+              <br />
+              See{' '}
+              <Link
+                to="https://docs.wandb.ai/guides/monitors/scorers#llm-as-a-judge-scorer"
+                target="_blank"
+                className="text-blue-500">
+                docs
+              </Link>{' '}
+              for more details.
+            </Typography>
+          ) : (
+            <Select<{label: string; ref: string}, false>
+              isDisabled={savedModelsLoading}
+              placeholder={
+                savedModelsLoading ? 'Loading...' : 'Select a judge model'
+              }
+              options={modelOptions}
+              value={selectedModel}
+              onChange={newValue => {
+                setJudgeModelRef(newValue?.ref);
+                onChangeCallback(scoringPrompt, newValue?.ref, scorerName);
+              }}
+            />
+          )}
+        </Box>
+
+        <Box>
+          <FieldName name="Scoring Prompt" />
+          <TextArea
+            value={scoringPrompt}
+            placeholder="Enter a scoring prompt. You can use the following variables: {output} and {input}."
+            onChange={e => {
+              setScoringPrompt(e.target.value);
+              onChangeCallback(e.target.value, judgeModelRef, scorerName);
+            }}
+          />
+          <Typography
+            className="mt-1 text-sm font-normal"
+            sx={{
+              ...typographyStyle,
+              color: 'text.secondary',
+            }}>
+            The scoring prompt will be used to score the output of your ops. You
+            can use the following variables: {'{output}'} and {'{input}'}. See{' '}
             <Link
               to="https://docs.wandb.ai/guides/monitors/scorers#llm-as-a-judge-scorer"
               target="_blank"
@@ -149,47 +196,8 @@ export const LLMAsAJudgeScorerForm = ({
             </Link>{' '}
             for more details.
           </Typography>
-        ) : (
-          <Select<{label: string; ref: string}, false>
-            isDisabled={savedModelsLoading}
-            placeholder={
-              savedModelsLoading ? 'Loading...' : 'Select a judge model'
-            }
-            options={modelOptions}
-            value={selectedModel}
-            onChange={newValue => {
-              setJudgeModelRef(newValue?.ref);
-              onChangeCallback(scoringPrompt, newValue?.ref, scorerName);
-            }}
-          />
-        )}
-      </Box>
-      <Box>
-        <FieldName name="Scoring Prompt" />
-        <TextArea
-          value={scoringPrompt}
-          placeholder="Enter a scoring prompt. You can use the following variables: {output} and {input}."
-          onChange={e => {
-            setScoringPrompt(e.target.value);
-            onChangeCallback(e.target.value, judgeModelRef, scorerName);
-          }}
-        />
-        <Typography
-          className="mt-1 text-sm font-normal"
-          sx={{
-            ...typographyStyle,
-            color: 'text.secondary',
-          }}>
-          The scoring prompt will be used to score the output of your ops. You
-          can use the following variables: {'{output}'} and {'{input}'}. See{' '}
-          <Link
-            to="https://docs.wandb.ai/guides/monitors/scorers#llm-as-a-judge-scorer"
-            target="_blank"
-            className="text-blue-500">
-            docs
-          </Link>{' '}
-          for more details.
-        </Typography>
+        </Box>
+        
       </Box>
     </Box>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
@@ -111,7 +111,7 @@ export const LLMAsAJudgeScorerForm = ({
       <Typography
         sx={typographyStyle}
         className="border-t border-moon-250 px-20 pb-8 pt-16 font-semibold uppercase tracking-wide text-moon-500">
-        LLM-as-a-Judge
+        LLM-as-a-Judge configuration
       </Typography>
 
       <Box className="flex flex-col gap-16 px-20">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
@@ -111,7 +111,7 @@ export const LLMAsAJudgeScorerForm = ({
       <Typography
         sx={typographyStyle}
         className="border-t border-moon-250 px-20 pb-8 pt-16 font-semibold uppercase tracking-wide text-moon-500">
-        LLM-as-a-Judge configuration
+        LLM-as-a-judge
       </Typography>
 
       <Box className="flex flex-col gap-16 px-20">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
@@ -1,17 +1,17 @@
 import {Box, Typography} from '@mui/material';
+import {Select} from '@wandb/weave/components/Form/Select';
 import {TextArea} from '@wandb/weave/components/Form/TextArea';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {Link} from 'react-router-dom';
+import {TextField} from '@wandb/weave/components/Form/TextField';
+import {useEntityProject} from '@wandb/weave/components/PagePanelComponents/Home/Browse3';
+import {validateDatasetName} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/datasets/datasetNameValidation';
 import {
   FieldName,
   typographyStyle,
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/FormComponents';
-import {useEntityProject} from '@wandb/weave/components/PagePanelComponents/Home/Browse3';
 import {useLeafObjectInstances} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/objectClassQuery';
 import {ObjectVersionSchema} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
-import {Select} from '@wandb/weave/components/Form/Select';
-import {TextField} from '@wandb/weave/components/Form/TextField';
-import {validateDatasetName} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/datasets/datasetNameValidation';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {Link} from 'react-router-dom';
 
 export const LLMAsAJudgeScorerForm = ({
   scorer,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
@@ -107,10 +107,10 @@ export const LLMAsAJudgeScorerForm = ({
   );
 
   return (
-    <Box className="flex flex-col pt-16 gap-8">
-      <Typography sx={typographyStyle} 
-        className="pt-16 pb-8 px-20 border-t border-moon-250 uppercase tracking-wide text-moon-500 font-semibold"
-      >
+    <Box className="flex flex-col gap-8 pt-16">
+      <Typography
+        sx={typographyStyle}
+        className="border-t border-moon-250 px-20 pb-8 pt-16 font-semibold uppercase tracking-wide text-moon-500">
         LLM-as-a-Judge configuration
       </Typography>
 
@@ -197,7 +197,6 @@ export const LLMAsAJudgeScorerForm = ({
             for more details.
           </Typography>
         </Box>
-        
       </Box>
     </Box>
   );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
@@ -116,7 +116,7 @@ export const LLMAsAJudgeScorerForm = ({
 
       <Box className="flex flex-col gap-16 px-20">
         <Box>
-          <FieldName name="Name" />
+          <FieldName name="Scorer name" />
           <TextField value={scorerName} onChange={onScorerNameChange} />
           {nameError && (
             <Typography
@@ -140,7 +140,7 @@ export const LLMAsAJudgeScorerForm = ({
         </Box>
 
         <Box>
-          <FieldName name="Judge Model" />
+          <FieldName name="Judge model" />
           {!savedModelsLoading && modelOptions.length === 0 ? (
             <Typography sx={typographyStyle} className="text-sm">
               No saved models found. Create one in the Playground.
@@ -171,7 +171,7 @@ export const LLMAsAJudgeScorerForm = ({
         </Box>
 
         <Box>
-          <FieldName name="Scoring Prompt" />
+          <FieldName name="Scoring prompt" />
           <TextArea
             value={scoringPrompt}
             placeholder="Enter a scoring prompt. You can use the following variables: {output} and {input}."

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/ScorerForms/LLMAsAJudgeScorerForm.tsx
@@ -111,7 +111,7 @@ export const LLMAsAJudgeScorerForm = ({
       <Typography
         sx={typographyStyle}
         className="border-t border-moon-250 px-20 pb-8 pt-16 font-semibold uppercase tracking-wide text-moon-500">
-        LLM-as-a-Judge configuration
+        LLM-as-a-Judge
       </Typography>
 
       <Box className="flex flex-col gap-16 px-20">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -239,11 +239,20 @@ export const EMPTY_PROPS_OBJECT_VERSIONS: EmptyProps = {
 
 export const EMPTY_PROPS_MONITORS: EmptyProps = {
   icon: 'job-automation' as const,
-  heading: 'No monitors yet',
-  description: 'Use monitors to automatically run scorers on incoming traces.',
+  heading: 'Create your first monitor',
+  description:
+    'Use monitors to automatically run scorers on incoming traces to track performance over time.',
   moreInformation: (
     <>
-      Learn about <TargetBlank href="">monitors</TargetBlank>.
+      Learn{' '}
+      <TargetBlank href="http://wandb.me/weave_monitors">
+        monitor basics
+      </TargetBlank>{' '}
+      or see how you can{' '}
+      <TargetBlank href="http://wandb.me/weave_eval_tut">
+        use monitors within an evaluation pipeline
+      </TargetBlank>
+      .
     </>
   ),
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/common/EmptyContent.tsx
@@ -6,6 +6,7 @@ import {TargetBlank} from '../../../../../../common/util/links';
 import {Button} from '../../../../../Button';
 import {CreateDatasetDrawer} from '../../datasets/CreateDatasetDrawer';
 import {useDatasetSaving} from '../../datasets/useDatasetSaving';
+import {MonitorDrawerRouter} from '../MonitorsPage/CreateMonitorDrawer';
 import {EmptyProps} from './Empty';
 import {Link} from './Links';
 
@@ -33,6 +34,30 @@ const NewDatasetButton: React.FC = () => {
         onSaveDataset={handleSaveDataset}
         isCreating={isCreatingDataset}
         data-testid="create-dataset-drawer"
+      />
+    </>
+  );
+};
+
+const NewMonitorButton: React.FC = () => {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const {entity, project} = useParams<{entity: string; project: string}>();
+
+  return (
+    <>
+      <Button
+        variant="primary"
+        icon="add-new"
+        onClick={() => setIsDrawerOpen(true)}
+        data-testid="create-monitor-button">
+        New monitor
+      </Button>
+      <MonitorDrawerRouter
+        entity={entity}
+        project={project}
+        open={isDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+        monitor={undefined}
       />
     </>
   );
@@ -253,6 +278,9 @@ export const EMPTY_PROPS_MONITORS: EmptyProps = {
         use monitors within an evaluation pipeline
       </TargetBlank>
       .
+      <Box sx={{mt: 2}}>
+        <NewMonitorButton />
+      </Box>
     </>
   ),
 };


### PR DESCRIPTION
## Description

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/6a5e09fd-49c7-457c-a534-4917c44fbbb4" />

Part of stacked PR:
https://github.com/wandb/weave/pull/4706 > feat(weave): Online evals with LLM-as-a-judge scorers
⎿ https://github.com/wandb/weave/pull/4728 > chore(ui): Monitor: Page layout / structure tweaks
&nbsp; &nbsp; ⎿ https://github.com/wandb/weave/pull/4729 > **chore(ui): Monitor: Form components**
&nbsp; &nbsp;&nbsp; &nbsp; ⎿ https://github.com/wandb/weave/pull/4731 > chore(ui): Monitor: OpSelector component update

Changes:
- Tweak to add additional filters to make it closer to ops selector.
- Styled range slider with our branding.
- Replaced scorer dropdown with a radio select for validation and switch for enabling LLM-as-judge.

Design next steps:
- Create a re-usable styled range component.
  - This is the right component to use, but even in Models in some places we use it un-styled.
  - We should also replace the MUI sliders in Playground with a variant of this as well.