### PR TITLE
fix(weave): sanitize memory addresses to prevent dupe ops

### DIFF
--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 
 import weave
 from weave.trace.object_record import pydantic_object_record
+from weave.trace.serialization.op_type import _replace_memory_address
 from weave.trace.serialization.serialize import (
     dictify,
     fallback_encode,
@@ -309,3 +310,20 @@ def test_to_json_function_with_memory_address_in_op(client) -> None:
 
     # this should still be the same op!
     assert len(log_me.calls()) == 4
+
+
+def test__replace_memory_address() -> None:
+    # Test with memory addresses of different lengths
+    assert (
+        _replace_memory_address("<Function object at 0x1234>")
+        == "<Function object at 0x0000>"
+    )
+    assert _replace_memory_address("<Class at 0xdeadbeef>") == "<Class at 0x00000000>"
+
+    # Test with multiple memory addresses
+    assert (
+        _replace_memory_address("<Object at 0x1234> and <Object at 0xabcd>")
+        == "<Object at 0x0000> and <Object at 0x0000>"
+    )
+    # Test with no memory addresses
+    assert _replace_memory_address("No memory address here") == "No memory address here"

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -34,7 +34,8 @@ logger = logging.getLogger(__name__)
 WEAVE_OP_PATTERN = re.compile(r"@weave\.op(\(\))?")
 WEAVE_OP_NO_PAREN_PATTERN = re.compile(r"@weave\.op(?!\()")
 
-MEMORY_ADDRESS_PATTERN = re.compile(r"0x[0-9a-fA-F]{9}>", re.ASCII)
+# Memory address with at least 4 charaters (decrease false positives)
+MEMORY_ADDRESS_PATTERN = re.compile(r"0x[0-9a-fA-F]{4,}>", re.ASCII)
 
 CODE_DEP_ERROR_SENTINEL = "<error>"
 

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -34,6 +34,8 @@ logger = logging.getLogger(__name__)
 WEAVE_OP_PATTERN = re.compile(r"@weave\.op(\(\))?")
 WEAVE_OP_NO_PAREN_PATTERN = re.compile(r"@weave\.op(?!\()")
 
+MEMORY_ADDRESS_PATTERN = re.compile(r"0x[0-9a-fA-F]{9}>", re.ASCII)
+
 CODE_DEP_ERROR_SENTINEL = "<error>"
 
 
@@ -466,9 +468,6 @@ def _get_code_deps(
                     )
                     code.append(code_paragraph)
     return {"import_code": import_code, "code": code, "warnings": warnings}
-
-
-MEMORY_ADDRESS_PATTERN = re.compile(r"0x[0-9a-fA-F]{9}>")
 
 
 def _has_memory_address(obj: Any) -> bool:

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -477,7 +477,14 @@ def _has_memory_address(obj: Any) -> bool:
 
 def _replace_memory_address(json_val: str) -> str:
     """Turn <Function object at 0x10c349010> into <Function object at 0x000000000>"""
-    return MEMORY_ADDRESS_PATTERN.sub("0x000000000>", json_val)
+
+    def _replacement_with_same_length(match: re.Match[str]) -> str:
+        # Get matched text and replace with 0s of the same length
+        address = match.group(0)
+        # Keep the 0x prefix and > suffix, replace the rest with 0s
+        return "0x" + "0" * (len(address) - 3) + ">"
+
+    return MEMORY_ADDRESS_PATTERN.sub(_replacement_with_same_length, json_val)
 
 
 def find_last_weave_op_function(


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25498](https://wandb.atlassian.net/browse/WB-25498)

Turn changing memory addresses into stable `0x000000000` so multiple instantiations of the same function at different memory addresses doesn't create multiple versions of ops. This impacts all `litellm` calls! 

Turn `<Function object at 0x10c349010>`  --> `<Function object at 0x000000000>`

_We could also move these two regex operations into one:_ `_try_replace_memory_address` 

## Testing

added test (fails without my change)


[WB-25498]: https://wandb.atlassian.net/browse/WB-25498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ