### PR TITLE
chore(weave): add model id copy button to details page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelDetailsLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelDetailsLoaded.tsx
@@ -176,7 +176,12 @@ export const ModelDetailsLoaded = ({
     codeExample = codeExample.replace('{model_id}', model.idPlayground);
   }
 
-  const onClickCopy = useCallback(() => {
+  const onClickCopyModelId = useCallback(() => {
+    copyToClipboard(model.idPlayground ?? '');
+    toast('Copied to clipboard');
+  }, [model.idPlayground]);
+
+  const onClickCopyCode = useCallback(() => {
     copyToClipboard(codeExample);
     toast.success('Copied to clipboard');
   }, [codeExample]);
@@ -198,6 +203,15 @@ export const ModelDetailsLoaded = ({
           </div>
         </div>
         <div className="flex items-center gap-8">
+          {model.idPlayground && (
+            <Button
+              size="large"
+              icon="copy"
+              variant="secondary"
+              onClick={onClickCopyModelId}
+              tooltip="Copy ID for API use to clipboard"
+            />
+          )}
           <Button
             size="large"
             onClick={onOpenPlayground}
@@ -299,36 +313,40 @@ export const ModelDetailsLoaded = ({
         </div>
       </div>
 
-      <div className="mt-16 text-lg font-semibold leading-8">
-        Use this model
-      </div>
+      {model.idPlayground && (
+        <>
+          <div className="mt-16 text-lg font-semibold leading-8">
+            Use this model
+          </div>
 
-      <div className="mb-8 flex items-center">
-        <div className="flex-grow">
-          <ToggleButtonGroup
-            options={[
-              {value: 'Python'},
-              // TODO {value: 'TypeScript'},
-              {value: 'Curl'},
-            ]}
-            value={selectedLanguage}
-            size="small"
-            onValueChange={setSelectedLanguage}
-          />
-        </div>
-        <div>
-          <Button variant="ghost" icon="copy" onClick={onClickCopy} />
-        </div>
-      </div>
-      <div className="[&_.monaco-editor]:!absolute">
-        <CodeEditor
-          value={codeExample}
-          language={CODE_LANGUAGE_MAP[selectedLanguage]}
-          readOnly
-          handleMouseWheel
-          alwaysConsumeMouseWheel={false}
-        />
-      </div>
+          <div className="mb-8 flex items-center">
+            <div className="flex-grow">
+              <ToggleButtonGroup
+                options={[
+                  {value: 'Python'},
+                  // TODO {value: 'TypeScript'},
+                  {value: 'Curl'},
+                ]}
+                value={selectedLanguage}
+                size="small"
+                onValueChange={setSelectedLanguage}
+              />
+            </div>
+            <div>
+              <Button variant="ghost" icon="copy" onClick={onClickCopyCode} />
+            </div>
+          </div>
+          <div className="[&_.monaco-editor]:!absolute">
+            <CodeEditor
+              value={codeExample}
+              language={CODE_LANGUAGE_MAP[selectedLanguage]}
+              readOnly
+              handleMouseWheel
+              alwaysConsumeMouseWheel={false}
+            />
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelTile.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelTile.tsx
@@ -175,13 +175,15 @@ export const ModelTile = ({
               Learn more
             </Button>
           </Link>
-          <Button
-            size="small"
-            icon="copy"
-            variant="ghost"
-            onClick={onClickCopy}
-            tooltip="Copy ID for API use to clipboard"
-          />
+          {model.idPlayground && (
+            <Button
+              size="small"
+              icon="copy"
+              variant="ghost"
+              onClick={onClickCopy}
+              tooltip="Copy ID for API use to clipboard"
+            />
+          )}
         </div>
       )}
       {hint && (


### PR DESCRIPTION
## Description

Previously added model ID copy button to model tile, design requested adding it to details page too.
Internal slack: https://weightsandbiases.slack.com/archives/C08RU04P36G/p1749746145399799?thread_ts=1749683637.172539&cid=C08RU04P36G

Recommend "Hide Whitespace". I also put in some better conditional rendering if `idPlayground` is missing, which is allowed by current type definitions but shouldn't come up in practice with our starting data.

<img width="232" alt="Screenshot 2025-06-12 at 3 53 27 PM" src="https://github.com/user-attachments/assets/8c9609e2-0fdc-4368-9eac-be6c7e03d110" />

## Testing

How was this PR tested?
