### PR TITLE
chore(dev): if run id verification fails for a trace do not dr op it, drop the run field

### DIFF
--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -258,6 +258,7 @@ class CallStartReq(BaseModel):
 class CallStartRes(BaseModel):
     id: str
     trace_id: str
+    warnings: Optional[list[str]] = None
 
 
 class CallEndReq(BaseModel):

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -125,6 +125,11 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             # handle 413 explicitly to provide actionable error message
             reason = json.loads(r.text)["reason"]
             raise requests.HTTPError(f"413 Client Error: {reason}", response=r)
+        response = tsi.CallCreateBatchRes.model_validate(r.json())
+        for item in response.res:
+            if isinstance(item, tsi.CallStartRes) and item.warnings:
+                for warning in item.warnings:
+                    logger.warning(warning)
         r.raise_for_status()
 
     def _flush_calls(


### PR DESCRIPTION
## Description

In `call_start` if the `wb_run_id` field is passed but the run does not exist or is in a project other than the call's, the server issues a 500 error. This PR modifies the behavior so that instead of dropping the call we drop the run id and step from the call and insert it. The validation error is logged and will be captured by dd.
