### PR TITLE
fix(weave): isolate call details loader to drawer

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -129,7 +129,23 @@ export const DEFAULT_PAGINATION_CALLS: GridPaginationModel = {
   page: 0,
 };
 
-const CustomLoadingOverlay: React.FC = () => {
+const CustomLoadingOverlay: React.FC<{hideControls?: boolean}> = ({
+  hideControls,
+}) => {
+  if (hideControls) {
+    return (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}>
+        <WaveLoader size="huge" />
+      </div>
+    );
+  }
   return (
     <div
       style={{
@@ -1153,7 +1169,9 @@ export const CallsTable: FC<{
             <IconPinToRight style={{transform: 'scaleX(-1)'}} />
           ),
           columnMenuPinRightIcon: IconPinToRight,
-          loadingOverlay: CustomLoadingOverlay,
+          loadingOverlay: () => (
+            <CustomLoadingOverlay hideControls={hideControls} />
+          ),
         }}
         className="tw-style"
       />


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25503](https://wandb.atlassian.net/browse/WB-25503)

Loading a call details drawer with a child calls table causes a loader on the entire page! It should only be loading in the drawer.

regression introduced in this pr: https://github.com/wandb/weave/pull/4343

## Testing

Prod
![prod-double-loader1](https://github.com/user-attachments/assets/93264d34-4224-40e8-bc8e-0e846e9560b3)

Branch
![prod-double-loader-branch](https://github.com/user-attachments/assets/abe61ba7-b2b1-4ee8-8597-b710acfc8120)



[WB-25503]: https://wandb.atlassian.net/browse/WB-25503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ