### PR TITLE
chore(ui): change icon for license field in model details page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelDetailsLoaded.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelDetailsLoaded.tsx
@@ -6,7 +6,7 @@ import {toast} from 'react-toastify';
 import {TargetBlank} from '../../../../../common/util/links';
 import {Button} from '../../../../Button';
 import {CodeEditor} from '../../../../CodeEditor';
-import {Icon, IconPrivacyOpen} from '../../../../Icon';
+import {Icon} from '../../../../Icon';
 import {ToggleButtonGroup} from '../../../../ToggleButtonGroup';
 import {Tooltip} from '../../../../Tooltip';
 import {Link} from '../pages/common/Links';
@@ -258,7 +258,7 @@ export const ModelDetailsLoaded = ({
             {model.license && (
               <>
                 <div className="flex items-center">
-                  <IconPrivacyOpen width={18} height={18} />
+                  <Icon name="checkmark-circle" width={18} height={18} />
                 </div>
                 <div className="flex items-center">
                   {getModelLicense(model)}


### PR DESCRIPTION
## Description

This is not the final icon either, updating per design's request until they can make us a new one.

Before:
<img width="129" alt="Screenshot 2025-06-12 at 7 41 36 PM" src="https://github.com/user-attachments/assets/c6d48fdd-4529-42d1-b693-09da7862e14e" />

After:
<img width="128" alt="Screenshot 2025-06-12 at 7 41 29 PM" src="https://github.com/user-attachments/assets/a2e6f90a-d4f4-4efb-9037-4a53a9a1c6b8" />


## Testing

How was this PR tested?
