### PR TITLE
chore(weave): When initializing client in a new project, flush the existing client first

### DIFF
--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -94,6 +94,8 @@ def init_weave(
         ):
             return _current_inited_client
         else:
+            # Flush any pending calls before switching to a new project
+            _current_inited_client.client.finish()
             _current_inited_client.reset()
 
     from weave.wandb_interface import wandb_api  # type: ignore


### PR DESCRIPTION
Resolves: https://wandb.atlassian.net/browse/WB-25497

This prevents calls from getting lost in case the first client gets cleaned up