### PR TITLE
fix(ui): compare models takes you to /inference

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdown.tsx
@@ -50,8 +50,9 @@ export const LLMDropdown: React.FC<LLMDropdownProps> = ({
 
   // TOOD: Avoid direct url manipulation
   const history = useHistory();
-  const handleViewCatalog = (path: string) => {
-    history.push(`${INFERENCE_PATH}/${path}`);
+  const handleViewCatalog = (path?: string) => {
+    const prefixedPath = path ? `${INFERENCE_PATH}/${path}` : INFERENCE_PATH;
+    history.push(prefixedPath);
   };
 
   const handleCloseDrawer = () => {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
@@ -67,7 +67,7 @@ export interface CustomOptionProps extends OptionProps<ProviderOption, false> {
   project: string;
   isAdmin?: boolean;
   onConfigureProvider?: (provider: string) => void;
-  onViewCatalog?: (provider: string) => void;
+  onViewCatalog?: (path?: string) => void;
 }
 
 const SubMenu = ({
@@ -92,7 +92,7 @@ const SubMenu = ({
   onSelect: () => void;
   isAdmin?: boolean;
   onConfigureProvider?: (provider: string) => void;
-  onViewCatalog?: (provider: string) => void;
+  onViewCatalog?: (path?: string) => void;
   providers?: ProviderOption[];
 }) => {
   return ReactDOM.createPortal(
@@ -197,7 +197,8 @@ const SubMenu = ({
         <Box
           onClick={e => {
             e.stopPropagation();
-            onViewCatalog(value);
+            // TODO: Pass the value as the path if we add comparison for other providers
+            onViewCatalog();
           }}
           sx={{
             display: 'flex',


### PR DESCRIPTION
## Description

Fix minor issue where "Compare models" wouldn't take you to the expected URL for the launch (though page still rendered as expected)

Internal Slack: https://weightsandbiases.slack.com/archives/C08RU04P36G/p1749773199212419?thread_ts=1749772570.373729&cid=C08RU04P36G

## Testing

How was this PR tested?
