### PR TITLE
fix(ui): don't render model tiles until we know available width

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/Explorer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/Explorer.tsx
@@ -34,12 +34,14 @@ export const Explorer = ({collectionId, inferenceContext}: ExplorerProps) => {
 
   return (
     <div ref={containerRef} className="h-full w-full">
-      <ExplorerLoaded
-        modelInfo={MODEL_INFO}
-        collectionId={collectionId}
-        width={width}
-        inferenceContext={inferenceContext}
-      />
+      {width > 0 ? (
+        <ExplorerLoaded
+          modelInfo={MODEL_INFO}
+          collectionId={collectionId}
+          width={width}
+          inferenceContext={inferenceContext}
+        />
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## Description

(Recommend hide whitespace)

Don't attempt to render the model catalog UI until we know the available width. Before, on load the initial width of the component would be 0, causing the computed number of tile columns to be 1, leading to a distracting animation when the actual width was available if the number of computed columns was greater than 1 (which was likely for common desktop browser widths).

## Testing

How was this PR tested?
