### PR TITLE
perf(weave): when filtering on heavy fields, only count first 1000

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -38,6 +38,7 @@ import {WFHighLevelCallFilter} from './callsTableFilter';
 import {useFilterSortby} from './callsTableQuery';
 
 const MAX_EXPORT = 10_000;
+const MAX_CALL_COUNT = 1000;
 
 type SelectionState = 'all' | 'selected' | 'limit';
 
@@ -735,6 +736,8 @@ export const PaginationButtons = ({hideControls}: PaginationButtonsProps) => {
     }
   };
 
+  const plusText = rowCount === MAX_CALL_COUNT ? '+' : '';
+
   return (
     <Box
       display="flex"
@@ -762,6 +765,7 @@ export const PaginationButtons = ({hideControls}: PaginationButtonsProps) => {
             justifyContent: 'center',
           }}>
           {start}-{end} of {rowCount}
+          {plusText}
         </Box>
         <Button
           variant="ghost"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableQuery.ts
@@ -90,12 +90,28 @@ export const useCallsForQuery = (
     includeFeedback: true,
   });
 
+  const hasHeavyField = (filterBy: Query | undefined) => {
+    if (filterBy == null) {
+      return false;
+    }
+    const filterStr = JSON.stringify(filterBy);
+    return filterStr.includes('inputs.') || filterStr.includes('output.');
+  };
+
+  const callsStatsLimit = useMemo(() => {
+    if (hasHeavyField(filterBy)) {
+      return 1_000;
+    }
+    return undefined;
+  }, [filterBy]);
+
   const callsStats = useCallsStats({
     entity,
     project,
     filter: lowLevelFilter,
     query: filterBy,
     refetchOnDelete: true,
+    limit: callsStatsLimit,
   });
 
   const callResults = useMemo(() => {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

When https://github.com/wandb/weave/pull/4664 lands, capping the stats query can improve performance. Especially when filtering by the inputs/output, we rarely need the exact count. 

TODO: 
- how do we provide the exact value if we need to get the exact count
