### PR TITLE
chore(weave): hide scrollbars when not needed in playground

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/PlaygroundChat.tsx
@@ -206,7 +206,7 @@ export const PlaygroundChat = ({
 
   return (
     <div className="flex h-full w-full flex-col items-center overflow-hidden">
-      <div className="mx-auto flex h-full w-full overflow-y-hidden overflow-x-scroll">
+      <div className="mx-auto flex h-full w-full overflow-x-auto overflow-y-hidden">
         <div className="mx-auto flex">
           {playgroundStates.map((state, idx) => (
             <React.Fragment key={idx}>
@@ -240,8 +240,8 @@ export const PlaygroundChat = ({
                     customProvidersResult={customProvidersResult}
                   />
                 </div>
-                <div className="h-full w-full flex-grow overflow-scroll px-[16px] pt-[48px]">
-                  <div className=" mx-auto mt-[32px] h-full pb-8">
+                <div className="h-full w-full flex-grow overflow-auto px-[16px] pt-[48px]">
+                  <div className=" mx-auto mt-[32px] pb-8">
                     {state.traceCall && (
                       <PlaygroundContext.Provider
                         value={{


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25327](https://wandb.atlassian.net/browse/WB-25327)

Hides scrollbars when not needed in playground. 

## Testing

Prod
Default view:
<img width="1673" alt="Screenshot 2025-06-13 at 1 44 52 PM" src="https://github.com/user-attachments/assets/91490cfc-7e27-47f8-bced-f18ef9b1bde8" />


Branch
Default view:
<img width="1669" alt="Screenshot 2025-06-13 at 1 45 10 PM" src="https://github.com/user-attachments/assets/1fe53c06-e43d-4919-818f-14f1007b05a4" />


With scrollable content:
<img width="850" alt="Screenshot 2025-06-13 at 1 44 23 PM" src="https://github.com/user-attachments/assets/24aafb2c-501a-46e1-9680-5f2979b96475" />


[WB-25327]: https://wandb.atlassian.net/browse/WB-25327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ