### PR TITLE
chore(ui): add Preview pill to model selection menu

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/LLMDropdownOptions.tsx
@@ -55,6 +55,7 @@ export interface ProviderOption {
   llms: Array<LLMOption>;
   isDisabled?: boolean;
   providers?: ProviderOption[];
+  isPreview?: boolean; // If true, show a preview pill in the dropdown
 }
 
 export interface CustomOptionProps extends OptionProps<ProviderOption, false> {
@@ -347,7 +348,10 @@ const SubMenuOption = ({
                 whiteSpace: 'normal',
                 width: '90%',
               }}>
-              {children}
+              <div className="flex items-center gap-8">
+                {children}
+                {props.data.isPreview && <Pill label="Preview" color="moon" />}
+              </div>
             </Box>
             <Box sx={{display: 'flex', gap: 1, alignItems: 'center'}}>
               {hasOptions && <Icon name="chevron-next" color="moon_500" />}
@@ -573,6 +577,7 @@ export const useLLMDropdownOptions = (
         label:
           LLM_PROVIDER_LABELS[provider as keyof typeof LLM_PROVIDER_LABELS],
         value: provider,
+        isPreview: provider === 'coreweave',
         llms: status ? providerLLMs : [],
         isDisabled: !status,
       };


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C08RU04P36G/p1749683637172539

Add Preview pill in model select component.

<img width="330" alt="Screenshot 2025-06-13 at 4 51 58 PM" src="https://github.com/user-attachments/assets/fa06d125-623d-4fe7-9464-b996b6aaf6e0" />

## Testing

How was this PR tested?
