### PR TITLE
chore(ui): smaller ignored click zone on model tile

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelTile.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/ModelTile.tsx
@@ -159,7 +159,7 @@ export const ModelTile = ({
       <div className="text-sm text-moon-650">{model.descriptionShort}</div>
       {onClickPlayground && (
         <div
-          className={`flex gap-8 py-6 transition-opacity duration-200 ${
+          className={`inline-flex gap-8 py-6 pr-6 transition-opacity duration-200 ${
             isSelected ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
           }`}
           onClick={onClickButtonRow}>


### PR DESCRIPTION
## Description

There's intentionally a small area around the model tile buttons where clicks are ignored - it's too easy to miss the button and cause a confusing tile deselection. However, the div was stretching across the tile, which made it confusing why selection wasn't toggling when you clicked to the right of the buttons.

Internal Notion report: https://www.notion.so/wandbai/W-B-Inference-QA-Testing-210e2f5c7ef38051a7e8d9dd2ab01cd6?source=copy_link#211e2f5c7ef380f5978bda678d2b72bc

## Testing

How was this PR tested?
