### PR TITLE
fix(weave): handle `KeyboardInterrupt`, `SystemExit` within ops

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -511,6 +511,9 @@ def _call_sync_func(
         if __should_raise:
             raise
         return None, call
+    except (SystemExit, KeyboardInterrupt) as e:
+        finish(exception=e)
+        raise
 
     res = box.box(res)
     try:
@@ -639,6 +642,9 @@ async def _call_async_func(
         if __should_raise:
             raise
         return None, call
+    except (SystemExit, KeyboardInterrupt) as e:
+        finish(exception=e)
+        raise
 
     res = box.box(res)
     try:


### PR DESCRIPTION
## Description

Error handling for ops only captures Exceptions, but we need to also handle KeyboardInterrupt, SystemExit which, like Exception, inherit from BaseException. Traces experiencing these would be left in a running state forever, and if the client context is re-used, eg in a notebook, all new calls will inherit the call stack from the point of failure.

Changing the blanket catch from `Exception` to `BaseException` will catch the things we want but will also catch `GeneratorExit`, which gets raised in healthy generator exits, kind of a weird implementation detail of python.