### PR TITLE
chore(weave): raise error on order by storage field

### DIFF
--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -2246,3 +2246,43 @@ def test_filter_length_validation():
     )
     with pytest.raises(ValueError):
         cq.as_sql(pb)
+
+
+def test_disallowed_fields():
+    cq = CallsQuery(project_id="test/project")
+    # allowed order field
+    cq.add_order("id", "ASC")
+    with pytest.raises(ValueError):
+        cq.add_order("storage_size_bytes", "ASC")
+    with pytest.raises(ValueError):
+        cq.add_order("total_storage_size_bytes", "DESC")
+    # with bogus direction
+    with pytest.raises(ValueError):
+        cq.add_order("storage_size_bytes", "ASCDESC")
+    # now try filtering with disallowed
+    with pytest.raises(ValueError):
+        cq.add_condition(
+            tsi_query.GtOperation.model_validate(
+                {
+                    "$gt": [
+                        {"$getField": "storage_size_bytes"},
+                        {"$literal": 1},
+                    ]
+                }
+            )
+        )
+        cq.as_sql(ParamBuilder())
+
+    cq = CallsQuery(project_id="test/project")  # reset
+    with pytest.raises(ValueError):
+        cq.add_condition(
+            tsi_query.GteOperation.model_validate(
+                {
+                    "$gte": [
+                        {"$getField": "total_storage_size_bytes"},
+                        {"$literal": 1},
+                    ]
+                }
+            )
+        )
+        cq.as_sql(ParamBuilder())

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -461,6 +461,8 @@ class CallsQuery(BaseModel):
         return self
 
     def add_order(self, field: str, direction: str) -> "CallsQuery":
+        if field in DISALLOWED_FILTERING_FIELDS:
+            raise ValueError(f"Field {field} is not allowed in ORDER BY")
         direction = direction.upper()
         if direction not in ("ASC", "DESC"):
             raise ValueError(f"Direction {direction} is not allowed")


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25518](https://wandb.atlassian.net/browse/WB-25518)

We already prevent filtering by storage fields, now prevent ordering. 

## Testing

- adds unit test
