### PR TITLE
fix(weave): Use last known state when useFile skip is true

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -989,7 +989,11 @@ const useFileContent = (
   return useMemo(() => {
     // Just submit the last known or initial state
     if (params.skip) {
-      return {loading: loadingRef.current, result: fileContentRes?.content ?? null, error };
+      return {
+        loading: loadingRef.current,
+        result: fileContentRes?.content ?? null,
+        error,
+      };
     }
     if (fileContentRes == null || loadingRef.current) {
       return {loading: true, result: null, error};


### PR DESCRIPTION
## Description

Currently even if a file has been loaded the result will be null if skip is passed as true. This just modifies the hook to return the last known state (which will be the same if the file has never been loaded). This makes it a bit easier to manage state for components using this hook.