### PR TITLE
perf(weave): op page in mem cache for stats

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/OpsPage/OpVersionsPage.tsx
@@ -123,6 +123,9 @@ export const FilterableOpVersionsTable: React.FC<{
   const columns: GridColDef[] = [
     basicField('op', 'Op', {
       hideable: false,
+      valueGetter: (unused: any, row: any) => {
+        return row.obj.opId;
+      },
       renderCell: cellParams => {
         // Icon to indicate navigation to the object version
         const obj: OpVersionSchema = cellParams.row.obj;


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25538](https://wandb.atlassian.net/browse/WB-25538)

Scrolling unmounts both the call count and peer versions count in the ops table, which causes excessive queries and long loading stats for projects with many calls or op versions. Cache in memory, refresh causes re-query, but scrolling uses cached values. 

## Testing

Prod
![op-callstats-cache-prod1](https://github.com/user-attachments/assets/1c86163b-b2b1-48a7-b7a9-ac1b75b981b7)

Branch
![op-callstats-cache-branch1](https://github.com/user-attachments/assets/e84abaaa-6d0d-44f3-aa21-978a06095152)


[WB-25538]: https://wandb.atlassian.net/browse/WB-25538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ