### PR TITLE
feat(weave): include the ingestion size in call compare view

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/ComparePageCalls.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/compare/ComparePageCalls.tsx
@@ -31,6 +31,7 @@ export const ComparePageCalls = ({
     entity,
     project,
     filter: {callIds},
+    includeStorageSize: true,
   });
   if (calls.loading) {
     return <LoadingDots />;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -123,6 +123,7 @@ export type TraceCallsQueryReq = {
   expand_columns?: string[];
   include_costs?: boolean;
   include_feedback?: boolean;
+  include_storage_size?: boolean;
   include_total_storage_size?: boolean;
 };
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -325,6 +325,7 @@ const useCallsNoExpansion = (
       columns: params.columns,
       include_costs: params.includeCosts,
       include_feedback: params.includeFeedback,
+      ...(params.includeStorageSize ? {include_storage_size: true} : null),
       ...(params.includeTotalStorageSize
         ? {include_total_storage_size: true}
         : null),
@@ -340,6 +341,7 @@ const useCallsNoExpansion = (
     params.columns,
     params.includeCosts,
     params.includeFeedback,
+    params.includeStorageSize,
     params.includeTotalStorageSize,
   ]);
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -190,6 +190,7 @@ export interface UseCallsParams {
   refetchOnDelete?: boolean;
   includeCosts?: boolean;
   includeFeedback?: boolean;
+  includeStorageSize?: boolean;
   includeTotalStorageSize?: boolean;
 }
 


### PR DESCRIPTION
## Description

- Adds support for retrieving storage size information for calls in the Compare Page
- Extends the trace server client types to include a new `include_storage_size` parameter
- Updates the data model hooks to pass this parameter to the API when requested

## Preview

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sjuXMNgR0xOaLu1czpDo/7cf7fa81-e330-413f-a225-a9be8266fbd6.png)

## Testing

Tested by verifying that the Compare Page successfully retrieves and displays storage size information for calls when the `includeStorageSize` parameter is set to true.