### PR TITLE
fix(weave): strip large fields from queue push on call end

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -336,7 +336,12 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         self._insert_call(ch_call)
 
         if wf_env.wf_enable_online_eval() and publish:
-            self.kafka_producer.produce_call_end(req.end)
+            # Strip large and optional fields, dont modify param
+            end_copy = req.end.model_copy()
+            end_copy.output = None
+            end_copy.summary = {}
+            end_copy.exception = None
+            self.kafka_producer.produce_call_end(end_copy)
 
         # Returns the id of the newly created call
         return tsi.CallEndRes()


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25559](https://wandb.atlassian.net/browse/WB-25559)

Fixes large call part insertion bug using new calls. We do not need these fields, in the `scoring_worker.py`, we only use `project_id` and `call_id`

## Testing

manual: 
<img width="666" alt="Screenshot 2025-06-16 at 8 48 39 PM" src="https://github.com/user-attachments/assets/57b60084-c545-4079-bb20-1a51136ff32d" />

prod has no trace, while branch has:
<img width="520" alt="image" src="https://github.com/user-attachments/assets/02e5ecb7-703d-49a5-bde8-5445a62d51ec" />



[WB-25559]: https://wandb.atlassian.net/browse/WB-25559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ