### PR TITLE
chore(artifacts): Add tag to indicate reference artifacts cannot be downloaded

### DIFF
--- a/weave-js/src/components/Panel2/PanelDir/Component.tsx
+++ b/weave-js/src/components/Panel2/PanelDir/Component.tsx
@@ -16,6 +16,8 @@ import React, {useState} from 'react';
 import {Icon, Pagination, Table} from 'semantic-ui-react';
 
 import * as LLReact from '../../../react';
+import {Tag} from '../../Tag';
+import {Tooltip} from '../../Tooltip';
 import * as Panel2 from '../panel';
 import {Panel2Loader} from '../PanelComp';
 import {inputType} from './common';
@@ -193,14 +195,27 @@ const SubfileRow: React.FC<SubfileRowProps> = props => {
         {numeral(file.size).format('0.0b')}
       </Table.Cell>
       <Table.Cell className="file-download-cell">
-        {isDownloadable && (
-          <a
-            href={file.url}
-            download={fileName}
-            onClick={e => e.stopPropagation()}>
-            <LegacyWBIcon name="download" />
-          </a>
-        )}
+        {isDownloadable &&
+          (file.ref ? (
+            <Tooltip
+              content={
+                <>
+                  This artifact exists externally and is <br />
+                  only referenced in the code. It cannot
+                  <br />
+                  be downloaded via the UI.
+                </>
+              }
+              trigger={<Tag label="Referenced" color={'moon'} />}
+            />
+          ) : (
+            <a
+              href={file.url}
+              download={fileName}
+              onClick={e => e.stopPropagation()}>
+              <LegacyWBIcon name="download" />
+            </a>
+          ))}
       </Table.Cell>
     </Table.Row>
   );


### PR DESCRIPTION
## Description

- Fixes WB-25478

What does the PR do? Include a concise description of the PR contents.

Reference artifacts cannot be downloaded via the UI. This PR replaces the download icon with a tag and popup that indicates to the user that this is a reference artifact and cannot be downloaded.

<img width="273" alt="Screenshot 2025-06-17 at 11 50 11 AM" src="https://github.com/user-attachments/assets/d78fb9b8-5f3a-4f1d-934f-153eb902b0a4" />


## Testing

Testing locally on SaaS.
