### PR TITLE
chore(weave): Add error toast for Playground stream errors

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/useChatCompletionFunctions.tsx
@@ -495,6 +495,11 @@ export const useChatCompletionFunctions = (
     updateCallback: () => void,
     throttleTimeout: number
   ) => {
+    // Handle error chunk
+    if ((chunk as any).error) {
+      toast((chunk as any).error, {type: 'error'});
+    }
+
     // Create a throttled version of the update callback to prevent React render queue saturation.
     // Frequent per-token setState calls from multiple parallel streams can saturate React's
     // render queue, making later streams appear to start only after earlier ones finish.


### PR DESCRIPTION
## Description

- Adds error handling to chat completion functions by displaying error messages as toasts
- Ensures users are notified when chat completion encounters an error

[Screen Recording 2025-06-17 at 12.17.55 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/EP6WIPJt2CEmlVsvzEO5/2fbaec67-d008-423b-9756-9c443965970d.mov" />](https://app.graphite.dev/media/video/EP6WIPJt2CEmlVsvzEO5/2fbaec67-d008-423b-9756-9c443965970d.mov)

## Testing

Tested by triggering error conditions in chat completion and verifying that error messages are properly displayed as toast notifications.