### PR TITLE
fix(weave): create project if not existent on weave init

### DIFF
--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -411,6 +411,11 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
 
     # Remaining Un-cacheable Methods:
 
+    def ensure_project_exists(
+        self, entity: str, project: str
+    ) -> tsi.EnsureProjectExistsRes:
+        return self._next_trace_server.ensure_project_exists(entity, project)
+
     # Call API
     def call_start(self, req: tsi.CallStartReq) -> tsi.CallStartRes:
         return self._next_trace_server.call_start(req)


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-25589

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fix per @jamie-rasmussen's recommendation. Properly pass through the `ensure_project_exists` endpoint so all projects that do not exist on weave init are upserted. 

## Testing

manual
