### PR TITLE
chore(ui): Playground: Only trigger scrollIntoView on new messages (not while streaming)

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatView.tsx
@@ -57,7 +57,7 @@ export const ChatView = ({chat}: ChatViewProps) => {
     ) {
       outputRef.current.scrollIntoView();
     }
-  }, [chatResult]);
+  }, [chat.request?.messages?.length]);
 
   return (
     <div className="flex flex-col pb-32">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatView.tsx
@@ -15,6 +15,7 @@ type ChatViewProps = {
 
 export const ChatView = ({chat}: ChatViewProps) => {
   const outputRef = useRef<HTMLDivElement>(null);
+  const prevMessageCountRef = useRef(0);
   const playgroundContext = usePlaygroundContext();
 
   const chatResult = useDeepMemo(chat.result);
@@ -49,7 +50,11 @@ export const ChatView = ({chat}: ChatViewProps) => {
   );
 
   useEffect(() => {
+    const currentMessageCount = chat.request?.messages?.length || 0;
+    const hasNewMessage = currentMessageCount > prevMessageCountRef.current;
+    
     if (
+      hasNewMessage &&
       outputRef.current &&
       chatResult &&
       'choices' in chatResult &&
@@ -57,7 +62,9 @@ export const ChatView = ({chat}: ChatViewProps) => {
     ) {
       outputRef.current.scrollIntoView();
     }
-  }, [chat.request?.messages?.length]);
+    
+    prevMessageCountRef.current = currentMessageCount;
+  }, [chatResult, chat.request?.messages]);
 
   return (
     <div className="flex flex-col pb-32">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatView.tsx
@@ -48,12 +48,16 @@ export const ChatView = ({chat}: ChatViewProps) => {
     [chatResult]
   );
 
-  // Only scroll when a new message is sent (messages array changes), not during streaming
   useEffect(() => {
-    if (outputRef.current) {
+    if (
+      outputRef.current &&
+      chatResult &&
+      'choices' in chatResult &&
+      chatResult.choices
+    ) {
       outputRef.current.scrollIntoView();
     }
-  }, [chat.request?.messages?.length]);
+  }, [chatResult]);
 
   return (
     <div className="flex flex-col pb-32">

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatView.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatView.tsx
@@ -48,16 +48,12 @@ export const ChatView = ({chat}: ChatViewProps) => {
     [chatResult]
   );
 
+  // Only scroll when a new message is sent (messages array changes), not during streaming
   useEffect(() => {
-    if (
-      outputRef.current &&
-      chatResult &&
-      'choices' in chatResult &&
-      chatResult.choices
-    ) {
+    if (outputRef.current) {
       outputRef.current.scrollIntoView();
     }
-  }, [chatResult]);
+  }, [chat.request?.messages?.length]);
 
   return (
     <div className="flex flex-col pb-32">


### PR DESCRIPTION
## Description

Problem:
- `scrollIntoView` currently triggers during streaming, causing a jerky behavior which makes it hard to read as the generation is occurring.

Solution:
- Only trigger when new messages are added.
- Added a counter so that we won't trigger when messages are deleted.