### PR TITLE
feat(weave): SDK support for using threads

### DIFF
--- a/tests/trace/test_call_object.py
+++ b/tests/trace/test_call_object.py
@@ -21,5 +21,7 @@ def test_call_to_dict(client):
         "id": call.id,
         "parent_id": call.parent_id,
         "trace_id": call.trace_id,
+        "thread_id": call.thread_id,
+        "turn_id": call.turn_id,
         "project_id": call.project_id,
     }

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -4580,3 +4580,556 @@ def test_calls_query_with_descendant_error(client):
         )
 
         assert len(calls) == count
+
+
+def test_thread_context_with_weave_api(client):
+    """Test thread context using the weave.thread() API with ThreadContext."""
+    import weave
+    from weave.trace.context import call_context
+
+    # Test default thread_id is None (using internal context for verification)
+    assert call_context.get_thread_id() is None
+
+    # Test using weave.thread context manager with ThreadContext
+    with weave.thread("api_thread_1") as t:
+        # Use ThreadContext object to access thread_id
+        assert t.thread_id == "api_thread_1"
+        assert (
+            call_context.get_thread_id() == "api_thread_1"
+        )  # Verify internal consistency
+
+        # Test nested context with ThreadContext
+        with weave.thread("api_thread_2") as inner_t:
+            assert inner_t.thread_id == "api_thread_2"
+            assert t.thread_id == "api_thread_1"  # Outer context unchanged
+            assert call_context.get_thread_id() == "api_thread_2"
+
+        # Should revert to parent context
+        assert t.thread_id == "api_thread_1"
+        assert call_context.get_thread_id() == "api_thread_1"
+
+    # Should revert to None
+    assert call_context.get_thread_id() is None
+
+
+def test_thread_id_in_calls(client):
+    """Test that thread_id is properly captured in call records, including auto-generation."""
+    import weave
+
+    @weave.op
+    def test_op_with_thread(x: int) -> int:
+        return x * 2
+
+    @weave.op
+    def test_op_without_thread(x: int) -> int:
+        return x * 3
+
+    @weave.op
+    def test_op_auto_thread(x: int) -> int:
+        return x * 4
+
+    # Call without thread context
+    result1 = test_op_without_thread(5)
+    assert result1 == 15
+
+    # Call with explicit thread context
+    with weave.thread("test_thread_id") as t:
+        assert t.thread_id == "test_thread_id"
+        result2 = test_op_with_thread(5)
+        assert result2 == 10
+
+    # Call with auto-generated thread_id
+    auto_thread_id = None
+    with weave.thread() as t:
+        auto_thread_id = t.thread_id
+        assert auto_thread_id is not None
+        assert isinstance(auto_thread_id, str)
+        assert len(auto_thread_id) > 20  # Should be UUID v7
+        result3 = test_op_auto_thread(5)
+        assert result3 == 20
+
+    # Get the calls to verify thread_id
+    calls = client.get_calls()
+
+    # Find our calls (most recent first)
+    auto_call = None
+    thread_call = None
+    no_thread_call = None
+
+    for call in calls:
+        if "test_op_auto_thread" in call.op_name:
+            auto_call = call
+        elif "test_op_with_thread" in call.op_name:
+            thread_call = call
+        elif "test_op_without_thread" in call.op_name:
+            no_thread_call = call
+
+    assert auto_call is not None
+    assert thread_call is not None
+    assert no_thread_call is not None
+
+    # Verify thread_id values
+    assert auto_call.thread_id == auto_thread_id  # Should match auto-generated ID
+    assert thread_call.thread_id == "test_thread_id"
+    assert no_thread_call.thread_id is None
+
+
+def test_thread_id_inheritance(client):
+    """Test that thread_id is inherited by child calls, demonstrated via ThreadContext."""
+    import weave
+
+    @weave.op
+    def child_op(x: int) -> int:
+        return x + 1
+
+    @weave.op
+    def parent_op(x: int) -> int:
+        return child_op(x) * 2
+
+    # Call with thread context, using ThreadContext to demonstrate inheritance
+    inherited_thread_id = None
+    with weave.thread("inherited_thread") as t:
+        inherited_thread_id = t.thread_id
+        assert inherited_thread_id == "inherited_thread"
+
+        # Both parent and child calls should inherit this thread_id
+        result = parent_op(10)
+        assert result == 22  # (10 + 1) * 2
+
+        # ThreadContext shows the current thread_id throughout execution
+        assert t.thread_id == "inherited_thread"
+
+    # Get the calls to verify thread_id inheritance
+    calls = client.get_calls()
+
+    # Find our calls
+    parent_call = None
+    child_call = None
+
+    for call in calls:
+        if "parent_op" in call.op_name:
+            parent_call = call
+        elif "child_op" in call.op_name:
+            child_call = call
+
+    assert parent_call is not None
+    assert child_call is not None
+
+    # Both should have the same thread_id that was shown in ThreadContext
+    assert parent_call.thread_id == inherited_thread_id
+    assert child_call.thread_id == inherited_thread_id
+    assert parent_call.thread_id == "inherited_thread"
+    assert child_call.thread_id == "inherited_thread"
+
+
+def test_thread_context_error_handling(client):
+    """Test that ThreadContext is properly managed even when exceptions occur."""
+    import weave
+    from weave.trace.context import call_context
+
+    @weave.op
+    def failing_op(should_fail: bool) -> str:
+        if should_fail:
+            raise ValueError("Test exception")
+        return "success"
+
+    # Test that thread context is properly restored after exception
+    assert call_context.get_thread_id() is None
+
+    # Test ThreadContext behavior during exception
+    exception_thread_context = None
+    try:
+        with weave.thread("exception_thread") as t:
+            exception_thread_context = t
+            assert t.thread_id == "exception_thread"
+            assert call_context.get_thread_id() == "exception_thread"
+            failing_op(True)  # This will raise an exception
+    except ValueError:
+        pass  # Expected
+
+    # Verify ThreadContext maintained its state even after exception
+    assert exception_thread_context.thread_id == "exception_thread"
+
+    # Thread context should be restored to None after exiting context
+    assert call_context.get_thread_id() is None
+
+    # Test successful call after exception with auto-generated thread
+    recovery_thread_id = None
+    with weave.thread() as t:  # Use auto-generation
+        recovery_thread_id = t.thread_id
+        assert recovery_thread_id is not None
+        assert len(recovery_thread_id) > 20  # Should be auto-generated UUID v7
+
+        result = failing_op(False)
+        assert result == "success"
+        assert t.thread_id == recovery_thread_id  # ThreadContext consistent
+
+    assert call_context.get_thread_id() is None
+
+
+def test_turn_id_functionality(client):
+    """Test that turn_id is properly assigned for turn calls and descendants."""
+    import weave
+
+    @weave.op
+    def child_op(x: int) -> int:
+        return x + 1
+
+    @weave.op
+    def turn_op_A(x: int) -> int:
+        return child_op(x) * 2
+
+    @weave.op
+    def turn_op_B(x: int) -> int:
+        return x * 3
+
+    @weave.op
+    def turn_op_C(x: int) -> int:
+        return child_op(x) * 4
+
+    # Test with thread context - sibling turns
+    with weave.thread("test_turns"):
+        result_a = turn_op_A(10)  # Should be a turn
+        result_b = turn_op_B(5)  # Should be a turn
+        result_c = turn_op_C(3)  # Should be a turn
+
+    assert result_a == 22  # (10 + 1) * 2
+    assert result_b == 15  # 5 * 3
+    assert result_c == 16  # (3 + 1) * 4
+
+    # Get calls and verify turn_id assignments
+    calls = client.get_calls()
+
+    turn_a_call = None
+    turn_b_call = None
+    turn_c_call = None
+    child_calls = []
+
+    for call in calls:
+        if "turn_op_A" in call.op_name:
+            turn_a_call = call
+        elif "turn_op_B" in call.op_name:
+            turn_b_call = call
+        elif "turn_op_C" in call.op_name:
+            turn_c_call = call
+        elif "child_op" in call.op_name:
+            child_calls.append(call)
+
+    # Verify turn calls have their own ID as turn_id
+    assert turn_a_call.turn_id == turn_a_call.id
+    assert turn_b_call.turn_id == turn_b_call.id
+    assert turn_c_call.turn_id == turn_c_call.id
+
+    # Verify all have the same thread_id
+    assert turn_a_call.thread_id == "test_turns"
+    assert turn_b_call.thread_id == "test_turns"
+    assert turn_c_call.thread_id == "test_turns"
+
+    # Verify child calls inherit turn_id from their parents
+    for child_call in child_calls:
+        assert child_call.thread_id == "test_turns"
+        # Child should inherit turn_id from its parent turn
+        parent_turn_id = None
+        for call in calls:
+            if call.id == child_call.parent_id:
+                parent_turn_id = call.turn_id
+                break
+        assert child_call.turn_id == parent_turn_id
+
+
+def test_nested_thread_contexts_turn_lineage(client):
+    """Test that nested thread contexts properly cut off turn lineage."""
+    import weave
+
+    @weave.op
+    def child_op(x: int) -> int:
+        return x + 1
+
+    @weave.op
+    def outer_turn_A(x: int) -> int:
+        return child_op(x) * 2
+
+    @weave.op
+    def inner_turn_B(x: int) -> int:
+        return x * 3
+
+    @weave.op
+    def inner_turn_C(x: int) -> int:
+        return child_op(x) * 4
+
+    @weave.op
+    def outer_turn_D(x: int) -> int:
+        return x * 5
+
+    # Test nested thread contexts
+    with weave.thread("outer_thread"):
+        result_a = outer_turn_A(10)  # Should be turn in outer_thread
+
+        with weave.thread("inner_thread"):
+            result_b = inner_turn_B(5)  # Should be turn in inner_thread
+            result_c = inner_turn_C(3)  # Should be turn in inner_thread
+
+        result_d = outer_turn_D(2)  # Should be turn in outer_thread again
+
+    assert result_a == 22  # (10 + 1) * 2
+    assert result_b == 15  # 5 * 3
+    assert result_c == 16  # (3 + 1) * 4
+    assert result_d == 10  # 2 * 5
+
+    # Get calls and verify turn_id assignments
+    calls = client.get_calls()
+
+    outer_a_call = None
+    inner_b_call = None
+    inner_c_call = None
+    outer_d_call = None
+    child_calls = []
+
+    for call in calls:
+        if "outer_turn_A" in call.op_name:
+            outer_a_call = call
+        elif "inner_turn_B" in call.op_name:
+            inner_b_call = call
+        elif "inner_turn_C" in call.op_name:
+            inner_c_call = call
+        elif "outer_turn_D" in call.op_name:
+            outer_d_call = call
+        elif "child_op" in call.op_name:
+            child_calls.append(call)
+
+    # Verify all turn calls have their own ID as turn_id
+    assert outer_a_call.turn_id == outer_a_call.id
+    assert inner_b_call.turn_id == inner_b_call.id
+    assert inner_c_call.turn_id == inner_c_call.id
+    assert outer_d_call.turn_id == outer_d_call.id
+
+    # Verify thread_id assignments
+    assert outer_a_call.thread_id == "outer_thread"
+    assert inner_b_call.thread_id == "inner_thread"
+    assert inner_c_call.thread_id == "inner_thread"
+    assert outer_d_call.thread_id == "outer_thread"
+
+    # Verify turn lineage is properly cut off - each thread creates new turns
+    # outer_turn_A and outer_turn_D should have different turn_ids
+    assert outer_a_call.turn_id != outer_d_call.turn_id
+    # inner_turn_B and inner_turn_C should have different turn_ids
+    assert inner_b_call.turn_id != inner_c_call.turn_id
+
+    # Verify child calls inherit turn_id from their parent turns
+    for child_call in child_calls:
+        parent_turn_id = None
+        for call in calls:
+            if call.id == child_call.parent_id:
+                parent_turn_id = call.turn_id
+                break
+        assert child_call.turn_id == parent_turn_id
+
+
+def test_thread_id_none_turn_id_none(client):
+    """Test that when thread_id is None, turn_id is also None."""
+    import weave
+    from weave.trace.context import call_context
+
+    @weave.op
+    def child_op(x: int) -> int:
+        return x + 1
+
+    @weave.op
+    def turn_op_A(x: int) -> int:
+        return child_op(x) * 2
+
+    @weave.op
+    def op_outside_thread(x: int) -> int:
+        return x * 3
+
+    # First, create a call within a thread context to set up turn context
+    with weave.thread("test_thread"):
+        result_a = turn_op_A(10)  # Should be a turn with turn_id
+
+    # After exiting thread context, both thread_id and turn_id should be None
+    assert call_context.get_thread_id() is None
+    assert call_context.get_turn_id() is None
+
+    # Now make a call outside any thread context
+    # This should have thread_id = None and turn_id = None
+    result_outside = op_outside_thread(5)
+
+    assert result_a == 22  # (10 + 1) * 2
+    assert result_outside == 15  # 5 * 3
+
+    # Get calls and verify turn_id/thread_id assignments
+    calls = client.get_calls()
+
+    turn_a_call = None
+    outside_call = None
+    child_call = None
+
+    for call in calls:
+        if "turn_op_A" in call.op_name:
+            turn_a_call = call
+        elif "op_outside_thread" in call.op_name:
+            outside_call = call
+        elif "child_op" in call.op_name:
+            child_call = call
+
+    # Verify the turn call has proper thread_id and turn_id
+    assert turn_a_call.thread_id == "test_thread"
+    assert turn_a_call.turn_id == turn_a_call.id
+
+    # Verify the child call inherits from its parent turn
+    assert child_call.thread_id == "test_thread"
+    assert child_call.turn_id == turn_a_call.turn_id
+
+    # Verify the call outside thread context has both None
+    assert outside_call.thread_id is None
+    assert outside_call.turn_id is None
+
+
+def test_nested_thread_disable_with_none(client):
+    """Test that ThreadContext properly shows thread_id=None when threading is disabled."""
+    import weave
+    from weave.trace.context import call_context
+
+    @weave.op
+    def turn_A(x: int) -> int:
+        return x * 2
+
+    @weave.op
+    def op_disabled_threading(x: int) -> int:
+        return x * 3
+
+    @weave.op
+    def turn_C(x: int) -> int:
+        return x * 4
+
+    # Test the realistic edge case: nested thread with thread_id=None
+    main_thread_context = None
+    disabled_thread_context = None
+
+    with weave.thread("main_thread") as t:
+        main_thread_context = t
+        assert t.thread_id == "main_thread"
+        result_a = turn_A(10)  # Should be a turn with turn_id
+
+        # Verify we're in thread context (turn_id is reset after call finishes)
+        assert call_context.get_thread_id() == "main_thread"
+
+        with weave.thread(None) as disabled_t:  # Explicitly disable thread tracking
+            disabled_thread_context = disabled_t
+            # ThreadContext shows None for disabled threading
+            assert disabled_t.thread_id is None
+            assert disabled_t.turn_id is None
+
+            # Verify thread context is disabled
+            assert call_context.get_thread_id() is None
+            assert call_context.get_turn_id() is None
+
+            result_b = op_disabled_threading(5)  # Should have no thread_id or turn_id
+
+        # Back in main thread - should create a new turn
+        # ThreadContext shows we're back in main thread
+        assert t.thread_id == "main_thread"
+        result_c = turn_C(3)  # Should be a new turn
+
+    # Verify ThreadContext objects maintained correct state throughout
+    assert main_thread_context.thread_id == "main_thread"
+    assert disabled_thread_context.thread_id is None
+
+    assert result_a == 20  # 10 * 2
+    assert result_b == 15  # 5 * 3
+    assert result_c == 12  # 3 * 4
+
+    # Get calls and verify assignments
+    calls = client.get_calls()
+
+    turn_a_call = None
+    disabled_call = None
+    turn_c_call = None
+
+    for call in calls:
+        if "turn_A" in call.op_name:
+            turn_a_call = call
+        elif "op_disabled_threading" in call.op_name:
+            disabled_call = call
+        elif "turn_C" in call.op_name:
+            turn_c_call = call
+
+    # Verify first turn has proper thread_id and turn_id
+    assert turn_a_call.thread_id == "main_thread"
+    assert turn_a_call.turn_id == turn_a_call.id
+
+    # Verify disabled call has both None (the edge case shown via ThreadContext)
+    assert disabled_call.thread_id is None
+    assert disabled_call.turn_id is None
+
+    # Verify third turn is a new turn in the main thread
+    assert turn_c_call.thread_id == "main_thread"
+    assert turn_c_call.turn_id == turn_c_call.id
+
+    # Verify the two turns in main_thread have different turn_ids
+    assert turn_a_call.turn_id != turn_c_call.turn_id
+
+
+def test_thread_api_with_auto_generation(client):
+    """Test the thread API with ThreadContext and auto-generation."""
+    import weave
+
+    @weave.op
+    def test_op(x: int) -> int:
+        return x * 2
+
+    # Test 1: Auto-generated thread_id
+    with weave.thread() as t:
+        assert t.thread_id is not None
+        assert isinstance(t.thread_id, str)
+        # Should be a valid UUID v7 format (starts with time-based prefix)
+        assert len(t.thread_id) > 20  # UUID v7 should be longer than 20 chars
+
+        result1 = test_op(10)
+        # turn_id is reset after turn call finishes, so it will be None here
+        # We'll verify turn assignment by checking the call data later
+
+    # Test 2: Explicit thread_id
+    with weave.thread("custom_thread_123") as t:
+        assert t.thread_id == "custom_thread_123"
+        result2 = test_op(20)
+        # turn_id is reset after turn call finishes
+
+    # Test 3: Disabled threading (explicit None)
+    with weave.thread(None) as t:
+        assert t.thread_id is None
+        result3 = test_op(30)
+        assert t.turn_id is None  # Should always be None when threading disabled
+
+    # Verify results
+    assert result1 == 20
+    assert result2 == 40
+    assert result3 == 60
+
+    # Get calls and verify thread assignments
+    calls = client.get_calls()
+
+    auto_call = None
+    custom_call = None
+    disabled_call = None
+
+    for call in calls:
+        if call.inputs.get("x") == 10:
+            auto_call = call
+        elif call.inputs.get("x") == 20:
+            custom_call = call
+        elif call.inputs.get("x") == 30:
+            disabled_call = call
+
+    # Verify auto-generated thread call
+    assert auto_call.thread_id is not None
+    assert len(auto_call.thread_id) > 20  # Should be UUID v7
+    assert auto_call.turn_id == auto_call.id  # Should be a turn
+
+    # Verify custom thread call
+    assert custom_call.thread_id == "custom_thread_123"
+    assert custom_call.turn_id == custom_call.id  # Should be a turn
+
+    # Verify disabled thread call
+    assert disabled_call.thread_id is None
+    assert disabled_call.turn_id is None

--- a/tests/trace_server/test_threads_query_builder.py
+++ b/tests/trace_server/test_threads_query_builder.py
@@ -1,0 +1,789 @@
+import datetime
+
+import pytest
+import sqlparse
+
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.threads_query_builder import (
+    _validate_and_map_sort_field,
+    make_threads_query,
+    make_threads_query_sqlite,
+)
+
+
+def assert_clickhouse_sql(expected_query: str, expected_params: dict, **kwargs):
+    """Helper to test ClickHouse query generation."""
+    pb = ParamBuilder("pb")
+    query = make_threads_query(pb=pb, **kwargs)
+    params = pb.get_params()
+
+    expected_formatted = sqlparse.format(expected_query, reindent=True)
+    found_formatted = sqlparse.format(query, reindent=True)
+
+    assert (
+        expected_formatted == found_formatted
+    ), f"Query mismatch:\nExpected:\n{expected_formatted}\n\nFound:\n{found_formatted}"
+    assert (
+        expected_params == params
+    ), f"Params mismatch:\nExpected: {expected_params}\nFound: {params}"
+
+
+def assert_sqlite_sql(expected_query: str, expected_params: list, **kwargs):
+    """Helper to test SQLite query generation."""
+    query, params = make_threads_query_sqlite(**kwargs)
+
+    expected_formatted = sqlparse.format(expected_query, reindent=True)
+    found_formatted = sqlparse.format(query, reindent=True)
+
+    assert (
+        expected_formatted == found_formatted
+    ), f"Query mismatch:\nExpected:\n{expected_formatted}\n\nFound:\n{found_formatted}"
+    assert (
+        expected_params == params
+    ), f"Params mismatch:\nExpected: {expected_params}\nFound: {params}"
+
+
+# Basic Functionality Tests
+
+
+def test_clickhouse_basic_query():
+    """Test basic ClickHouse query with turn-only filtering."""
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        {"pb_0": "test_project"},
+        project_id="test_project",
+    )
+
+
+def test_sqlite_basic_query():
+    """Test basic SQLite query with turn-only filtering."""
+    assert_sqlite_sql(
+        """
+            SELECT
+                thread_id,
+                COUNT(*) as turn_count,
+                MIN(started_at) as start_time,
+                MAX(ended_at) as last_updated,
+                -- Get turn ID with earliest start time for this thread
+                (SELECT id FROM calls c2
+                 WHERE c2.thread_id = c1.thread_id
+                 AND c2.project_id = c1.project_id
+                 AND c2.id = c2.turn_id
+                 ORDER BY c2.started_at ASC
+                 LIMIT 1) as first_turn_id,
+                -- Get turn ID with latest end time for this thread
+                (SELECT id FROM calls c2
+                 WHERE c2.thread_id = c1.thread_id
+                 AND c2.project_id = c1.project_id
+                 AND c2.id = c2.turn_id
+                 ORDER BY c2.ended_at DESC
+                 LIMIT 1) as last_turn_id,
+                -- P50 calculation placeholder - might be implemented properly later
+                -1 as p50_turn_duration_ms,
+                -- P99 calculation placeholder - might be implemented properly later
+                -1 as p99_turn_duration_ms
+            FROM calls c1
+            WHERE project_id = ?
+                AND thread_id IS NOT NULL
+                AND thread_id != ''
+                AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+
+            GROUP BY thread_id
+            ORDER BY last_updated DESC
+            """,
+        ["test_project"],
+        project_id="test_project",
+    )
+
+
+# Sorting Tests
+
+
+def test_clickhouse_custom_sorting():
+    """Test ClickHouse query with custom sorting."""
+    sort_by = [
+        tsi.SortBy(field="turn_count", direction="asc"),
+        tsi.SortBy(field="start_time", direction="desc"),
+    ]
+
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY turn_count ASC, start_time DESC
+        """,
+        {"pb_0": "test_project"},
+        project_id="test_project",
+        sort_by=sort_by,
+    )
+
+
+def test_sqlite_custom_sorting():
+    """Test SQLite query with custom sorting."""
+    sort_by = [
+        tsi.SortBy(field="thread_id", direction="asc"),
+        tsi.SortBy(field="turn_count", direction="desc"),
+    ]
+
+    assert_sqlite_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            MIN(started_at) as start_time,
+            MAX(ended_at) as last_updated,
+            -- Get turn ID with earliest start time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.started_at ASC
+             LIMIT 1) as first_turn_id,
+            -- Get turn ID with latest end time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.ended_at DESC
+             LIMIT 1) as last_turn_id,
+            -- P50 calculation placeholder - might be implemented properly later
+            -1 as p50_turn_duration_ms,
+            -- P99 calculation placeholder - might be implemented properly later
+            -1 as p99_turn_duration_ms
+        FROM calls c1
+        WHERE project_id = ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
+            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+
+        GROUP BY thread_id
+        ORDER BY thread_id ASC, turn_count DESC
+        """,
+        ["test_project"],
+        project_id="test_project",
+        sort_by=sort_by,
+    )
+
+
+# Pagination Tests
+
+
+def test_clickhouse_with_limit():
+    """Test ClickHouse query with limit."""
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        LIMIT {pb_1: Int64}
+        """,
+        {"pb_0": "test_project", "pb_1": 50},
+        project_id="test_project",
+        limit=50,
+    )
+
+
+def test_clickhouse_with_limit_and_offset():
+    """Test ClickHouse query with limit and offset."""
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        LIMIT {pb_1: Int64}
+        OFFSET {pb_2: Int64}
+        """,
+        {"pb_0": "test_project", "pb_1": 25, "pb_2": 100},
+        project_id="test_project",
+        limit=25,
+        offset=100,
+    )
+
+
+def test_sqlite_with_limit_and_offset():
+    """Test SQLite query with limit and offset."""
+    assert_sqlite_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            MIN(started_at) as start_time,
+            MAX(ended_at) as last_updated,
+            -- Get turn ID with earliest start time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.started_at ASC
+             LIMIT 1) as first_turn_id,
+            -- Get turn ID with latest end time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.ended_at DESC
+             LIMIT 1) as last_turn_id,
+            -- P50 calculation placeholder - might be implemented properly later
+            -1 as p50_turn_duration_ms,
+            -- P99 calculation placeholder - might be implemented properly later
+            -1 as p99_turn_duration_ms
+        FROM calls c1
+        WHERE project_id = ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
+            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        LIMIT ?
+        OFFSET ?
+        """,
+        ["test_project", 10, 20],
+        project_id="test_project",
+        limit=10,
+        offset=20,
+    )
+
+
+# Date Filtering Tests
+
+
+def test_clickhouse_with_date_filters():
+    """Test ClickHouse query with sortable_datetime filters."""
+    after_date = datetime.datetime(2024, 1, 1, 12, 0, 0)
+    before_date = datetime.datetime(2024, 12, 31, 23, 59, 59)
+
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+                AND sortable_datetime > {pb_1: String} AND sortable_datetime < {pb_2: String}
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        {
+            "pb_0": "test_project",
+            "pb_1": "2024-01-01 12:00:00.000000",
+            "pb_2": "2024-12-31 23:59:59.000000",
+        },
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+        sortable_datetime_before=before_date,
+    )
+
+
+def test_sqlite_with_date_filters():
+    """Test SQLite query with started_at filters."""
+    after_date = datetime.datetime(2024, 6, 15, 10, 30, 0)
+    before_date = datetime.datetime(2024, 6, 15, 18, 0, 0)
+
+    assert_sqlite_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            MIN(started_at) as start_time,
+            MAX(ended_at) as last_updated,
+            -- Get turn ID with earliest start time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.started_at ASC
+             LIMIT 1) as first_turn_id,
+            -- Get turn ID with latest end time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.ended_at DESC
+             LIMIT 1) as last_turn_id,
+            -- P50 calculation placeholder - might be implemented properly later
+            -1 as p50_turn_duration_ms,
+            -- P99 calculation placeholder - might be implemented properly later
+            -1 as p99_turn_duration_ms
+        FROM calls c1
+        WHERE project_id = ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
+            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+            AND started_at > ? AND started_at < ?
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        ["test_project", "2024-06-15T10:30:00", "2024-06-15T18:00:00"],
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+        sortable_datetime_before=before_date,
+    )
+
+
+# Complex Scenarios
+
+
+def test_clickhouse_full_featured_query():
+    """Test ClickHouse query with all features: custom sorting, pagination, and date filtering."""
+    after_date = datetime.datetime(2024, 1, 1)
+    before_date = datetime.datetime(2024, 12, 31)
+    sort_by = [tsi.SortBy(field="turn_count", direction="desc")]
+
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+                AND sortable_datetime > {pb_1: String} AND sortable_datetime < {pb_2: String}
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY turn_count DESC
+        LIMIT {pb_3: Int64}
+        OFFSET {pb_4: Int64}
+        """,
+        {
+            "pb_0": "test_project",
+            "pb_1": "2024-01-01 00:00:00.000000",
+            "pb_2": "2024-12-31 00:00:00.000000",
+            "pb_3": 15,
+            "pb_4": 30,
+        },
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+        sortable_datetime_before=before_date,
+        sort_by=sort_by,
+        limit=15,
+        offset=30,
+    )
+
+
+def test_sqlite_full_featured_query():
+    """Test SQLite query with all features: custom sorting, pagination, and date filtering."""
+    after_date = datetime.datetime(2024, 3, 15)
+    sort_by = [
+        tsi.SortBy(field="last_updated", direction="asc"),
+        tsi.SortBy(field="thread_id", direction="desc"),
+    ]
+
+    assert_sqlite_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            MIN(started_at) as start_time,
+            MAX(ended_at) as last_updated,
+            -- Get turn ID with earliest start time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.started_at ASC
+             LIMIT 1) as first_turn_id,
+            -- Get turn ID with latest end time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.ended_at DESC
+             LIMIT 1) as last_turn_id,
+            -- P50 calculation placeholder - might be implemented properly later
+            -1 as p50_turn_duration_ms,
+            -- P99 calculation placeholder - might be implemented properly later
+            -1 as p99_turn_duration_ms
+        FROM calls c1
+        WHERE project_id = ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
+            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+            AND started_at > ?
+        GROUP BY thread_id
+        ORDER BY last_updated ASC, thread_id DESC
+        LIMIT ?
+        """,
+        ["test_project", "2024-03-15T00:00:00", 5],
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+        sort_by=sort_by,
+        limit=5,
+    )
+
+
+# Edge Cases
+
+
+def test_clickhouse_only_after_date():
+    """Test ClickHouse query with only after date filter."""
+    after_date = datetime.datetime(2024, 1, 1, 0, 0, 0)
+
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+                AND sortable_datetime > {pb_1: String}
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        {"pb_0": "test_project", "pb_1": "2024-01-01 00:00:00.000000"},
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+    )
+
+
+def test_sqlite_only_before_date():
+    """Test SQLite query with only before date filter."""
+    before_date = datetime.datetime(2024, 12, 31, 23, 59, 59)
+
+    assert_sqlite_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            MIN(started_at) as start_time,
+            MAX(ended_at) as last_updated,
+            -- Get turn ID with earliest start time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.started_at ASC
+             LIMIT 1) as first_turn_id,
+            -- Get turn ID with latest end time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.ended_at DESC
+             LIMIT 1) as last_turn_id,
+            -- P50 calculation placeholder - might be implemented properly later
+            -1 as p50_turn_duration_ms,
+            -- P99 calculation placeholder - might be implemented properly later
+            -1 as p99_turn_duration_ms
+        FROM calls c1
+        WHERE project_id = ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
+            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+            AND started_at < ?
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        ["test_project", "2024-12-31T23:59:59"],
+        project_id="test_project",
+        sortable_datetime_before=before_date,
+    )
+
+
+# Validation Tests
+
+
+def test_validate_and_map_sort_field():
+    """Test the sort field validation function."""
+    # Test valid fields
+    assert _validate_and_map_sort_field("thread_id") == "thread_id"
+    assert _validate_and_map_sort_field("turn_count") == "turn_count"
+    assert _validate_and_map_sort_field("start_time") == "start_time"
+    assert _validate_and_map_sort_field("last_updated") == "last_updated"
+    assert (
+        _validate_and_map_sort_field("p50_turn_duration_ms") == "p50_turn_duration_ms"
+    )
+    assert (
+        _validate_and_map_sort_field("p99_turn_duration_ms") == "p99_turn_duration_ms"
+    )
+
+    # Test invalid fields - call IDs should not be sortable since they're just identifiers
+    with pytest.raises(ValueError) as exc_info:
+        _validate_and_map_sort_field("first_turn_id")
+    assert "Unsupported sort field: first_turn_id" in str(exc_info.value)
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_and_map_sort_field("last_turn_id")
+    assert "Unsupported sort field: last_turn_id" in str(exc_info.value)
+
+    with pytest.raises(ValueError) as exc_info:
+        _validate_and_map_sort_field("invalid_field")
+    assert "Unsupported sort field: invalid_field" in str(exc_info.value)
+    assert (
+        "Supported fields: ['thread_id', 'turn_count', 'start_time', 'last_updated', 'p50_turn_duration_ms', 'p99_turn_duration_ms']"
+        in str(exc_info.value)
+    )
+
+
+def test_sort_field_validation_in_query():
+    """Test that invalid sort fields raise errors in query generation."""
+    with pytest.raises(ValueError):
+        invalid_sort = [tsi.SortBy(field="nonexistent_field", direction="asc")]
+        make_threads_query_sqlite(project_id="test_project", sort_by=invalid_sort)
+
+
+# Turn-ID Filtering Behavior Tests
+
+
+def test_turn_filtering_explanation():
+    """
+    Test that demonstrates the key behavior: only turn calls are included.
+
+    This test is more about documenting the expected behavior than testing
+    implementation details. It shows that the filtering `id = turn_id` ensures
+    only turn calls are included in thread statistics, not their descendants.
+    """
+    # The key filtering conditions in both implementations:
+    # ClickHouse: "id = any(turn_id)" in HAVING clause
+    # SQLite: "id = turn_id" in WHERE clause
+
+    # This means:
+    # ✅ Turn calls (where call.id == call.turn_id) are included
+    # ❌ Descendant calls (where call.id != call.turn_id) are excluded
+
+    # Verify this is present in both query builders
+    pb = ParamBuilder("pb")
+    clickhouse_query = make_threads_query(project_id="test", pb=pb)
+    sqlite_query, _ = make_threads_query_sqlite(project_id="test")
+
+    # Check that turn filtering is present
+    assert "id = any(turn_id)" in clickhouse_query
+    assert "id = turn_id" in sqlite_query
+
+    # Check that thread filtering is also present (non-null, non-empty)
+    assert "thread_id IS NOT NULL AND thread_id != ''" in clickhouse_query
+    assert "thread_id IS NOT NULL" in sqlite_query
+    assert "thread_id != ''" in sqlite_query
+
+
+def test_query_structure_documentation():
+    """
+    Test that documents the structure and purpose of the threads query.
+
+    This test serves as living documentation of what the threads query does
+    and why it's structured the way it is.
+    """
+    pb = ParamBuilder("pb")
+    query = make_threads_query(project_id="test_project", pb=pb)
+
+    # Should be a two-level aggregation for ClickHouse
+    assert "SELECT" in query  # Outer query
+    assert "FROM (" in query  # Inner subquery
+    assert "GROUP BY thread_id" in query  # Outer aggregation by thread
+    assert "GROUP BY id" in query  # Inner aggregation by call
+
+    # Should include key aggregations
+    assert "COUNT(*) as turn_count" in query
+    assert "min(call_start_time) as start_time" in query
+    assert "max(call_end_time) as last_updated" in query
+
+    # Should include turn filtering
+    assert "id = any(turn_id)" in query
+
+    # Should have default ordering
+    assert "ORDER BY last_updated DESC" in query

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -41,6 +41,7 @@ __docspec__ = [
     finish,
     op,
     attributes,
+    thread,
     # Re-exported from flow module
     Object,
     Dataset,
@@ -87,4 +88,5 @@ __all__ = [
     "SavedView",
     "Scorer",
     "StringPrompt",
+    "thread",
 ]

--- a/weave/trace/context/call_context.py
+++ b/weave/trace/context/call_context.py
@@ -22,6 +22,16 @@ logger = logging.getLogger(__name__)
 
 _tracing_enabled = contextvars.ContextVar("tracing_enabled", default=True)
 
+# Thread ID context variable for tracking execution threads
+_thread_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "thread_id", default=None
+)
+
+# Turn ID context variable for tracking turns within threads
+_turn_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "turn_id", default=None
+)
+
 
 def push_call(call: Call) -> None:
     new_stack = copy.copy(_call_stack.get())
@@ -164,3 +174,47 @@ def set_tracing_enabled(enabled: bool) -> Iterator[None]:
 def tracing_disabled() -> Iterator[None]:
     with set_tracing_enabled(False):
         yield
+
+
+def get_thread_id() -> str | None:
+    """Get the current thread_id from context.
+
+    Returns:
+        The current thread_id if set, None otherwise.
+    """
+    return _thread_id.get()
+
+
+@contextlib.contextmanager
+def set_thread_id(thread_id: str | None) -> Iterator[str | None]:
+    """Set the thread_id in the current context.
+
+    Args:
+        thread_id: The thread_id to set in context.
+
+    Yields:
+        The thread_id that was set.
+    """
+    token = _thread_id.set(thread_id)
+    try:
+        yield thread_id
+    finally:
+        _thread_id.reset(token)
+
+
+def get_turn_id() -> str | None:
+    """Get the current turn_id from context.
+
+    Returns:
+        The current turn_id if set, None otherwise.
+    """
+    return _turn_id.get()
+
+
+def set_turn_id(turn_id: str | None) -> None:
+    """Set the turn_id in the current context.
+
+    Args:
+        turn_id: The turn_id to set in context.
+    """
+    _turn_id.set(turn_id)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -506,6 +506,8 @@ class CallDict(TypedDict):
     started_at: datetime.datetime | None
     ended_at: datetime.datetime | None
     deleted_at: datetime.datetime | None
+    thread_id: str | None
+    turn_id: str | None
 
 
 @dataclasses.dataclass
@@ -534,6 +536,8 @@ class Call:
     started_at: datetime.datetime | None = None
     ended_at: datetime.datetime | None = None
     deleted_at: datetime.datetime | None = None
+    thread_id: str | None = None
+    turn_id: str | None = None
 
     # These are the live children during logging
     _children: list[Call] = dataclasses.field(default_factory=list)
@@ -741,6 +745,8 @@ class Call:
             started_at=self.started_at,
             ended_at=self.ended_at,
             deleted_at=self.deleted_at,
+            thread_id=self.thread_id,
+            turn_id=self.turn_id,
         )
 
 
@@ -772,6 +778,8 @@ def make_client_call(
         started_at=server_call.started_at,
         ended_at=server_call.ended_at,
         deleted_at=server_call.deleted_at,
+        thread_id=server_call.thread_id,
+        turn_id=server_call.turn_id,
     )
     if isinstance(call.attributes, AttributesDict):
         call.attributes.freeze()
@@ -1266,7 +1274,24 @@ class WeaveClient:
 
         op_name_future = self.future_executor.defer(lambda: op_def_ref.uri())
 
+        # Get thread_id from context
+        thread_id = call_context.get_thread_id()
+        current_turn_id = call_context.get_turn_id()
+
         call_id = generate_id()
+
+        # Determine turn_id: call becomes a turn if thread boundary is crossed
+        if thread_id is None:
+            # No thread context, no turn_id
+            turn_id = None
+        elif parent is None or parent.thread_id != thread_id:
+            # This is a turn call - use its own ID as turn_id
+            turn_id = call_id
+            call_context.set_turn_id(call_id)
+        else:
+            # Inherit turn_id from context
+            turn_id = current_turn_id
+
         call = Call(
             _op_name=op_name_future,
             project_id=self._project_id(),
@@ -1276,6 +1301,8 @@ class WeaveClient:
             # It feels like this should be inputs_postprocessed, not the refs.
             inputs=inputs_with_refs,
             attributes=attributes_dict,
+            thread_id=thread_id,
+            turn_id=turn_id,
         )
         # Disallow further modification of attributes after the call is created
         attributes_dict.freeze()
@@ -1321,6 +1348,8 @@ class WeaveClient:
                     attributes=attributes_dict,
                     wb_run_id=current_wb_run_id,
                     wb_run_step=current_wb_run_step,
+                    thread_id=thread_id,
+                    turn_id=turn_id,
                 )
             )
 
@@ -1487,6 +1516,10 @@ class WeaveClient:
             self.server.call_end(call_end_req)
 
         self.future_executor.defer(send_end_call)
+
+        # If a turn call is finishing, reset turn context for next sibling
+        if call.turn_id == call.id and call.thread_id:
+            call_context.set_turn_id(None)
 
         call_context.pop_call(call.id)
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -412,6 +412,10 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.project_stats, req)
 
-    def threads_query(self, req: tsi.ThreadsQueryReq) -> tsi.ThreadsQueryRes:
+    def threads_query_stream(
+        self, req: tsi.ThreadsQueryReq
+    ) -> Iterator[tsi.ThreadSchema]:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
-        return self._ref_apply(self._internal_trace_server.threads_query, req)
+        return self._stream_ref_apply(
+            self._internal_trace_server.threads_query_stream, req
+        )

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -411,3 +411,7 @@ class ExternalTraceServer(tsi.TraceServerInterface):
     def project_stats(self, req: tsi.ProjectStatsReq) -> tsi.ProjectStatsRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.project_stats, req)
+
+    def threads_query(self, req: tsi.ThreadsQueryReq) -> tsi.ThreadsQueryRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.threads_query, req)

--- a/weave/trace_server/threads_query_builder.py
+++ b/weave/trace_server/threads_query_builder.py
@@ -1,0 +1,234 @@
+import datetime
+from typing import Optional, Union
+
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.orm import ParamBuilder
+
+
+def make_threads_query(
+    project_id: str,
+    pb: ParamBuilder,
+    *,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+    sort_by: Optional[list[tsi.SortBy]] = None,
+    sortable_datetime_after: Optional[datetime.datetime] = None,
+    sortable_datetime_before: Optional[datetime.datetime] = None,
+) -> str:
+    """
+    Generate a query to fetch threads with aggregated statistics.
+
+    IMPORTANT: This uses two-level aggregation to handle ClickHouse materialized view behavior.
+
+    ClickHouse Background:
+    - calls_merged is populated by a materialized view from call_parts
+    - ClickHouse initially creates partial inserts, then background processes merge them
+    - Before merging, we may have multiple rows per call_id with different field combinations:
+      * Row 1: id=call-123, thread_id=NULL, started_at=T1, ended_at=NULL
+      * Row 2: id=call-123, thread_id="thread-abc", started_at=NULL, ended_at=T2
+    - SimpleAggregateFunction columns store values to be merged later
+
+    Problem:
+    - Direct GROUP BY thread_id would count partial rows incorrectly
+    - Some calls might be missing thread_id in certain rows
+    - Timing data might be split across multiple rows
+
+    Solution:
+    - Inner query: GROUP BY (id, trace_id) to properly aggregate each call first
+    - Outer query: GROUP BY thread_id for final thread-level statistics
+
+    Args:
+        project_id: The project ID to filter by
+        pb: Parameter builder for safe SQL parameter injection
+        limit: Maximum number of threads to return
+        offset: Number of threads to skip
+        sort_by: List of sort criteria
+        sortable_datetime_after: Only include calls with sortable_datetime after this timestamp.
+                                Uses sortable_datetime column for efficient granule filtering.
+        sortable_datetime_before: Only include calls with sortable_datetime before this timestamp.
+                                 Uses sortable_datetime column for efficient granule filtering.
+
+    Returns:
+        SQL query string for threads aggregation
+    """
+    project_id_param = pb.add_param(project_id)
+
+    # Build optional sortable_datetime filter clauses for ClickHouse granule optimization
+    sortable_datetime_filter_clauses = []
+
+    if sortable_datetime_after is not None:
+        # Convert to datetime string format expected by ClickHouse
+        datetime_str = sortable_datetime_after.strftime("%Y-%m-%d %H:%M:%S.%f")
+        sortable_datetime_param = pb.add_param(datetime_str)
+        sortable_datetime_filter_clauses.append(
+            f"AND sortable_datetime > {{{sortable_datetime_param}: String}}"
+        )
+
+    if sortable_datetime_before is not None:
+        # Convert to datetime string format expected by ClickHouse
+        datetime_str = sortable_datetime_before.strftime("%Y-%m-%d %H:%M:%S.%f")
+        sortable_datetime_param = pb.add_param(datetime_str)
+        sortable_datetime_filter_clauses.append(
+            f"AND sortable_datetime < {{{sortable_datetime_param}: String}}"
+        )
+
+    sortable_datetime_filter_clause = " ".join(sortable_datetime_filter_clauses)
+
+    # Two-level aggregation to handle ClickHouse materialized view partial merges
+    query = f"""
+    SELECT
+        thread_id,
+        COUNT(DISTINCT trace_id) as trace_count,
+        min(start_time) as start_time,
+        max(last_updated) as last_updated
+    FROM (
+        -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+        -- This handles cases where calls_merged has multiple partial rows per call_id
+        -- due to ClickHouse materialized view background merge behavior
+        SELECT
+            id,                              -- Call identifier
+            trace_id,                        -- Trace identifier
+            any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                            -- (all non-null values should be identical)
+            min(started_at) as start_time,   -- Earliest start time for this call
+            max(ended_at) as last_updated    -- Latest end time for this call
+        FROM calls_merged
+        WHERE project_id = {{{project_id_param}: String}}
+            {sortable_datetime_filter_clause}
+        GROUP BY id, trace_id               -- Group by call to merge partial rows
+        HAVING thread_id IS NOT NULL AND thread_id != ''  -- Filter after aggregation
+    ) as properly_merged_calls
+    -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+    GROUP BY thread_id
+    """
+
+    # Add sorting
+    if sort_by:
+        order_clauses = []
+        for sort in sort_by:
+            field = _validate_and_map_sort_field(sort.field)
+            direction = sort.direction.upper()
+            order_clauses.append(f"{field} {direction}")
+        query += f" ORDER BY {', '.join(order_clauses)}"
+    else:
+        # Default sorting by last_updated descending
+        query += " ORDER BY last_updated DESC"
+
+    # Add pagination
+    if limit is not None:
+        limit_param = pb.add_param(limit)
+        query += f" LIMIT {{{limit_param}: Int64}}"
+
+    if offset is not None:
+        offset_param = pb.add_param(offset)
+        query += f" OFFSET {{{offset_param}: Int64}}"
+
+    return query
+
+
+def make_threads_query_sqlite(
+    project_id: str,
+    *,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+    sort_by: Optional[list[tsi.SortBy]] = None,
+    sortable_datetime_after: Optional[datetime.datetime] = None,
+    sortable_datetime_before: Optional[datetime.datetime] = None,
+) -> tuple[str, list]:
+    """
+    Generate a SQLite query to fetch threads with aggregated statistics.
+
+    Args:
+        project_id: The project ID to filter by
+        limit: Maximum number of threads to return
+        offset: Number of threads to skip
+        sort_by: List of sort criteria
+        sortable_datetime_after: Only include calls that started after this timestamp.
+                                SQLite uses started_at since it doesn't have sortable_datetime column.
+        sortable_datetime_before: Only include calls that started before this timestamp.
+                                 SQLite uses started_at since it doesn't have sortable_datetime column.
+
+    Returns:
+        Tuple of (SQL query string, parameters list) for SQLite
+    """
+    parameters: list[Union[str, int]] = [project_id]
+
+    # Build optional timestamp filter clauses (SQLite uses started_at instead of sortable_datetime)
+    timestamp_filter_clauses = []
+
+    if sortable_datetime_after is not None:
+        timestamp_filter_clauses.append("AND started_at > ?")
+        parameters.append(sortable_datetime_after.isoformat())
+
+    if sortable_datetime_before is not None:
+        timestamp_filter_clauses.append("AND started_at < ?")
+        parameters.append(sortable_datetime_before.isoformat())
+
+    timestamp_filter_clause = " ".join(timestamp_filter_clauses)
+
+    # Base query - group by thread_id and collect statistics
+    query = f"""
+    SELECT
+        thread_id,
+        COUNT(DISTINCT trace_id) as trace_count,
+        MIN(started_at) as start_time,
+        MAX(ended_at) as last_updated
+    FROM calls
+    WHERE project_id = ?
+        AND thread_id IS NOT NULL
+        AND thread_id != ''
+        {timestamp_filter_clause}
+    GROUP BY thread_id
+    """
+
+    # Add sorting
+    if sort_by:
+        order_clauses = []
+        for sort in sort_by:
+            field = _validate_and_map_sort_field(sort.field)
+            direction = sort.direction.upper()
+            order_clauses.append(f"{field} {direction}")
+        query += f" ORDER BY {', '.join(order_clauses)}"
+    else:
+        # Default sorting by last_updated descending
+        query += " ORDER BY last_updated DESC"
+
+    # Add pagination
+    if limit is not None:
+        query += " LIMIT ?"
+        parameters.append(limit)
+
+    if offset is not None:
+        query += " OFFSET ?"
+        parameters.append(offset)
+
+    return query, parameters
+
+
+def _validate_and_map_sort_field(field: str) -> str:
+    """
+    Validate and map sort field names to their SQL equivalents.
+
+    Args:
+        field: The field name from the API request
+
+    Returns:
+        The SQL column name to use in the query
+
+    Raises:
+        ValueError: If the field is not supported for sorting
+    """
+    # Map of API field names to SQL column names
+    valid_fields = {
+        "thread_id": "thread_id",
+        "trace_count": "trace_count",
+        "start_time": "start_time",
+        "last_updated": "last_updated",
+    }
+
+    if field not in valid_fields:
+        raise ValueError(
+            f"Unsupported sort field: {field}. Supported fields: {list(valid_fields.keys())}"
+        )
+
+    return valid_fields[field]

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1042,6 +1042,45 @@ class ProjectStatsRes(BaseModel):
     files_storage_size_bytes: int
 
 
+# Thread API
+
+
+class ThreadSchema(BaseModel):
+    thread_id: str
+    trace_count: int
+    start_time: datetime.datetime
+    last_updated: datetime.datetime
+
+
+class ThreadsQueryReq(BaseModel):
+    project_id: str = Field(
+        description="The ID of the project", examples=["my_entity/my_project"]
+    )
+    limit: Optional[int] = Field(
+        default=None, description="Maximum number of threads to return"
+    )
+    offset: Optional[int] = Field(default=None, description="Number of threads to skip")
+    sort_by: Optional[list[SortBy]] = Field(
+        default=None,
+        description="Sorting criteria for the threads. Supported fields: 'last_updated', 'trace_count', 'thread_id'.",
+        examples=[[SortBy(field="last_updated", direction="desc")]],
+    )
+    sortable_datetime_after: Optional[datetime.datetime] = Field(
+        default=None,
+        description="Only include calls with sortable_datetime after this timestamp. Used for ClickHouse granule optimization to limit memory usage by filtering out old data granules efficiently. For SQLite, filters on started_at.",
+        examples=["2024-01-01T00:00:00Z"],
+    )
+    sortable_datetime_before: Optional[datetime.datetime] = Field(
+        default=None,
+        description="Only include calls with sortable_datetime before this timestamp. Used for ClickHouse granule optimization to limit memory usage by filtering out recent data granules efficiently. For SQLite, filters on started_at.",
+        examples=["2024-12-31T23:59:59Z"],
+    )
+
+
+class ThreadsQueryRes(BaseModel):
+    threads: list[ThreadSchema]
+
+
 class TraceServerInterface(Protocol):
     def ensure_project_exists(
         self, entity: str, project: str
@@ -1120,3 +1159,6 @@ class TraceServerInterface(Protocol):
 
     # Project statistics API
     def project_stats(self, req: ProjectStatsReq) -> ProjectStatsRes: ...
+
+    # Thread API
+    def threads_query(self, req: ThreadsQueryReq) -> ThreadsQueryRes: ...

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -502,8 +502,10 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
     def project_stats(self, req: tsi.ProjectStatsReq) -> tsi.ProjectStatsRes:
         return self._next_trace_server.project_stats(req)
 
-    def threads_query(self, req: tsi.ThreadsQueryReq) -> tsi.ThreadsQueryRes:
-        return self._next_trace_server.threads_query(req)
+    def threads_query_stream(
+        self, req: tsi.ThreadsQueryReq
+    ) -> Iterator[tsi.ThreadSchema]:
+        return self._next_trace_server.threads_query_stream(req)
 
 
 def pydantic_bytes_safe_dump(obj: BaseModel) -> str:

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -502,6 +502,9 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
     def project_stats(self, req: tsi.ProjectStatsReq) -> tsi.ProjectStatsRes:
         return self._next_trace_server.project_stats(req)
 
+    def threads_query(self, req: tsi.ThreadsQueryReq) -> tsi.ThreadsQueryRes:
+        return self._next_trace_server.threads_query(req)
+
 
 def pydantic_bytes_safe_dump(obj: BaseModel) -> str:
     raw_dict = obj.model_dump()

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -625,6 +625,11 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/project/stats", req, tsi.ProjectStatsReq, tsi.ProjectStatsRes
         )
 
+    def threads_query(self, req: tsi.ThreadsQueryReq) -> tsi.ThreadsQueryRes:
+        return self._generic_request(
+            "/threads/query", req, tsi.ThreadsQueryReq, tsi.ThreadsQueryRes
+        )
+
 
 __docspec__ = [
     RemoteHTTPTraceServer,

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -625,9 +625,11 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/project/stats", req, tsi.ProjectStatsReq, tsi.ProjectStatsRes
         )
 
-    def threads_query(self, req: tsi.ThreadsQueryReq) -> tsi.ThreadsQueryRes:
-        return self._generic_request(
-            "/threads/query", req, tsi.ThreadsQueryReq, tsi.ThreadsQueryRes
+    def threads_query_stream(
+        self, req: tsi.ThreadsQueryReq
+    ) -> Iterator[tsi.ThreadSchema]:
+        return self._generic_stream_request(
+            "/threads/stream_query", req, tsi.ThreadsQueryReq, tsi.ThreadSchema
         )
 
 


### PR DESCRIPTION
## Description

- Adds thread context support to Weave, allowing users to group related operations under a common thread ID
- Implements `weave.thread()` context manager for setting thread IDs on calls
- Adds turn_id tracking to identify top-level operations within a thread
- Introduces ThreadContext class that provides access to thread_id and turn_id
- Adds thread_id and turn_id fields to Call objects and ensures proper inheritance

## Design Doc:

Please review this doc for the overall plan
https://www.notion.so/wandbai/Threads-API-Design-Document-PRD-21ee2f5c7ef3806f93ecfdb38b8982fb

## Testing

Added comprehensive test cases that verify:
- Thread context management with the weave.thread() API
- Thread ID capture in call records
- Thread ID inheritance by child calls
- Error handling within thread contexts
- Turn ID functionality for tracking top-level operations
- Nested thread contexts and thread disabling
- Auto-generation of thread IDs