### PR TITLE
feat(weave): Read inference service base URL from env var

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2845,18 +2845,20 @@ def _setup_completion_model_info(
     elif model_name.startswith("coreweave/"):
         # See https://docs.litellm.ai/docs/providers/openai_compatible
         # but ignore the bit about omitting the /v1 because it is actually necessary
-        req.inputs.model = "openai/" + model_name.replace("coreweave/", "", 1)
+        req.inputs.model = model_name.replace("coreweave/", "openai/", 1)
+
         provider = "custom"
-        base_url = "https://api.inference.wandb.ai/v1"
+
+        base_url = wf_env.inference_service_base_url()
+
         # The API key should have been passed in as an extra header.
         if req.inputs.extra_headers:
-            hostname = req.inputs.extra_headers.get("trace_server_hostname", None)
-            if hostname == "weave-trace.qa.wandb.ai":
-                base_url = "https://api.qa.inference.coreweave.com/v1"
             api_key = req.inputs.extra_headers.pop("api_key", None)
             extra_headers = req.inputs.extra_headers
             req.inputs.extra_headers = None
+
         return_type = "openai"
+
     else:
         # Custom provider path
         custom_provider_info = get_custom_provider_info(

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -195,3 +195,11 @@ def wf_file_storage_project_ramp_pct() -> Optional[int]:
         )
 
     return pct
+
+
+# Inference Service Settings
+
+
+def inference_service_base_url() -> Optional[str]:
+    """The base URL for the inference service."""
+    return os.environ.get("INFERENCE_SERVICE_BASE_URL")


### PR DESCRIPTION
## Description

Reads the inference service base URL from an env var instead of inferring from request hostname.

- Fixes WB-25624

## Testing

Tested on QA.