### PR TITLE
chore(ui): change playground default to use Inference Service

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/llmMaxTokens.ts
@@ -781,7 +781,8 @@ export const LLM_MAX_TOKENS = {
   },
 };
 
-export const DEFAULT_LLM_MODEL: LLMMaxTokensKey = 'gpt-4.1-mini-2025-04-14';
+export const DEFAULT_LLM_MODEL: LLMMaxTokensKey =
+  'cw_meta-llama_Llama-3.1-8B-Instruct';
 
 export type LLMMaxTokensKey = keyof typeof LLM_MAX_TOKENS;
 


### PR DESCRIPTION
## Description

Fix https://wandb.atlassian.net/browse/WB-25632

Change the default model selection for the playground to be from our Inference Service. This should be safe even if the current account does not have access to the inference service (e.g. personal account, dedicated) because the `isValueAvailable` handling in the useEffect will fall back to the first value that is available. (And the previous default model selection happens to be the first model that was in OpenAI, which was the first provider.)

## Testing

How was this PR tested?
