### PR TITLE
fix(weave): use threading lock instead of multiprocessing lock to fix Lambda issue

### DIFF
--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -7,7 +7,7 @@ import logging
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from multiprocessing import Lock
+from threading import Lock
 from types import MethodType
 from typing import Annotated, Any, TypeVar, Union, cast
 


### PR DESCRIPTION
## Description

Using Lock function from multiprocessing library leads to a FileNotFoundError in AWS Lambda environment

- Fixes #4835

## Testing

This fix was run in Lambda environment, and now the logging to Weave works correctly. Local evaluations also work. Screen for each below.

<img width="1396" alt="Screenshot 2025-06-22 at 11 11 26" src="https://github.com/user-attachments/assets/2bf5f1b7-2f1c-41e0-948b-573145cba8da" />

<img width="1396" alt="Screenshot 2025-06-22 at 11 12 33" src="https://github.com/user-attachments/assets/2c18c751-968c-4853-ae6f-c5e4b98827a9" />
