### PR TITLE
fix(weave): Ensure summary logging does not crash when custom summary includes non-primitives

### DIFF
--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -239,9 +239,23 @@ class Evaluation(Object):
         eval_results = await self.get_eval_results(model)
         summary = await self.summarize(eval_results)
 
-        logger.info(f"Evaluation summary {json.dumps(summary, indent=2)}")
+        summary_str = _safe_summarize_to_str(summary)
+        if summary_str:
+            logger.info(f"Evaluation summary {summary_str}")
 
         return summary
+
+
+def _safe_summarize_to_str(summary: dict) -> str:
+    summary_str = ""
+    try:
+        summary_str = json.dumps(summary, indent=2)
+    except Exception:
+        try:
+            summary_str = str(summary)
+        except Exception:
+            pass
+    return summary_str
 
 
 def evaluate(


### PR DESCRIPTION
Fixes WB-25648

A customer is returning a custom object from their summary (in this case pydantic), which crashes on the json dump. We should never fail when all we are doing is logging some info to the user. This PR simply makes that a safe procedure