### PR TITLE
feat(weave): Add monitors to overflow menu

### DIFF
--- a/weave-js/src/components/FancyPage/useProjectSidebar.ts
+++ b/weave-js/src/components/FancyPage/useProjectSidebar.ts
@@ -251,6 +251,7 @@ export const useProjectSidebar = (
             isShown: isShowAll,
             menu: [
               'weave/prompts',
+              ...(isWandbAdmin ? ['weave/monitors'] : []),
               'weave/models',
               'weave/datasets',
               'weave/scorers',


### PR DESCRIPTION
Monitors are missing from the overflow menu when both Models and Weave items are shown.
