### PR TITLE
fix(app): Fix bounding box outline disappearing on resize

### DIFF
--- a/weave-js/src/components/Panel2/ImageWithOverlays.tsx
+++ b/weave-js/src/components/Panel2/ImageWithOverlays.tsx
@@ -557,7 +557,7 @@ export const BoundingBoxesCanvas: FC<BoundingBoxCanvasProps> = ({
                 className="absolute"
                 style={{
                   left,
-                  top: top,
+                  top,
                 }}>
                 <div className="relative">
                   <Tooltip.Provider delayDuration={0}>
@@ -565,7 +565,7 @@ export const BoundingBoxesCanvas: FC<BoundingBoxCanvasProps> = ({
                       <Tooltip.Trigger>
                         <div
                           style={{
-                            outline: outlineWidth,
+                            outlineWidth,
                             outlineColor: color,
                             outlineStyle:
                               lineStyle === 'line'


### PR DESCRIPTION
## Description

Fixes this warning in the console that caused an issue with the bounding boxes disappearing

![Screenshot 2025-06-23 at 3 06 13 PM](https://github.com/user-attachments/assets/1c2453cf-160b-4027-8c9c-4dc9bd901931)


## Testing

How was this PR tested?

Before:

https://github.com/user-attachments/assets/b700a323-8c30-44a4-8ddf-0e40c4a4e3df



After:



https://github.com/user-attachments/assets/3f6a7bbb-4ecf-49b1-b65a-e8efd55c7f59


