### PR TITLE
chore(weave): add thread_id to stats view and table

### DIFF
--- a/weave/trace_server/migrations/016_add_thread_id_to_stats.down.sql
+++ b/weave/trace_server/migrations/016_add_thread_id_to_stats.down.sql
@@ -1,0 +1,28 @@
+-- Revert stats materialized view to exclude thread_id
+ALTER TABLE calls_merged_stats_view MODIFY QUERY
+SELECT
+    call_parts.project_id,
+    call_parts.id,
+    anySimpleState(call_parts.trace_id) as trace_id,
+    anySimpleState(call_parts.parent_id) as parent_id,
+    anySimpleState(call_parts.op_name) as op_name,
+    anySimpleState(call_parts.started_at) as started_at,
+    anySimpleState(length(call_parts.attributes_dump)) as attributes_size_bytes,
+    anySimpleState(length(call_parts.inputs_dump)) as inputs_size_bytes,
+    anySimpleState(call_parts.ended_at) as ended_at,
+    anySimpleState(length(call_parts.output_dump)) as output_size_bytes,
+    anySimpleState(length(call_parts.summary_dump)) as summary_size_bytes,
+    anySimpleState(length(call_parts.exception)) as exception_size_bytes,
+    anySimpleState(call_parts.wb_user_id) as wb_user_id,
+    anySimpleState(call_parts.wb_run_id) as wb_run_id,
+    anySimpleState(call_parts.wb_run_step) as wb_run_step,
+    anySimpleState(call_parts.deleted_at) as deleted_at,
+    maxSimpleState(call_parts.created_at) as updated_at,
+    argMaxState(call_parts.display_name, call_parts.created_at) as display_name
+FROM call_parts
+GROUP BY
+    call_parts.project_id,
+    call_parts.id;
+
+-- Remove thread_id from stats table
+ALTER TABLE calls_merged_stats DROP COLUMN thread_id; 

--- a/weave/trace_server/migrations/016_add_thread_id_to_stats.up.sql
+++ b/weave/trace_server/migrations/016_add_thread_id_to_stats.up.sql
@@ -1,0 +1,30 @@
+-- Add thread_id to stats table
+ALTER TABLE calls_merged_stats
+    ADD COLUMN thread_id SimpleAggregateFunction(any, Nullable(String));
+
+-- Update stats materialized view to include thread_id
+ALTER TABLE calls_merged_stats_view MODIFY QUERY
+SELECT
+    call_parts.project_id,
+    call_parts.id,
+    anySimpleState(call_parts.trace_id) as trace_id,
+    anySimpleState(call_parts.parent_id) as parent_id,
+    anySimpleState(call_parts.thread_id) as thread_id,
+    anySimpleState(call_parts.op_name) as op_name,
+    anySimpleState(call_parts.started_at) as started_at,
+    anySimpleState(length(call_parts.attributes_dump)) as attributes_size_bytes,
+    anySimpleState(length(call_parts.inputs_dump)) as inputs_size_bytes,
+    anySimpleState(call_parts.ended_at) as ended_at,
+    anySimpleState(length(call_parts.output_dump)) as output_size_bytes,
+    anySimpleState(length(call_parts.summary_dump)) as summary_size_bytes,
+    anySimpleState(length(call_parts.exception)) as exception_size_bytes,
+    anySimpleState(call_parts.wb_user_id) as wb_user_id,
+    anySimpleState(call_parts.wb_run_id) as wb_run_id,
+    anySimpleState(call_parts.wb_run_step) as wb_run_step,
+    anySimpleState(call_parts.deleted_at) as deleted_at,
+    maxSimpleState(call_parts.created_at) as updated_at,
+    argMaxState(call_parts.display_name, call_parts.created_at) as display_name
+FROM call_parts
+GROUP BY
+    call_parts.project_id,
+    call_parts.id; 


### PR DESCRIPTION
## Description

Adds `thread_id` to the `calls_merged_stats` table and updates the `calls_merged_stats_view` materialized view to include this field. This change enables tracking thread information in call statistics, which will help with analyzing execution flow across threads.

This was missed in PR https://github.com/wandb/weave/pull/4805 

## Testing

This PR was tested by:
- Applying the migration to a test database
- Verifying that the `thread_id` column was properly added to the `calls_merged_stats` table
- Confirming that the materialized view correctly includes the thread_id field
