### PR TITLE
fix(flow): Allow MessagesPrompt to have nested dict messages

### DIFF
--- a/tests/flow/test_prompt.py
+++ b/tests/flow/test_prompt.py
@@ -20,3 +20,32 @@ def test_messagesprompt_format():
         {"role": "system", "content": "You are a pirate."},
         {"role": "user", "content": "Tell us your thoughts on airplanes."},
     ]
+
+
+def test_messagesprompt_nesteddict_format():
+    prompt = MessagesPrompt(
+        [
+            {"role": "system", "content": "You are a pirate."},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Tell us your thoughts on {topic}.",
+                    }
+                ],
+            },
+        ]
+    )
+    assert prompt.format(topic="airplanes") == [
+        {"role": "system", "content": "You are a pirate."},
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Tell us your thoughts on airplanes.",
+                }
+            ],
+        },
+    ]

--- a/weave/flow/prompt/prompt.py
+++ b/weave/flow/prompt/prompt.py
@@ -23,7 +23,7 @@ from weave.trace.vals import WeaveObject
 
 class Message(TypedDict):
     role: str
-    content: str
+    content: str | list[dict]
 
 
 def maybe_dedent(content: str, dedent: bool) -> str:
@@ -108,10 +108,12 @@ class MessagesPrompt(Prompt):
         self.messages = messages
 
     def format_message(self, message: dict, **kwargs: Any) -> dict:
-        m = {}
+        m: dict[str, Any] = {}
         for k, v in message.items():
             if isinstance(v, str):
                 m[k] = v.format(**kwargs)
+            elif isinstance(v, list) and all(isinstance(d, dict) for d in v):
+                m[k] = [self.format_message(d, **kwargs) for d in v]
             else:
                 m[k] = v
         return m


### PR DESCRIPTION
## Description

This PR allow `MessagesPrompt` to format nested dict messages.
Currently, if `MessagesPrompt` is similar to:

```python
prompt = MessagesPrompt(
    [
        {"role": "system", "content": "You are a pirate."},
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "Tell us your thoughts on {topic}.",
                }
            ],
        },
    ]
)
```
Then `{topic}` will not be replaced when using `prompt.format(topic="airplanes")`.

This is because the `.format()` method considers that `content`'s value is a `str`.

Yet, LLM client do allow `content` to be a `list[dict]`, see [this example](https://docs.mistral.ai/capabilities/OCR/document_qna/) with Mistral OCR:
```python
messages = [
    {
        "role": "user",
        "content": [
            {
                "type": "text",
                "text": "what is the last sentence in the document"
            },
            {
                "type": "document_url",
                "document_url": "https://arxiv.org/pdf/1805.04770"
            }
        ]
    }
]
```


## Testing

Added a unit test to cover this use case.
