### PR TITLE
chore(weave): Disable automatic down migrations to prevent un-intended behavior

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -224,7 +224,7 @@ class ClickHouseTraceServerMigrator:
             # Do not run down migrations if not explicitly requesting target_version
             if current_version > target_version:
                 logger.warning(
-                    f"NOT running down migration from {current_version} to {target_version}"
+                    f"Found current version ({current_version}) greater than known versions ({len(migration_map)}). Will not run any migrations."
                 )
                 return []
         if target_version < 0 or target_version > len(migration_map):
@@ -238,12 +238,15 @@ class ClickHouseTraceServerMigrator:
                 res.append((i, f"{migration_map[i]['up']}"))
             return res
         if target_version < current_version:
-            res = []
-            for i in range(current_version, target_version, -1):
-                if migration_map[i]["down"] is None:
-                    raise MigrationError(f"Missing down migration file for version {i}")
-                res.append((i - 1, f"{migration_map[i]['down']}"))
-            return res
+            logger.warning(
+                f"Automatically running down migrations is disabled and should be done manually. Current version ({current_version}) is greater than target version ({target_version})."
+            )
+            # res = []
+            # for i in range(current_version, target_version, -1):
+            #     if migration_map[i]["down"] is None:
+            #         raise MigrationError(f"Missing down migration file for version {i}")
+            #     res.append((i - 1, f"{migration_map[i]['down']}"))
+            # return res
 
         return []
 


### PR DESCRIPTION
This pull request updates the `_determine_migrations_to_apply` method in `weave/trace_server/clickhouse_trace_server_migrator.py` to improve clarity and enforce stricter migration behavior. The changes include refining warning messages and disabling automatic down migrations.

### Migration behavior updates:

* Updated the warning message when the current version exceeds the known versions to provide clearer context about the situation.
* Disabled automatic down migrations by replacing the logic with a warning message, instructing users to handle down migrations manually. This ensures greater control and prevents unintended operations.