### PR TITLE
fix(weave): Include entity in weave.init in Python code sample

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTableButtons.tsx
@@ -186,6 +186,7 @@ export const ExportSelector = ({
   };
 
   const pythonText = makeCodeText(
+    callQueryParams.entity,
     callQueryParams.project,
     selectionState === 'selected' ? selectedCalls : undefined,
     lowLevelFilter,
@@ -570,6 +571,7 @@ function makeLeafColumns(visibleColumns: string[]) {
 }
 
 function makeCodeText(
+  entity: string,
   project: string,
   callIds: string[] | undefined,
   filter: CallFilter,
@@ -578,7 +580,7 @@ function makeCodeText(
   includeFeedback: boolean,
   includeCosts: boolean
 ) {
-  let codeStr = `import weave\n\nclient = weave.init("${project}")`;
+  let codeStr = `import weave\n\nclient = weave.init("${entity}/${project}")`;
   codeStr += `\ncalls = client.get_calls(\n`;
   const filteredCallIds = callIds ?? filter.callIds;
   if (filteredCallIds && filteredCallIds.length > 0) {


### PR DESCRIPTION
## Description

Internal Jira: https://wandb.atlassian.net/browse/WB-25727
Internal Slack: https://weightsandbiases.slack.com/archives/C01T8BLDHKP/p1750792719999149

We should scope with the entity when doing a `weave.init` in the Python export code sample - if your default entity is not the one you are looking at, the code sample could confusingly create a different project with the same name and the query would return 0 results.

Note that the curl code sample does already include the entity.

## Testing

How was this PR tested?
