### PR TITLE
fix(weave): fix option click filter then delete

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/filterUtils.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/filterUtils.ts
@@ -2,25 +2,27 @@ import {GridFilterItem} from '@mui/x-data-grid-pro';
 
 import {FilterId} from './common';
 
+// Global counter to ensure unique filter IDs
+let globalFilterIdCounter = 0;
+
 /**
- * Computes the next available filter ID based on existing filter items.
- * - Returns 0 if items array is empty
- * - Handles null/undefined IDs by defaulting to 0
- * - Converts string IDs to numbers, defaulting to 0 if parsing fails
- * - Returns the maximum ID + 1
+ * Computes the next available filter ID using a global counter.
+ * This ensures unique IDs even when filters are deleted and added.
  */
 export const getNextFilterId = (items: GridFilterItem[]): number => {
-  if (items.length === 0) {
-    return 0;
+  // Initialize counter based on existing items if this is the first call
+  if (globalFilterIdCounter === 0 && items.length > 0) {
+    const existingIds = items.map(item => {
+      const id = item.id;
+      if (id == null) {
+        return 0;
+      }
+      return typeof id === 'number' ? id : parseInt(String(id), 10) || 0;
+    });
+    globalFilterIdCounter = Math.max(...existingIds) + 1;
   }
-  const ids = items.map(item => {
-    const id = item.id;
-    if (id == null) {
-      return 0;
-    }
-    return typeof id === 'number' ? id : parseInt(String(id), 10) || 0;
-  });
-  return Math.max(...ids) + 1;
+
+  return globalFilterIdCounter++;
 };
 
 /**

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/CallsTable.tsx
@@ -55,6 +55,7 @@ import {
 import {OnUpdateFilter} from '../../filters/CellFilterWrapper';
 import {getDefaultOperatorForValue} from '../../filters/common';
 import {FilterPanel} from '../../filters/FilterPanel';
+import {getNextFilterId} from '../../filters/filterUtils';
 import {flattenObjectPreservingWeaveTypes} from '../../flattenObject';
 import {DEFAULT_PAGE_SIZE} from '../../grid/pagination';
 import {StyledDataGrid} from '../../StyledDataGrid';
@@ -479,7 +480,7 @@ export const CallsTable: FC<{
             items: [
               ...filterModel.items,
               {
-                id: filterModel.items.length,
+                id: getNextFilterId(filterModel.items),
                 field,
                 operator: op,
                 value: strVal,


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25753](https://wandb.atlassian.net/browse/WB-25753)

Okay kinda wild, but use a global constant to never ever assign the same id when creating a filter. This should prevent collisions, even when filters are in a un-saved state. Also, use the `getNextFilterId` when option clicking! 

## Testing
Prod
![filter-bar-delete-prod](https://github.com/user-attachments/assets/8b2cd96d-4c40-4eee-bfd3-427adddc7166)


Branch
![filter-bar-delete-fix](https://github.com/user-attachments/assets/8d263492-e4dc-4589-abec-c5435867d721)



[WB-25753]: https://wandb.atlassian.net/browse/WB-25753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ