### PR TITLE
perf(weave): slight refactor to storage query, big perf improvement

### DIFF
--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -818,7 +818,8 @@ class CallsQuery(BaseModel):
                 FROM calls_merged_stats
                 WHERE project_id = {param_slot(project_param, "String")}
                 GROUP BY id
-            ) as {STORAGE_SIZE_TABLE_NAME} USING id
+            ) as {STORAGE_SIZE_TABLE_NAME}
+                ON calls_merged.id = {STORAGE_SIZE_TABLE_NAME}.id
             """
 
         total_storage_size_sql = ""
@@ -837,7 +838,8 @@ class CallsQuery(BaseModel):
                 FROM calls_merged_stats
                 WHERE project_id = {param_slot(project_param, "String")}
                 GROUP BY trace_id
-            ) as {ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME} USING trace_id
+            ) as {ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME}
+                ON calls_merged.trace_id = {ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME}.trace_id
             """
 
         raw_sql = f"""


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25774](https://wandb.atlassian.net/browse/WB-25774)

Refactors for performance aggregation of call storage. This query in prod fails for large projects. Due to not grouping by call_id, this new query is technically slightly different than prod. While the # of calls is consistent, the bytes is off by <1%. I wonder if this is a big deal....

[Failing example dd trace.](https://us5.datadoghq.com/logs?query=trace_id%3A685d8f9400000000c16e4b1cdbfbd301&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZeteO2o_kro-AAAABhBWmV0ZVFNY0FBREJ0c1hIZm03S0dBQUoAAAAkMDE5N2FkNzktMjA5Ni00YmVlLTkwMmUtNzYzZGNjMjFhY2M2AAA58Q&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1750961068851&to_ts=1750963073745&live=false)

## Testing


|   env   | duration | rows       | memory      | # calls | bytes |
|---------|----------|------------|-------------| ------- | ----- |
| prod    | 8.114s   | 131259491  | 29.25  GiB  | 65517099 | 731193577615 |
| branch  | 2.637s   | 131259797  | 583.01 MiB  | 65517099 | 731228264910 |



[WB-25774]: https://wandb.atlassian.net/browse/WB-25774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ