### PR TITLE
perf(weave): remove extra storage query from weave overview

### DIFF
--- a/weave-js/src/common/components/WeaveStatsSummarySection.tsx
+++ b/weave-js/src/common/components/WeaveStatsSummarySection.tsx
@@ -19,7 +19,6 @@ export const WeaveStatsSummarySection = ({
   const {result, loading: callsStatsLoading} = useCallsStats({
     entity,
     project,
-    includeTotalStorageSize: true,
   });
 
   const {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

No need to query for the storage in the calls query, we don't even use it! And it can cause db OOms. 

## Testing

| prod | branch | 
| ----- | ------ | 
| ![Screenshot 2025-06-26 at 1 06 25 PM](https://github.com/user-attachments/assets/0bbabf20-d92b-44d2-9b13-c0291edb8ef0) | ![image](https://github.com/user-attachments/assets/a9214e13-612a-4ff7-b5a3-f6c415661647) | 

