### PR TITLE
feat(weave): add deepeval scorers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ trace_server = [
   "opentelemetry-proto>=1.12.0",
   "opentelemetry-semantic-conventions-ai>=0.4.3",
   "openinference-semantic-conventions>=0.1.17",
+  "deepeval>=3.2.0"
 ]
 trace_server_tests = [
   # BYOB - S3

--- a/tests/scorers/test_deepeval_scorer.py
+++ b/tests/scorers/test_deepeval_scorer.py
@@ -1,0 +1,77 @@
+import pytest
+# import asyncio
+from unittest.mock import patch
+
+from weave.scorers.deepeval_scorer import (
+    DeepEvalContextualPrecisionScorer,
+    DeepEvalContextualRecallScorer,
+    DeepEvalFaithfulnessScorer,
+    DeepEvalAnswerRelevancyScorer,
+)
+
+class MockDeepEvalMetric:
+    def __init__(self, **kwargs):
+        self.score = 1.0
+        self.reason = "Mocked reason: This is a successful test."
+    async def a_measure(self, test_case):
+        pass
+
+class MockLLMTestCase:
+    def __init__(self, **kwargs):
+        pass
+
+@pytest.mark.asyncio
+@patch('weave.scorers.deepeval_scorer.ContextualPrecisionMetric', new=MockDeepEvalMetric)
+@patch('weave.scorers.deepeval_scorer.LLMTestCase', new=MockLLMTestCase)
+async def test_deepeval_contextual_precision_scorer():
+    scorer = DeepEvalContextualPrecisionScorer(model_id="mock-model")
+    result = await scorer.score(
+        output="Paris is the capital of France.",
+        input="What is the capital of France?",
+        expected_output="The capital of France is Paris.",
+        context=["France's capital is Paris.", "The sky is blue."]
+    )
+    assert result['score'] == 1.0
+    assert "Mocked reason" in result['reason']
+
+
+@pytest.mark.asyncio
+@patch('weave.scorers.deepeval_scorer.ContextualRecallMetric', new=MockDeepEvalMetric)
+@patch('weave.scorers.deepeval_scorer.LLMTestCase', new=MockLLMTestCase)
+async def test_deepeval_contextual_recall_scorer():
+    scorer = DeepEvalContextualRecallScorer(model_id="mock-model")
+    result = await scorer.score(
+        output="Paris is the capital.",
+        input="What is France's capital?",
+        expected_output="The capital of France is Paris.",
+        context=["France's capital city is Paris."]
+    )
+    assert result['score'] == 1.0
+    assert "Mocked reason" in result['reason']
+
+
+@pytest.mark.asyncio
+@patch('weave.scorers.deepeval_scorer.FaithfulnessMetric', new=MockDeepEvalMetric)
+@patch('weave.scorers.deepeval_scorer.LLMTestCase', new=MockLLMTestCase)
+async def test_deepeval_faithfulness_scorer():
+    scorer = DeepEvalFaithfulnessScorer(model_id="mock-model")
+    result = await scorer.score(
+        output="Paris is the capital of France.",
+        input="What is France's capital?",
+        context=["Paris is the capital city of France."]
+    )
+    assert result['score'] == 1.0
+    assert "Mocked reason" in result['reason']
+
+
+@pytest.mark.asyncio
+@patch('weave.scorers.deepeval_scorer.AnswerRelevancyMetric', new=MockDeepEvalMetric)
+@patch('weave.scorers.deepeval_scorer.LLMTestCase', new=MockLLMTestCase)
+async def test_deepeval_answer_relevancy_scorer():
+    scorer = DeepEvalAnswerRelevancyScorer(model_id="mock-model")
+    result = await scorer.score(
+        output="Paris is the capital of France.",
+        input="What is the capital of France?"
+    )
+    assert result['score'] == 1.0
+    assert "Mocked reason" in result['reason']

--- a/weave/scorers/__init__.py
+++ b/weave/scorers/__init__.py
@@ -3,6 +3,12 @@ from weave.scorers.classification_scorer import (
 )
 from weave.scorers.coherence_scorer import WeaveCoherenceScorerV1
 from weave.scorers.context_relevance_scorer import WeaveContextRelevanceScorerV1
+from weave.scorers.deepeval_scorer import (
+    DeepEvalAnswerRelevancyScorer,
+    DeepEvalContextualPrecisionScorer,
+    DeepEvalContextualRecallScorer,
+    DeepEvalFaithfulnessScorer,
+)
 from weave.scorers.fluency_scorer import WeaveFluencyScorerV1
 from weave.scorers.hallucination_scorer import (
     HallucinationFreeScorer,
@@ -66,4 +72,8 @@ __all__ = [
     "WeaveHallucinationScorerV1",
     "WeaveContextRelevanceScorerV1",
     "WeaveTrustScorerV1",
+    "DeepEvalAnswerRelevancyScorer",
+    "DeepEvalContextualPrecisionScorer",
+    "DeepEvalContextualRecallScorer",
+    "DeepEvalFaithfulnessScorer",
 ]

--- a/weave/scorers/deepeval_scorer.py
+++ b/weave/scorers/deepeval_scorer.py
@@ -1,0 +1,137 @@
+from typing import Any
+import weave
+from weave.scorers.default_models import OPENAI_DEFAULT_MODEL
+from weave.scorers.scorer_types import LLMScorer
+
+try:
+    from deepeval.metrics import (
+        ContextualPrecisionMetric,
+        ContextualRecallMetric,
+        FaithfulnessMetric,
+        AnswerRelevancyMetric,
+    )
+    from deepeval.test_case import LLMTestCase
+except ImportError:
+    raise
+
+
+class DeepEvalContextualPrecisionScorer(LLMScorer):
+    model_id: str = OPENAI_DEFAULT_MODEL
+    threshold: float = 0.5
+    include_reason: bool = True
+    strict_mode: bool = False
+
+    @weave.op()
+    async def score(self, *, output: Any, **kwargs: Any) -> dict:
+        input_str = kwargs.get("input")
+        expected_output = kwargs.get("expected_output")
+        context = kwargs.get("context")
+
+        if not all([input_str, expected_output, context]):
+            raise ValueError("ContextualPrecisionScorer requires 'input', 'expected_output', and 'context' in kwargs.")
+
+        metric = ContextualPrecisionMetric(
+            threshold=self.threshold, 
+            model=self.model_id, 
+            include_reason=self.include_reason,
+            strict_mode=self.strict_mode, 
+            async_mode=True,
+        )
+        test_case = LLMTestCase(
+            input=input_str, 
+            actual_output=output, 
+            expected_output=expected_output,
+            retrieval_context=context
+        )
+        await metric.a_measure(test_case)
+        return {"score": metric.score, "reason": metric.reason}
+
+
+class DeepEvalContextualRecallScorer(LLMScorer):
+    model_id: str = OPENAI_DEFAULT_MODEL
+    threshold: float = 0.5
+    include_reason: bool = True
+    strict_mode: bool = False
+
+    @weave.op()
+    async def score(self, *, output: str, **kwargs: Any) -> dict:
+        input_str = kwargs.get("input")
+        expected_output = kwargs.get("expected_output")
+        context = kwargs.get("context")
+
+        assert isinstance(input_str, str)
+        assert isinstance(expected_output, str)
+        assert isinstance(context, list)
+
+        if not all([input_str, expected_output, context]):
+            raise ValueError("ContextualRecallScorer requires 'input', 'expected_output', and 'context' in kwargs.")
+
+        metric = ContextualRecallMetric(
+            threshold=self.threshold, model=self.model_id, include_reason=self.include_reason,
+            strict_mode=self.strict_mode, async_mode=True,
+        )
+        test_case = LLMTestCase(
+            input=input_str, actual_output=output, expected_output=expected_output,
+            retrieval_context=context
+        )
+        await metric.a_measure(test_case)
+        return {"score": metric.score, "reason": metric.reason}
+
+
+class DeepEvalFaithfulnessScorer(LLMScorer):
+    model_id: str = OPENAI_DEFAULT_MODEL
+    threshold: float = 0.5
+    include_reason: bool = True
+    strict_mode: bool = False
+
+    @weave.op()
+    async def score(self, *, output: str, **kwargs: Any) -> dict:
+        input_str = kwargs.get("input")
+        context = kwargs.get("context")
+
+        assert isinstance(input_str, str)
+        assert isinstance(context, list)
+
+
+        if not all([input_str, context]):
+            raise ValueError("FaithfulnessScorer requires 'input' and 'context' in kwargs.")
+
+        metric = FaithfulnessMetric(
+            threshold=self.threshold, 
+            model=self.model_id, 
+            include_reason=self.include_reason,
+            strict_mode=self.strict_mode, 
+            async_mode=True,
+        )
+        test_case = LLMTestCase(
+            input=input_str, actual_output=output, retrieval_context=context
+        )
+        await metric.a_measure(test_case)
+        return {"score": metric.score, "reason": metric.reason}
+
+
+class DeepEvalAnswerRelevancyScorer(LLMScorer):
+    model_id: str = OPENAI_DEFAULT_MODEL
+    threshold: float = 0.5
+    include_reason: bool = True
+    strict_mode: bool = False
+
+    @weave.op()
+    async def score(self, *, output: str, **kwargs: Any) -> dict:
+        input_str = kwargs.get("input")
+
+        assert isinstance(input_str, str)
+
+        if not input_str:
+            raise ValueError("AnswerRelevancyScorer requires 'input' in kwargs.")
+
+        metric = AnswerRelevancyMetric(
+            threshold=self.threshold, 
+            model=self.model_id, 
+            include_reason=self.include_reason,
+            strict_mode=self.strict_mode, 
+            async_mode=True,
+        )
+        test_case = LLMTestCase(input=input_str, actual_output=output)
+        await metric.a_measure(test_case)
+        return {"score": metric.score, "reason": metric.reason}


### PR DESCRIPTION
accompanies #4930 

## Description

This PR introduces a new integration with the popular LLM evaluation library, deepeval, to significantly enhance Weave's built-in support for RAG evaluation. It adds four of the most critical RAG metrics as native Weave scorers, addressing the gap identified in the linked issue.

This allows users to easily evaluate their RAG pipelines on dimensions like Faithfulness, Answer Relevancy, Contextual Precision, and Contextual Recall without leaving the Weave ecosystem.
What does the PR do? Include a concise description of the PR contents.

It adds four new scorer classes in weave/scorers/deepeval_scorer.py:

1. DeepEvalFaithfulnessScorer

2. DeepEvalAnswerRelevancyScorer

3. DeepEvalContextualPrecisionScorer

4. DeepEvalContextualRecallScorer

I'm new here but I've tried to match weave's scorer design pattern as closely as possible. I would be happy to work on the feedback provided by weave team!

## Testing

Comprehensive unit tests have been added in tests/scorers/test_deepeval_scorer.py.

The testing strategy focuses on validating the integration "glue code" without making external network calls to LLM providers. This is achieved by:

Using unittest.mock.patch to replace the actual deepeval metric classes with mock objects during testing.

Verifying that our Weave scorer classes correctly instantiate and call the underlying deepeval metric with the right data.

Asserting that the returned score dictionaries have the correct format.

This ensures the tests are fast, deterministic, and free to run.

