### PR TITLE
chore(weave): Code Refactor: Datasets 1

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CreateDatasetDrawerContext.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CreateDatasetDrawerContext.tsx
@@ -96,6 +96,7 @@ interface CreateDatasetContextType {
   state: CreateDatasetState;
   dispatch: Dispatch<CreateDatasetAction>;
   parseFile: (file: File) => Promise<void>;
+  initializeDataset: (transformedRows: Record<string, any>[]) => void;
   handleCloseDrawer: () => void;
   handlePublishDataset: () => void;
   clearDataset: () => void;
@@ -133,6 +134,50 @@ const CreateDatasetProviderInner: React.FC<{
     message: string;
     row?: number;
   }
+
+  const initializeDataset = useCallback(
+    (transformedRows: Record<string, any>[]) => {
+      // Add weave metadata to each row
+      transformedRows = transformedRows.map(
+        (row: Record<string, any>, index: number) => ({
+          ...row,
+          ___weave: {
+            id: `row-${index}`,
+            index,
+            isNew: true,
+          },
+        })
+      );
+
+      // Create a Map of the transformed rows for the editor context
+      const rowsMap = new Map<string, any>(
+        transformedRows.map((row: Record<string, any>) => [
+          row.___weave.id,
+          row,
+        ])
+      );
+
+      const transformedData: DatasetObjectVal = {
+        _type: 'Dataset',
+        name: state.datasetName || null,
+        description: null,
+        rows: JSON.stringify(transformedRows),
+        _class_name: 'Dataset',
+        _bases: ['Object', 'BaseModel'],
+      };
+
+      dispatch({
+        type: CREATE_DATASET_ACTIONS.SET_PARSED_DATA,
+        payload: transformedData,
+      });
+
+      // Initialize the editor context with the transformed rows
+      editorContext.setEditedRows(new Map());
+      editorContext.setDeletedRows([]);
+      editorContext.setAddedRows(rowsMap);
+    },
+    [dispatch, state.datasetName, editorContext]
+  );
 
   const parseFile = useCallback(
     async (file: File) => {
@@ -196,44 +241,7 @@ const CreateDatasetProviderInner: React.FC<{
             );
         }
 
-        // Add weave metadata to each row
-        transformedRows = transformedRows.map(
-          (row: Record<string, any>, index: number) => ({
-            ...row,
-            ___weave: {
-              id: `row-${index}`,
-              index,
-              isNew: true,
-            },
-          })
-        );
-
-        // Create a Map of the transformed rows for the editor context
-        const rowsMap = new Map<string, any>(
-          transformedRows.map((row: Record<string, any>) => [
-            row.___weave.id,
-            row,
-          ])
-        );
-
-        const transformedData: DatasetObjectVal = {
-          _type: 'Dataset',
-          name: state.datasetName || null,
-          description: null,
-          rows: JSON.stringify(transformedRows),
-          _class_name: 'Dataset',
-          _bases: ['Object', 'BaseModel'],
-        };
-
-        dispatch({
-          type: CREATE_DATASET_ACTIONS.SET_PARSED_DATA,
-          payload: transformedData,
-        });
-
-        // Initialize the editor context with the transformed rows
-        editorContext.setEditedRows(new Map());
-        editorContext.setDeletedRows([]);
-        editorContext.setAddedRows(rowsMap);
+        initializeDataset(transformedRows);
       } catch (error) {
         dispatch({
           type: CREATE_DATASET_ACTIONS.SET_ERROR,
@@ -244,7 +252,7 @@ const CreateDatasetProviderInner: React.FC<{
         dispatch({type: CREATE_DATASET_ACTIONS.SET_IS_LOADING, payload: false});
       }
     },
-    [dispatch, state.datasetName, editorContext]
+    [initializeDataset]
   );
 
   // Handle drawer close
@@ -281,6 +289,7 @@ const CreateDatasetProviderInner: React.FC<{
         state,
         dispatch,
         parseFile,
+        initializeDataset,
         handleCloseDrawer,
         handlePublishDataset,
         clearDataset,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.test.ts
@@ -89,7 +89,7 @@ describe('updateExistingDataset', () => {
 
   it('should update existing dataset with new version', async () => {
     mockTableUpdate.mockResolvedValue({digest: 'updated-digest'});
-    mockObjCreate.mockResolvedValue("v2");
+    mockObjCreate.mockResolvedValue('v2');
 
     const result = await updateExistingDataset(updateOptions);
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.test.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.test.ts
@@ -31,11 +31,12 @@ describe('createNewDataset', () => {
 
   it('should create a new dataset with initial data', async () => {
     mockTableCreate.mockResolvedValue({digest: 'new-digest'});
-    mockObjCreate.mockResolvedValue({version: 'v1'});
+    mockObjCreate.mockResolvedValue('v1');
 
     const result = await createNewDataset(createOptions);
 
     expect(result).toEqual({
+      objectDigest: 'v1',
       url: '/mock-url',
       objectId: 'new-dataset',
     });
@@ -88,11 +89,12 @@ describe('updateExistingDataset', () => {
 
   it('should update existing dataset with new version', async () => {
     mockTableUpdate.mockResolvedValue({digest: 'updated-digest'});
-    mockObjCreate.mockResolvedValue({version: 'v2'});
+    mockObjCreate.mockResolvedValue("v2");
 
     const result = await updateExistingDataset(updateOptions);
 
     expect(result).toEqual({
+      objectDigest: 'v2',
       url: '/mock-url',
       objectId: 'dataset-123',
     });

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.ts
@@ -30,7 +30,7 @@ export interface UpdateDatasetOptions {
     {pop: {index: number}} | {insert: {index: number; row: Record<string, any>}}
   >;
   tableUpdate: (useTableUpdateParams: UseTableUpdateParams) => Promise<any>;
-  objCreate: (useObjCreateParams: UseObjCreateParams) => Promise<any>;
+  objCreate: (useObjCreateParams: UseObjCreateParams) => Promise<string>;
   router: any;
 }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.ts
@@ -43,7 +43,11 @@ export const createNewDataset = async ({
   tableCreate,
   objCreate,
   router,
-}: CreateNewDatasetOptions) => {
+}: CreateNewDatasetOptions): Promise<{
+  url: string;
+  objectId: string;
+  objectDigest: string;
+}> => {
   const newTableResult = await tableCreate({
     table: {
       project_id: projectId,
@@ -88,6 +92,7 @@ export const createNewDataset = async ({
   return {
     url: newDatasetUrl,
     objectId: datasetName,
+    objectDigest: newDatasetResp,
   };
 };
 
@@ -141,5 +146,6 @@ export const updateExistingDataset = async ({
   return {
     url: updatedDatasetUrl,
     objectId: selectedDataset.objectId,
+    objectDigest: updatedDatasetResp,
   };
 };


### PR DESCRIPTION
I am using the dataset editor in the Eval Playground and need to refactor some dataset code. This PR extracts the non-functional changes for easier review.

Specifically:
1. Extracts `DatasetFilePicker` for external use in `weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CreateDatasetDrawer.tsx`. This will allow me to directly embed this in another part of the app.
2. Exposes `initializeDataset` as part of the CreateDatasetDrawerContext in `weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/CreateDatasetDrawerContext.tsx`. This allows me to directly bootstrap a new dataset with raw data
3. Correctly types `createNewDataset` and allows me to get the ref back out `weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/datasetOperations.ts`
4. Extends useDatasetSaving to optionally show toast and return the ref: `weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/useDatasetSaving.tsx`