### PR TITLE
fix(weave): fix scroll not reaching bottom of code

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/OpCodeViewer.tsx
@@ -29,6 +29,7 @@ const OpCodeViewerContainer = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 `;
 OpCodeViewerContainer.displayName = 'S.OpCodeViewerContainer';
 
@@ -41,6 +42,12 @@ const SelectVersionBar = styled.div`
   display: flex;
 `;
 SelectVersionBar.displayName = 'S.SelectVersionBar';
+
+const ContentArea = styled.div`
+  flex: 1;
+  overflow: auto;
+`;
+ContentArea.displayName = 'S.ContentArea';
 
 const VersionHeader = styled.div`
   display: flex;
@@ -155,7 +162,9 @@ export const OpCodeViewer = ({
     <OpCodeViewerContainer>
       {diffBar}
       {diffState.left == null || diffState.right == null ? (
-        <OpDefCode uri={currentVersionURI} />
+        <ContentArea>
+          <OpDefCode uri={currentVersionURI} />
+        </ContentArea>
       ) : (
         <>
           <SelectVersionBar>
@@ -190,11 +199,13 @@ export const OpCodeViewer = ({
               />
             </VersionHeader>
           </SelectVersionBar>
-          <OpCodeViewerDiff
-            left={diffState.left}
-            right={diffState.right}
-            onSplitResize={onSplitResize}
-          />
+          <ContentArea>
+            <OpCodeViewerDiff
+              left={diffState.left}
+              right={diffState.right}
+              onSplitResize={onSplitResize}
+            />
+          </ContentArea>
         </>
       )}
     </OpCodeViewerContainer>


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-25598

What does the PR do? Include a concise description of the PR contents.
Added a parent container for the code viewer with some styling for overflow handling

## Testing
Bug was reproduced: In the view accessible by clicking on the op+version from the summary tab the code tab is opened by default and does not reach the bottom.
After this change, even when first opened the code will scroll to the bottom

![image](https://github.com/user-attachments/assets/c451eed7-c155-4685-902b-5a7ae7975bef)

