### PR TITLE
fix(app): Fix 3D bounding box colors

### DIFF
--- a/weave-js/src/common/util/render_babylon.ts
+++ b/weave-js/src/common/util/render_babylon.ts
@@ -539,7 +539,8 @@ const pointCloudScene = (
       textBlock.linkOffsetY = -20;
     }
 
-    lines.color = new Color3(...color);
+    // Babylon expects colors in the range 0-1 but our sdk is expecting 0-255. So convert it here.
+    lines.color = new Color3(color[0] / 255, color[1] / 255, color[2] / 255);
   });
 
   itemsInScene.push(pcMesh);


### PR DESCRIPTION
## Description

- https://wandb.atlassian.net/browse/WB-16573

Babylon expects colors in the range 0-1 https://doc.babylonjs.com/typedoc/classes/BABYLON.Color3#constructorcolor3 but our sdk expects them in the range 0-255 https://docs.wandb.ai/guides/track/log/media/#3d-visualizations. So we need to divide by 255 before we pass them into Babylon.

## Testing

How was this PR tested?

Before - any value that is not 0 is interpreted the same as 255, causing the bounding box to be white if all three rgb values are different from 0 regardless of their value:


https://github.com/user-attachments/assets/7e5c922e-96e6-482c-b018-87035eabbda9


After - bounding box values are correctly interpreted for their intended colors:

https://github.com/user-attachments/assets/db72b5fb-2ffb-44ce-a7c3-5db1dc28dfb2


