### PR TITLE
fix(ui): Page crash in chat view for OpenAI responses when exception was thrown

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatFormats/openai.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ChatView/ChatFormats/openai.ts
@@ -174,7 +174,8 @@ export const isTraceCallChatFormatOAIResponses = (
 ): boolean => {
   return (
     isTraceCallChatFormatOAIResponsesRequest(call.inputs) &&
-    isTraceCallChatFormatOAIResponsesResult(call.output)
+    (call.output == null ||
+      isTraceCallChatFormatOAIResponsesResult(call.output))
   );
 };
 


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-25767

If an exception was thrown during op execution, call.output will be null. Our checking for whether the call matches the OpenAI responses format was not handling this case.

```
TypeError: Cannot use 'in' operator to search for 'object' in null
 at isTraceCallChatFormatOAIResponsesResult
```

## Testing

How was this PR tested?
