### PR TITLE
fix(weave): Make scorer column mapping work with scorers that use kwargs

### DIFF
--- a/weave/flow/scorer.py
+++ b/weave/flow/scorer.py
@@ -249,7 +249,7 @@ def preparer_scorer_op_args(
 
         # Build arguments dictionary using column mapping
         for arg in score_arg_names:
-            if arg == "output" or arg == "model_output":
+            if arg in ("output", "model_output", "kwargs"):
                 continue
             if arg in example:
                 score_args[arg] = example[arg]


### PR DESCRIPTION
Previously we did not skip 'kwargs' which would cause column mappings to fail