### PR TITLE
fix(weave): Fetch correct scorer in monitor form

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorFormDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorFormDrawer.tsx
@@ -169,7 +169,6 @@ export const MonitorFormDrawer = ({
     });
     setFilterModel(queryToGridFilterModel(monitor.val['query']) ?? {items: []});
     setSelectedOpVersionOption(monitor.val['op_names'] ?? []);
-    //setScorers(existingScorers ?? []);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [monitor]);
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorFormDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorFormDrawer.tsx
@@ -70,8 +70,9 @@ const SCORER_FORMS: Map<string, ScorerFormType | null> = new Map([
 ]);
 
 export const MonitorDrawerRouter = (props: MonitorFormDrawerProps) => {
+  // Empty props.monitor.val['scorers'] should not happen but some such monitors
+  // were persisted in the DB due to an early bug.
   if (props.monitor && props.monitor.val['scorers'].length > 0) {
-    console.log('EditMonitorDrawerWithScorers props.monitor', props.monitor);
     return (
       <EditMonitorDrawerWithScorers {...props} monitor={props.monitor} /> // Repeating monitor to appease type checking
     );

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorFormDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorFormDrawer.tsx
@@ -30,18 +30,22 @@ import {queryToGridFilterModel} from '@wandb/weave/components/PagePanelComponent
 import {useWFHooks} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/context';
 import {
   useObjCreate,
-  useRootObjectVersions,
+  useObjectVersion,
 } from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks';
-import {ObjectVersionSchema} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
+import {
+  ObjectVersionKey,
+  ObjectVersionSchema,
+} from '@wandb/weave/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface';
 import {
   Root as SwitchRoot,
   Thumb as SwitchThumb,
 } from '@wandb/weave/components/Switch';
 import {Tailwind} from '@wandb/weave/components/Tailwind';
-import {parseRef} from '@wandb/weave/react';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {toast} from 'react-toastify';
 import {useList} from 'react-use';
+
+import {refUriToObjectVersionKey} from '../wfReactInterface/utilities';
 
 const PAGE_SIZE = 10;
 const PAGE_OFFSET = 0;
@@ -66,7 +70,8 @@ const SCORER_FORMS: Map<string, ScorerFormType | null> = new Map([
 ]);
 
 export const MonitorDrawerRouter = (props: MonitorFormDrawerProps) => {
-  if (props.monitor) {
+  if (props.monitor && props.monitor.val['scorers'].length > 0) {
+    console.log('EditMonitorDrawerWithScorers props.monitor', props.monitor);
     return (
       <EditMonitorDrawerWithScorers {...props} monitor={props.monitor} /> // Repeating monitor to appease type checking
     );
@@ -77,27 +82,20 @@ export const MonitorDrawerRouter = (props: MonitorFormDrawerProps) => {
 const EditMonitorDrawerWithScorers = (
   props: MonitorFormDrawerProps & {monitor: ObjectVersionSchema}
 ) => {
-  const {entity, project} = useEntityProject();
-  const scorerIds: string[] = useMemo(() => {
-    return (
-      props.monitor.val['scorers'].map(
-        (scorerRefUri: string) => parseRef(scorerRefUri).artifactName
-      ) || []
-    );
-  }, [props.monitor]);
+  // Supporting only one scorer for now
+  const scorerVersionKey: ObjectVersionKey = useMemo(
+    () => refUriToObjectVersionKey(props.monitor.val['scorers'][0])!,
+    [props.monitor]
+  );
 
-  const {result: scorers, loading} = useRootObjectVersions({
-    entity,
-    project,
-    filter: {
-      objectIds: scorerIds,
-      latestOnly: true,
-    },
+  const {result: scorer, loading: scorerLoading} = useObjectVersion({
+    key: scorerVersionKey,
   });
-  return loading || !scorers ? (
+
+  return scorerLoading || !scorer ? (
     <WaveLoader size="huge" />
   ) : (
-    <MonitorFormDrawer {...props} scorers={scorers} />
+    <MonitorFormDrawer {...props} scorers={[scorer]} />
   );
 };
 
@@ -132,7 +130,7 @@ export const MonitorFormDrawer = ({
 
   const {useCalls} = useWFHooks();
 
-  const [scorers, {set: setScorers}] = useList<ObjectVersionSchema>(
+  const [scorers] = useList<ObjectVersionSchema>(
     existingScorers || [
       {
         scheme: 'weave',
@@ -169,7 +167,7 @@ export const MonitorFormDrawer = ({
     });
     setFilterModel(queryToGridFilterModel(monitor.val['query']) ?? {items: []});
     setSelectedOpVersionOption(monitor.val['op_names'] ?? []);
-    setScorers(existingScorers ?? []);
+    //setScorers(existingScorers ?? []);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [monitor]);
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorFormDrawer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/MonitorsPage/MonitorFormDrawer.tsx
@@ -72,6 +72,7 @@ const SCORER_FORMS: Map<string, ScorerFormType | null> = new Map([
 export const MonitorDrawerRouter = (props: MonitorFormDrawerProps) => {
   // Empty props.monitor.val['scorers'] should not happen but some such monitors
   // were persisted in the DB due to an early bug.
+  // Fixed here: https://github.com/wandb/weave/pull/4945
   if (props.monitor && props.monitor.val['scorers'].length > 0) {
     return (
       <EditMonitorDrawerWithScorers {...props} monitor={props.monitor} /> // Repeating monitor to appease type checking


### PR DESCRIPTION
Before this PR, the monitor form would always fetch the latest object named after the scorer object. Those names are not unique across object types.
In the case where the user names the scorer the same as the monitor, the fetched scorer would actually be the monitor object, resulting in the form not showing the scorer sub-form. Then upon saving, the scorer is removed from the monitor.

This PR uses the exact scorer version key to fetch it from the server.