### PR TITLE
fix(weave): contains operator work with json arrays

### DIFF
--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -831,6 +831,15 @@ class CallsQuery(BaseModel):
             on calls_merged.trace_id = {ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME}.trace_id
             """
 
+        session_settings_sql = ""
+        if any(
+            isinstance(field, CallsMergedAggField) and field.is_heavy()
+            for field in self.select_fields
+        ):
+            session_settings_sql = (
+                "SETTINGS function_json_value_return_type_allow_complex = 1"
+            )
+
         raw_sql = f"""
         SELECT {select_fields_sql}
         FROM calls_merged
@@ -854,7 +863,10 @@ class CallsQuery(BaseModel):
         {order_by_sql}
         {limit_sql}
         {offset_sql}
+        {session_settings_sql}
         """
+
+        print(safely_format_sql(raw_sql, logger))
 
         return safely_format_sql(raw_sql, logger)
 

--- a/weave/trace_server/calls_query_builder/optimization_builder.py
+++ b/weave/trace_server/calls_query_builder/optimization_builder.py
@@ -423,12 +423,7 @@ def _create_like_optimized_eq_condition(
         # Empty string is not a valid value for LIKE optimization
         return None
 
-    # Boolean literals are not wrapped in quotes in JSON payloads
-    if literal_value in ("true", "false"):
-        like_pattern = f"%{literal_value}%"
-    else:
-        like_pattern = f'%"{literal_value}"%'
-
+    like_pattern = f"%{literal_value}%"
     like_condition = _create_like_condition(field, like_pattern, pb, table_alias)
     if _field_requires_null_check(field):
         return f"({like_condition} OR {table_alias}.{field} IS NULL)"
@@ -464,7 +459,7 @@ def _create_like_optimized_contains_condition(
         return None
 
     case_insensitive = operation.contains_.case_insensitive or False
-    like_pattern = f'%"%{substr_value}%"%'
+    like_pattern = f"%{substr_value}%"
 
     like_condition = _create_like_condition(
         field, like_pattern, pb, table_alias, case_insensitive
@@ -510,7 +505,7 @@ def _create_like_optimized_in_condition(
         ):
             return None
 
-        like_pattern = f'%"{value_operand.literal_}"%'
+        like_pattern = f"%{value_operand.literal_}%"
         like_condition = _create_like_condition(field, like_pattern, pb, table_alias)
         like_conditions.append(like_condition)
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -479,6 +479,8 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             pb.get_params(),
         )
 
+        print("parameters", pb.get_params())
+
         select_columns = [c.field for c in cq.select_fields]
         expand_columns = req.expand_columns or []
         include_feedback = req.include_feedback or False


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25645](https://wandb.atlassian.net/browse/WB-25645)

Now the filter bar supports "contains" operations on json keys to complex values like lists. 

We do this by adding a setting to the calls query, with the `SETTINGS` block appendix. 

## Testing

Prod
![Screenshot 2025-07-01 at 1 02 16 PM](https://github.com/user-attachments/assets/fc1235dc-4432-44ed-a73b-a1f713733d35)

Branch
![Screenshot 2025-07-01 at 1 02 41 PM](https://github.com/user-attachments/assets/fd97f4ca-dafa-43b4-aa67-497aac4bb71b)
