### PR TITLE
chore(weave): Update clickhouse server version test pin

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -311,7 +311,7 @@ jobs:
         ports:
           - "10000:10000"
       weave_clickhouse:
-        image: clickhouse/clickhouse-server:24.12
+        image: clickhouse/clickhouse-server:25.4
         env:
           CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
           CLICKHOUSE_USER: default


### PR DESCRIPTION
Update clickhouse server version test pin from `24.12` to `25.4` to match prod