### PR TITLE
chore(weave): Remove omitted admin-only feature gate for online evals

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -6,7 +6,6 @@ import {Popover} from '@mui/material';
 import {GridFilterItem, GridFilterModel} from '@mui/x-data-grid-pro';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
-import {useViewerInfo} from '../../../../../common/hooks/useViewerInfo';
 import {Button} from '../../../../Button';
 import {DraggableGrow, DraggableHandle} from '../../../../DraggablePopups';
 import {IconFilterAlt} from '../../../../Icon';
@@ -83,9 +82,6 @@ export const FilterBar = ({
   const [incompleteFilters, setIncompleteFilters] = useState<GridFilterItem[]>(
     []
   );
-
-  const {loading, userInfo} = useViewerInfo();
-  const isWandbAdmin = (!loading && userInfo?.admin) ?? false;
 
   // Merge the parent filter model with our incomplete filters
   useEffect(() => {
@@ -181,13 +177,11 @@ export const FilterBar = ({
     value: 'id',
     label: 'Call ID',
   });
-  if (isWandbAdmin) {
-    (options[0] as GroupedOption).options.push({
-      value: MONITORED_FILTER_VALUE,
-      label: 'Monitored',
-      description: 'Find all calls scored by a particular monitor',
-    });
-  }
+  (options[0] as GroupedOption).options.push({
+    value: MONITORED_FILTER_VALUE,
+    label: 'Monitored',
+    description: 'Find all calls scored by a particular monitor',
+  });
 
   const onRemoveAll = () => {
     // Check if there's only one filter and it's a datetime filter


### PR DESCRIPTION
I forgot to remove the feature gate around the "Monitored by" filter option.