### PR TITLE
chore(ui): add alternate get example for models and other objects

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
@@ -462,7 +462,9 @@ const ObjectVersionPageInner: React.FC<{
                   <TabUseModel
                     name={objectName}
                     uri={refUri}
+                    entityName={entityName}
                     projectName={projectName}
+                    versionIndex={objectVersionIndex}
                   />
                 ) : baseObjectClass === 'AnnotationSpec' ? (
                   <TabUseAnnotationSpec
@@ -472,7 +474,13 @@ const ObjectVersionPageInner: React.FC<{
                     data={viewerDataAsObject}
                   />
                 ) : (
-                  <TabUseObject name={objectName} uri={refUri} />
+                  <TabUseObject
+                    name={objectName}
+                    uri={refUri}
+                    entityName={entityName}
+                    projectName={projectName}
+                    versionIndex={objectVersionIndex}
+                  />
                 )}
               </Tailwind>
             </ScrollableTabContent>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/Tabs/TabUseModel.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/Tabs/TabUseModel.tsx
@@ -11,14 +11,25 @@ import {TabUseBanner} from '../../common/TabUseBanner';
 type TabUseModelProps = {
   name: string;
   uri: string;
+  entityName: string;
   projectName: string;
+  versionIndex: number;
 };
 
-export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
+export const TabUseModel = ({
+  name,
+  uri,
+  entityName,
+  projectName,
+  versionIndex,
+}: TabUseModelProps) => {
   const pythonName = isValidVarName(name) ? name : 'model';
   const ref = parseRef(uri);
   const isParentObject = !ref.artifactRefExtra;
   const label = isParentObject ? 'model version' : 'object';
+
+  const long = `weave.init('${entityName}/${projectName}')
+${pythonName} = weave.ref('${name}:v${versionIndex}').get()`;
 
   return (
     <Box className="text-sm">
@@ -40,6 +51,8 @@ export const TabUseModel = ({name, uri, projectName}: TabUseModelProps) => {
           copyText={`${pythonName} = weave.ref("${uri}").get()`}
           tooltipText="Click to copy unabridged string"
         />
+        <div className="mt-8">or</div>
+        <CopyableText language="python" text={long} />
       </Box>
       {/* Temporarily commenting this out until the serve and deploy features are fixed */}
       {/* {isParentObject && (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/Tabs/TabUseObject.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/Tabs/TabUseObject.tsx
@@ -10,10 +10,22 @@ import {TabUseBanner} from '../../common/TabUseBanner';
 type TabUseObjectProps = {
   name: string;
   uri: string;
+  entityName: string;
+  projectName: string;
+  versionIndex: number;
 };
 
-export const TabUseObject = ({name, uri}: TabUseObjectProps) => {
+export const TabUseObject = ({
+  name,
+  uri,
+  entityName,
+  projectName,
+  versionIndex,
+}: TabUseObjectProps) => {
   const pythonName = isValidVarName(name) ? name : 'obj';
+  const long = `weave.init('${entityName}/${projectName}')
+${pythonName} = weave.ref('${name}:v${versionIndex}').get()`;
+
   return (
     <Box className="text-sm">
       <TabUseBanner>
@@ -37,6 +49,8 @@ export const TabUseObject = ({name, uri}: TabUseObjectProps) => {
           copyText={`${pythonName} = weave.ref("${uri}").get()`}
           tooltipText="Click to copy unabridged string"
         />
+        <div className="mt-8">or</div>
+        <CopyableText language="python" text={long} />
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Description

Same change as in https://github.com/wandb/weave/pull/4944 but for models and other Weave objects. Adds an example to the Use tabs showing how to access with a name and version index instead of complete URI.

<img width="638" alt="Screenshot 2025-07-02 at 2 36 59 PM" src="https://github.com/user-attachments/assets/5087e79c-3d2d-4aed-bfdf-6f012f55cb7f" />

## Testing

Checked copied code samples in ipython