### PR TITLE
feat(weave): Saved view support for Threads page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadsPage/ThreadsPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadsPage/ThreadsPage.tsx
@@ -1,25 +1,78 @@
 import {
+  GridColumnVisibilityModel,
   GridFilterModel,
   GridPaginationModel,
+  GridPinnedColumnFields,
   GridSortModel,
 } from '@mui/x-data-grid-pro';
-import React, {FC, useMemo} from 'react';
+import _ from 'lodash';
+import React, {FC, useCallback, useMemo, useState} from 'react';
+import {useHistory} from 'react-router-dom';
+import {useAsyncFn} from 'react-use';
 
+import {toast} from '../../../../../../common/components/elements/Toast';
 import {Tailwind} from '../../../../../Tailwind';
 import {
   WeaveHeaderExtrasContext,
   WeaveHeaderExtrasProvider,
 } from '../../context';
+import {useEntityProject} from '../../context';
 import {
   SimplePageLayout,
   SimplePageLayoutContext,
 } from '../common/SimplePageLayout';
 import {SavedViewPrefix} from '../SavedViews/SavedViewPrefix';
 import {SavedViewSuffix} from '../SavedViews/SavedViewSuffix';
-import {getDefaultViewId, SavedViewsInfo} from '../SavedViews/savedViewUtil';
+import {
+  convertGridSortItemToSortBy,
+  getDefaultViewId,
+  getNewViewId,
+  savedViewDefinitionToParams,
+  SavedViewsInfo,
+  uiFormatFiltersToQuery,
+  useCreateSavedView,
+} from '../SavedViews/savedViewUtil';
 import {ViewName} from '../SavedViews/ViewName';
+import {ViewNameEditing} from '../SavedViews/ViewNameEditing';
+import {SavedViewDefinition} from '../wfReactInterface/generatedBuiltinObjectClasses.zod';
+import {useGetTraceServerClientContext} from '../wfReactInterface/traceServerClientContext';
 import {TraceObjSchema} from '../wfReactInterface/traceServerClientTypes';
+import {projectIdFromParts} from '../wfReactInterface/tsDataModelHooks';
 import {ThreadsTable} from './ThreadsTable';
+
+// Current view definition for threads
+const useCurrentViewDefinitionForThreads = (
+  baseView: TraceObjSchema,
+  filterModel: GridFilterModel,
+  sortModel: GridSortModel,
+  paginationModel: GridPaginationModel,
+  columnVisibilityModel: GridColumnVisibilityModel,
+  pinModel: GridPinnedColumnFields
+): SavedViewDefinition => {
+  return useMemo(() => {
+    const query = uiFormatFiltersToQuery(filterModel as any);
+    const sort_by = sortModel.map(convertGridSortItemToSortBy);
+
+    return {
+      ...baseView.val.definition,
+      ...(query && {query}),
+      ...(sort_by.length > 0 && {sort_by}),
+      page_size: paginationModel.pageSize,
+      cols: columnVisibilityModel,
+      pin: pinModel,
+    };
+  }, [
+    baseView.val.definition,
+    filterModel,
+    sortModel,
+    paginationModel,
+    columnVisibilityModel,
+    pinModel,
+  ]);
+};
+
+// For threads, we now track filters, sort, pageSize, cols, pin
+const THREADS_PARAM_KEYS = ['filters', 'sort', 'pageSize', 'cols', 'pin'];
 
 const HeaderExtras = () => {
   const {renderExtras} = React.useContext(WeaveHeaderExtrasContext);
@@ -35,6 +88,12 @@ export const ThreadsPage: FC<{
   onRecordLastView: (view: string) => void;
   fetchViews: () => void;
 
+  columnVisibilityModel: GridColumnVisibilityModel;
+  setColumnVisibilityModel: (newModel: GridColumnVisibilityModel) => void;
+
+  pinModel: GridPinnedColumnFields;
+  setPinModel: (newModel: GridPinnedColumnFields) => void;
+
   filterModel: GridFilterModel;
   setFilterModel: (newModel: GridFilterModel) => void;
 
@@ -44,34 +103,209 @@ export const ThreadsPage: FC<{
   paginationModel: GridPaginationModel;
   setPaginationModel: (newModel: GridPaginationModel) => void;
 }> = props => {
-  const {baseView, views} = props;
+  const {entity, project} = useEntityProject();
+  const {baseView, views, fetchViews, onRecordLastView} = props;
 
   const table = 'threads';
   const view = baseView.object_id;
+
+  const getTsClient = useGetTraceServerClientContext();
+  const tsClient = getTsClient();
+  const currentViewDefinition = useCurrentViewDefinitionForThreads(
+    baseView,
+    props.filterModel,
+    props.sortModel,
+    props.paginationModel,
+    props.columnVisibilityModel,
+    props.pinModel
+  );
+  const history = useHistory();
+
+  const createSavedView = useCreateSavedView(entity, project, table);
+
+  const [upsertState, onUpsertView] = useAsyncFn(
+    async (
+      objectId: string,
+      label: string | null,
+      successMessage: string,
+      reloadAfter: boolean
+    ) => {
+      try {
+        const resolvedLabel = label ?? baseView.val.label;
+        await createSavedView(objectId, resolvedLabel, currentViewDefinition);
+
+        const newQuery = new URLSearchParams(history.location.search);
+        newQuery.set('view', objectId);
+        history.push({search: newQuery.toString()});
+
+        if (reloadAfter) {
+          fetchViews();
+        }
+
+        toast(successMessage);
+        onRecordLastView(objectId);
+      } catch (error) {
+        toast('Failed to persist Saved View.', {
+          type: 'error',
+        });
+        throw error; // Re-throw to maintain useAsyncFn error state if needed
+      }
+    },
+    [
+      baseView.val.label,
+      createSavedView,
+      currentViewDefinition,
+      fetchViews,
+      history,
+      onRecordLastView,
+    ]
+  );
+
+  const onLoadView = useCallback(
+    (viewToLoad: TraceObjSchema) => {
+      // We want to preserve any params that are not part of view definition,
+      // e.g. peek drawer state.
+      const newQuery = new URLSearchParams(history.location.search);
+
+      // Clear out any params related to saved views
+      for (const key of THREADS_PARAM_KEYS) {
+        newQuery.delete(key);
+      }
+
+      // Update with params from the view definition
+      const params = savedViewDefinitionToParams(viewToLoad.val.definition);
+      for (const [key, value] of Object.entries(params)) {
+        if (THREADS_PARAM_KEYS.includes(key)) {
+          newQuery.set(key, JSON.stringify(value));
+        }
+      }
+
+      newQuery.set('view', viewToLoad.object_id);
+      history.push({search: newQuery.toString()});
+      props.onRecordLastView(viewToLoad.object_id);
+    },
+    [history, props]
+  );
+
+  const onResetView = useCallback(() => {
+    let viewToLoad = views?.find(v => v.object_id === view);
+    if (!viewToLoad) {
+      const defaultViewId = getDefaultViewId(table);
+      viewToLoad = views?.find(v => v.object_id === defaultViewId);
+    }
+    if (viewToLoad) {
+      onLoadView(viewToLoad);
+    } else {
+      console.error('could not find view to reset to');
+    }
+  }, [views, view, onLoadView]);
+
+  const onSaveNewView = useCallback(() => {
+    const objectId = getNewViewId(table);
+    const newName = 'Untitled view';
+    // Update the local state with the new name
+    baseView.val.label = newName;
+    onUpsertView(objectId, newName, 'Successfully created new view.', true);
+  }, [table, baseView, onUpsertView]);
+
+  const onSaveView = useCallback(() => {
+    if (view === getDefaultViewId(table)) {
+      onSaveNewView();
+      return;
+    }
+    onUpsertView(view, null, 'Successfully saved view.', true);
+  }, [view, table, onSaveNewView, onUpsertView]);
+
+  const onRenameView = useCallback(
+    (newName: string) => {
+      onUpsertView(view, newName, 'Successfully renamed view.', false);
+    },
+    [view, onUpsertView]
+  );
+
+  const [, onDeleteView] = useAsyncFn(async () => {
+    try {
+      await tsClient.objDelete({
+        project_id: projectIdFromParts({entity, project}),
+        object_id: view,
+      });
+
+      // Don't need to fetch views again as we will reload the page.
+      // Using history replace instead of push because can't navigate back to deleted view.
+      toast('Successfully deleted view.');
+      onRecordLastView(getDefaultViewId(table));
+      const newQuery = new URLSearchParams();
+      history.replace({search: newQuery.toString()});
+    } catch (error) {
+      toast('Failed to delete view.', {
+        type: 'error',
+      });
+      throw error; // Re-throw to maintain useAsyncFn error state if needed
+    }
+  }, [tsClient, entity, project, view, onRecordLastView, table, history]);
 
   const savedViewsInfo: SavedViewsInfo = useMemo(
     () => ({
       currentViewerId: props.currentViewerId,
       currentViewId: view,
-      currentViewDefinition: baseView.val.definition,
+      currentViewDefinition,
       isDefault: view === getDefaultViewId(table),
-      isModified: false, // Simplified for threads
-      isSaving: false,
+      isModified: !_.isEqual(currentViewDefinition, baseView.val.definition),
+      isSaving: upsertState.loading,
       views,
       baseView,
-      onLoadView: () => {}, // Simplified for threads
-      onSaveView: () => {}, // Simplified for threads
-      onSaveNewView: () => {}, // Simplified for threads
-      onResetView: () => {}, // Simplified for threads
-      onDeleteView: () => {}, // Simplified for threads
+      onLoadView,
+      onSaveView,
+      onSaveNewView,
+      onResetView,
+      onDeleteView,
     }),
-    [props.currentViewerId, view, baseView, views, table]
+    [
+      props.currentViewerId,
+      view,
+      currentViewDefinition,
+      table,
+      baseView,
+      upsertState.loading,
+      views,
+      onLoadView,
+      onSaveView,
+      onSaveNewView,
+      onResetView,
+      onDeleteView,
+    ]
+  );
+
+  const onNameChanged = useCallback(
+    (newName: string) => {
+      // Update the local state with the new name
+      baseView.val.label = newName;
+      // Update the server with the new name
+      onRenameView(newName);
+    },
+    [baseView, onRenameView]
   );
 
   const activeName = baseView.val.label ?? 'Threads view';
+  const [isEditingName, setIsEditingName] = useState(false);
+  const canEditName = !props.isReadonly && !savedViewsInfo.isDefault;
   const title = (
     <Tailwind>
-      <ViewName value={activeName} />
+      {!canEditName ? (
+        <ViewName value={activeName} />
+      ) : isEditingName ? (
+        <ViewNameEditing
+          value={activeName}
+          onChanged={onNameChanged}
+          onExit={() => setIsEditingName(false)}
+        />
+      ) : (
+        <ViewName
+          value={activeName}
+          onEditNameStart={() => setIsEditingName(true)}
+          tooltip="Click to rename view"
+        />
+      )}
     </Tailwind>
   );
 
@@ -102,6 +336,10 @@ export const ThreadsPage: FC<{
               label: 'All',
               content: (
                 <ThreadsTable
+                  columnVisibilityModel={props.columnVisibilityModel}
+                  setColumnVisibilityModel={props.setColumnVisibilityModel}
+                  pinModel={props.pinModel}
+                  setPinModel={props.setPinModel}
                   filterModel={props.filterModel}
                   setFilterModel={props.setFilterModel}
                   sortModel={props.sortModel}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadsPage/ThreadsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadsPage/ThreadsTable.tsx
@@ -1,7 +1,9 @@
 import {
   GridColDef,
+  GridColumnVisibilityModel,
   GridFilterModel,
   GridPaginationModel,
+  GridPinnedColumnFields,
   GridSortModel,
   useGridApiRef,
 } from '@mui/x-data-grid-pro';
@@ -57,6 +59,12 @@ const convertFilterModelToDatetimeFilters = (
 };
 
 export const ThreadsTable: FC<{
+  columnVisibilityModel: GridColumnVisibilityModel;
+  setColumnVisibilityModel: (newModel: GridColumnVisibilityModel) => void;
+
+  pinModel: GridPinnedColumnFields;
+  setPinModel: (newModel: GridPinnedColumnFields) => void;
+
   filterModel: GridFilterModel;
   setFilterModel: (newModel: GridFilterModel) => void;
 
@@ -66,6 +74,10 @@ export const ThreadsTable: FC<{
   paginationModel: GridPaginationModel;
   setPaginationModel: (newModel: GridPaginationModel) => void;
 }> = ({
+  columnVisibilityModel,
+  setColumnVisibilityModel,
+  pinModel,
+  setPinModel,
   filterModel,
   setFilterModel,
   sortModel,
@@ -338,6 +350,11 @@ export const ThreadsTable: FC<{
         rows={tableData}
         columns={columns}
         loading={loading}
+        // Column management
+        columnVisibilityModel={columnVisibilityModel}
+        onColumnVisibilityModelChange={setColumnVisibilityModel}
+        pinnedColumns={pinModel}
+        onPinnedColumnsChange={setPinModel}
         // Column Menu - disable filter and column management features
         disableColumnFilter={true}
         // Pagination


### PR DESCRIPTION
## Description

This PR supplements https://github.com/wandb/weave/pull/4889 which didn't support saved views properly.

- Enhances the Threads view with improved saved view functionality

This PR adds proper saved view functionality to the Threads page, matching the capabilities already available in Calls, Evaluations, and Traces views. It includes:

- Default configuration for Threads views with a 1-week filter and sorting by last_updated
- Support for saving column visibility and pin settings in Threads views
- Implementation of view renaming, saving, and deletion for Threads
- Refactored common configuration for Calls, Evaluations, and Traces into shared constants

## Testing

Tested by:
- Creating, saving, and loading Thread views with different configurations
- Verifying that column visibility, pin settings, filters, and sorts are properly persisted
- Confirming that the default 1-week filter works correctly for new Thread views
- Testing view renaming and deletion functionality