### PR TITLE
feat(weave): Show the thread detail drawer view

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -58,6 +58,7 @@ import {PlaygroundPage} from './Browse3/pages/PlaygroundPage/PlaygroundPage';
 import {ScorersPage} from './Browse3/pages/ScorersPage/ScorersPage';
 import {TablePage} from './Browse3/pages/TablePage';
 import {TablesPage} from './Browse3/pages/TablesPage';
+import {ThreadDetailPage} from './Browse3/pages/ThreadDetailPage/ThreadDetailPage';
 import {ThreadsPageLoadView} from './Browse3/pages/ThreadsPage/ThreadsPageLoadView';
 import {useURLSearchParamsDict} from './Browse3/pages/util';
 import {
@@ -420,6 +421,9 @@ const Browse3ProjectRoot: FC<{
         </Route>
         <Route path={`${projectRoot}/:tab(evaluations|traces|calls)`}>
           <CallsPageBinding />
+        </Route>
+        <Route path={`${projectRoot}/threads/:itemName`}>
+          <ThreadDetailPageBinding />
         </Route>
         <Route path={`${projectRoot}/threads`}>
           <ThreadsPageBinding />
@@ -1024,4 +1028,9 @@ const PlaygroundPageBinding = () => {
 const ThreadsPageBinding = () => {
   const query = useURLSearchParamsDict();
   return <ThreadsPageLoadView view={query.view} />;
+};
+
+const ThreadDetailPageBinding = () => {
+  const params = useParamsDecoded<Browse3TabItemParams>();
+  return <ThreadDetailPage threadId={params.itemName} />;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -218,6 +218,13 @@ export const browse2Context = {
   ) => {
     throw new Error('Not implemented');
   },
+
+  threadsUIUrl: (entityName: string, projectName: string) => {
+    throw new Error('Not implemented');
+  },
+  threadUIUrl: (entityName: string, projectName: string, threadId: string) => {
+    throw new Error('Not implemented');
+  },
 };
 
 export const browse3ContextGen = (
@@ -488,6 +495,16 @@ export const browse3ContextGen = (
         .join('&');
       return `${projectRoot(entityName, projectName)}/compare?${params}`;
     },
+    threadsUIUrl: (entityName: string, projectName: string) => {
+      return `${projectRoot(entityName, projectName)}/threads`;
+    },
+    threadUIUrl: (
+      entityName: string,
+      projectName: string,
+      threadId: string
+    ) => {
+      return `${projectRoot(entityName, projectName)}/threads/${threadId}`;
+    },
   };
   return browse3Context;
 };
@@ -587,6 +604,12 @@ type RouteType = {
     entityName: string,
     projectName: string,
     objectSpecifiers: string[]
+  ) => string;
+  threadsUIUrl: (entityName: string, projectName: string) => string;
+  threadUIUrl: (
+    entityName: string,
+    projectName: string,
+    threadId: string
   ) => string;
 };
 
@@ -718,6 +741,12 @@ const useMakePeekingRouter = (): RouteType => {
       ...args: Parameters<typeof baseContext.compareObjectsUri>
     ) => {
       return setSearchParam(PEEK_PARAM, baseContext.compareObjectsUri(...args));
+    },
+    threadsUIUrl: (...args: Parameters<typeof baseContext.threadsUIUrl>) => {
+      throw new Error('Threads list not available in peek mode');
+    },
+    threadUIUrl: (...args: Parameters<typeof baseContext.threadUIUrl>) => {
+      return setSearchParam(PEEK_PARAM, baseContext.threadUIUrl(...args));
     },
   };
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadDetailPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadDetailPage.tsx
@@ -1,0 +1,186 @@
+import {Button} from '@wandb/weave/components/Button';
+import {Icon} from '@wandb/weave/components/Icon';
+import {Tailwind} from '@wandb/weave/components/Tailwind';
+import React, {FC, useState} from 'react';
+
+import {useEntityProject} from '../../context';
+import {SimplePageLayout} from '../common/SimplePageLayout';
+import {SplitPanelLeft} from '../common/SplitPanels/SplitPanelLeft';
+import {SplitPanelRight} from '../common/SplitPanels/SplitPanelRight';
+import {StatusChip} from '../common/StatusChip';
+import {ComputedCallStatusType} from '../wfReactInterface/traceServerClientTypes';
+import {useThreadTurns} from '../wfReactInterface/tsDataModelHooks';
+import {ThreadMetadata} from './ThreadMetadata';
+import {ThreadTurnDetails} from './ThreadTurnDetails';
+import {ThreadTurnsList} from './ThreadTurnsList';
+
+export interface ThreadDetailHeaderProps {
+  threadId: string;
+  status?: ComputedCallStatusType;
+  onUpClick: () => void;
+  onDownClick: () => void;
+}
+
+/**
+ * ThreadDetailHeader displays the thread title with turn navigation controls.
+ *
+ * Shows the thread ID with status indicator and up/down navigation buttons
+ * for moving between turns within the thread.
+ *
+ * @param threadId - The ID of the current thread
+ * @param status - The status of the thread (e.g., 'success', 'error', 'running')
+ * @param onUpClick - Callback function triggered when up button is clicked (previous turn)
+ * @param onDownClick - Callback function triggered when down button is clicked (next turn)
+ *
+ * @example
+ * <ThreadDetailHeader
+ *   threadId="thread_abc123"
+ *   status="success"
+ *   onUpClick={() => console.log('Navigate to previous turn')}
+ *   onDownClick={() => console.log('Navigate to next turn')}
+ * />
+ */
+export const ThreadDetailHeader: FC<ThreadDetailHeaderProps> = ({
+  threadId,
+  status,
+  onUpClick,
+  onDownClick,
+}) => {
+  return (
+    <Tailwind>
+      <div className="flex w-full items-center gap-4">
+        <div className="flex items-center gap-4">
+          <Button
+            icon="sort-ascending"
+            tooltip="Previous turn"
+            variant="ghost"
+            onClick={onUpClick}
+            className="mr-2"
+          />
+          <Button
+            icon="sort-descending"
+            tooltip="Next turn"
+            variant="ghost"
+            onClick={onDownClick}
+          />
+        </div>
+        <Icon name="forum-chat-bubble" />
+        <span className="text-lg font-semibold">{threadId}</span>
+        {status && (
+          <div className=" h-min ">
+            <StatusChip value={status} iconOnly />
+          </div>
+        )}
+      </div>
+    </Tailwind>
+  );
+};
+
+export interface ThreadDetailPageProps {
+  threadId: string;
+}
+
+/**
+ * ThreadDetailPage displays details for a specific thread.
+ *
+ * This page shows comprehensive information about a thread including:
+ * - Thread metadata (ID, status, turn count, etc.)
+ * - Timeline of turns within the thread
+ * - Performance metrics and latency information
+ *
+ * @param threadId - The ID of the thread to display
+ *
+ * @example
+ * <ThreadDetailPage threadId="thread_abc123" />
+ */
+export const ThreadDetailPage: FC<ThreadDetailPageProps> = ({threadId}) => {
+  // State for selected turn index
+  const [selectedTurnIndex, setSelectedTurnIndex] = useState<number>(0);
+
+  // TODO: Replace with actual status from API/state
+  const status: ComputedCallStatusType = 'success';
+
+  const {entity, project} = useEntityProject();
+
+  const {turnsState} = useThreadTurns(`${entity}/${project}`, threadId);
+
+  const turnCount = turnsState.value?.length || 0;
+
+  // Navigation callbacks - navigate between turns
+  const handleUpClick = () => {
+    if (selectedTurnIndex > 0) {
+      setSelectedTurnIndex(selectedTurnIndex - 1);
+    }
+  };
+
+  const handleDownClick = () => {
+    if (selectedTurnIndex < turnCount - 1) {
+      setSelectedTurnIndex(selectedTurnIndex + 1);
+    }
+  };
+
+  const handleTurnSelect = (index: number) => {
+    setSelectedTurnIndex(index);
+  };
+
+  // Get the currently selected turn ID from the index
+  const selectedTurnId = turnsState.value?.[selectedTurnIndex]?.id;
+
+  return (
+    <SimplePageLayout
+      title={
+        <ThreadDetailHeader
+          threadId={threadId}
+          status={status}
+          onUpClick={handleUpClick}
+          onDownClick={handleDownClick}
+        />
+      }
+      hideTabsIfSingle
+      tabs={[
+        {
+          label: 'Overview',
+          content: (
+            <Tailwind style={{height: '100%'}}>
+              <div className="flex h-full flex-col">
+                {/* Upper part: Thread metadata */}
+                <ThreadMetadata turnsState={turnsState} />
+
+                {/* Lower part: Split panel with turns list and main content */}
+                <div className="min-h-0 flex-1">
+                  <SplitPanelLeft
+                    minWidth={250}
+                    defaultWidth={300}
+                    maxWidth="50%"
+                    isDrawerOpen={true} // Always open
+                    drawer={
+                      <ThreadTurnsList
+                        turnsState={turnsState}
+                        selectedTurnId={selectedTurnId}
+                        onTurnSelect={handleTurnSelect}
+                      />
+                    }
+                    main={
+                      <SplitPanelRight
+                        minWidth={200}
+                        defaultWidth={200}
+                        maxWidth="0%" // No right drawer needed
+                        isDrawerOpen={false}
+                        main={
+                          <ThreadTurnDetails
+                            selectedTurnId={selectedTurnId}
+                            isLoading={turnsState.loading}
+                          />
+                        }
+                      />
+                    }
+                  />
+                </div>
+              </div>
+            </Tailwind>
+          ),
+        },
+      ]}
+    />
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadMetadata.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadMetadata.tsx
@@ -1,0 +1,79 @@
+import React, {FC, useMemo} from 'react';
+
+import {
+  traceCallLatencyMs,
+  useThreadTurns,
+} from '../wfReactInterface/tsDataModelHooks';
+
+export interface ThreadMetadataProps {
+  turnsState: ReturnType<typeof useThreadTurns>['turnsState'];
+}
+
+/**
+ * ThreadMetadata displays calculated metrics for a thread.
+ *
+ * Shows turn count, p50 latency, and p99 latency in a clean grid layout.
+ *
+ * @param turnsState - State object containing turns data from useThreadTurns hook
+ *
+ * @example
+ * <ThreadMetadata turnsState={turnsState} />
+ */
+export const ThreadMetadata: FC<ThreadMetadataProps> = ({turnsState}) => {
+  const metrics = useMemo(() => {
+    if (!turnsState.value || turnsState.loading) {
+      return {
+        turnCount: 0,
+        p50Latency: '-',
+        p99Latency: '-',
+      };
+    }
+
+    const turns = turnsState.value;
+    const turnCount = turns.length;
+
+    // Calculate latencies for completed turns (convert ms to seconds)
+    const latencies = turns
+      .filter(turn => turn.ended_at) // Only completed turns
+      .map(turn => traceCallLatencyMs(turn) / 1000) // Convert to seconds
+      .sort((a, b) => a - b);
+
+    if (latencies.length === 0) {
+      return {
+        turnCount,
+        p50Latency: '-',
+        p99Latency: '-',
+      };
+    }
+
+    // Calculate percentiles
+    const p50Index = Math.floor(latencies.length * 0.5);
+    const p99Index = Math.floor(latencies.length * 0.99);
+
+    const p50Latency = `${latencies[p50Index].toFixed(3)}s`;
+    const p99Latency = `${latencies[p99Index].toFixed(3)}s`;
+
+    return {
+      turnCount,
+      p50Latency,
+      p99Latency,
+    };
+  }, [turnsState]);
+
+  return (
+    <div className="grid h-72 w-fit flex-shrink-0 grid-flow-col grid-cols-[auto_auto_auto] grid-rows-2 gap-x-24 border-b border-solid border-moon-150 px-16 py-12">
+      <span className="text-sm font-medium text-moon-600">Turns</span>
+      <span className="truncate text-base font-semibold text-moon-800">
+        {metrics.turnCount}
+      </span>
+      <span className="text-sm font-medium text-moon-600">p50 latency</span>
+      <span className="truncate text-base font-semibold text-moon-800">
+        {metrics.p50Latency}
+      </span>
+      <span className="text-sm font-medium text-moon-600">p99 latency</span>
+      <span className="truncate text-base font-semibold text-moon-800">
+        {metrics.p99Latency}
+      </span>
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadTurnDetails.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadTurnDetails.tsx
@@ -1,0 +1,48 @@
+import React, {FC} from 'react';
+
+export interface ThreadTurnDetailsProps {
+  selectedTurnId?: string;
+  isLoading?: boolean;
+}
+
+/**
+ * ThreadTurnDetails displays detailed information for a selected turn.
+ *
+ * Shows input/output data, performance metrics, and other turn-specific information.
+ *
+ * @param selectedTurnId - The ID of the turn to display details for
+ * @param isLoading - Whether turn details are currently loading
+ *
+ * @example
+ * <ThreadTurnDetails
+ *   selectedTurnId="turn_1"
+ *   isLoading={false}
+ * />
+ */
+export const ThreadTurnDetails: FC<ThreadTurnDetailsProps> = ({
+  selectedTurnId,
+  isLoading,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center p-16">
+        <div className="text-gray-500">Loading turn details...</div>
+      </div>
+    );
+  }
+
+  if (!selectedTurnId) {
+    return (
+      <div className="h-full p-16">
+        <div className="flex h-full items-center justify-center rounded-lg border bg-white p-24">
+          <div className="text-gray-500 text-center">
+            <h3 className="mb-4 text-lg font-medium">No Turn Selected</h3>
+            <p>Select a turn from the list to view its details.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return <div className="h-full p-16">TBD</div>;
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadTurnsList.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadTurnsList.tsx
@@ -1,0 +1,117 @@
+import {LoadingDots} from '@wandb/weave/components/LoadingDots';
+import React, {FC, useMemo} from 'react';
+import {clsx} from 'yet-another-react-lightbox';
+
+import {StatusChip} from '../common/StatusChip';
+import {ComputedCallStatusType} from '../wfReactInterface/traceServerClientTypes';
+import {
+  parseSpanName,
+  traceCallStatusCode,
+  useThreadTurns,
+} from '../wfReactInterface/tsDataModelHooks';
+
+export interface Turn {
+  id: string;
+  status: ComputedCallStatusType;
+  input?: string;
+  opName: string;
+}
+
+export interface ThreadTurnsListProps {
+  turnsState: ReturnType<typeof useThreadTurns>['turnsState'];
+  selectedTurnId?: string;
+  onTurnSelect?: (index: number) => void;
+}
+
+/**
+ * ThreadTurnsList displays a list of turns in a thread.
+ *
+ * Shows each turn with its number, status, and input preview.
+ * Supports selection and click handlers for turn navigation.
+ *
+ * @param turnsState - State object containing turns data from useThreadTurns hook
+ * @param selectedTurnId - ID of the currently selected turn
+ * @param onTurnSelect - Callback when a turn is selected, receives the turn index
+ *
+ * @example
+ * <ThreadTurnsList
+ *   turnsState={turnsState}
+ *   selectedTurnId="turn_1"
+ *   onTurnSelect={(index) => console.log('Selected turn index:', index)}
+ * />
+ */
+export const ThreadTurnsList: FC<ThreadTurnsListProps> = ({
+  turnsState,
+  selectedTurnId,
+  onTurnSelect,
+}) => {
+  const handleTurnClick = (index: number) => {
+    if (onTurnSelect) {
+      onTurnSelect(index);
+    }
+  };
+
+  const turns = useMemo(() => {
+    if (turnsState.loading || !turnsState.value) {
+      return [];
+    }
+
+    return turnsState.value.map((traceCall): Turn => {
+      // Convert inputs object to a string preview
+      const inputPreview = traceCall.inputs
+        ? JSON.stringify(traceCall.inputs).substring(0, 100) + '...'
+        : undefined;
+
+      return {
+        id: traceCall.id,
+        status: traceCallStatusCode(traceCall),
+        input: inputPreview,
+        opName: parseSpanName(traceCall.op_name),
+      };
+    });
+  }, [turnsState]);
+
+  // Show a loading state if the turnsState is loading
+  if (turnsState.loading) {
+    return (
+      <div className="flex w-full items-center justify-center">
+        <LoadingDots />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      {turns.map((turn, index) => {
+        const isSelected = turn.id === selectedTurnId;
+        return (
+          <div
+            key={turn.id}
+            className={clsx(
+              'h-64 cursor-pointer border border-b border-solid border-moon-150 p-12 px-8 py-7 transition-colors',
+              isSelected && 'bg-moon-100',
+              !isSelected && 'hover:bg-moon-100'
+            )}
+            onClick={() => handleTurnClick(index)}>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-6 text-sm text-moon-800">
+                <span className=" flex h-18 w-18 items-center justify-center rounded-[20px] bg-moon-200 font-bold ">
+                  {index + 1}
+                </span>
+                <span className="truncate font-semibold">{turn.opName}</span>
+              </div>
+              <div>
+                <StatusChip value={turn.status} iconOnly />
+              </div>
+            </div>
+            {turn.input && (
+              <div className="text-gray-500 mt-4 truncate text-sm">
+                {turn.input}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadsPage/ThreadsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadsPage/ThreadsTable.tsx
@@ -9,11 +9,11 @@ import {WaveLoader} from '@wandb/weave/components/Loaders/WaveLoader';
 import {LoadingDots} from '@wandb/weave/components/LoadingDots';
 import {Tooltip} from '@wandb/weave/components/Tooltip';
 import React, {FC, useCallback, useMemo} from 'react';
+import {useHistory} from 'react-router-dom';
 
-import {monthRoundedTime} from '../../../../../../common/util/time';
 import {TailwindContents} from '../../../../../Tailwind';
 import {Timestamp} from '../../../../../Timestamp';
-import {useEntityProject} from '../../context';
+import {useEntityProject, useWeaveflowRouteContext} from '../../context';
 import {FilterPanel} from '../../filters/FilterPanel';
 import {StyledDataGrid} from '../../StyledDataGrid';
 import {ColumnInfo} from '../../types';
@@ -74,6 +74,8 @@ export const ThreadsTable: FC<{
   setPaginationModel,
 }) => {
   const {entity, project} = useEntityProject();
+  const history = useHistory();
+  const {peekingRouter} = useWeaveflowRouteContext();
 
   // Setup Ref to underlying table
   const apiRef = useGridApiRef();
@@ -177,6 +179,20 @@ export const ThreadsTable: FC<{
         width: 100,
         flex: 1,
         sortable: false,
+        renderCell: params => (
+          <div
+            className="hover:text-blue-800 cursor-pointer text-blue-600 hover:underline"
+            onClick={() => {
+              const threadId = params.value;
+              if (threadId) {
+                history.push(
+                  peekingRouter.threadUIUrl(entity, project, threadId)
+                );
+              }
+            }}>
+            {params.value}
+          </div>
+        ),
       },
       {
         field: 'status',
@@ -265,7 +281,7 @@ export const ThreadsTable: FC<{
           if (!params.value) return '';
           // Convert from milliseconds to seconds for monthRoundedTime
           const timeS = params.value / 1000;
-          return monthRoundedTime(timeS);
+          return timeS.toFixed(3) + 's';
         },
       },
       {
@@ -278,11 +294,13 @@ export const ThreadsTable: FC<{
           if (!params.value) return '';
           // Convert from milliseconds to seconds for monthRoundedTime
           const timeS = params.value / 1000;
-          return monthRoundedTime(timeS);
+          return timeS.toFixed(3) + 's';
         },
       },
     ],
-    [turnCallsDataResult]
+    // Adding the missing peekingRouter to the dependency array causes a re-render loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [turnCallsDataResult, entity, history, project]
   );
 
   return (


### PR DESCRIPTION
## Description

- Adds a new Thread Detail Page to view individual thread information
- Implements navigation from Threads list to Thread Detail view
- Creates components for displaying thread metadata, turns list, and turn details
- Adds routing support for thread detail pages

The PR introduces a Thread Detail Page that displays information about a specific thread, including its metadata, a list of turns within the thread, and detailed information about each turn. Users can navigate between turns and view performance thread-level metrics like p50 and p90 latency.

The chatlog view is intentionally left blank and will be implemented in the next PR.

## Testing

Manually tested by:
- Navigating from the Threads list to a Thread Detail page
- Verifying thread metadata display
- Testing turn navigation and selection
- Confirming proper routing between pages

## Preview
<img width="1524" alt="image" src="https://github.com/user-attachments/assets/ee59323e-8847-403d-94fb-75042c216cf6" />
