### PR TITLE
chore(weave): Parallelize trace tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -260,7 +260,10 @@ jobs:
             #
           ]
         nox-shard: [
-            "trace",
+            "trace1",
+            "trace2",
+            "trace3",
+            "trace4",
             "flow",
             "trace_server",
             "trace_server_bindings",

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,7 @@ PY313_INCOMPATIBLE_SHARDS = [
     "crewai",
 ]
 PY39_INCOMPATIBLE_SHARDS = ["crewai", "google_genai", "mcp", "smolagents", "dspy"]
+NUM_TRACE_SHARDS = 4
 
 
 @nox.session
@@ -35,6 +36,9 @@ def lint(session):
         session.run("pre-commit", "run", "--hook-stage=pre-push", "--all-files")
 
 
+trace_shards = [f"trace{i}" for i in range(1, NUM_TRACE_SHARDS + 1)]
+
+
 @nox.session(python=SUPPORTED_PYTHON_VERSIONS)
 @nox.parametrize(
     "shard",
@@ -45,7 +49,6 @@ def lint(session):
         # For example,
         #   nox -e "tests-3.12(shard='custom')" -- test_your_thing.py
         "custom",
-        "trace",
         "flow",
         "trace_server",
         "trace_server_bindings",
@@ -73,6 +76,8 @@ def lint(session):
         "huggingface",
         "smolagents",
         "mcp",
+        "trace",
+        *trace_shards,
     ],
 )
 def tests(session, shard):
@@ -122,12 +127,13 @@ def tests(session, shard):
     default_test_dirs = [f"integrations/{shard}/"]
     test_dirs_dict = {
         "custom": [],
-        "trace": ["trace/"],
         "flow": ["flow/"],
         "trace_server": ["trace_server/"],
         "trace_server_bindings": ["trace_server_bindings"],
         "mistral": ["integrations/mistral/"],
         "scorers": ["scorers/"],
+        "trace": ["trace/"],
+        **{shard: ["trace/"] for shard in trace_shards},
     }
 
     test_dirs = test_dirs_dict.get(shard, default_test_dirs)
@@ -136,13 +142,25 @@ def tests(session, shard):
     if shard == "llamaindex":
         session.posargs.insert(0, "-n4")
 
-    session.run(
+    # Add sharding logic for trace1, trace2, trace3
+    pytest_args = [
         "pytest",
         "--durations=20",
         "--strict-markers",
         "--cov=weave",
         "--cov-report=html",
         "--cov-branch",
+    ]
+
+    # Handle trace sharding: run every 3rd test starting at different offsets
+    if shard in trace_shards:
+        shard_id = int(shard[-1]) - 1
+        pytest_args.extend(
+            ["--shard-id", str(shard_id), "--num-shards", str(NUM_TRACE_SHARDS)]
+        )
+
+    session.run(
+        *pytest_args,
         *session.posargs,
         *test_dirs,
         env=env,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ test = [
   "pytest-xdist>=3.1.0",
   "pytest-rerunfailures>=12.0",
   "pytest-rerunfailures>=14.0",
+  "pytest-shard==0.1.2",
   "clickhouse_connect==0.7.0",
   "fastapi>=0.110.0",
   "sqlparse==0.5.0",


### PR DESCRIPTION
Parallelize trace tests by splitting them into shards.  Speeds up tests from ~17 min to ~6.5min (62%)