### PR TITLE
fix(app): Clean up full screen babylon point cloud scene after exit

### DIFF
--- a/weave-js/src/common/util/render_babylon.ts
+++ b/weave-js/src/common/util/render_babylon.ts
@@ -180,7 +180,7 @@ export async function renderScreenshot(
 }
 
 export async function renderFullscreen(result: RenderResult<RenderFullscreen>) {
-  const {scene, context} = result;
+  const {scene, context, cleanup} = result;
   const {canvas, engine} = context;
 
   // canvas elements can't contain other html elements, so we create
@@ -208,6 +208,7 @@ export async function renderFullscreen(result: RenderResult<RenderFullscreen>) {
   });
 
   onNextExitFullscreen(() => {
+    cleanup?.();
     canvas.remove();
     fullScreenElement.remove();
     requestAnimationFrame(() => {


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-16738

The GPU % keeps climbing up as you open and close various point clouds in full screen. This is because the full screen scene was never properly cleaned up after closing it. The fix is to call the `cleanup` function which calls `scene.dispose()` on full screen exit.

## Testing

How was this PR tested?

Before - GPU % keeps climbing up as I open and close each point cloud in full screen:


https://github.com/user-attachments/assets/9ca817a9-17fe-43fa-9dc6-93cade595008


After - GPU % dies back down to 0% after each point cloud full screen is exited:


https://github.com/user-attachments/assets/898b2763-b85b-4419-a20a-d052b11cc3f7

