### PR TITLE
chore(ui): add error boundary around trace navigator

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -5,6 +5,7 @@ import React, {FC, useCallback, useContext, useEffect, useRef} from 'react';
 
 import {makeRefCall} from '../../../../../../util/refs';
 import {Button} from '../../../../../Button';
+import {ErrorBoundary} from '../../../../../ErrorBoundary';
 import {Tailwind} from '../../../../../Tailwind';
 import {TableRowSelectionContext} from '../../../TableRowSelectionContext';
 import {TraceNavigator} from '../../components/TraceNavigator/TraceNavigator';
@@ -358,17 +359,19 @@ const CallPageInnerVertical: FC<CallPageInnerProps> = ({
       isLeftSidebarOpen={!hideTraceTreeActual}
       leftSidebarContent={
         <Tailwind style={{display: 'contents'}}>
-          <div className="h-full bg-moon-50">
-            <TraceNavigator
-              entity={focusedCall.entity}
-              project={focusedCall.project}
-              traceId={focusedCall.traceId}
-              focusedCallId={focusedCallId}
-              rootCallId={rootCallId}
-              setFocusedCallId={setFocusedCallId}
-              setRootCallId={setRootCallId}
-            />
-          </div>
+          <ErrorBoundary>
+            <div className="h-full bg-moon-50">
+              <TraceNavigator
+                entity={focusedCall.entity}
+                project={focusedCall.project}
+                traceId={focusedCall.traceId}
+                focusedCallId={focusedCallId}
+                rootCallId={rootCallId}
+                setFocusedCallId={setFocusedCallId}
+                setRootCallId={setRootCallId}
+              />
+            </div>
+          </ErrorBoundary>
         </Tailwind>
       }
       tabs={callTabs}


### PR DESCRIPTION
## Description

Wrap the Trace navigator in an ErrorBoundary to avoid a whole page crash on error. (Hide whitespace)

## Testing

Tried with the issue in https://github.com/wandb/weave/pull/4983 before that fix.