### PR TITLE
perf(weave): defer call stats to summary component

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -70,8 +70,10 @@ export const CallPage: FC<CallPageProps> = props => {
     // in null response (bug on server side). As a result, the summary
     // will not show costs. FIXME (This results in a second query in
     // CallSummary.tsx)
+    // This flag and the below storage flag can cause long query times
+    // defer loading to the summary component
     // includeCosts: true,
-    includeTotalStorageSize: true,
+    // includeTotalStorageSize: true,
     refetchOnRename: true,
   });
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25950](https://wandb.atlassian.net/browse/WB-25950)

Move the expensive loading of trace size to when a user opens the summary page, rather than delaying the main call details tab from loading. 

## Testing

Prod
![loading-storage-prod](https://github.com/user-attachments/assets/36f7aff5-2fea-4937-ad36-76497f93a200)

Branch
![loading-storage-branch](https://github.com/user-attachments/assets/0e525889-9435-43e0-ba0b-759b2e510768)


[WB-25950]: https://wandb.atlassian.net/browse/WB-25950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ