### PR TITLE
feat(weave): Add support for auto-patching Anthropic beta model

### DIFF
--- a/tests/integrations/anthropic/anthropic_test.py
+++ b/tests/integrations/anthropic/anthropic_test.py
@@ -17,10 +17,8 @@ model = "claude-3-haiku-20240307"
 def test_anthropic(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
-    anthropic_client = Anthropic(
-        api_key=api_key,
-    )
+    api_key = os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
+    anthropic_client = Anthropic(api_key=api_key)
     message = anthropic_client.messages.create(
         model=model,
         max_tokens=1024,
@@ -57,10 +55,8 @@ def test_anthropic(
 def test_anthropic_stream(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
-    anthropic_client = Anthropic(
-        api_key=api_key,
-    )
+    api_key = os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
+    anthropic_client = Anthropic(api_key=api_key)
     stream = anthropic_client.messages.create(
         model=model,
         stream=True,
@@ -109,7 +105,7 @@ async def test_async_anthropic(
 ) -> None:
     anthropic_client = AsyncAnthropic(
         # This is the default and can be omitted
-        api_key=os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
+        api_key=os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
     )
 
     message = await anthropic_client.messages.create(
@@ -151,7 +147,7 @@ async def test_async_anthropic_stream(
 ) -> None:
     anthropic_client = AsyncAnthropic(
         # This is the default and can be omitted
-        api_key=os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
+        api_key=os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
     )
 
     stream = await anthropic_client.messages.create(
@@ -199,10 +195,8 @@ async def test_async_anthropic_stream(
 def test_tools_calling(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
-    anthropic_client = Anthropic(
-        api_key=api_key,
-    )
+    api_key = os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
+    anthropic_client = Anthropic(api_key=api_key)
     message = anthropic_client.messages.create(
         model=model,
         max_tokens=1024,
@@ -261,10 +255,8 @@ def test_tools_calling(
 def test_anthropic_messages_stream_ctx_manager(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
-    anthropic_client = Anthropic(
-        api_key=api_key,
-    )
+    api_key = os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
+    anthropic_client = Anthropic(api_key=api_key)
 
     all_content = ""
     with anthropic_client.messages.stream(
@@ -312,7 +304,7 @@ async def test_async_anthropic_messages_stream_ctx_manager(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
     anthropic_client = AsyncAnthropic(
-        api_key=os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
+        api_key=os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
     )
 
     all_content = ""
@@ -360,10 +352,8 @@ async def test_async_anthropic_messages_stream_ctx_manager(
 def test_anthropic_messages_stream_ctx_manager_text(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
-    anthropic_client = Anthropic(
-        api_key=api_key,
-    )
+    api_key = os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
+    anthropic_client = Anthropic(api_key=api_key)
 
     all_content = ""
     with anthropic_client.messages.stream(
@@ -410,7 +400,7 @@ async def test_async_anthropic_messages_stream_ctx_manager_text(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
     anthropic_client = AsyncAnthropic(
-        api_key=os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
+        api_key=os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
     )
 
     all_content = ""
@@ -457,10 +447,8 @@ async def test_async_anthropic_messages_stream_ctx_manager_text(
 def test_beta_anthropic(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
-    anthropic_client = Anthropic(
-        api_key=api_key,
-    )
+    api_key = os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
+    anthropic_client = Anthropic(api_key=api_key)
     message = anthropic_client.beta.messages.create(
         model=model,
         max_tokens=1024,
@@ -497,10 +485,8 @@ def test_beta_anthropic(
 def test_beta_anthropic_stream(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
-    anthropic_client = Anthropic(
-        api_key=api_key,
-    )
+    api_key = os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY")
+    anthropic_client = Anthropic(api_key=api_key)
     stream = anthropic_client.beta.messages.create(
         model=model,
         stream=True,
@@ -549,7 +535,7 @@ async def test_beta_async_anthropic(
 ) -> None:
     anthropic_client = AsyncAnthropic(
         # This is the default and can be omitted
-        api_key=os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
+        api_key=os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
     )
 
     message = await anthropic_client.beta.messages.create(
@@ -591,7 +577,7 @@ async def test_beta_async_anthropic_stream(
 ) -> None:
     anthropic_client = AsyncAnthropic(
         # This is the default and can be omitted
-        api_key=os.environ.get("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
+        api_key=os.getenv("ANTHROPIC_API_KEY", "DUMMY_API_KEY"),
     )
 
     stream = await anthropic_client.beta.messages.create(

--- a/tests/integrations/anthropic/cassettes/anthropic_test/test_beta_anthropic.yaml
+++ b/tests/integrations/anthropic/cassettes/anthropic_test/test_beta_anthropic.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Hello, Claude"}],"model":"claude-3-haiku-20240307"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '108'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.47.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.47.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.14
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//ZJBPS0MxEMS/SpyLl1ReW0GaixftH/AgKB4UCSFZ27RpUpNNtT763eVV
+        LRRPC/ObnWW2hXdQWJe5bvqTcZ7cP9/dPE3Go7flI21vH+bLL0jwbkOdi0oxc4JETqETTCm+sIkM
+        iXVyFKBgg6mOesPewvhV7Q2awWUzbK4gYVNkigz10v4lMn12u4ehMKUQ0pmY8XkR0VsSnMSaiMUu
+        1QsxTR/Cmihm4udspwpOzuyusX+VKJw2OpMpKUKBotNcc8QvKPReKVqCijUEiXpoolr4uKmsOa0o
+        Fqh+I2GNXZC2mQz7FPWp4cgzGfefpconcSOJQnnrLWn2lKHQ/cuZ7LDffwMAAP//AwBaOUeIfQEA
+        AA==
+    headers:
+      CF-RAY:
+      - 95b9cfc77a0cacaa-ORD
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 07 Jul 2025 19:40:08 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - d6c583ad-17bd-4375-ae1f-6751feb78523
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-07-07T19:40:08Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-07-07T19:40:08Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-07-07T19:40:05Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-07-07T19:40:08Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CQtE4Z7A58SskfNq8UE11
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/anthropic/cassettes/anthropic_test/test_beta_anthropic_stream.yaml
+++ b/tests/integrations/anthropic/cassettes/anthropic_test/test_beta_anthropic_stream.yaml
@@ -1,0 +1,152 @@
+interactions:
+- request:
+    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Hello, Claude"}],"model":"claude-3-haiku-20240307","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.47.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.47.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.14
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01A6teYjSvHPYCkwXv6gwnZE","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}      }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!
+        How"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        can I assist you today"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"?"}           }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0     }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":12}      }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"      }
+
+
+        '
+    headers:
+      CF-RAY:
+      - 95ba1420ea17b266-ORD
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 07 Jul 2025 20:26:46 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - d6c583ad-17bd-4375-ae1f-6751feb78523
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-07-07T20:26:45Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-07-07T20:26:45Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-07-07T20:26:45Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-07-07T20:26:45Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CQtHcvEdh979LQSwdrUTb
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/anthropic/cassettes/anthropic_test/test_beta_async_anthropic.yaml
+++ b/tests/integrations/anthropic/cassettes/anthropic_test/test_beta_async_anthropic.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Hello, Claude"}],"model":"claude-3-haiku-20240307"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '108'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.47.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.47.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.14
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2SQTUvEMBCG/0p9zyl0u4qYixdhK8KCBy+KhJAMu6FpUpPJ6lr636XrByyeBuZ5
+        52F4JzgLiSHvVLPaftJDctvnzaHf8NUjPQ03pbuDAB9HWlKUs94RBFL0y0Ln7DLrwBAYoiUPCeN1
+        sVSv6712fanbpr1s1s01BEwMTIEhX6ZfI9PHcnsaEh15Hy+qLr5XRofqvvr2V8dYKo5WH28xvwpk
+        jqNKpHMMkKBgFZcU8AMyvRUKhiBD8V6gnF6WE1wYCyuOPYUMuWoEjDZ7UiaRZheDOg/88UTa/mex
+        8JmuFciUDs6QYkcJEksxVieLef4CAAD//wMA9yYU/mYBAAA=
+    headers:
+      CF-RAY:
+      - 95ba1b11dba86211-ORD
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 07 Jul 2025 20:31:31 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - d6c583ad-17bd-4375-ae1f-6751feb78523
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-07-07T20:31:31Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-07-07T20:31:31Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-07-07T20:31:29Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-07-07T20:31:31Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CQtHytBCCarSXdzKRLhPc
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/anthropic/cassettes/anthropic_test/test_beta_async_anthropic_stream.yaml
+++ b/tests/integrations/anthropic/cassettes/anthropic_test/test_beta_async_anthropic_stream.yaml
@@ -1,0 +1,147 @@
+interactions:
+- request:
+    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Hello, Claude"}],"model":"claude-3-haiku-20240307","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.47.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.47.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.14
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01SWM5Rb5S7sadixCbGxZjdP","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3,"service_tier":"standard"}}    }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!
+        How"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        can I assist you today"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"?"}   }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0          }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":12}             }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"    }
+
+
+        '
+    headers:
+      CF-RAY:
+      - 95ba1b944ec261a5-ORD
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 07 Jul 2025 20:31:51 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - d6c583ad-17bd-4375-ae1f-6751feb78523
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-07-07T20:31:50Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-07-07T20:31:50Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-07-07T20:31:50Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-07-07T20:31:50Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CQtJ1R5ay1NRFpgn1DjKc
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## Description

User reported that they had stopped getting traces logged when using newer versions of PydanticAI. We were able to reproduce - it worked in pydantic 0.2.6, didn't work >= 0.2.7. From the [Pydantic AI Changelog](https://github.com/pydantic/pydantic-ai/compare/v0.2.6...v0.2.7) we noticed [this PR](https://github.com/pydantic/pydantic-ai/pull/1818) where PydanticAI switched to using the beta methods of the Anthropic client. Weave's Anthropic integration wasn't autopatching those beta methods. 

This PR adds patching for the beta methods. It also updates a few imports to use preferred aliases, see e.g. https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/types/message_delta_event.py#L8

Internal Slack: https://weightsandbiases.slack.com/archives/C0880TX4U5V/p1749207082348889
Internal Jira: https://wandb.atlassian.net/browse/WB-25800


## Testing

Tried pydantic AI 0.3.7 with anthropic, beta call appears in UI. Added unit tests.