### PR TITLE
feat(weave): Add link to go to trace detail view

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3.tsx
@@ -237,6 +237,7 @@ const MainPeekingLayout: FC = () => {
 
   // State to track whether the user is currently dragging the drawer resize handle
   const [isDragging, setIsDragging] = useState(false);
+  const [previousUrl, setPreviousUrl] = useState<string | undefined>(undefined);
 
   // Callback function to handle the end of dragging
   const handleDragEnd = useCallback(() => {
@@ -321,7 +322,12 @@ const MainPeekingLayout: FC = () => {
                 }}
               />
               {peekLocation && (
-                <WeaveflowPeekContext.Provider value={{isPeeking: true}}>
+                <WeaveflowPeekContext.Provider
+                  value={{
+                    isPeeking: true,
+                    previousUrl,
+                    setPreviousUrl,
+                  }}>
                   <SimplePageLayoutContext.Provider
                     value={{
                       headerSuffix: (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/context.tsx
@@ -761,6 +761,8 @@ const WeaveflowRouteContext = createContext<{
 
 export const WeaveflowPeekContext = createContext<{
   isPeeking?: boolean;
+  previousUrl?: string;
+  setPreviousUrl?: (url: string) => void;
 }>({
   isPeeking: false,
 });
@@ -774,6 +776,26 @@ export const useClosePeek = () => {
       history.replace({
         search: queryParams.toString(),
       });
+    }
+  };
+};
+
+export const useBackNavigation = () => {
+  const history = useHistory();
+  const {previousUrl} = useContext(WeaveflowPeekContext);
+
+  return () => {
+    if (previousUrl) {
+      history.push(previousUrl);
+    } else {
+      // Fallback to closing peek if no previous URL
+      const queryParams = new URLSearchParams(history.location.search);
+      if (queryParams.has(PEEK_PARAM)) {
+        queryParams.delete(PEEK_PARAM);
+        history.replace({
+          search: queryParams.toString(),
+        });
+      }
     }
   };
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/CallPage.tsx
@@ -9,7 +9,7 @@ import {ErrorBoundary} from '../../../../../ErrorBoundary';
 import {Tailwind} from '../../../../../Tailwind';
 import {TableRowSelectionContext} from '../../../TableRowSelectionContext';
 import {TraceNavigator} from '../../components/TraceNavigator/TraceNavigator';
-import {WeaveflowPeekContext} from '../../context';
+import {useBackNavigation, WeaveflowPeekContext} from '../../context';
 import {FeedbackGrid} from '../../feedback/FeedbackGrid';
 import {ScorerFeedbackGrid} from '../../feedback/ScorerFeedbackGrid';
 import {FeedbackSidebar} from '../../feedback/StructuredFeedback/FeedbackSidebar';
@@ -295,10 +295,15 @@ const CallPageInnerVertical: FC<CallPageInnerProps> = ({
   );
 
   const {rowIdsConfigured} = useContext(TableRowSelectionContext);
-  const {isPeeking} = useContext(WeaveflowPeekContext);
+  const {isPeeking, previousUrl} = useContext(WeaveflowPeekContext);
   const showPaginationControls = isPeeking && rowIdsConfigured;
 
   const callTabs = useCallTabs(focusedCall);
+  const backNavigation = useBackNavigation();
+
+  const handleBackClick = useCallback(() => {
+    backNavigation();
+  }, [backNavigation]);
 
   const setRootCallIdForPagination = useCallback(
     (callId: string) => {
@@ -318,12 +323,23 @@ const CallPageInnerVertical: FC<CallPageInnerProps> = ({
             justifyContent: 'space-between',
             alignItems: 'center',
           }}>
-          {showPaginationControls && (
-            <PaginationControls
-              callId={rootCallId}
-              setRootCallId={setRootCallIdForPagination}
-            />
-          )}
+          <Box sx={{display: 'flex', alignItems: 'center'}}>
+            {isPeeking && previousUrl && (
+              <Button
+                icon="back"
+                tooltip="Go back"
+                variant="ghost"
+                onClick={handleBackClick}
+                className="mr-4"
+              />
+            )}
+            {showPaginationControls && (
+              <PaginationControls
+                callId={rootCallId}
+                setRootCallId={setRootCallIdForPagination}
+              />
+            )}
+          </Box>
           <Box sx={{marginLeft: showPaginationControls ? 0 : 'auto'}}>
             <Button
               icon="layout-tabs"

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/TurnAnchor.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/TurnAnchor.tsx
@@ -1,11 +1,37 @@
-import {FC} from 'react';
+import {FC, useCallback, useContext, useMemo} from 'react';
 import React from 'react';
+import {Link} from 'react-router-dom';
+
+import {
+  useEntityProject,
+  useWeaveflowRouteContext,
+  WeaveflowPeekContext,
+} from '../../context';
 
 export interface TurnAnchorProps {
   turnId: string;
 }
 
 export const TurnAnchor: FC<TurnAnchorProps> = ({turnId}) => {
+  const {peekingRouter, baseRouter} = useWeaveflowRouteContext();
+  const {entity, project} = useEntityProject();
+  const {setPreviousUrl, isPeeking} = useContext(WeaveflowPeekContext);
+
+  const to = useMemo(() => {
+    // If we're already in a peek view, use peekingRouter to open another peek
+    // If we're not in a peek view, use baseRouter for normal navigation
+    const router = isPeeking ? peekingRouter : baseRouter;
+    return router.callUIUrl(entity, project, '', turnId, turnId, false, false);
+  }, [entity, project, turnId, peekingRouter, baseRouter, isPeeking]);
+
+  const handleClick = useCallback(() => {
+    if (setPreviousUrl && isPeeking) {
+      // Only store previousUrl if we're in a peek view
+      const currentUrl = window.location.pathname + window.location.search;
+      setPreviousUrl(currentUrl);
+    }
+  }, [setPreviousUrl, isPeeking]);
+
   return (
     <div
       className={
@@ -17,7 +43,12 @@ export const TurnAnchor: FC<TurnAnchorProps> = ({turnId}) => {
         </span>{' '}
         You can inspect inputs and outputs in the trace view
       </span>
-      <span className={'font-semibold'}>View trace</span>
+      <Link
+        to={to}
+        onClick={handleClick}
+        className="font-semibold hover:text-blue-500">
+        View trace
+      </Link>
     </div>
   );
 };


### PR DESCRIPTION
## Improved Navigation in Thread and Call Views

This PR enhances navigation between thread and call views by:

1. Adding back navigation capability in peek views with a new back button
2. Implementing a "previous URL" tracking system to enable proper navigation history
3. Making "View trace" links clickable in the TurnAnchor component
4. Adding a "Trace" button to each turn in the ThreadTurnsList for quick access to trace details

These changes improve the user experience by:
- Preserving navigation context when moving between related views
- Providing intuitive ways to navigate back to previous screens
- Adding convenient access points to trace information from thread views

The implementation uses React Router for navigation and maintains state about previous URLs to enable proper back navigation, especially within peek views.

## Preview:

![capture.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sjuXMNgR0xOaLu1czpDo/97dc84ba-cb08-45bf-a558-3a1ec6e9c512.gif)

The video recording is distorted due to compression, the actual floating button on each turn actually looks like this: 
<img width="292" height="116" alt="image" src="https://github.com/user-attachments/assets/c769b921-28d2-46c9-b32b-b4cda127f5c3" />
