### PR TITLE
fix(weave): datetime filter reliability on threads list page

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/SelectDatetimeDropdown.tsx
@@ -65,6 +65,7 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLUListElement>(null);
   const debounceTimeoutRef = useRef<NodeJS.Timeout>();
+  const suggestionClickedRef = useRef<boolean>(false);
 
   // Format and set input value whenever the value prop changes
   useEffect(() => {
@@ -242,9 +243,18 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
       setSelectedSuggestion(suggestionValue);
       setDropdownVisible(false);
       setIsInvalid(false);
+
+      // Set flag to prevent blur handler from reverting the value
+      suggestionClickedRef.current = true;
+
       if (inputRef.current) {
         inputRef.current.blur();
       }
+
+      // Reset flag after a short delay
+      setTimeout(() => {
+        suggestionClickedRef.current = false;
+      }, 100);
     },
     [parseAndUpdateDate]
   );
@@ -326,7 +336,8 @@ export const SelectDatetimeDropdown: React.FC<SelectDatetimeDropdownProps> = ({
               setIsInputFocused(false);
 
               // When user leaves the input, immediately parse what they've typed
-              if (inputValue !== value) {
+              // Skip parsing if a suggestion was just clicked to prevent race condition
+              if (inputValue !== value && !suggestionClickedRef.current) {
                 parseAndUpdateDate(inputValue, true);
               }
             }}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadsPage/ThreadsTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadsPage/ThreadsTable.tsx
@@ -358,7 +358,6 @@ export const ThreadsTable: FC<{
         onPaginationModelChange={onPaginationModelChange}
         // Filtering
         filterModel={filterModel}
-        onFilterModelChange={setFilterModel}
         filterMode="server"
         // Sorting
         sortModel={sortModel}


### PR DESCRIPTION
## Description

- Fixes a race condition in the datetime dropdown component
- Improves default filter handling in the ThreadsPage
- Removes the onFilterModelChange handler from ThreadsTable which complicates the procedure of what FilterPanel does.

This PR addresses two issues:

1. Fixes a race condition in the SelectDatetimeDropdown component by adding a flag to prevent the blur handler from reverting values when a suggestion is clicked.

2. Improves the default filter handling in ThreadsPage by tracking when the default filter has been adopted, preventing it from being repeatedly applied. This fixes a bug that clearing all the datetime filters using the following UI would still revert to the default filter (Past 1wk).

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sjuXMNgR0xOaLu1czpDo/aeab3022-39fe-4520-8505-584937b59b35.png)


## Testing

Manually tested the datetime dropdown to ensure selecting suggestions works correctly without reverting to previous values.

Verified that clearing all the datetime filters does not revert back to a default filter (Past 1wk)