### PR TITLE
fix(weave): Align serialization payloads between Typescript and Python

### DIFF
--- a/sdks/node/src/__tests__/live/prompt.test.ts
+++ b/sdks/node/src/__tests__/live/prompt.test.ts
@@ -66,23 +66,27 @@ describe('Prompt persistence', () => {
 
     const prompt = new StringPrompt({
       content: 'Hello, {name}!',
+      name: 'test-prompt',
+      description: 'test-description',
     });
 
     const ref = await client.publish(prompt);
 
     expect(ref.uri()).toBe(
-      'weave:///test-entity/test-project/object/StringPrompt:test-digest'
+      'weave:///test-entity/test-project/object/test-prompt:test-digest'
     );
 
     expect(mockObjCreateObjCreatePost).toHaveBeenCalledWith({
       obj: {
         project_id: 'test-entity/test-project',
-        object_id: 'StringPrompt',
+        object_id: 'test-prompt',
         val: {
           _type: 'StringPrompt',
           _class_name: 'StringPrompt',
           _bases: ['Prompt', 'Object', 'BaseModel'],
           content: 'Hello, {name}!',
+          name: 'test-prompt',
+          description: 'test-description',
         },
       },
     });
@@ -127,6 +131,21 @@ describe('Prompt persistence', () => {
     expect(ref.uri()).toBe(
       'weave:///test-entity/test-project/object/MessagesPrompt:test-digest'
     );
+
+    expect(mockObjCreateObjCreatePost).toHaveBeenCalledWith({
+      obj: {
+        project_id: 'test-entity/test-project',
+        object_id: 'MessagesPrompt',
+        val: {
+          _type: 'MessagesPrompt',
+          _class_name: 'MessagesPrompt',
+          _bases: ['Prompt', 'Object', 'BaseModel'],
+          messages: [{role: 'user', content: 'Hello, {name}!'}],
+          name: undefined,
+          description: undefined,
+        },
+      },
+    });
 
     const retrievedObj = await ref.get();
 

--- a/sdks/node/src/__tests__/live/publish.test.ts
+++ b/sdks/node/src/__tests__/live/publish.test.ts
@@ -50,7 +50,7 @@ describe.skip('Publishing Various Data Types', () => {
 
   const datasetOp = op(async function dataset() {
     return new Dataset({
-      id: 'my-dataset',
+      name: 'my-dataset',
       rows: [
         {name: 'Alice', age: 10},
         {name: 'Bob', age: 20},

--- a/sdks/node/src/__tests__/live/weaveObject.test.ts
+++ b/sdks/node/src/__tests__/live/weaveObject.test.ts
@@ -4,7 +4,7 @@ import {WeaveObject} from '../../weaveObject';
 
 class ExampleObject extends WeaveObject {
   constructor(
-    public name: string,
+    public key: string,
     public value: number
   ) {
     super({});
@@ -13,7 +13,7 @@ class ExampleObject extends WeaveObject {
   }
 
   async method() {
-    return this.name + '!';
+    return this.key + '!';
   }
 }
 

--- a/sdks/node/src/dataset.ts
+++ b/sdks/node/src/dataset.ts
@@ -50,7 +50,7 @@ export class Dataset<R extends DatasetRow> extends WeaveObject {
 
   constructor(parameters: DatasetParameters<R>) {
     const baseParameters = {
-      id: parameters.id,
+      name: parameters.name,
       description: parameters.description,
     };
     super(baseParameters);

--- a/sdks/node/src/evaluation.ts
+++ b/sdks/node/src/evaluation.ts
@@ -152,7 +152,7 @@ export class Evaluation<
     this.evaluate = op(this, this.evaluate, {
       parameterNames: 'useParam0Object',
       callDisplayName: inputs =>
-        `${this.id}_${weaveCallableName(inputs.model)}`,
+        `${this.name}_${weaveCallableName(inputs.model)}`,
     });
     this.predictAndScore = op(this, this.predictAndScore, {
       parameterNames: 'useParam0Object',

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -300,10 +300,10 @@ export class WeaveClient {
     if (t == 'StringPrompt') {
       const {StringPrompt} = await import('./prompt');
 
-      const {content, description} = val;
+      const {content, description, name} = val;
 
       let obj = new StringPrompt({
-        id: dataObj.id,
+        name,
         description,
         content,
       });
@@ -316,10 +316,10 @@ export class WeaveClient {
     if (t == 'MessagesPrompt') {
       const {MessagesPrompt} = await import('./prompt');
 
-      const {description, messages} = val;
+      const {description, messages, name} = val;
 
       let obj = new MessagesPrompt({
-        id: dataObj.id,
+        name,
         description,
         messages,
       });
@@ -333,10 +333,10 @@ export class WeaveClient {
       // Avoid circular dependency
       const {Dataset} = await import('./dataset');
 
-      const {description, rows} = val;
+      const {description, rows, name} = val;
 
       let obj = new Dataset({
-        id: dataObj.id,
+        name: name || dataObj.id,
         description,
         rows,
       });
@@ -430,7 +430,7 @@ export class WeaveClient {
       const classChain = getClassChain(obj);
       const className = classChain[0];
       if (!objId) {
-        objId = sanitizeObjectName(obj.id);
+        objId = objectNameToId(obj.name);
       }
 
       let saveAttrs = obj.saveAttrs();
@@ -905,7 +905,7 @@ async function maybeFormatCode(code: string) {
   //   }
 }
 
-function sanitizeObjectName(name: string): string {
+function objectNameToId(name: string): string {
   // Replaces any non-alphanumeric characters with a single dash and removes
   // any leading or trailing dashes. This is more restrictive than the DB
   // constraints and can be relaxed if needed.

--- a/sdks/node/src/weaveObject.ts
+++ b/sdks/node/src/weaveObject.ts
@@ -5,7 +5,7 @@ import {getGlobalDomain} from './urls';
 export interface Callable {}
 
 export interface WeaveObjectParameters {
-  id?: string;
+  name?: string;
   description?: string;
 }
 
@@ -55,7 +55,10 @@ export class WeaveObject {
   }
 
   saveAttrs() {
-    const attrs: {[key: string]: any} = {};
+    const attrs: {[key: string]: any} = {
+      name: this._baseParameters?.name,
+      description: this._baseParameters?.description,
+    };
 
     for (const key of Object.keys(this)) {
       if (!key.startsWith('_')) {
@@ -70,8 +73,8 @@ export class WeaveObject {
     return attrs;
   }
 
-  get id() {
-    return this._baseParameters.id ?? this.constructor.name;
+  get name() {
+    return this._baseParameters.name ?? this.constructor.name;
   }
 
   get description() {


### PR DESCRIPTION
## Description

The current serialization payload for TS objects looks like this:

```
{
  ...
  val: {
    "_type": "<Type>",
    "_class_name": "<ClassName>",
    "_bases": [...],
    "_baseParameters": {
      "id": "<id>",
      "description": "<description>"
    }
  }
}
```

This is misaligned with payloads for Python objects. This PR changes it to match as such:

```
{
  ...
  val: {
    "_type": "<Type>",
    "_class_name": "<ClassName>",
    "_bases": [...],
    "name": "<name>",
    "description": "<description>"
  }
}
```


- Fixes WB-26068

## Testing

- unit tests