### PR TITLE
chore(ui): Eval compare: Updated compare table header height

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CompareEvaluationsPage/sections/ExampleCompareSection/ExampleCompareSectionTable.tsx
@@ -997,6 +997,7 @@ export const ExampleCompareSectionTableModelsAsRows: React.FC<
         left: ['inputDigest'],
       }}
       rowHeight={props.rowHeight}
+      columnHeaderHeight={40}
       rowSelectionModel={selectedRowInputDigest}
       unstable_rowSpanning={true}
       columns={columnsWithControlledWidths}
@@ -1292,6 +1293,7 @@ export const ExampleCompareSectionTableModelsAsColumns: React.FC<
         left: ['inputDigest'],
       }}
       rowHeight={props.rowHeight}
+      columnHeaderHeight={40}
       rowSelectionModel={selectedRowInputDigest}
       unstable_rowSpanning={true}
       columns={columnsWithControlledWidths}


### PR DESCRIPTION
## Description

| Before | After |
| -------- | ------- |
| <img width="1470" alt="image" src="https://github.com/user-attachments/assets/a12d33af-db3e-4028-92af-b41245b71047" /> | <img width="1470" alt="image" src="https://github.com/user-attachments/assets/d6ac39c7-b694-467c-9597-4bec11b1b060" /> |

Small change, updated header height to make it more compressed (`40px`, same as CallsTable).

