### PR TITLE
fix(weave): shutdown health check thread immediately on exit

### DIFF
--- a/weave/trace_server_bindings/async_batch_processor.py
+++ b/weave/trace_server_bindings/async_batch_processor.py
@@ -264,7 +264,9 @@ class AsyncBatchProcessor(Generic[T]):
     def _health_check(self) -> None:
         """Health check thread that monitors and revives the processing thread if it dies."""
         while self.is_accepting_new_work():
-            time.sleep(HEALTH_CHECK_INTERVAL)
+            # wait HEALTH_CHECK_INTERVAL unless we are shutting down
+            if self.stop_accepting_work_event.wait(timeout=HEALTH_CHECK_INTERVAL):
+                break
 
             # If we're shutting down, don't revive
             if self.stop_accepting_work_event.is_set():


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-26078](https://wandb.atlassian.net/browse/WB-26078)

Don't naively sleep, wait on shutdown condition with timeout. 

## Testing

manual testing, appears to be fixed


[WB-26078]: https://wandb.atlassian.net/browse/WB-26078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ