### PR TITLE
fix(weave): don't print warnings if autogen not installed

### DIFF
--- a/weave/integrations/autogen/autogen_sdk.py
+++ b/weave/integrations/autogen/autogen_sdk.py
@@ -560,6 +560,10 @@ def get_autogen_patcher(
         return _autogen_patcher
 
     try:
+        if importlib.util.find_spec("autogen_agentchat") is None:
+            logger.debug("autogen_agentchat package not found, skipping patching")
+            return NoOpPatcher()
+
         # Preload autogen-ext modules to ensure subclasses are properly discovered
         _preload_autogen_extensions()
 


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-26083

On `weave.init` we were printed a lot of warnings if autogen was not installed. This change skips attempting the patching if it is not available.

```
weave: autogen-ext package not found, skipping extension preloading
weave: Module autogen_agentchat.agents._base_chat_agent not found, skipping patching for BaseChatAgent: No module named 'autogen_agentchat'
weave: Module autogen_agentchat.tools._task_runner_tool not found, skipping patching for TaskRunnerTool: No module named 'autogen_agentchat'
weave: Module autogen_agentchat.teams._group_chat._base_group_chat not found, skipping patching for BaseGroupChat: No module named 'autogen_agentchat'
weave: Module autogen_core._base_agent not found, skipping patching for BaseAgent: No module named 'autogen_core'
weave: Module autogen_core._agent_runtime not found, skipping patching for AgentRuntime: No module named 'autogen_core'
weave: Module autogen_core.tools._base not found, skipping patching for BaseTool: No module named 'autogen_core'
weave: Module autogen_core.models._model_client not found, skipping patching for ChatCompletionClient: No module named 'autogen_core'
weave: Module autogen_core.memory._base_memory not found, skipping patching for Memory: No module named 'autogen_core'
weave: Module autogen_core.code_executor._base not found, skipping patching for CodeExecutor: No module named 'autogen_core'
weave: Module autogen_core._cache_store not found, skipping patching for CacheStore: No module named 'autogen_core'
```

## Testing

How was this PR tested?
