### PR TITLE
perf(weave): dont query for individual feedbacks

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/flattenObject.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/flattenObject.ts
@@ -6,13 +6,17 @@
 export const flattenObjectPreservingWeaveTypes = (obj: {
   [key: string]: any;
 }) => {
-  return flattenObject(obj, '', {}, (key, value) => {
+  const shouldFlatten = (key: string, value: any) => {
+    if (key.startsWith('summary.weave.feedback.')) {
+      return false;
+    }
     return (
       typeof value !== 'object' ||
       value == null ||
       value._type !== 'CustomWeaveType'
     );
-  });
+  };
+  return flattenObject(obj, '', {}, shouldFlatten);
 };
 
 const flattenObject = (

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallsPage/callsTableColumns.tsx
@@ -342,7 +342,7 @@ function buildCallsTableColumns(
       },
     },
     {
-      field: 'feedback',
+      field: 'summary.weave.feedback',
       headerName: 'Feedback',
       width: 150,
       sortable: false,
@@ -353,9 +353,17 @@ function buildCallsTableColumns(
         );
         const callId = rowParams.row.id;
         const weaveRef = makeRefCall(entity, project, callId);
+        // Extract wandb feedback reactions and notes
+        const feedbackKeys = Object.keys(rowParams.row).filter(key =>
+          key.startsWith('summary.weave.feedback.wandb')
+        );
+        const feedbackData = feedbackKeys.flatMap(key => {
+          return rowParams.row[key];
+        });
         return (
           <Reactions
             weaveRef={weaveRef}
+            feedbackData={feedbackData}
             forceVisible={rowIndex === 0}
             twWrapperStyles={{
               width: '100%',

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/tsDataModelHooks.ts
@@ -718,7 +718,8 @@ const useFeedback = (
     if (doReload) {
       setDoReload(false);
     }
-    if (!deepKey) {
+    if (!deepKey || params.skip) {
+      setResult({loading: false, result: null, error: null});
       return;
     }
     setResult({loading: true, result: null, error: null});
@@ -753,7 +754,7 @@ const useFeedback = (
     return () => {
       mounted = false;
     };
-  }, [deepKey, getTsClient, doReload, params.sortBy]);
+  }, [deepKey, getTsClient, doReload, params.sortBy, params.skip]);
 
   return {...result, refetch};
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/wfDataModelHooksInterface.ts
@@ -353,6 +353,7 @@ export interface UseFileContentParams {
 
 export interface UseFeedbackParams {
   key: FeedbackKey | null;
+  skip?: boolean;
   sortBy?: traceServerClientTypes.SortBy[];
 }
 

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -32,6 +32,7 @@ def make_feedback_query_req(
     feedback_query_req = tsi.FeedbackQueryReq(
         project_id=project_id,
         fields=[
+            "id",
             "feedback_type",
             "weave_ref",
             "payload",


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Requires that one line backend change. 

Don't query for feedback for every call, just use the feedback that we already attach to the calls query response! 

## Testing

prod
![lots-of-feedback-prod](https://github.com/user-attachments/assets/62db18ab-5839-465e-abbc-25c197bd5e82)


branch
![lots-of-feedback-branch](https://github.com/user-attachments/assets/5907ace3-0485-4a93-87ba-4e0ca92eda8f)

