### PR TITLE
chore(weave): Add warning that we will drop support for python 3.9

### DIFF
--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import sys
+import warnings
 from collections.abc import Iterator
 from typing import Any, Union, cast
 
@@ -72,6 +74,13 @@ def init(
         A Weave client.
     """
     configure_logger()
+
+    if sys.version_info < (3, 10):
+        warnings.warn(
+            "Python 3.9 will reach end of life in October 2025, after which weave will drop support for it.  Please upgrade to Python 3.10 or later!",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     parse_and_apply_settings(settings)
 


### PR DESCRIPTION
py39 will be EOL in Oct 2025 (https://devguide.python.org/versions/)