### PR TITLE
chore(weave): Fixes small bug with mixed project protection

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -2065,7 +2065,7 @@ class WeaveClient:
                 return val
             # Check if existing ref is to current project, if not,
             # remove the ref and recreate it in the current project
-            if val.project == self.project:
+            if val.project == self.project and val.entity == self.entity:
                 return val
             val = orig_val
 


### PR DESCRIPTION
While implemented backend evals, I noticed that our mixed project check was not checking for entity equality. This is equally as important! Adding this for safety 