### PR TITLE
chore(weave): Ensure that LLM-based evaluations can be serialized and deserialized correctly

### DIFF
--- a/tests/trace/test_evaluation_ref_get.py
+++ b/tests/trace/test_evaluation_ref_get.py
@@ -1,0 +1,50 @@
+import pytest
+
+import weave
+from weave.scorers import LLMAsAJudgeScorer
+from weave.trace_server.interface.builtin_object_classes.builtin_object_registry import (
+    LLMStructuredCompletionModel,
+)
+from weave.trace_server.interface.builtin_object_classes.llm_structured_model import (
+    LLMStructuredCompletionModelDefaultParams,
+)
+
+
+@pytest.mark.asyncio
+async def test_basic_llm_evaluations(client):
+    scorer = LLMAsAJudgeScorer(
+        model=LLMStructuredCompletionModel(
+            llm_model_id="gpt-4o-mini",
+            default_params=LLMStructuredCompletionModelDefaultParams(
+                messages_template=[
+                    {
+                        "role": "system",
+                        "content": "You are a judge, respond with json. 'score' (0-1), 'reasoning' (string)",
+                    }
+                ],
+                response_format="json_object",
+            ),
+        ),
+        scoring_prompt="Here are the inputs: {inputs}. Here is the output: {output}. Is the output correct?",
+    )
+    dataset = [{"question": "what 2+2?"}]
+    evaluation = weave.Evaluation(dataset=dataset, scorers=[scorer])
+    model = LLMStructuredCompletionModel(
+        llm_model_id="gpt-4o-mini",
+        default_params=LLMStructuredCompletionModelDefaultParams(
+            messages_template=[
+                {"role": "system", "content": "You are a helpful assistant."}
+            ],
+            response_format="text",
+        ),
+    )
+
+    published_eval_ref = weave.publish(evaluation)
+    published_model_ref = weave.publish(model)
+
+    gotten_eval = weave.get(published_eval_ref.uri())
+    gotten_model = weave.get(published_model_ref.uri())
+
+    result = await gotten_eval.evaluate(gotten_model)
+
+    assert result == "NO WAY"

--- a/tests/trace/test_evaluation_ref_get.py
+++ b/tests/trace/test_evaluation_ref_get.py
@@ -1,5 +1,3 @@
-import pytest
-
 import weave
 from weave.scorers import LLMAsAJudgeScorer
 from weave.trace_server.interface.builtin_object_classes.builtin_object_registry import (
@@ -10,8 +8,12 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
-@pytest.mark.asyncio
-async def test_basic_llm_evaluations(client):
+def test_publish_and_load_evaluation(client):
+    """
+    This test just verifies the round trip for the evaluation.
+
+    We do not actually run it here,
+    """
     scorer = LLMAsAJudgeScorer(
         model=LLMStructuredCompletionModel(
             llm_model_id="gpt-4o-mini",
@@ -44,7 +46,9 @@ async def test_basic_llm_evaluations(client):
 
     gotten_eval = weave.get(published_eval_ref.uri())
     gotten_model = weave.get(published_model_ref.uri())
+    assert isinstance(gotten_model, LLMStructuredCompletionModel)
 
-    result = await gotten_eval.evaluate(gotten_model)
-
-    assert result == "NO WAY"
+    assert isinstance(gotten_eval, weave.Evaluation)
+    assert isinstance(gotten_eval.dataset, weave.Dataset)
+    for scorer in gotten_eval.scorers:
+        assert isinstance(scorer, LLMAsAJudgeScorer)

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -120,12 +120,15 @@ class Evaluation(Object):
 
         # Start mega-hack
         # This is a very bad hack. Our deserialization/portability logic
-        # if totally broken. It will require a complete re-write of our
-        # deserialziation layer to fix. In the meantime, this is such a
-        # common pattern, that I am going to fix it here. If you are a
-        # future dev and you actually fix the serialization stuff, that
-        # may or may not break this. That is OK! please feel free to remove
-        # this as we have tests that validate the end-user experience.
+        # is totally broken. It will require a complete re-write of our
+        # deserialization layer to fix. The specific issue is that our
+        # deserialization code does not recursively deserialize custom objects
+        # (in this case scorers) and therefore needs to be done manually.
+        # In the meantime, this is such a common pattern, that I am going to
+        # fix it here. If you are a future dev and you actually fix the
+        # serialization stuff, that may or may not break this. That is OK!
+        # please feel free to remove this as we have tests that validate the
+        # end-user experience.
         if orig_scorers := field_values.get("scorers"):
             from weave import scorers as weave_scorers
 

--- a/weave/flow/eval.py
+++ b/weave/flow/eval.py
@@ -118,6 +118,17 @@ class Evaluation(Object):
             if hasattr(obj, field_name):
                 field_values[field_name] = getattr(obj, field_name)
 
+        # special case for scorers
+        # if orig_scorers := field_values.get("scorers"):
+        #     from weave import scorers as weave_scorers
+
+        #     assert weave_scorers
+        #     scorers = []
+        #     for scorer in orig_scorers:
+        #         objectified = maybe_objectify(scorer)
+        #         scorers.append(objectified)
+        #     field_values["scorers"] = scorers
+
         return cls(**field_values)
 
     def model_post_init(self, __context: Any) -> None:

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -320,7 +320,7 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
             if cls:
                 # Filter out metadata fields before validation
                 obj_data = {
-                    k: v for k, v in obj.items() if k not in ("_class_name", "_bases")
+                    k: v for k, v in obj.items() if k in cls.model_fields.keys()
                 }
                 return cls.model_validate(obj_data)
 


### PR DESCRIPTION
Our serialization/deserialization strategy is sorely in need of a re-write. I attempted it here, but it is a big change with wide-spread blast radius. Instead, I just made a very pointed hack to make sure we can deserialize things correctly. I learned a lot though, and am tempted to fix it once and for all soon.