### PR TITLE
fix(weave): make type annotations work on Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,7 +176,6 @@ test = [
   "fastapi>=0.110.0",
   "sqlparse==0.5.0",
   "freezegun",
-  "eval_type_backport",
 
   # Integration Tests
   "pytest-recording>=0.13.2",


### PR DESCRIPTION
## Description

On Python 3.9 we're getting errors like the below. Fixed as suggested in the Pydantic error message by adding the lightweight [eval_type_backport](https://pypi.org/project/eval-type-backport/) dependency.

```
Traceback (most recent call last):
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py", line 466, in _eval_type_backport
    return _eval_type(value, globalns, localns, type_params)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py", line 500, in _eval_type
    return typing._eval_type(  # type: ignore
  File "/Users/jamie/.pyenv/versions/3.9.13/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py", line 292, in _eval_type
    return t._evaluate(globalns, localns, recursive_guard)
  File "/Users/jamie/.pyenv/versions/3.9.13/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py", line 554, in _evaluate
    eval(self.__forward_code__, globalns, localns),
  File "<string>", line 1, in <module>
TypeError: unsupported operand type(s) for |: '_AnnotatedAlias' and 'NoneType'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jamie/source/jcr/weaverel/test.py", line 1, in <module>
    import weave
  File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/__init__.py", line 4, in <module>
    from weave.trace.api import *
  File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/trace/api.py", line 15, in <module>
    from weave.trace import urls, weave_client, weave_init
  File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/trace/weave_client.py", line 924, in <module>
    class WeaveClient:
  File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/trace/weave_client.py", line 1077, in WeaveClient
    def get_calls(
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/validate_call_decorator.py", line 114, in validate_call
    return validate(func)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/validate_call_decorator.py", line 108, in validate
    validate_call_wrapper = _validate_call.ValidateCallWrapper(
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_validate_call.py", line 87, in __init__
    self._create_validators()
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_validate_call.py", line 93, in _create_validators
    schema = gen_schema.clean_schema(gen_schema.generate_schema(self.function))
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 711, in generate_schema
    schema = self._generate_schema_inner(obj)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 1009, in _generate_schema_inner
    return self.match_type(obj)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 1110, in match_type
    return self._call_schema(obj)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 2007, in _call_schema
    arguments_schema = self._arguments_schema(function)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_generate_schema.py", line 2039, in _arguments_schema
    type_hints = _typing_extra.get_function_type_hints(function, globalns=globalns, localns=localns)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py", line 551, in get_function_type_hints
    type_hints[name] = eval_type_backport(value, globalns, localns, type_params)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py", line 429, in eval_type_backport
    return _eval_type_backport(value, globalns, localns, type_params)
  File "/Users/jamie/source/jcr/weaverel/.venv/lib/python3.9/site-packages/pydantic/_internal/_typing_extra.py", line 474, in _eval_type_backport
    raise TypeError(
TypeError: Unable to evaluate type annotation 'CallsFilterLike | None'. If you are making use of the new typing syntax (unions using `|` since Python 3.10 or builtins subscripting since Python 3.9), you should either replace the use of new syntax with the existing `typing` constructs or install the `eval_type_backport` package.
```

## Testing

How was this PR tested?
