### PR TITLE
feat(weave): customize chart names in trace table

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/charts/CallsCharts.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/charts/CallsCharts.tsx
@@ -217,6 +217,7 @@ const CallsChartsInner = ({
                 binCount={chart.binCount}
                 aggregation={chart.aggregation}
                 title={chartTitle}
+                customName={chart.customName}
                 chartId={chart.id}
                 entity={entity}
                 project={project}

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/charts/ChartModal.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/charts/ChartModal.tsx
@@ -11,8 +11,10 @@ import React from 'react';
 import NumberInput from '../../../../../common/components/elements/NumberInput';
 import {Button} from '../../../../Button';
 import {Select as CustomSelect} from '../../../../Form/Select';
+import {TextField} from '../../../../Form/TextField';
 import {Icon} from '../../../../Icon';
 import {BarChart} from './BarChart';
+import {generateChartAutoName} from './Chart';
 import {useMultipleOperations} from './chartDataProcessing';
 import {
   convertSchemaToAxisFields,
@@ -404,7 +406,35 @@ export const ChartModal: React.FC<ChartModalProps> = ({
               p: 3,
               backgroundColor: MOON_50,
             }}>
-            <SectionHeader first>Plot Type</SectionHeader>
+            <SectionHeader first>Chart Name</SectionHeader>
+            <Box sx={{mb: 2}}>
+              <TextField
+                value={localConfig.customName || ''}
+                onChange={value =>
+                  setLocalConfig(prev => ({
+                    ...prev,
+                    customName: value || undefined,
+                  }))
+                }
+                placeholder={
+                  localConfig.yAxis &&
+                  localConfig.plotType &&
+                  localConfig.aggregation
+                    ? generateChartAutoName(
+                        localConfig.yAxis,
+                        localConfig.plotType,
+                        localConfig.aggregation,
+                        localConfig.xAxis || 'started_at',
+                        callData
+                      )
+                    : 'Chart name'
+                }
+                variant="default"
+                size="medium"
+              />
+            </Box>
+
+            <SectionHeader>Plot Type</SectionHeader>
             <CustomSelect
               value={
                 plotTypeOptions.find(

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/charts/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/charts/types.ts
@@ -115,6 +115,7 @@ export type ChartConfig = {
   binCount?: number; // For line plots and bar charts
   aggregation?: AggregationMethod; // For line plots and bar charts
   groupKeys?: string[]; // For grouping by multiple keys (op_name and user-selected fields)
+  customName?: string; // For custom chart names
 };
 
 export type ChartsState = {


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-26065

## Description

- Adds custom naming capability for charts in the trace table chart section
- Implements a utility function `generateChartAutoName` to create automatic chart names based on axis fields and plot type
- Adds a text field in the ChartModal to allow users to set custom names for charts
- Using auto-generated names when custom names aren't provided

## Testing

Tested by creating various chart types (scatter, line, bar) and verifying that:
- Default auto-generated names are created correctly based on chart configuration
- Custom names can be entered and are properly displayed
- Names persist when charts are saved and reopened for editing

https://github.com/user-attachments/assets/ff6705f9-fd69-414d-b0cd-d826badc6f47


