### PR TITLE
fix(weave): add wandb dependency back in

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ classifiers = [
 requires-python = ">=3.9"
 dynamic = ["version"]
 dependencies = [
+  "wandb>=0.17.1",
   "sentry-sdk>=2.0.0,<3.0.0",
   "pydantic>=2.0.0",
   "packaging>=21.0",          # For version parsing in integrations


### PR DESCRIPTION
## Description

Temporarily adding the wandb dependency back in (removed in https://github.com/wandb/weave/pull/4982) because there are a few cases we're not handling right without it yet.

## Testing

How was this PR tested?
