### PR TITLE
chore(weave): Adds backend evaluation stubs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,6 +175,14 @@ class ThrowingServer(tsi.TraceServerInterface):
     def feedback_purge(self, req: tsi.FeedbackPurgeReq) -> tsi.FeedbackPurgeRes:
         raise DummyTestException("FAILURE - feedback_purge, req:", req)
 
+    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
+        raise DummyTestException("FAILURE - evaluate_model, req:", req)
+
+    def evaluation_status(
+        self, req: tsi.EvaluationStatusReq
+    ) -> tsi.EvaluationStatusRes:
+        raise DummyTestException("FAILURE - evaluation_status, req:", req)
+
 
 @pytest.fixture
 def client_with_throwing_server(client):

--- a/tests/trace_server/conftest_lib/trace_server_external_adapter.py
+++ b/tests/trace_server/conftest_lib/trace_server_external_adapter.py
@@ -124,6 +124,10 @@ class TestOnlyUserInjectingExternalTraceServer(
         req.obj.wb_user_id = self._user_id
         return super().obj_create(req)
 
+    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
+        req.wb_user_id = self._user_id
+        return super().evaluate_model(req)
+
 
 def externalize_trace_server(
     trace_server: tsi.TraceServerInterface, user_id: str = "test_user"

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2066,6 +2066,14 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             self._insert_call, chunk_iter, start_call, model_name, req.project_id
         )
 
+    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
+        raise NotImplementedError("Evaluate model is not implemented")
+
+    def evaluation_status(
+        self, req: tsi.EvaluationStatusReq
+    ) -> tsi.EvaluationStatusRes:
+        raise NotImplementedError("Evaluation status is not implemented")
+
     # Private Methods
     @property
     def ch_client(self) -> CHClient:

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -419,3 +419,15 @@ class ExternalTraceServer(tsi.TraceServerInterface):
         return self._stream_ref_apply(
             self._internal_trace_server.threads_query_stream, req
         )
+
+    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        if req.wb_user_id is not None:
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
+        return self._ref_apply(self._internal_trace_server.evaluate_model, req)
+
+    def evaluation_status(
+        self, req: tsi.EvaluationStatusReq
+    ) -> tsi.EvaluationStatusRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.evaluation_status, req)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1529,6 +1529,18 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 p99_turn_duration_ms=p99_turn_duration_ms,
             )
 
+    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
+        raise NotImplementedError(
+            "evaluate_model is not implemented for SQLite trace server"
+        )
+
+    def evaluation_status(
+        self, req: tsi.EvaluationStatusReq
+    ) -> tsi.EvaluationStatusRes:
+        raise NotImplementedError(
+            "evaluation_status is not implemented for SQLite trace server"
+        )
+
     def _table_row_read(self, project_id: str, row_digest: str) -> tsi.TableRowSchema:
         conn, cursor = get_conn_cursor(self.db_path)
         # Now get the rows

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1108,6 +1108,51 @@ class ThreadsQueryReq(BaseModel):
     )
 
 
+class EvaluateModelReq(BaseModel):
+    project_id: str
+    evaluation_ref: str
+    model_ref: str
+    wb_user_id: Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)
+
+
+class EvaluateModelRes(BaseModel):
+    call_id: str
+
+
+class EvaluationStatusReq(BaseModel):
+    project_id: str
+    call_id: str
+
+
+class EvaluationStatusPending(BaseModel):
+    status: Literal["pending"]
+
+
+class EvaluationStatusRunning(BaseModel):
+    status: Literal["running"]
+    completed_rows: int
+    total_rows: int
+
+
+class EvaluationStatusFailed(BaseModel):
+    status: Literal["failed"]
+    error: Optional[str] = None
+
+
+class EvaluationStatusComplete(BaseModel):
+    status: Literal["complete"]
+    output: Optional[Any] = None
+
+
+class EvaluationStatusRes(BaseModel):
+    status: Union[
+        EvaluationStatusPending,
+        EvaluationStatusRunning,
+        EvaluationStatusFailed,
+        EvaluationStatusComplete,
+    ]
+
+
 class TraceServerInterface(Protocol):
     def ensure_project_exists(
         self, entity: str, project: str
@@ -1189,3 +1234,7 @@ class TraceServerInterface(Protocol):
 
     # Thread API
     def threads_query_stream(self, req: ThreadsQueryReq) -> Iterator[ThreadSchema]: ...
+
+    # Evaluation API
+    def evaluate_model(self, req: EvaluateModelReq) -> EvaluateModelRes: ...
+    def evaluation_status(self, req: EvaluationStatusReq) -> EvaluationStatusRes: ...

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -507,6 +507,14 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
     ) -> Iterator[tsi.ThreadSchema]:
         return self._next_trace_server.threads_query_stream(req)
 
+    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
+        return self._next_trace_server.evaluate_model(req)
+
+    def evaluation_status(
+        self, req: tsi.EvaluationStatusReq
+    ) -> tsi.EvaluationStatusRes:
+        return self._next_trace_server.evaluation_status(req)
+
 
 def pydantic_bytes_safe_dump(obj: BaseModel) -> str:
     raw_dict = obj.model_dump()

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -642,6 +642,14 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/threads/stream_query", req, tsi.ThreadsQueryReq, tsi.ThreadSchema
         )
 
+    def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
+        raise NotImplementedError("evaluate_model is not implemented")
+
+    def evaluation_status(
+        self, req: tsi.EvaluationStatusReq
+    ) -> tsi.EvaluationStatusRes:
+        raise NotImplementedError("evaluation_status is not implemented")
+
 
 __docspec__ = [
     RemoteHTTPTraceServer,


### PR DESCRIPTION
Simple PR that adds the scaffolding for:
* `evaluate_model`
* `evaluation_status`

These are not implemented currently and will not have user impact. I am on my 3rd iteration of the underlying implementation now and I just want to get the stubs landed to make incremental delivery easier