### PR TITLE
feat(weave): Let Thread API to support filter by thread id

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -5062,33 +5062,47 @@ def test_threads_query_endpoint(client):
     # Should include our threads since they're before this future time
     assert len(before_filter_res) >= 3
 
-    # Test thread_id filtering
-    # Test filtering by specific thread_id
+    # Test thread_ids filtering
+    # Test filtering by specific thread_ids (single thread)
     for test_thread_id in thread_ids:
-        thread_id_filter_res = list(
+        thread_ids_filter_res = list(
             client.server.threads_query_stream(
                 tsi.ThreadsQueryReq(
                     project_id=get_client_project_id(client),
-                    filter=tsi.ThreadsQueryFilter(thread_id=test_thread_id),
+                    filter=tsi.ThreadsQueryFilter(thread_ids=[test_thread_id]),
                 )
             )
         )
         # Should find exactly one thread with the specified thread_id
-        assert len(thread_id_filter_res) == 1
-        assert thread_id_filter_res[0].thread_id == test_thread_id
+        assert len(thread_ids_filter_res) == 1
+        assert thread_ids_filter_res[0].thread_id == test_thread_id
 
-    # Test filtering by non-existent thread_id
+    # Test filtering by multiple thread_ids
+    multiple_thread_ids_filter_res = list(
+        client.server.threads_query_stream(
+            tsi.ThreadsQueryReq(
+                project_id=get_client_project_id(client),
+                filter=tsi.ThreadsQueryFilter(thread_ids=thread_ids[:2]),
+            )
+        )
+    )
+    # Should find exactly two threads
+    assert len(multiple_thread_ids_filter_res) == 2
+    found_thread_ids = {t.thread_id for t in multiple_thread_ids_filter_res}
+    assert found_thread_ids == set(thread_ids[:2])
+
+    # Test filtering by non-existent thread_ids
     nonexistent_filter_res = list(
         client.server.threads_query_stream(
             tsi.ThreadsQueryReq(
                 project_id=get_client_project_id(client),
-                filter=tsi.ThreadsQueryFilter(thread_id="nonexistent_thread_id"),
+                filter=tsi.ThreadsQueryFilter(thread_ids=["nonexistent_thread_id"]),
             )
         )
     )
     assert len(nonexistent_filter_res) == 0
 
-    # Test combining thread_id filter with other filters
+    # Test combining thread_ids filter with other filters
     combo_thread_filter_res = list(
         client.server.threads_query_stream(
             tsi.ThreadsQueryReq(
@@ -5096,13 +5110,13 @@ def test_threads_query_endpoint(client):
                 limit=1,
                 sort_by=[tsi.SortBy(field="turn_count", direction="desc")],
                 filter=tsi.ThreadsQueryFilter(
-                    thread_id="analytics_thread",
+                    thread_ids=["analytics_thread"],
                     after_datetime=middle_time,
                 ),
             )
         )
     )
-    # Should find at most 1 thread matching the specific thread_id and time filter
+    # Should find at most 1 thread matching the specific thread_ids and time filter
     assert len(combo_thread_filter_res) <= 1
     if len(combo_thread_filter_res) == 1:
         assert combo_thread_filter_res[0].thread_id == "analytics_thread"

--- a/tests/trace_server/test_threads_query_builder.py
+++ b/tests/trace_server/test_threads_query_builder.py
@@ -52,7 +52,7 @@ def test_clickhouse_basic_query():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
+            aggregated_thread_id AS thread_id,
             COUNT(*) AS turn_count,
             min(call_start_time) AS start_time,
             max(call_end_time) AS last_updated,
@@ -63,7 +63,7 @@ def test_clickhouse_basic_query():
         FROM (
             SELECT
                 id,
-                any(thread_id) AS thread_id,
+                any(thread_id) AS aggregated_thread_id,
                 min(started_at) AS call_start_time,
                 max(ended_at) AS call_end_time,
                 CASE
@@ -74,10 +74,10 @@ def test_clickhouse_basic_query():
             FROM calls_merged
             WHERE project_id = {pb_0: String}
 
-            GROUP BY id
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
         ) AS properly_merged_calls
-        GROUP BY thread_id
+        GROUP BY aggregated_thread_id
         ORDER BY last_updated DESC
         """,
         {"pb_0": "test_project"},
@@ -110,10 +110,9 @@ def test_sqlite_basic_query():
                 -1 AS p99_turn_duration_ms
             FROM calls c1
             WHERE project_id = ?
+                AND id = turn_id
                 AND thread_id IS NOT NULL
                 AND thread_id != ''
-                AND id = turn_id
-
             GROUP BY thread_id
             ORDER BY last_updated DESC
             """,
@@ -135,7 +134,7 @@ def test_clickhouse_custom_sorting():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
+            aggregated_thread_id AS thread_id,
             COUNT(*) AS turn_count,
             min(call_start_time) AS start_time,
             max(call_end_time) AS last_updated,
@@ -146,7 +145,7 @@ def test_clickhouse_custom_sorting():
         FROM (
             SELECT
                 id,
-                any(thread_id) AS thread_id,
+                any(thread_id) AS aggregated_thread_id,
                 min(started_at) AS call_start_time,
                 max(ended_at) AS call_end_time,
                 CASE
@@ -157,10 +156,10 @@ def test_clickhouse_custom_sorting():
             FROM calls_merged
             WHERE project_id = {pb_0: String}
 
-            GROUP BY id
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
         ) AS properly_merged_calls
-        GROUP BY thread_id
+        GROUP BY aggregated_thread_id
         ORDER BY turn_count ASC, start_time DESC
         """,
         {"pb_0": "test_project"},
@@ -199,10 +198,9 @@ def test_sqlite_custom_sorting():
             -1 AS p99_turn_duration_ms
         FROM calls c1
         WHERE project_id = ?
+            AND id = turn_id
             AND thread_id IS NOT NULL
             AND thread_id != ''
-            AND id = turn_id
-
         GROUP BY thread_id
         ORDER BY thread_id ASC, turn_count DESC
         """,
@@ -220,7 +218,7 @@ def test_clickhouse_with_limit():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
+            aggregated_thread_id AS thread_id,
             COUNT(*) AS turn_count,
             min(call_start_time) AS start_time,
             max(call_end_time) AS last_updated,
@@ -231,7 +229,7 @@ def test_clickhouse_with_limit():
         FROM (
             SELECT
                 id,
-                any(thread_id) AS thread_id,
+                any(thread_id) AS aggregated_thread_id,
                 min(started_at) AS call_start_time,
                 max(ended_at) AS call_end_time,
                 CASE
@@ -242,10 +240,10 @@ def test_clickhouse_with_limit():
             FROM calls_merged
             WHERE project_id = {pb_0: String}
 
-            GROUP BY id
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
         ) AS properly_merged_calls
-        GROUP BY thread_id
+        GROUP BY aggregated_thread_id
         ORDER BY last_updated DESC
         LIMIT {pb_1: Int64}
         """,
@@ -260,7 +258,7 @@ def test_clickhouse_with_limit_and_offset():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
+            aggregated_thread_id AS thread_id,
             COUNT(*) AS turn_count,
             min(call_start_time) AS start_time,
             max(call_end_time) AS last_updated,
@@ -271,7 +269,7 @@ def test_clickhouse_with_limit_and_offset():
         FROM (
             SELECT
                 id,
-                any(thread_id) AS thread_id,
+                any(thread_id) AS aggregated_thread_id,
                 min(started_at) AS call_start_time,
                 max(ended_at) AS call_end_time,
                 CASE
@@ -282,10 +280,10 @@ def test_clickhouse_with_limit_and_offset():
             FROM calls_merged
             WHERE project_id = {pb_0: String}
 
-            GROUP BY id
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
         ) AS properly_merged_calls
-        GROUP BY thread_id
+        GROUP BY aggregated_thread_id
         ORDER BY last_updated DESC
         LIMIT {pb_1: Int64}
         OFFSET {pb_2: Int64}
@@ -322,10 +320,9 @@ def test_sqlite_with_limit_and_offset():
             -1 AS p99_turn_duration_ms
         FROM calls c1
         WHERE project_id = ?
+            AND id = turn_id
             AND thread_id IS NOT NULL
             AND thread_id != ''
-            AND id = turn_id
-
         GROUP BY thread_id
         ORDER BY last_updated DESC
         LIMIT ?
@@ -349,7 +346,7 @@ def test_clickhouse_with_date_filters():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
+            aggregated_thread_id AS thread_id,
             COUNT(*) AS turn_count,
             min(call_start_time) AS start_time,
             max(call_end_time) AS last_updated,
@@ -360,7 +357,7 @@ def test_clickhouse_with_date_filters():
         FROM (
             SELECT
                 id,
-                any(thread_id) AS thread_id,
+                any(thread_id) AS aggregated_thread_id,
                 min(started_at) AS call_start_time,
                 max(ended_at) AS call_end_time,
                 CASE
@@ -371,10 +368,10 @@ def test_clickhouse_with_date_filters():
             FROM calls_merged
             WHERE project_id = {pb_0: String}
                 AND sortable_datetime > {pb_1: String} AND sortable_datetime < {pb_2: String}
-            GROUP BY id
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
         ) AS properly_merged_calls
-        GROUP BY thread_id
+        GROUP BY aggregated_thread_id
         ORDER BY last_updated DESC
         """,
         {
@@ -416,10 +413,10 @@ def test_sqlite_with_date_filters():
             -1 AS p99_turn_duration_ms
         FROM calls c1
         WHERE project_id = ?
-            AND thread_id IS NOT NULL
-            AND thread_id != ''
             AND id = turn_id
             AND started_at > ? AND started_at < ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
         GROUP BY thread_id
         ORDER BY last_updated DESC
         """,
@@ -442,7 +439,7 @@ def test_clickhouse_full_featured_query():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
+            aggregated_thread_id AS thread_id,
             COUNT(*) AS turn_count,
             min(call_start_time) AS start_time,
             max(call_end_time) AS last_updated,
@@ -453,7 +450,7 @@ def test_clickhouse_full_featured_query():
         FROM (
             SELECT
                 id,
-                any(thread_id) AS thread_id,
+                any(thread_id) AS aggregated_thread_id,
                 min(started_at) AS call_start_time,
                 max(ended_at) AS call_end_time,
                 CASE
@@ -464,10 +461,10 @@ def test_clickhouse_full_featured_query():
             FROM calls_merged
             WHERE project_id = {pb_0: String}
                 AND sortable_datetime > {pb_1: String} AND sortable_datetime < {pb_2: String}
-            GROUP BY id
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
         ) AS properly_merged_calls
-        GROUP BY thread_id
+        GROUP BY aggregated_thread_id
         ORDER BY turn_count DESC
         LIMIT {pb_3: Int64}
         OFFSET {pb_4: Int64}
@@ -519,10 +516,10 @@ def test_sqlite_full_featured_query():
             -1 AS p99_turn_duration_ms
         FROM calls c1
         WHERE project_id = ?
-            AND thread_id IS NOT NULL
-            AND thread_id != ''
             AND id = turn_id
             AND started_at > ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
         GROUP BY thread_id
         ORDER BY last_updated ASC, thread_id DESC
         LIMIT ?
@@ -545,7 +542,7 @@ def test_clickhouse_only_after_date():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
+            aggregated_thread_id AS thread_id,
             COUNT(*) AS turn_count,
             min(call_start_time) AS start_time,
             max(call_end_time) AS last_updated,
@@ -556,7 +553,7 @@ def test_clickhouse_only_after_date():
         FROM (
             SELECT
                 id,
-                any(thread_id) AS thread_id,
+                any(thread_id) AS aggregated_thread_id,
                 min(started_at) AS call_start_time,
                 max(ended_at) AS call_end_time,
                 CASE
@@ -567,10 +564,10 @@ def test_clickhouse_only_after_date():
             FROM calls_merged
             WHERE project_id = {pb_0: String}
                 AND sortable_datetime > {pb_1: String}
-            GROUP BY id
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id)
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
         ) AS properly_merged_calls
-        GROUP BY thread_id
+        GROUP BY aggregated_thread_id
         ORDER BY last_updated DESC
         """,
         {"pb_0": "test_project", "pb_1": "2024-01-01 00:00:00.000000"},
@@ -606,10 +603,10 @@ def test_sqlite_only_before_date():
             -1 AS p99_turn_duration_ms
         FROM calls c1
         WHERE project_id = ?
-            AND thread_id IS NOT NULL
-            AND thread_id != ''
             AND id = turn_id
             AND started_at < ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
         GROUP BY thread_id
         ORDER BY last_updated DESC
         """,
@@ -690,7 +687,11 @@ def test_turn_filtering_explanation():
     assert "id = turn_id" in sqlite_query
 
     # Check that thread filtering is also present (non-null, non-empty)
-    assert "thread_id IS NOT NULL AND thread_id != ''" in clickhouse_query
+    # For ClickHouse, filtering is now in the HAVING clause using aggregated_thread_id
+    assert (
+        "aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''"
+        in clickhouse_query
+    )
     assert "thread_id IS NOT NULL" in sqlite_query
     assert "thread_id != ''" in sqlite_query
 
@@ -703,43 +704,37 @@ def test_clickhouse_with_thread_id_filter():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
-            COUNT(*) as turn_count,
-            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
-            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
-            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
-            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
-            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
-            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+            aggregated_thread_id AS thread_id,
+            COUNT(*) AS turn_count,
+            min(call_start_time) AS start_time,
+            max(call_end_time) AS last_updated,
+            argMin(id, call_start_time) AS first_turn_id,
+            argMax(id, call_end_time) AS last_turn_id,
+            quantile(0.5)(call_duration) AS p50_turn_duration_ms,
+            quantile(0.99)(call_duration) AS p99_turn_duration_ms
         FROM (
-            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
-            -- This handles cases where calls_merged has multiple partial rows per call_id
-            -- due to ClickHouse materialized view background merge behavior
             SELECT
-                id,                              -- Call identifier
-                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
-                                                -- (all non-null values should be identical)
-                min(started_at) as call_start_time,   -- Earliest start time for this call
-                max(ended_at) as call_end_time,   -- Latest end time for this call
-                -- Calculate call duration in milliseconds
+                id,
+                any(thread_id) AS aggregated_thread_id,
+                min(started_at) AS call_start_time,
+                max(ended_at) AS call_end_time,
                 CASE
                     WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
                     THEN dateDiff('millisecond', call_start_time, call_end_time)
                     ELSE NULL
-                END as call_duration
+                END AS call_duration
             FROM calls_merged
             WHERE project_id = {pb_0: String}
-
-            GROUP BY id                         -- Group by call id to merge partial rows
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id) AND thread_id = {pb_1: String}  -- Filter to turn calls only
-        ) as properly_merged_calls
-        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
-        GROUP BY thread_id
-        ORDER BY last_updated DESC
+                AND (thread_id IS NULL OR thread_id IN ({pb_1: String}))
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IN ({pb_1: String})
+        ) AS properly_merged_calls
+        GROUP BY aggregated_thread_id
+         ORDER BY last_updated DESC
         """,
         {"pb_0": "test_project", "pb_1": "my_specific_thread"},
         project_id="test_project",
-        thread_id="my_specific_thread",
+        thread_ids=["my_specific_thread"],
     )
 
 
@@ -749,40 +744,33 @@ def test_sqlite_with_thread_id_filter():
         """
         SELECT
             thread_id,
-            COUNT(*) as turn_count,
-            MIN(started_at) as start_time,
-            MAX(ended_at) as last_updated,
-            -- Get turn ID with earliest start time for this thread
+            COUNT(*) AS turn_count,
+            MIN(started_at) AS start_time,
+            MAX(ended_at) AS last_updated,
             (SELECT id FROM calls c2
              WHERE c2.thread_id = c1.thread_id
              AND c2.project_id = c1.project_id
              AND c2.id = c2.turn_id
              ORDER BY c2.started_at ASC
-             LIMIT 1) as first_turn_id,
-            -- Get turn ID with latest end time for this thread
+             LIMIT 1) AS first_turn_id,
             (SELECT id FROM calls c2
              WHERE c2.thread_id = c1.thread_id
              AND c2.project_id = c1.project_id
              AND c2.id = c2.turn_id
              ORDER BY c2.ended_at DESC
-             LIMIT 1) as last_turn_id,
-            -- P50 calculation placeholder - might be implemented properly later
-            -1 as p50_turn_duration_ms,
-            -- P99 calculation placeholder - might be implemented properly later
-            -1 as p99_turn_duration_ms
+             LIMIT 1) AS last_turn_id,
+            -1 AS p50_turn_duration_ms,
+            -1 AS p99_turn_duration_ms
         FROM calls c1
         WHERE project_id = ?
-            AND thread_id IS NOT NULL
-            AND thread_id != ''
-            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
-
-            AND thread_id = ?
+            AND id = turn_id
+            AND thread_id IN (?)
         GROUP BY thread_id
         ORDER BY last_updated DESC
         """,
         ["test_project", "another_thread_id"],
         project_id="test_project",
-        thread_id="another_thread_id",
+        thread_ids=["another_thread_id"],
     )
 
 
@@ -794,39 +782,34 @@ def test_clickhouse_with_thread_id_and_date_filters():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
-            COUNT(*) as turn_count,
-            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
-            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
-            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
-            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
-            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
-            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+            aggregated_thread_id AS thread_id,
+            COUNT(*) AS turn_count,
+            min(call_start_time) AS start_time,
+            max(call_end_time) AS last_updated,
+            argMin(id, call_start_time) AS first_turn_id,
+            argMax(id, call_end_time) AS last_turn_id,
+            quantile(0.5)(call_duration) AS p50_turn_duration_ms,
+            quantile(0.99)(call_duration) AS p99_turn_duration_ms
         FROM (
-            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
-            -- This handles cases where calls_merged has multiple partial rows per call_id
-            -- due to ClickHouse materialized view background merge behavior
             SELECT
-                id,                              -- Call identifier
-                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
-                                                -- (all non-null values should be identical)
-                min(started_at) as call_start_time,   -- Earliest start time for this call
-                max(ended_at) as call_end_time,   -- Latest end time for this call
-                -- Calculate call duration in milliseconds
+                id,
+                any(thread_id) AS aggregated_thread_id,
+                min(started_at) AS call_start_time,
+                max(ended_at) AS call_end_time,
                 CASE
                     WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
                     THEN dateDiff('millisecond', call_start_time, call_end_time)
                     ELSE NULL
-                END as call_duration
+                END AS call_duration
             FROM calls_merged
             WHERE project_id = {pb_0: String}
                 AND sortable_datetime > {pb_1: String} AND sortable_datetime < {pb_2: String}
-            GROUP BY id                         -- Group by call id to merge partial rows
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id) AND thread_id = {pb_3: String}  -- Filter to turn calls only
-        ) as properly_merged_calls
-        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
-        GROUP BY thread_id
-        ORDER BY last_updated DESC
+                AND (thread_id IS NULL OR thread_id IN ({pb_3: String}))
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IN ({pb_3: String})
+        ) AS properly_merged_calls
+        GROUP BY aggregated_thread_id
+         ORDER BY last_updated DESC
         """,
         {
             "pb_0": "test_project",
@@ -837,7 +820,7 @@ def test_clickhouse_with_thread_id_and_date_filters():
         project_id="test_project",
         sortable_datetime_after=after_date,
         sortable_datetime_before=before_date,
-        thread_id="thread_with_dates",
+        thread_ids=["thread_with_dates"],
     )
 
 
@@ -850,34 +833,28 @@ def test_sqlite_with_thread_id_and_date_filters():
         """
         SELECT
             thread_id,
-            COUNT(*) as turn_count,
-            MIN(started_at) as start_time,
-            MAX(ended_at) as last_updated,
-            -- Get turn ID with earliest start time for this thread
+            COUNT(*) AS turn_count,
+            MIN(started_at) AS start_time,
+            MAX(ended_at) AS last_updated,
             (SELECT id FROM calls c2
              WHERE c2.thread_id = c1.thread_id
              AND c2.project_id = c1.project_id
              AND c2.id = c2.turn_id
              ORDER BY c2.started_at ASC
-             LIMIT 1) as first_turn_id,
-            -- Get turn ID with latest end time for this thread
+             LIMIT 1) AS first_turn_id,
             (SELECT id FROM calls c2
              WHERE c2.thread_id = c1.thread_id
              AND c2.project_id = c1.project_id
              AND c2.id = c2.turn_id
              ORDER BY c2.ended_at DESC
-             LIMIT 1) as last_turn_id,
-            -- P50 calculation placeholder - might be implemented properly later
-            -1 as p50_turn_duration_ms,
-            -- P99 calculation placeholder - might be implemented properly later
-            -1 as p99_turn_duration_ms
+             LIMIT 1) AS last_turn_id,
+            -1 AS p50_turn_duration_ms,
+            -1 AS p99_turn_duration_ms
         FROM calls c1
         WHERE project_id = ?
-            AND thread_id IS NOT NULL
-            AND thread_id != ''
-            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+            AND id = turn_id
             AND started_at > ? AND started_at < ?
-            AND thread_id = ?
+            AND thread_id IN (?)
         GROUP BY thread_id
         ORDER BY last_updated DESC
         """,
@@ -890,7 +867,7 @@ def test_sqlite_with_thread_id_and_date_filters():
         project_id="test_project",
         sortable_datetime_after=after_date,
         sortable_datetime_before=before_date,
-        thread_id="specific_thread",
+        thread_ids=["specific_thread"],
     )
 
 
@@ -903,41 +880,36 @@ def test_clickhouse_with_thread_id_and_all_options():
     assert_clickhouse_sql(
         """
         SELECT
-            thread_id,
-            COUNT(*) as turn_count,
-            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
-            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
-            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
-            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
-            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
-            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+            aggregated_thread_id AS thread_id,
+            COUNT(*) AS turn_count,
+            min(call_start_time) AS start_time,
+            max(call_end_time) AS last_updated,
+            argMin(id, call_start_time) AS first_turn_id,
+            argMax(id, call_end_time) AS last_turn_id,
+            quantile(0.5)(call_duration) AS p50_turn_duration_ms,
+            quantile(0.99)(call_duration) AS p99_turn_duration_ms
         FROM (
-            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
-            -- This handles cases where calls_merged has multiple partial rows per call_id
-            -- due to ClickHouse materialized view background merge behavior
             SELECT
-                id,                              -- Call identifier
-                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
-                                                -- (all non-null values should be identical)
-                min(started_at) as call_start_time,   -- Earliest start time for this call
-                max(ended_at) as call_end_time,   -- Latest end time for this call
-                -- Calculate call duration in milliseconds
+                id,
+                any(thread_id) AS aggregated_thread_id,
+                min(started_at) AS call_start_time,
+                max(ended_at) AS call_end_time,
                 CASE
                     WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
                     THEN dateDiff('millisecond', call_start_time, call_end_time)
                     ELSE NULL
-                END as call_duration
+                END AS call_duration
             FROM calls_merged
             WHERE project_id = {pb_0: String}
                 AND sortable_datetime > {pb_1: String} AND sortable_datetime < {pb_2: String}
-            GROUP BY id                         -- Group by call id to merge partial rows
-            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id) AND thread_id = {pb_3: String}  -- Filter to turn calls only
-        ) as properly_merged_calls
-        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
-        GROUP BY thread_id
-        ORDER BY turn_count DESC
-        LIMIT {pb_4: Int64}
-        OFFSET {pb_5: Int64}
+                AND (thread_id IS NULL OR thread_id IN ({pb_3: String}))
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IN ({pb_3: String})
+        ) AS properly_merged_calls
+        GROUP BY aggregated_thread_id
+         ORDER BY turn_count DESC
+         LIMIT {pb_4: Int64}
+         OFFSET {pb_5: Int64}
         """,
         {
             "pb_0": "test_project",
@@ -953,7 +925,7 @@ def test_clickhouse_with_thread_id_and_all_options():
         sort_by=sort_by,
         limit=15,
         offset=30,
-        thread_id="full_featured_thread",
+        thread_ids=["full_featured_thread"],
     )
 
 
@@ -969,34 +941,28 @@ def test_sqlite_with_thread_id_and_all_options():
         """
         SELECT
             thread_id,
-            COUNT(*) as turn_count,
-            MIN(started_at) as start_time,
-            MAX(ended_at) as last_updated,
-            -- Get turn ID with earliest start time for this thread
+            COUNT(*) AS turn_count,
+            MIN(started_at) AS start_time,
+            MAX(ended_at) AS last_updated,
             (SELECT id FROM calls c2
              WHERE c2.thread_id = c1.thread_id
              AND c2.project_id = c1.project_id
              AND c2.id = c2.turn_id
              ORDER BY c2.started_at ASC
-             LIMIT 1) as first_turn_id,
-            -- Get turn ID with latest end time for this thread
+             LIMIT 1) AS first_turn_id,
             (SELECT id FROM calls c2
              WHERE c2.thread_id = c1.thread_id
              AND c2.project_id = c1.project_id
              AND c2.id = c2.turn_id
              ORDER BY c2.ended_at DESC
-             LIMIT 1) as last_turn_id,
-            -- P50 calculation placeholder - might be implemented properly later
-            -1 as p50_turn_duration_ms,
-            -- P99 calculation placeholder - might be implemented properly later
-            -1 as p99_turn_duration_ms
+             LIMIT 1) AS last_turn_id,
+            -1 AS p50_turn_duration_ms,
+            -1 AS p99_turn_duration_ms
         FROM calls c1
         WHERE project_id = ?
-            AND thread_id IS NOT NULL
-            AND thread_id != ''
-            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+            AND id = turn_id
             AND started_at > ?
-            AND thread_id = ?
+            AND thread_id IN (?)
         GROUP BY thread_id
         ORDER BY last_updated ASC, thread_id DESC
         LIMIT ?
@@ -1006,7 +972,7 @@ def test_sqlite_with_thread_id_and_all_options():
         sortable_datetime_after=after_date,
         sort_by=sort_by,
         limit=5,
-        thread_id="comprehensive_thread",
+        thread_ids=["comprehensive_thread"],
     )
 
 
@@ -1015,11 +981,11 @@ def test_thread_id_filter_no_match():
     # This test verifies that the SQL generation doesn't break with thread_id filter
     pb = ParamBuilder("pb")
     query = make_threads_query(
-        project_id="test_project", pb=pb, thread_id="nonexistent_thread"
+        project_id="test_project", pb=pb, thread_ids=["nonexistent_thread"]
     )
 
     # Should contain the thread filter
-    assert "thread_id = {pb_1: String}" in query
+    assert "thread_id IN ({pb_1: String})" in query
 
     # Should have the expected parameter
     params = pb.get_params()
@@ -1033,15 +999,15 @@ def test_thread_id_filter_consistency():
 
     # Generate both queries with same parameters
     clickhouse_query = make_threads_query(
-        project_id="test_project", pb=pb, thread_id="consistency_test"
+        project_id="test_project", pb=pb, thread_ids=["consistency_test"]
     )
     sqlite_query, sqlite_params = make_threads_query_sqlite(
-        project_id="test_project", thread_id="consistency_test"
+        project_id="test_project", thread_ids=["consistency_test"]
     )
 
-    # Both should filter by thread_id
-    assert "thread_id = {pb_1: String}" in clickhouse_query  # ClickHouse style
-    assert "AND thread_id = ?" in sqlite_query  # SQLite style
+    # Both should filter by thread_ids
+    assert "thread_id IN ({pb_1: String})" in clickhouse_query  # ClickHouse style
+    assert "AND thread_id IN (?)" in sqlite_query  # SQLite style
 
     # Parameters should be consistent
     ch_params = pb.get_params()
@@ -1062,8 +1028,8 @@ def test_query_structure_documentation():
     # Should be a two-level aggregation for ClickHouse
     assert "SELECT" in query  # Outer query
     assert "FROM (" in query  # Inner subquery
-    assert "GROUP BY thread_id" in query  # Outer aggregation by thread
-    assert "GROUP BY id" in query  # Inner aggregation by call
+    assert "GROUP BY aggregated_thread_id" in query  # Outer aggregation by thread
+    assert "GROUP BY (project_id, id)" in query  # Inner aggregation by call
 
     # Should include key aggregations
     assert "COUNT(*) AS turn_count" in query

--- a/tests/trace_server/test_threads_query_builder.py
+++ b/tests/trace_server/test_threads_query_builder.py
@@ -695,6 +695,360 @@ def test_turn_filtering_explanation():
     assert "thread_id != ''" in sqlite_query
 
 
+# Thread ID Filtering Tests
+
+
+def test_clickhouse_with_thread_id_filter():
+    """Test ClickHouse query with thread_id filter."""
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id) AND thread_id = {pb_1: String}  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        {"pb_0": "test_project", "pb_1": "my_specific_thread"},
+        project_id="test_project",
+        thread_id="my_specific_thread",
+    )
+
+
+def test_sqlite_with_thread_id_filter():
+    """Test SQLite query with thread_id filter."""
+    assert_sqlite_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            MIN(started_at) as start_time,
+            MAX(ended_at) as last_updated,
+            -- Get turn ID with earliest start time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.started_at ASC
+             LIMIT 1) as first_turn_id,
+            -- Get turn ID with latest end time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.ended_at DESC
+             LIMIT 1) as last_turn_id,
+            -- P50 calculation placeholder - might be implemented properly later
+            -1 as p50_turn_duration_ms,
+            -- P99 calculation placeholder - might be implemented properly later
+            -1 as p99_turn_duration_ms
+        FROM calls c1
+        WHERE project_id = ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
+            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+
+            AND thread_id = ?
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        ["test_project", "another_thread_id"],
+        project_id="test_project",
+        thread_id="another_thread_id",
+    )
+
+
+def test_clickhouse_with_thread_id_and_date_filters():
+    """Test ClickHouse query with both thread_id and date filters."""
+    after_date = datetime.datetime(2024, 1, 1, 12, 0, 0)
+    before_date = datetime.datetime(2024, 12, 31, 23, 59, 59)
+
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+                AND sortable_datetime > {pb_1: String} AND sortable_datetime < {pb_2: String}
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id) AND thread_id = {pb_3: String}  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        {
+            "pb_0": "test_project",
+            "pb_1": "2024-01-01 12:00:00.000000",
+            "pb_2": "2024-12-31 23:59:59.000000",
+            "pb_3": "thread_with_dates",
+        },
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+        sortable_datetime_before=before_date,
+        thread_id="thread_with_dates",
+    )
+
+
+def test_sqlite_with_thread_id_and_date_filters():
+    """Test SQLite query with both thread_id and date filters."""
+    after_date = datetime.datetime(2024, 6, 15, 10, 30, 0)
+    before_date = datetime.datetime(2024, 6, 15, 18, 0, 0)
+
+    assert_sqlite_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            MIN(started_at) as start_time,
+            MAX(ended_at) as last_updated,
+            -- Get turn ID with earliest start time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.started_at ASC
+             LIMIT 1) as first_turn_id,
+            -- Get turn ID with latest end time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.ended_at DESC
+             LIMIT 1) as last_turn_id,
+            -- P50 calculation placeholder - might be implemented properly later
+            -1 as p50_turn_duration_ms,
+            -- P99 calculation placeholder - might be implemented properly later
+            -1 as p99_turn_duration_ms
+        FROM calls c1
+        WHERE project_id = ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
+            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+            AND started_at > ? AND started_at < ?
+            AND thread_id = ?
+        GROUP BY thread_id
+        ORDER BY last_updated DESC
+        """,
+        [
+            "test_project",
+            "2024-06-15T10:30:00",
+            "2024-06-15T18:00:00",
+            "specific_thread",
+        ],
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+        sortable_datetime_before=before_date,
+        thread_id="specific_thread",
+    )
+
+
+def test_clickhouse_with_thread_id_and_all_options():
+    """Test ClickHouse query with thread_id, dates, sorting, and pagination."""
+    after_date = datetime.datetime(2024, 1, 1)
+    before_date = datetime.datetime(2024, 12, 31)
+    sort_by = [tsi.SortBy(field="turn_count", direction="desc")]
+
+    assert_clickhouse_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            min(call_start_time) as start_time,          -- Earliest start time across all calls in thread
+            max(call_end_time) as last_updated,          -- Latest end time across all calls in thread
+            argMin(id, call_start_time) as first_turn_id,     -- Turn ID with earliest start_time
+            argMax(id, call_end_time) as last_turn_id,   -- Turn ID with latest last_updated
+            quantile(0.5)(call_duration) as p50_turn_duration_ms,  -- P50 of turn durations in milliseconds
+            quantile(0.99)(call_duration) as p99_turn_duration_ms  -- P99 of turn durations in milliseconds
+        FROM (
+            -- INNER QUERY: Consolidate each individual call before thread-level aggregation
+            -- This handles cases where calls_merged has multiple partial rows per call_id
+            -- due to ClickHouse materialized view background merge behavior
+            SELECT
+                id,                              -- Call identifier
+                any(thread_id) as thread_id,     -- Get any non-null thread_id for this call
+                                                -- (all non-null values should be identical)
+                min(started_at) as call_start_time,   -- Earliest start time for this call
+                max(ended_at) as call_end_time,   -- Latest end time for this call
+                -- Calculate call duration in milliseconds
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END as call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+                AND sortable_datetime > {pb_1: String} AND sortable_datetime < {pb_2: String}
+            GROUP BY id                         -- Group by call id to merge partial rows
+            HAVING thread_id IS NOT NULL AND thread_id != '' AND id = any(turn_id) AND thread_id = {pb_3: String}  -- Filter to turn calls only
+        ) as properly_merged_calls
+        -- OUTER QUERY: Now aggregate at thread level with properly consolidated calls
+        GROUP BY thread_id
+        ORDER BY turn_count DESC
+        LIMIT {pb_4: Int64}
+        OFFSET {pb_5: Int64}
+        """,
+        {
+            "pb_0": "test_project",
+            "pb_1": "2024-01-01 00:00:00.000000",
+            "pb_2": "2024-12-31 00:00:00.000000",
+            "pb_3": "full_featured_thread",
+            "pb_4": 15,
+            "pb_5": 30,
+        },
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+        sortable_datetime_before=before_date,
+        sort_by=sort_by,
+        limit=15,
+        offset=30,
+        thread_id="full_featured_thread",
+    )
+
+
+def test_sqlite_with_thread_id_and_all_options():
+    """Test SQLite query with thread_id, dates, sorting, and pagination."""
+    after_date = datetime.datetime(2024, 3, 15)
+    sort_by = [
+        tsi.SortBy(field="last_updated", direction="asc"),
+        tsi.SortBy(field="thread_id", direction="desc"),
+    ]
+
+    assert_sqlite_sql(
+        """
+        SELECT
+            thread_id,
+            COUNT(*) as turn_count,
+            MIN(started_at) as start_time,
+            MAX(ended_at) as last_updated,
+            -- Get turn ID with earliest start time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.started_at ASC
+             LIMIT 1) as first_turn_id,
+            -- Get turn ID with latest end time for this thread
+            (SELECT id FROM calls c2
+             WHERE c2.thread_id = c1.thread_id
+             AND c2.project_id = c1.project_id
+             AND c2.id = c2.turn_id
+             ORDER BY c2.ended_at DESC
+             LIMIT 1) as last_turn_id,
+            -- P50 calculation placeholder - might be implemented properly later
+            -1 as p50_turn_duration_ms,
+            -- P99 calculation placeholder - might be implemented properly later
+            -1 as p99_turn_duration_ms
+        FROM calls c1
+        WHERE project_id = ?
+            AND thread_id IS NOT NULL
+            AND thread_id != ''
+            AND id = turn_id                 -- Only include turn calls for meaningful thread stats
+            AND started_at > ?
+            AND thread_id = ?
+        GROUP BY thread_id
+        ORDER BY last_updated ASC, thread_id DESC
+        LIMIT ?
+        """,
+        ["test_project", "2024-03-15T00:00:00", "comprehensive_thread", 5],
+        project_id="test_project",
+        sortable_datetime_after=after_date,
+        sort_by=sort_by,
+        limit=5,
+        thread_id="comprehensive_thread",
+    )
+
+
+def test_thread_id_filter_no_match():
+    """Test that thread_id filter doesn't break query even if no threads match."""
+    # This test verifies that the SQL generation doesn't break with thread_id filter
+    pb = ParamBuilder("pb")
+    query = make_threads_query(
+        project_id="test_project", pb=pb, thread_id="nonexistent_thread"
+    )
+
+    # Should contain the thread filter
+    assert "thread_id = {pb_1: String}" in query
+
+    # Should have the expected parameter
+    params = pb.get_params()
+    assert "pb_1" in params
+    assert params["pb_1"] == "nonexistent_thread"
+
+
+def test_thread_id_filter_consistency():
+    """Test that both ClickHouse and SQLite handle thread_id filtering consistently."""
+    pb = ParamBuilder("pb")
+
+    # Generate both queries with same parameters
+    clickhouse_query = make_threads_query(
+        project_id="test_project", pb=pb, thread_id="consistency_test"
+    )
+    sqlite_query, sqlite_params = make_threads_query_sqlite(
+        project_id="test_project", thread_id="consistency_test"
+    )
+
+    # Both should filter by thread_id
+    assert "thread_id = {pb_1: String}" in clickhouse_query  # ClickHouse style
+    assert "AND thread_id = ?" in sqlite_query  # SQLite style
+
+    # Parameters should be consistent
+    ch_params = pb.get_params()
+    assert ch_params["pb_1"] == "consistency_test"
+    assert "consistency_test" in sqlite_params
+
+
 def test_query_structure_documentation():
     """
     Test that documents the structure and purpose of the threads query.

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -553,7 +553,6 @@ export type ThreadSchema = {
 export type ThreadsQueryFilter = {
   after_datetime?: string;
   before_datetime?: string;
-  thread_id?: string;
 };
 
 export type ThreadsQueryReq = {

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/wfReactInterface/traceServerClientTypes.ts
@@ -553,6 +553,7 @@ export type ThreadSchema = {
 export type ThreadsQueryFilter = {
   after_datetime?: string;
   before_datetime?: string;
+  thread_id?: string;
 };
 
 export type ThreadsQueryReq = {

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1194,11 +1194,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         # Extract filter values
         after_datetime = None
         before_datetime = None
-        thread_id = None
+        thread_ids = None
         if req.filter is not None:
             after_datetime = req.filter.after_datetime
             before_datetime = req.filter.before_datetime
-            thread_id = req.filter.thread_id
+            thread_ids = req.filter.thread_ids
 
         # Use the dedicated query builder
         query = make_threads_query(
@@ -1209,7 +1209,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             sort_by=req.sort_by,
             sortable_datetime_after=after_datetime,
             sortable_datetime_before=before_datetime,
-            thread_id=thread_id,
+            thread_ids=thread_ids,
         )
 
         # Stream the results using _query_stream

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1194,9 +1194,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         # Extract filter values
         after_datetime = None
         before_datetime = None
+        thread_id = None
         if req.filter is not None:
             after_datetime = req.filter.after_datetime
             before_datetime = req.filter.before_datetime
+            thread_id = req.filter.thread_id
 
         # Use the dedicated query builder
         query = make_threads_query(
@@ -1207,6 +1209,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             sort_by=req.sort_by,
             sortable_datetime_after=after_datetime,
             sortable_datetime_before=before_datetime,
+            thread_id=thread_id,
         )
 
         # Stream the results using _query_stream

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1472,9 +1472,11 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         # Extract filter values
         after_datetime = None
         before_datetime = None
+        thread_id = None
         if req.filter is not None:
             after_datetime = req.filter.after_datetime
             before_datetime = req.filter.before_datetime
+            thread_id = req.filter.thread_id
 
         # Use the dedicated query builder
         query, parameters = make_threads_query_sqlite(
@@ -1484,6 +1486,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             sort_by=req.sort_by,
             sortable_datetime_after=after_datetime,
             sortable_datetime_before=before_datetime,
+            thread_id=thread_id,
         )
 
         cursor.execute(query, parameters)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1472,11 +1472,11 @@ class SqliteTraceServer(tsi.TraceServerInterface):
         # Extract filter values
         after_datetime = None
         before_datetime = None
-        thread_id = None
+        thread_ids = None
         if req.filter is not None:
             after_datetime = req.filter.after_datetime
             before_datetime = req.filter.before_datetime
-            thread_id = req.filter.thread_id
+            thread_ids = req.filter.thread_ids
 
         # Use the dedicated query builder
         query, parameters = make_threads_query_sqlite(
@@ -1486,7 +1486,7 @@ class SqliteTraceServer(tsi.TraceServerInterface):
             sort_by=req.sort_by,
             sortable_datetime_after=after_datetime,
             sortable_datetime_before=before_datetime,
-            thread_id=thread_id,
+            thread_ids=thread_ids,
         )
 
         cursor.execute(query, parameters)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1111,6 +1111,11 @@ class ThreadsQueryFilter(BaseModel):
         description="Only include threads with last_updated before this timestamp",
         examples=["2024-12-31T23:59:59Z"],
     )
+    thread_id: Optional[str] = Field(
+        default=None,
+        description="Only include threads with this specific thread_id",
+        examples=["my_thread_id"],
+    )
 
 
 class ThreadsQueryReq(BaseModel):

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1111,10 +1111,10 @@ class ThreadsQueryFilter(BaseModel):
         description="Only include threads with last_updated before this timestamp",
         examples=["2024-12-31T23:59:59Z"],
     )
-    thread_id: Optional[str] = Field(
+    thread_ids: Optional[list[str]] = Field(
         default=None,
-        description="Only include threads with this specific thread_id",
-        examples=["my_thread_id"],
+        description="Only include threads with thread_ids in this list",
+        examples=[["thread_1", "thread_2", "my_thread_id"]],
     )
 
 


### PR DESCRIPTION
## Description

- Adds thread_id filtering capability to the threads_query API
- Implements thread_id filtering in both ClickHouse and SQLite query builders
- Updates the ThreadsQueryFilter model to include the new thread_id field
- Adds comprehensive tests for thread_id filtering, including combinations with other filters

This changed is needed for refactoring of the Thread details page in https://github.com/wandb/weave/pull/5064

## Testing

- Added unit tests for thread_id filtering in both ClickHouse and SQLite query builders
- Added integration tests that verify thread_id filtering works correctly in the API
- Tested combinations of thread_id with other filters (date ranges, sorting, pagination)