### PR TITLE
fix(weave): limit the size of data loaded in thread chat view

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadDetailPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadDetailPage.tsx
@@ -11,7 +11,7 @@ import {SplitPanelRight} from '../common/SplitPanels/SplitPanelRight';
 import {StatusChip} from '../common/StatusChip';
 import {ComputedCallStatusType} from '../wfReactInterface/traceServerClientTypes';
 import {useThreadTurns} from '../wfReactInterface/tsDataModelHooks';
-import {ThreadChatView, ThreadChatViewRef} from './ThreadChatView';
+import {ThreadChatViewRef, ThreadChatViewStaging} from './ThreadChatView';
 import {ThreadMetadata} from './ThreadMetadata';
 import {ThreadTurnsList} from './ThreadTurnsList';
 
@@ -116,13 +116,13 @@ export const ThreadDetailPage: FC<ThreadDetailPageProps> = ({threadId}) => {
 
   const {turnsState} = useThreadTurns(`${entity}/${project}`, threadId);
 
-  const turnCount = turnsState.value?.length || 0;
+  const turnCount = turnsState.value?.turnCalls?.length || 0;
 
   // Ref for ThreadChatView to enable programmatic scrolling
   const chatViewRef = useRef<ThreadChatViewRef>(null);
 
   // Get the currently selected turn ID from the index
-  const selectedTurnId = turnsState.value?.[selectedTurnIndex]?.id;
+  const selectedTurnId = turnsState.value?.turnCalls?.[selectedTurnIndex]?.id;
 
   // Track previous selectedTurnId
   const prevSelectedTurnId = usePrevious(selectedTurnId);
@@ -215,10 +215,9 @@ export const ThreadDetailPage: FC<ThreadDetailPageProps> = ({threadId}) => {
                         maxWidth="0%" // No right drawer needed
                         isDrawerOpen={false}
                         main={
-                          <ThreadChatView
+                          <ThreadChatViewStaging
                             ref={chatViewRef}
                             turnsState={turnsState}
-                            threadId={threadId}
                             onVisibleTurnChange={handleVisibleTurnChange}
                           />
                         }

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadMetadata.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadMetadata.tsx
@@ -1,9 +1,6 @@
 import React, {FC, useMemo} from 'react';
 
-import {
-  traceCallLatencyMs,
-  useThreadTurns,
-} from '../wfReactInterface/tsDataModelHooks';
+import {useThreadTurns} from '../wfReactInterface/tsDataModelHooks';
 
 export interface ThreadMetadataProps {
   turnsState: ReturnType<typeof useThreadTurns>['turnsState'];
@@ -30,28 +27,14 @@ export const ThreadMetadata: FC<ThreadMetadataProps> = ({turnsState}) => {
     }
 
     const turns = turnsState.value;
-    const turnCount = turns.length;
+    const turnCount = turns.thread.turn_count;
 
-    // Calculate latencies for completed turns (convert ms to seconds)
-    const latencies = turns
-      .filter(turn => turn.ended_at) // Only completed turns
-      .map(turn => traceCallLatencyMs(turn) / 1000) // Convert to seconds
-      .sort((a, b) => a - b);
-
-    if (latencies.length === 0) {
-      return {
-        turnCount,
-        p50Latency: '-',
-        p99Latency: '-',
-      };
-    }
-
-    // Calculate percentiles
-    const p50Index = Math.floor(latencies.length * 0.5);
-    const p99Index = Math.floor(latencies.length * 0.99);
-
-    const p50Latency = `${latencies[p50Index].toFixed(3)}s`;
-    const p99Latency = `${latencies[p99Index].toFixed(3)}s`;
+    const p50Latency = `${(
+      (turns.thread.p50_turn_duration_ms ?? 0) / 1e3
+    ).toFixed(3)}s`;
+    const p99Latency = `${(
+      (turns.thread.p99_turn_duration_ms ?? 0) / 1e3
+    ).toFixed(3)}s`;
 
     return {
       turnCount,

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadTurnsList.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ThreadDetailPage/ThreadTurnsList.tsx
@@ -107,7 +107,7 @@ export const ThreadTurnsList: FC<ThreadTurnsListProps> = ({
       return [];
     }
 
-    return turnsState.value.map((traceCall): Turn => {
+    return turnsState.value.turnCalls.map((traceCall): Turn => {
       // Convert inputs object to a string preview
       const inputPreview = traceCall.inputs
         ? JSON.stringify(traceCall.inputs).substring(0, 100) + '...'
@@ -122,6 +122,15 @@ export const ThreadTurnsList: FC<ThreadTurnsListProps> = ({
     });
   }, [turnsState]);
 
+  const firstTurnIndex = useMemo(() => {
+    if (turnsState.value) {
+      const totalTurns = turnsState.value.thread.turn_count;
+      const firstTurnIndex = totalTurns - turnsState.value.turnCalls.length;
+      return firstTurnIndex;
+    }
+    return 0;
+  }, [turnsState]);
+
   // Show a loading state if the turnsState is loading
   if (turnsState.loading) {
     return (
@@ -133,6 +142,11 @@ export const ThreadTurnsList: FC<ThreadTurnsListProps> = ({
 
   return (
     <div className="h-full overflow-y-auto">
+      {firstTurnIndex !== 0 && (
+        <div className="flex items-center justify-center text-sm text-moon-800">
+          ... Turn 1 to {firstTurnIndex} are omitted ...
+        </div>
+      )}
       {turns.map((turn, index) => {
         const isSelected = turn.id === selectedTurnId;
 
@@ -148,7 +162,7 @@ export const ThreadTurnsList: FC<ThreadTurnsListProps> = ({
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-6 text-sm text-moon-800">
                 <span className=" flex h-18 w-18 items-center justify-center rounded-[20px] bg-moon-200 font-bold ">
-                  {index + 1}
+                  {firstTurnIndex + index + 1}
                 </span>
                 <span className="truncate font-semibold">{turn.opName}</span>
               </div>


### PR DESCRIPTION
## Description

This PR is a performance optimization by limiting the number of turns displayed in thread detail view.

Refactors the ThreadChatView component to support pagination of thread turns. This change:

1. Introduces a new ThreadChatViewStaging component that handles the staged data loading

2. Updates ThreadChatView to accept turnIds directly instead of requiring the full turnsState, so it only load data for specific turns.

3. Adds support for displaying turn numbers correctly when some turns are omitted

4. Implements batched loading of message data to handle large threads efficiently

5. Modifies the thread turns query to fetch only the most recent 500 turns

6. Updates the ThreadMetadata component to use pre-calculated latency metrics from the thread object

## Testing

Tested with threads of various sizes to ensure:
- Correct rendering of turn numbers when some turns are omitted
- Proper loading of message data in batches
- Accurate display of thread metadata
- Smooth scrolling and navigation between turns


## Preview

<img width="1165" height="826" alt="image" src="https://github.com/user-attachments/assets/1c360fd1-d73c-4385-bb88-a3766e8db78a" />
