### PR TITLE
fix(weave): update call details during ref traversal

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/CallPage/ObjectViewer.tsx
@@ -165,6 +165,9 @@ export const ObjectViewer = ({
   // `resolvedData`.
   useEffect(() => {
     if (refsData.loading) {
+      // Still update resolvedData with fresh truncated data while loading
+      const {result: freshTruncatedData} = traverseAndTruncate(data);
+      setResolvedData(freshTruncatedData);
       return;
     }
     const resolvedRefData = refsData.result;


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-25980](https://wandb.atlassian.net/browse/WB-25980)

While doing ref traversal, there is a race condition where we don't actually update the call detail state. With deep refs this is bad enough that the detail page never gets updated! 

## Testing

prod
![call-details-prod](https://github.com/user-attachments/assets/d89c2cf1-5fd1-4807-97df-7bec897da4ff)

branch
![call-details-branch](https://github.com/user-attachments/assets/7cbf7d16-8b2f-45bb-8afe-a08300f6d1a0)


[WB-25980]: https://wandb.atlassian.net/browse/WB-25980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ