### PR TITLE
fix(weave): remove datetime filter callstack exceeded error

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -202,6 +202,7 @@ export const FilterBar = ({
     ) {
       setFilterToDelete(localFilterModel.items[0].id);
       setShowDeleteWarning(true);
+      setAnchorEl(null); // Close popover to avoid focus trap conflicts
       return;
     }
 
@@ -286,6 +287,7 @@ export const FilterBar = ({
       if (isFirstDatetimeFilter) {
         setFilterToDelete(filterId);
         setShowDeleteWarning(true);
+        setAnchorEl(null); // Close popover to avoid focus trap conflicts
         return;
       }
 

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/filters/FilterBar.tsx
@@ -325,6 +325,7 @@ export const FilterBar = ({
   const handleCancelDelete = useCallback(() => {
     setShowDeleteWarning(false);
     setFilterToDelete(null);
+    setAnchorEl(refBar.current); // Reopen popover after cancel
   }, []);
 
   const onSetSelected = useCallback(() => {


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-26056](https://wandb.atlassian.net/browse/WB-26056)

Fix for double popovers causing contention and call stack exceeded runtime errors. 

## Testing

prod
![call-stack-filter-prod](https://github.com/user-attachments/assets/be1561d8-ede4-42a2-92cd-0c23b158ac44)

branch
![call-stack-filter-branch](https://github.com/user-attachments/assets/3f7f7578-b283-4ca0-bd38-23cbb5bb58d2)


[WB-26056]: https://wandb.atlassian.net/browse/WB-26056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ