### PR TITLE
chore(weave): fix test flake sort by latency

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -2405,20 +2405,20 @@ def test_calls_query_sort_by_latency(client):
     # Fast call - minimal latency
     fast_call = client.create_call("x", {"a": 1, "b": 1, "test_id": test_id})
     client.finish_call(fast_call, "fast result")
+    client.flush()
 
     # Medium latency
     medium_call = client.create_call("x", {"a": 2, "b": 2, "test_id": test_id})
     # Sleep to ensure different latency
     time.sleep(0.05)
     client.finish_call(medium_call, "medium result")
+    client.flush()
 
     # Slow call - higher latency
     slow_call = client.create_call("x", {"a": 3, "b": 3, "test_id": test_id})
     # Sleep to ensure different latency
     time.sleep(0.1)
     client.finish_call(slow_call, "slow result")
-
-    # Flush to make sure all calls are committed
     client.flush()
 
     # Create a query to find just our test calls


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Test flakes: https://github.com/wandb/weave/actions/runs/16226956842/job/45821009761?pr=5066

I think this is because the client queues up calls in unexpected batches. In theory this test should never flake already, but it does.... This change ensures the client waits until the previous call is uploaded before proceeding, further reducing chance of flake. 

## Testing

test
