### PR TITLE
chore(ui): add inference service advertisement banner to playground

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/types.ts
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/inference/types.ts
@@ -118,6 +118,8 @@ export type InferenceBillingInfo = {
   billingPeriodStart: Date;
   billingPeriodEnd: Date;
   usage: number;
+
+  inferenceFreeLimit?: number;
   inferenceSafetyLimit: number;
 
   formatAsDollar: (value: number) => string;

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/InferenceBanner.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/InferenceBanner.tsx
@@ -3,14 +3,19 @@ import React from 'react';
 import {Alert} from '../../../../../../Alert';
 import {AccountPlanType} from '../../../inference/types';
 import {useInferenceContext} from '../../../inference/util';
+import {InferenceBannerAdvertise} from './InferenceBannerAdvertise';
 
 export const InferenceBanner = () => {
   const inferenceContext = useInferenceContext();
-  const {billing} = inferenceContext;
-  if (!billing) return null;
+  const {isInferenceEnabled, billing} = inferenceContext;
+  if (!isInferenceEnabled || !billing) {
+    return null;
+  }
+
   let {
     accountPlanType,
     usage,
+    inferenceFreeLimit,
     inferenceSafetyLimit,
     billingPeriodEnd,
     getFormattedBillingDate,
@@ -21,6 +26,10 @@ export const InferenceBanner = () => {
   let exceededLimitStatusMsg: string | undefined;
 
   switch (accountPlanType) {
+    case AccountPlanType.Personal:
+      // Personal accounts don't have Inference service.
+      // The isInferenceEnabled check above should handle this case but handling it explicitly.
+      return null;
     case AccountPlanType.Free:
       if (inferenceSafetyLimit * 0.9 <= usage && usage < inferenceSafetyLimit) {
         exceededLimitStatusMsg = 'Upgrade your plan to keep going.';
@@ -47,14 +56,20 @@ export const InferenceBanner = () => {
       break;
   }
 
-  if (!exceededLimitStatusMsg) return null;
+  if (exceededLimitStatusMsg) {
+    return (
+      <div className="mb-16 mt-12 w-[800px]">
+        <Alert severity="warning">
+          <b>{exceededLimitBoldStatusMsg} </b>
+          <span>{exceededLimitStatusMsg}</span>
+        </Alert>
+      </div>
+    );
+  }
 
-  return (
-    <div className="mb-16 mt-12 w-[800px]">
-      <Alert severity="warning">
-        <b>{exceededLimitBoldStatusMsg} </b>
-        <span>{exceededLimitStatusMsg}</span>
-      </Alert>
-    </div>
-  );
+  // Don't need to warn user about anything. If they have free credits, advertise them.
+  if (inferenceFreeLimit != null && inferenceFreeLimit > 0) {
+    return <InferenceBannerAdvertise inferenceFreeLimit={inferenceFreeLimit} />;
+  }
+  return null;
 };

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/InferenceBannerAdvertise.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/PlaygroundPage/PlaygroundChat/InferenceBannerAdvertise.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {useLocalStorage} from 'react-use';
+
+import {Alert} from '../../../../../../Alert';
+import {Button} from '../../../../../../Button';
+import {INFERENCE_PATH} from '../../../inference/util';
+import {Link} from '../../common/Links';
+
+const USD_FORMATTER = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const formatAsDollars = (amount: number) => {
+  return USD_FORMATTER.format(amount);
+};
+
+type InferenceBannerAdvertiseProps = {
+  inferenceFreeLimit: number;
+};
+
+export const InferenceBannerAdvertise = ({
+  inferenceFreeLimit,
+}: InferenceBannerAdvertiseProps) => {
+  const [isHidden, setIsHidden] = useLocalStorage<boolean>(
+    `hint.playground.inference.advertise`,
+    false
+  );
+  const onClose = () => {
+    setIsHidden(true);
+  };
+  if (isHidden) {
+    return null;
+  }
+
+  const limitDollars = inferenceFreeLimit / 100;
+
+  return (
+    <div className="mb-16 mt-12 w-[800px]">
+      <Alert severity="info">
+        <div className="flex items-center gap-12">
+          <div>
+            <b>New: Test open source models right in Weave!</b>{' '}
+            <span>
+              Jumpstart your workflows with powerful models, no setup needed.
+              For a limited time, get {formatAsDollars(limitDollars)} in monthly
+              credits.
+            </span>
+          </div>
+          <Link className="whitespace-nowrap" to={INFERENCE_PATH}>
+            Browse all models
+          </Link>
+          <Button variant="ghost" icon="close" onClick={onClose} />
+        </div>
+      </Alert>
+    </div>
+  );
+};


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-26164 

Note: banner won't appear until a [small core PR](https://github.com/wandb/core/pull/31583) that passes in `inferenceFreeLimit` lands.

<img width="833" height="320" alt="Screenshot 2025-07-11 at 2 39 15 PM" src="https://github.com/user-attachments/assets/952350ce-60cc-4b26-aaf9-2140ee9e05de" />

## Testing

Expected banner on Personal, Enterprise (wandb), Free accounts.