### PR TITLE
feat(weave): Adapt to new export format for OpenAI integration

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weave",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "AI development toolkit",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

- Fixes a bug in the OpenAI integration proxy implementation in TypeScript SDK
- Bumps Node SDK version from 0.9.1 to 0.9.2

Around May 29, OpenAI has released 5.0.0 with significant changes https://github.com/openai/openai-node/commit/7a857b3a609eaa471292bf8337ae5ae69dd74ac2

## Under CommonJS mode:

One impacting change is that it changes from emitting a Class object into a Function object. In javascript, one can modify a property of a class, but not a property of a function. 

So doing `exports.OpenAI = {} ` no longer works if `exports` is a Function. 

However `Object.defineProperty` can set a property of a Function. Luckily it so happens that `Object.defineProperty` works universally on Class object as well. That means it is a backward compatible approach for 4.X versions as well. 

## Under ESM mode:

What gets more complicated is that under ESM model the `exports` is a Module object, which does not allow `Object.defineProperty()` to operate on Module object, so we still have to rely on direct property access for ESM mode.

During testing, I also found out that the ESM distribution eliminated some of the beta APIs, so I have to safe guard against the absence of those APIs. 

## Testing

Tested by verifying that the OpenAI integration works correctly with both 4.x and 5.X versions for cjs and esm mode.