### PR TITLE
chore(weave): adding modifiers to SliderInput key bindings

### DIFF
--- a/weave-js/src/common/components/elements/SliderInput.tsx
+++ b/weave-js/src/common/components/elements/SliderInput.tsx
@@ -138,9 +138,18 @@ const SliderInput: React.FC<SliderInputProps> = React.memo(
         if (isEmpty(keyboardBindings) || isFormField(document.activeElement)) {
           return;
         }
-        const eventKey = event.key;
-        const operation = (keyboardBindings ?? {})[eventKey];
+
+        // Build the key combination string based on modifiers
+        const modifiers = [];
+        if (event.metaKey) modifiers.push('Meta');
+        if (event.ctrlKey) modifiers.push('Control');
+
+        const keyCombo = [...modifiers, event.key].join('+');
+        const operation = (keyboardBindings ?? {})[keyCombo];
+
         if (operation && operation in keyboardOperations) {
+          event.preventDefault();
+          event.stopPropagation();
           const handler = keyboardOperations[operation];
           return handler(event);
         }


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-26214

What does the PR do? Include a concise description of the PR contents.

Based on feedback from Cécile, adds support for cmd / ctrl + left/ right arrow keys when incrementing and decrementing media panel steps. 

The commands will be:
 > and < to change panel in panel full screen
 > and < to change run in media full screen
And Ctrl > and Ctrl < to change steps.

corresponding core change: https://github.com/wandb/core/pull/31665

## Testing

How was this PR tested?
