### PR TITLE
chore(ui): remove duplicate object version information

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/DatasetVersionPage.tsx
@@ -262,10 +262,6 @@ export const DatasetVersionPage: React.FC<{
                 </ObjectVersionsLink>
               </div>
               <div className="block">
-                <p className="text-moon-500">Version</p>
-                <p>{objectVersionIndex}</p>
-              </div>
-              <div className="block">
                 <p className="text-moon-500">Created</p>
                 <p>
                   <Timestamp value={createdAtMs / 1000} format="relative" />

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/pages/ObjectsPage/ObjectVersionPage.tsx
@@ -288,10 +288,6 @@ const ObjectVersionPageInner: React.FC<{
               </div>
             </div>
             <div className="block">
-              <p className="text-moon-500">Version</p>
-              <p>{objectVersionIndex}</p>
-            </div>
-            <div className="block">
               <p className="text-moon-500">Last updated</p>
               <p>
                 <Timestamp value={createdAtMs / 1000} format="relative" />


### PR DESCRIPTION
## Description

Internal Slack: https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1752505286225219

Remove duplicate "Version" information from object details - the version index is already shown as part of the title and we need the space for other things.

Before:
<img width="827" height="95" alt="Screenshot 2025-07-14 at 10 31 24 PM" src="https://github.com/user-attachments/assets/86141873-cb38-4708-9db3-bb91d3375486" />

After:
<img width="835" height="103" alt="Screenshot 2025-07-14 at 10 31 09 PM" src="https://github.com/user-attachments/assets/47f5caad-a460-48d9-9437-70e2d51de214" />

## Testing

How was this PR tested?
