### PR TITLE
fix(weave): Make EvaluationLogger work with Leaderboards

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -65,10 +65,12 @@ def test_basic_evaluation(
     assert evaluate_call.inputs["self"]._class_name == "Evaluation"
     assert evaluate_call.inputs["model"]._class_name == "Model"
     assert evaluate_call.output == {
-        "avg_score": 1.0,
-        "total_examples": 3,
         "greater_than_2_scorer": {"true_count": 3, "true_fraction": 1.0},
         "greater_than_4_scorer": {"true_count": 3, "true_fraction": 1.0},
+        "output": {
+            "avg_score": 1.0,
+            "total_examples": 3,
+        },
     }
 
     for i, (inputs, output_val, score1, score2) in enumerate(
@@ -119,10 +121,12 @@ def test_basic_evaluation(
     assert summarize_call.attributes["_weave_eval_meta"]["imperative"] is True
     assert summarize_call.inputs["self"]._class_name == "Evaluation"
     assert summarize_call.output == {
-        "avg_score": 1.0,
-        "total_examples": 3,
         "greater_than_2_scorer": {"true_count": 3, "true_fraction": 1.0},
         "greater_than_4_scorer": {"true_count": 3, "true_fraction": 1.0},
+        "output": {
+            "avg_score": 1.0,
+            "total_examples": 3,
+        },
     }
 
 
@@ -468,7 +472,7 @@ def test_evaluation_no_auto_summarize(client):
     calls = client.get_calls()
     # assert len(calls) == 1
     summarize_call = calls[4]
-    assert summarize_call.output == {}
+    assert summarize_call.output == {"output": {}}
 
 
 def test_evaluation_no_auto_summarize_with_custom_dict(client):
@@ -482,4 +486,8 @@ def test_evaluation_no_auto_summarize_with_custom_dict(client):
     calls = client.get_calls()
     # assert len(calls) == 1
     summarize_call = calls[4]
-    assert summarize_call.output == {"something": 1, "else": 2}
+    assert summarize_call.output == {
+        "something": 1,
+        "else": 2,
+        "output": {"something": 1, "else": 2},
+    }

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -546,7 +546,7 @@ class EvaluationLogger(BaseModel):
         if summary_data:
             final_summary = summary_data
         if summary is not None:
-            final_summary = {**final_summary, **summary}
+            final_summary = {**final_summary, "output": summary}
 
         # Call the summarize op
         assert self._evaluate_call is not None, (


### PR DESCRIPTION
Modifies the leaderboard UI code to support `EvaluationLogger` (imperative-style) evals

See example code where we only log summary data:
```py
import weave
import random

weave.init('testing1009')

for k in range(2):
    ev = weave.EvaluationLogger(model=f"abc{k}", dataset="def")
    ev.log_summary({f"metric{i}": random.random() for i in range(4)})
```

<img width="1633" height="502" alt="image" src="https://github.com/user-attachments/assets/52e2b10d-3eec-4c42-95aa-ff1c3296a8f0" />
