### PR TITLE
Griffin/weave error registry

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -317,7 +317,9 @@ def simple_line_call_bootstrap() -> OpCallSpec:
     @weave.op
     def multiplier(
         a: Number, b
-    ) -> int:  # intentionally deviant in returning plain int - so that we have a different type
+    ) -> (
+        int
+    ):  # intentionally deviant in returning plain int - so that we have a different type
         return a.value * b
 
     @weave.op
@@ -934,6 +936,7 @@ def test_trace_call_sort_with_mixed_types(client):
         )
 
         for i, call in enumerate(inner_res.calls):
+            print(i, "CALL", call.inputs)
             assert call.inputs["in_val"].get("prim") == seq[i]
 
 
@@ -2536,9 +2539,9 @@ def test_read_call_start_with_cost(client):
         pass
     elif isinstance(summary, dict):
         # Check that the costs object was NOT added
-        assert COST_OBJECT_NAME not in summary.get("weave", {}), (
-            f"Did not expect '{COST_OBJECT_NAME}' key in summary['weave'] when initial summary was null/empty"
-        )
+        assert COST_OBJECT_NAME not in summary.get(
+            "weave", {}
+        ), f"Did not expect '{COST_OBJECT_NAME}' key in summary['weave'] when initial summary was null/empty"
     else:
         pytest.fail(f"summary_dump was not None or dict: {type(summary)} {summary}")
 
@@ -3322,7 +3325,9 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
         # no need to strip in sqlite
         return
 
-    original_insert_call_batch = weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer._insert_call_batch
+    original_insert_call_batch = (
+        weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer._insert_call_batch
+    )
 
     # Patch _insert_call_batch to raise InsertTooLarge
     def mock_insert_call_batch(self, batch):

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -317,9 +317,7 @@ def simple_line_call_bootstrap() -> OpCallSpec:
     @weave.op
     def multiplier(
         a: Number, b
-    ) -> (
-        int
-    ):  # intentionally deviant in returning plain int - so that we have a different type
+    ) -> int:  # intentionally deviant in returning plain int - so that we have a different type
         return a.value * b
 
     @weave.op
@@ -2539,9 +2537,9 @@ def test_read_call_start_with_cost(client):
         pass
     elif isinstance(summary, dict):
         # Check that the costs object was NOT added
-        assert COST_OBJECT_NAME not in summary.get(
-            "weave", {}
-        ), f"Did not expect '{COST_OBJECT_NAME}' key in summary['weave'] when initial summary was null/empty"
+        assert COST_OBJECT_NAME not in summary.get("weave", {}), (
+            f"Did not expect '{COST_OBJECT_NAME}' key in summary['weave'] when initial summary was null/empty"
+        )
     else:
         pytest.fail(f"summary_dump was not None or dict: {type(summary)} {summary}")
 
@@ -3325,9 +3323,7 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
         # no need to strip in sqlite
         return
 
-    original_insert_call_batch = (
-        weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer._insert_call_batch
-    )
+    original_insert_call_batch = weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer._insert_call_batch
 
     # Patch _insert_call_batch to raise InsertTooLarge
     def mock_insert_call_batch(self, batch):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -202,7 +202,8 @@ DEFAULT_MAX_MEMORY_USAGE = 16 * 1024 * 1024 * 1024  # 16 GiB
 # https://clickhouse.com/docs/operations/settings/settings#max_execution_time
 DEFAULT_MAX_EXECUTION_TIME = 60 * 1  # 1 minute
 CLICKHOUSE_DEFAULT_QUERY_SETTINGS = {
-    "max_memory_usage": DEFAULT_MAX_MEMORY_USAGE,
+    "max_memory_usage": wf_env.wf_clickhouse_max_memory_usage()
+    or DEFAULT_MAX_MEMORY_USAGE,
     "max_execution_time": wf_env.wf_clickhouse_max_execution_time()
     or DEFAULT_MAX_EXECUTION_TIME,
     "function_json_value_return_type_allow_complex": "1",
@@ -477,13 +478,10 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             cq.set_offset(req.offset)
 
         pb = ParamBuilder()
-        sql = cq.as_sql(pb)
-        params = pb.get_params()
-
-        if not req.include_costs and not req.include_storage_size:
-            print(_format_clickhouse_sql_for_debug(sql, params))
-
-        raw_res = self._query_stream(sql, params)
+        raw_res = self._query_stream(
+            cq.as_sql(pb),
+            pb.get_params(),
+        )
 
         select_columns = [c.field for c in cq.select_fields]
         expand_columns = req.expand_columns or []
@@ -2404,34 +2402,6 @@ def _num_bytes(data: Any) -> int:
         return len(str(data).encode("utf-8"))
     except Exception:
         return 0
-
-
-def _format_clickhouse_sql_for_debug(sql: str, params: dict[str, Any]) -> str:
-    """
-    Format ClickHouse SQL with parameters for debug printing.
-
-    ClickHouse uses format like {param_name:Type} but Python's format()
-    interprets :Type as a format specifier, causing errors.
-    This function safely replaces ClickHouse parameters with their values.
-    """
-    import re
-
-    formatted_sql = sql
-    # Pattern matches {param_name:Type} format used by ClickHouse
-    pattern = r"\{([^}]+):[^}]+\}"
-
-    def replace_param(match):
-        param_name = match.group(1)
-        if param_name in params:
-            value = params[param_name]
-            if isinstance(value, str):
-                return f"'{value}'"
-            else:
-                return str(value)
-        return match.group(0)  # Return original if param not found
-
-    formatted_sql = re.sub(pattern, replace_param, formatted_sql)
-    return formatted_sql
 
 
 def _dict_value_to_dump(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -198,11 +198,11 @@ CLICKHOUSE_SINGLE_VALUE_BYTES_LIMIT = 1 * 1024 * 1024  # 1 MiB
 ENTITY_TOO_LARGE_PAYLOAD = '{"_weave": {"error":"<EXCEEDS_LIMITS>"}}'
 
 # https://clickhouse.com/docs/operations/settings/settings#max_memory_usage
-DEFAULT_MAX_MEMORY_USAGE = 16 * 1024  # 16 GiB
+DEFAULT_MAX_MEMORY_USAGE = 16 * 1024 * 1024 * 1024  # 16 GiB
 # https://clickhouse.com/docs/operations/settings/settings#max_execution_time
 DEFAULT_MAX_EXECUTION_TIME = 60 * 1  # 1 minute
 CLICKHOUSE_DEFAULT_QUERY_SETTINGS = {
-    "max_memory_usage": 16 * 1024,
+    "max_memory_usage": DEFAULT_MAX_MEMORY_USAGE,
     "max_execution_time": wf_env.wf_clickhouse_max_execution_time()
     or DEFAULT_MAX_EXECUTION_TIME,
     "function_json_value_return_type_allow_complex": "1",
@@ -477,10 +477,13 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             cq.set_offset(req.offset)
 
         pb = ParamBuilder()
-        raw_res = self._query_stream(
-            cq.as_sql(pb),
-            pb.get_params(),
-        )
+        sql = cq.as_sql(pb)
+        params = pb.get_params()
+
+        if not req.include_costs and not req.include_storage_size:
+            print(_format_clickhouse_sql_for_debug(sql, params))
+
+        raw_res = self._query_stream(sql, params)
 
         select_columns = [c.field for c in cq.select_fields]
         expand_columns = req.expand_columns or []
@@ -2401,6 +2404,34 @@ def _num_bytes(data: Any) -> int:
         return len(str(data).encode("utf-8"))
     except Exception:
         return 0
+
+
+def _format_clickhouse_sql_for_debug(sql: str, params: dict[str, Any]) -> str:
+    """
+    Format ClickHouse SQL with parameters for debug printing.
+
+    ClickHouse uses format like {param_name:Type} but Python's format()
+    interprets :Type as a format specifier, causing errors.
+    This function safely replaces ClickHouse parameters with their values.
+    """
+    import re
+
+    formatted_sql = sql
+    # Pattern matches {param_name:Type} format used by ClickHouse
+    pattern = r"\{([^}]+):[^}]+\}"
+
+    def replace_param(match):
+        param_name = match.group(1)
+        if param_name in params:
+            value = params[param_name]
+            if isinstance(value, str):
+                return f"'{value}'"
+            else:
+                return str(value)
+        return match.group(0)  # Return original if param not found
+
+    formatted_sql = re.sub(pattern, replace_param, formatted_sql)
+    return formatted_sql
 
 
 def _dict_value_to_dump(

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -1,4 +1,10 @@
 import datetime
+import json
+from typing import Any, Callable, Optional
+
+import clickhouse_connect
+import requests
+from gql.transport.exceptions import TransportQueryError
 
 
 class Error(Exception):
@@ -21,6 +27,12 @@ class InvalidRequest(Error):
 
 class InsertTooLarge(Error):
     """Raised when a single insert is too large."""
+
+    pass
+
+
+class QueryMemoryLimitExceeded(Error):
+    """Raised when a query memory limit is exceeded."""
 
     pass
 
@@ -51,3 +63,197 @@ class ObjectDeletedError(Error):
     def __init__(self, message: str, deleted_at: datetime.datetime):
         self.deleted_at = deleted_at
         super().__init__(message)
+
+
+# Error Registry System
+class ErrorDefinition:
+    """Represents a single error handler definition."""
+
+    def __init__(
+        self,
+        exception_class: type,
+        status_code: int,
+        formatter: Callable[[Exception], dict[str, Any]],
+    ):
+        self.exception_class = exception_class
+        self.status_code = status_code
+        self.formatter = formatter
+
+
+class ErrorRegistry:
+    """Central registry for all error handling definitions."""
+
+    def __init__(self) -> None:
+        self._definitions: dict[type, ErrorDefinition] = {}
+        self._setup_builtin_errors()
+
+    def register(
+        self,
+        exception_class: type,
+        status_code: int,
+        formatter: Optional[Callable[[Exception], dict[str, Any]]] = None,
+    ) -> None:
+        """Register an exception with its handling definition."""
+        if formatter is None:
+            formatter = self._default_json_formatter
+
+        self._definitions[exception_class] = ErrorDefinition(
+            exception_class, status_code, formatter
+        )
+
+    def get_definition(self, exception_class: type) -> Optional[ErrorDefinition]:
+        """Get error definition for an exception class."""
+        return self._definitions.get(exception_class)
+
+    def get_all_definitions(self) -> dict[type, ErrorDefinition]:
+        """Get all registered error definitions."""
+        return self._definitions.copy()
+
+    def handle_exception(self, exc: Exception) -> tuple[dict[str, Any], int]:
+        """Handle an exception using registered definitions."""
+        exc_type = type(exc)
+        definition = self.get_definition(exc_type)
+
+        if definition:
+            error_content = definition.formatter(exc)
+            return error_content, definition.status_code
+        else:
+            # Fallback for unknown exceptions
+            return {"reason": "Internal server error"}, 500
+
+    def _default_json_formatter(self, exc: Exception) -> dict[str, Any]:
+        """Default formatter that tries to parse JSON or falls back to reason."""
+        exc_str = str(exc)
+        try:
+            return json.loads(exc_str)
+        except json.JSONDecodeError:
+            return {"reason": exc_str}
+
+    def _setup_builtin_errors(self) -> None:
+        """Register all built-in error handlers."""
+        # Import here to avoid circular imports
+        from src import id_converters as idc
+
+        from weave.trace_server import clickhouse_trace_server_batched as cts
+        from weave.trace_server.trace_server_converter import InvalidExternalRef
+
+        # InsertTooLarge (413)
+        self.register(InsertTooLarge, 413, self._format_insert_too_large)
+
+        # RequestTooLarge (413)
+        self.register(RequestTooLarge, 413, lambda exc: {"reason": "Request too large"})
+
+        # QueryMemoryLimitExceeded (502)
+        self.register(
+            QueryMemoryLimitExceeded,
+            502,
+            lambda exc: {"reason": "Query memory limit exceeded"},
+        )
+
+        # Timeout errors (504)
+        self.register(
+            requests.exceptions.ReadTimeout, 504, lambda exc: {"reason": "Read timeout"}
+        )
+        self.register(
+            requests.exceptions.ConnectTimeout,
+            504,
+            lambda exc: {"reason": "Connection timeout"},
+        )
+
+        # ClickHouse errors (502)
+        self.register(
+            clickhouse_connect.driver.exceptions.DatabaseError,
+            502,
+            lambda exc: {"reason": "Temporary backend error"},
+        )
+        self.register(
+            clickhouse_connect.driver.exceptions.OperationalError,
+            502,
+            lambda exc: {"reason": "Temporary backend error"},
+        )
+
+        # Client errors (400)
+        self.register(ValueError, 400, self._default_json_formatter)
+        self.register(InvalidExternalRef, 400, self._default_json_formatter)
+        self.register(MissingLLMApiKeyError, 400, self._format_missing_llm_api_key)
+
+        # Permission errors (403)
+        self.register(InvalidFieldError, 403, self._default_json_formatter)
+        self.register(TransportQueryError, 403, self._format_transport_query_error)
+
+        # Not found errors (404)
+        self.register(cts.NotFoundError, 404, self._default_json_formatter)
+        self.register(idc.ProjectNotFound, 404, self._default_json_formatter)
+        self.register(ObjectDeletedError, 404, self._format_object_deleted_error)
+
+    def _format_insert_too_large(self, exc: Exception) -> dict[str, Any]:
+        """Format InsertTooLarge exception."""
+        exc_str = str(exc)
+        try:
+            return json.loads(exc_str)
+        except json.JSONDecodeError:
+            return {"reason": exc_str}
+
+    def _format_transport_query_error(self, exc: Exception) -> dict[str, Any]:
+        """Format TransportQueryError with special permission logic."""
+        transport_exc = exc if isinstance(exc, TransportQueryError) else None
+        if transport_exc and transport_exc.errors:
+            for error in transport_exc.errors:
+                if error.get("extensions", {}).get("code") == "PERMISSION_ERROR":
+                    return {"reason": "Forbidden"}
+                if error.get("message") == "project not found" and error.get(
+                    "path"
+                ) == ["upsertBucket"]:
+                    # This seems counter intuitive, but gorilla returns this error when the project exists
+                    # but the user does not have access to it. This seems like a bug on Gorilla's side.
+                    return {"reason": "Forbidden"}
+        return {"reason": "Forbidden"}
+
+    def _format_missing_llm_api_key(self, exc: Exception) -> dict[str, Any]:
+        """Format MissingLLMApiKeyError with api_key field."""
+        if isinstance(exc, MissingLLMApiKeyError):
+            return {"reason": str(exc), "api_key": exc.api_key_name}
+        return {"reason": str(exc)}
+
+    def _format_object_deleted_error(self, exc: Exception) -> dict[str, Any]:
+        """Format ObjectDeletedError with deleted_at timestamp."""
+        exc_str = str(exc)
+        try:
+            return json.loads(exc_str)
+        except json.JSONDecodeError:
+            if isinstance(exc, ObjectDeletedError):
+                return {"reason": exc_str, "deleted_at": exc.deleted_at.isoformat()}
+            return {"reason": exc_str}
+
+
+# Global registry instance
+_error_registry: Optional[ErrorRegistry] = None
+
+
+def get_error_registry() -> ErrorRegistry:
+    """Get the global error registry, initializing it if needed."""
+    global _error_registry
+    if _error_registry is None:
+        _error_registry = ErrorRegistry()
+    return _error_registry
+
+
+def register_error(
+    exception_class: type,
+    status_code: int,
+    formatter: Optional[Callable[[Exception], dict[str, Any]]] = None,
+) -> None:
+    """Convenience function to register an error with the global registry."""
+    get_error_registry().register(exception_class, status_code, formatter)
+
+
+def error_handler(
+    status_code: int, formatter: Optional[Callable[[Exception], dict[str, Any]]] = None
+) -> Callable[[type], type]:
+    """Decorator to register an exception class with error handling."""
+
+    def decorator(exception_class: type) -> type:
+        register_error(exception_class, status_code, formatter)
+        return exception_class
+
+    return decorator

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -1,0 +1,73 @@
+import json
+import logging
+from typing import TYPE_CHECKING, Union
+
+from weave.trace_server import requests
+
+if TYPE_CHECKING:
+    from weave.trace_server_bindings.models import EndBatchItem, StartBatchItem
+
+logger = logging.getLogger(__name__)
+
+
+def log_dropped_call_batch(
+    batch: list[Union["StartBatchItem", "EndBatchItem"]], e: Exception
+) -> None:
+    """Log details about a dropped call batch for debugging purposes."""
+    logger.error(f"Error sending batch of {len(batch)} call events to server")
+    dropped_start_ids = []
+    dropped_end_ids = []
+    for item in batch:
+        # Use string comparison to avoid circular imports
+        if hasattr(item, 'mode') and item.mode == "start":
+            dropped_start_ids.append(item.req.start.id)
+        elif hasattr(item, 'mode') and item.mode == "end":
+            dropped_end_ids.append(item.req.end.id)
+    if dropped_start_ids:
+        logger.error(f"dropped call start ids: {dropped_start_ids}")
+    if dropped_end_ids:
+        logger.error(f"dropped call end ids: {dropped_end_ids}")
+    if isinstance(e, requests.HTTPError) and e.response is not None:
+        logger.error(f"status code: {e.response.status_code}")
+        logger.error(f"reason: {e.response.reason}")
+        logger.error(f"text: {e.response.text}")
+    else:
+        logger.error(f"error: {e}")
+
+
+def handle_response_error(response: requests.Response, url: str) -> None:
+    """
+    Handle HTTP response errors with user-friendly messages.
+    
+    Args:
+        response: The HTTP response object
+        url: The endpoint URL that was called
+        
+    Raises:
+        requests.HTTPError: With a well-formatted error message
+    """
+    if 200 <= response.status_code < 300:
+        return
+    
+    # Try to extract error message from JSON response
+    error_message = None
+    try:
+        error_data = response.json()
+        if isinstance(error_data, dict):
+            # Common error message fields
+            error_message = (
+                error_data.get("message") or 
+                error_data.get("error") or 
+                error_data.get("detail") or
+                error_data.get("reason")
+            )
+    except (json.JSONDecodeError, ValueError):
+        pass
+    
+    # Use extracted message or fallback to simple default
+    if error_message:
+        message = f"{response.status_code} Error for url {url}: {error_message}"
+    else:
+        message = f"{response.status_code} Error for url {url}: Request failed"
+    
+    raise requests.HTTPError(message, response=response)

--- a/weave/trace_server_bindings/models.py
+++ b/weave/trace_server_bindings/models.py
@@ -1,0 +1,23 @@
+from typing import Union
+
+from pydantic import BaseModel
+
+from weave.trace_server import trace_server_interface as tsi
+
+
+class StartBatchItem(BaseModel):
+    mode: str = "start"
+    req: tsi.CallStartReq
+
+
+class EndBatchItem(BaseModel):
+    mode: str = "end"
+    req: tsi.CallEndReq
+
+
+class Batch(BaseModel):
+    batch: list[Union[StartBatchItem, EndBatchItem]]
+
+
+class ServerInfoRes(BaseModel):
+    min_required_weave_python_version: str 

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -252,14 +252,14 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             data=req.model_dump_json(by_alias=True).encode("utf-8"),
             stream=stream,
         )
-        if r.status_code == 500:
+        if r.status_code != 200:
             reason_val = r.text
             try:
                 reason_val = json.dumps(json.loads(reason_val), indent=2)
             except json.JSONDecodeError:
                 reason_val = f"Reason: {reason_val}"
             raise requests.HTTPError(
-                f"500 Server Error: Internal Server Error for url: {url}. {reason_val}",
+                f"{r.status_code} Error for url {url}: {reason_val}",
                 response=r,
             )
         r.raise_for_status()

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -1,5 +1,4 @@
 import io
-import json
 import logging
 from collections.abc import Iterator
 from typing import Any, Optional, Union, cast
@@ -11,6 +10,16 @@ from weave.trace.settings import max_calls_queue_size, should_enable_disk_fallba
 from weave.trace_server import requests
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
+from weave.trace_server_bindings.http_utils import (
+    handle_response_error,
+    log_dropped_call_batch,
+)
+from weave.trace_server_bindings.models import (
+    Batch,
+    EndBatchItem,
+    ServerInfoRes,
+    StartBatchItem,
+)
 from weave.utils.retry import _is_retryable_exception, get_current_retry_id, with_retry
 from weave.wandb_interface import project_creator
 
@@ -22,50 +31,9 @@ logger = logging.getLogger(__name__)
 # DEFAULT_TIMEOUT = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
 
 
-class StartBatchItem(BaseModel):
-    mode: str = "start"
-    req: tsi.CallStartReq
-
-
-class EndBatchItem(BaseModel):
-    mode: str = "end"
-    req: tsi.CallEndReq
-
-
-class Batch(BaseModel):
-    batch: list[Union[StartBatchItem, EndBatchItem]]
-
-
-class ServerInfoRes(BaseModel):
-    min_required_weave_python_version: str
-
-
 REMOTE_REQUEST_BYTES_LIMIT = (
     (32 - 1) * 1024 * 1024
 )  # 32 MiB (real limit) - 1 MiB (buffer)
-
-
-def _log_dropped_call_batch(
-    batch: list[Union[StartBatchItem, EndBatchItem]], e: Exception
-) -> None:
-    logger.error(f"Error sending batch of {len(batch)} call events to server")
-    dropped_start_ids = []
-    dropped_end_ids = []
-    for item in batch:
-        if isinstance(item, StartBatchItem):
-            dropped_start_ids.append(item.req.start.id)
-        elif isinstance(item, EndBatchItem):
-            dropped_end_ids.append(item.req.end.id)
-    if dropped_start_ids:
-        logger.error(f"dropped call start ids: {dropped_start_ids}")
-    if dropped_end_ids:
-        logger.error(f"dropped call end ids: {dropped_end_ids}")
-    if isinstance(e, requests.HTTPError) and e.response is not None:
-        logger.error(f"status code: {e.response.status_code}")
-        logger.error(f"reason: {e.response.reason}")
-        logger.error(f"text: {e.response.text}")
-    else:
-        logger.error(f"error: {e}")
 
 
 class RemoteHTTPTraceServer(tsi.TraceServerInterface):
@@ -151,11 +119,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/call/upsert_batch",
             data=encoded_data,  # type: ignore
         )
-        if r.status_code == 413:
-            # handle 413 explicitly to provide actionable error message
-            reason = json.loads(r.text)["reason"]
-            raise requests.HTTPError(f"413 Client Error: {reason}", response=r)
-        r.raise_for_status()
+        handle_response_error(r, "/call/upsert_batch")
 
     def _flush_calls(
         self,
@@ -204,7 +168,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             self._send_batch_to_server(encoded_data)
         except Exception as e:
             if not _is_retryable_exception(e):
-                _log_dropped_call_batch(batch, e)
+                log_dropped_call_batch(batch, e)
             else:
                 # Add items back to the queue for later processing, but only if the processor is still accepting work
                 logger.warning(
@@ -252,17 +216,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             data=req.model_dump_json(by_alias=True).encode("utf-8"),
             stream=stream,
         )
-        if r.status_code != 200:
-            reason_val = r.text
-            try:
-                reason_val = json.dumps(json.loads(reason_val), indent=2)
-            except json.JSONDecodeError:
-                reason_val = f"Reason: {reason_val}"
-            raise requests.HTTPError(
-                f"{r.status_code} Error for url {url}: {reason_val}",
-                response=r,
-            )
-        r.raise_for_status()
+        handle_response_error(r, url)
 
         return r
 
@@ -297,7 +251,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
         r = self.get(
             "/server_info",
         )
-        r.raise_for_status()
+        handle_response_error(r, "/server_info")
         return ServerInfoRes.model_validate(r.json())
 
     def otel_export(self, req: tsi.OtelExportReq) -> tsi.OtelExportRes:
@@ -543,7 +497,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             data={"project_id": req.project_id},
             files={"file": (req.name, req.content)},
         )
-        r.raise_for_status()
+        handle_response_error(r, "/files/create")
         return tsi.FileCreateRes.model_validate(r.json())
 
     @with_retry
@@ -552,7 +506,7 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/files/content",
             json={"project_id": req.project_id, "digest": req.digest},
         )
-        r.raise_for_status()
+        handle_response_error(r, "/files/content")
         # TODO: Should stream to disk rather than to memory
         bytes = io.BytesIO()
         bytes.writelines(r.iter_content())
@@ -665,8 +619,4 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
 
 __docspec__ = [
     RemoteHTTPTraceServer,
-    ServerInfoRes,
-    StartBatchItem,
-    EndBatchItem,
-    Batch,
 ]


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr:
- adds an error registry so we only define errors in one place and they are handled across the trace server
- updates error handling in the client to give more detailed messages
- catches errors in the streaming iterator and re-raises them manually, which fastapi handlers can't do
- streaming handler returns **both** content chunks _and_ a status_code, which allows for dynamic status code header assignment. in practice this means that a stream can be 200 green and then error and turn into a 500 error.



## Testing

todo: 
- lots of manual testing