### PR TITLE
fix(weave): actually do validation on client side call queries

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -4342,7 +4342,7 @@ def test_calls_query_stats_with_limit(client):
     # test limit and filter, should use limit but not special optimization
     assert calls_stats(limit=1, filter={"trace_roots_only": True}).count == 1
     # test filter, should not use special optimization
-    assert calls_stats(filter={"trace_id": trace_id}).count == 2
+    assert calls_stats(filter={"trace_ids": [trace_id]}).count == 2
 
     with pytest.raises(ValueError):
         calls_stats(limit=-1)

--- a/tests/trace/test_publish_round_trip.py
+++ b/tests/trace/test_publish_round_trip.py
@@ -19,6 +19,8 @@ def test_publish_round_trip_query_object(client) -> None:
     ref = weave.publish(query)
     res = client.server.refs_read_batch(RefsReadBatchReq(refs=[ref.uri()]))
 
+    # remove the extra python class information that round tripping generates
+    # specifically: _type, _class_name, _bases
     clean = {"$expr": res.vals[0]["$expr"]}
     query_2 = Query.model_validate(clean)
     assert query_2 == query

--- a/tests/trace/test_publish_round_trip.py
+++ b/tests/trace/test_publish_round_trip.py
@@ -18,7 +18,9 @@ def test_publish_round_trip_query_object(client) -> None:
     query = Query(**query_raw)
     ref = weave.publish(query)
     res = client.server.refs_read_batch(RefsReadBatchReq(refs=[ref.uri()]))
-    query_2 = Query.model_validate(res.vals[0])
+
+    clean = {"$expr": res.vals[0]["$expr"]}
+    query_2 = Query.model_validate(clean)
     assert query_2 == query
 
 

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -784,11 +784,13 @@ def test_dataset_calls(client):
         weave.Dataset(rows=[{"doc": "xx", "label": "c"}, {"doc": "yy", "label": "d"}]),
         "my-dataset",
     )
+    op_name = ""
     for row in ref.rows:
         call = client.create_call("x", {"a": row["doc"]})
+        op_name = call.op_name
         client.finish_call(call, None)
 
-    calls = list(client.get_calls(filter={"op_names": ["x"]}))
+    calls = list(client.get_calls(filter={"op_names": [op_name]}))
     assert calls[0].inputs["a"] == "xx"
     assert calls[1].inputs["a"] == "yy"
 

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -788,7 +788,7 @@ def test_dataset_calls(client):
         call = client.create_call("x", {"a": row["doc"]})
         client.finish_call(call, None)
 
-    calls = list(client.get_calls(filter={"op_name": "x"}))
+    calls = list(client.get_calls(filter={"op_names": ["x"]}))
     assert calls[0].inputs["a"] == "xx"
     assert calls[1].inputs["a"] == "yy"
 

--- a/weave/trace_server/interface/query.py
+++ b/weave/trace_server/interface/query.py
@@ -24,7 +24,7 @@ simplifications:
 
 import typing
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 # Operations: all operations have the form of a single property
 # with the name of the operation suffixed with an underscore.
@@ -319,6 +319,8 @@ ContainsOperation.model_rebuild()
 
 
 class Query(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     # Here, we use `expr_` to match the MongoDB query language's "aggregation" operator syntax.
     # This is certainly a subset of the full MongoDB query language, but it is a good starting point.
     # https://www.mongodb.com/docs/manual/reference/operator/query/expr/#mongodb-query-op.-expr

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -363,6 +363,8 @@ class CompletionsCreateRes(BaseModel):
 
 
 class CallsFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     op_names: Optional[list[str]] = None
     input_refs: Optional[list[str]] = None
     output_refs: Optional[list[str]] = None
@@ -377,6 +379,8 @@ class CallsFilter(BaseModel):
 
 
 class SortBy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     # Field should be a key of `CallSchema`. For dictionary fields
     # (`attributes`, `inputs`, `outputs`, `summary`), the field can be
     # dot-separated.


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Partially solves: [WB-25859](https://wandb.atlassian.net/browse/WB-25859)

Currently we allow extra keys in both the `CallsFilter`, `SortBy`, and `Query` portions of the `client.get_calls` query, which basically renders the existing validation worthless! Lets be stricter, and tell users if they have typed in something wrong...

This predictably also exposes a few unrelated errors for incorrect usages of these types!

## Testing

- add explicit tests
- fix broken tests that weren't being validated



[WB-25859]: https://wandb.atlassian.net/browse/WB-25859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ