### PR TITLE
fix(weave): Suppres Pydantic warning

### DIFF
--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1145,6 +1145,9 @@ class EvaluateModelReq(BaseModel):
     evaluation_ref: str
     model_ref: str
     wb_user_id: Optional[str] = Field(None, description=WB_USER_ID_DESCRIPTION)
+    # Fixes the following warning:
+    # UserWarning: Field "model_ref" has conflict with protected namespace "model_".
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class EvaluateModelRes(BaseModel):


### PR DESCRIPTION
Suppresses the following warning:
```
/usr/local/lib/python3.11/site-packages/pydantic/_internal/_fields.py:160: UserWarning: Field "model_ref" has conflict with protected namespace "model_".
You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
```