### PR TITLE
chore(weave): Reorder pre-commits to have most relevant checks run first

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 default_stages: [pre-push]
 
 repos:
+  - repo: https://github.com/Instagram/Fixit
+    rev: v2.1.0
+    hooks:
+      - id: fixit-fix
+        exclude: "(weave_query|weave-js)"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.3
     hooks:
@@ -12,11 +17,20 @@ repos:
       - id: ruff-format
         args: [--config=pyproject.toml]
         types_or: [python, pyi, jupyter]
-  - repo: https://github.com/Instagram/Fixit
-    rev: v2.1.0
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.387
     hooks:
-      - id: fixit-fix
-        exclude: "(weave_query|weave-js)"
+      - id: pyright
+        additional_dependencies: [".[tests]"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.17.0"
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          [types-pkg-resources==0.1.3, types-all, wandb>=0.15.5, wandb<0.19.0]
+        # Note: You have to update pyproject.toml[tool.mypy] too!
+        args: ["--config-file=pyproject.toml"]
+        exclude: (.*pyi$)|(weave_query)|(tests)|(examples)
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
@@ -38,28 +52,12 @@ repos:
       - id: typos
         # Excluding extra things to make initial reviews easier, starting with `examples``
         exclude: "(weave_query|weave-js|cassettes|examples|tests|tools|docs)"
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.17.0"
-    hooks:
-      - id: mypy
-        additional_dependencies:
-          [types-pkg-resources==0.1.3, types-all, wandb>=0.15.5, wandb<0.19.0]
-        # Note: You have to update pyproject.toml[tool.mypy] too!
-        args: ["--config-file=pyproject.toml"]
-        exclude: (.*pyi$)|(weave_query)|(tests)|(examples)
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.387
-    hooks:
-      - id: pyright
-        additional_dependencies: [".[tests]"]
   - repo: https://github.com/oxipng/oxipng
     rev: v9.1.5
     hooks:
       - id: oxipng
         args: ["-o", "2", "--strip", "safe", "--alpha"]
         exclude: (weave_query|weave-js)
-  # This is legacy Weave when we were building a notebook product - should be removed
   - repo: local
     hooks:
       - id: jupyter-nb-clear-output


### PR DESCRIPTION
This PR:
1. Moves the Fixit command first as it is a codemod and will affect all downstream checks
2. Moves pyright up before mypy because it's faster
3. Moves mypy up before the other checks which are not specifically code related