### PR TITLE
fix(weave): indeterminate ordering in callsquery w/ identical started_at

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -471,8 +471,13 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         if req.sort_by is not None:
             for sort_by in req.sort_by:
                 cq.add_order(sort_by.field, sort_by.direction)
+            # If the only sort field is "started_at", add "id" as secondary sort for consistency
+            if len(req.sort_by) == 1 and req.sort_by[0].field == "started_at":
+                cq.add_order("id", "asc")
         else:
+            # Default sorting: started_at with id as secondary sort for consistency
             cq.add_order("started_at", "asc")
+            cq.add_order("id", "asc")
         if req.limit is not None:
             cq.set_limit(req.limit)
         if req.offset is not None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -471,8 +471,10 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         if req.sort_by is not None:
             for sort_by in req.sort_by:
                 cq.add_order(sort_by.field, sort_by.direction)
-            # If the only sort field is "started_at", add "id" as secondary sort for consistency
-            if len(req.sort_by) == 1 and req.sort_by[0].field == "started_at":
+            # If user isn't already sorting by id, add id as secondary sort for consistency
+            if req.sort_by and not any(
+                sort_by.field == "id" for sort_by in req.sort_by
+            ):
                 cq.add_order("id", "asc")
         else:
             # Default sorting: started_at with id as secondary sort for consistency

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -472,9 +472,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
             for sort_by in req.sort_by:
                 cq.add_order(sort_by.field, sort_by.direction)
             # If user isn't already sorting by id, add id as secondary sort for consistency
-            if req.sort_by and not any(
-                sort_by.field == "id" for sort_by in req.sort_by
-            ):
+            if not any(sort_by.field == "id" for sort_by in req.sort_by):
                 cq.add_order("id", "asc")
         else:
             # Default sorting: started_at with id as secondary sort for consistency


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-26077](https://wandb.atlassian.net/browse/WB-26077)

The solution is to always order by `started_at, id` instead of just `started_at`. 

Actually, we should probably be adding order by id after ALL non-null sorts. The user should not be responsible for figuring that out...

## Testing

- adds `test_trace_call_query_timings` which fails in prod


[WB-26077]: https://wandb.atlassian.net/browse/WB-26077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ