### PR TITLE
perf(weave): massively improve filter calls by forcing index

### DIFF
--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -485,41 +485,41 @@ def test_query_with_simple_feedback_sort() -> None:
     assert_sql(
         cq,
         """
-        SELECT
-            calls_merged.id AS id
-        FROM
-            calls_merged
-        LEFT JOIN (
-            SELECT * FROM feedback WHERE project_id = {pb_4:String}
-        ) AS feedback ON (
-            feedback.weave_ref = concat('weave-trace-internal:///',
-            {pb_4:String},
-            '/call/',
-            calls_merged.id))
-        WHERE
-            calls_merged.project_id = {pb_4:String}
-        GROUP BY
-            (calls_merged.project_id,
-            calls_merged.id)
-        HAVING
-            (((any(calls_merged.deleted_at) IS NULL))
-                AND ((NOT ((any(calls_merged.started_at) IS NULL)))))
-        ORDER BY
-            (NOT (JSONType(anyIf(feedback.payload_dump,
-            feedback.feedback_type = {pb_0:String}),
-            {pb_1:String},
-            {pb_2:String}) = 'Null'
-                OR JSONType(anyIf(feedback.payload_dump,
+            SELECT
+                calls_merged.id AS id
+            FROM
+                calls_merged
+            LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String}
+            ) AS feedback ON (
+                feedback.weave_ref = concat('weave-trace-internal:///',
+                {pb_4:String},
+                '/call/',
+                calls_merged.id))
+            WHERE
+                calls_merged.project_id = {pb_4:String}
+            GROUP BY
+                (calls_merged.project_id,
+                calls_merged.id)
+            HAVING
+                (((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.started_at) IS NULL)))))
+            ORDER BY
+                (NOT (JSONType(anyIf(feedback.payload_dump,
                 feedback.feedback_type = {pb_0:String}),
                 {pb_1:String},
-                {pb_2:String}) IS NULL)) desc,
-            toFloat64OrNull(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump,
-            feedback.feedback_type = {pb_0:String}),
-            {pb_3:String}), 'null'), '')) DESC,
-            toString(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump,
-            feedback.feedback_type = {pb_0:String}),
-            {pb_3:String}), 'null'), '')) DESC
-        """,
+                {pb_2:String}) = 'Null'
+                    OR JSONType(anyIf(feedback.payload_dump,
+                    feedback.feedback_type = {pb_0:String}),
+                    {pb_1:String},
+                    {pb_2:String}) IS NULL)) desc,
+                toFloat64OrNull(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump,
+                feedback.feedback_type = {pb_0:String}),
+                {pb_3:String}), 'null'), '')) DESC,
+                toString(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump,
+                feedback.feedback_type = {pb_0:String}),
+                {pb_3:String}), 'null'), '')) DESC
+            """,
         {
             "pb_0": "wandb.runnable.my_op",
             "pb_1": "output",
@@ -548,17 +548,17 @@ def test_query_with_simple_feedback_sort_with_op_name() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN (
-            SELECT * FROM feedback WHERE project_id = {pb_5:String}
-        ) AS feedback ON (
-            feedback.weave_ref = concat('weave-trace-internal:///',
-            {pb_5:String},
-            '/call/',
-            calls_merged.id))
-        WHERE
-            calls_merged.project_id = {pb_5:String}
-            AND ((calls_merged.op_name IN {pb_0:Array(String)})
-                OR (calls_merged.op_name IS NULL))
+                    LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_5:String}
+            ) AS feedback ON (
+                feedback.weave_ref = concat('weave-trace-internal:///',
+                {pb_5:String},
+                '/call/',
+                calls_merged.id))
+            WHERE
+                calls_merged.project_id = {pb_5:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
+                    OR (calls_merged.op_name IS NULL))
         GROUP BY
             (calls_merged.project_id,
             calls_merged.id)
@@ -585,16 +585,16 @@ def test_query_with_simple_feedback_sort_with_op_name() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN (
-            SELECT * FROM feedback WHERE project_id = {pb_5:String}
-        ) AS feedback ON (
-            feedback.weave_ref = concat('weave-trace-internal:///',
-            {pb_5:String},
-            '/call/',
-            calls_merged.id))
-        WHERE
-            calls_merged.project_id = {pb_5:String}
-            AND (calls_merged.id IN filtered_calls)
+                    LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_5:String}
+            ) AS feedback ON (
+                feedback.weave_ref = concat('weave-trace-internal:///',
+                {pb_5:String},
+                '/call/',
+                calls_merged.id))
+            WHERE
+                calls_merged.project_id = {pb_5:String}
+                AND (calls_merged.id IN filtered_calls)
         GROUP BY
             (calls_merged.project_id,
             calls_merged.id)
@@ -649,9 +649,9 @@ def test_query_with_simple_feedback_filter() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN (
-            SELECT * FROM feedback WHERE project_id = {pb_3:String}
-        ) AS feedback ON (
+                    LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_3:String}
+            ) AS feedback ON (
             feedback.weave_ref = concat('weave-trace-internal:///',
             {pb_3:String},
             '/call/',
@@ -702,9 +702,9 @@ def test_query_with_simple_feedback_sort_and_filter() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN (
-            SELECT * FROM feedback WHERE project_id = {pb_6:String}
-        ) AS feedback ON (
+                    LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_6:String}
+            ) AS feedback ON (
             feedback.weave_ref = concat('weave-trace-internal:///',
             {pb_6:String},
             '/call/',
@@ -1983,7 +1983,7 @@ def test_query_with_feedback_filter_and_datetime_and_string_filter() -> None:
         WITH filtered_calls AS
             (SELECT calls_merged.id AS id
             FROM calls_merged
-            LEFT JOIN (SELECT * FROM feedback WHERE project_id = {pb_8:String}) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_8:String}, '/call/', calls_merged.id))
+                            LEFT JOIN (SELECT * FROM feedback WHERE feedback.project_id = {pb_8:String}) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_8:String}, '/call/', calls_merged.id))
             WHERE calls_merged.project_id = {pb_8:String}
                 AND (calls_merged.sortable_datetime > {pb_7:String})
                 AND ((calls_merged.inputs_dump LIKE {pb_6:String}

--- a/tests/trace_server/test_calls_query_builder.py
+++ b/tests/trace_server/test_calls_query_builder.py
@@ -489,8 +489,9 @@ def test_query_with_simple_feedback_sort() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN feedback ON
-            (feedback.project_id = {pb_4:String} AND
+        LEFT JOIN (
+            SELECT * FROM feedback WHERE project_id = {pb_4:String}
+        ) AS feedback ON (
             feedback.weave_ref = concat('weave-trace-internal:///',
             {pb_4:String},
             '/call/',
@@ -547,8 +548,9 @@ def test_query_with_simple_feedback_sort_with_op_name() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN feedback ON
-            (feedback.project_id = {pb_5:String} AND
+        LEFT JOIN (
+            SELECT * FROM feedback WHERE project_id = {pb_5:String}
+        ) AS feedback ON (
             feedback.weave_ref = concat('weave-trace-internal:///',
             {pb_5:String},
             '/call/',
@@ -583,8 +585,9 @@ def test_query_with_simple_feedback_sort_with_op_name() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN feedback ON
-            (feedback.project_id = {pb_5:String} AND
+        LEFT JOIN (
+            SELECT * FROM feedback WHERE project_id = {pb_5:String}
+        ) AS feedback ON (
             feedback.weave_ref = concat('weave-trace-internal:///',
             {pb_5:String},
             '/call/',
@@ -646,8 +649,9 @@ def test_query_with_simple_feedback_filter() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN feedback ON
-            (feedback.project_id = {pb_3:String} AND
+        LEFT JOIN (
+            SELECT * FROM feedback WHERE project_id = {pb_3:String}
+        ) AS feedback ON (
             feedback.weave_ref = concat('weave-trace-internal:///',
             {pb_3:String},
             '/call/',
@@ -698,8 +702,9 @@ def test_query_with_simple_feedback_sort_and_filter() -> None:
             calls_merged.id AS id
         FROM
             calls_merged
-        LEFT JOIN feedback ON
-            (feedback.project_id = {pb_6:String} AND
+        LEFT JOIN (
+            SELECT * FROM feedback WHERE project_id = {pb_6:String}
+        ) AS feedback ON (
             feedback.weave_ref = concat('weave-trace-internal:///',
             {pb_6:String},
             '/call/',
@@ -1978,7 +1983,7 @@ def test_query_with_feedback_filter_and_datetime_and_string_filter() -> None:
         WITH filtered_calls AS
             (SELECT calls_merged.id AS id
             FROM calls_merged
-            LEFT JOIN feedback ON (feedback.project_id = {pb_8:String} AND feedback.weave_ref = concat('weave-trace-internal:///', {pb_8:String}, '/call/', calls_merged.id))
+            LEFT JOIN (SELECT * FROM feedback WHERE project_id = {pb_8:String}) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_8:String}, '/call/', calls_merged.id))
             WHERE calls_merged.project_id = {pb_8:String}
                 AND (calls_merged.sortable_datetime > {pb_7:String})
                 AND ((calls_merged.inputs_dump LIKE {pb_6:String}

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -930,8 +930,9 @@ class CallsQuery(BaseModel):
         feedback_join_sql = ""
         if needs_feedback:
             feedback_join_sql = f"""
-            LEFT JOIN feedback ON (
-                feedback.project_id = {param_slot(project_param, "String")} AND
+            LEFT JOIN (
+                SELECT * FROM feedback WHERE project_id = {param_slot(project_param, "String")}
+            ) AS feedback ON (
                 feedback.weave_ref = concat('weave-trace-internal:///', {param_slot(project_param, "String")}, '/call/', calls_merged.id))
             """
 

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -931,7 +931,7 @@ class CallsQuery(BaseModel):
         if needs_feedback:
             feedback_join_sql = f"""
             LEFT JOIN (
-                SELECT * FROM feedback WHERE project_id = {param_slot(project_param, "String")}
+                SELECT * FROM feedback WHERE feedback.project_id = {param_slot(project_param, "String")}
             ) AS feedback ON (
                 feedback.weave_ref = concat('weave-trace-internal:///', {param_slot(project_param, "String")}, '/call/', calls_merged.id))
             """


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Filtering calls by feedback is crazy slow, this pr filters feedback first in a subquery, both forcing the use of the primary index and pre-filtering. 

## Testing
Update unit tests

Manual testing in cloud console: 

| Env    | Elapsed   | Rows Read         | Data Read | Peak Memory   |
|--------|-----------|-------------------|-----------|---------------|
| prod   | 3.028s    | 28,424,000 rows   | 15.54 GB  | 12 GB         |
| branch | 0.114s    | 283,865 rows      | 43.70 MB  | 197.57 MiB    |
