### PR TITLE
chore(weave): threads query builder style cleanup

### DIFF
--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -938,25 +938,29 @@ class CallsQuery(BaseModel):
         storage_size_sql = ""
         if self.include_storage_size:
             storage_size_sql = f"""
-            LEFT JOIN (SELECT
-                id,
-                sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0)) as storage_size_bytes
-            FROM calls_merged_stats
-            WHERE project_id = {param_slot(project_param, "String")}
-            GROUP BY id) as {STORAGE_SIZE_TABLE_NAME}
-            on calls_merged.id = {STORAGE_SIZE_TABLE_NAME}.id
+            LEFT JOIN (
+                SELECT
+                    id,
+                    sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0)) AS storage_size_bytes
+                FROM calls_merged_stats
+                WHERE project_id = {param_slot(project_param, "String")}
+                GROUP BY id
+            ) AS {STORAGE_SIZE_TABLE_NAME}
+            ON calls_merged.id = {STORAGE_SIZE_TABLE_NAME}.id
             """
 
         total_storage_size_sql = ""
         if self.include_total_storage_size:
             total_storage_size_sql = f"""
-            LEFT JOIN (SELECT
-                trace_id,
-                sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0)) as total_storage_size_bytes
-            FROM calls_merged_stats
-            WHERE project_id = {param_slot(project_param, "String")}
-            GROUP BY trace_id) as {ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME}
-            on calls_merged.trace_id = {ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME}.trace_id
+            LEFT JOIN (
+                SELECT
+                    trace_id,
+                    sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0)) AS total_storage_size_bytes
+                FROM calls_merged_stats
+                WHERE project_id = {param_slot(project_param, "String")}
+                GROUP BY trace_id
+            ) AS {ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME}
+            ON calls_merged.trace_id = {ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME}.trace_id
             """
 
         # Add JOINs for object reference ordering
@@ -1602,7 +1606,7 @@ def optimized_project_contains_call_query(
         )
         THEN 1
         ELSE 0
-        END as has_any
+        END AS has_any
     """,
         logger,
     )


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Tiny style nits on the threads query builder: 
- use capitals for SQL terms like `AS` and `ON`
- move comments from the query itself, these get logged to dd and imo actually make it harder to understand the query.

## Testing

updates tests
