### PR TITLE
fix(weave): Fix docs build failure caused by empty SchemaTabs components

### DIFF
--- a/docs/scripts/generate_service_api_spec.py
+++ b/docs/scripts/generate_service_api_spec.py
@@ -85,10 +85,7 @@ def apply_doc_fixes(raw_json):
 
     # Fix 3: Fix anyOf arrays that contain empty objects or problematic combinations
     def empty_object_fix_mapper(value):
-        if (
-            isinstance(value, dict)
-            isinstance(value.get("anyOf"), list)
-        ):
+        if isinstance(value, dict) and isinstance(value.get("anyOf"), list):
             # Filter out empty objects from anyOf arrays
             filtered_any_of = [item for item in value["anyOf"] if item != {}]
             if len(filtered_any_of) != len(value["anyOf"]):
@@ -101,11 +98,12 @@ def apply_doc_fixes(raw_json):
 
             # Also handle the case where we only have object and null types
             # This can cause empty tabs in the docs generator
-            if "anyOf" in value and len(value["anyOf"]) == 2:
-                types = set()
-                for item in value["anyOf"]:
-                    if isinstance(item, dict) and "type" in item:
-                        types.add(item["type"])
+            if len(value["anyOf"]) == 2:
+                types = {
+                    item["type"]
+                    for item in value["anyOf"]
+                    if isinstance(item, dict) and "type" in item
+                }
 
                 if types == {"object", "null"}:
                     # Replace with just object type to avoid empty tabs

--- a/docs/scripts/generate_service_api_spec.py
+++ b/docs/scripts/generate_service_api_spec.py
@@ -87,8 +87,7 @@ def apply_doc_fixes(raw_json):
     def empty_object_fix_mapper(value):
         if (
             isinstance(value, dict)
-            and "anyOf" in value
-            and isinstance(value["anyOf"], list)
+            isinstance(value.get("anyOf"), list)
         ):
             # Filter out empty objects from anyOf arrays
             filtered_any_of = [item for item in value["anyOf"] if item != {}]

--- a/docs/scripts/generate_service_api_spec.py
+++ b/docs/scripts/generate_service_api_spec.py
@@ -83,6 +83,39 @@ def apply_doc_fixes(raw_json):
 
     raw_json = apply_mapper(raw_json, optional_dict_fix_mapper)
 
+    # Fix 3: Fix anyOf arrays that contain empty objects or problematic combinations
+    def empty_object_fix_mapper(value):
+        if (
+            isinstance(value, dict)
+            and "anyOf" in value
+            and isinstance(value["anyOf"], list)
+        ):
+            # Filter out empty objects from anyOf arrays
+            filtered_any_of = [item for item in value["anyOf"] if item != {}]
+            if len(filtered_any_of) != len(value["anyOf"]):
+                if len(filtered_any_of) == 0:
+                    # If all items were empty, replace with a single object type
+                    del value["anyOf"]
+                    value["type"] = "object"
+                else:
+                    value["anyOf"] = filtered_any_of
+
+            # Also handle the case where we only have object and null types
+            # This can cause empty tabs in the docs generator
+            if "anyOf" in value and len(value["anyOf"]) == 2:
+                types = set()
+                for item in value["anyOf"]:
+                    if isinstance(item, dict) and "type" in item:
+                        types.add(item["type"])
+
+                if types == {"object", "null"}:
+                    # Replace with just object type to avoid empty tabs
+                    del value["anyOf"]
+                    value["type"] = "object"
+        return value
+
+    raw_json = apply_mapper(raw_json, empty_object_fix_mapper)
+
     return raw_json
 
 


### PR DESCRIPTION
Problem

  The make docs command was failing with a Docusaurus error:
  Error: Docusaurus error: the <Tabs> component requires at least one <TabItem> children component

  The build was failing specifically on the /reference/service-api/inference-chat-completions-inference-v-1-chat-completions-post page due to empty <SchemaTabs>
  components being generated without any <TabItem> children.

  Root Cause

  The issue was in the OpenAPI specification processing pipeline. The API spec contained anyOf arrays with problematic combinations:

  1. Empty objects: Some anyOf arrays contained empty objects {} alongside valid type definitions
  2. Object-null combinations: Fields like response_format had anyOf arrays with only {"type": "object"} and {"type": "null"}

  When the Docusaurus API docs generator processed these schemas, it created <SchemaTabs> components but couldn't generate valid <TabItem> children for the empty
   objects or the simplified object-null combinations, resulting in empty tabs that caused the build to fail.

  Solution

  Modified scripts/generate_service_api_spec.py to add a new fix (empty_object_fix_mapper) that:

  1. Filters empty objects: Removes any empty objects {} from anyOf arrays
  2. Simplifies object-null combinations: When an anyOf array contains only {"type": "object"} and {"type": "null"}, replaces the entire anyOf with a simple
  {"type": "object"}
  3. Handles edge cases: If all items in an anyOf array were empty, converts to a single object type

  Why This Fix Is Correct

  1. Preserves semantic meaning: Converting anyOf: [{"type": "object"}, {"type": "null"}] to {"type": "object"} is semantically valid for documentation purposes
  - we're documenting the object structure, not implementing runtime validation
  2. Follows existing patterns: The fix extends the existing doc fixes (optional_any_fix_mapper, optional_dict_fix_mapper) that already handle similar OpenAPI
  spec incompatibilities with the docs generator
  3. Minimal impact: The changes only affect documentation generation, not the actual API behavior or validation
  4. Comprehensive: Handles both the immediate issue (empty objects) and the underlying pattern (object-null combinations) that could cause similar problems in
  the future

  Verification

  - ✅ make docs now builds successfully without errors
  - ✅ The response_format field renders correctly as a simple object type instead of empty tabs
  - ✅ All other API documentation continues to generate properly