### PR TITLE
docs(weave): Update inference docs usage and limits

### DIFF
--- a/docs/docs/guides/integrations/inference.md
+++ b/docs/docs/guides/integrations/inference.md
@@ -13,7 +13,7 @@ Using Weave, you can trace, evaluate, monitor, and iterate on your W&B Inference
 :::important
 W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
 
-- Free accounts must upgrade to a paid plan to continue using W&B Inference. **[Upgrade to either Pro or Enterprise to continue using inference.](https://wandb.ai/subscriptions)**
+- Free accounts must upgrade to a paid plan to continue using W&B Inference. **[Upgrade to either Pro or Enterprise to continue using W&B Inference.](https://wandb.ai/subscriptions)**
 - Pro plan users will be billed for Inference overages on a monthly basis, based on the model-specific pricing.
 - Enterprise accounts will need to contact their account executive.
 
@@ -56,7 +56,7 @@ For model pricing information, visit [https://wandb.ai/site/pricing/inference](h
 
 W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
 
-- Free accounts must upgrade to a paid plan to continue using W&B Inference. **[Upgrade to either Pro or Enterprise to continue using inference.](https://wandb.ai/subscriptions)**
+- Free accounts must upgrade to a paid plan to continue using W&B Inference. **[Upgrade to either Pro or Enterprise to continue using W&B Inference.](https://wandb.ai/subscriptions)**
 - Pro plan users will be billed for Inference overages on a monthly basis, based on the [model-specific pricing](https://wandb.ai/site/pricing/inference).
 - Enterprise accounts will need to contact their account executive.
 
@@ -72,7 +72,7 @@ W&B applies rate limits per W&B project. For example, if you have 3 projects ass
 Personal entities were deprecated in May 2024, so the following information only applies to legacy accounts.
 :::
 
-Personal accounts (personal entities) don’t support the W&B Inference service. To access W&B Inference, switch to a non-personal account. You can do this by creating a team.
+Personal accounts (personal entities) don’t support the W&B Inference service. To access W&B Inference, switch to a non-personal account. You can do this by creating a Team.
 
 ### Geographic restrictions
 
@@ -496,5 +496,6 @@ Visit the [Inference pricing page for a breakdown of per-model pricing](https://
 | 403        | Country, region, or territory not supported                                 | Accessing the API from an unsupported location.                                          | Please see [Geographic restrictions](#geographic-restrictions)                                     |
 | 429        | Concurrency limit reached for requests                                      | Too many concurrent requests.                                                            | Reduce the number of concurrent requests or increase your limits. For more information, see [Usage information and limits](#usage-information-and-limits).                                                             |
 | 429        | You exceeded your current quota, please check your plan and billing details | Out of credits or reached monthly spending cap.                                          | Purchase more credits or increase your limits. For more information, see [Usage information and limits](#usage-information-and-limits).                                                     |
+| 429 | W&B Inference is not available for personal accounts. Please switch to a non-personal account to access W&B Inference | The user is on a personal account, which does not have access to W&B Inference. | Switch to a non-personal account. If one is not avalible, create a Team to create a non-personal account. For more information, see [Personal entities unsupported](#personal-entities-unsupported).|
 | 500        | The server had an error while processing your request                       | Internal server error.                                                                   | Retry after a brief wait and contact support if it persists.                                       |
 | 503        | The engine is currently overloaded, please try again later                  | Server is experiencing high traffic.                                                     | Retry your request after a short delay.                                                            |

--- a/docs/docs/guides/integrations/inference.md
+++ b/docs/docs/guides/integrations/inference.md
@@ -11,8 +11,9 @@ _W&B Inference_ provides access to leading open-source foundation models via W&B
 :::important
 W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
 
-- Free accounts must upgrade to a Pro plan to continue using Inference.
+- Free accounts must upgrade to a Pro plan to continue using Inference. **[Upgrade your plan here](https://wandb.ai/subscriptions)**.
 - Pro plan users will be billed for Inference overages on a monthly basis, based on the model-specific pricing.
+- Enterprise accounts will need to contact their account executive.
 
 To learn more, see the [pricing page](https://wandb.ai/site/pricing/) and [W&B Inference model costs](https://wandb.ai/site/pricing/inference).
 :::
@@ -452,23 +453,27 @@ Visit the [Inference pricing page for a breakdown of per-model pricing](https://
 
 The following section describes important usage information and limits. Familiarize yourself with this information before using the service.
 
-### Geographic restrictions
-
-The Inference service is only accessible from supported geographic locations. For more information, see the [Terms of Service](https://docs.coreweave.com/docs/policies/terms-of-service/terms-of-use#geographic-restrictions).
-
-### Concurrency limits
-
-To ensure fair usage and stable performance, the W&B Inference API enforces rate limits at the user and project level. These limits help:
-
-- Prevent misuse and protect API stability
-- Ensure access for all users
-- Manage infrastructure load effectively
-
-If a rate limit is exceeded, the API will return a `429 Concurrency limit reached for requests` response. To resolve this error, reduce the number of concurrent requests.
-
 ### Pricing
 
 For model pricing information, visit [https://wandb.ai/site/pricing/inference](https://wandb.ai/site/pricing/inference).
+
+### Purchase more credits
+
+W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
+
+- Free accounts must upgrade to a Pro plan to continue using Inference. **[Upgrade your plan here](https://wandb.ai/subscriptions)**.
+- Pro plan users will be billed for Inference overages on a monthly basis, based on the model-specific pricing.
+- Enterprise accounts will need to contact their account executive.
+
+### Concurrency limits
+
+If a rate limit is exceeded, the API will return a `429 Concurrency limit reached for requests` response. To resolve this error, reduce the number of concurrent requests.
+
+W&B applies rate limits per W&B project. For example, if you have 3 projects associated with a team, each project has its own rate limit quota. Users on [Paid plans](https://wandb.ai/site/pricing) have higher rate limits than Free plans.
+
+### Geographic restrictions
+
+The Inference service is only accessible from supported geographic locations. For more information, see the [Terms of Service](https://docs.coreweave.com/docs/policies/terms-of-service/terms-of-use#geographic-restrictions).
 
 ## API errors
 
@@ -476,7 +481,7 @@ For model pricing information, visit [https://wandb.ai/site/pricing/inference](h
 | ---------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
 | 401        | Invalid Authentication                                                      | Invalid authentication credentials or your W&B project entity and/or name are incorrect. | Ensure the correct API key is being used and/or that your W&B project name and entity are correct. |
 | 403        | Country, region, or territory not supported                                 | Accessing the API from an unsupported location.                                          | Please see [Geographic restrictions](#geographic-restrictions)                                     |
-| 429        | Concurrency limit reached for requests                                      | Too many concurrent requests.                                                            | Reduce the number of concurrent requests.                                                          |
-| 429        | You exceeded your current quota, please check your plan and billing details | Out of credits or reached monthly spending cap.                                          | Purchase more credits or increase your limits.                                                     |
+| 429        | Concurrency limit reached for requests                                      | Too many concurrent requests.                                                            | Reduce the number of concurrent requests or increase your limits. For more information, see [Usage information and limits](#usage-information-and-limits).                                                             |
+| 429        | You exceeded your current quota, please check your plan and billing details | Out of credits or reached monthly spending cap.                                          | Purchase more credits or increase your limits. For more information, see [Usage information and limits](#usage-information-and-limits).                                                     |
 | 500        | The server had an error while processing your request                       | Internal server error.                                                                   | Retry after a brief wait and contact support if it persists.                                       |
 | 503        | The engine is currently overloaded, please try again later                  | Server is experiencing high traffic.                                                     | Retry your request after a short delay.                                                            |

--- a/docs/docs/guides/integrations/inference.md
+++ b/docs/docs/guides/integrations/inference.md
@@ -13,7 +13,7 @@ Using Weave, you can trace, evaluate, monitor, and iterate on your W&B Inference
 :::important
 W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
 
-- Free accounts must upgrade to a Pro plan to continue using Inference. **[Upgrade your plan here](https://wandb.ai/subscriptions)**.
+- Free accounts must upgrade to a paid plan to continue using W&B Inference. **[Upgrade to either Pro or Enterprise to continue using inference.](https://wandb.ai/subscriptions)**
 - Pro plan users will be billed for Inference overages on a monthly basis, based on the model-specific pricing.
 - Enterprise accounts will need to contact their account executive.
 
@@ -56,15 +56,15 @@ For model pricing information, visit [https://wandb.ai/site/pricing/inference](h
 
 W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
 
-- Free accounts must upgrade to a Pro plan to continue using Inference. **[Upgrade your plan here](https://wandb.ai/subscriptions)**.
-- Pro plan users will be billed for Inference overages on a monthly basis, based on the model-specific pricing.
+- Free accounts must upgrade to a paid plan to continue using W&B Inference. **[Upgrade to either Pro or Enterprise to continue using inference.](https://wandb.ai/subscriptions)**
+- Pro plan users will be billed for Inference overages on a monthly basis, based on the [model-specific pricing](https://wandb.ai/site/pricing/inference).
 - Enterprise accounts will need to contact their account executive.
 
 ### Concurrency limits
 
 If a rate limit is exceeded, the API will return a `429 Concurrency limit reached for requests` response. To resolve this error, reduce the number of concurrent requests.
 
-W&B applies rate limits per W&B project. For example, if you have 3 projects associated with a team, each project has its own rate limit quota. Users on [Paid plans](https://wandb.ai/site/pricing) have higher rate limits than Free plans.
+W&B applies rate limits per W&B project. For example, if you have 3 projects associated with a team, each project has its own rate limit quota.
 
 ### Personal entities unsupported
 
@@ -72,7 +72,7 @@ W&B applies rate limits per W&B project. For example, if you have 3 projects ass
 Personal entities were deprecated in May 2024, so the following information only applies to legacy accounts.
 :::
 
-Personal accounts (personal entities) don’t support the Inference service. To access Inference, you either need to create a team, or switch to a non-personal account. 
+Personal accounts (personal entities) don’t support the W&B Inference service. To access W&B Inference, switch to a non-personal account. You can do this by creating a team.
 
 ### Geographic restrictions
 

--- a/docs/docs/guides/integrations/inference.md
+++ b/docs/docs/guides/integrations/inference.md
@@ -6,7 +6,9 @@ import TabItem from '@theme/TabItem';
 _W&B Inference_ provides access to leading open-source foundation models via W&B Weave and an OpenAI-compliant API. With W&B Inference, you can:
 
 - Develop AI applications and agents without signing up for a hosting provider or self-hosting a model.
-- Try the supported models in the W&B Weave Playground.
+- Try the [supported models](#available-models) in the W&B Weave Playground.
+
+Using Weave, you can trace, evaluate, monitor, and iterate on your W&B Inference-powered applications.
 
 :::important
 W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
@@ -18,7 +20,17 @@ W&B Inference credits are included with Free, Pro, and Academic plans for a limi
 To learn more, see the [pricing page](https://wandb.ai/site/pricing/) and [W&B Inference model costs](https://wandb.ai/site/pricing/inference).
 :::
 
-Using Weave, you can trace, evaluate, monitor, and iterate on your W&B Inference-powered applications.
+## Get started
+
+To get started with the Inference service, complete the following steps:
+
+1. Familiarize yourself with the [available models](#available-models) and the [Usage information and limits](#usage-information-and-limits).
+2. Complete the [prerequisites](#prerequisites).
+3. Use the service programmatically (see the [usage examples](#usage-examples) and [API specification](#api-specification)) or via the [UI](#ui).
+
+## Available models
+
+The following models are available through W&B Inference:
 
 | Model                      | Model ID (for API usage)                  | Type(s)      | Context Window | Parameters                  | Description                                                                                                                    |
 | -------------------------- | ----------------------------------------- | ------------ | -------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
@@ -32,25 +44,45 @@ Using Weave, you can trace, evaluate, monitor, and iterate on your W&B Inference
 | Meta Llama 4 Scout              | meta-llama/Llama-4-Scout-17B-16E-Instruct | Text, Vision | 64K            | 17B - 109B (Active - Total) | Multimodal model integrating text and image understanding, ideal for visual tasks and combined analysis.                       |
 | Microsoft Phi 4 Mini 3.8B                | microsoft/Phi-4-mini-instruct             | Text         | 128K           | 3.8B (Active - Total)       | Compact, efficient model ideal for fast responses in resource-constrained environments.                                        |
 
-This guide provides the following information:
+## Usage information and limits
 
-- [Prerequisites](#prerequisites)
-  - [Additional prerequisites for using the API via Python](#additional-prerequisites-for-using-the-api-via-python)
-- [API specification](#api-specification)
-  - [Endpoint](#endpoint)
-  - [Available methods](#available-methods)
-    - [Chat completions](#chat-completions)
-    - [List supported models](#list-supported-models)
-- [Usage examples](#usage-examples)
-- [UI](#ui)
-  - [Access the Inference service](#access-the-inference-service)
-  - [Try a model in the Playground](#try-a-model-in-the-playground)
-  - [Compare multiple models](#compare-multiple-models)
-  - [View billing and usage information](#view-billing-and-usage-information)
-- [Usage information and limits ](#usage-information-and-limits)
-- [API errors](#api-errors)
+The following section describes important usage information and limits. Familiarize yourself with this information before using the service.
+
+### Pricing
+
+For model pricing information, visit [https://wandb.ai/site/pricing/inference](https://wandb.ai/site/pricing/inference).
+
+### Purchase more credits
+
+W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
+
+- Free accounts must upgrade to a Pro plan to continue using Inference. **[Upgrade your plan here](https://wandb.ai/subscriptions)**.
+- Pro plan users will be billed for Inference overages on a monthly basis, based on the model-specific pricing.
+- Enterprise accounts will need to contact their account executive.
+
+### Concurrency limits
+
+If a rate limit is exceeded, the API will return a `429 Concurrency limit reached for requests` response. To resolve this error, reduce the number of concurrent requests.
+
+W&B applies rate limits per W&B project. For example, if you have 3 projects associated with a team, each project has its own rate limit quota. Users on [Paid plans](https://wandb.ai/site/pricing) have higher rate limits than Free plans.
+
+### Personal entities unsupported
+
+:::tip
+Personal entities were deprecated in May 2024, so the following information only applies to legacy accounts.
+:::
+
+Personal accounts (personal entities) don’t support the Inference service. To access Inference, you either need to create a team, or switch to a non-personal account. 
+
+### Geographic restrictions
+
+The Inference service is only accessible from supported geographic locations. For more information, see the [Terms of Service](https://docs.coreweave.com/docs/policies/terms-of-service/terms-of-use#geographic-restrictions).
 
 ## Prerequisites
+
+:::tip
+Before using the Inference service, familiarize yourself with the [Usage information and limits](#usage-information-and-limits).
+:::
 
 The following prerequisites are required to access the W&B Inference service via the API or the W&B Weave UI.
 
@@ -61,11 +93,14 @@ The following prerequisites are required to access the W&B Inference service via
 
 ### Additional prerequisites for using the API via Python
 
-To use the Inference API via Python, first complete the general prerequisites. Then, install the `openai` and `weave` libraries in your local environment:
+To use the Inference API via Python, do the following:
 
-```bash
-pip install openai weave
-```
+1. Complete the [general prerequisites](#prerequisites). 
+2. Install the `openai` and `weave` libraries in your local environment:
+
+    ```bash
+    pip install openai weave
+    ```
 
 :::note
 The `weave` library is only required if you'll be using Weave to trace your LLM applications. For information on getting started with Weave, see the [Weave Quickstart](../../quickstart.md).
@@ -74,6 +109,10 @@ For usage examples demonstrating how to use the W&B Inference service with Weave
 :::
 
 ## API specification
+
+:::tip
+Are you trying to troubleshoot API errors? See [API errors](#api-errors) and [usage information and limits](#usage-information-and-limits).
+:::
 
 The following section provides API specification information and API usage examples.
 
@@ -187,7 +226,7 @@ Use the API to query all currently available models and their IDs. This is usefu
     curl https://api.inference.wandb.ai/v1/models \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer <your-api-key>" \
-      -H "OpenAI-Project: <your-team>/<your-project>" \
+      -H "OpenAI-Project: <your-team>/<your-project>" 
     ```
   </TabItem>
   <TabItem value="python" label="Python">
@@ -227,7 +266,7 @@ Learn more about [tracing in Weave](../tracking/tracing.mdx).
 In this example:
 
 - You define a `@weave.op()`-decorated function, `run_chat`, which makes a chat completion request using the OpenAI-compatible client.
-- Your traces are recorded and associated with your W&B entity and project `project="<your-team>/<your-project>`
+- Your traces are recorded and associated with your W&B entity and project `project="<your-team>/<your-project>"`
 - The function is automatically traced by Weave, so its inputs, outputs, latency, and metadata (like model ID) are logged.
 - The result is printed in the terminal, and the trace appears in your **Traces** tab at [https://wandb.ai](https://wandb.ai) under the specified project.
 
@@ -418,7 +457,7 @@ You can compare multiple Inference models in the Playground. The Compare view ca
 1. From the left sidebar, select **Inference**. A page with available models and model information displays.
 2. To select models for comparison, click anywhere on a model card (except for the model name). The border of the model card is highlighted in blue to indicate the selection.
 3. Repeat step 2 for each model you want to compare.
-4. In any of the selected cards, click the **Compare N models in the Playground** button (`N` is the number of models you are comparing. For example, when 3 models are selected, the button displays as **Compare 3 models in the Playground**). The comparison view opens.
+4. In any of the selected cards, click the **Compare N models in the Playground** button. `N` is the number of models you are comparing. For example, when 3 models are selected, the button displays as **Compare 3 models in the Playground**. The comparison view opens.
 
 Now, you can compare models in the Playground, and use any of the features described in [Try a model in the Playground](#try-a-model-in-the-playground).
 
@@ -440,7 +479,7 @@ Now, you can compare models in the Playground, and use any of the features descr
 Organization admins can track current Inference credit balance, usage history, and upcoming billing (if applicable) directly from the W&B UI:
 
 1. In the W&B UI, navigate to the W&B **Billing** page.
-2. In the bottom righthand corner, the Inference billing information card is displayed. From here, you can:
+2. In the bottom right-hand corner, the Inference billing information card is displayed. From here, you can:
 
 - Click the **View usage** button in the Inference billing information card to view your usage over time.
 - If you're on a paid plan, view your upcoming inference charges.
@@ -448,32 +487,6 @@ Organization admins can track current Inference credit balance, usage history, a
 :::tip
 Visit the [Inference pricing page for a breakdown of per-model pricing](https://wandb.ai/site/pricing/inference)
 :::
-
-## Usage information and limits
-
-The following section describes important usage information and limits. Familiarize yourself with this information before using the service.
-
-### Pricing
-
-For model pricing information, visit [https://wandb.ai/site/pricing/inference](https://wandb.ai/site/pricing/inference).
-
-### Purchase more credits
-
-W&B Inference credits are included with Free, Pro, and Academic plans for a limited time. Availability may vary for Enterprise. Once credits are consumed:
-
-- Free accounts must upgrade to a Pro plan to continue using Inference. **[Upgrade your plan here](https://wandb.ai/subscriptions)**.
-- Pro plan users will be billed for Inference overages on a monthly basis, based on the model-specific pricing.
-- Enterprise accounts will need to contact their account executive.
-
-### Concurrency limits
-
-If a rate limit is exceeded, the API will return a `429 Concurrency limit reached for requests` response. To resolve this error, reduce the number of concurrent requests.
-
-W&B applies rate limits per W&B project. For example, if you have 3 projects associated with a team, each project has its own rate limit quota. Users on [Paid plans](https://wandb.ai/site/pricing) have higher rate limits than Free plans.
-
-### Geographic restrictions
-
-The Inference service is only accessible from supported geographic locations. For more information, see the [Terms of Service](https://docs.coreweave.com/docs/policies/terms-of-service/terms-of-use#geographic-restrictions).
 
 ## API errors
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1671

Addresses feedback here https://weightsandbiases.slack.com/archives/C08RU04P36G/p1753316192306759?thread_ts=1753311721.674809&cid=C08RU04P36G

- direct unpaid users to https://wandb.ai/subscriptions to upgrade and access pay-as-you-go inference if they run out of free credits
- Note that this doesn’t apply to enterprise users—they'll need to contact their account executive. 
- Clarify the 429 error code and what users should do
- Cosmetics, nits and a few typos
- Reorg page a bit so it's easier to parse and nav. Group content under new subsections for linkability

## Testing

yarn start on local
