### PR TITLE
feat(weave): performant call descendants query in db and client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,11 @@ class ThrowingServer(tsi.TraceServerInterface):
     def call_update(self, req: tsi.CallUpdateReq) -> tsi.CallUpdateRes:
         raise DummyTestException("FAILURE - call_update, req:", req)
 
+    def calls_descendants(
+        self, req: tsi.CallsDescendantsReq
+    ) -> Iterator[tsi.CallSchema]:
+        raise DummyTestException("FAILURE - calls_descendants, req:", req)
+
     # Op API
     def op_create(self, req: tsi.OpCreateReq) -> tsi.OpCreateRes:
         raise DummyTestException("FAILURE - op_create, req:", req)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -22,6 +22,7 @@ from weave.trace_server.errors import (
     InvalidRequest,
     NotFoundError,
     ObjectDeletedError,
+    RequestTooLarge,
 )
 from weave.trace_server.feedback import (
     TABLE_FEEDBACK,
@@ -682,6 +683,105 @@ class SqliteTraceServer(tsi.TraceServerInterface):
                 if call.total_storage_size_bytes is not None
             ),
         )
+
+    def call_descendants(self, req: tsi.CallDescendantsReq) -> tsi.CallDescendantsRes:
+        """Get descendant calls for given call IDs."""
+        if req.depth is not None and req.depth < 0:
+            raise ValueError("Depth must be a positive integer")
+
+        limit = req.limit or 100_000
+        if limit > 100_000:
+            raise RequestTooLarge(
+                f"Cannot get more than 100000 children at once (requested: {req.limit})."
+            )
+        elif limit < 0:
+            raise ValueError("Limit must be a positive integer")
+
+        conn, cursor = get_conn_cursor(self.db_path)
+        # Get all child calls recursively
+        cursor.execute(
+            """
+            WITH RECURSIVE call_tree AS (
+                -- Base case: get immediate children
+                SELECT
+                    c.id,
+                    c.project_id,
+                    c.trace_id,
+                    c.parent_id,
+                    c.op_name,
+                    c.started_at,
+                    c.ended_at,
+                    c.inputs,
+                    c.output,
+                    c.attributes,
+                    c.summary,
+                    c.exception,
+                    c.wb_user_id,
+                    c.wb_run_id,
+                    c.deleted_at,
+                    c.display_name,
+                    1 as depth
+                FROM calls c
+                WHERE c.parent_id IN ({})
+                    AND c.deleted_at IS NULL
+                    AND c.project_id = ?
+
+                UNION ALL
+
+                -- Recursive case: get children of children
+                SELECT
+                    c.id,
+                    c.project_id,
+                    c.trace_id,
+                    c.parent_id,
+                    c.op_name,
+                    c.started_at,
+                    c.ended_at,
+                    c.inputs,
+                    c.output,
+                    c.attributes,
+                    c.summary,
+                    c.exception,
+                    c.wb_user_id,
+                    c.wb_run_id,
+                    c.deleted_at,
+                    c.display_name,
+                    ct.depth + 1 as depth
+                FROM calls c
+                JOIN call_tree ct ON c.parent_id = ct.id
+                WHERE c.project_id = ?
+                    AND c.deleted_at IS NULL
+                    AND (? IS NULL OR ct.depth < ?)
+            )
+            SELECT * FROM call_tree
+            ORDER BY started_at ASC
+            LIMIT ?
+            """.format(",".join("?" * len(req.call_ids))),
+            req.call_ids
+            + [req.project_id, req.project_id, req.depth, req.depth, limit],
+        )
+
+        rows = cursor.fetchall()
+
+        for row in rows:
+            yield tsi.CallSchema(
+                id=row[0],
+                project_id=row[1],
+                trace_id=row[2],
+                parent_id=row[3],
+                op_name=row[4],
+                started_at=row[5],
+                ended_at=row[6],
+                inputs=json.loads(row[7]) if row[7] else {},
+                output=json.loads(row[8]) if row[8] else {},
+                attributes=json.loads(row[9]) if row[9] else None,
+                summary=json.loads(row[10]) if row[10] else None,
+                exception=row[11],
+                wb_user_id=row[12],
+                wb_run_id=row[13],
+                deleted_at=row[14],
+                display_name=row[15],
+            )
 
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
         assert_non_null_wb_user_id(req)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -474,6 +474,56 @@ class CallsQueryStatsRes(BaseModel):
     total_storage_size_bytes: Optional[int] = None
 
 
+class CallDescendantsReq(BaseModel):
+    """
+    Request to get descendants of calls.
+
+    Can specify either:
+    - parent_call_ids: List of parent call IDs to get descendants for (batch mode)
+    - parent_call_id: Single parent call ID (for single call mode)
+    """
+
+    project_id: str
+    parent_call_ids: Optional[list[str]] = Field(
+        default=None,
+        description="List of parent call IDs to get descendants for",
+        examples=[["call_123", "call_456"]],
+    )
+    parent_call_id: Optional[str] = Field(
+        default=None,
+        description="Single parent call ID to get descendants for",
+        examples=["call_123"],
+    )
+    limit: Optional[int] = Field(
+        default=None,
+        description="Maximum number of descendants to return across all parent calls",
+    )
+    depth: Optional[int] = Field(
+        default=None,
+        description="Maximum depth of descendants to return (1 = direct children only)",
+    )
+    include_costs: Optional[bool] = Field(
+        default=False,
+        description="If true, the response will include any model costs for each call.",
+    )
+    include_feedback: Optional[bool] = Field(
+        default=False,
+        description="If true, the response will include feedback for each call.",
+    )
+    columns: Optional[list[str]] = Field(
+        default=None,
+        description="Columns to include in the response",
+    )
+    expand_columns: Optional[list[str]] = Field(
+        default=None,
+        description="Columns to expand, i.e. refs to other objects",
+    )
+
+
+class CallDescendantsRes(BaseModel):
+    calls: list[CallSchema]
+
+
 class CallUpdateReq(BaseModel):
     # required for all updates
     project_id: str
@@ -1210,6 +1260,7 @@ class TraceServerInterface(Protocol):
     def calls_query_stream(self, req: CallsQueryReq) -> Iterator[CallSchema]: ...
     def calls_delete(self, req: CallsDeleteReq) -> CallsDeleteRes: ...
     def calls_query_stats(self, req: CallsQueryStatsReq) -> CallsQueryStatsRes: ...
+    def call_descendants(self, req: CallDescendantsReq) -> CallDescendantsRes: ...
     def call_update(self, req: CallUpdateReq) -> CallUpdateRes: ...
     def call_start_batch(self, req: CallCreateBatchReq) -> CallCreateBatchRes: ...
 

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -325,6 +325,13 @@ class RemoteHTTPTraceServer(tsi.TraceServerInterface):
             "/calls/query_stats", req, tsi.CallsQueryStatsReq, tsi.CallsQueryStatsRes
         )
 
+    def call_descendants(
+        self, req: Union[tsi.CallDescendantsReq, dict[str, Any]]
+    ) -> tsi.CallDescendantsRes:
+        return self._generic_request(
+            "/call/descendants", req, tsi.CallDescendantsReq, tsi.CallDescendantsRes
+        )
+
     def calls_delete(
         self, req: Union[tsi.CallsDeleteReq, dict[str, Any]]
     ) -> tsi.CallsDeleteRes:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr:

creates a new clickhouse database function that queries for descendents using a recursive CTE query
exposes endpoint on the client so that users can ask for descendents
Usage:

```
client = weave.init("project")

calls = client.get_calls()
first_root_call = calls[0]
first_root_call_descendents = client.get_call_descendants(first_root_call)
for descendant in first_root_call_descendents:
   print(descendant.display_name)

# Or, in batch
all_root_descendants = client.get_call_descendants(call_ids=[c.id for c in calls])

# Or with the class method
first_root_depth_2 = first_root_call.descendants(depth=2) # only children + grandchildren
```

## Testing

adds tests
