### PR TITLE
chore(dev) remove weave js package publish

### DIFF
--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -14,36 +14,11 @@ permissions:
   packages: write
 
 jobs:
-  publish-package:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure npm for GitHub Packages
-        run: |
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> weave-js/.npmrc
-
-      - name: Publish package
-        run: |
-          cd weave-js
-          yarn install --frozen-lockfile
-          npm version 0.0.0-${{ github.sha }} --no-git-tag-version
-          yarn generate
-          cp package.json README.md .npmrc src/
-          cd src
-          # E409 means the package already exists, in which case we don't want to fail this job
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            npm publish 2>&1 | tee publish_output.log || grep -q "E409" publish_output.log
-          else
-            npm publish --tag prerelease 2>&1 | tee publish_output.log || grep -q "E409" publish_output.log
-          fi
-
   check-which-tests-to-run:
     uses: ./.github/workflows/check-which-tests-to-run.yaml
 
   notify-wandb-core:
-    needs: [check-which-tests-to-run, publish-package]
+    needs: [check-which-tests-to-run]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

- Removes the `publish-package` job from the `notify-wandb-core.yaml` workflow
- Weave-js moved to core, so there's no point in publishing it from here