### PR TITLE
feat(weave): allow omitting coreweave/ prefix on hosted model strings

### DIFF
--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -1,4 +1,40 @@
 {
+  "Qwen/Qwen3-235B-A22B-Instruct-2507": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "Qwen/Qwen3-Coder-480B-A35B-Instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "moonshotai/Kimi-K2-Instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "meta-llama/Llama-3.1-8B-Instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "deepseek-ai/DeepSeek-R1-0528": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "deepseek-ai/DeepSeek-V3-0324": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "meta-llama/Llama-3.3-70B-Instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "microsoft/Phi-4-mini-instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
   "omni-moderation-latest": {
     "litellm_provider": "openai",
     "api_key_name": "OPENAI_API_KEY"
@@ -1652,6 +1688,30 @@
     "api_key_name": "GEMINI_API_KEY"
   },
   "gemini/gemini-gemma-2-9b-it": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/imagen-4.0-generate-preview-06-06": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/imagen-4.0-ultra-generate-preview-06-06": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/imagen-4.0-fast-generate-preview-06-06": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/imagen-3.0-generate-002": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/imagen-3.0-generate-001": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/imagen-3.0-fast-generate-001": {
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -7,6 +7,10 @@
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
+  "Qwen/Qwen3-235B-A22B-Thinking-2507": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
   "moonshotai/Kimi-K2-Instruct": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"

--- a/weave/trace_server/model_providers/model_providers.py
+++ b/weave/trace_server/model_providers/model_providers.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from pathlib import Path
 from typing import TypedDict
 
 import requests
@@ -9,14 +8,8 @@ import requests
 model_providers_url = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
 MODEL_PROVIDER_INFO_FILE = "model_providers.json"
 
-HOSTED_MODEL_INFO_DIR = (
-    Path(__file__)
-    .parent.joinpath(
-        "../../../../../../frontends/weave/src/components/PagePanelComponents/Home/Browse3/inference"
-    )
-    .resolve()
-)
-HOSTED_MODEL_INFO_FILE = HOSTED_MODEL_INFO_DIR / "modelsFinal.json"
+# This is a symlink to the catalog file in the frontend to avoid further ground truth dilution.
+HOSTED_MODEL_INFO_FILE = "modelsFinal.json"
 
 
 PROVIDER_TO_API_KEY_NAME_MAP = {
@@ -61,12 +54,11 @@ def read_model_to_provider_info_map(
 def main(
     file_name: str = MODEL_PROVIDER_INFO_FILE,
 ) -> dict[str, LLMModelProviderInfo]:
-    full_path = os.path.join(os.path.dirname(__file__), file_name)
-
     providers: dict[str, LLMModelProviderInfo] = {}
 
     # Start with information about CoreWeave hosted models
-    with open(HOSTED_MODEL_INFO_FILE) as f:
+    full_path_hosted = os.path.join(os.path.dirname(__file__), HOSTED_MODEL_INFO_FILE)
+    with open(full_path_hosted) as f:
         hosted_models = json.load(f)
     for model in hosted_models["models"]:
         provider = model["provider"]
@@ -99,11 +91,12 @@ def main(
             providers[k] = LLMModelProviderInfo(
                 litellm_provider=provider, api_key_name=api_key_name
             )
-    os.makedirs(os.path.dirname(full_path), exist_ok=True)
-    with open(full_path, "w") as f:
+    full_path_output = os.path.join(os.path.dirname(__file__), file_name)
+    os.makedirs(os.path.dirname(full_path_output), exist_ok=True)
+    with open(full_path_output, "w") as f:
         json.dump(providers, f, indent=2)
     print(
-        f"Updated model to model provider info file at: {full_path}. {len(providers)} models updated."
+        f"Updated model to model provider info file at: {full_path_output}. {len(providers)} models updated."
     )
     return providers
 

--- a/weave/trace_server/model_providers/modelsFinal.json
+++ b/weave/trace_server/model_providers/modelsFinal.json
@@ -1,0 +1,1 @@
+../../../../../../frontends/weave/src/components/PagePanelComponents/Home/Browse3/inference/modelsFinal.json


### PR DESCRIPTION
## Description

Updates our script that creates the `models_providers.json` file to also pull in information about CoreWeave hosted models.
This gives us a way to know which model strings should result in delegation to the Inference Service without having to prefix the model strings with `coreweave/`

The `gemini/` changes are unrelated update from re-running `make update_model_providers`

## Testing

How was this PR tested?
