### PR TITLE
chore(weave): Add return_expanded_column_values option to get_calls

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -163,6 +163,7 @@ def _make_calls_iterator(
     include_feedback: bool = False,
     columns: list[str] | None = None,
     expand_columns: list[str] | None = None,
+    return_expanded_column_values: bool = True,
     page_size: int = DEFAULT_CALLS_PAGE_SIZE,
 ) -> CallsIter:
     def fetch_func(offset: int, limit: int) -> list[CallSchema]:
@@ -185,6 +186,7 @@ def _make_calls_iterator(
                     sort_by=sort_by,
                     columns=columns,
                     expand_columns=expand_columns,
+                    return_expanded_column_values=return_expanded_column_values,
                 )
             )
         )
@@ -814,6 +816,7 @@ class WeaveClient:
         include_feedback: bool = False,
         columns: list[str] | None = None,
         expand_columns: list[str] | None = None,
+        return_expanded_column_values: bool = True,
         scored_by: str | list[str] | None = None,
         page_size: int = DEFAULT_CALLS_PAGE_SIZE,
     ) -> CallsIter:
@@ -870,6 +873,7 @@ class WeaveClient:
             include_feedback=include_feedback,
             columns=columns,
             expand_columns=expand_columns,
+            return_expanded_column_values=return_expanded_column_values,
             page_size=page_size,
         )
 


### PR DESCRIPTION
Exposes the option to NOT auto-resolve refs in `get_calls`, which can be helpful for specific  performance-sensitive queries