### PR TITLE
feat: handle error states in imperative eval logger

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import json
 from typing import Callable, TypedDict
 
 import pytest
@@ -474,6 +475,18 @@ def test_evaluation_no_auto_summarize(client):
     # assert len(calls) == 1
     summarize_call = calls[4]
     assert summarize_call.output == {"output": {}}
+
+def test_evaluation_finish_with_exception(client):
+    ev = weave.EvaluationLogger()
+    ex = ValueError("test")
+    ev.finish(exception=ex)
+    client.flush()
+
+    calls = client.get_calls()
+    assert len(calls) == 1
+    finish_call = calls[0]
+    assert finish_call.output is None
+    assert finish_call.exception == json.dumps({"type": "ValueError", "message": "test"})
 
 
 def test_evaluation_no_auto_summarize_with_custom_dict(client):

--- a/weave/flow/eval_imperative.py
+++ b/weave/flow/eval_imperative.py
@@ -463,7 +463,7 @@ class EvaluationLogger(BaseModel):
                 # This is best effort.  If we fail, just swallow the error.
                 pass
 
-    def _finalize_evaluation(self, output: Any = None) -> None:
+    def _finalize_evaluation(self, output: Any = None, exception: BaseException | None = None) -> None:
         """Handles the final steps of the evaluation: cleaning up predictions and finishing the main call."""
         if self._is_finalized:
             return
@@ -479,7 +479,7 @@ class EvaluationLogger(BaseModel):
         wc = require_weave_client()
         # Ensure the call is finished even if there was an error during summarize or elsewhere
         try:
-            wc.finish_call(self._evaluate_call, output=output)
+            wc.finish_call(self._evaluate_call, output=output, exception=exception)
         except Exception:
             # Log error but continue cleanup
             logger.error(
@@ -571,7 +571,7 @@ class EvaluationLogger(BaseModel):
 
         self._finalize_evaluation(output=final_summary)
 
-    def finish(self) -> None:
+    def finish(self, exception: BaseException | None = None) -> None:
         """Clean up the evaluation resources explicitly without logging a summary.
 
         Ensures all prediction calls and the main evaluation call are finalized.
@@ -581,7 +581,7 @@ class EvaluationLogger(BaseModel):
             return
 
         # Finalize with None output, indicating closure without summary
-        self._finalize_evaluation(output=None)
+        self._finalize_evaluation(output=None, exception=exception)
 
         # Remove from global registry since we've manually finalized
         if self in _active_evaluation_loggers:


### PR DESCRIPTION
## Description

When using the imperative eval logger, it is possible that we might encounter an error state. In such cases, the eval logger cannot currently make the eval as failed, which gives the appearance of hanging evals in the UI. This PR adds the option to pass an exception to the finish method, which allows the eval logger to gracefully handle error states.

## Testing

Unit tested + tried it in a test project
