### PR TITLE
docs(weave): Fix broken anchors in documentation

### DIFF
--- a/docs/docs/guides/evaluation/guardrails_and_monitors.md
+++ b/docs/docs/guides/evaluation/guardrails_and_monitors.md
@@ -496,7 +496,7 @@ score = scorer.score(output="some text")
 ### Score Analysis
 
 
-For detailed information about querying calls and their scorer results, see our [Score Analysis Guide](./scorers.md#score-analysis) and our [Data Access Guide](/guides/tracking/tracing#querying--exporting-calls).
+For detailed information about querying calls and their scorer results, see our [Score Analysis Guide](./scorers.md#score-analysis) and our [Data Access Guide](/guides/tracking/tracing#querying-and-exporting-calls).
 
 
 ## Production Best Practices

--- a/docs/docs/guides/evaluation/scorers.md
+++ b/docs/docs/guides/evaluation/scorers.md
@@ -315,7 +315,7 @@ While this guide shows you how to create custom scorers, Weave comes with a vari
 
 To apply scorers to your Weave ops, you'll need to use the `.call()` method which provides access to both the operation's result and its tracking information. This allows you to associate scorer results with specific calls in Weave's database.
 
-For more information on how to use the `.call()` method, see the [Calling Ops](../tracking/tracing#calling-ops#getting-a-handle-to-the-call-object-during-execution) guide.
+For more information on how to use the `.call()` method, see the [Calling Ops](../tracking/tracing.mdx#getting-a-handle-to-the-call-object-during-execution) guide.
 
 <Tabs groupId="programming-language" queryString>
   <TabItem value="python" label="Python" default>
@@ -364,7 +364,7 @@ The `preprocess_model_input` function only transforms inputs before they are pas
 Scorer functions always receive the original dataset examples, without any preprocessing applied.
 :::
 
-For usage information and an example, see [Using `preprocess_model_input` to format dataset rows before evaluating](../core-types/evaluations.md#using-preprocess_model_input-to-format-dataset-rows-before-evaluating).
+For usage information and an example, see [Using `preprocess_model_input` to format dataset rows before evaluating](../core-types/evaluations.md#format-dataset-rows-before-evaluating).
 
 ## Score Analysis
 

--- a/docs/docs/guides/integrations/js.md
+++ b/docs/docs/guides/integrations/js.md
@@ -9,7 +9,7 @@ As of [PR #4554](https://github.com/wandb/weave/pull/4554), supported libraries 
 weave.wrapOpenAI(new OpenAI());
 ```
 
-Weave will generally handle this automatically. However, there may be [edge cases](#advanced-usage).
+Weave will generally handle this automatically. However, there may be [edge cases](#advanced-usage-and-troubleshooting).
 :::
 
 ## Usage instructions

--- a/docs/docs/guides/platform/weave-self-managed.md
+++ b/docs/docs/guides/platform/weave-self-managed.md
@@ -63,7 +63,7 @@ Modify the following parameters:
 - `auth.password`
 - S3 bucket-related configurations
 
-W&B recommends keeping the `clusterName` value in `values.yaml` set to `weave_cluster`.  This is the expected cluster name when W&B Weave runs the database migration. If you need to use a different name, see the [Setting `clusterName`](#setting-clustername) section for more information.
+W&B recommends keeping the `clusterName` value in `values.yaml` set to `weave_cluster`.  This is the expected cluster name when W&B Weave runs the database migration. If you need to use a different name, see step 3 in the [Deploy Weave](#4-deploy-weave) section for more information.
 
 ```yaml
 ## @param clusterName ClickHouse cluster name

--- a/docs/docs/guides/tools/playground.md
+++ b/docs/docs/guides/tools/playground.md
@@ -24,7 +24,7 @@ Get started with the Playground to optimize your LLM interactions and streamline
   - [Access the Playground](#access-the-playground)
 - [Select an LLM](#select-an-llm)
 - [Customize settings](#customize-settings)
-- [Message controls](#add-retry-edit-and-delete-messages)
+- [Message controls](#retry-edit-and-delete-messages)
 - [Compare LLMs](#compare-llms)
 - [Custom providers](#custom-providers)
 - [Saved models](#saved-models) 

--- a/docs/docs/guides/tracking/threads.md
+++ b/docs/docs/guides/tracking/threads.md
@@ -10,8 +10,8 @@ To get started with Threads, do the following:
    - [The UI experience](#ui-overview)
    - [API specification](#api-specification)
 2. Try the code samples, which demonstrate common usage patterns and real-world use cases.
-   - [Basic usage examples](#basic-examples)
-   - [Advanced usage examples](#advanced-examples)
+   - [Basic usage examples](#basic-thread-creation)
+- [Advanced usage examples](#manual-agent-loop-implementation)
 
 ## Use cases
 

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -15,7 +15,7 @@ Weights & Biases (W&B) Weave is a framework for tracking, experimenting with, ev
 - **Tracing & Monitoring**: [Track LLM calls and application logic](./guides/tracking/) to debug and analyze production systems.
 - **Systematic Iteration**: Refine and iterate on [prompts](./guides/core-types/prompts.md), [datasets](./guides/core-types/datasets.md), and [models](./guides/core-types/models.md).
 - **Experimentation**: Experiment with different models and prompts in the [LLM Playground](./guides/tools/playground.md). 
-- **Evaluation**: Use custom or [pre-built scorers](./guides/evaluation/scorers#predefined-scorers) alongside our [comparison tools](./guides/tools/comparison.md) to systematically assess and enhance application performance.
+- **Evaluation**: Use custom or [pre-built scorers](./guides/evaluation/builtin_scorers.mdx) alongside our [comparison tools](./guides/tools/comparison.md) to systematically assess and enhance application performance.
 - **Guardrails**: Protect your application with [pre- and post-safeguards](./guides/evaluation/guardrails_and_monitors.md) for content moderation, prompt safety, and more.
 
 Integrate Weave with your existing development stack via the:

--- a/docs/docs/reference/gen_notebooks/pii.md
+++ b/docs/docs/reference/gen_notebooks/pii.md
@@ -150,7 +150,7 @@ print('PII data first sample: "' + pii_data[0]["text"] + '"')
 
 ## Redaction methods overview
 
-Once you've completed the [setup](#setup), you can 
+Once you've completed the [prerequisites](#prerequisites), you can 
 
 To detect and protect our PII data, we'll identify and redact PII data and optionally anonymize it using the following methods:
 
@@ -629,7 +629,7 @@ for entry in pii_data:
 
 ### `autopatch_settings` method
 
-In the following example, we set `postprocess_inputs` for `anthropic` to the `postprocess_inputs_regex()` function () at initialization. The `postprocess_inputs_regex` function applies the`redact_with_regex` method defined in [Method 1: Regular Expression Filtering](#method-1-regular-expression-filtering). Now, `redact_with_regex` will be applied to all inputs to any `anthropic` models.
+In the following example, we set `postprocess_inputs` for `anthropic` to the `postprocess_inputs_regex()` function () at initialization. The `postprocess_inputs_regex` function applies the`redact_with_regex` method defined in [Method 1: Filter using regular expressions](#method-1-filter-using-regular-expressions). Now, `redact_with_regex` will be applied to all inputs to any `anthropic` models.
 
 
 ```python


### PR DESCRIPTION
## Summary

This PR fixes all broken anchor links in the Weave documentation that were causing build warnings.

## Changes

Fixed broken anchors in the following files:
- `docs/guides/evaluation/guardrails_and_monitors.md` - Updated data access guide link
- `docs/guides/evaluation/scorers.md` - Fixed tracing guide and evaluations guide links
- `docs/guides/integrations/js.md` - Corrected advanced usage section link
- `docs/guides/platform/weave-self-managed.md` - Updated cluster name configuration reference
- `docs/guides/tools/playground.md` - Fixed message controls section link
- `docs/guides/tracking/threads.md` - Updated basic and advanced examples links
- `docs/reference/gen_notebooks/pii.md` - Fixed prerequisites and method 1 links
- `docs/introduction.md` - Corrected pre-built scorers link

## Testing

- ✅ Ran `npm run build` in the docs directory
- ✅ Verified no broken anchor warnings in the build output
- ✅ All internal documentation links now resolve correctly

## Impact

This ensures a better documentation experience for users by fixing all broken internal links.