### PR TITLE
feat(weave): add OTEL parsing for thread_id and handling for is_turn

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -201,8 +201,6 @@ def test_otel_export_clickhouse(client: weave_client.WeaveClient):
 
 def test_otel_export_with_turn_and_thread(client: weave_client.WeaveClient):
     """Test the otel_export method with turn and thread attributes."""
-    import re
-
     # Create a test export request
     export_req = create_test_export_request()
     project_id = client._project_id()
@@ -236,11 +234,9 @@ def test_otel_export_with_turn_and_thread(client: weave_client.WeaveClient):
 
     call = res.calls[0]
 
-    # Verify turn_id is set and is a valid UUID
+    # Verify turn_id equals call.id when is_turn is True
     assert hasattr(call, "turn_id")
-    assert call.turn_id is not None
-    uuid_pattern = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-    assert re.match(uuid_pattern, call.turn_id)
+    assert call.turn_id == call.id
 
     # Verify thread_id is set correctly
     assert hasattr(call, "thread_id")
@@ -390,9 +386,7 @@ class TestPythonSpans:
         assert end_call.exception is None
 
     def test_span_to_call_with_turn_and_thread(self):
-        """Test that turn_id and thread_id are correctly handled in span to_call conversion."""
-        import re
-
+        """Test that turn_id equals thread_id when is_turn is True."""
         # Create a test span with turn and thread attributes
         pb_span = create_test_span()
         test_thread_id = str(uuid.uuid4())
@@ -411,12 +405,8 @@ class TestPythonSpans:
         py_span = PySpan.from_proto(pb_span)
         start_call, end_call = py_span.to_call("test_project")
 
-        # Verify turn_id is generated as a UUID when is_turn is True
-        assert start_call.turn_id is not None
-        # Check that turn_id is a valid UUID
-        uuid_pattern = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-        assert re.match(uuid_pattern, start_call.turn_id)
-
+        # Verify turn_id equals call.id (span_id) when is_turn is True
+        assert start_call.turn_id == py_span.span_id
         # Verify thread_id is passed through
         assert start_call.thread_id == test_thread_id
 

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -132,7 +132,10 @@ WB_KEYS = {
     # Custom display name for the call in the UI
     "display_name": ["wandb.display_name"],
     "thread_id": ["gcp.vertex.agent.session_id", "wandb.thread_id"],
-    "is_turn": ["gcp.vertex.agent.session_id", "wandb.is_turn"], # We just check if this is truthy so we can reuse session_id
+    "is_turn": [
+        "gcp.vertex.agent.session_id",
+        "wandb.is_turn",
+    ],  # We just check if this is truthy so we can reuse session_id
 }
 
 # These represent fields that are set by a provider which override top level span information

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -131,6 +131,8 @@ ATTRIBUTE_KEYS = {
 WB_KEYS = {
     # Custom display name for the call in the UI
     "display_name": ["wandb.display_name"],
+    "thread_id": ["wandb.thread_id"],
+    "is_turn": ["wandb.is_turn"],
 }
 
 # These represent fields that are set by a provider which override top level span information

--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -131,8 +131,8 @@ ATTRIBUTE_KEYS = {
 WB_KEYS = {
     # Custom display name for the call in the UI
     "display_name": ["wandb.display_name"],
-    "thread_id": ["wandb.thread_id"],
-    "is_turn": ["wandb.is_turn"],
+    "thread_id": ["gcp.vertex.agent.session_id", "wandb.thread_id"],
+    "is_turn": ["gcp.vertex.agent.session_id", "wandb.is_turn"], # We just check if this is truthy so we can reuse session_id
 }
 
 # These represent fields that are set by a provider which override top level span information

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -352,9 +352,7 @@ class Span:
 
         thread_id = wandb_attributes.get("thread_id") or None
         if thread_id is not None and (wandb_attributes.get("is_turn")):
-            from uuid import uuid4
-
-            turn_id = str(uuid4())
+            turn_id = self.span_id
         else:
             turn_id = None
 

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -353,6 +353,7 @@ class Span:
         thread_id = wandb_attributes.get("thread_id") or None
         if thread_id is not None and (wandb_attributes.get("is_turn")):
             from uuid import uuid4
+
             turn_id = str(uuid4())
         else:
             turn_id = None

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -11,7 +11,6 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
-from uuid import uuid4
 
 from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope
 from opentelemetry.proto.resource.v1.resource_pb2 import Resource as PbResource
@@ -353,6 +352,7 @@ class Span:
 
         thread_id = wandb_attributes.get("thread_id") or None
         if thread_id is not None and (wandb_attributes.get("is_turn")):
+            from uuid import uuid4
             turn_id = str(uuid4())
         else:
             turn_id = None

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -11,6 +11,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Optional
+from uuid import uuid4
 
 from opentelemetry.proto.common.v1.common_pb2 import InstrumentationScope
 from opentelemetry.proto.resource.v1.resource_pb2 import Resource as PbResource
@@ -350,6 +351,15 @@ class Span:
         if display_name and len(display_name) >= MAX_DISPLAY_NAME_LENGTH:
             display_name = shorten_name(display_name, MAX_DISPLAY_NAME_LENGTH)
 
+        thread_id = wandb_attributes.get("thread_id") or None
+        if thread_id is not None and (wandb_attributes.get("is_turn")):
+            turn_id = str(uuid4())
+        else:
+            turn_id = None
+
+        if display_name and len(display_name) >= MAX_DISPLAY_NAME_LENGTH:
+            display_name = shorten_name(display_name, MAX_DISPLAY_NAME_LENGTH)
+
         if len(op_name) >= MAX_OP_NAME_LENGTH:
             # Since op_name will typically be what is displayed, we don't want to just truncate
             # Create an identifier abbreviation so similar long names can be distinguished
@@ -373,7 +383,10 @@ class Span:
             display_name=display_name,
             wb_user_id=None,
             wb_run_id=None,
+            turn_id=turn_id,
+            thread_id=thread_id,
         )
+
         exception_msg = (
             self.status.message if self.status.code == StatusCode.ERROR else None
         )


### PR DESCRIPTION
## Description

- Fixes WB-26584

Add parsing and handling for these two attributes:
wandb.thread_id
wandb.is_turn

When wandb.is_turn is set to true, sets turn_id to the span.id (which is used for call.id)
When wandb.is_turn is set but thread_id is unset, ignore, is_turn is ignored

## Testing

Added detailed test cases for the different scenarios