### PR TITLE
fix(weave): sort by output when string

### DIFF
--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -386,7 +386,7 @@ class OrderField(BaseModel):
         field_path = self.field.field
         if field_path.endswith("_dump"):
             field_path = field_path[:-5]
-        if hasattr(self.field, "extra_path"):
+        if hasattr(self.field, "extra_path") and self.field.extra_path:
             field_path += "." + ".".join(self.field.extra_path)
         return field_path
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Fixes: [WB-26607](https://wandb.atlassian.net/browse/WB-26607)

Error: `Error streaming response: can only join an iterable`

## Testing

Master
![sort-by-output-branch](https://github.com/user-attachments/assets/b32d37ee-25f6-4c50-8406-0f7f033eb598)

Branch
![sort-by-output-branch-actually-branch](https://github.com/user-attachments/assets/fb45e472-1273-433d-9580-b80e37056013)


[WB-26607]: https://wandb.atlassian.net/browse/WB-26607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ