### PR TITLE
chore(weave): sort call inserts for grouping

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -168,7 +168,7 @@ CallCHInsertable = Union[
 ]
 
 
-all_call_insert_columns = list(
+all_call_insert_columns = sorted(
     CallStartCHInsertable.model_fields.keys()
     | CallEndCHInsertable.model_fields.keys()
     | CallDeleteCHInsertable.model_fields.keys()
@@ -191,7 +191,7 @@ all_obj_select_columns = list(SelectableCHObjSchema.model_fields.keys())
 all_obj_insert_columns = list(ObjCHInsertable.model_fields.keys())
 
 # Let's just make everything required for now ... can optimize when we implement column selection
-required_obj_select_columns = list(set(all_obj_select_columns) - set())
+required_obj_select_columns = list(set(all_obj_select_columns))
 
 ObjRefListType = list[ri.InternalObjectRef]
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Call inserts have a random order, making grouping in ch cloud annoying. Lets sort these so they all appear under the same query.  also fix an empty set operation

Example:
<img width="723" height="898" alt="Screenshot 2025-08-05 at 9 12 41 AM" src="https://github.com/user-attachments/assets/56882f06-6e7f-4e82-904e-622353e98aa6" />

