### PR TITLE
feat(ui): import otel spans into datasets

### DIFF
--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/NewDatasetSchemaStep.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/NewDatasetSchemaStep.tsx
@@ -257,7 +257,8 @@ export const NewDatasetSchemaStep: React.FC<NewDatasetSchemaStepProps> = ({
                       whiteSpace: 'nowrap',
                       maxWidth: '100%',
                     }}>
-                    {config.sourceField}
+                    {sourceSchema.find(f => f.name === config.sourceField)
+                      ?.displayName || config.sourceField}
                   </Typography>
                 </DataPreviewTooltip>
               </Box>

--- a/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/SchemaMappingStep.tsx
+++ b/weave-js/src/components/PagePanelComponents/Home/Browse3/datasets/SchemaMappingStep.tsx
@@ -388,7 +388,10 @@ export const SchemaMappingStep: React.FC<SchemaMappingStepProps> = ({
                       value={
                         currentMapping
                           ? {
-                              label: currentMapping.sourceField,
+                              label:
+                                sourceSchema.find(
+                                  f => f.name === currentMapping.sourceField
+                                )?.displayName || currentMapping.sourceField,
                               value: currentMapping.sourceField,
                             }
                           : null
@@ -396,7 +399,7 @@ export const SchemaMappingStep: React.FC<SchemaMappingStepProps> = ({
                       options={[
                         {label: '-- None --', value: ''},
                         ...sourceSchema.map(field => ({
-                          label: field.name,
+                          label: field.displayName || field.name,
                           value: field.name,
                         })),
                       ]}


### PR DESCRIPTION
## Description

Allow for the inclusion of otel spans into datasets when importing calls into a dataset in the UI.