### PR TITLE
chore(weave): Start testing py313 for anthropic and crewai

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -9,11 +9,9 @@ nox.options.stop_on_first_error = True
 
 SUPPORTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 PY313_INCOMPATIBLE_SHARDS = [
-    "anthropic",
     "cohere",
     "dspy",
     "notdiamond",
-    "crewai",
 ]
 PY39_INCOMPATIBLE_SHARDS = [
     "crewai",


### PR DESCRIPTION
Starts testing for py313 now that this version is officially supported by these packages