### PR TITLE
docs(weave): Fix sidebar - remove inference page reference

### DIFF
--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -170,7 +170,6 @@ const sidebars: SidebarsConfig = {
           collapsed: true,
           label: "LLM Providers",
           items: [
-            "guides/integrations/inference",
             "guides/integrations/bedrock",
             "guides/integrations/anthropic",
             "guides/integrations/cerebras",


### PR DESCRIPTION
## Summary

This PR fixes the sidebar configuration after the inference page was moved to the W&B docs site in PR #5222.

## Problem

After merging PR #5222, the sidebar still contained a reference to the deleted `guides/integrations/inference` page, causing a build error:
```
[ERROR] Error: Invalid sidebar file at "sidebars.ts".
These sidebar document ids do not exist:
- guides/integrations/inference
```

## Changes

- Removed the reference to `guides/integrations/inference` from the LLM Providers section in `sidebars.ts`

This ensures the documentation builds successfully without referencing the non-existent page.