### PR TITLE
docs(weave): Fix broken links to inference documentation

### DIFF
--- a/docs/docs/guides/evaluation/guardrails_and_monitors.md
+++ b/docs/docs/guides/evaluation/guardrails_and_monitors.md
@@ -188,7 +188,7 @@ Learn how to [create a monitor in general](#create-a-monitor) or try out the [en
         - **Judge model**: Select the model that will score your ops. Three types of models are available:
             - [Saved models](../tools/playground.md#saved-models)
             - Models from providers configured by your W&B admin
-            - [W&B Inference models](../integrations/inference.md)
+            - [W&B Inference models](https://docs.wandb.ai/guides/inference/)
         
         For the selected model, configure the following settings:
             - **Configuration name**

--- a/docs/docs/guides/integrations/index.md
+++ b/docs/docs/guides/integrations/index.md
@@ -10,7 +10,7 @@ Weave provides automatic logging integrations for popular LLM providers and orch
 
 LLM providers are the vendors that offer access to large language models for generating predictions. Weave integrates with these providers to log and trace the interactions with their APIs:
 
-- **[W&B Inference Service](/guides/integrations/inference)**
+- **[W&B Inference Service](https://docs.wandb.ai/guides/inference/)**
 - **[Amazon Bedrock](/guides/integrations/bedrock)**
 - **[Anthropic](/guides/integrations/anthropic)**
 - **[Cerebras](/guides/integrations/cerebras)**

--- a/docs/docs/guides/tools/playground.md
+++ b/docs/docs/guides/tools/playground.md
@@ -2,7 +2,7 @@
 
 :::tip
 For a limited time, the new W&B Inference service is included in your free tier. W&B Inference provides access to leading open-source foundation models via API and the Weave Playground. 
-- [Developer documentation](../integrations/inference.md)
+- [Developer documentation](https://docs.wandb.ai/guides/inference/)
 - [Product page](https://wandb.ai/site/inference) 
 :::
 

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -6,7 +6,7 @@ slug: /
 
 :::tip
 For a limited time, the new W&B Inference service is included in your free tier. W&B Inference provides access to leading open-source foundation models via API and the Weave [Playground](./guides/tools/playground.md). 
-- [Developer documentation](./guides/integrations/inference.md)
+- [Developer documentation](https://docs.wandb.ai/guides/inference/)
 - [Product page](https://wandb.ai/site/inference) 
 :::
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -5,7 +5,7 @@ import TabItem from '@theme/TabItem';
 
 :::tip
 For a limited time, the new W&B Inference service is included in your free tier. W&B Inference provides access to leading open-source foundation models via API and the Weave [Playground](./guides/tools/playground.md). 
-- [Developer documentation](./guides/integrations/inference.md)
+- [Developer documentation](https://docs.wandb.ai/guides/inference/)
 - [Product page](https://wandb.ai/site/inference) 
 :::
 


### PR DESCRIPTION
## Summary

This PR fixes broken links to the inference documentation that was moved to the W&B docs site in PR #5222.

## Problem

After moving the inference page to https://docs.wandb.ai/guides/inference/, several documentation pages still contained broken links to the old location:

```
Exhaustive list of all broken links found:
- Broken link on source page path = /guides/evaluation/guardrails_and_monitors:
   -> linking to ../integrations/inference.md (resolved as: /guides/integrations/inference.md)
- Broken link on source page path = /guides/integrations/:
   -> linking to /guides/integrations/inference
- Broken link on source page path = /guides/tools/playground:
   -> linking to ../integrations/inference.md (resolved as: /guides/integrations/inference.md)
- Broken link on source page path = /quickstart:
   -> linking to ./guides/integrations/inference.md (resolved as: /guides/integrations/inference.md)
- Broken link on source page path = /:
   -> linking to ./guides/integrations/inference.md (resolved as: /guides/integrations/inference.md)
```

## Changes

Updated all broken links to point to the new external URL `https://docs.wandb.ai/guides/inference/` in:
- `docs/guides/evaluation/guardrails_and_monitors.md`
- `docs/guides/tools/playground.md`
- `docs/introduction.md`
- `docs/quickstart.md`
- `docs/guides/integrations/index.md`

This ensures all documentation properly redirects users to the new location.