### PR TITLE
fix(weave): Add accumulator for reasoning-content to completions_create

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2743,6 +2743,7 @@ def _build_aggregated_output(
     assistant_acc: list[str],
     tool_calls: list[dict[str, Any]],
     chunk: dict[str, Any],
+    reasoning_content: list[str],
 ) -> dict[str, Any]:
     """Build the aggregated output from accumulated data."""
     current_finish_reason = chunk.get("choices", [{}])[0].get("finish_reason")
@@ -2767,6 +2768,9 @@ def _build_aggregated_output(
                     "role": "assistant",
                     "tool_calls": (cleaned_tool_calls if cleaned_tool_calls else None),
                     "function_call": None,
+                    "reasoning_content": (
+                        "".join(reasoning_content) if reasoning_content else None
+                    ),
                 },
             }
         ],
@@ -2793,6 +2797,7 @@ def _create_tracked_stream_wrapper(
         assistant_acc: list[str] = []
         tool_calls: list[dict[str, Any]] = []
         aggregated_metadata: dict[str, Any] = {}
+        reasoning_content: list[str] = []
 
         try:
             for chunk in chunk_iter:
@@ -2819,14 +2824,25 @@ def _create_tracked_stream_wrapper(
                         if tool_call_delta:
                             _process_tool_call_delta(tool_call_delta, tool_calls)
 
+                        # Handle reasoning content
+                        reasoning_content_delta = delta.get("reasoning_content")
+                        if reasoning_content_delta:
+                            reasoning_content.append(reasoning_content_delta)
+
                 # Build aggregated output
                 aggregated_output = _build_aggregated_output(
-                    aggregated_metadata, assistant_acc, tool_calls, chunk
+                    aggregated_metadata,
+                    assistant_acc,
+                    tool_calls,
+                    chunk,
+                    reasoning_content,
                 )
 
         finally:
             # Handle fallback case for aggregated output
-            if aggregated_output is None and (assistant_acc or tool_calls):
+            if aggregated_output is None and (
+                assistant_acc or tool_calls or reasoning_content
+            ):
                 cleaned_tool_calls = _clean_tool_calls(tool_calls)
                 aggregated_output = {
                     "choices": [
@@ -2840,6 +2856,11 @@ def _create_tracked_stream_wrapper(
                                 ),
                                 "tool_calls": (
                                     cleaned_tool_calls if cleaned_tool_calls else None
+                                ),
+                                "reasoning_content": (
+                                    "".join(reasoning_content)
+                                    if reasoning_content
+                                    else None
                                 ),
                             }
                         }


### PR DESCRIPTION
## Description
Accumulator of reasoning_content for completions_create_stream so thinking tokens are saved on call

<img width="1672" height="836" alt="Screenshot 2025-08-06 at 1 33 15 PM" src="https://github.com/user-attachments/assets/510559ae-57df-4260-804b-59e1ee12ffb4" />

## Testing

How was this PR tested?
