### PR TITLE
chore(weave): Pin openapi version to unblock CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,8 @@ anthropic = ["anthropic>=0.18.0"]
 cerebras = ["cerebras-cloud-sdk"]
 cohere = ["cohere>=5.9.1,<5.9.3"]
 # Pin until https://github.com/crewAIInc/crewAI/pull/2553 is released
-crewai = ["crewai>=0.100.1,<=0.108.0", "crewai-tools>=0.38.0", "openai<1.92.0"]
-dspy = ["dspy>=2.6.27", "openai<1.92.0"]
+crewai = ["crewai>=0.100.1,<=0.108.0", "crewai-tools>=0.38.0", "openai<1.99.0"]
+dspy = ["dspy>=2.6.27", "openai<1.99.0"]
 google_ai_studio = ["google-generativeai>=0.8.3"]
 google_genai = ["google-genai>=1.0.0,<=1.23.0", "pillow>=11.1.0"]
 groq = ["groq>=0.13.0"]
@@ -123,7 +123,7 @@ instructor = [
   "instructor>=1.4.3,<1.7.0; python_version <= '3.9'",
   "instructor>=1.4.3; python_version > '3.9'",
   "google-genai>=1.5.0",
-  "openai<1.92.0",
+  "openai<1.99.0",
 ]
 langchain = [
   "langchain-core>=0.2.1",


### PR DESCRIPTION
Pins to avoid an import introduced in `openai==1.99.1`