### PR TITLE
chore(weave): Update codegen to include new endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,9 +253,6 @@ exclude = [
 
 # [tool.hatch.metadata]
 # allow-direct-references = true
-
-[tool.hatch.metadata]
-allow-direct-references = true
 [tool.pytest.ini_options]
 filterwarnings = [
   # treat warnings as errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,6 +253,9 @@ exclude = [
 
 # [tool.hatch.metadata]
 # allow-direct-references = true
+
+[tool.hatch.metadata]
+allow-direct-references = true
 [tool.pytest.ini_options]
 filterwarnings = [
   # treat warnings as errors

--- a/tools/codegen/openapi.json
+++ b/tools/codegen/openapi.json
@@ -1395,6 +1395,101 @@
         ]
       }
     },
+    "/completions/create": {
+      "post": {
+        "tags": [
+          "Completions"
+        ],
+        "summary": "Completions Create",
+        "operationId": "completions_create_completions_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompletionsCreateReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompletionsCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBasic": []
+          }
+        ]
+      }
+    },
+    "/completions/create_stream": {
+      "post": {
+        "tags": [
+          "Completions"
+        ],
+        "summary": "Completions Create Stream",
+        "operationId": "completions_create_stream_completions_create_stream_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompletionsCreateReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Stream of data in JSONL format",
+            "content": {
+              "application/jsonl": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Schema"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBasic": []
+          }
+        ]
+      }
+    },
     "/threads/stream_query": {
       "post": {
         "tags": [
@@ -2429,6 +2524,375 @@
           "count"
         ],
         "title": "CallsQueryStatsRes"
+      },
+      "CompletionsCreateReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "inputs": {
+            "$ref": "#/components/schemas/CompletionsCreateRequestInputs"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          },
+          "track_llm_call": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Llm Call",
+            "description": "Whether to track this LLM call in the trace server",
+            "default": true
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "project_id",
+          "inputs"
+        ],
+        "title": "CompletionsCreateReq"
+      },
+      "CompletionsCreateRequestInputs": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "messages": {
+            "items": {},
+            "type": "array",
+            "title": "Messages",
+            "default": []
+          },
+          "timeout": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timeout"
+          },
+          "temperature": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Temperature"
+          },
+          "top_p": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top P"
+          },
+          "n": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N"
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stop"
+          },
+          "max_completion_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Completion Tokens"
+          },
+          "max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Tokens"
+          },
+          "modalities": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Modalities"
+          },
+          "presence_penalty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Presence Penalty"
+          },
+          "frequency_penalty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Frequency Penalty"
+          },
+          "stream": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stream"
+          },
+          "logit_bias": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logit Bias"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User"
+          },
+          "response_format": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Format"
+          },
+          "seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Seed"
+          },
+          "tools": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tools"
+          },
+          "tool_choice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Choice"
+          },
+          "logprobs": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logprobs"
+          },
+          "top_logprobs": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Top Logprobs"
+          },
+          "parallel_tool_calls": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parallel Tool Calls"
+          },
+          "extra_headers": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extra Headers"
+          },
+          "functions": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Functions"
+          },
+          "function_call": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Function Call"
+          },
+          "api_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "model"
+        ],
+        "title": "CompletionsCreateRequestInputs"
+      },
+      "CompletionsCreateRes": {
+        "properties": {
+          "response": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Response"
+          },
+          "weave_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weave Call Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "response"
+        ],
+        "title": "CompletionsCreateRes"
       },
       "ContainsOperation": {
         "properties": {

--- a/tools/codegen/openapi.stainless.yml
+++ b/tools/codegen/openapi.stainless.yml
@@ -160,18 +160,10 @@ resources:
     methods:
       export: post /otel/v1/trace
 
-  actions:
-    methods:
-      execute_batch: post /actions/execute_batch
-
   completions:
     methods:
       create: post /completions/create
       create_stream: post /completions/create_stream
-
-  project:
-    methods:
-      stats: post /project/stats
 
   threads:
     methods:

--- a/tools/codegen/openapi.stainless.yml
+++ b/tools/codegen/openapi.stainless.yml
@@ -156,6 +156,27 @@ resources:
       purge: post /feedback/purge
       replace: post /feedback/replace
 
+  otel:
+    methods:
+      export: post /otel/v1/trace
+
+  actions:
+    methods:
+      execute_batch: post /actions/execute_batch
+
+  completions:
+    methods:
+      create: post /completions/create
+      create_stream: post /completions/create_stream
+
+  project:
+    methods:
+      stats: post /project/stats
+
+  threads:
+    methods:
+      stream_query: post /threads/stream_query
+
 settings:
   license: Apache-2.0
 

--- a/weave/trace_server/reference/generate.py
+++ b/weave/trace_server/reference/generate.py
@@ -426,9 +426,7 @@ def generate_routes(
     ) -> tsi.ActionsExecuteBatchRes:
         return service.trace_server_interface.actions_execute_batch(req)
 
-    @router.post(
-        "/completions/create", tags=[COMPLETIONS_TAG_NAME], include_in_schema=False
-    )
+    @router.post("/completions/create", tags=[COMPLETIONS_TAG_NAME])
     def completions_create(
         req: tsi.CompletionsCreateReq,
         service: weave.trace_server.trace_service.TraceService = Depends(get_service),  # noqa: B008
@@ -438,7 +436,6 @@ def generate_routes(
     @router.post(
         "/completions/create_stream",
         tags=[COMPLETIONS_TAG_NAME],
-        include_in_schema=False,
         response_class=StreamingResponse,
         responses={
             200: {


### PR DESCRIPTION
Adds OTEL, completions, and threads endpoints.

Additionally exposes the `completions` endpoint which was previously hidden