### PR TITLE
docs(weave): document Content API

### DIFF
--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -7,25 +7,25 @@ W&B Weave supports logging and has dedicated displays for numerous content types
 
 ## Content API
 
-The Content API is a modern way of handling any data as media objects in Weave. Instead of using specific modules and classes like `PIL.Image` or `moviepy.VideoFileClip`, you can simply import Content from Weave to process base64 data, file paths, raw bytes, or text.
+The Content API handles media objects in Weave. Instead of using specific modules and classes like `PIL.Image` or `moviepy.VideoFileClip`, using the Content API allows you to import content into Weave as base64 data, file paths, raw bytes, or text.
 
-For media with pre-existing support in Weave (such as MP3, MP4, or PNG files), your data will display identically in the web app regardless of which API you use. For certain large file types like videos, using Content provides significant performance improvements.
+The Content API introduces special handlers in the web app for media types that don't have legacy API handlers, such as PDF and HTML files. For media with pre-existing support in Weave (such as MP3, MP4, or PNG files), your data will display identically in the web app regardless of which API you use, however, for certain large file types like videos, using the Content API provides significant performance improvements.
 
-Additionally, Content introduces special handlers in the web app for media types that don't have legacy API handlers, such as PDF and HTML files.
+
 
 :::note
-Content support is currently only available in Python.
+The Content API is only available in Python.
 :::
 
 ### Usage
 
 There are two primary ways to use the Content API: type annotations and direct initialization.
 
-Type annotations are usually more ergonomic and automatically detect the proper constructor to use, while direct initialization provides more fine-grained control and lets you take advantage of runtime features of the Content API in your code.
+Type annotations automatically detect the proper constructor to use, while direct initialization provides more fine-grained control and lets you take advantage of runtime features of the Content API in your code.
 
 ### Type Annotations
 
-The Weave Content API is designed to primarily be used through type annotations. Annotations have no runtime side-effects on your code but signal to Weave that traced inputs and outputs should be processed and stored as Content blobs.
+The Weave Content API is designed to primarily be used through type annotations, which signal to Weave that traced inputs and outputs should be processed and stored as content blobs.
 
 ```python
 import weave
@@ -73,12 +73,9 @@ content.model_dump()  # Dumps the model attributes to JSON
 
 ### Custom Mimetypes
 
-The `polyfile-weave` library can detect most binary mimetypes, but custom mimetypes and text documents such as markdown may not be automatically detected.
+Weave can detect most binary mimetypes, but custom mimetypes and text documents such as markdown may not be automatically detected, requiring you to manually specify the mimetype or extension of your file.
 
 #### Custom Mimetypes with Type Annotations
-
-To manually specify the mimetype or extension of your file from a type annotation, you can pass it as a type parameter to Content:
-
 ```python
 import weave
 from weave import Content

--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # Logging media
 
-Weave supports logging and has dedicated displays for numerous content types such as videos, images, audio files, PDFs, CSVs and HTML.
+W&B Weave supports logging and has dedicated displays for numerous content types such as videos, images, audio files, PDFs, CSVs and HTML.
 
 ## Content API
 

--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -129,18 +129,16 @@ For a comprehensive list of class attributes and methods view the [Content refer
 
 #### Initialization Methods
 
- - `Content.from_path(path, mimetype=None, metadata=None)`
+Create `content` object from a file path:
 
 ```python
-# Create Content from a file path:
 content = Content.from_path("assets/photo.jpg")
 print(content.mimetype, content.size)
 ```
 
- - `Content.from_bytes(data, extension=None, mimetype=None, metadata=None)`
+Create `content` object from raw bytes:
 
 ```python
-# Create Content from raw bytes:
 content = Content.from_bytes(
     data_bytes,
     filename="audio.mp3", 
@@ -149,17 +147,14 @@ content = Content.from_bytes(
 content.save("output.mp3")
 ```
 
- - `Content.from_text(text, extension=None, mimetype=None, metadata=None)`
+Create `content` object from text:
 
 ```python
-# Create Content from text:
 content = Content.from_text("Hello, World!", mimetype="text/plain")
-```
 
- - `Content.from_base64(b64_data, extension=None, mimetype=None, metadata=None)`
+Create `content` object from base64-encoded data:
 
 ```python
-# Create Content from base64-encoded data:
 content = Content.from_base64(base64_string)
 print(content.metadata)
 ```

--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -151,6 +151,8 @@ Create `content` object from text:
 
 ```python
 content = Content.from_text("Hello, World!", mimetype="text/plain")
+print(content.as_string())
+```
 
 Create `content` object from base64-encoded data:
 

--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -13,174 +13,171 @@ For media with pre-existing support in Weave (such as MP3, MP4, or PNG files), y
 
 Additionally, Content introduces special handlers in the web app for media types that don't have legacy API handlers, such as PDF and HTML files.
 
+:::note
+Content support is currently only available in Python.
+:::
+
 ### Usage
 
 There are two primary ways to use the Content API: type annotations and direct initialization.
 
 Type annotations are usually more ergonomic and automatically detect the proper constructor to use, while direct initialization provides more fine-grained control and lets you take advantage of runtime features of the Content API in your code.
 
-<Tabs groupId="programming-language" queryString>
-  <TabItem value="python" label="Python" default>
+### Type Annotations
 
-    ### Type Annotations
+The Weave Content API is designed to primarily be used through type annotations. Annotations have no runtime side-effects on your code but signal to Weave that traced inputs and outputs should be processed and stored as Content blobs.
 
-    The Weave Content API is designed to primarily be used through type annotations. Annotations have no runtime side-effects on your code but signal to Weave that traced inputs and outputs should be processed and stored as Content blobs.
+```python
+import weave
+from weave import Content
+from pathlib import Path
+from typing import Annotated
 
-    ```python
-    import weave
-    from weave import Content
-    from pathlib import Path
-    from typing import Annotated
+@weave.op
+def content_annotation(path: Annotated[str, Content]) -> Annotated[bytes, Content]:
+    data = Path(path).read_bytes()
+    return data
 
-    @weave.op
-    def content_annotation(path: Annotated[str, Content]) -> Annotated[bytes, Content]:
-        data = Path(path).read_bytes()
-        return data
+# Both input and output will show up as an MP4 file in Weave
+# Input is a string and return value is bytes
+bytes_data = content_annotation('./path/to/your/file.mp4')
+```
 
-    # Both input and output will show up as an MP4 file in Weave
-    # Input is a string and return value is bytes
-    bytes_data = content_annotation('./path/to/your/file.mp4')
-    ```
+### Direct Initialization
 
-    ### Direct Initialization
+If you want to take advantage of features such as:
+- Opening a file with a default application (such as a PDF viewer)
+- Dumping the model to JSON to upload to your own blob storage (such as S3)
+- Passing custom metadata to associate with the Content blob (such as the model used to generate it)
 
-    If you want to take advantage of features such as:
-    - Opening a file with a default application (such as a PDF viewer)
-    - Dumping the model to JSON to upload to your own blob storage (such as S3)
-    - Passing custom metadata to associate with the Content blob (such as the model used to generate it)
+You can initialize content directly from your target type using one of the following methods:
+- `Content.from_path` - Create from a file path
+- `Content.from_bytes` - Create from raw bytes
+- `Content.from_text` - Create from text string
+- `Content.from_base64` - Create from base64-encoded data
 
-    You can initialize content directly from your target type using one of the following methods:
-    - `Content.from_path` - Create from a file path
-    - `Content.from_bytes` - Create from raw bytes
-    - `Content.from_text` - Create from text string
-    - `Content.from_base64` - Create from base64-encoded data
+```python
+import weave
+from weave import Content
 
-    ```python
-    import weave
-    from weave import Content
+@weave.op
+def content_initialization(path: str) -> Content:
+    return Content.from_path(path)
 
-    @weave.op
-    def content_initialization(path: str) -> Content:
-        return Content.from_path(path)
+# Input shows up as path string and output as PDF file in Weave
+content = content_initialization('./path/to/your/file.pdf')
 
-    # Input shows up as path string and output as PDF file in Weave
-    content = content_initialization('./path/to/your/file.pdf')
+content.open()  # Opens the file in your PDF viewer
+content.model_dump()  # Dumps the model attributes to JSON
+```
 
-    content.open()  # Opens the file in your PDF viewer
-    content.model_dump()  # Dumps the model attributes to JSON
-    ```
+### Custom Mimetypes
 
-    ### Custom Mimetypes
+The `polyfile-weave` library can detect most binary mimetypes, but custom mimetypes and text documents such as markdown may not be automatically detected.
 
-    The `polyfile-weave` library can detect most binary mimetypes, but custom mimetypes and text documents such as markdown may not be automatically detected.
+#### Custom Mimetypes with Type Annotations
 
-    #### Custom Mimetypes with Type Annotations
+To manually specify the mimetype or extension of your file from a type annotation, you can pass it as a type parameter to Content:
 
-    To manually specify the mimetype or extension of your file from a type annotation, you can pass it as a type parameter to Content:
+```python
+import weave
+from weave import Content
+from pathlib import Path
+from typing import Annotated, Literal
 
-    ```python
-    import weave
-    from weave import Content
-    from pathlib import Path
-    from typing import Annotated, Literal
+@weave.op
+def markdown_content(
+    path: Annotated[str, Content[Literal['md']]]
+) -> Annotated[str, Content[Literal['text/markdown']]]:
+    return Path(path).read_text()
 
-    @weave.op
-    def markdown_content(
-        path: Annotated[str, Content[Literal['md']]]
-    ) -> Annotated[str, Content[Literal['text/markdown']]]:
-        return Path(path).read_text()
+markdown_content('path/to/your/document.md')
+```
 
-    markdown_content('path/to/your/document.md')
-    ```
+#### Custom Mimetypes with Direct Initialization
 
-    #### Custom Mimetypes with Direct Initialization
+```python
+video_bytes = Path('/path/to/video.mp4').read_bytes()
 
-    ```python
-    video_bytes = Path('/path/to/video.mp4').read_bytes()
+# Pass an extension such as 'mp4' or '.mp4' to the extension parameter
+# (not available for `from_path`)
+content = Content.from_bytes(video_bytes, extension='.mp4')
 
-    # Pass an extension such as 'mp4' or '.mp4' to the extension parameter
-    # (not available for `from_path`)
-    content = Content.from_bytes(video_bytes, extension='.mp4')
+# Pass a mimetype such as 'video/mp4' to the mimetype parameter
+content = Content.from_bytes(video_bytes, mimetype='video/mp4')
+```
 
-    # Pass a mimetype such as 'video/mp4' to the mimetype parameter
-    content = Content.from_bytes(video_bytes, mimetype='video/mp4')
-    ```
+### Properties
 
-    ### Properties
+| Property    | Type             | Description                             |
+| ----------- | ---------------- | --------------------------------------- |
+| `data`      | `bytes`          | Raw binary content                      |
+| `metadata`  | `dict[str, Any]` | Custom metadata dictionary              |
+| `size`      | `int`            | Size of content in bytes                |
+| `filename`  | `str`            | Extracted or provided filename          |
+| `extension` | `str`            | File extension (e.g., `"jpg"`, `"mp3"`) |
+| `mimetype`  | `str`            | MIME type (e.g., `"image/jpeg"`)        |
+| `path`      | `str \| None`    | Source file path, if applicable         |
+| `digest`    | `str`            | SHA256 hash of the content              |
 
-    | Property    | Type             | Description                             |
-    | ----------- | ---------------- | --------------------------------------- |
-    | `data`      | `bytes`          | Raw binary content                      |
-    | `metadata`  | `dict[str, Any]` | Custom metadata dictionary              |
-    | `size`      | `int`            | Size of content in bytes                |
-    | `filename`  | `str`            | Extracted or provided filename          |
-    | `extension` | `str`            | File extension (e.g., `"jpg"`, `"mp3"`) |
-    | `mimetype`  | `str`            | MIME type (e.g., `"image/jpeg"`)        |
-    | `path`      | `str \| None`    | Source file path, if applicable         |
-    | `digest`    | `str`            | SHA256 hash of the content              |
+### Methods
 
-    ### Methods
+- `save(dest: str | Path) -> None`: Save content to a file
+- `open() -> bool`: Open file using system default application (requires the content to have been saved or loaded from a path)
+- `as_string() -> str`: Display the data as a string (bytes are decoded using the encoding attribute)
 
-    - `save(dest: str | Path) -> None`: Save content to a file
-    - `open() -> bool`: Open file using system default application (requires the content to have been saved or loaded from a path)
-    - `as_string() -> str`: Display the data as a string (bytes are decoded using the encoding attribute)
+### Creation Methods
 
-    ### Creation Methods
+#### `Content.from_path(path, mimetype=None, metadata=None)`
 
-    #### `Content.from_path(path, mimetype=None, metadata=None)`
+Create Content from a file path:
 
-    Create Content from a file path:
+```python
+content = Content.from_path("assets/photo.jpg")
+print(content.mimetype, content.size)
+```
 
-    ```python
-    content = Content.from_path("assets/photo.jpg")
-    print(content.mimetype, content.size)
-    ```
+#### `Content.from_bytes(data, extension=None, mimetype=None, metadata=None)`
 
-    #### `Content.from_bytes(data, extension=None, mimetype=None, metadata=None)`
+Create Content from raw bytes:
 
-    Create Content from raw bytes:
+```python
+content = Content.from_bytes(
+    data_bytes,
+    filename="audio.mp3", 
+    mimetype="audio/mpeg"
+)
+content.save("output.mp3")
+```
 
-    ```python
-    content = Content.from_bytes(data_bytes, 
-                                  filename="audio.mp3", 
-                                  mimetype="audio/mpeg")
-    content.save("output.mp3")
-    ```
+#### `Content.from_text(text, extension=None, mimetype=None, metadata=None)`
 
-    #### `Content.from_text(text, extension=None, mimetype=None, metadata=None)`
+Create Content from text:
 
-    Create Content from text:
+```python
+content = Content.from_text("Hello, World!", mimetype="text/plain")
+```
 
-    ```python
-    content = Content.from_text("Hello, World!", 
-                                mimetype="text/plain")
-    ```
+#### `Content.from_base64(b64_data, extension=None, mimetype=None, metadata=None)`
 
-    #### `Content.from_base64(b64_data, extension=None, mimetype=None, metadata=None)`
+Create Content from base64-encoded data:
 
-    Create Content from base64-encoded data:
+```python
+content = Content.from_base64(base64_string)
+print(content.metadata)
+```
 
-    ```python
-    content = Content.from_base64(base64_string)
-    print(content.metadata)
-    ```
+### Adding Custom Metadata
 
-    ### Adding Custom Metadata
+You can attach custom metadata to any Content object:
 
-    You can attach custom metadata to any Content object:
-
-    ```python
-    content = Content.from_bytes(data, 
-                                  metadata={"resolution": "1920x1080", 
-                                            "model": "dall-e-3"})
-    print(content.metadata["resolution"])
-    ```
-
-  </TabItem>
-  <TabItem value="typescript" label="TypeScript">
-  This feature is not yet available in TypeScript.
-  </TabItem>
-</Tabs>
+```python
+content = Content.from_bytes(
+    data,
+    metadata={"resolution": "1920x1080", "model": "dall-e-3" }
+)
+print(content.metadata["resolution"])
+```
 
 ## Video
 

--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 # Logging media
 
-Weave supports logging and displaying video, images, audio, PDFs, and CSVs.
+Weave supports logging and has dedicated displays for numerous content types such as videos, images, audio files, PDFs, CSVs and HTML.
 
 ## Content API
 

--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -129,20 +129,18 @@ For a comprehensive list of class attributes and methods view the [Content refer
 
 #### Initialization Methods
 
-##### `Content.from_path(path, mimetype=None, metadata=None)`
-
-Create Content from a file path:
+ - `Content.from_path(path, mimetype=None, metadata=None)`
 
 ```python
+# Create Content from a file path:
 content = Content.from_path("assets/photo.jpg")
 print(content.mimetype, content.size)
 ```
 
-##### `Content.from_bytes(data, extension=None, mimetype=None, metadata=None)`
-
-Create Content from raw bytes:
+ - `Content.from_bytes(data, extension=None, mimetype=None, metadata=None)`
 
 ```python
+# Create Content from raw bytes:
 content = Content.from_bytes(
     data_bytes,
     filename="audio.mp3", 
@@ -151,19 +149,17 @@ content = Content.from_bytes(
 content.save("output.mp3")
 ```
 
-##### `Content.from_text(text, extension=None, mimetype=None, metadata=None)`
-
-Create Content from text:
+ - `Content.from_text(text, extension=None, mimetype=None, metadata=None)`
 
 ```python
+# Create Content from text:
 content = Content.from_text("Hello, World!", mimetype="text/plain")
 ```
 
-##### `Content.from_base64(b64_data, extension=None, mimetype=None, metadata=None)`
-
-Create Content from base64-encoded data:
+ - `Content.from_base64(b64_data, extension=None, mimetype=None, metadata=None)`
 
 ```python
+# Create Content from base64-encoded data:
 content = Content.from_base64(base64_string)
 print(content.metadata)
 ```

--- a/docs/docs/guides/core-types/media.md
+++ b/docs/docs/guides/core-types/media.md
@@ -104,7 +104,11 @@ content = Content.from_bytes(video_bytes, extension='.mp4')
 content = Content.from_bytes(video_bytes, mimetype='video/mp4')
 ```
 
-### Properties
+### Content properties
+
+For a comprehensive list of class attributes and methods view the [Content reference docs](https://weave-docs.wandb.ai/reference/python-sdk/weave/#class-content)
+
+#### Attributes
 
 | Property    | Type             | Description                             |
 | ----------- | ---------------- | --------------------------------------- |
@@ -117,15 +121,15 @@ content = Content.from_bytes(video_bytes, mimetype='video/mp4')
 | `path`      | `str \| None`    | Source file path, if applicable         |
 | `digest`    | `str`            | SHA256 hash of the content              |
 
-### Methods
+#### Utility Methods
 
 - `save(dest: str | Path) -> None`: Save content to a file
 - `open() -> bool`: Open file using system default application (requires the content to have been saved or loaded from a path)
 - `as_string() -> str`: Display the data as a string (bytes are decoded using the encoding attribute)
 
-### Creation Methods
+#### Initialization Methods
 
-#### `Content.from_path(path, mimetype=None, metadata=None)`
+##### `Content.from_path(path, mimetype=None, metadata=None)`
 
 Create Content from a file path:
 
@@ -134,7 +138,7 @@ content = Content.from_path("assets/photo.jpg")
 print(content.mimetype, content.size)
 ```
 
-#### `Content.from_bytes(data, extension=None, mimetype=None, metadata=None)`
+##### `Content.from_bytes(data, extension=None, mimetype=None, metadata=None)`
 
 Create Content from raw bytes:
 
@@ -147,7 +151,7 @@ content = Content.from_bytes(
 content.save("output.mp3")
 ```
 
-#### `Content.from_text(text, extension=None, mimetype=None, metadata=None)`
+##### `Content.from_text(text, extension=None, mimetype=None, metadata=None)`
 
 Create Content from text:
 
@@ -155,7 +159,7 @@ Create Content from text:
 content = Content.from_text("Hello, World!", mimetype="text/plain")
 ```
 
-#### `Content.from_base64(b64_data, extension=None, mimetype=None, metadata=None)`
+##### `Content.from_base64(b64_data, extension=None, mimetype=None, metadata=None)`
 
 Create Content from base64-encoded data:
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes https://wandb.atlassian.net/browse/DOCS-1520

Updates the docs from https://github.com/wandb/weave/pull/4528 to represent the current state of the API and moves the Content docs to the top of the media page since it is the preferred way to handle all media now.
