### PR TITLE
chore(weave): Remove model_providers from build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,6 +251,7 @@ exclude = [
   "docs",
   "dev_docs",
   "weave/clear_cache.py",
+  "weave/trace_server/model_providers",
 ]
 
 [tool.hatch.metadata]


### PR DESCRIPTION
This is not used in the SDK and has a symlink to core which breaks builds