### PR TITLE
chore(weave): Add support for gql>=4.0.0 (pt2)

### DIFF
--- a/weave/compat/wandb/wandb_thin/internal_api.py
+++ b/weave/compat/wandb/wandb_thin/internal_api.py
@@ -46,7 +46,7 @@ class Api:
         # bother.
         client = gql.Client(transport=transport, fetch_schema_from_transport=False)
         session = client.connect_sync()  # type: ignore
-        return session.execute(query, kwargs)
+        return session.execute(query, variable_values=kwargs)
 
     SERVER_INFO_QUERY = gql.gql(
         """
@@ -256,7 +256,7 @@ class ApiAsync:
         # bother.
         client = gql.Client(transport=transport, fetch_schema_from_transport=False)
         session = await client.connect_async(reconnecting=False)  # type: ignore
-        result = await session.execute(query, kwargs)
+        result = await session.execute(query, variable_values=kwargs)
         # Manually reset the connection, bypassing the SSL bug, avoiding ERROR:asyncio:Unclosed client session
         await transport.session.close()
         return result


### PR DESCRIPTION
Re-adds support for gql>=4.0.0 which was previously added then accidentally removed in https://github.com/wandb/weave/commit/e70cfe4af2eb0e3371ee48608c918d2595e67738#diff-a106ba8e7cd28ff9ea9bd95a182b7397daa2c2fa24394faf35cca07202be9953