### PR TITLE
chore(weave): raise error on call ref resolution

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1117,6 +1117,12 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         if any(isinstance(r, ri.InternalTableRef) for r in parsed_raw_refs):
             raise ValueError("Table refs not supported")
 
+        # Business logic to ensure that we don't have raw CallRefs (not allowed)
+        if any(isinstance(r, ri.InternalCallRef) for r in parsed_raw_refs):
+            raise ValueError(
+                "Call refs not supported in batch read, use calls_query_stream"
+            )
+
         parsed_refs = cast(ObjRefListType, parsed_raw_refs)
         vals = self._parsed_refs_read_batch(parsed_refs)
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

We don't support resolving call refs in the refs_read_batch endpoint, that is for objects. raise an explicit error instead of [attribute error](https://us5.datadoghq.com/apm/traces?query=env%3A%2A%20operation_name%3Afastapi.request%20service%3Aweave-trace%20-resource_name%3A%28%22POST%20%2Ffiles%2Fcontent%22%20OR%20%22POST%20%2Fcall%2Fupsert_batch%22%20OR%20%22POST%20%2Fobjs%2Fquery%22%20OR%20%22POST%20%2Ffeedback%2Fquery%22%20OR%20%22POST%20%2Ffiles%2Fcreate%22%29%20-%40weave_trace_server.auth_scope.project%3Acounts%20%40weave_trace_server.auth_scope.project%3A%2A%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=%40http.status_code%2Cservice%2Cresource_name%2C%40duration%2C%40_span.count%2C%40_duration.by_service%2C%40weave_trace_server.auth_scope.email%2C%40weave_trace_server.auth_scope.project%2C%40error.message&fromUser=false&graphType=flamegraph&historicalData=true&messageDisplay=inline&query_translation_version=v0&refresh_mode=sliding&shouldShowLegend=true&sort=time&spanID=11468969386919084519&spanType=all&spanViewType=metadata&storage=hot&timeHint=1755615695794&trace=AwAAAZjC2ZOywUNVfwAAABhBWmpDMlpXQ0FBQkk1VmJLM2JKSElBalIAAAAkZjE5OGMyZGYtOWYwMS00Y2M3LTk4NmQtNGQzOWE2ZmI0MTU3AAIu_w&traceID=68a491cf00000000d1081936e8d7d255&traceQuery=&view=spans&start=1755613103469&end=1755616703469&paused=false).

## Testing

How was this PR tested?
