### PR TITLE
chore(weave): macro for running sqlite trace server in tests

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -34,6 +34,12 @@ def pytest_addoption(parser):
             help="Use clickhouse server (shorthand for --trace-server=clickhouse)",
         )
         parser.addoption(
+            "--sq",
+            "--sqlite",
+            action="store_true",
+            help="Use sqlite server (shorthand for --trace-server=sqlite)",
+        )
+        parser.addoption(
             "--clickhouse-process",
             action="store",
             default="false",
@@ -53,6 +59,8 @@ def pytest_collection_modifyitems(config, items):
 def get_trace_server_flag(request):
     if request.config.getoption("--clickhouse"):
         return "clickhouse"
+    if request.config.getoption("--sqlite"):
+        return "sqlite"
     weave_server_flag = request.config.getoption("--trace-server")
     return weave_server_flag
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Now use `pytest path/to/test.py --sq` to run against sqlite. 
