### PR TITLE
chore(weave): Add more efficient future handling for FutureExecutor

### DIFF
--- a/weave/trace/concurrent/futures.py
+++ b/weave/trace/concurrent/futures.py
@@ -183,8 +183,8 @@ class FutureExecutor:
         with self._active_futures_lock:
             self._active_futures.discard(future)
 
-        if exception := future.exception():
-            logger.error(f"Task failed: {_format_exception(exception)}")
+            if exception := future.exception():
+                logger.error(f"Task failed: {_format_exception(exception)}")
 
     def _shutdown(self) -> None:
         """Shutdown the thread pool executor. Should only be called when the program is exiting."""


### PR DESCRIPTION
Changes the `_active_futures` container from list to set because we can get O(1) operations on set instead of O(N) operations on list