### PR TITLE
chore(weave): Remove jsonschema dep from client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
   "rich",                     # Used for special formatting of tables (should be made optional)
   "click",                    # Used for terminal/stdio printing
   "gql[aiohttp,requests]",    # Used exclusively in wandb_api.py
-  "jsonschema>=4.23.0",       # Used by scorers for field validation
   "diskcache==5.6.3",         # Used for data caching
   "nest-asyncio==1.6.0",      # Used to support nested event loops in asyncio
 
@@ -88,6 +87,7 @@ trace_server = [
   "openinference-semantic-conventions>=0.1.17",
   # For emoji shortcode support in Feedback
   "emoji>=2.12.1",
+  "jsonschema>=4.23.0", # Used by scorers for field validation
 ]
 trace_server_tests = [
   # BYOB - S3


### PR DESCRIPTION
This is only used in the trace server, so moving the dep there